### PR TITLE
Fix: If tier tag is not present show other tags.

### DIFF
--- a/catalog-rest-service/src/main/resources/ui/src/components/common/table-data-card/TableDataCard.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/components/common/table-data-card/TableDataCard.tsx
@@ -70,11 +70,9 @@ const TableDataCard: FunctionComponent<Props> = ({
   ];
 
   const getAssetTags = () => {
-    const assetTags = [
-      ...(tags as Array<string>).filter((tag) => !tag.includes(tier)),
-    ];
+    const assetTags = [...(tags as Array<string>)];
     if (tier) {
-      assetTags.unshift(tier);
+      assetTags.filter((tag) => !tag.includes(tier)).unshift(tier);
     }
 
     return [...new Set(assetTags)];


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the asset tags because of the need to fix the issue of tags not showing up if the tier tag is not present.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@shahsank3t, @darth-coder00
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
