### PR TITLE
Fix: Add support of auto positioning for tag's drop-down 

### DIFF
--- a/catalog-rest-service/src/main/resources/ui/src/components/dropdown/DropDownList.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/components/dropdown/DropDownList.tsx
@@ -16,9 +16,11 @@
 */
 
 import classNames from 'classnames';
-import { isNil, lowerCase } from 'lodash';
+import { isNil, isUndefined, lowerCase } from 'lodash';
 import React, { FunctionComponent, useEffect, useRef, useState } from 'react';
+import { useWindowDimensions } from '../../hooks/useWindowDimensions';
 import { getCountBadge } from '../../utils/CommonUtils';
+import { getTopPosition } from '../../utils/DropDownUtils';
 import { DropDownListItem, DropDownListProp } from './types';
 
 const DropDownList: FunctionComponent<DropDownListProp> = ({
@@ -30,10 +32,15 @@ const DropDownList: FunctionComponent<DropDownListProp> = ({
   value,
   onSelect,
   groupType = 'label',
+  domPosition,
 }: DropDownListProp) => {
+  const { height: windowHeight } = useWindowDimensions();
   const isMounted = useRef<boolean>(false);
   const [searchedList, setSearchedList] = useState(dropDownList);
   const [searchText, setSearchText] = useState(searchString);
+  const [dropDownPosition, setDropDownPosition] = useState<
+    { bottom: string } | {}
+  >({});
 
   const setCurrentTabOnMount = () => {
     const selectedItem = dropDownList.find((l) => l.value === value);
@@ -110,6 +117,14 @@ const DropDownList: FunctionComponent<DropDownListProp> = ({
   }, [searchText]);
 
   useEffect(() => {
+    if (!isUndefined(domPosition)) {
+      setDropDownPosition(
+        getTopPosition(windowHeight, domPosition.bottom, domPosition.height)
+      );
+    }
+  }, [domPosition, searchText]);
+
+  useEffect(() => {
     setActiveTab(setCurrentTabOnMount());
     isMounted.current = true;
   }, []);
@@ -134,7 +149,8 @@ const DropDownList: FunctionComponent<DropDownListProp> = ({
               horzPosRight ? 'dd-horz-right' : 'dd-horz-left'
             )}
             data-testid="dropdown-list"
-            role="menu">
+            role="menu"
+            style={dropDownPosition}>
             {showSearchBar && (
               <div className="has-search tw-p-4 tw-pb-2">
                 <input

--- a/catalog-rest-service/src/main/resources/ui/src/components/dropdown/types.ts
+++ b/catalog-rest-service/src/main/resources/ui/src/components/dropdown/types.ts
@@ -53,6 +53,7 @@ export type DropDownListProp = {
   ) => void;
   setIsOpen?: (value: boolean) => void;
   groupType?: GroupType;
+  domPosition?: DOMRect;
 };
 
 export type DropDownProp = {

--- a/catalog-rest-service/src/main/resources/ui/src/components/tags-container/tags-container.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/components/tags-container/tags-container.tsx
@@ -16,7 +16,7 @@
 */
 
 import classNames from 'classnames';
-import { capitalize, isEmpty } from 'lodash';
+import { capitalize, isEmpty, isNull } from 'lodash';
 import { EntityTags } from 'Models';
 import React, { FunctionComponent, useEffect, useRef, useState } from 'react';
 import { Button } from '../buttons/Button/Button';
@@ -43,6 +43,7 @@ const TagsContainer: FunctionComponent<TagsContainerProps> = ({
   const [hasFocus, setFocus] = useState<boolean>(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const node = useRef<HTMLDivElement>(null);
+  const [inputDomRect, setInputDomRect] = useState<DOMRect>();
   // const [inputWidth, setInputWidth] = useState(INPUT_COLLAPED);
   // const [inputMinWidth, setInputMinWidth] = useState(INPUT_AUTO);
 
@@ -63,6 +64,12 @@ const TagsContainer: FunctionComponent<TagsContainerProps> = ({
       setFocus(true);
     }
   };
+
+  useEffect(() => {
+    if (!isNull(inputRef.current)) {
+      setInputDomRect(inputRef.current.getBoundingClientRect());
+    }
+  }, [newTag]);
 
   const getTagList = () => {
     const newTags = tagList
@@ -227,6 +234,7 @@ const TagsContainer: FunctionComponent<TagsContainerProps> = ({
             {newTag && (
               <DropDownList
                 horzPosRight
+                domPosition={inputDomRect}
                 dropDownList={getTagList()}
                 searchString={newTag}
                 onSelect={handleTagSelection}

--- a/catalog-rest-service/src/main/resources/ui/src/hooks/useWindowDimensions.ts
+++ b/catalog-rest-service/src/main/resources/ui/src/hooks/useWindowDimensions.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+
+function getWindowDimensions() {
+  const { innerWidth: width, innerHeight: height } = window;
+
+  return {
+    width,
+    height,
+  };
+}
+
+export function useWindowDimensions() {
+  const [windowDimensions, setWindowDimensions] = useState(
+    getWindowDimensions()
+  );
+
+  useEffect(() => {
+    function handleResize() {
+      setWindowDimensions(getWindowDimensions());
+    }
+
+    window.addEventListener('resize', handleResize);
+
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return windowDimensions;
+}

--- a/catalog-rest-service/src/main/resources/ui/src/utils/DropDownUtils.ts
+++ b/catalog-rest-service/src/main/resources/ui/src/utils/DropDownUtils.ts
@@ -1,4 +1,4 @@
-const BUFFER_VALUE = 150;
+const BUFFER_VALUE = 200;
 const GAP = 10;
 
 export const getTopPosition = (

--- a/catalog-rest-service/src/main/resources/ui/src/utils/DropDownUtils.ts
+++ b/catalog-rest-service/src/main/resources/ui/src/utils/DropDownUtils.ts
@@ -1,0 +1,12 @@
+const BUFFER_VALUE = 150;
+const GAP = 10;
+
+export const getTopPosition = (
+  windowHeight: number,
+  bottomPosition: number,
+  elementHeight: number
+) => {
+  const bottomSpace = windowHeight - (bottomPosition + BUFFER_VALUE);
+
+  return bottomSpace < 0 ? { bottom: `${elementHeight + GAP}px` } : {};
+};


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on this because Tags listing overlaps with bottom panel #1131 
Changes:-
- Add support to the auto-adjust  position of drop-down

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement
- [x] New feature


#
### Frontend Preview (Screenshots) :
![image](https://user-images.githubusercontent.com/71748675/141474006-8b88ce7f-bb4a-4ef3-bb02-0033470bc833.png)
![image](https://user-images.githubusercontent.com/71748675/141474141-09d13a6c-66e6-492d-9d73-6b4f551acd0b.png)


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya
