### PR TITLE
[ISSUE - 686] - Use Create Reference in PUT & POST and fix wrong references

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/charts/ChartResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/charts/ChartResource.java
@@ -28,7 +28,6 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.openmetadata.catalog.api.data.CreateChart;
 import org.openmetadata.catalog.entity.data.Chart;
-import org.openmetadata.catalog.entity.data.Dashboard;
 import org.openmetadata.catalog.jdbi3.ChartRepository;
 import org.openmetadata.catalog.resources.Collection;
 import org.openmetadata.catalog.security.CatalogAuthorizer;
@@ -175,7 +174,7 @@ public class ChartResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "The chart",
                           content = @Content(mediaType = "application/json",
-                                  schema = @Schema(implementation = Dashboard.class))),
+                                  schema = @Schema(implementation = Chart.class))),
                   @ApiResponse(responseCode = "404", description = "Chart for instance {id} is not found")
           })
   public Chart get(@Context UriInfo uriInfo, @PathParam("id") String id,
@@ -214,7 +213,7 @@ public class ChartResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "The chart",
                           content = @Content(mediaType = "application/json",
-                                  schema = @Schema(implementation = Chart.class))),
+                                  schema = @Schema(implementation = CreateChart.class))),
                   @ApiResponse(responseCode = "400", description = "Bad request")
           })
   public Response create(@Context UriInfo uriInfo, @Context SecurityContext securityContext,
@@ -262,7 +261,7 @@ public class ChartResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "The updated chart ",
                           content = @Content(mediaType = "application/json",
-                                  schema = @Schema(implementation = Chart.class)))
+                                  schema = @Schema(implementation = CreateChart.class)))
           })
   public Response createOrUpdate(@Context UriInfo uriInfo,
                                  @Context SecurityContext securityContext,

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/dashboards/DashboardResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/dashboards/DashboardResource.java
@@ -215,7 +215,7 @@ public class DashboardResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "The dashboard",
                           content = @Content(mediaType = "application/json",
-                          schema = @Schema(implementation = Dashboard.class))),
+                          schema = @Schema(implementation = CreateDashboard.class))),
                   @ApiResponse(responseCode = "400", description = "Bad request")
           })
   public Response create(@Context UriInfo uriInfo, @Context SecurityContext securityContext,
@@ -261,7 +261,7 @@ public class DashboardResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "The dashboard",
                           content = @Content(mediaType = "application/json",
-                          schema = @Schema(implementation = Dashboard.class))),
+                          schema = @Schema(implementation = CreateDashboard.class))),
                   @ApiResponse(responseCode = "400", description = "Bad request")
           })
   public Response createOrUpdate(@Context UriInfo uriInfo,

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/databases/DatabaseResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/databases/DatabaseResource.java
@@ -27,7 +27,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.openmetadata.catalog.api.data.CreateDatabase;
-import org.openmetadata.catalog.entity.data.Dashboard;
 import org.openmetadata.catalog.entity.data.Database;
 import org.openmetadata.catalog.jdbi3.DatabaseRepository;
 import org.openmetadata.catalog.resources.Collection;
@@ -179,7 +178,7 @@ public class DatabaseResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "The database",
                           content = @Content(mediaType = "application/json",
-                          schema = @Schema(implementation = Dashboard.class))),
+                          schema = @Schema(implementation = Database.class))),
                   @ApiResponse(responseCode = "404", description = "Database for instance {id} is not found")
           })
   public Response get(@Context UriInfo uriInfo, @PathParam("id") String id,
@@ -200,7 +199,7 @@ public class DatabaseResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "The database",
                           content = @Content(mediaType = "application/json",
-                          schema = @Schema(implementation = Dashboard.class))),
+                          schema = @Schema(implementation = Database.class))),
                   @ApiResponse(responseCode = "404", description = "Database for instance {id} is not found")
           })
   public Response getByName(@Context UriInfo uriInfo, @PathParam("fqn") String fqn,
@@ -220,7 +219,7 @@ public class DatabaseResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "The database",
                           content = @Content(mediaType = "application/json",
-                          schema = @Schema(implementation = Database.class))),
+                          schema = @Schema(implementation = CreateDatabase.class))),
                   @ApiResponse(responseCode = "400", description = "Bad request")
           })
   public Response create(@Context UriInfo uriInfo, @Context SecurityContext securityContext,
@@ -261,7 +260,7 @@ public class DatabaseResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "The updated database ",
                           content = @Content(mediaType = "application/json",
-                          schema = @Schema(implementation = Database.class)))
+                          schema = @Schema(implementation = CreateDatabase.class)))
           })
   public Response createOrUpdate(@Context UriInfo uriInfo,
                                  @Context SecurityContext securityContext,

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/databases/TableResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/databases/TableResource.java
@@ -213,7 +213,7 @@ public class TableResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "table",
                           content = @Content(mediaType = "application/json",
-                          schema = @Schema(implementation = Table.class))),
+                          schema = @Schema(implementation = CreateTable.class))),
                   @ApiResponse(responseCode = "400", description = "Bad request")
           })
   public Response create(@Context UriInfo uriInfo,
@@ -234,7 +234,7 @@ public class TableResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "The table",
                           content = @Content(mediaType = "application/json",
-                          schema = @Schema(implementation = Table.class))),
+                          schema = @Schema(implementation = CreateTable.class))),
                   @ApiResponse(responseCode = "400", description = "Bad request")
           })
   public Response createOrUpdate(@Context UriInfo uriInfo,

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/feeds/FeedResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/feeds/FeedResource.java
@@ -120,7 +120,7 @@ public class FeedResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "The thread",
                           content = @Content(mediaType = "application/json",
-                          schema = @Schema(implementation = Thread.class))),
+                          schema = @Schema(implementation = CreateThread.class))),
                   @ApiResponse(responseCode = "400", description = "Bad request")
           })
   public Response create(@Context UriInfo uriInfo, @Valid CreateThread cr) throws IOException {

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/metrics/MetricsResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/metrics/MetricsResource.java
@@ -17,7 +17,6 @@
 package org.openmetadata.catalog.resources.metrics;
 
 import com.google.inject.Inject;
-import org.openmetadata.catalog.entity.data.Dashboard;
 import org.openmetadata.catalog.entity.data.Metrics;
 import org.openmetadata.catalog.jdbi3.MetricsRepository;
 import org.openmetadata.catalog.resources.Collection;
@@ -110,7 +109,7 @@ public class MetricsResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "The metrics",
                           content = @Content(mediaType = "application/json",
-                          schema = @Schema(implementation = Dashboard.class))),
+                          schema = @Schema(implementation = Metrics.class))),
                   @ApiResponse(responseCode = "404", description = "Metrics for instance {id} is not found")
           })
   public Metrics get(@Context UriInfo uriInfo,

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/pipelines/PipelineResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/pipelines/PipelineResource.java
@@ -216,7 +216,7 @@ public class PipelineResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "The pipeline",
                           content = @Content(mediaType = "application/json",
-                                  schema = @Schema(implementation = Pipeline.class))),
+                                  schema = @Schema(implementation = CreatePipeline.class))),
                   @ApiResponse(responseCode = "400", description = "Bad request")
           })
   public Response create(@Context UriInfo uriInfo, @Context SecurityContext securityContext,
@@ -262,7 +262,7 @@ public class PipelineResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "The pipeline",
                           content = @Content(mediaType = "application/json",
-                                  schema = @Schema(implementation = Pipeline.class))),
+                                  schema = @Schema(implementation = CreatePipeline.class))),
                   @ApiResponse(responseCode = "400", description = "Bad request")
           })
   public Response createOrUpdate(@Context UriInfo uriInfo,

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/reports/ReportResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/reports/ReportResource.java
@@ -17,7 +17,6 @@
 package org.openmetadata.catalog.resources.reports;
 
 import com.google.inject.Inject;
-import org.openmetadata.catalog.entity.data.Dashboard;
 import org.openmetadata.catalog.entity.data.Report;
 import org.openmetadata.catalog.jdbi3.ReportRepository;
 import org.openmetadata.catalog.resources.Collection;
@@ -110,7 +109,7 @@ public class ReportResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "The report",
                           content = @Content(mediaType = "application/json",
-                          schema = @Schema(implementation = Dashboard.class))),
+                          schema = @Schema(implementation = Report.class))),
                   @ApiResponse(responseCode = "404", description = "Report for instance {id} is not found")
           })
   public Report get(@Context UriInfo uriInfo, @PathParam("id") String id,

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/dashboard/DashboardServiceResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/dashboard/DashboardServiceResource.java
@@ -26,7 +26,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.openmetadata.catalog.api.services.CreateDashboardService;
 import org.openmetadata.catalog.api.services.UpdateDashboardService;
-import org.openmetadata.catalog.entity.data.Dashboard;
 import org.openmetadata.catalog.entity.services.DashboardService;
 import org.openmetadata.catalog.jdbi3.DashboardServiceRepository;
 import org.openmetadata.catalog.resources.Collection;
@@ -112,7 +111,7 @@ public class DashboardServiceResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "Dashboard service instance",
                           content = @Content(mediaType = "application/json",
-                          schema = @Schema(implementation = Dashboard.class))),
+                          schema = @Schema(implementation = DashboardService.class))),
                   @ApiResponse(responseCode = "404", description = "Dashboard service for instance {id} is not found")
           })
   public DashboardService get(@Context UriInfo uriInfo,
@@ -128,7 +127,7 @@ public class DashboardServiceResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "Dashboard service instance",
                           content = @Content(mediaType = "application/json",
-                          schema = @Schema(implementation = Dashboard.class))),
+                          schema = @Schema(implementation = DashboardService.class))),
                   @ApiResponse(responseCode = "404", description = "Dashboard service for instance {id} is not found")
           })
   public DashboardService getByName(@Context UriInfo uriInfo,
@@ -143,7 +142,7 @@ public class DashboardServiceResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "Dashboard service instance",
                           content = @Content(mediaType = "application/json",
-                          schema = @Schema(implementation = DashboardService.class))),
+                          schema = @Schema(implementation = CreateDashboardService.class))),
                   @ApiResponse(responseCode = "400", description = "Bad request")
           })
   public Response create(@Context UriInfo uriInfo,
@@ -169,7 +168,7 @@ public class DashboardServiceResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "Dashboard service instance",
                           content = @Content(mediaType = "application/json",
-                          schema = @Schema(implementation = DashboardService.class))),
+                          schema = @Schema(implementation = CreateDashboardService.class))),
                   @ApiResponse(responseCode = "400", description = "Bad request")
           })
   public Response update(@Context UriInfo uriInfo,

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/database/DatabaseServiceResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/database/DatabaseServiceResource.java
@@ -21,7 +21,6 @@ import com.google.inject.Inject;
 import org.openmetadata.catalog.jdbi3.DatabaseServiceRepository;
 import org.openmetadata.catalog.api.services.CreateDatabaseService;
 import org.openmetadata.catalog.api.services.UpdateDatabaseService;
-import org.openmetadata.catalog.entity.data.Dashboard;
 import org.openmetadata.catalog.entity.services.DatabaseService;
 import org.openmetadata.catalog.resources.Collection;
 import org.openmetadata.catalog.security.SecurityUtil;
@@ -111,7 +110,7 @@ public class DatabaseServiceResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "Database service instance",
                           content = @Content(mediaType = "application/json",
-                          schema = @Schema(implementation = Dashboard.class))),
+                          schema = @Schema(implementation = DatabaseService.class))),
                   @ApiResponse(responseCode = "404", description = "Database service for instance {id} is not found")
           })
   public DatabaseService get(@Context UriInfo uriInfo,
@@ -127,7 +126,7 @@ public class DatabaseServiceResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "Database service instance",
                           content = @Content(mediaType = "application/json",
-                          schema = @Schema(implementation = Dashboard.class))),
+                          schema = @Schema(implementation = DatabaseService.class))),
                   @ApiResponse(responseCode = "404", description = "Database service for instance {id} is not found")
           })
   public DatabaseService getByName(@Context UriInfo uriInfo,
@@ -142,7 +141,7 @@ public class DatabaseServiceResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "Database service instance",
                           content = @Content(mediaType = "application/json",
-                          schema = @Schema(implementation = DatabaseService.class))),
+                          schema = @Schema(implementation = CreateDatabaseService.class))),
                   @ApiResponse(responseCode = "400", description = "Bad request")
           })
   public Response create(@Context UriInfo uriInfo,
@@ -165,7 +164,7 @@ public class DatabaseServiceResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "Database service instance",
                           content = @Content(mediaType = "application/json",
-                          schema = @Schema(implementation = DatabaseService.class))),
+                          schema = @Schema(implementation = CreateDatabaseService.class))),
                   @ApiResponse(responseCode = "400", description = "Bad request")
           })
   public Response update(@Context UriInfo uriInfo,

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/messaging/MessagingServiceResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/messaging/MessagingServiceResource.java
@@ -26,7 +26,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.openmetadata.catalog.api.services.CreateMessagingService;
 import org.openmetadata.catalog.api.services.UpdateMessagingService;
-import org.openmetadata.catalog.entity.data.Dashboard;
 import org.openmetadata.catalog.entity.services.MessagingService;
 import org.openmetadata.catalog.jdbi3.MessagingServiceRepository;
 import org.openmetadata.catalog.resources.Collection;
@@ -127,7 +126,7 @@ public class MessagingServiceResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "Messaging service instance",
                           content = @Content(mediaType = "application/json",
-                          schema = @Schema(implementation = Dashboard.class))),
+                          schema = @Schema(implementation = MessagingService.class))),
                   @ApiResponse(responseCode = "404", description = "Messaging service for instance {id} is not found")
           })
   public MessagingService getByName(@Context UriInfo uriInfo,
@@ -142,7 +141,7 @@ public class MessagingServiceResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "Messaging service instance",
                           content = @Content(mediaType = "application/json",
-                          schema = @Schema(implementation = MessagingService.class))),
+                          schema = @Schema(implementation = CreateMessagingService.class))),
                   @ApiResponse(responseCode = "400", description = "Bad request")
           })
   public Response create(@Context UriInfo uriInfo,
@@ -167,7 +166,7 @@ public class MessagingServiceResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "Messaging service instance",
                           content = @Content(mediaType = "application/json",
-                          schema = @Schema(implementation = MessagingService.class))),
+                          schema = @Schema(implementation = CreateMessagingService.class))),
                   @ApiResponse(responseCode = "400", description = "Bad request")
           })
   public Response update(@Context UriInfo uriInfo,

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/pipeline/PipelineServiceResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/pipeline/PipelineServiceResource.java
@@ -26,7 +26,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.openmetadata.catalog.api.services.CreatePipelineService;
 import org.openmetadata.catalog.api.services.UpdatePipelineService;
-import org.openmetadata.catalog.entity.data.Dashboard;
 import org.openmetadata.catalog.entity.services.PipelineService;
 import org.openmetadata.catalog.jdbi3.PipelineServiceRepository;
 import org.openmetadata.catalog.resources.Collection;
@@ -128,7 +127,7 @@ public class PipelineServiceResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "Pipeline service instance",
                           content = @Content(mediaType = "application/json",
-                          schema = @Schema(implementation = Dashboard.class))),
+                          schema = @Schema(implementation = PipelineService.class))),
                   @ApiResponse(responseCode = "404", description = "Pipeline service for instance {id} is not found")
           })
   public PipelineService getByName(@Context UriInfo uriInfo,
@@ -143,7 +142,7 @@ public class PipelineServiceResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "Pipeline service instance",
                           content = @Content(mediaType = "application/json",
-                          schema = @Schema(implementation = PipelineService.class))),
+                          schema = @Schema(implementation = CreatePipelineService.class))),
                   @ApiResponse(responseCode = "400", description = "Bad request")
           })
   public Response create(@Context UriInfo uriInfo,
@@ -166,7 +165,7 @@ public class PipelineServiceResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "Pipeline service instance",
                           content = @Content(mediaType = "application/json",
-                          schema = @Schema(implementation = PipelineService.class))),
+                          schema = @Schema(implementation = CreatePipelineService.class))),
                   @ApiResponse(responseCode = "400", description = "Bad request")
           })
   public Response update(@Context UriInfo uriInfo,

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/tags/TagResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/tags/TagResource.java
@@ -232,7 +232,7 @@ public class TagResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "The user ",
                           content = @Content(mediaType = "application/json", schema = @Schema(implementation =
-                                  TagCategory.class))),
+                                  CreateTagCategory.class))),
                   @ApiResponse(responseCode = "400", description = "Bad request")
           })
   public Response createCategory(@Context UriInfo uriInfo,
@@ -252,7 +252,7 @@ public class TagResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "The user ",
                           content = @Content(mediaType = "application/json", schema = @Schema(implementation =
-                                  Tag.class))),
+                                  CreateTag.class))),
                   @ApiResponse(responseCode = "400", description = "Bad request")
           })
   public Response createPrimaryTag(@Context UriInfo uriInfo,
@@ -276,7 +276,7 @@ public class TagResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "The user ",
                           content = @Content(mediaType = "application/json", schema = @Schema(implementation =
-                                  Tag.class))),
+                                  CreateTag.class))),
                   @ApiResponse(responseCode = "400", description = "Bad request")
           })
   public Response createSecondaryTag(@Context UriInfo uriInfo,

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/tasks/TaskResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/tasks/TaskResource.java
@@ -27,8 +27,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.openmetadata.catalog.api.data.CreateTask;
-import org.openmetadata.catalog.entity.data.Chart;
-import org.openmetadata.catalog.entity.data.Dashboard;
 import org.openmetadata.catalog.entity.data.Task;
 import org.openmetadata.catalog.jdbi3.TaskRepository;
 import org.openmetadata.catalog.resources.Collection;
@@ -131,7 +129,7 @@ public class TaskResource {
                   "parameter to get only necessary fields. Use cursor-based pagination to limit the number " +
                   "entries in the list using `limit` and `before` or `after` query params.",
           responses = {
-                  @ApiResponse(responseCode = "200", description = "List of charts",
+                  @ApiResponse(responseCode = "200", description = "List of tasks",
                           content = @Content(mediaType = "application/json",
                                   schema = @Schema(implementation = TaskList.class)))
           })
@@ -140,7 +138,7 @@ public class TaskResource {
                         @Parameter(description = "Fields requested in the returned resource",
                                 schema = @Schema(type = "string", example = FIELDS))
                         @QueryParam("fields") String fieldsParam,
-                        @Parameter(description = "Filter charts by service name",
+                        @Parameter(description = "Filter tasks by service name",
                                 schema = @Schema(type = "string", example = "superset"))
                         @QueryParam("service") String serviceParam,
                         @Parameter(description = "Limit the number tasks returned. (1 to 1000000, default = 10)")
@@ -148,10 +146,10 @@ public class TaskResource {
                         @Min(1)
                         @Max(1000000)
                         @QueryParam("limit") int limitParam,
-                        @Parameter(description = "Returns list of charts before this cursor",
+                        @Parameter(description = "Returns list of tasks before this cursor",
                                 schema = @Schema(type = "string"))
                         @QueryParam("before") String before,
-                        @Parameter(description = "Returns list of charts after this cursor",
+                        @Parameter(description = "Returns list of tasks after this cursor",
                                 schema = @Schema(type = "string"))
                         @QueryParam("after") String after
   ) throws IOException, GeneralSecurityException {
@@ -175,7 +173,7 @@ public class TaskResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "The Task",
                           content = @Content(mediaType = "application/json",
-                                  schema = @Schema(implementation = Dashboard.class))),
+                                  schema = @Schema(implementation = Task.class))),
                   @ApiResponse(responseCode = "404", description = "Task for instance {id} is not found")
           })
   public Task get(@Context UriInfo uriInfo, @PathParam("id") String id,
@@ -189,13 +187,13 @@ public class TaskResource {
 
   @GET
   @Path("/name/{fqn}")
-  @Operation(summary = "Get a chart by name", tags = "charts",
-          description = "Get a chart by fully qualified name.",
+  @Operation(summary = "Get a task by name", tags = "tasks",
+          description = "Get a task by fully qualified name.",
           responses = {
-                  @ApiResponse(responseCode = "200", description = "The chart",
+                  @ApiResponse(responseCode = "200", description = "The task",
                           content = @Content(mediaType = "application/json",
-                                  schema = @Schema(implementation = Chart.class))),
-                  @ApiResponse(responseCode = "404", description = "Chart for instance {id} is not found")
+                                  schema = @Schema(implementation = Task.class))),
+                  @ApiResponse(responseCode = "404", description = "Task for instance {id} is not found")
           })
   public Response getByName(@Context UriInfo uriInfo, @PathParam("fqn") String fqn,
                             @Context SecurityContext securityContext,
@@ -209,12 +207,12 @@ public class TaskResource {
   }
 
   @POST
-  @Operation(summary = "Create a chart", tags = "charts",
-          description = "Create a chart under an existing `service`.",
+  @Operation(summary = "Create a task", tags = "tasks",
+          description = "Create a task under an existing `service`.",
           responses = {
-                  @ApiResponse(responseCode = "200", description = "The chart",
+                  @ApiResponse(responseCode = "200", description = "The task",
                           content = @Content(mediaType = "application/json",
-                                  schema = @Schema(implementation = Chart.class))),
+                                  schema = @Schema(implementation = CreateTask.class))),
                   @ApiResponse(responseCode = "400", description = "Bad request")
           })
   public Response create(@Context UriInfo uriInfo, @Context SecurityContext securityContext,
@@ -266,7 +264,7 @@ public class TaskResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "The updated task ",
                           content = @Content(mediaType = "application/json",
-                                  schema = @Schema(implementation = Task.class)))
+                                  schema = @Schema(implementation = CreateTask.class)))
           })
   public Response createOrUpdate(@Context UriInfo uriInfo,
                                  @Context SecurityContext securityContext,

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/teams/TeamResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/teams/TeamResource.java
@@ -198,7 +198,7 @@ public class TeamResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "The team",
                           content = @Content(mediaType = "application/json",
-                          schema = @Schema(implementation = Team.class))),
+                          schema = @Schema(implementation = CreateTeam.class))),
                   @ApiResponse(responseCode = "400", description = "Bad request")
           })
   public Response create(@Context UriInfo uriInfo,

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/teams/UserResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/teams/UserResource.java
@@ -222,7 +222,7 @@ public class UserResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "The user ",
                           content = @Content(mediaType = "application/json",
-                          schema = @Schema(implementation = User.class))),
+                          schema = @Schema(implementation = CreateUser.class))),
                   @ApiResponse(responseCode = "400", description = "Bad request")
           })
   public Response createUser(@Context UriInfo uriInfo, @Context SecurityContext securityContext,
@@ -243,7 +243,7 @@ public class UserResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "The user ",
                           content = @Content(mediaType = "application/json",
-                                  schema = @Schema(implementation = User.class))),
+                                  schema = @Schema(implementation = CreateUser.class))),
                   @ApiResponse(responseCode = "400", description = "Bad request")
           })
   public Response createOrUpdateUser(@Context UriInfo uriInfo,

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/topics/TopicResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/topics/TopicResource.java
@@ -27,7 +27,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.openmetadata.catalog.api.data.CreateTopic;
-import org.openmetadata.catalog.entity.data.Dashboard;
 import org.openmetadata.catalog.entity.data.Topic;
 import org.openmetadata.catalog.jdbi3.TopicRepository;
 import org.openmetadata.catalog.resources.Collection;
@@ -193,7 +192,7 @@ public class TopicResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "The topic",
                           content = @Content(mediaType = "application/json",
-                                  schema = @Schema(implementation = Dashboard.class))),
+                                  schema = @Schema(implementation = Topic.class))),
                   @ApiResponse(responseCode = "404", description = "Topic for instance {id} is not found")
           })
   public Response getByName(@Context UriInfo uriInfo, @PathParam("fqn") String fqn,
@@ -213,7 +212,7 @@ public class TopicResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "The topic",
                           content = @Content(mediaType = "application/json",
-                                  schema = @Schema(implementation = Topic.class))),
+                                  schema = @Schema(implementation = CreateTopic.class))),
                   @ApiResponse(responseCode = "400", description = "Bad request")
           })
   public Response create(@Context UriInfo uriInfo, @Context SecurityContext securityContext,
@@ -264,7 +263,7 @@ public class TopicResource {
           responses = {
                   @ApiResponse(responseCode = "200", description = "The updated topic ",
                           content = @Content(mediaType = "application/json",
-                                  schema = @Schema(implementation = Topic.class)))
+                                  schema = @Schema(implementation = CreateTopic.class)))
           })
   public Response createOrUpdate(@Context UriInfo uriInfo,
                                  @Context SecurityContext securityContext,


### PR DESCRIPTION
### Describe your changes :
In #679 we noticed an issue where for the `POST` operation to create an Entity, we were not passing the correct `Create` class as the API schema.

Reviewing all the Resource classes, there were multiple inconsistencies in both `POST` and `PUT`. Moreover, multiple references in other operations were pointing to different classes.

### Type of change :
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.


### Reviewers
@harshach, @sureshms would appreciate your input here.

Thanks 🙏 