### PR TITLE
Add columns as default field for Table in GET operations

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/TableRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/TableRepository.java
@@ -83,7 +83,7 @@ public class TableRepository extends EntityRepository<Table> {
 
   @Override
   public Table setFields(Table table, Fields fields) throws IOException, ParseException {
-    table.setColumns(fields.contains("columns") ? table.getColumns() : null);
+    table.setColumns(table.getColumns());
     table.setTableConstraints(fields.contains("tableConstraints") ? table.getTableConstraints() : null);
     table.setOwner(fields.contains("owner") ? getOwner(table) : null);
     table.setFollowers(fields.contains("followers") ? getFollowers(table) : null);

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/databases/TableResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/databases/TableResourceTest.java
@@ -1174,7 +1174,7 @@ public class TableResourceTest extends CatalogApplicationTest {
         table.getColumns().forEach(column -> assertNull(column.getTags()));
       }
     } else {
-      assertNull(table.getColumns());
+      assertNotNull(table.getColumns());
     }
     if (fields.contains("tableConstraints")) {
       assertNotNull(table.getTableConstraints());


### PR DESCRIPTION
### Describe your changes :

This PR adds `Columns` as a default response field for Table.

We are aligning the `Table` entity GET results so that we have a properly formatted table with all required fields by default in the response.

Thanks!

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation


#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@sureshms @harshach if you could take a look, please!
