### PR TITLE
Fixed #598 Explore/Search filters should be in ordered fashion

### DIFF
--- a/catalog-rest-service/src/main/resources/ui/src/components/common/facetfilter/FacetFilter.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/components/common/facetfilter/FacetFilter.tsx
@@ -34,11 +34,6 @@ const FacetFilter: FunctionComponent<FacetProp> = ({
   const [showAllTags, setShowAllTags] = useState<boolean>(false);
   const [showAllServices, setShowAllServices] = useState<boolean>(false);
   const [showAllTier, setShowAllTier] = useState<boolean>(false);
-  const sortAggregations = () => {
-    return aggregations.sort((a, b) =>
-      a.buckets.length > b.buckets.length ? 1 : -1
-    );
-  };
   const getLinkText = (
     length: number,
     state: boolean,
@@ -128,7 +123,7 @@ const FacetFilter: FunctionComponent<FacetProp> = ({
 
   return (
     <>
-      {sortAggregations().map((aggregation: AggregationType, index: number) => {
+      {aggregations.map((aggregation: AggregationType, index: number) => {
         return (
           <Fragment key={index}>
             {aggregation.buckets.length > 0 ? (

--- a/catalog-rest-service/src/main/resources/ui/src/constants/constants.ts
+++ b/catalog-rest-service/src/main/resources/ui/src/constants/constants.ts
@@ -54,6 +54,8 @@ export const tiers = [
   { key: 'Tier.Tier5', doc_count: 0 },
 ];
 
+export const visibleFilters = ['service', 'tier', 'tags'];
+
 export const tableSortingFields = [
   {
     name: 'Last Updated',

--- a/catalog-rest-service/src/main/resources/ui/src/pages/explore/explore.constants.ts
+++ b/catalog-rest-service/src/main/resources/ui/src/pages/explore/explore.constants.ts
@@ -43,7 +43,7 @@ export const getBucketList = (buckets: Array<Bucket>) => {
 export const getAggrWithDefaultValue = (
   aggregations: Array<AggregationType>,
   visibleAgg: Array<string> = []
-) => {
+): Array<AggregationType> => {
   const aggregation = aggregations.find(
     (aggregation) => aggregation.title === 'Tier'
   );
@@ -55,9 +55,19 @@ export const getAggrWithDefaultValue = (
     aggregations[index].buckets = getBucketList(aggregations[index].buckets);
   }
 
-  return !allowedAgg.length
+  const visibleAggregations = !allowedAgg.length
     ? aggregations
     : aggregations.filter((item) => allowedAgg.includes(lowerCase(item.title)));
+
+  return allowedAgg
+    .map((agg) => {
+      const aggregation = visibleAggregations.find(
+        (a) => lowerCase(a.title) === agg
+      );
+
+      return aggregation;
+    })
+    .filter(Boolean) as Array<AggregationType>;
 };
 
 export const tabsInfo = [

--- a/catalog-rest-service/src/main/resources/ui/src/pages/explore/index.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/pages/explore/index.tsx
@@ -38,6 +38,7 @@ import {
   getExplorePathWithSearch,
   PAGE_SIZE,
   tableSortingFields,
+  visibleFilters,
 } from '../../constants/constants';
 import { SearchIndex } from '../../enums/search.enum';
 import { usePrevious } from '../../hooks/usePrevious';
@@ -50,8 +51,6 @@ import { dropdownIcon as DropDownIcon } from '../../utils/svgconstant';
 import SVGIcons from '../../utils/SvgUtils';
 import { getAggrWithDefaultValue, tabsInfo } from './explore.constants';
 import { Params } from './explore.interface';
-
-const visibleFilters = ['tags', 'service', 'tier'];
 
 const getQueryParam = (urlSearchQuery = ''): FilterObject => {
   const arrSearchQuery = urlSearchQuery


### PR DESCRIPTION
Closes #598 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the faceted filter because #598 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :
![image](https://user-images.githubusercontent.com/59080942/135047809-eca16628-8d05-4307-a8e5-28bc4b4049fa.png)

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@shahsank3t, @darth-coder00
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata Community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms -->
<!--- Ingestion: @ayush-shah -->