### PR TITLE
[Issue-1260] - Github action to generate pydantic models

### DIFF
--- a/.github/workflows/py-checkstyle.yml
+++ b/.github/workflows/py-checkstyle.yml
@@ -18,8 +18,12 @@ name: py-checkstyle
 on:
   push:
     branches: [main]
+    paths:
+      - 'ingestion/**'
   pull_request:
     branches: [main]
+    paths:
+      - 'ingestion/**'
 
 jobs:
   build:

--- a/.github/workflows/py-generate.yml
+++ b/.github/workflows/py-generate.yml
@@ -1,11 +1,6 @@
-name: Generate Pydantic Models
+name: Validate Pydantic Models
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'catalog-rest-service/src/main/resources/json/**'
   pull_request:
     branches:
       - main
@@ -13,7 +8,7 @@ on:
       - 'catalog-rest-service/src/main/resources/json/**'
 
 jobs:
-  generate:
+  validate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -33,12 +28,3 @@ jobs:
         run: |
           source env/bin/activate
           make generate
-      - name: Push models
-        # Push the generated models if we are running in a push to main
-        if: ${{ github.event_name == 'push' }}
-        run: |
-          git config --global user.name 'open-metadata'
-          git config --global user.email 'open-metadata@users.noreply.github.com'
-          git add -A
-          git commit -m "Automated Pydantic Models generation"
-          git push

--- a/.github/workflows/py-generate.yml
+++ b/.github/workflows/py-generate.yml
@@ -8,13 +8,26 @@ on:
       - 'catalog-rest-service/src/main/resources/json/**'
 
 jobs:
-  report:
+  generate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install Ubuntu related dependencies
+        run: |
+          sudo apt-get install -y libsasl2-dev unixodbc-dev python3-venv
+      - name: Install Python & dev dependencies
+        run: |
+          python3 -m venv env
+          source env/bin/activate
+          make install_dev
       - name: Commit Models
         run: |
           set -ex
+          source env/bin/activate
           make generate
           git config --global user.name 'open-metadata'
           git config --global user.email 'open-metadata@users.noreply.github.com'

--- a/.github/workflows/py-generate.yml
+++ b/.github/workflows/py-generate.yml
@@ -1,0 +1,23 @@
+name: Generate Pydantic Models
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'catalog-rest-service/src/main/resources/json/**'
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Commit Models
+        run: |
+          set -ex
+          make generate
+          git config --global user.name 'open-metadata'
+          git config --global user.email 'open-metadata@users.noreply.github.com'
+          git add -A
+          git commit -m "Automated Pydantic Models generation"
+          git push

--- a/.github/workflows/py-generate.yml
+++ b/.github/workflows/py-generate.yml
@@ -6,6 +6,11 @@ on:
       - main
     paths:
       - 'catalog-rest-service/src/main/resources/json/**'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'catalog-rest-service/src/main/resources/json/**'
 
 jobs:
   generate:
@@ -24,11 +29,14 @@ jobs:
           python3 -m venv env
           source env/bin/activate
           make install_dev
-      - name: Commit Models
+      - name: Generate models
         run: |
-          set -ex
           source env/bin/activate
           make generate
+      - name: Push models
+        # Push the generated models if we are running in a push to main
+        if: ${{ github.event_name == 'push' }}
+        run: |
           git config --global user.name 'open-metadata'
           git config --global user.email 'open-metadata@users.noreply.github.com'
           git add -A

--- a/ingestion/tests/unit/test_ometa_endpoints.py
+++ b/ingestion/tests/unit/test_ometa_endpoints.py
@@ -17,7 +17,6 @@ from metadata.generated.schema.entity.data.model import Model
 from metadata.generated.schema.entity.data.pipeline import Pipeline
 from metadata.generated.schema.entity.data.report import Report
 from metadata.generated.schema.entity.data.table import Table
-from metadata.generated.schema.entity.data.task import Task
 from metadata.generated.schema.entity.data.topic import Topic
 from metadata.generated.schema.entity.services.dashboardService import DashboardService
 from metadata.generated.schema.entity.services.databaseService import DatabaseService


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->

This PR fixes https://github.com/open-metadata/OpenMetadata/issues/1260.

We currently have the make generate recipe taking care of generating the models. However, it is easy to miss updates and get code not properly aligned.

The prepared action checks all pushes against `main` that update code inside `catalog-rest-service/src/main/resources/json/**`, so it will only run if we are indeed changing JSON schemas.

Then, it will run the `make generate` recipe and push the code to the repo with a fake user `open-metadata`.

Here we might need to check if this is the right approach or if we should have a bot account with proper write permissions.

> OBS: It also fixes a random missed import that breaks a test

Thanks!

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have performed a self-review of my own. 
- [ ] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@sureshms @harshach, if you could take a look, please! 🙏  Any thoughts on the permissions?

Thanks!

