### PR TITLE
Fixed #537 Recently viewed is not showing tier info

### DIFF
--- a/catalog-rest-service/src/main/resources/ui/src/components/recently-viewed/RecentlyViewed.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/components/recently-viewed/RecentlyViewed.tsx
@@ -42,7 +42,7 @@ const RecentlyViewed: FunctionComponent = () => {
         case EntityType.DATASET: {
           const res = await getTableDetailsByFQN(
             oData.fqn,
-            'database, usageSummary, tags, owner'
+            'database, usageSummary, tags, owner,columns'
           );
 
           const {
@@ -53,6 +53,7 @@ const RecentlyViewed: FunctionComponent = () => {
             owner,
             usageSummary,
             fullyQualifiedName,
+            tags,
           } = res.data;
           const tableTags = getTableTags(columns || []);
           arrData.push({
@@ -63,8 +64,11 @@ const RecentlyViewed: FunctionComponent = () => {
             name,
             owner: getOwnerFromId(owner?.id)?.name || '--',
             serviceType: oData.serviceType,
-            tags: tableTags.map((tag) => tag.tagFQN),
-            tier: getTierFromTableTags(tableTags),
+            tags: [
+              getTierFromTableTags(tags),
+              ...tableTags.map((tag) => tag.tagFQN),
+            ].filter((tag) => tag),
+            tier: getTierFromTableTags(tags),
             weeklyPercentileRank: usageSummary?.weeklyStats.percentileRank || 0,
           });
 


### PR DESCRIPTION
Closes #537 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the Recently viewed thing because it is not showing tier info

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :
![image](https://user-images.githubusercontent.com/59080942/134123416-46fb0980-260c-47c7-99fb-1f3e564986b1.png)

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@shahsank3t, @darth-coder00
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata Community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms -->
<!--- Ingestion: @ayush-shah -->