### PR TITLE
Bug fix for location findEntityReferenceById

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/TableRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/TableRepository.java
@@ -102,7 +102,7 @@ public class TableRepository extends EntityRepository<Table> {
     table.setSampleData(fields.contains("sampleData") ? getSampleData(table) : null);
     table.setViewDefinition(fields.contains("viewDefinition") ? table.getViewDefinition() : null);
     table.setTableProfile(fields.contains("tableProfile") ? getTableProfile(table) : null);
-    table.setLocation(fields.contains("location") ? getLocation(table): null);
+    table.setLocation(fields.contains("location") ? getLocation(table.getId()): null);
     table.setTableQueries(fields.contains("tableQueries") ? getQueries(table): null);
     return table;
   }
@@ -374,13 +374,11 @@ public class TableRepository extends EntityRepository<Table> {
     return dao.databaseDAO().findEntityReferenceById(UUID.fromString(result.get(0)));
   }
 
-  private EntityReference getLocation(Table table) throws IOException {
-    // Find database for the table
-    String id = table.getId().toString();
-    List<String> result = dao.relationshipDAO().findTo(id, Relationship.HAS.ordinal(), Entity.LOCATION);
+  private EntityReference getLocation(UUID tableId) throws IOException {
+    // Find the location of the table
+    List<String> result = dao.relationshipDAO().findTo(tableId.toString(), Relationship.HAS.ordinal(), Entity.LOCATION);
     if (result.size() == 1) {
-      Location location = dao.locationDAO().findEntityById(UUID.fromString(result.get(0)));
-      return new EntityReference().withName(location.getName()).withId(location.getId()).withType("location");
+      return dao.locationDAO().findEntityReferenceById(UUID.fromString(result.get(0)));
     } else {
       return null;
     }

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/util/TestUtils.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/util/TestUtils.java
@@ -222,13 +222,10 @@ public final class TestUtils {
     assertNotNull(ref.getName());
     assertNotNull(ref.getType());
     // Ensure data entities use fully qualified name
-    if (List.of("table", "database", "metrics", "dashboard", "pipeline", "report", "topic", "chart")
+    if (List.of("table", "database", "metrics", "dashboard", "pipeline", "report", "topic", "chart", "location")
             .contains(ref.getType())) {
       // FullyQualifiedName has "." as separator
       assertTrue(ref.getName().contains("."), "entity name is not fully qualified - " + ref.getName());
-    }
-    if (List.of("location").contains(ref.getName())) {
-      ref.getName().contains(":/"); // FullyQualifiedName has ":/" as separator
     }
   }
 


### PR DESCRIPTION

### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Bugfix for location findEntityReferenceById. getName was not returning the FQN. Now location is behaving like the other entities and the service name and the location name are joined using a dot. ```marketing.s3://bucket/dwh/schema/table```. getName was returning ```s3://bucket//dwh/schema/table``` and TestUtils was checking for ```:/``` instead of ```.```. Fixing the test uncovered the bug.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@sureshms @harshach
