### PR TITLE
Fixed #333 sort frequently used tables based on usage.

### DIFF
--- a/catalog-rest-service/src/main/resources/ui/src/components/my-data-details/FrequentlyJoinedTables.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/components/my-data-details/FrequentlyJoinedTables.tsx
@@ -28,19 +28,21 @@ type Props = {
 const viewCap = 3;
 
 const getUniqueTablesWithCount = (tableFQNs: Props['tableList']) => {
-  return tableFQNs.reduce((resList, curr) => {
-    let duplicates = false;
-    for (const table of resList) {
-      if (table.fqn === curr.fqn) {
-        table.joinCount += curr.joinCount;
-        duplicates = true;
+  return tableFQNs
+    .reduce((resList, curr) => {
+      let duplicates = false;
+      for (const table of resList) {
+        if (table.fqn === curr.fqn) {
+          table.joinCount += curr.joinCount;
+          duplicates = true;
 
-        break;
+          break;
+        }
       }
-    }
 
-    return duplicates ? resList : [...resList, curr];
-  }, [] as Props['tableList']);
+      return duplicates ? resList : [...resList, curr];
+    }, [] as Props['tableList'])
+    .sort((a, b) => (a.joinCount < b.joinCount ? 1 : -1));
 };
 
 const FrequentlyJoinedTables: FunctionComponent<Props> = ({


### PR DESCRIPTION
Closes #333 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the frequently used table joins part because needs to sort frequently used tables based on usage.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
![ss1](https://user-images.githubusercontent.com/59080942/131447931-e5fa5465-517c-47ed-a2be-03e1c68d65ca.png)


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
 @shahsank3t, @darth-coder00
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata Community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms -->
<!--- Ingestion: @ayush-shah -->