### PR TITLE
Fix : Services search visible only after service count increases by 10

### DIFF
--- a/catalog-rest-service/src/main/resources/ui/src/pages/services/index.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/pages/services/index.tsx
@@ -423,7 +423,7 @@ const ServicesPage = () => {
             </div>
             <div className="tw-flex">
               <div className="tw-w-4/12">
-                {searchText || serviceList.length > 0 ? (
+                {searchText || serviceList.length > 10 ? (
                   <Searchbar
                     placeholder={`Search for ${servicesDisplayName[serviceName]}...`}
                     searchValue={searchText}


### PR DESCRIPTION
### Describe your changes :
Closes #874 
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the Services page because need to update UI for search-bar based on total services available

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Frontend Preview (Screenshots) :
<p align="center">
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@shahsank3t @Sachin-chaurasiya 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
