### PR TITLE
Fixed #549 Manage should always be last tab in data asset details page

### DIFF
--- a/catalog-rest-service/src/main/resources/ui/src/pages/topic-details/index.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/pages/topic-details/index.tsx
@@ -93,7 +93,7 @@ const MyTopicDetailPage = () => {
         title: 'Config',
       },
       isProtected: false,
-      position: 3,
+      position: 2,
     },
     {
       name: 'Manage',
@@ -104,7 +104,7 @@ const MyTopicDetailPage = () => {
       },
       isProtected: true,
       protectedState: !owner || hasEditAccess(),
-      position: 2,
+      position: 3,
     },
   ];
   const fetchTags = () => {

--- a/catalog-rest-service/src/main/resources/ui/src/pages/topic-details/index.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/pages/topic-details/index.tsx
@@ -86,6 +86,16 @@ const MyTopicDetailPage = () => {
       position: 1,
     },
     {
+      name: 'Config',
+      icon: {
+        alt: 'config',
+        name: 'icon-config',
+        title: 'Config',
+      },
+      isProtected: false,
+      position: 3,
+    },
+    {
       name: 'Manage',
       icon: {
         alt: 'manage',
@@ -95,16 +105,6 @@ const MyTopicDetailPage = () => {
       isProtected: true,
       protectedState: !owner || hasEditAccess(),
       position: 2,
-    },
-    {
-      name: 'Config',
-      icon: {
-        alt: 'config',
-        name: 'icon-config',
-        title: 'Config',
-      },
-      isProtected: false,
-      position: 3,
     },
   ];
   const fetchTags = () => {


### PR DESCRIPTION
Closes #549 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the tabs pane because Manage should always be last tab in data asset details page

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@shahsank3t, @darth-coder00
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata Community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms -->
<!--- Ingestion: @ayush-shah -->