### PR TITLE
Fix #141 Change schema URL from github to open-metadata.org

### DIFF
--- a/catalog-rest-service/src/main/resources/json/schema/entity/bots.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/bots.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://github.com/open-metadata/OpenMetadata/blob/main/catalog-rest-service/src/main/resources/json/schema/entity/bots.json",
+  "$id": "https://open-metadata.org/schema/entity/bots.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Bot",
   "description": "This schema defines Bot entity. A bot automates tasks, such as adding description, identifying the importance of data. It runs as a special user in the system.",

--- a/catalog-rest-service/src/main/resources/json/schema/entity/data/dashboard.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/data/dashboard.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://github.com/open-metadata/OpenMetadata/blob/main/catalog-rest-service/src/main/resources/json/schema/entity/data/dashboard.json",
+  "$id": "https://open-metadata.org/schema/entity/data/dashboard.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Dashboard",
   "description": "This schema defines the Dashboard entity. Dashboards are computed from data and visually present data, metrics, and KIPs. They are updated in real-time and allow interactive data exploration.",

--- a/catalog-rest-service/src/main/resources/json/schema/entity/data/database.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/data/database.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://github.com/open-metadata/OpenMetadata/blob/main/catalog-rest-service/src/main/resources/json/schema/entity/data/database.json",
+  "$id": "https://open-metadata.org/schema/entity/data/database.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Database",
   "description": "This schema defines the Database entity. A database also referred to as Database Catalog is a collection tables.",

--- a/catalog-rest-service/src/main/resources/json/schema/entity/data/metrics.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/data/metrics.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://github.com/open-metadata/OpenMetadata/blob/main/catalog-rest-service/src/main/resources/json/schema/entity/data/metrics.json",
+  "$id": "https://open-metadata.org/schema/entity/data/metrics.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Metrics",
   "description": "This schema defines the Metrics entity. Metrics are measurements computed from data such as `Monthly Active Users`. Some of the metrics that measures used to determine performance against an objective are called KPIs or Key Performance Indicators, such as `User Retention`.",

--- a/catalog-rest-service/src/main/resources/json/schema/entity/data/pipeline.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/data/pipeline.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://github.com/open-metadata/OpenMetadata/blob/main/catalog-rest-service/src/main/resources/json/schema/entity/data/pipeline.json",
+  "$id": "https://open-metadata.org/schema/entity/data/pipeline.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Pipeline",
   "description": "This schema defines the Pipeline entity. A pipeline enables flow of data from source to destination through a series of processing steps. ETL is a type of pipeline where the series of steps Extract, Transform, and load the data.",

--- a/catalog-rest-service/src/main/resources/json/schema/entity/data/report.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/data/report.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://github.com/open-metadata/OpenMetadata/blob/main/catalog-rest-service/src/main/resources/json/schema/entity/data/report.json",
+  "$id": "https://open-metadata.org/schema/entity/data/report.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Report",
   "description": "This schema defines the Report entity. Reports are static information computed from data periodically that includes data in text, table, and in visual form.",

--- a/catalog-rest-service/src/main/resources/json/schema/entity/data/table.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/data/table.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://github.com/open-metadata/OpenMetadata/blob/main/catalog-rest-service/src/main/resources/json/schema/entity/data/table.json",
+  "$id": "https://open-metadata.org/schema/entity/data/table.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Table",
   "description": "This schema defines the Table entity. A Table organizes data in rows and columns and is defined by a Schema. OpenMetadata does not have a separate abstraction for Schema. Both Table and Schema are captured in this entity.",

--- a/catalog-rest-service/src/main/resources/json/schema/entity/feed/thread.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/feed/thread.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://github.com/open-metadata/OpenMetadata/blob/main/catalog-rest-service/src/main/resources/json/schema/entity/feed/thread.json",
+  "$id": "https://open-metadata.org/schema/entity/feed/thread.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Thread",
   "description": "This schema defines the Thread entity. A Thread is a collection of posts made by the users. The first post that starts a thread is **about** a data asset **from** a user. Other users can respond to this post by creating new posts in the thread. Note that bot users can also interact with a thread. A post can contains links that mention Users or other Data Assets.",

