### PR TITLE
Fix: search-query bug on initial page load

### DIFF
--- a/catalog-rest-service/src/main/resources/ui/src/components/Explore/Explore.component.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/components/Explore/Explore.component.tsx
@@ -42,6 +42,7 @@ import {
   getAggrWithDefaultValue,
   getCurrentIndex,
   getCurrentTab,
+  getQueryParam,
   INITIAL_SORT_FIELD,
   INITIAL_SORT_ORDER,
   tabsInfo,
@@ -56,24 +57,6 @@ import { getFilterString } from '../../utils/FilterUtils';
 import { dropdownIcon as DropDownIcon } from '../../utils/svgconstant';
 import SVGIcons from '../../utils/SvgUtils';
 import { ExploreProps } from './explore.interface';
-
-const getQueryParam = (urlSearchQuery = ''): FilterObject => {
-  const arrSearchQuery = urlSearchQuery
-    ? urlSearchQuery.startsWith('?')
-      ? urlSearchQuery.substr(1).split('&')
-      : urlSearchQuery.split('&')
-    : [];
-
-  return arrSearchQuery
-    .map((filter) => {
-      const arrFilter = filter.split('=');
-
-      return { [arrFilter[0]]: [arrFilter[1]] };
-    })
-    .reduce((prev, curr) => {
-      return Object.assign(prev, curr);
-    }, {}) as FilterObject;
-};
 
 const Explore: React.FC<ExploreProps> = ({
   tabCounts,

--- a/catalog-rest-service/src/main/resources/ui/src/constants/explore.constants.ts
+++ b/catalog-rest-service/src/main/resources/ui/src/constants/explore.constants.ts
@@ -16,7 +16,7 @@
 */
 
 import { lowerCase } from 'lodash';
-import { AggregationType, Bucket } from 'Models';
+import { AggregationType, Bucket, FilterObject } from 'Models';
 import { SearchIndex } from '../enums/search.enum';
 import { Icons } from '../utils/SvgUtils';
 import { tableSortingFields, tiers, topicSortingFields } from './constants';
@@ -40,6 +40,24 @@ export const getBucketList = (buckets: Array<Bucket>) => {
   });
 
   return bucketList ?? [];
+};
+
+export const getQueryParam = (urlSearchQuery = ''): FilterObject => {
+  const arrSearchQuery = urlSearchQuery
+    ? urlSearchQuery.startsWith('?')
+      ? urlSearchQuery.substr(1).split('&')
+      : urlSearchQuery.split('&')
+    : [];
+
+  return arrSearchQuery
+    .map((filter) => {
+      const arrFilter = filter.split('=');
+
+      return { [arrFilter[0]]: [arrFilter[1]] };
+    })
+    .reduce((prev, curr) => {
+      return Object.assign(prev, curr);
+    }, {}) as FilterObject;
 };
 
 export const getAggrWithDefaultValue = (

--- a/catalog-rest-service/src/main/resources/ui/src/pages/explore/ExplorePage.component.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/pages/explore/ExplorePage.component.tsx
@@ -32,6 +32,7 @@ import {
   emptyValue,
   getCurrentIndex,
   getCurrentTab,
+  getQueryParam,
   INITIAL_FROM,
   INITIAL_SORT_FIELD,
   INITIAL_SORT_ORDER,
@@ -39,6 +40,7 @@ import {
   ZERO_SIZE,
 } from '../../constants/explore.constants';
 import { SearchIndex } from '../../enums/search.enum';
+import { getFilterString } from '../../utils/FilterUtils';
 import { getTotalEntityCountByService } from '../../utils/ServiceUtils';
 
 const ExplorePage: FunctionComponent = () => {
@@ -187,7 +189,7 @@ const ExplorePage: FunctionComponent = () => {
         queryString: searchText,
         from: INITIAL_FROM,
         size: PAGE_SIZE,
-        filters: emptyValue,
+        filters: getFilterString(getQueryParam(location.search)),
         sortField: initialSortField,
         sortOrder: INITIAL_SORT_ORDER,
         searchIndex: getCurrentIndex(tab),
@@ -196,7 +198,7 @@ const ExplorePage: FunctionComponent = () => {
         queryString: searchText,
         from: INITIAL_FROM,
         size: ZERO_SIZE,
-        filters: emptyValue,
+        filters: getFilterString(getQueryParam(location.search)),
         sortField: initialSortField,
         sortOrder: INITIAL_SORT_ORDER,
         searchIndex: getCurrentIndex(tab),
@@ -205,7 +207,7 @@ const ExplorePage: FunctionComponent = () => {
         queryString: searchText,
         from: INITIAL_FROM,
         size: ZERO_SIZE,
-        filters: emptyValue,
+        filters: getFilterString(getQueryParam(location.search)),
         sortField: initialSortField,
         sortOrder: INITIAL_SORT_ORDER,
         searchIndex: getCurrentIndex(tab),
@@ -214,7 +216,7 @@ const ExplorePage: FunctionComponent = () => {
         queryString: searchText,
         from: INITIAL_FROM,
         size: ZERO_SIZE,
-        filters: emptyValue,
+        filters: getFilterString(getQueryParam(location.search)),
         sortField: initialSortField,
         sortOrder: INITIAL_SORT_ORDER,
         searchIndex: getCurrentIndex(tab),


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Resolved bug related to the search query on initial load

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
 Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya 
