### PR TITLE
Fix #845: Fix FQN when the service is passed with Entity ID and Type only

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/ChartRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/ChartRepository.java
@@ -184,9 +184,10 @@ public abstract class ChartRepository {
   }
 
   private void validateRelationships(Chart chart) throws IOException {
+    EntityReference dashboardService = getService(chart.getService());
+    chart.setService(dashboardService);
     chart.setFullyQualifiedName(getFQN(chart));
     EntityUtil.populateOwner(userDAO(), teamDAO(), chart.getOwner()); // Validate owner
-    getService(chart.getService());
     chart.setTags(EntityUtil.addDerivedTags(tagDAO(), chart.getTags()));
   }
 

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/DashboardRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/DashboardRepository.java
@@ -270,9 +270,10 @@ public abstract class DashboardRepository {
 
   private void validateRelationships(Dashboard dashboard)
           throws IOException {
+    EntityReference dashboardService =  getService(dashboard.getService());
+    dashboard.setService(dashboardService);
     dashboard.setFullyQualifiedName(getFQN(dashboard));
     EntityUtil.populateOwner(userDAO(), teamDAO(), dashboard.getOwner()); // Validate owner
-    getService(dashboard.getService());
     dashboard.setTags(EntityUtil.addDerivedTags(tagDAO(), dashboard.getTags()));
   }
 

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/DatabaseRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/DatabaseRepository.java
@@ -202,9 +202,10 @@ public abstract class DatabaseRepository {
   }
 
   private void validateRelationships(Database database) throws IOException {
+    EntityReference dbService = getService(database.getService());
+    database.setService(dbService);
     database.setFullyQualifiedName(getFQN(database));
     database.setOwner(EntityUtil.populateOwner(userDAO(), teamDAO(), database.getOwner())); // Validate owner
-    getService(database.getService());
   }
 
   private void addRelationships(Database database) throws IOException {

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/PipelineRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/PipelineRepository.java
@@ -229,9 +229,10 @@ public abstract class PipelineRepository {
   }
 
   private void validateRelationships(Pipeline pipeline) throws IOException {
+    EntityReference pipelineService = getService(pipeline.getService());
+    pipeline.setService(pipelineService);
     pipeline.setFullyQualifiedName(getFQN(pipeline));
     EntityUtil.populateOwner(userDAO(), teamDAO(), pipeline.getOwner()); // Validate owner
-    getService(pipeline.getService());
     pipeline.setTags(EntityUtil.addDerivedTags(tagDAO(), pipeline.getTags()));
   }
 

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/TaskRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/TaskRepository.java
@@ -186,9 +186,10 @@ public abstract class TaskRepository {
   }
 
   private void validateRelationships(Task task) throws IOException {
+    EntityReference pipelineService = getService(task.getService());
+    task.setService(pipelineService);
     task.setFullyQualifiedName(getFQN(task));
     EntityUtil.populateOwner(userDAO(), teamDAO(), task.getOwner()); // Validate owner
-    getService(task.getService());
     task.setTags(EntityUtil.addDerivedTags(tagDAO(), task.getTags()));
   }
 

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/charts/ChartResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/charts/ChartResourceTest.java
@@ -130,11 +130,14 @@ public class ChartResourceTest extends CatalogApplicationTest {
   @Test
   public void post_validCharts_as_admin_200_OK(TestInfo test) throws HttpResponseException {
     // Create team with different optional fields
-    CreateChart create = create(test);
+    CreateChart create = create(test).withService(new EntityReference().
+            withId(SUPERSET_REFERENCE.getId()).withType(SUPERSET_REFERENCE.getType()));
     createAndCheckChart(create, adminAuthHeaders());
 
     create.withName(getChartName(test, 1)).withDescription("description");
-    createAndCheckChart(create, adminAuthHeaders());
+    Chart chart = createAndCheckChart(create, adminAuthHeaders());
+    String expectedFQN = SUPERSET_REFERENCE.getName() + "." + chart.getName();
+    assertEquals(expectedFQN, chart.getFullyQualifiedName());
   }
 
   @Test

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/dashboards/DashboardResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/dashboards/DashboardResourceTest.java
@@ -217,12 +217,14 @@ public class DashboardResourceTest extends CatalogApplicationTest {
 
     // Create Dashboard for each service and test APIs
     for (EntityReference service : differentServices) {
-      createAndCheckDashboard(create(test).withService(service), adminAuthHeaders());
-
+      createAndCheckDashboard(create(test).withService(new EntityReference().withId(service.getId())
+              .withType(service.getType())), adminAuthHeaders());
       // List Dashboards by filtering on service name and ensure right Dashboards are returned in the response
       DashboardList list = listDashboards("service", service.getName(), adminAuthHeaders());
       for (Dashboard db : list.getData()) {
         assertEquals(service.getName(), db.getService().getName());
+        String expectedFQN = service.getName() + "." + db.getName();
+        assertEquals(expectedFQN, db.getFullyQualifiedName());
       }
     }
   }

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/databases/DatabaseResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/databases/DatabaseResourceTest.java
@@ -143,6 +143,17 @@ public class DatabaseResourceTest extends CatalogApplicationTest {
   }
 
   @Test
+  public void post_databaseFQN_as_admin_200_OK(TestInfo test) throws HttpResponseException {
+    // Create team with different optional fields
+    CreateDatabase create = create(test);
+    create.setService(new EntityReference().withId(SNOWFLAKE_REFERENCE.getId()).withType("databaseService"));
+    Database db = createAndCheckDatabase(create, adminAuthHeaders());
+    String expectedFQN = SNOWFLAKE_REFERENCE.getName()+"."+create.getName();
+    assertEquals(expectedFQN, db.getFullyQualifiedName());
+
+  }
+
+  @Test
   public void post_databaseWithUserOwner_200_ok(TestInfo test) throws HttpResponseException {
     createAndCheckDatabase(create(test).withOwner(USER_OWNER1), adminAuthHeaders());
   }

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/databases/TableResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/databases/TableResourceTest.java
@@ -232,7 +232,12 @@ public class TableResourceTest extends CatalogApplicationTest {
 
     // Optional fields tableType
     create.withName(getTableName(test, 1)).withTableType(TableType.View);
-    createAndCheckTable(create, adminAuthHeaders());
+    Table table = createAndCheckTable(create, adminAuthHeaders());
+
+    // check the FQN
+    Database db = DatabaseResourceTest.getDatabase(table.getDatabase().getId(), null, adminAuthHeaders());
+    String expectedFQN = db.getFullyQualifiedName()+"."+table.getName();
+    assertEquals(expectedFQN, expectedFQN);
   }
 
   private static Column getColumn(String name, ColumnDataType columnDataType, TagLabel tag) {

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/pipelines/PipelineResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/pipelines/PipelineResourceTest.java
@@ -370,7 +370,8 @@ public class PipelineResourceTest extends CatalogApplicationTest {
 
   @Test
   public void put_PipelineUrlUpdate_200(TestInfo test) throws HttpResponseException, URISyntaxException {
-    CreatePipeline request = create(test).withService(AIRFLOW_REFERENCE).withDescription("description");
+    CreatePipeline request = create(test).withService(new EntityReference().withId(AIRFLOW_REFERENCE.getId())
+            .withType("pipelineService")).withDescription("description");
     createAndCheckPipeline(request, adminAuthHeaders());
     URI pipelineURI = new URI("https://airflow.open-metadata.org/tree?dag_id=airflow_redshift_usage");
     Integer pipelineConcurrency = 110;
@@ -380,9 +381,11 @@ public class PipelineResourceTest extends CatalogApplicationTest {
     Pipeline pipeline = updatePipeline(request.withPipelineUrl(pipelineURI)
             .withConcurrency(pipelineConcurrency)
             .withStartDate(startDate), OK, adminAuthHeaders());
+    String expectedFQN = AIRFLOW_REFERENCE.getName()+"."+pipeline.getName();
     assertEquals(pipelineURI, pipeline.getPipelineUrl());
     assertEquals(startDate, pipeline.getStartDate());
     assertEquals(pipelineConcurrency, pipeline.getConcurrency());
+    assertEquals(expectedFQN, pipeline.getFullyQualifiedName());
   }
 
   @Test

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/tasks/TaskResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/tasks/TaskResourceTest.java
@@ -306,8 +306,11 @@ public class TaskResourceTest extends CatalogApplicationTest {
   @Test
   public void put_taskCreate_200(TestInfo test) throws HttpResponseException, URISyntaxException {
     // Create a new task with PUT
-    CreateTask request = create(test).withService(AIRFLOW_REFERENCE).withOwner(USER_OWNER1);
-    updateAndCheckTask(null, request, CREATED, adminAuthHeaders(), NO_CHANGE);
+    CreateTask request = create(test).withService(new EntityReference().withId(AIRFLOW_REFERENCE.getId())
+            .withType(AIRFLOW_REFERENCE.getType())).withOwner(USER_OWNER1);
+    Task task = updateAndCheckTask(null, request, CREATED, adminAuthHeaders(), NO_CHANGE);
+    String expectedFQN = AIRFLOW_REFERENCE.getName() + "." + task.getName();
+    assertEquals(expectedFQN, task.getFullyQualifiedName());
   }
 
   @Test

--- a/ingestion/src/metadata/ingestion/ometa/openmetadata_rest.py
+++ b/ingestion/src/metadata/ingestion/ometa/openmetadata_rest.py
@@ -352,6 +352,7 @@ class OpenMetadataAPIClient(object):
         self, create_table_request: CreateTableEntityRequest
     ) -> Table:
         """Create or Update a Table"""
+        print("WTF")
         resp = self.client.put("/tables", data=create_table_request.json())
         resp.pop("database", None)
         return Table(**resp)


### PR DESCRIPTION
### Describe your changes :
EntityReference has ID and type as the requirements and in ingestion, we only set those and publish them to OpenMetadata APIs. On the backend, we are looking at entity.getService() to set the fullyQualifiedName, if we only set Id and Type from ingestion this will turn the fullyQualifiedName as null.entity_name.
To fix this I've changed the validate relationships method , moved the checking service at the top, and assign that to entity.setService() so that we get full details of the service
#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x]  I have tagged my reviewers below.
- [x ] I have added tests that prove my fix is effective or that my feature works.
- [x ] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata Community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah -->
