### PR TITLE
Fixed #519 As admin UI doesn't list the user or teams list

### DIFF
--- a/catalog-rest-service/src/main/resources/ui/src/components/dropdown/DropDownList.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/components/dropdown/DropDownList.tsx
@@ -96,7 +96,7 @@ const DropDownList: FunctionComponent<DropDownListProp> = ({
             {showSearchBar && (
               <div className="has-search tw-p-4 tw-pb-2">
                 <input
-                  className="form-control form-control-sm search"
+                  className="tw-form-inputs tw-px-3 tw-py-1"
                   placeholder="Search..."
                   type="text"
                   onChange={(e) => {
@@ -114,11 +114,13 @@ const DropDownList: FunctionComponent<DropDownListProp> = ({
               {listGroups.map((grp, index) => {
                 return (
                   <div key={index}>
-                    <span className="tw-flex tw-my-1 tw-text-grey-muted">
-                      <hr className="tw-mt-2 tw-w-full " />
-                      <span className="tw-text-xs tw-px-0.5">{grp}</span>{' '}
-                      <hr className="tw-mt-2 tw-w-full" />
-                    </span>
+                    {getSearchedListByGroup(grp).length > 0 && (
+                      <span className="tw-flex tw-my-1 tw-text-grey-muted">
+                        <hr className="tw-mt-2 tw-w-full " />
+                        <span className="tw-text-xs tw-px-0.5">{grp}</span>{' '}
+                        <hr className="tw-mt-2 tw-w-full" />
+                      </span>
+                    )}
                     {getSearchedListByGroup(grp).map(
                       (item: DropDownListItem, index: number) =>
                         getDropDownElement(item, index)


### PR DESCRIPTION
Closes #519 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the manage tab because if a user is an admin need to show all users and teams list for entity owner.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :
![image](https://user-images.githubusercontent.com/59080942/133921913-446165c9-c8d2-45cc-9f65-5ac7158103cc.png)

![image](https://user-images.githubusercontent.com/59080942/133921947-1303baef-0682-41e3-8d64-bbedb33d6f4d.png)


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@shahsank3t, @darth-coder00
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata Community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms -->
<!--- Ingestion: @ayush-shah -->