### PR TITLE
Fixes docs that reference messaging service

### DIFF
--- a/catalog-rest-service/src/main/resources/json/schema/entity/services/dashboardService.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/services/dashboardService.json
@@ -2,7 +2,7 @@
   "$id": "https://open-metadata.org/schema/entity/services/dashboardService.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Dashboard Service",
-  "description": "This schema defines the Messaging Service entity, such as Kafka and Pulsar.",
+  "description": "This schema defines the Dashboard Service entity, such as Looker and Superset.",
   "type": "object",
   "definitions": {
     "dashboardServiceType": {
@@ -67,7 +67,7 @@
       "$ref": "../../type/schedule.json"
     },
     "href": {
-      "description": "Link to the resource corresponding to this messaging service.",
+      "description": "Link to the resource corresponding to this dashboard service.",
       "$ref": "../../type/basic.json#/definitions/href"
     }
   },

--- a/catalog-rest-service/src/main/resources/json/schema/entity/services/pipelineService.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/services/pipelineService.json
@@ -1,7 +1,7 @@
 {
   "$id": "https://open-metadata.org/schema/entity/services/messagingService.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Messaging Service",
+  "title": "Pipeline Service",
   "description": "This schema defines the Pipeline Service entity, such as Airflow and Prefect.",
   "type": "object",
   "definitions": {
@@ -38,7 +38,7 @@
       "$ref": "#/definitions/pipelineServiceType"
     },
     "description": {
-      "description": "Description of a messaging service instance.",
+      "description": "Description of a pipeline service instance.",
       "type": "string"
     },
     "pipelineUrl": {
@@ -51,7 +51,7 @@
       "$ref": "../../type/schedule.json"
     },
     "href": {
-      "description": "Link to the resource corresponding to this messaging service.",
+      "description": "Link to the resource corresponding to this pipeline service.",
       "$ref": "../../type/basic.json#/definitions/href"
     }
   },

--- a/catalog-rest-service/src/main/resources/ui/src/generated/entity/services/dashboardService.ts
+++ b/catalog-rest-service/src/main/resources/ui/src/generated/entity/services/dashboardService.ts
@@ -17,7 +17,7 @@
  */
 
 /**
- * This schema defines the Messaging Service entity, such as Kafka and Pulsar.
+ * This schema defines the Dashboard Service entity, such as Looker and Superset.
  */
 export interface DashboardService {
   /**
@@ -29,7 +29,7 @@ export interface DashboardService {
    */
   description?: string;
   /**
-   * Link to the resource corresponding to this messaging service.
+   * Link to the resource corresponding to this dashboard service.
    */
   href?: string;
   /**

--- a/catalog-rest-service/src/main/resources/ui/src/generated/entity/services/pipelineService.ts
+++ b/catalog-rest-service/src/main/resources/ui/src/generated/entity/services/pipelineService.ts
@@ -21,11 +21,11 @@
  */
 export interface PipelineService {
   /**
-   * Description of a messaging service instance.
+   * Description of a pipeline service instance.
    */
   description?: string;
   /**
-   * Link to the resource corresponding to this messaging service.
+   * Link to the resource corresponding to this pipeline service.
    */
   href?: string;
   /**

--- a/docs/openmetadata-apis/schemas/entities/dashboardservice.md
+++ b/docs/openmetadata-apis/schemas/entities/dashboardservice.md
@@ -1,6 +1,6 @@
 # Dashboard Service
 
-This schema defines the Messaging Service entity, such as Kafka and Pulsar.
+This schema defines the Dashboard Service entity, such as Looker and Superset.
 
 **$id: https://open-metadata.org/schema/entity/services/dashboardService.json**
 
@@ -34,7 +34,7 @@ Type: `object`
    - Schedule for running metadata ingestion jobs.
    - $ref: [../../type/schedule.json](../types/schedule.md)
  - **href**
-   - Link to the resource corresponding to this messaging service.
+   - Link to the resource corresponding to this dashboard service.
    - $ref: [../../type/basic.json#/definitions/href](../types/basic.md#href)
 
 

--- a/ingestion/src/metadata/generated/schema/entity/services/dashboardService.py
+++ b/ingestion/src/metadata/generated/schema/entity/services/dashboardService.py
@@ -47,5 +47,5 @@ class DashboardService(BaseModel):
     )
     href: Optional[basic.Href] = Field(
         None,
-        description='Link to the resource corresponding to this messaging service.',
+        description='Link to the resource corresponding to this dashboard service.',
     )

--- a/ingestion/src/metadata/generated/schema/entity/services/pipelineService.py
+++ b/ingestion/src/metadata/generated/schema/entity/services/pipelineService.py
@@ -28,7 +28,7 @@ class MessagingService(BaseModel):
         None, description='Type of pipeline service such as Airflow or Prefect...'
     )
     description: Optional[str] = Field(
-        None, description='Description of a messaging service instance.'
+        None, description='Description of a pipeline service instance.'
     )
     pipelineUrl: AnyUrl = Field(..., description='Pipeline Service Management/UI URL')
     ingestionSchedule: Optional[schedule.Schedule] = Field(
@@ -36,5 +36,5 @@ class MessagingService(BaseModel):
     )
     href: Optional[basic.Href] = Field(
         None,
-        description='Link to the resource corresponding to this messaging service.',
+        description='Link to the resource corresponding to this pipeline service.',
     )


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the documentation because it incorrectly referenced "messaging service" instead of "pipeline" or "dashboard".

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata Community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms -->
<!--- Ingestion: @ayush-shah -->