### PR TITLE
fix: filter goes blank on click of any filter value

### DIFF
--- a/catalog-rest-service/src/main/resources/ui/src/components/Explore/Explore.component.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/components/Explore/Explore.component.tsx
@@ -16,7 +16,7 @@
 */
 
 import classNames from 'classnames';
-import { cloneDeep } from 'lodash';
+import { cloneDeep, isUndefined } from 'lodash';
 import {
   AggregationType,
   FilterObject,
@@ -456,7 +456,7 @@ const Explore: React.FC<ExploreProps> = ({
 
   useEffect(() => {
     if (!isMounting.current && previsouIndex === getCurrentIndex(tab)) {
-      forceSetAgg.current = Boolean(searchIndex);
+      forceSetAgg.current = isUndefined(tab);
       fetchTableData();
     }
   }, [currentPage, filters, sortField, sortOrder]);


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on this because the Filter part goes blank on click of any filter option

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
@shahsank3t, @darth-coder00, @Sachin-chaurasiya
