### PR TITLE
Fixed #480 In Secure-mode, "Need help" icon shows User profile image

### DIFF
--- a/catalog-rest-service/src/main/resources/ui/src/components/app-bar/Appbar.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/components/app-bar/Appbar.tsx
@@ -198,7 +198,7 @@ const Appbar: React.FC = (): JSX.Element => {
                 icon={
                   <SVGIcons
                     alt="Doc icon"
-                    className="tw-align-middle tw-mr-1"
+                    className="tw-align-middle tw-mt-0.5 tw-mr-1"
                     icon={Icons.HELP_CIRCLE}
                     width="16"
                   />
@@ -218,14 +218,25 @@ const Appbar: React.FC = (): JSX.Element => {
                   },
                 ]}
                 icon={
-                  <IconDefaultUserProfile
-                    className=""
-                    style={{
-                      height: '24px',
-                      width: '24px',
-                      borderRadius: '50%',
-                    }}
-                  />
+                  <>
+                    {appState.userDetails.profile?.images.image512 ? (
+                      <div className="profile-image">
+                        <img
+                          alt="user"
+                          src={appState.userDetails.profile.images.image512}
+                        />
+                      </div>
+                    ) : (
+                      <IconDefaultUserProfile
+                        className=""
+                        style={{
+                          height: '24px',
+                          width: '24px',
+                          borderRadius: '50%',
+                        }}
+                      />
+                    )}
+                  </>
                 }
                 label=""
                 type="link"

--- a/catalog-rest-service/src/main/resources/ui/src/components/dropdown/DropDown.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/components/dropdown/DropDown.tsx
@@ -17,7 +17,6 @@
 
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
-import AppState from '../../AppState';
 import { activeLink, normalLink } from '../../utils/styleconstant';
 import { dropdownIcon as DropdownIcon } from '../../utils/svgconstant';
 import AnchorDropDownList from './AnchorDropDownList';
@@ -102,20 +101,7 @@ const DropDown: React.FC<DropDownProp> = ({
               </>
             ) : (
               <>
-                {Icon && (
-                  <div className="">
-                    {AppState.userDetails.profile?.images.image512 ? (
-                      <div className="profile-image">
-                        <img
-                          alt="user"
-                          src={AppState.userDetails.profile.images.image512}
-                        />
-                      </div>
-                    ) : (
-                      Icon
-                    )}
-                  </div>
-                )}
+                {Icon && Icon}
                 {label && (
                   <p
                     className="hover:tw-underline"


### PR DESCRIPTION
Closes #480 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the App bar because In Secure-mode, the "Need help" icon shows the User profile image.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@shahsank3t, @darth-coder00
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata Community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms -->
<!--- Ingestion: @ayush-shah -->