### PR TITLE
Fixed #362  UI should show suggestions across all entities and group them by type

### DIFF
--- a/catalog-rest-service/src/main/resources/ui/src/axiosAPIs/miscAPI.ts
+++ b/catalog-rest-service/src/main/resources/ui/src/axiosAPIs/miscAPI.ts
@@ -16,6 +16,7 @@
 */
 
 import { AxiosResponse } from 'axios';
+import { SearchIndex } from '../enums/search.enum';
 import { getCurrentUserId } from '../utils/CommonUtils';
 import APIClient from './index';
 
@@ -55,5 +56,8 @@ export const fetchAuthorizerConfig: Function = (): Promise<AxiosResponse> => {
 export const getSuggestions: Function = (
   queryString: string
 ): Promise<AxiosResponse> => {
-  return APIClient.get(`/search/suggest?q=${queryString}`);
+  return APIClient.get(
+    `/search/suggest?q=${queryString}&index=${SearchIndex.DASHBOARD},${SearchIndex.TABLE},${SearchIndex.TOPIC}
+    `
+  );
 };


### PR DESCRIPTION
Closes #405 , Closes #362 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the Search Suggestions Thing because the need to show suggestions for all the entities type.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] New feature


#
### Frontend Preview (Screenshots) :
![image](https://user-images.githubusercontent.com/59080942/132185315-05c051bc-315e-4680-a1c1-58b85fdc9e78.png)



#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@shahsank3t, @darth-coder00
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata Community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms -->
<!--- Ingestion: @ayush-shah -->