### PR TITLE
Fixed #539 Kafka description page, max message size needs to have bytes next to it

### DIFF
--- a/catalog-rest-service/src/main/resources/ui/src/pages/topic-details/index.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/pages/topic-details/index.tsx
@@ -306,7 +306,7 @@ const MyTopicDetailPage = () => {
       { key: 'Replication Factor', value: replicationFactor },
       { key: 'Retention Size', value: bytesToSize(retentionSize) },
       { key: 'CleanUp Policies', value: cleanupPolicies.join(',') },
-      { key: 'Max Message Size', value: maximumMessageSize },
+      { key: 'Max Message Size', value: bytesToSize(maximumMessageSize) },
     ];
   };
 


### PR DESCRIPTION
Closes #539 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the topics page because max message size needs to have bytes next to it

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@shahsank3t, @darth-coder00
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata Community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms -->
<!--- Ingestion: @ayush-shah -->