### PR TITLE
Map SQL columns with unknown type to VARCHAR

### DIFF
--- a/ingestion/setup.py
+++ b/ingestion/setup.py
@@ -45,7 +45,7 @@ base_requirements = {
     "typing_extensions>=3.7.4"
     "mypy_extensions>=0.4.3",
     "typing-inspect",
-    "pydantic==1.7.4",
+    "pydantic>=1.7.4",
     "pydantic[email]>=1.7.2",
     "google>=3.0.0",
     "google-auth>=1.33.0",

--- a/ingestion/src/metadata/ingestion/source/sql_source.py
+++ b/ingestion/src/metadata/ingestion/source/sql_source.py
@@ -406,6 +406,11 @@ class SQLSource(Source):
                 if col_data_length is None:
                     col_data_length = 1
                 try:
+                    if col_type == "NULL":
+                        col_type = "VARCHAR"
+                        logger.warning(
+                            f"Unknown type mapped to VARCHAR: {column['name']}"
+                        )
                     om_column = Column(
                         name=column["name"],
                         description=column.get("comment", None),


### PR DESCRIPTION
and add the _NST (Non Standard Type) extension to the column name.

### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
We are a heavy user of the PostgreSQL PostGIS extension and currently
columns with that type are completely dropped from the metadata.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement

#

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have performed a self-review of my own. 
- [x ] I have tagged my reviewers below.
- [ x] I have commented on my code, particularly in hard-to-understand areas.
- [ x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->

<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
