### PR TITLE
Fixed #388 Show the document count in explore page next to tabs and a…

### DIFF
--- a/catalog-rest-service/src/main/resources/ui/src/pages/services/index.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/pages/services/index.tsx
@@ -49,7 +49,7 @@ import {
   servicesDisplayName,
 } from '../../constants/services.const';
 import { ServiceCategory } from '../../enums/service.enum';
-import { getTabClasses } from '../../utils/CommonUtils';
+import { getCountBadge, getTabClasses } from '../../utils/CommonUtils';
 import { getFrequencyTime, serviceTypeLogo } from '../../utils/ServiceUtils';
 import SVGIcons from '../../utils/SvgUtils';
 
@@ -281,6 +281,7 @@ const ServicesPage = () => {
                       setServiceList(services[tab.name]);
                     }}>
                     {tab.displayName}
+                    {getCountBadge(services[tab.name].length)}
                   </button>
                 ))}
               </nav>

--- a/catalog-rest-service/src/main/resources/ui/src/pages/teams/index.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/pages/teams/index.tsx
@@ -37,7 +37,7 @@ import Loader from '../../components/Loader/Loader';
 import FormModal from '../../components/Modals/FormModal';
 import { ModalWithMarkdownEditor } from '../../components/Modals/ModalWithMarkdownEditor/ModalWithMarkdownEditor';
 import { ERROR404 } from '../../constants/constants';
-import { countBackground } from '../../utils/styleconstant';
+import { getCountBadge } from '../../utils/CommonUtils';
 import SVGIcons from '../../utils/SvgUtils';
 import AddUsersModal from './AddUsersModal';
 import Form from './Form';
@@ -143,16 +143,6 @@ const TeamsPage = () => {
     return tab === currentTab ? 'active' : '';
   };
 
-  const getCount = (count = 0) => {
-    return (
-      <span
-        className=" tw-py-0.5 tw-px-1 tw-ml-1 tw-border tw-rounded tw-text-xs"
-        style={{ background: countBackground }}>
-        <span data-testid="filter-count">{count}</span>
-      </span>
-    );
-  };
-
   const getTabs = () => {
     return (
       <div className="tw-mb-3 ">
@@ -163,7 +153,7 @@ const TeamsPage = () => {
               setCurrentTab(1);
             }}>
             Users
-            {getCount(currentTeam?.users.length)}
+            {getCountBadge(currentTeam?.users.length)}
           </button>
           <button
             className={`tw-pb-2 tw-px-4 tw-gh-tabs ${getActiveTabClass(2)}`}
@@ -171,7 +161,7 @@ const TeamsPage = () => {
               setCurrentTab(2);
             }}>
             Assets
-            {getCount(currentTeam?.owns.length)}
+            {getCountBadge(currentTeam?.owns.length)}
           </button>
         </nav>
       </div>

--- a/catalog-rest-service/src/main/resources/ui/src/react-app-env.d.ts
+++ b/catalog-rest-service/src/main/resources/ui/src/react-app-env.d.ts
@@ -24,3 +24,4 @@ declare module 'react-draft-wysiwyg';
 declare module 'markdown-draft-js';
 declare module 'react-syntax-highlighter';
 declare module 'rehype-raw';
+declare module 'react-codemirror2';

--- a/catalog-rest-service/src/main/resources/ui/src/utils/CommonUtils.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/utils/CommonUtils.tsx
@@ -1,6 +1,8 @@
 import { isEmpty } from 'lodash';
 import { UserTeam } from 'Models';
+import React from 'react';
 import AppState from '../AppState';
+import { countBackground } from './styleconstant';
 
 export const arraySorterByKey = (
   key: string,
@@ -90,4 +92,14 @@ export const getTabClasses = (
   activeTab: number | string
 ) => {
   return 'tw-gh-tabs' + (activeTab === tab ? ' active' : '');
+};
+
+export const getCountBadge = (count = 0) => {
+  return (
+    <span
+      className=" tw-py-0.5 tw-px-1 tw-ml-1 tw-border tw-rounded tw-text-xs"
+      style={{ background: countBackground }}>
+      <span data-testid="filter-count">{count}</span>
+    </span>
+  );
 };


### PR DESCRIPTION
 Closes #388 

### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the explore page and services page to show docs count besides tab label.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] New feature


#
### Frontend Preview (Screenshots) :
on Explore page
![image](https://user-images.githubusercontent.com/59080942/132017859-49375181-bc14-4243-a487-d66f1ec34cbc.png)

on Service page

![image](https://user-images.githubusercontent.com/59080942/132017970-57f57429-050a-4ab1-a36a-cd2924b433b7.png)


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@shahsank3t, @darth-coder00
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata Community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms -->
<!--- Ingestion: @ayush-shah -->