### PR TITLE
Fix : UI: not show add user button if the logged-in user is not admin

### DIFF
--- a/catalog-rest-service/src/main/resources/ui/src/pages/teams/index.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/pages/teams/index.tsx
@@ -42,6 +42,7 @@ import {
 } from '../../constants/constants';
 import { Team } from '../../generated/entity/teams/team';
 import { User } from '../../generated/entity/teams/user';
+import { useAuth } from '../../hooks/authHooks';
 import { UserTeam } from '../../interface/team.interface';
 import { getCountBadge } from '../../utils/CommonUtils';
 import SVGIcons from '../../utils/SvgUtils';
@@ -52,6 +53,7 @@ import UserCard from './UserCard';
 const TeamsPage = () => {
   const { team } = useParams() as Record<string, string>;
   const history = useHistory();
+  const { isAuthDisabled, isAdminUser } = useAuth();
   const [teams, setTeams] = useState<Array<Team>>([]);
   const [currentTeam, setCurrentTeam] = useState<Team>();
   const [error, setError] = useState<string>('');
@@ -189,18 +191,20 @@ const TeamsPage = () => {
     if ((currentTeam?.users?.length as number) <= 0) {
       return (
         <div className="tw-flex tw-flex-col tw-items-center tw-place-content-center tw-mt-40 tw-gap-1">
-          <p>There are not any users added yet.</p>
-          <p>Would like to start adding some?</p>
-          <NonAdminAction position="bottom" title={TITLE_FOR_NON_ADMIN_ACTION}>
-            <Button
-              className="tw-h-8 tw-rounded tw-mb-2"
-              size="small"
-              theme="primary"
-              variant="contained"
-              onClick={() => setIsAddingUsers(true)}>
-              Add new user
-            </Button>
-          </NonAdminAction>
+          <p>There are no users added yet.</p>
+          {isAdminUser || isAuthDisabled ? (
+            <>
+              <p>Would like to start adding some?</p>
+              <Button
+                className="tw-h-8 tw-rounded tw-my-2"
+                size="small"
+                theme="primary"
+                variant="contained"
+                onClick={() => setIsAddingUsers(true)}>
+                Add new user
+              </Button>
+            </>
+          ) : null}
         </div>
       );
     }


### PR DESCRIPTION
### Describe your changes :
Closes #702 
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the Teams page because need to remove `Add new user` button from Users tab if logged-in user is not admin

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Frontend Preview (Screenshots) :
<p align="center">
Non-admin users:
<img width="1791" alt="Screenshot 2021-11-02 at 6 32 32 PM" src="https://user-images.githubusercontent.com/86726556/139851861-52ad1c86-def2-431a-8872-76b46eda839f.png">

Admin users:
<img width="1792" alt="Screenshot 2021-11-02 at 6 34 31 PM" src="https://user-images.githubusercontent.com/86726556/139852215-afe7cb05-4293-44b5-a901-525795bf6ddc.png">

</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@shahsank3t @Sachin-chaurasiya 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
