### PR TITLE
Fix #662: PipelineResource API tagging has both pipeline and pipelines causing it to divide into 2 sections in API docs

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/pipelines/PipelineResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/pipelines/PipelineResource.java
@@ -191,7 +191,7 @@ public class PipelineResource {
 
   @GET
   @Path("/name/{fqn}")
-  @Operation(summary = "Get a pipeline by name", tags = "pipeline",
+  @Operation(summary = "Get a pipeline by name", tags = "pipelines",
           description = "Get a pipeline by fully qualified name.",
           responses = {
                   @ApiResponse(responseCode = "200", description = "The pipeline",
@@ -257,7 +257,7 @@ public class PipelineResource {
   }
 
   @PUT
-  @Operation(summary = "Create or update a pipeline", tags = "pipeline",
+  @Operation(summary = "Create or update a pipeline", tags = "pipelines",
           description = "Create a new pipeline, if it does not exist or update an existing pipeline.",
           responses = {
                   @ApiResponse(responseCode = "200", description = "The pipeline",
@@ -281,7 +281,7 @@ public class PipelineResource {
 
   @PUT
   @Path("/{id}/followers")
-  @Operation(summary = "Add a follower", tags = "pipeline",
+  @Operation(summary = "Add a follower", tags = "pipelines",
           description = "Add a user identified by `userId` as follower of this pipeline",
           responses = {
                   @ApiResponse(responseCode = "200", description = "OK"),
@@ -320,7 +320,7 @@ public class PipelineResource {
 
   @DELETE
   @Path("/{id}")
-  @Operation(summary = "Delete a Pipeline", tags = "pipeline",
+  @Operation(summary = "Delete a Pipeline", tags = "pipelines",
           description = "Delete a pipeline by `id`.",
           responses = {
                   @ApiResponse(responseCode = "200", description = "OK"),


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the ..... because ...

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [ ] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have performed a self-review of my own. 
- [ ] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata Community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms -->
<!--- Ingestion: @ayush-shah -->