--- a/catalog-rest-service/src/main/resources/json/schema/entity/services/databaseService.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/services/databaseService.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://github.com/open-metadata/OpenMetadata/blob/main/catalog-rest-service/src/main/resources/json/schema/entity/services/databaseService.json",
+  "$id": "https://open-metadata.org/schema/entity/services/databaseService.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Database Service",
   "description": "This schema defines the Database Service entity, such as MySQL, BigQuery, Redshift, Postgres, or Snowflake. Alternative terms such as Database Cluster, Database Server instance are also used.",

--- a/catalog-rest-service/src/main/resources/json/schema/entity/tags/tagCategory.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/tags/tagCategory.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://github.com/open-metadata/OpenMetadata/blob/main/catalog-rest-service/src/main/resources/json/schema/entity/tags/tagCategory.json",
+  "$id": "https://open-metadata.org/schema/entity/tags/tagCategory.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Tag Category",
   "description": "This schema defines the Tag Category entity. A Tag Category has one more children tags called Primary Tags. Primary Tags can further have children Tags called Secondary Tags. Only two levels of tags are supported currently.",

--- a/catalog-rest-service/src/main/resources/json/schema/entity/teams/team.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/teams/team.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://github.com/open-metadata/OpenMetadata/blob/main/catalog-rest-service/src/main/resources/json/schema/entity/teams/team.json",
+  "$id": "https://open-metadata.org/schema/entity/teams/team.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Team",
   "description": "This schema defines the Team entity. A Team is a group of zero or more users. Teams can own zero or more data assets.",

--- a/catalog-rest-service/src/main/resources/json/schema/entity/teams/user.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/teams/user.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://github.com/open-metadata/OpenMetadata/blob/main/catalog-rest-service/src/main/resources/json/schema/entity/teams/user.json",
+  "$id": "https://open-metadata.org/schema/entity/teams/user.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "User",
   "description": "This schema defines the User entity. A user can be part of 0 or more teams. A special type of user called Bot is used for automation. A user can be an owner of zero or more data assets. A user can also follow zero or more data assets.",

--- a/catalog-rest-service/src/main/resources/json/schema/type/auditLog.json
+++ b/catalog-rest-service/src/main/resources/json/schema/type/auditLog.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://github.com/open-metadata/OpenMetadata/blob/main/catalog-rest-service/src/main/resources/json/schema/type/auditLog.json",
+  "$id": "https://open-metadata.org/schema/type/auditLog.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Audit Log",
   "description": "This schema defines Audit Log type to capture the audit trail of POST, PUT, and PATCH API operations.",

--- a/catalog-rest-service/src/main/resources/json/schema/type/basic.json
+++ b/catalog-rest-service/src/main/resources/json/schema/type/basic.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://github.com/open-metadata/OpenMetadata/blob/main/catalog-rest-service/src/main/resources/json/schema/type/basic.json",
+  "$id": "https://open-metadata.org/schema/type/basic.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Basic",
   "description": "This schema defines basic common types that are used by other schemas.",

--- a/catalog-rest-service/src/main/resources/json/schema/type/collectionDescriptor.json
+++ b/catalog-rest-service/src/main/resources/json/schema/type/collectionDescriptor.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://github.com/open-metadata/OpenMetadata/blob/main/catalog-rest-service/src/main/resources/json/schema/type/collectionDescriptor.json",
+  "$id": "https://open-metadata.org/schema/type/collectionDescriptor.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Schema for collection descriptor",
   "description": "Type used for capturing the details of a collection.",

--- a/catalog-rest-service/src/main/resources/json/schema/type/dailyCount.json
+++ b/catalog-rest-service/src/main/resources/json/schema/type/dailyCount.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://github.com/open-metadata/OpenMetadata/blob/main/catalog-rest-service/src/main/resources/json/schema/type/dailyCount.json",
+  "$id": "https://open-metadata.org/schema/type/dailyCount.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Daily count of some measurement",
   "description": "This schema defines the type for reporting the daily count of some measurement. Example - number of times a table was used in queries per day.",

