### PR TITLE
Added credentials path to the bigquery config

### DIFF
--- a/docs/install/setup-ingestion.md
+++ b/docs/install/setup-ingestion.md
@@ -79,7 +79,6 @@ metadata ingest -c ./examples/workflows/redshift.json
 
 ```text
  source env/bin/activate
- export GOOGLE_APPLICATION_CREDENTIALS="$PWD/examples/creds/bigquery-cred.json"
  metadata ingest -c ./examples/workflows/bigquery.json
 ```
 

--- a/ingestion/examples/workflows/bigquery.json
+++ b/ingestion/examples/workflows/bigquery.json
@@ -6,6 +6,9 @@
       "host_port": "https://bigquery.googleapis.com",
       "username": "gcpuser@project_id.iam.gserviceaccount.com",
       "service_name": "gcp_bigquery",
+      "options": {
+        "credentials_path": "examples/creds/bigquery-cred.json"
+      },
       "service_type": "BigQuery",
       "filter_pattern": {
         "excludes": [


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Added credentials_path to bigquery config options.
No need to use `export GOOGLE_APPLICATION_CREDENTIALS=path/to/cred.json`

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] New feature

### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata Community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
@sureshms
<!--- Ingestion: @ayush-shah -->