### PR TITLE
Fix: made whole area clickable for drop-down box

### DIFF
--- a/catalog-rest-service/src/main/resources/ui/src/components/app-bar/Appbar.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/components/app-bar/Appbar.tsx
@@ -297,6 +297,7 @@ const Appbar: React.FC = (): JSX.Element => {
                     to: '',
                     disabled: false,
                     icon: <></>,
+                    isVersion: true,
                   },
                   {
                     name: 'Logout',

--- a/catalog-rest-service/src/main/resources/ui/src/components/dropdown/AnchorDropDownList.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/components/dropdown/AnchorDropDownList.tsx
@@ -37,61 +37,68 @@ const AnchorDropDownList = ({ dropDownList, setIsOpen }: DropDownListProp) => {
         role="menu">
         <div className="py-1" role="none">
           {dropDownList.map((item: DropDownListItem, index: number) => (
-            <Link
-              aria-disabled={item.disabled}
-              className={classNames(
-                'tw-block tw-py-2 hover:tw-bg-body-hover ',
-                {
-                  'link-text': !item.icon,
-                }
-              )}
-              data-testid={`menu-item-${item.name}`}
-              id={`menu-item-${index}`}
-              key={index}
-              role="menuitem"
-              target={item.isOpenNewTab ? '_blank' : '_self'}
-              to={{ pathname: item.to }}
-              onClick={() => {
-                item.method && item.method();
-                setIsOpen && setIsOpen(false);
-              }}>
-              <div className="tw-flex tw-gap-1 tw-px-2">
-                {item.icon && item.icon}
-                {item.icon ? (
-                  <button className="tw-text-grey-body">
-                    {item.isOpenNewTab ? (
-                      <span className="tw-flex">
-                        <span className="tw-mr-1">{item.name}</span>
-                        <SVGIcons
-                          alt="external-link"
-                          className="tw-align-middle"
-                          icon="external-link"
-                          width="12px"
-                        />
-                      </span>
+            <div key={index}>
+              {item.isVersion ? (
+                <div className="tw-px-2 tw-py-2 tw-font-normal">
+                  {item.name}
+                </div>
+              ) : (
+                <Link
+                  aria-disabled={item.disabled}
+                  className={classNames(
+                    'tw-block tw-py-2 hover:tw-bg-body-hover ',
+                    {
+                      'link-text': !item.icon,
+                    }
+                  )}
+                  data-testid={`menu-item-${item.name}`}
+                  id={`menu-item-${index}`}
+                  role="menuitem"
+                  target={item.isOpenNewTab ? '_blank' : '_self'}
+                  to={{ pathname: item.to }}
+                  onClick={() => {
+                    item.method && item.method();
+                    setIsOpen && setIsOpen(false);
+                  }}>
+                  <div className="tw-flex tw-gap-1 tw-px-2">
+                    {item.icon && item.icon}
+                    {item.icon ? (
+                      <button className="tw-text-grey-body">
+                        {item.isOpenNewTab ? (
+                          <span className="tw-flex">
+                            <span className="tw-mr-1">{item.name}</span>
+                            <SVGIcons
+                              alt="external-link"
+                              className="tw-align-middle"
+                              icon="external-link"
+                              width="12px"
+                            />
+                          </span>
+                        ) : (
+                          item.name
+                        )}{' '}
+                      </button>
                     ) : (
-                      item.name
-                    )}{' '}
-                  </button>
-                ) : (
-                  <>
-                    {item.isOpenNewTab ? (
-                      <span className="tw-flex">
-                        <span className="tw-mr-1">{item.name}</span>
-                        <SVGIcons
-                          alt="external-link"
-                          className="tw-align-middle"
-                          icon="external-link"
-                          width="12px"
-                        />
-                      </span>
-                    ) : (
-                      item.name
+                      <>
+                        {item.isOpenNewTab ? (
+                          <span className="tw-flex">
+                            <span className="tw-mr-1">{item.name}</span>
+                            <SVGIcons
+                              alt="external-link"
+                              className="tw-align-middle"
+                              icon="external-link"
+                              width="12px"
+                            />
+                          </span>
+                        ) : (
+                          item.name
+                        )}
+                      </>
                     )}
-                  </>
-                )}
-              </div>
-            </Link>
+                  </div>
+                </Link>
+              )}
+            </div>
           ))}
         </div>
       </div>

--- a/catalog-rest-service/src/main/resources/ui/src/components/dropdown/AnchorDropDownList.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/components/dropdown/AnchorDropDownList.tsx
@@ -32,29 +32,31 @@ const AnchorDropDownList = ({ dropDownList, setIsOpen }: DropDownListProp) => {
         aria-labelledby="menu-button"
         aria-orientation="vertical"
         className="tw-origin-top-right tw-absolute tw-z-10
-              tw-right-0 tw-mt-2 tw-w-32 tw-rounded-md tw-shadow-lg 
+              tw-right-0 tw-mt-2 tw-w-32 tw-rounded-md tw-shadow-lg
               tw-bg-white tw-ring-1 tw-ring-black tw-ring-opacity-5 focus:tw-outline-none"
         role="menu">
         <div className="py-1" role="none">
           {dropDownList.map((item: DropDownListItem, index: number) => (
-            <div
-              className="tw-flex tw-gap-1 hover:tw-bg-body-hover tw-px-2"
-              key={index}>
-              {item.icon && item.icon}
-              <Link
-                aria-disabled={item.disabled}
-                className={classNames('tw-block tw-py-2 ', {
+            <Link
+              aria-disabled={item.disabled}
+              className={classNames(
+                'tw-block tw-py-2 hover:tw-bg-body-hover ',
+                {
                   'link-text': !item.icon,
-                })}
-                data-testid={`menu-item-${item.name}`}
-                id={`menu-item-${index}`}
-                role="menuitem"
-                target={item.isOpenNewTab ? '_blank' : '_self'}
-                to={{ pathname: item.to }}
-                onClick={() => {
-                  item.method && item.method();
-                  setIsOpen && setIsOpen(false);
-                }}>
+                }
+              )}
+              data-testid={`menu-item-${item.name}`}
+              id={`menu-item-${index}`}
+              key={index}
+              role="menuitem"
+              target={item.isOpenNewTab ? '_blank' : '_self'}
+              to={{ pathname: item.to }}
+              onClick={() => {
+                item.method && item.method();
+                setIsOpen && setIsOpen(false);
+              }}>
+              <div className="tw-flex tw-gap-1 tw-px-2">
+                {item.icon && item.icon}
                 {item.icon ? (
                   <button className="tw-text-grey-body">
                     {item.isOpenNewTab ? (
@@ -88,8 +90,8 @@ const AnchorDropDownList = ({ dropDownList, setIsOpen }: DropDownListProp) => {
                     )}
                   </>
                 )}
-              </Link>
-            </div>
+              </div>
+            </Link>
           ))}
         </div>
       </div>

--- a/catalog-rest-service/src/main/resources/ui/src/components/dropdown/types.ts
+++ b/catalog-rest-service/src/main/resources/ui/src/components/dropdown/types.ts
@@ -32,6 +32,7 @@ export type DropDownListItem = {
   method?: () => void;
   icon?: React.ReactElement;
   isOpenNewTab?: boolean;
+  isVersion?: boolean;
 } & Record<
   string,
   string | number | boolean | undefined | Function | React.ReactElement


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the #1109
Changes:- 
Make the whole area clickable for the drop-down box.
it Closes #1109 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Frontend Preview (Screenshots) :
![image](https://user-images.githubusercontent.com/71748675/141057360-4c1d74e6-0b06-4b18-834a-828d47d00033.png)
![image](https://user-images.githubusercontent.com/71748675/141057407-7b428631-9cbd-4821-8db1-5490292eaac3.png)


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya 
