### PR TITLE
Fix : #1221 UI: Versioning right panel should wrap the summary.

### DIFF
--- a/catalog-rest-service/src/main/resources/ui/src/components/EntityVersionTimeLine/EntityVersionTimeLine.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/components/EntityVersionTimeLine/EntityVersionTimeLine.tsx
@@ -55,7 +55,7 @@ const EntityVersionTimeLine: React.FC<Props> = ({
                 })}>
                 v{parseFloat(currV?.version).toFixed(1)}
               </p>
-              <div className="tw-text-xs tw-font-normal">
+              <div className="tw-text-xs tw-font-normal tw-break-all">
                 {getSummary(currV?.changeDescription)}
               </div>
               <p className="tw-text-xs tw-italic">

--- a/catalog-rest-service/src/main/resources/ui/src/utils/EntityVersionUtils.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/utils/EntityVersionUtils.tsx
@@ -166,9 +166,9 @@ export const summaryFormatter = (v: FieldChange) => {
       : '{}'
   );
   if (v.name === 'columns') {
-    return `columns ${value?.map((val: any) => val?.name).join(',')}`;
+    return `columns ${value?.map((val: any) => val?.name).join(', ')}`;
   } else if (v.name === 'tags' || v.name?.endsWith('tags')) {
-    return `tags ${value?.map((val: any) => val?.tagFQN)?.join(',')}`;
+    return `tags ${value?.map((val: any) => val?.tagFQN)?.join(', ')}`;
   } else {
     return v.name;
   }
@@ -182,13 +182,19 @@ export const getSummary = (changeDescription: ChangeDescription) => {
   return (
     <Fragment>
       {fieldsAdded?.length > 0 ? (
-        <p>{fieldsAdded?.map(summaryFormatter)} has been added</p>
+        <p className="tw-mb-2">
+          {fieldsAdded?.map(summaryFormatter)} has been added
+        </p>
       ) : null}
       {fieldsUpdated?.length ? (
-        <p>{fieldsUpdated?.map(summaryFormatter)} has been updated</p>
+        <p className="tw-mb-2">
+          {fieldsUpdated?.map(summaryFormatter)} has been updated
+        </p>
       ) : null}
       {fieldsDeleted?.length ? (
-        <p>{fieldsDeleted?.map(summaryFormatter)} has been deleted</p>
+        <p className="tw-mb-2">
+          {fieldsDeleted?.map(summaryFormatter)} has been deleted
+        </p>
       ) : null}
     </Fragment>
   );


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the versioning side panel because need to fix the summary text-overflow styling issue.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :
![image](https://user-images.githubusercontent.com/59080942/142181384-093d7ba8-c9f9-43ea-ac24-fec6a4744ef2.png)


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@shahsank3t, @darth-coder00
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
