### PR TITLE
Fix #379 - Add total number of entities to list APIs

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/CatalogHealthCheck.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/CatalogHealthCheck.java
@@ -17,13 +17,12 @@
 package org.openmetadata.catalog;
 
 import com.codahale.metrics.health.HealthCheck;
-import org.openmetadata.catalog.entity.teams.User;
 import org.openmetadata.catalog.jdbi3.UserRepository;
+import org.openmetadata.catalog.resources.teams.UserResource.UserList;
 import org.openmetadata.catalog.util.EntityUtil;
 import org.skife.jdbi.v2.DBI;
 
 import java.io.IOException;
-import java.util.List;
 
 import static org.openmetadata.catalog.resources.teams.UserResource.FIELD_LIST;
 
@@ -39,7 +38,7 @@ public class CatalogHealthCheck extends HealthCheck {
   @Override
   protected Result check() throws Exception {
     try {
-      List<User> users = userRepository.listAfter(fields, 1, "");
+      UserList users = userRepository.listAfter(fields, 1, "");
       return Result.healthy();
     } catch (IOException e) {
       return Result.unhealthy(e.getMessage());

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/util/ResultList.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/util/ResultList.java
@@ -19,6 +19,7 @@ package org.openmetadata.catalog.util;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import org.openmetadata.catalog.type.Paging;
 import org.openmetadata.common.utils.CipherText;
 
 import javax.validation.constraints.NotNull;
@@ -38,38 +39,6 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"data"})
 public class ResultList<T> {
-
-  public static class Paging {
-    @JsonProperty("before")
-    @NotNull
-    private String before;
-
-    @JsonProperty("after")
-    @NotNull
-    private String after;
-
-    @JsonProperty("before")
-    public String getBefore() {
-      return before;
-    }
-
-    @JsonProperty("before")
-    public Paging setBefore(String before) {
-      this.before = before;
-      return this;
-    }
-
-    @JsonProperty("after")
-    public String getAfter() {
-      return after;
-    }
-
-    @JsonProperty("after")
-    public Paging setAfter(String after) {
-      this.after = after;
-      return this;
-    }
-  }
 
   @JsonProperty("data")
   @NotNull
@@ -139,12 +108,11 @@ public class ResultList<T> {
    *          -------- BACKWARD SCROLLING ENDS -------------
    *
    */
-  public ResultList(List<T> data, int limit, String beforeCursor, String afterCursor) throws GeneralSecurityException,
+  public ResultList(List<T> data, String beforeCursor, String afterCursor, int total) throws GeneralSecurityException,
           UnsupportedEncodingException {
     this.data = data;
-    paging = new Paging();
-    paging.before = CipherText.instance().encrypt(beforeCursor);
-    paging.after = CipherText.instance().encrypt(afterCursor);
+    paging = new Paging().withBefore(CipherText.instance().encrypt(beforeCursor))
+                    .withAfter(CipherText.instance().encrypt(afterCursor)).withTotal(total);
   }
 
   @JsonProperty("data")
@@ -167,5 +135,4 @@ public class ResultList<T> {
     this.paging = paging;
     return this;
   }
-
 }

--- a/catalog-rest-service/src/main/resources/json/schema/type/basic.json
+++ b/catalog-rest-service/src/main/resources/json/schema/type/basic.json
@@ -34,6 +34,7 @@
     },
     "timeInterval": {
       "type": "object",
+      "description": "Time interval in unixTimeMillis.",
       "javaType": "org.openmetadata.catalog.type.TimeInterval",
       "properties": {
         "start": {

--- a/catalog-rest-service/src/main/resources/json/schema/type/paging.json
+++ b/catalog-rest-service/src/main/resources/json/schema/type/paging.json
@@ -1,0 +1,23 @@
+{
+  "$id": "https://open-metadata.org/schema/type/paging.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Paging",
+  "description": "Type used for cursor based pagination information in GET list responses.",
+  "type": "object",
+  "javaType": "org.openmetadata.catalog.type.Paging",
+  "properties": {
+    "before": {
+      "description": "Before cursor used for getting the previous page (see API pagination for details).",
+      "type": "string"
+    },
+    "after": {
+      "description": "After cursor used for getting the next page (see API pagination for details).",
+      "type": "string"
+    },
+    "total": {
+      "description": "Total number of entries available to page through.",
+      "type" : "integer"
+    }
+  },
+  "required": ["total"]
+}

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/util/TestUtils.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/util/TestUtils.java
@@ -121,6 +121,8 @@ public final class TestUtils {
     for (int i = 0; i < actual.getData().size(); i++) {
       assertEquals(allEntities.get(offset + i), actual.getData().get(i));
     }
+    // Ensure total count returned in paging is correct
+    assertEquals(allEntities.size(), actual.getPaging().getTotal());
   }
 
   public static void post(WebTarget target, Map<String, String> headers) throws HttpResponseException {


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Total number of entities is required in listing APIs. The count of entities can be found in paging as shown below in list results:
```
{
  "data" : [ ...],
  "paging": {
     "total": "count" <-- total number of entities here
     "after": "afterCursor",
     "before": "beforeCursor"
  }
}

```

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [] Bug fix
- [x] New feature
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [ x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ x] I have performed a self-review of my own. 
- [x ] I have tagged my reviewers below.
- [x ] I have commented on my code, particularly in hard-to-understand areas.
- [x ] My changes generate no new warnings.
- [ x] I have added tests that prove my fix is effective or that my feature works.
- [ x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata Community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms -->
<!--- Ingestion: @ayush-shah -->
@harshach 