### PR TITLE
Fix #1007: Health check api returns unhealthy if there are no users bootstrapped

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/CatalogHealthCheck.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/CatalogHealthCheck.java
@@ -25,6 +25,7 @@ import org.openmetadata.catalog.util.EntityUtil;
 import java.io.IOException;
 
 import static org.openmetadata.catalog.resources.teams.UserResource.FIELD_LIST;
+import static org.openmetadata.catalog.resources.teams.UserResource.LOG;
 
 public class CatalogHealthCheck extends HealthCheck {
   private final UserRepository userRepository;
@@ -39,9 +40,10 @@ public class CatalogHealthCheck extends HealthCheck {
   @Override
   protected Result check() throws Exception {
     try {
-      userRepository.listAfter(fields, null, 1, "");
+      userRepository.listAfter(fields, null, 1, null);
       return Result.healthy();
     } catch (IOException e) {
+      LOG.error("Health check error {}", e.getMessage());
       return Result.unhealthy(e.getMessage());
     }
   }


### PR DESCRIPTION
#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have performed a self-review of my own. 
- [ ] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
