### PR TITLE
Sdscheduler changed to simplescheduler

### DIFF
--- a/docs/install/metadata-ingestion/scheduler.md
+++ b/docs/install/metadata-ingestion/scheduler.md
@@ -1,6 +1,6 @@
 ---
 description: >-
-  This guide will help install Sdscheduler and schedule connectors for
+  This guide will help install Simple Scheduler and schedule connectors for
   ingestion.
 ---
 

--- a/ingestion/ingestion_scheduler/jobs.py
+++ b/ingestion/ingestion_scheduler/jobs.py
@@ -15,7 +15,7 @@
 
 import json
 from metadata.ingestion.workflow.workflow import Workflow
-from sdscheduler.corescheduler import job
+from simplescheduler.corescheduler import job
 
 
 class MetadataLoaderJob(job.JobBase, Workflow):

--- a/ingestion/ingestion_scheduler/scheduler.py
+++ b/ingestion/ingestion_scheduler/scheduler.py
@@ -14,10 +14,10 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from sdscheduler.server import server
+from simplescheduler.server import server
 import os
 import json
-from sdscheduler.server import server
+from simplescheduler.server import server
 
 
 class SimpleServer(server.SchedulerServer):

--- a/ingestion/setup.py
+++ b/ingestion/setup.py
@@ -68,7 +68,7 @@ connector_requirements = {
 }
 scheduler_requirements = {
     "apns@git+git://github.com/djacobs/PyAPNs.git#egg=apns",
-    "sdscheduler@git+https://github.com/StreamlineData/sdscheduler.git#egg=sdscheduler"
+    "simplescheduler@git+https://github.com/StreamlineData/sdscheduler.git#egg=simplescheduler"
 }
 base_plugins = {
     "pii-tags",
@@ -113,7 +113,7 @@ setup(
     package_dir={"": "src"},
     packages=find_namespace_packages(where='src', exclude=['tests*']),
     dependency_links=['git+git://github.com/djacobs/PyAPNs.git#egg=apns',
-                      'git+https://github.com/StreamlineData/sdscheduler.git#egg=sdscheduler'],
+                      'git+https://github.com/StreamlineData/sdscheduler.git#egg=simplescheduler'],
     entry_points={
         "console_scripts": ["metadata = metadata.cmd:metadata"],
         "metadata.ingestion.source.plugins": [


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done !-->
<!-- Be sure to tag your assigned issue !-->
I worked on the modification of scheduler package's name because the name has changed from sdscheduler to simplescheduler.

#
### Type of change :

<!-- You should choice 1 option and delete options that aren't relevant -->

- [x] Bug fix

### Checklist:
<!-- If you have access, please choose the right review label ("Review: Needs 1" OR "Review: Needs 2")!-->
<!-- add an x in [] if done !-->
<!-- don't mark items that you didn't do !-->

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] All new and existing tests passed.
#

### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata Community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
+@sureshms