### PR TITLE
fixed #450 Show entity icon and redirect to respective entity details page for teams assets .

### DIFF
--- a/catalog-rest-service/src/main/resources/ui/src/pages/teams/UserCard.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/pages/teams/UserCard.tsx
@@ -1,9 +1,12 @@
+import classNames from 'classnames';
 import { capitalize } from 'lodash';
 import React from 'react';
 import { Link } from 'react-router-dom';
 import Avatar from '../../components/common/avatar/Avatar';
+import { SearchIndex } from '../../enums/search.enum';
 import { getPartialNameFromFQN } from '../../utils/CommonUtils';
-import SVGIcons from '../../utils/SvgUtils';
+import SVGIcons, { Icons } from '../../utils/SvgUtils';
+import { getEntityLink } from '../../utils/TableUtils';
 
 type Props = {
   item: { description: string; name: string; id?: string };
@@ -15,6 +18,12 @@ type Props = {
   onRemove?: (value: string) => void;
 };
 
+enum DatasetType {
+  TABLE = 'table',
+  TOPIC = 'topic',
+  DASHBOARD = 'dashboard',
+}
+
 const UserCard = ({
   item,
   isActionVisible = false,
@@ -24,18 +33,72 @@ const UserCard = ({
   onSelect,
   onRemove,
 }: Props) => {
+  const getArrForPartialName = (
+    type: string
+  ): Array<'service' | 'database' | 'table' | 'column'> => {
+    switch (type) {
+      case DatasetType.TABLE:
+        return ['database', 'table'];
+      case DatasetType.TOPIC:
+      case DatasetType.DASHBOARD:
+      default:
+        return ['service', 'database', 'table'];
+    }
+  };
+
+  const getDatasetTitle = (type: string, fqn: string) => {
+    let icon = '';
+    let link = '';
+    switch (type) {
+      case DatasetType.TOPIC:
+        icon = Icons.TOPIC;
+        link = getEntityLink(SearchIndex.TOPIC, fqn);
+
+        break;
+      case DatasetType.DASHBOARD:
+        icon = Icons.DASHBOARD;
+        link = getEntityLink(SearchIndex.DASHBOARD, fqn);
+
+        break;
+      case DatasetType.TABLE:
+      default:
+        icon = Icons.TABLE;
+        link = getEntityLink(SearchIndex.TABLE, fqn);
+
+        break;
+    }
+
+    return (
+      <div className="tw-flex tw-gap-1">
+        <SVGIcons
+          alt="icon"
+          className={classNames('tw-h-4 tw-w-4', {
+            'tw-mt-0.5': type !== DatasetType.DASHBOARD,
+          })}
+          icon={icon}
+        />
+        <Link to={link}>
+          <button className="tw-font-normal tw-text-grey-body">
+            {getPartialNameFromFQN(fqn, getArrForPartialName(type))}
+          </button>
+        </Link>
+      </div>
+    );
+  };
+
   return (
     <div className="tw-card tw-flex tw-justify-between tw-py-2 tw-px-3 tw-group">
       <div className={`tw-flex ${isCheckBoxes ? 'tw-mr-2' : 'tw-gap-1'}`}>
-        {isIconVisible ? <Avatar name={item.description} /> : null}
+        {isIconVisible && !isDataset ? (
+          <Avatar name={item.description} />
+        ) : null}
 
-        <div className="tw-flex tw-flex-col tw-pl-2">
+        <div
+          className={classNames('tw-flex tw-flex-col', {
+            'tw-pl-2': !isDataset,
+          })}>
           {isDataset ? (
-            <Link to={`/dataset/${item.description}`}>
-              <button className="tw-font-normal tw-text-grey-body">
-                {getPartialNameFromFQN(item.description, ['database', 'table'])}
-              </button>
-            </Link>
+            <>{getDatasetTitle(item.name, item.description)}</>
           ) : (
             <p className="tw-font-normal">{item.description}</p>
           )}

--- a/catalog-rest-service/src/main/resources/ui/src/pages/teams/index.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/pages/teams/index.tsx
@@ -240,7 +240,9 @@ const TeamsPage = () => {
           {currentTeam?.owns.map((dataset, index) => {
             const Dataset = { description: dataset.name, name: dataset.type };
 
-            return <UserCard isDataset item={Dataset} key={index} />;
+            return (
+              <UserCard isDataset isIconVisible item={Dataset} key={index} />
+            );
           })}
         </div>
       </>


### PR DESCRIPTION
Closes #450 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the team's page because of the need to Show the entity icon and redirect to respective entity details pages for the team's assets.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] New feature


#
### Frontend Preview (Screenshots) :
![image](https://user-images.githubusercontent.com/59080942/132665924-47dc3f27-dfae-4010-9f88-a48c3283344a.png)

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@shahsank3t, @darth-coder00
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata Community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms -->
<!--- Ingestion: @ayush-shah -->