--- a/catalog-rest-service/src/main/resources/json/schema/type/entityReference.json
+++ b/catalog-rest-service/src/main/resources/json/schema/type/entityReference.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://github.com/open-metadata/OpenMetadata/blob/main/catalog-rest-service/src/main/resources/json/schema/type/entityReference.json",
+  "$id": "https://open-metadata.org/schema/type/entityReference.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Entity Reference",
   "description": "This schema defines EntityReference type used for referencing an entity. EntityReference is used for capturing relationship from one entity to another. For example, table has an attribute called database of type EntityReference that captures the relationship of a table `belongs to a` database.",

--- a/catalog-rest-service/src/main/resources/json/schema/type/entityUsage.json
+++ b/catalog-rest-service/src/main/resources/json/schema/type/entityUsage.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://github.com/open-metadata/OpenMetadata/blob/main/catalog-rest-service/src/main/resources/json/schema/type/entityUsage.json",
+  "$id": "https://open-metadata.org/schema/type/entityUsage.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Usage details of an entity",
   "description": "This schema defines the type used for capturing usage details of an entity.",

--- a/catalog-rest-service/src/main/resources/json/schema/type/jdbcConnection.json
+++ b/catalog-rest-service/src/main/resources/json/schema/type/jdbcConnection.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://github.com/open-metadata/OpenMetadata/blob/main/catalog-rest-service/src/main/resources/json/schema/type/jdbcConnection.json",
+  "$id": "https://open-metadata.org/schema/type/jdbcConnection.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "JDBC connection",
   "description": "This schema defines the type used for JDBC connection information.",

--- a/catalog-rest-service/src/main/resources/json/schema/type/profile.json
+++ b/catalog-rest-service/src/main/resources/json/schema/type/profile.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://github.com/open-metadata/OpenMetadata/blob/main/catalog-rest-service/src/main/resources/json/schema/type/profile.json",
+  "$id": "https://open-metadata.org/schema/type/profile.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Profile",
   "description": "This schema defines the type for profile of a user, team, or an organization.",

--- a/catalog-rest-service/src/main/resources/json/schema/type/schedule.json
+++ b/catalog-rest-service/src/main/resources/json/schema/type/schedule.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://github.com/open-metadata/OpenMetadata/blob/main/catalog-rest-service/src/main/resources/json/schema/type/schedule.json",
+  "$id": "https://open-metadata.org/schema/type/schedule.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Type used for schedule with start time and repeat frequency",
   "description": "This schema defines the type used for schedule. Schedule has a start time and repeat frequency.",

--- a/catalog-rest-service/src/main/resources/json/schema/type/tagLabel.json
+++ b/catalog-rest-service/src/main/resources/json/schema/type/tagLabel.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://github.com/open-metadata/OpenMetadata/blob/main/catalog-rest-service/src/main/resources/json/schema/type/tagLabel.json",
+  "$id": "https://open-metadata.org/schema/type/tagLabel.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Tag Label",
   "description": "This schema defines the type for labeling an entity with a Tag.",

--- a/catalog-rest-service/src/main/resources/json/schema/type/usageDetails.json
+++ b/catalog-rest-service/src/main/resources/json/schema/type/usageDetails.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://github.com/open-metadata/OpenMetadata/blob/main/catalog-rest-service/src/main/resources/json/schema/type/usageDetails.json",
+  "$id": "https://open-metadata.org/schema/type/usageDetails.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Type used to return usage details of an entity",
   "description": "This schema defines the type for usage details. Daily, weekly, and monthly aggregation of usage is computed along with the percentile rank based on the usage for a given day.",


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Updating the schema URL in JSON schemas to open-metadata.org instead of github to make it more readable and making open-metadata.org as the standard URL.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [] Bug fix
- [] New feature
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [ x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x ] I have performed a self-review of my own. 
- [ ] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata Community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms -->
<!--- Ingestion: @ayush-shah -->