### PR TITLE
adding clear filter option for faceted filters

### DIFF
--- a/catalog-rest-service/src/main/resources/ui/src/components/common/facetfilter/FacetFilter.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/components/common/facetfilter/FacetFilter.tsx
@@ -26,6 +26,7 @@ const FacetFilter: FunctionComponent<FacetProp> = ({
   aggregations,
   onSelectHandler,
   filters,
+  onClearFilter,
 }: FacetProp) => {
   const [showAllTags, setShowAllTags] = useState<boolean>(false);
   const [showAllServices, setShowAllServices] = useState<boolean>(false);
@@ -117,6 +118,17 @@ const FacetFilter: FunctionComponent<FacetProp> = ({
     );
   };
 
+  const isClearFilter = (aggregation: AggregationType) => {
+    const buckets = getBucketsByTitle(aggregation.title, aggregation.buckets);
+    const flag = buckets.some((bucket) =>
+      filters[lowerCase(aggregation.title) as keyof FilterObject].includes(
+        bucket.key
+      )
+    );
+
+    return flag;
+  };
+
   return (
     <>
       {sortAggregations().map((aggregation: AggregationType, index: number) => {
@@ -124,7 +136,20 @@ const FacetFilter: FunctionComponent<FacetProp> = ({
           <Fragment key={index}>
             {aggregation.buckets.length > 0 ? (
               <>
-                <h6 className="tw-heading">{aggregation.title}</h6>
+                <div className="tw-flex tw-justify-between">
+                  <h6 className="tw-heading">{aggregation.title}</h6>
+                  {isClearFilter(aggregation) && (
+                    <p
+                      className="link-text"
+                      onClick={() =>
+                        onClearFilter(
+                          lowerCase(aggregation.title) as keyof FilterObject
+                        )
+                      }>
+                      Clear filter
+                    </p>
+                  )}
+                </div>
                 <div className="sidebar-my-data-holder mt-2 mb-3">
                   {getFilterItems(aggregation)}
                 </div>

--- a/catalog-rest-service/src/main/resources/ui/src/components/common/facetfilter/FacetTypes.ts
+++ b/catalog-rest-service/src/main/resources/ui/src/components/common/facetfilter/FacetTypes.ts
@@ -25,6 +25,7 @@ export type FacetProp = {
     type: keyof FilterObject
   ) => void;
   filters: FilterObject;
+  onClearFilter: (value: keyof FilterObject) => void;
 };
 
 export type FilterContainerProp = {

--- a/catalog-rest-service/src/main/resources/ui/src/components/common/table-data-card/TableDataCard.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/components/common/table-data-card/TableDataCard.tsx
@@ -74,7 +74,7 @@ const TableDataCard: FunctionComponent<Props> = ({
       </div>
       <div className="tw-pt-2">
         <TableDataCardBody
-          description={description || 'No description'}
+          description={description || ''}
           extraInfo={OtherDetails}
           tags={[...new Set(tags)]}
         />

--- a/catalog-rest-service/src/main/resources/ui/src/components/common/table-data-card/TableDataCardBody.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/components/common/table-data-card/TableDataCardBody.tsx
@@ -37,7 +37,11 @@ const TableDataCardBody: FunctionComponent<Props> = ({
   return (
     <>
       <div className="tw-mb-1 description-text">
-        <RichTextEditorPreviewer markdown={description} />
+        {description.trim() ? (
+          <RichTextEditorPreviewer markdown={description} />
+        ) : (
+          <span className="tw-no-description">No description added</span>
+        )}
       </div>
       <p className="tw-py-1">
         {extraInfo.map(({ key, value }, i) =>

--- a/catalog-rest-service/src/main/resources/ui/src/pages/explore/index.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/pages/explore/index.tsx
@@ -104,6 +104,16 @@ const ExplorePage: React.FC = (): React.ReactElement => {
       setFilters((prevState) => ({ ...prevState, [type]: filter }));
     }
   };
+
+  const onClearFilterHandler = (type: keyof FilterObject) => {
+    setFilters((prevFilters) => {
+      return {
+        ...prevFilters,
+        [type]: [],
+      };
+    });
+  };
+
   const paginate = (pageNumber: number) => {
     setCurrentPage(pageNumber);
   };
@@ -261,6 +271,7 @@ const ExplorePage: React.FC = (): React.ReactElement => {
       <FacetFilter
         aggregations={getAggrWithDefaultValue(aggregations, visibleFilters)}
         filters={getFacetedFilter()}
+        onClearFilter={(value) => onClearFilterHandler(value)}
         onSelectHandler={handleSelectedFilter}
       />
     );

--- a/catalog-rest-service/src/main/resources/ui/src/pages/my-data-details/index.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/pages/my-data-details/index.tsx
@@ -498,7 +498,7 @@ const MyDataDetailsPage = () => {
                         className="tw-pl-3"
                         data-testid="description"
                         id="description">
-                        {description ? (
+                        {description.trim() ? (
                           <RichTextEditorPreviewer markdown={description} />
                         ) : (
                           <span className="tw-no-description">


### PR DESCRIPTION
Close #26 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the faceted filtering because previously there was no option to clear the filter selection.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] New feature


#
### Frontend Preview (Screenshots) :
![image](https://user-images.githubusercontent.com/59080942/130217850-011ca586-69c5-44b8-9c27-bc984d378190.png)

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@shahsank3t, @darth-coder00
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata Community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms -->
<!--- Ingestion: @ayush-shah -->