### PR TITLE
Fixed #427, #428 Sample Data breaks -UI and elastic-search unsecure mode breaks

### DIFF
--- a/catalog-rest-service/src/main/resources/ui/src/components/common/error-with-placeholder/ErrorPlaceHolderES.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/components/common/error-with-placeholder/ErrorPlaceHolderES.tsx
@@ -70,7 +70,9 @@ const ErrorPlaceHolderES = ({ type, errorMessage }: Props) => {
       <div className="tw-flex tw-flex-col tw-items-center tw-mt-10 tw-text-base tw-font-normal">
         <p className="tw-text-lg tw-font-bold tw-mb-1 tw-text-primary">
           {`Hi, ${
-            AppState.userDetails.displayName || AppState.users[0].displayName
+            AppState.userDetails.displayName || AppState.users?.length > 0
+              ? AppState.users[0].displayName
+              : 'User'
           }!`}
         </p>
         {type === 'noData' && noRecordForES()}

--- a/catalog-rest-service/src/main/resources/ui/src/components/my-data-details/SampleDataTable.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/components/my-data-details/SampleDataTable.tsx
@@ -61,13 +61,13 @@ const SampleDataTable: FunctionComponent<Props> = ({ sampleData }: Props) => {
                 )}
                 data-testid="row"
                 key={rowIndex}>
-                {row.map((data) => {
+                {row.map((data, index) => {
                   return (
                     <td
                       className="tableBody-cell"
                       data-testid="cell"
-                      key={data}>
-                      {data}
+                      key={index}>
+                      {data ? data.toString() : '--'}
                     </td>
                   );
                 })}


### PR DESCRIPTION
Closes #427 , #428 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the sample data and elastic search error placeholder because of #427 and #428

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@shahsank3t, @darth-coder00
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata Community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms -->
<!--- Ingestion: @ayush-shah -->