### PR TITLE
Fix topic partition count min to be an integer instead of string

### DIFF
--- a/catalog-rest-service/src/main/resources/json/schema/entity/data/topic.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/data/topic.json
@@ -86,7 +86,7 @@
     "partitions" : {
       "description" : "Number of partitions into which the topic is divided.",
       "type" : "integer",
-      "minimum": "1"
+      "minimum": 1
     },
     "schemaText" : {
       "description" : "Schema used for message serialization. Optional as some topics may not have associated schemas.",


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on this due to #1062


### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
@sureshms @harshach
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
