### PR TITLE
Issue-787: sql_source should mark entities failed to ingest as warning instead of failed

### DIFF
--- a/ingestion/src/metadata/ingestion/source/sql_source.py
+++ b/ingestion/src/metadata/ingestion/source/sql_source.py
@@ -246,7 +246,7 @@ class SQLSource(Source):
                 yield table_and_db
             except Exception as err:
                 logger.error(err)
-                self.status.failures.append(
+                self.status.warnings.append(
                     "{}.{}".format(self.config.service_name, table_name)
                 )
                 continue
@@ -304,7 +304,7 @@ class SQLSource(Source):
                 yield table_and_db
             except Exception as err:
                 logger.error(err)
-                self.status.failures.append(
+                self.status.warnings.append(
                     "{}.{}".format(self.config.service_name, view_name)
                 )
                 continue


### PR DESCRIPTION
### Describe your changes :
Failed to ingest entities should be marked in a warning rather than failures. If we add any records to the failures report it will raise an error which will cause workflows deployed on airflow to not only be marked as failed and will get re-run.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata Community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah -->
