### PR TITLE
feat: Docker Image Push Workflow

### DIFF
--- a/.github/workflows/docker-openmetadata-db.yml
+++ b/.github/workflows/docker-openmetadata-db.yml
@@ -1,0 +1,33 @@
+name: docker-openmetadata-db docker
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_docker_hub:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the Repo
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_OPENMETADATA_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_OPENMETADATA_TOKEN }}
+      
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'release' }}
+          # Update tags before every release
+          tags: 'openmetadata/db:0.6.0,openmetadata/db:latest'
+          file: ./docker/local-metadata/Dockerfile_mysql

--- a/.github/workflows/docker-openmetadata-ingestion.yml
+++ b/.github/workflows/docker-openmetadata-ingestion.yml
@@ -1,0 +1,33 @@
+name: docker-openmetadata-ingestion docker
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_docker_hub:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the Repo
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_OPENMETADATA_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_OPENMETADATA_TOKEN }}
+      
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'release' }}
+          # Update tags before every release
+          tags: 'openmetadata/ingestion:0.6.0,openmetadata/ingestion:latest'
+          file: ./ingestion/Dockerfile

--- a/.github/workflows/docker-openmetadata-server.yml
+++ b/.github/workflows/docker-openmetadata-server.yml
@@ -1,0 +1,33 @@
+name: docker-openmetadata-server docker
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_docker_hub:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the Repo
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_OPENMETADATA_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_OPENMETADATA_TOKEN }}
+      
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'release' }}
+          # Update tags before every release
+          tags: 'openmetadata/server:0.6.0,openmetadata/server:latest'
+          file: ./docker/metadata/Dockerfile

--- a/docker/local-metadata/Dockerfile_mysql
+++ b/docker/local-metadata/Dockerfile_mysql
@@ -1,4 +1,4 @@
 FROM mysql/mysql-server:latest
 WORKDIR /docker-entrypoint-initdb.d
-COPY mysql-script.sql .
+COPY docker/local-metadata/mysql-script.sql .
 RUN chmod -R 775 /docker-entrypoint-initdb.d


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->

This PR fixes bug in Dockerfile_msql to build with root context as every other dockerfile is configured.

This PR also adds feature for Docker Hub Image Push workflow for openmetadata/server, openmetadata/db, openmetadata/ingestion on New Release Publishes.

@harshach , @shahsank3t  - We will require github repository secrets to be created to login to docker hub. Let's connect on getting that setup as I do not have access to create those.

Secrets Configuration -
- DOCKERHUB_OPENMETADATA_USERNAME
- DOCKERHUB_OPENMETADATA_TOKEN

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [x] New feature

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.