### PR TITLE
Fix #590 Same column name is allowed to be repeated in Table entity APIs

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/databases/DatabaseUtil.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/databases/DatabaseUtil.java
@@ -79,11 +79,22 @@ public final class DatabaseUtil {
   }
 
   public static void validateColumns(Table table) {
+    validateColumnNames(table.getColumns());
     for (Column c : table.getColumns()) {
       validateColumnDataTypeDisplay(c);
       validateColumnDataLength(c);
       validateArrayColumn(c);
       validateStructColumn(c);
+    }
+  }
+
+  public static void validateColumnNames(List<Column> columns) {
+    List<String> columnNames = new ArrayList<>();
+    for (Column c : columns) {
+      if (columnNames.contains(c.getName())) {
+        throw new IllegalArgumentException(String.format("Column name %s is repeated", c.getName()));
+      }
+      columnNames.add(c.getName());
     }
   }
 
@@ -143,6 +154,7 @@ public final class DatabaseUtil {
                 "must not be null");
       }
 
+      validateColumnNames(column.getChildren());
       if (!column.getDataTypeDisplay().startsWith("struct<")) {
         throw new IllegalArgumentException("For column data type struct, dataTypeDisplay must be of type " +
                 "stuct<member fields>");

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/databases/TableResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/databases/TableResourceTest.java
@@ -201,6 +201,18 @@ public class TableResourceTest extends CatalogApplicationTest {
   }
 
   @Test
+  public void post_duplicateColumnName_400(TestInfo test) {
+    // Duplicate column names c1
+    String repeatedColumnName = "c1";
+    List<Column> columns = Arrays.asList(getColumn(repeatedColumnName, ARRAY, "array<int>", null),
+            getColumn(repeatedColumnName, INT, null));
+    CreateTable create = create(test).withColumns(columns);
+    HttpResponseException exception = assertThrows(HttpResponseException.class, () ->
+            createTable(create, adminAuthHeaders()));
+    assertResponse(exception, BAD_REQUEST, String.format("Column name %s is repeated", repeatedColumnName));
+  }
+
+  @Test
   public void post_tableAlreadyExists_409_conflict(TestInfo test) throws HttpResponseException {
     CreateTable create = create(test);
     createTable(create, adminAuthHeaders());
@@ -227,9 +239,9 @@ public class TableResourceTest extends CatalogApplicationTest {
   }
 
   private static Column getColumn(String name, ColumnDataType columnDataType, String dataTypeDisplay, TagLabel tag) {
-
+    List<TagLabel> tags = tag == null ? new ArrayList<>() : singletonList(tag);
     return new Column().withName(name).withDataType(columnDataType)
-            .withDataTypeDisplay(dataTypeDisplay).withTags(singletonList(tag));
+            .withDataTypeDisplay(dataTypeDisplay).withTags(tags);
   }
 
   @Test


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Fixing a bug where the same column name can be repeated

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [] New feature
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [ ] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata Community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms -->
<!--- Ingestion: @ayush-shah -->