### PR TITLE
Fix #315: Allow Editing of fields in Messaging service

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/MessagingServiceRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/MessagingServiceRepository.java
@@ -34,6 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.List;
 
 import static org.openmetadata.catalog.exception.CatalogExceptionMessage.entityNotFound;
@@ -71,12 +72,14 @@ public abstract class MessagingServiceRepository {
     return messagingService;
   }
 
-  public MessagingService update(String id, String description, Schedule ingestionSchedule)
+  public MessagingService update(String id, String description, List<String> brokers, URI schemaRegistry,
+                                 Schedule ingestionSchedule)
           throws IOException {
     validateIngestionSchedule(ingestionSchedule);
     MessagingService dbService = EntityUtil.validate(id, messagingServiceDOA().findById(id), MessagingService.class);
     // Update fields
-    dbService.withDescription(description).withIngestionSchedule(ingestionSchedule);
+    dbService.withDescription(description).withIngestionSchedule(ingestionSchedule)
+            .withSchemaRegistry(schemaRegistry).withBrokers(brokers);
     messagingServiceDOA().update(id, JsonUtils.pojoToJson(dbService));
     return dbService;
   }

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/messaging/MessagingServiceResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/messaging/MessagingServiceResource.java
@@ -177,7 +177,8 @@ public class MessagingServiceResource {
                          @Valid UpdateMessagingService update) throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     MessagingService service = addHref(uriInfo,
-            dao.update(id, update.getDescription(), update.getIngestionSchedule()));
+            dao.update(id, update.getDescription(), update.getBrokers(), update.getSchemaRegistry(),
+                    update.getIngestionSchedule()));
     return Response.ok(service).build();
   }
 

--- a/catalog-rest-service/src/main/resources/json/schema/api/services/updateMessagingService.json
+++ b/catalog-rest-service/src/main/resources/json/schema/api/services/updateMessagingService.json
@@ -10,6 +10,14 @@
       "description": "Description of Messaging service entity.",
       "type": "string"
     },
+    "brokers": {
+      "$ref" : "../../entity/services/messagingService.json#/definitions/brokers"
+    },
+    "schemaRegistry" : {
+      "description": "Schema registry URL.",
+      "type": "string",
+      "format": "uri"
+    },
     "ingestionSchedule" :  {
       "description": "Schedule for running metadata ingestion jobs",
       "$ref" : "../../type/schedule.json"

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/MessagingServiceResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/MessagingServiceResourceTest.java
@@ -199,6 +199,7 @@ public class MessagingServiceResourceTest extends CatalogApplicationTest {
     // Update description and ingestion schedule again
     update.withDescription("description1").withIngestionSchedule(schedule.withRepeatFrequency("PT1H"));
     updateAndCheckService(id, update, OK, adminAuthHeaders());
+
   }
 
   @Test


### PR DESCRIPTION
### Describe your changes :
 Allow Editing of fields in Messaging service. PUT method is not updating the brokersList or schemaRegistry

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [x ] I have added tests that prove my fix is effective or that my feature works.

