### PR TITLE
adding number of users and asset count on teams page

### DIFF
--- a/catalog-rest-service/src/main/resources/ui/src/pages/teams/index.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/pages/teams/index.tsx
@@ -37,6 +37,7 @@ import Loader from '../../components/Loader/Loader';
 import FormModal from '../../components/Modals/FormModal';
 import { ModalWithMarkdownEditor } from '../../components/Modals/ModalWithMarkdownEditor/ModalWithMarkdownEditor';
 import { ERROR404 } from '../../constants/constants';
+import { countBackground } from '../../utils/styleconstant';
 import SVGIcons from '../../utils/SvgUtils';
 import AddUsersModal from './AddUsersModal';
 import Form from './Form';
@@ -152,6 +153,13 @@ const TeamsPage = () => {
               setCurrentTab(1);
             }}>
             Users
+            <span
+              className=" tw-py-0.5 tw-px-1 tw-ml-1 tw-border tw-rounded tw-text-xs"
+              style={{ background: countBackground }}>
+              <span data-testid="filter-count">
+                {currentTeam?.users.length}
+              </span>
+            </span>
           </button>
           <button
             className={`tw-pb-2 tw-px-4 tw-gh-tabs ${getActiveTabClass(2)}`}
@@ -159,6 +167,11 @@ const TeamsPage = () => {
               setCurrentTab(2);
             }}>
             Assets
+            <span
+              className=" tw-py-0.5 tw-px-1 tw-ml-1 tw-border tw-rounded tw-text-xs"
+              style={{ background: countBackground }}>
+              <span data-testid="filter-count">{currentTeam?.owns.length}</span>
+            </span>
           </button>
         </nav>
       </div>

--- a/catalog-rest-service/src/main/resources/ui/src/pages/teams/index.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/pages/teams/index.tsx
@@ -143,6 +143,16 @@ const TeamsPage = () => {
     return tab === currentTab ? 'active' : '';
   };
 
+  const getCount = (count: number) => {
+    return (
+      <span
+        className=" tw-py-0.5 tw-px-1 tw-ml-1 tw-border tw-rounded tw-text-xs"
+        style={{ background: countBackground }}>
+        <span data-testid="filter-count">{count}</span>
+      </span>
+    );
+  };
+
   const getTabs = () => {
     return (
       <div className="tw-mb-3 ">
@@ -153,13 +163,7 @@ const TeamsPage = () => {
               setCurrentTab(1);
             }}>
             Users
-            <span
-              className=" tw-py-0.5 tw-px-1 tw-ml-1 tw-border tw-rounded tw-text-xs"
-              style={{ background: countBackground }}>
-              <span data-testid="filter-count">
-                {currentTeam?.users.length}
-              </span>
-            </span>
+            {getCount(currentTeam?.users.length as number)}
           </button>
           <button
             className={`tw-pb-2 tw-px-4 tw-gh-tabs ${getActiveTabClass(2)}`}
@@ -167,11 +171,7 @@ const TeamsPage = () => {
               setCurrentTab(2);
             }}>
             Assets
-            <span
-              className=" tw-py-0.5 tw-px-1 tw-ml-1 tw-border tw-rounded tw-text-xs"
-              style={{ background: countBackground }}>
-              <span data-testid="filter-count">{currentTeam?.owns.length}</span>
-            </span>
+            {getCount(currentTeam?.owns.length as number)}
           </button>
         </nav>
       </div>

--- a/catalog-rest-service/src/main/resources/ui/src/pages/teams/index.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/pages/teams/index.tsx
@@ -143,7 +143,7 @@ const TeamsPage = () => {
     return tab === currentTab ? 'active' : '';
   };
 
-  const getCount = (count: number) => {
+  const getCount = (count = 0) => {
     return (
       <span
         className=" tw-py-0.5 tw-px-1 tw-ml-1 tw-border tw-rounded tw-text-xs"
@@ -163,7 +163,7 @@ const TeamsPage = () => {
               setCurrentTab(1);
             }}>
             Users
-            {getCount(currentTeam?.users.length as number)}
+            {getCount(currentTeam?.users.length)}
           </button>
           <button
             className={`tw-pb-2 tw-px-4 tw-gh-tabs ${getActiveTabClass(2)}`}
@@ -171,7 +171,7 @@ const TeamsPage = () => {
               setCurrentTab(2);
             }}>
             Assets
-            {getCount(currentTeam?.owns.length as number)}
+            {getCount(currentTeam?.owns.length)}
           </button>
         </nav>
       </div>


### PR DESCRIPTION
Closes #210 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the team's page because of the need to add users and asset count.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] New feature



### Frontend Preview (Screenshots) :



### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@shahsank3t, @darth-coder00
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata Community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms -->
<!--- Ingestion: @ayush-shah -->