### PR TITLE
Fixed # 599 Column level tag window needs to be manually closed before another column tag dialog to open

### DIFF
--- a/catalog-rest-service/src/main/resources/ui/src/components/tags-container/tags-container.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/components/tags-container/tags-container.tsx
@@ -42,6 +42,7 @@ const TagsContainer: FunctionComponent<TagsContainerProps> = ({
   const [newTag, setNewTag] = useState<string>('');
   const [hasFocus, setFocus] = useState<boolean>(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const node = useRef<HTMLDivElement>(null);
   // const [inputWidth, setInputWidth] = useState(INPUT_COLLAPED);
   // const [inputMinWidth, setInputMinWidth] = useState(INPUT_AUTO);
 
@@ -153,10 +154,30 @@ const TagsContainer: FunctionComponent<TagsContainerProps> = ({
       return getTagsContainer(tag, index);
     }
   };
+  const handleClick = (e: MouseEvent) => {
+    if (node?.current?.contains(e.target as Node)) {
+      return;
+    } else {
+      e.stopPropagation();
+      handleCancel(e as unknown as React.MouseEvent<HTMLElement, MouseEvent>);
+    }
+  };
 
   useEffect(() => {
     setTags(selectedTags);
   }, [selectedTags]);
+
+  useEffect(() => {
+    if (editable) {
+      document.addEventListener('mousedown', handleClick);
+    } else {
+      document.removeEventListener('mousedown', handleClick);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+    };
+  }, [editable]);
 
   return (
     <div
@@ -168,6 +189,7 @@ const TagsContainer: FunctionComponent<TagsContainerProps> = ({
         { 'hover:tw-border-main': !hasFocus }
       )}
       data-testid="tag-conatiner"
+      ref={node}
       onClick={(event) => {
         if (editable) {
           event.preventDefault();


### PR DESCRIPTION
Closes #599 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on issue #599 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
 @shahsank3t, @darth-coder00
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata Community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms -->
<!--- Ingestion: @ayush-shah -->