### PR TITLE
Fix #384: Check if the elastic search index exists and make sure we have document mappings

### DIFF
--- a/ingestion/src/metadata/ingestion/source/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/metadata.py
@@ -40,9 +40,13 @@ class MetadataSourceStatus(SourceStatus):
     failures: List[str] = field(default_factory=list)
     warnings: List[str] = field(default_factory=list)
 
-    def scanned(self, table_name: str) -> None:
+    def scanned_table(self, table_name: str) -> None:
         self.success.append(table_name)
         logger.info('Table Scanned: {}'.format(table_name))
+
+    def scanned_topic(self, topic_name: str) -> None:
+        self.success.append(topic_name)
+        logger.info('Topic Scanned: {}'.format(topic_name))
 
     def filtered(self, table_name: str, err: str, dataset_name: str = None, col_type: str = None) -> None:
         self.warnings.append(table_name)
@@ -81,9 +85,10 @@ class MetadataSource(Source):
 
     def next_record(self) -> Iterable[Record]:
         for table in self.tables:
-            self.status.scanned(table.name.__root__)
+            self.status.scanned_table(table.name.__root__)
             yield table
         for topic in self.topics:
+            self.status.scanned_topic(topic.name.__root__)
             yield topic
 
     def get_status(self) -> SourceStatus:


### PR DESCRIPTION
### Describe your changes :
This bug happens with the following steps
1. Run clean DB, open metadata server
2. Run sample-tables connector
3. During the API requests OpenMetadataServer's even handler tries to update the elasticsearch index. 
4. At this stage we do not have any indexes yet as we didn't run the elasticsearch ingestion
5. UpdateRequests will create an index but it doesn't create document mappings
6. Which will cause the listing and explore page to break with the errors mentioned in Issue #384 
7. Fix is to check if the mappings exists even if the index exists , if not update the mapping.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] All new and existing tests passed.


@ayush-shah 