### PR TITLE
Fixed #868 For Owner already set to a team, "Select owner" list should open with teams tab as active.

### DIFF
--- a/catalog-rest-service/src/main/resources/ui/src/components/dropdown/DropDownList.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/components/dropdown/DropDownList.tsx
@@ -70,6 +70,15 @@ const DropDownList: FunctionComponent<DropDownListProp> = ({
     );
   };
 
+  const setCurrentTabOnMount = () => {
+    const owner = dropDownList.find((l) => l.value === value);
+    if (owner) {
+      const index = listGroups.indexOf(owner.group as string);
+
+      setActiveTab(index >= 0 ? index + 1 : 1);
+    }
+  };
+
   useEffect(() => {
     setSearchText(searchString);
   }, [searchString]);
@@ -100,6 +109,7 @@ const DropDownList: FunctionComponent<DropDownListProp> = ({
 
   useEffect(() => {
     isMounted.current = true;
+    setCurrentTabOnMount();
   }, []);
 
   return (


### PR DESCRIPTION
Closes #868 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on issue #868 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@shahsank3t, @darth-coder00
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata Community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah -->
