### PR TITLE
Fix: API call onClick of explore link from explore page

### DIFF
--- a/catalog-rest-service/src/main/resources/ui/src/components/Explore/Explore.test.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/components/Explore/Explore.test.tsx
@@ -40,13 +40,7 @@ jest.mock('../../components/searched-data/SearchedData', () => {
     ));
 });
 
-const handleSearchText = jest.fn();
-const updateTableCount = jest.fn();
-const updateTopicCount = jest.fn();
-const updateDashboardCount = jest.fn();
-const updatePipelineCount = jest.fn();
-const handlePathChange = jest.fn();
-const fetchData = jest.fn();
+const mockFunction = jest.fn();
 
 const mockSearchResult = {
   resSearchResults: mockResponse as unknown as SearchResponse,
@@ -60,9 +54,10 @@ describe('Test Explore component', () => {
     const { container } = render(
       <Explore
         error=""
-        fetchData={fetchData}
-        handlePathChange={handlePathChange}
-        handleSearchText={handleSearchText}
+        fetchCount={mockFunction}
+        fetchData={mockFunction}
+        handlePathChange={mockFunction}
+        handleSearchText={mockFunction}
         searchQuery=""
         searchResult={mockSearchResult}
         searchText=""
@@ -74,10 +69,10 @@ describe('Test Explore component', () => {
           dashboard: 8,
           pipeline: 5,
         }}
-        updateDashboardCount={updateDashboardCount}
-        updatePipelineCount={updatePipelineCount}
-        updateTableCount={updateTableCount}
-        updateTopicCount={updateTopicCount}
+        updateDashboardCount={mockFunction}
+        updatePipelineCount={mockFunction}
+        updateTableCount={mockFunction}
+        updateTopicCount={mockFunction}
       />,
       {
         wrapper: MemoryRouter,

--- a/catalog-rest-service/src/main/resources/ui/src/components/Explore/explore.interface.ts
+++ b/catalog-rest-service/src/main/resources/ui/src/components/Explore/explore.interface.ts
@@ -41,6 +41,7 @@ export interface ExploreProps {
   tab: string;
   error: string;
   searchQuery: string;
+  fetchCount: () => void;
   handlePathChange: (path: string) => void;
   handleSearchText: (text: string) => void;
   updateTableCount: (count: number) => void;

--- a/catalog-rest-service/src/main/resources/ui/src/pages/explore/ExplorePage.component.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/pages/explore/ExplorePage.component.tsx
@@ -44,6 +44,7 @@ import { getFilterString } from '../../utils/FilterUtils';
 import { getTotalEntityCountByService } from '../../utils/ServiceUtils';
 
 const ExplorePage: FunctionComponent = () => {
+  const initialFilter = getFilterString(getQueryParam(location.search));
   const [isLoading, setIsLoading] = useState(true);
   const [isLoadingForData, setIsLoadingForData] = useState(true);
   const [error, setError] = useState<string>('');
@@ -93,7 +94,15 @@ const ExplorePage: FunctionComponent = () => {
     ];
 
     const entityCounts = entities.map((entity) =>
-      searchData(searchText, 0, 0, emptyValue, emptyValue, emptyValue, entity)
+      searchData(
+        searchText,
+        0,
+        0,
+        initialFilter,
+        emptyValue,
+        emptyValue,
+        entity
+      )
     );
 
     Promise.allSettled(entityCounts)
@@ -189,7 +198,7 @@ const ExplorePage: FunctionComponent = () => {
         queryString: searchText,
         from: INITIAL_FROM,
         size: PAGE_SIZE,
-        filters: getFilterString(getQueryParam(location.search)),
+        filters: initialFilter,
         sortField: initialSortField,
         sortOrder: INITIAL_SORT_ORDER,
         searchIndex: getCurrentIndex(tab),
@@ -198,7 +207,7 @@ const ExplorePage: FunctionComponent = () => {
         queryString: searchText,
         from: INITIAL_FROM,
         size: ZERO_SIZE,
-        filters: getFilterString(getQueryParam(location.search)),
+        filters: initialFilter,
         sortField: initialSortField,
         sortOrder: INITIAL_SORT_ORDER,
         searchIndex: getCurrentIndex(tab),
@@ -207,7 +216,7 @@ const ExplorePage: FunctionComponent = () => {
         queryString: searchText,
         from: INITIAL_FROM,
         size: ZERO_SIZE,
-        filters: getFilterString(getQueryParam(location.search)),
+        filters: initialFilter,
         sortField: initialSortField,
         sortOrder: INITIAL_SORT_ORDER,
         searchIndex: getCurrentIndex(tab),
@@ -216,7 +225,7 @@ const ExplorePage: FunctionComponent = () => {
         queryString: searchText,
         from: INITIAL_FROM,
         size: ZERO_SIZE,
-        filters: getFilterString(getQueryParam(location.search)),
+        filters: initialFilter,
         sortField: initialSortField,
         sortOrder: INITIAL_SORT_ORDER,
         searchIndex: getCurrentIndex(tab),
@@ -231,6 +240,7 @@ const ExplorePage: FunctionComponent = () => {
       ) : (
         <Explore
           error={error}
+          fetchCount={fetchCounts}
           fetchData={fetchData}
           handlePathChange={handlePathChange}
           handleSearchText={handleSearchText}


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
- I worked on this because If we click on explore page, and switch to another tab and change the filter like click on Tier1 then if we click on explore again, it calls api with filters (Tier1).
- tab count issue fixed
- fix failing test

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya 
