### PR TITLE
Fix #611: ElasticSearch matches are case-sensitive

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/search/SearchResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/search/SearchResource.java
@@ -104,7 +104,7 @@ public class SearchResource {
                            @DefaultValue("10") @QueryParam("size") int size,
                          @Parameter(description = "Sort the search results by field, available fields to " +
                                  "sort weekly_stats" +
-                                 " , daily_stats, monthly_stats, last_updated_timestamp defaults to weekly_stats")
+                                 " , daily_stats, monthly_stats, last_updated_timestamp")
                                   @QueryParam("sort_field") String sortFieldParam,
                          @Parameter(description = "Sort order asc for ascending or desc for descending, " +
                                  "defaults to desc")

--- a/ingestion/src/metadata/ingestion/sink/elasticsearch_constants.py
+++ b/ingestion/src/metadata/ingestion/sink/elasticsearch_constants.py
@@ -21,8 +21,7 @@ TABLE_ELASTICSEARCH_INDEX_MAPPING = textwrap.dedent(
     "mappings":{
           "properties": {
             "table_name": {
-              "type":"text",
-              "analyzer": "keyword"
+              "type":"text"
             },
             "schema": {
               "type":"text",
@@ -34,10 +33,10 @@ TABLE_ELASTICSEARCH_INDEX_MAPPING = textwrap.dedent(
               }
             },
             "display_name": {
-              "type": "keyword"
+              "type": "text"
             },
             "owner": {
-              "type": "keyword"
+              "type": "text"
             },
             "followers": {
               "type": "keyword"
@@ -53,7 +52,7 @@ TABLE_ELASTICSEARCH_INDEX_MAPPING = textwrap.dedent(
               "type": "keyword"
             },
             "column_names": {
-              "type":"keyword"
+              "type":"text"
             },
             "column_descriptions": {
               "type": "text"
@@ -71,7 +70,7 @@ TABLE_ELASTICSEARCH_INDEX_MAPPING = textwrap.dedent(
               "type": "keyword"
             },
             "database": {
-              "type": "keyword"
+              "type": "text"
             },
             "suggest": {
               "type": "completion"
@@ -106,8 +105,7 @@ TOPIC_ELASTICSEARCH_INDEX_MAPPING = textwrap.dedent(
     "mappings":{
           "properties": {
             "topic_name": {
-              "type":"text",
-              "analyzer": "keyword"
+              "type":"text"
             },
             "schema": {
               "type":"text",
@@ -119,10 +117,10 @@ TOPIC_ELASTICSEARCH_INDEX_MAPPING = textwrap.dedent(
               }
             },
             "display_name": {
-              "type": "keyword"
+              "type": "text"
             },
             "owner": {
-              "type": "keyword"
+              "type": "text"
             },
             "followers": {
               "type": "keyword"
@@ -161,11 +159,10 @@ DASHBOARD_ELASTICSEARCH_INDEX_MAPPING = textwrap.dedent(
     "mappings":{
           "properties": {
             "dashboard_name": {
-              "type":"text",
-              "analyzer": "keyword"
+              "type":"text"
             },
             "display_name": {
-              "type": "keyword"
+              "type": "text"
             },
             "owner": {
               "type": "keyword"
@@ -181,7 +178,7 @@ DASHBOARD_ELASTICSEARCH_INDEX_MAPPING = textwrap.dedent(
               "type": "text"
             },
             "chart_names": {
-              "type":"keyword"
+              "type":"text"
             },
             "chart_descriptions": {
               "type": "text"


### PR DESCRIPTION
### Describe your changes :
ElasticSearch matches are case-sensitive this will not match tables with capitalized words etc.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [ ] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have performed a self-review of my own. 
- [ ] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata Community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms -->
<!--- Ingestion: @ayush-shah -->