### PR TITLE
Fixed frequently joined col to trim more than 3 entries

### DIFF
--- a/catalog-rest-service/src/main/resources/ui/src/components/my-data-details/SchemaTable.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/components/my-data-details/SchemaTable.tsx
@@ -35,6 +35,7 @@ import {
 import SVGIcons from '../../utils/SvgUtils';
 import { getConstraintIcon } from '../../utils/TableUtils';
 import { getTagCategories, getTaglist } from '../../utils/TagsUtils';
+import PopOver from '../common/popover/PopOver';
 import RichTextEditorPreviewer from '../common/rich-text-editor/RichTextEditorPreviewer';
 // import { EditSchemaColumnModal } from '../Modals/EditSchemaColumnModal/EditSchemaColumnModal';
 import { ModalWithMarkdownEditor } from '../Modals/ModalWithMarkdownEditor/ModalWithMarkdownEditor';
@@ -202,6 +203,7 @@ const SchemaTable: FunctionComponent<Props> = ({
       setEditColumn(undefined);
     }
   };
+
   useEffect(() => {
     if (!searchText) {
       setSearchedColumns(columns);
@@ -292,8 +294,9 @@ const SchemaTable: FunctionComponent<Props> = ({
                         <span className="tw-text-gray-400 tw-mr-1">
                           Frequently joined columns:
                         </span>
-                        {getFrequentlyJoinedWithColumns(column.name).map(
-                          (columnJoin, index) => (
+                        {getFrequentlyJoinedWithColumns(column.name)
+                          .slice(0, 3)
+                          .map((columnJoin, index) => (
                             <Fragment key={index}>
                               {index > 0 && <span className="tw-mr-1">,</span>}
                               <Link
@@ -314,7 +317,42 @@ const SchemaTable: FunctionComponent<Props> = ({
                                 )}
                               </Link>
                             </Fragment>
-                          )
+                          ))}
+                        {getFrequentlyJoinedWithColumns(column.name).length >
+                          3 && (
+                          <PopOver
+                            html={
+                              <div className="tw-text-left">
+                                {getFrequentlyJoinedWithColumns(column.name)
+                                  ?.slice(3)
+                                  .map((columnJoin, index) => (
+                                    <Fragment key={index}>
+                                      <a
+                                        className="link-text tw-block tw-py-1"
+                                        href={getDatasetDetailsPath(
+                                          getTableFQNFromColumnFQN(
+                                            columnJoin.fullyQualifiedName
+                                          ),
+                                          getPartialNameFromFQN(
+                                            columnJoin.fullyQualifiedName,
+                                            ['column']
+                                          )
+                                        )}
+                                        onClick={handleClick}>
+                                        {getPartialNameFromFQN(
+                                          columnJoin.fullyQualifiedName,
+                                          ['database', 'table', 'column']
+                                        )}
+                                      </a>
+                                    </Fragment>
+                                  ))}
+                              </div>
+                            }
+                            position="bottom"
+                            theme="light"
+                            trigger="click">
+                            <span className="show-more tw-ml-1">...</span>
+                          </PopOver>
                         )}
                       </div>
                     )}


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the Schema table because need to trim joined columns if more than 3 entries available

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<p align="center">
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@shahsank3t @Sachin-chaurasiya 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata Community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms -->
<!--- Ingestion: @ayush-shah -->