### PR TITLE
Fix : #1047 Lineage and Dataprofiler should show helpful text when there is no data available.

### DIFF
--- a/catalog-rest-service/src/main/resources/ui/src/components/EntityLineage/EntityLineage.component.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/components/EntityLineage/EntityLineage.component.tsx
@@ -18,6 +18,7 @@ import ReactFlow, {
   ReactFlowProvider,
   removeElements,
 } from 'react-flow-renderer';
+import { Link } from 'react-router-dom';
 import {
   Edge as LineageEdge,
   EntityLineage,
@@ -382,7 +383,19 @@ const Entitylineage: FunctionComponent<{ entityLineage: EntityLineage }> = ({
           </ReactFlowProvider>
         ) : (
           <div className="tw-mt-4 tw-ml-4 tw-flex tw-justify-center tw-font-medium tw-items-center tw-border tw-border-main tw-rounded-md tw-p-8">
-            No Lineage data available
+            <span>
+              Lineage is currently supported for Airflow. To enable lineage
+              collection from Airflow, Please follow the docs
+            </span>
+            <Link
+              className="tw-ml-1"
+              target="_blank"
+              to={{
+                pathname:
+                  'https://docs.open-metadata.org/install/metadata-ingestion/airflow/configure-airflow-lineage',
+              }}>
+              here
+            </Link>
           </div>
         )}
       </div>

--- a/catalog-rest-service/src/main/resources/ui/src/components/EntityLineage/EntityLineage.component.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/components/EntityLineage/EntityLineage.component.tsx
@@ -385,7 +385,7 @@ const Entitylineage: FunctionComponent<{ entityLineage: EntityLineage }> = ({
           <div className="tw-mt-4 tw-ml-4 tw-flex tw-justify-center tw-font-medium tw-items-center tw-border tw-border-main tw-rounded-md tw-p-8">
             <span>
               Lineage is currently supported for Airflow. To enable lineage
-              collection from Airflow, Please follow the docs
+              collection from Airflow, Please follow the documentation
             </span>
             <Link
               className="tw-ml-1"

--- a/catalog-rest-service/src/main/resources/ui/src/components/TableProfiler/TableProfiler.component.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/components/TableProfiler/TableProfiler.component.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import React, { Fragment, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { Table, TableProfile } from '../../generated/entity/data/table';
 import TableProfilerGraph from './TableProfilerGraph.component';
 
@@ -184,7 +185,19 @@ const TableProfiler = ({ tableProfiles, columns }: Props) => {
         </table>
       ) : (
         <div className="tw-mt-4 tw-ml-4 tw-flex tw-justify-center tw-font-medium tw-items-center tw-border tw-border-main tw-rounded-md tw-p-8">
-          No profiler data available
+          <span>
+            Data Profiler optional configuration in Ingestion. Please enable the
+            data profiler by following the documentation
+          </span>
+          <Link
+            className="tw-ml-1"
+            target="_blank"
+            to={{
+              pathname:
+                'https://docs.open-metadata.org/openmetadata/connectors',
+            }}>
+            here
+          </Link>
         </div>
       )}
     </>

--- a/catalog-rest-service/src/main/resources/ui/src/components/TableProfiler/TableProfiler.component.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/components/TableProfiler/TableProfiler.component.tsx
@@ -186,8 +186,8 @@ const TableProfiler = ({ tableProfiles, columns }: Props) => {
       ) : (
         <div className="tw-mt-4 tw-ml-4 tw-flex tw-justify-center tw-font-medium tw-items-center tw-border tw-border-main tw-rounded-md tw-p-8">
           <span>
-            Data Profiler optional configuration in Ingestion. Please enable the
-            data profiler by following the documentation
+            Data Profiler is an optional configuration in Ingestion. Please
+            enable the data profiler by following the documentation
           </span>
           <Link
             className="tw-ml-1"


### PR DESCRIPTION
Fixes #1047 

### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the Lineage and Dataprofiler because need to add helpful text when there is no data available.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] Improvement


#
### Frontend Preview (Screenshots) :
Profiler
![image](https://user-images.githubusercontent.com/59080942/140632939-60953ec4-9f81-45d5-8e24-59ff48c549f0.png)


Lineage
![image](https://user-images.githubusercontent.com/59080942/140632975-9c9af86d-c12a-4c9b-88f9-02a562ea3b4a.png)


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@shahsank3t, @darth-coder00
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
