### PR TITLE
Issue 813: Missing entities will be removed from recent data instead of showing loader infinitely

### DIFF
--- a/catalog-rest-service/src/main/resources/ui/src/utils/CommonUtils.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/utils/CommonUtils.tsx
@@ -160,6 +160,14 @@ export const getRecentlyViewedData = (): Array<RecentlyViewedData> => {
   return [];
 };
 
+export const setRecentlyViewedData = (
+  recentData: Array<RecentlyViewedData>
+): void => {
+  reactLocalStorage.setObject(LOCALSTORAGE_RECENTLY_VIEWED, {
+    data: recentData,
+  });
+};
+
 export const getHtmlForNonAdminAction = (isClaimOwner: boolean) => {
   return (
     <>


### PR DESCRIPTION
### Describe your changes :
Closes #813 
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the Recently viewed tab because it showed loader if api does not return queried entity after re-ingestion, in-case entity is missing

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<p align="center">
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@shahsank3t @Sachin-chaurasiya 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata Community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah -->
