### PR TITLE
Add GET with fields param

### DIFF
--- a/ingestion/src/metadata/ingestion/ometa/ometa_api.py
+++ b/ingestion/src/metadata/ingestion/ometa/ometa_api.py
@@ -297,28 +297,36 @@ class OpenMetadata(OMetaLineageMixin, OMetaTableMixin, Generic[T, C]):
         resp = method(self.get_suffix(entity), data=data.json())
         return entity_class(**resp)
 
-    def get_by_name(self, entity: Type[T], fqdn: str) -> Optional[T]:
+    def get_by_name(
+        self, entity: Type[T], fqdn: str, fields: Optional[List[str]] = None
+    ) -> Optional[T]:
         """
         Return entity by name or None
         """
 
-        return self._get(entity=entity, path=f"name/{fqdn}")
+        return self._get(entity=entity, path=f"name/{fqdn}", fields=fields)
 
-    def get_by_id(self, entity: Type[T], entity_id: str) -> Optional[T]:
+    def get_by_id(
+        self, entity: Type[T], entity_id: str, fields: Optional[List[str]] = None
+    ) -> Optional[T]:
         """
         Return entity by ID or None
         """
 
-        return self._get(entity=entity, path=entity_id)
+        return self._get(entity=entity, path=entity_id, fields=fields)
 
-    def _get(self, entity: Type[T], path: str) -> Optional[T]:
+    def _get(
+        self, entity: Type[T], path: str, fields: Optional[List[str]] = None
+    ) -> Optional[T]:
         """
         Generic GET operation for an entity
         :param entity: Entity Class
         :param path: URL suffix by FQDN or ID
+        :param fields: List of fields to return
         """
+        fields_str = "?fields=" + ",".join(fields) if fields else ""
         try:
-            resp = self.client.get(f"{self.get_suffix(entity)}/{path}")
+            resp = self.client.get(f"{self.get_suffix(entity)}/{path}{fields_str}")
             return entity(**resp)
         except APIError as err:
             logger.error(

--- a/ingestion/tests/integration/ometa/test_ometa_model_api.py
+++ b/ingestion/tests/integration/ometa/test_ometa_model_api.py
@@ -65,6 +65,20 @@ class OMetaModelTest(TestCase):
         self.assertEqual(res_create.id, res.id)
         self.assertEqual(res.owner.id, self.user.id)
 
+        # Getting without owner field does not return it by default
+        res_none = self.metadata.get_by_name(
+            entity=Model, fqdn=self.entity.fullyQualifiedName
+        )
+        self.assertIsNone(res_none.owner)
+
+        # We can request specific fields to be added
+        res_owner = self.metadata.get_by_name(
+            entity=Model,
+            fqdn=self.entity.fullyQualifiedName,
+            fields=["owner", "followers"],
+        )
+        self.assertEqual(res_owner.owner.id, self.user.id)
+
     def test_get_name(self):
         """
         We can fetch a model by name and get it back as Entity
@@ -129,7 +143,7 @@ class OMetaModelTest(TestCase):
 
         # Then we should not find it
         res = self.metadata.list_entities(entity=Model)
-        print(res)
+
         assert not next(
             iter(
                 ent


### PR DESCRIPTION
### Describe your changes :
Small addition that fixes #999.

We are adding the possibility of passing a `fields` list as a parameter for GET requests in the high-level API.

Thanks!

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@harshach @ayush-shah 
