### PR TITLE
Fix #941: Fix Topic FQDN

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/TopicRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/TopicRepository.java
@@ -75,9 +75,10 @@ public class TopicRepository extends EntityRepository<Topic> {
 
   @Override
   public void validate(Topic topic) throws IOException {
+    EntityReference messagingService = getService(topic.getService());
+    topic.setService(messagingService);
     topic.setFullyQualifiedName(getFQN(topic));
     EntityUtil.populateOwner(dao.userDAO(), dao.teamDAO(), topic.getOwner()); // Validate owner
-    getService(topic.getService());
     topic.setTags(EntityUtil.addDerivedTags(dao.tagDAO(), topic.getTags()));
   }
 

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/topics/TopicResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/topics/TopicResourceTest.java
@@ -128,11 +128,14 @@ public class TopicResourceTest extends CatalogApplicationTest {
   @Test
   public void post_validTopics_as_admin_200_OK(TestInfo test) throws HttpResponseException {
     // Create team with different optional fields
-    CreateTopic create = create(test);
+    CreateTopic create = create(test).withService(new EntityReference().withId(KAFKA_REFERENCE.getId())
+    .withType(KAFKA_REFERENCE.getType()));
     createAndCheckTopic(create, adminAuthHeaders());
 
     create.withName(getTopicName(test, 1)).withDescription("description");
-    createAndCheckTopic(create, adminAuthHeaders());
+    Topic topic = createAndCheckTopic(create, adminAuthHeaders());
+    String expectedFQN = KAFKA_REFERENCE.getName() + "." + topic.getName();
+    assertEquals(expectedFQN, topic.getFullyQualifiedName());
   }
 
   @Test

--- a/ingestion/src/metadata/ingestion/ometa/openmetadata_rest.py
+++ b/ingestion/src/metadata/ingestion/ometa/openmetadata_rest.py
@@ -352,7 +352,6 @@ class OpenMetadataAPIClient(object):
         self, create_table_request: CreateTableEntityRequest
     ) -> Table:
         """Create or Update a Table"""
-        print("WTF")
         resp = self.client.put("/tables", data=create_table_request.json())
         resp.pop("database", None)
         return Table(**resp)


### PR DESCRIPTION
### Describe your changes :
The service name can be null when passed with service.id and type only for Topic Entity Creation

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x ] I have performed a self-review of my own. 
- [ x] I have tagged my reviewers below.
- [x ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
