### PR TITLE
Fix: description issue where non-admin or non-owner can able to access edit description dialog box in UI

### DIFF
--- a/catalog-rest-service/src/main/resources/ui/src/components/DashboardDetails/DashboardDetails.component.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/components/DashboardDetails/DashboardDetails.component.tsx
@@ -361,30 +361,39 @@ const DashboardDetails = ({
                               {chart.chartType}
                             </td>
                             <td className="tw-group tableBody-cell tw-relative">
-                              <div
-                                className="tw-cursor-pointer hover:tw-underline tw-flex"
-                                data-testid="description"
-                                onClick={() => handleUpdateChart(chart, index)}>
-                                <div>
-                                  {chart.description ? (
-                                    <RichTextEditorPreviewer
-                                      markdown={chart.description}
-                                    />
-                                  ) : (
-                                    <span className="tw-no-description">
-                                      No description added
-                                    </span>
-                                  )}
+                              <NonAdminAction
+                                html={getHtmlForNonAdminAction(Boolean(owner))}
+                                isOwner={hasEditAccess()}
+                                position="top">
+                                <div className="tw-inline-block">
+                                  <div
+                                    className="tw-cursor-pointer hover:tw-underline tw-flex"
+                                    data-testid="description"
+                                    onClick={() =>
+                                      handleUpdateChart(chart, index)
+                                    }>
+                                    <div>
+                                      {chart.description ? (
+                                        <RichTextEditorPreviewer
+                                          markdown={chart.description}
+                                        />
+                                      ) : (
+                                        <span className="tw-no-description">
+                                          No description added
+                                        </span>
+                                      )}
+                                    </div>
+                                    <button className="tw-self-start tw-w-8 tw-h-auto tw-opacity-0 tw-ml-1 group-hover:tw-opacity-100 focus:tw-outline-none">
+                                      <SVGIcons
+                                        alt="edit"
+                                        icon="icon-edit"
+                                        title="Edit"
+                                        width="10px"
+                                      />
+                                    </button>
+                                  </div>
                                 </div>
-                                <button className="tw-self-start tw-w-8 tw-h-auto tw-opacity-0 tw-ml-1 group-hover:tw-opacity-100 focus:tw-outline-none">
-                                  <SVGIcons
-                                    alt="edit"
-                                    icon="icon-edit"
-                                    title="Edit"
-                                    width="10px"
-                                  />
-                                </button>
-                              </div>
+                              </NonAdminAction>
                             </td>
                             <td
                               className="tw-group tw-relative tableBody-cell"

--- a/catalog-rest-service/src/main/resources/ui/src/components/EntityTable/EntityTable.component.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/components/EntityTable/EntityTable.component.tsx
@@ -584,40 +584,47 @@ const EntityTable = ({
                       )}
                       {cell.column.id === 'description' && (
                         <div>
-                          <div
-                            className={classNames('tw-flex', {
-                              'tw-cursor-pointer hover:tw-underline':
-                                !isReadOnly,
-                            })}
-                            data-testid="description"
-                            id={`column-description-${index}`}
-                            onClick={() => {
-                              if (!isReadOnly) {
-                                handleEditColumn(row.original, row.id);
-                              }
-                            }}>
-                            <div>
-                              {cell.value ? (
-                                <RichTextEditorPreviewer
-                                  markdown={cell.value}
-                                />
-                              ) : (
-                                <span className="tw-no-description">
-                                  No description added
-                                </span>
-                              )}
+                          <NonAdminAction
+                            html={getHtmlForNonAdminAction(Boolean(owner))}
+                            isOwner={hasEditAccess}
+                            position="top">
+                            <div className="tw-inline-block">
+                              <div
+                                className={classNames('tw-flex', {
+                                  'tw-cursor-pointer hover:tw-underline':
+                                    !isReadOnly,
+                                })}
+                                data-testid="description"
+                                id={`column-description-${index}`}
+                                onClick={() => {
+                                  if (!isReadOnly) {
+                                    handleEditColumn(row.original, row.id);
+                                  }
+                                }}>
+                                <div>
+                                  {cell.value ? (
+                                    <RichTextEditorPreviewer
+                                      markdown={cell.value}
+                                    />
+                                  ) : (
+                                    <span className="tw-no-description">
+                                      No description added
+                                    </span>
+                                  )}
+                                </div>
+                                {!isReadOnly ? (
+                                  <button className="tw-self-start tw-w-8 tw-h-auto tw-opacity-0 tw-ml-1 group-hover:tw-opacity-100 focus:tw-outline-none">
+                                    <SVGIcons
+                                      alt="edit"
+                                      icon="icon-edit"
+                                      title="Edit"
+                                      width="10px"
+                                    />
+                                  </button>
+                                ) : null}
+                              </div>
                             </div>
-                            {!isReadOnly ? (
-                              <button className="tw-self-start tw-w-8 tw-h-auto tw-opacity-0 tw-ml-1 group-hover:tw-opacity-100 focus:tw-outline-none">
-                                <SVGIcons
-                                  alt="edit"
-                                  icon="icon-edit"
-                                  title="Edit"
-                                  width="10px"
-                                />
-                              </button>
-                            ) : null}
-                          </div>
+                          </NonAdminAction>
                           {checkIfJoinsAvailable(row.original.name) && (
                             <div
                               className="tw-mt-3"

--- a/catalog-rest-service/src/main/resources/ui/src/pages/database-details/index.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/pages/database-details/index.tsx
@@ -32,6 +32,7 @@ import { postFeed } from '../../axiosAPIs/feedsAPI';
 import { getServiceById } from '../../axiosAPIs/serviceAPI';
 import { getDatabaseTables } from '../../axiosAPIs/tableAPI';
 import NextPrevious from '../../components/common/next-previous/NextPrevious';
+import NonAdminAction from '../../components/common/non-admin-action/NonAdminAction';
 import PopOver from '../../components/common/popover/PopOver';
 import RichTextEditorPreviewer from '../../components/common/rich-text-editor/RichTextEditorPreviewer';
 import TitleBreadcrumb from '../../components/common/title-breadcrumb/title-breadcrumb.component';
@@ -45,6 +46,7 @@ import {
   getExplorePathWithSearch,
   getServiceDetailsPath,
   pagingObject,
+  TITLE_FOR_NON_ADMIN_ACTION,
 } from '../../constants/constants';
 import { Database } from '../../generated/entity/data/database';
 import { Table } from '../../generated/entity/data/table';
@@ -258,17 +260,21 @@ const DatabaseDetails: FunctionComponent = () => {
                       Description
                     </span>
                     <div className="tw-flex-initial">
-                      <button
-                        className="focus:tw-outline-none"
-                        data-testid="description-edit-button"
-                        onClick={onDescriptionEdit}>
-                        <SVGIcons
-                          alt="edit"
-                          icon="icon-edit"
-                          title="Edit"
-                          width="12px"
-                        />
-                      </button>
+                      <NonAdminAction
+                        position="left"
+                        title={TITLE_FOR_NON_ADMIN_ACTION}>
+                        <button
+                          className="focus:tw-outline-none"
+                          data-testid="description-edit-button"
+                          onClick={onDescriptionEdit}>
+                          <SVGIcons
+                            alt="edit"
+                            icon="icon-edit"
+                            title="Edit"
+                            width="12px"
+                          />
+                        </button>
+                      </NonAdminAction>
                     </div>
                   </div>
                   <div className="tw-px-3 tw-pl-5 tw-py-2 tw-overflow-y-auto">

--- a/catalog-rest-service/src/main/resources/ui/src/pages/service/index.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/pages/service/index.tsx
@@ -27,6 +27,7 @@ import { getPipelines } from '../../axiosAPIs/pipelineAPI';
 import { getServiceByFQN, updateService } from '../../axiosAPIs/serviceAPI';
 import { getTopics } from '../../axiosAPIs/topicsAPI';
 import NextPrevious from '../../components/common/next-previous/NextPrevious';
+import NonAdminAction from '../../components/common/non-admin-action/NonAdminAction';
 import PopOver from '../../components/common/popover/PopOver';
 import RichTextEditorPreviewer from '../../components/common/rich-text-editor/RichTextEditorPreviewer';
 import TitleBreadcrumb from '../../components/common/title-breadcrumb/title-breadcrumb.component';
@@ -35,7 +36,10 @@ import PageContainer from '../../components/containers/PageContainer';
 import Loader from '../../components/Loader/Loader';
 import { ModalWithMarkdownEditor } from '../../components/Modals/ModalWithMarkdownEditor/ModalWithMarkdownEditor';
 import Tags from '../../components/tags/tags';
-import { pagingObject } from '../../constants/constants';
+import {
+  pagingObject,
+  TITLE_FOR_NON_ADMIN_ACTION,
+} from '../../constants/constants';
 import { SearchIndex } from '../../enums/search.enum';
 import {
   DashboardServiceType,
@@ -695,17 +699,21 @@ const ServicePage: FunctionComponent = () => {
                       Description
                     </span>
                     <div className="tw-flex-initial">
-                      <button
-                        className="focus:tw-outline-none"
-                        data-testid="description-edit"
-                        onClick={onDescriptionEdit}>
-                        <SVGIcons
-                          alt="edit"
-                          icon="icon-edit"
-                          title="Edit"
-                          width="12px"
-                        />
-                      </button>
+                      <NonAdminAction
+                        position="left"
+                        title={TITLE_FOR_NON_ADMIN_ACTION}>
+                        <button
+                          className="focus:tw-outline-none"
+                          data-testid="description-edit"
+                          onClick={onDescriptionEdit}>
+                          <SVGIcons
+                            alt="edit"
+                            icon="icon-edit"
+                            title="Edit"
+                            width="12px"
+                          />
+                        </button>
+                      </NonAdminAction>
                     </div>
                   </div>
                   <div className="tw-px-3 tw-pl-5 tw-py-2 tw-overflow-y-auto">

--- a/catalog-rest-service/src/main/resources/ui/src/pages/tags/index.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/pages/tags/index.tsx
@@ -347,46 +347,50 @@ const TagsPage = () => {
                                 setIsEditTag(true);
                                 setEditTag(tag);
                               }}>
-                              <div className="tw-cursor-pointer hover:tw-underline tw-flex">
-                                <div>
-                                  {tag.description ? (
-                                    <RichTextEditorPreviewer
-                                      markdown={tag.description}
+                              <NonAdminAction
+                                position="left"
+                                title={TITLE_FOR_NON_ADMIN_ACTION}>
+                                <div className="tw-cursor-pointer hover:tw-underline tw-flex">
+                                  <div>
+                                    {tag.description ? (
+                                      <RichTextEditorPreviewer
+                                        markdown={tag.description}
+                                      />
+                                    ) : (
+                                      <span className="tw-no-description">
+                                        No description added
+                                      </span>
+                                    )}
+                                  </div>
+                                  <button className="tw-self-start tw-w-8 tw-h-auto tw-opacity-0 tw-ml-1 group-hover:tw-opacity-100 focus:tw-outline-none">
+                                    <SVGIcons
+                                      alt="edit"
+                                      data-testid="editTagDescription"
+                                      icon="icon-edit"
+                                      title="Edit"
+                                      width="10px"
                                     />
+                                  </button>
+                                </div>
+                                <div className="tw-mt-1">
+                                  <span className="tw-text-grey-muted tw-mr-1">
+                                    Usage:
+                                  </span>
+                                  {tag.usageCount ? (
+                                    <Link
+                                      className="link-text tw-align-middle"
+                                      to={getUsageCountLink(
+                                        tag.fullyQualifiedName || ''
+                                      )}>
+                                      {tag.usageCount}
+                                    </Link>
                                   ) : (
                                     <span className="tw-no-description">
-                                      No description added
+                                      Not used
                                     </span>
                                   )}
                                 </div>
-                                <button className="tw-self-start tw-w-8 tw-h-auto tw-opacity-0 tw-ml-1 group-hover:tw-opacity-100 focus:tw-outline-none">
-                                  <SVGIcons
-                                    alt="edit"
-                                    data-testid="editTagDescription"
-                                    icon="icon-edit"
-                                    title="Edit"
-                                    width="10px"
-                                  />
-                                </button>
-                              </div>
-                              <div className="tw-mt-1">
-                                <span className="tw-text-grey-muted tw-mr-1">
-                                  Usage:
-                                </span>
-                                {tag.usageCount ? (
-                                  <Link
-                                    className="link-text tw-align-middle"
-                                    to={getUsageCountLink(
-                                      tag.fullyQualifiedName || ''
-                                    )}>
-                                    {tag.usageCount}
-                                  </Link>
-                                ) : (
-                                  <span className="tw-no-description">
-                                    Not used
-                                  </span>
-                                )}
-                              </div>
+                              </NonAdminAction>
                             </td>
                             <td
                               className="tw-group tableBody-cell"


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Now Non-admin/non-owner will not able to open the edit description dialog box in UI.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Frontend Preview (Screenshots) :
![image](https://user-images.githubusercontent.com/71748675/142223187-3fe1b0c5-46cb-430c-a2e6-af4e6c6c5898.png)

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya 
