### PR TITLE
[Issue-1293] - Disable additional properties

### DIFF
--- a/catalog-rest-service/src/main/resources/json/schema/entity/data/chart.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/data/chart.json
@@ -138,5 +138,6 @@
       "$ref": "../../type/entityHistory.json#/definitions/changeDescription"
     }
   },
-  "required": ["id", "name", "service"]
+  "required": ["id", "name", "service"],
+  "additionalProperties": false
 }

--- a/catalog-rest-service/src/main/resources/json/schema/entity/data/dashboard.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/data/dashboard.json
@@ -89,5 +89,6 @@
       "$ref": "../../type/entityHistory.json#/definitions/changeDescription"
     }
   },
-  "required": ["id", "name", "service"]
+  "required": ["id", "name", "service"],
+  "additionalProperties": false
 }

--- a/catalog-rest-service/src/main/resources/json/schema/entity/data/database.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/data/database.json
@@ -77,5 +77,6 @@
       "$ref": "../../type/entityHistory.json#/definitions/changeDescription"
     }
   },
-  "required": ["name", "service"]
+  "required": ["name", "service"],
+  "additionalProperties": false
 }

--- a/catalog-rest-service/src/main/resources/json/schema/entity/data/location.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/data/location.json
@@ -101,5 +101,6 @@
   "required": [
     "name",
     "service"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/catalog-rest-service/src/main/resources/json/schema/entity/data/metrics.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/data/metrics.json
@@ -72,5 +72,6 @@
       "$ref": "../../type/entityHistory.json#/definitions/changeDescription"
     }
   },
-  "required": ["id", "name", "service"]
+  "required": ["id", "name", "service"],
+  "additionalProperties": false
 }

--- a/catalog-rest-service/src/main/resources/json/schema/entity/data/mlmodel.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/data/mlmodel.json
@@ -248,5 +248,6 @@
       "$ref": "../../type/entityHistory.json#/definitions/changeDescription"
     }
   },
-  "required": ["id", "name", "algorithm"]
+  "required": ["id", "name", "algorithm"],
+  "additionalProperties": false
 }

--- a/catalog-rest-service/src/main/resources/json/schema/entity/data/pipeline.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/data/pipeline.json
@@ -150,5 +150,6 @@
       "$ref": "../../type/entityHistory.json#/definitions/changeDescription"
     }
   },
-  "required": ["id", "name", "service"]
+  "required": ["id", "name", "service"],
+  "additionalProperties": false
 }

--- a/catalog-rest-service/src/main/resources/json/schema/entity/data/report.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/data/report.json
@@ -64,5 +64,6 @@
       "$ref": "../../type/entityHistory.json#/definitions/changeDescription"
     }
   },
-  "required": ["id", "name", "service"]
+  "required": ["id", "name", "service"],
+  "additionalProperties": false
 }

--- a/catalog-rest-service/src/main/resources/json/schema/entity/data/topic.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/data/topic.json
@@ -154,5 +154,6 @@
     "name",
     "partitions",
     "service"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/catalog-rest-service/src/main/resources/json/schema/entity/feed/thread.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/feed/thread.json
@@ -56,5 +56,6 @@
       }
     }
   },
-  "required": ["id", "about", "posts"]
+  "required": ["id", "about", "posts"],
+  "additionalProperties": false
 }

--- a/catalog-rest-service/src/main/resources/json/schema/entity/policies/accessControl/rule.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/policies/accessControl/rule.json
@@ -25,5 +25,6 @@
   "required": [
     "filters",
     "actions"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/catalog-rest-service/src/main/resources/json/schema/entity/policies/accessControl/tagBased.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/policies/accessControl/tagBased.json
@@ -35,5 +35,6 @@
   "required": [
     "tags",
     "allow"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/catalog-rest-service/src/main/resources/json/schema/entity/policies/lifecycle/deleteAction.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/policies/lifecycle/deleteAction.json
@@ -28,5 +28,6 @@
         "daysAfterModification"
       ]
     }
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/catalog-rest-service/src/main/resources/json/schema/entity/policies/lifecycle/moveAction.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/policies/lifecycle/moveAction.json
@@ -48,5 +48,6 @@
         "destination"
       ]
     }
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/catalog-rest-service/src/main/resources/json/schema/entity/policies/lifecycle/rule.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/policies/lifecycle/rule.json
@@ -28,5 +28,6 @@
   "required": [
     "filters",
     "actions"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/catalog-rest-service/src/main/resources/json/schema/entity/policies/policy.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/policies/policy.json
@@ -108,5 +108,6 @@
     "name",
     "owner",
     "policyType"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/catalog-rest-service/src/main/resources/json/schema/entity/services/dashboardService.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/services/dashboardService.json
@@ -96,5 +96,6 @@
     "name",
     "serviceType",
     "dashboardUrl"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/catalog-rest-service/src/main/resources/json/schema/entity/services/databaseService.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/services/databaseService.json
@@ -128,5 +128,6 @@
     "serviceType",
     "href",
     "jdbc"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/catalog-rest-service/src/main/resources/json/schema/entity/services/messagingService.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/services/messagingService.json
@@ -92,5 +92,6 @@
     "name",
     "serviceType",
     "brokers"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/catalog-rest-service/src/main/resources/json/schema/entity/services/pipelineService.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/services/pipelineService.json
@@ -83,5 +83,6 @@
     "id",
     "name",
     "pipelineUrl"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/catalog-rest-service/src/main/resources/json/schema/entity/services/storageService.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/services/storageService.json
@@ -54,5 +54,6 @@
     "name",
     "serviceType",
     "href"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/catalog-rest-service/src/main/resources/json/schema/entity/teams/team.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/teams/team.json
@@ -67,5 +67,6 @@
       "$ref": "../../type/entityHistory.json#/definitions/changeDescription"
     }
   },
-  "required" : ["id", "name", "href"]
+  "required" : ["id", "name", "href"],
+  "additionalProperties": false
 }

--- a/catalog-rest-service/src/main/resources/json/schema/operations/workflows/ingestion.json
+++ b/catalog-rest-service/src/main/resources/json/schema/operations/workflows/ingestion.json
@@ -274,5 +274,6 @@
       "$ref": "../../type/entityHistory.json#/definitions/changeDescription"
     }
   },
-  "required": ["name", "service", "connectorConfig", "startDate"]
+  "required": ["name", "service", "connectorConfig", "startDate"],
+  "additionalProperties": false
 }

--- a/catalog-rest-service/src/main/resources/json/schema/type/auditLog.json
+++ b/catalog-rest-service/src/main/resources/json/schema/type/auditLog.json
@@ -41,5 +41,6 @@
       "$ref": "basic.json#/definitions/dateTime"
     }
   },
-  "required": ["method", "responseCode", "path", "userName", "entityId", "entityType"]
+  "required": ["method", "responseCode", "path", "userName", "entityId", "entityType"],
+  "additionalProperties": false
 }

--- a/catalog-rest-service/src/main/resources/json/schema/type/entityUsage.json
+++ b/catalog-rest-service/src/main/resources/json/schema/type/entityUsage.json
@@ -18,5 +18,6 @@
       }
     }
   },
-  "required": ["entity", "usage"]
+  "required": ["entity", "usage"],
+  "additionalProperties": false
 }

--- a/catalog-rest-service/src/main/resources/json/schema/type/jdbcConnection.json
+++ b/catalog-rest-service/src/main/resources/json/schema/type/jdbcConnection.json
@@ -53,6 +53,7 @@
     }
   },
 
-  "required": ["driverClass", "connectionUrl", "userName", "password"]
+  "required": ["driverClass", "connectionUrl", "userName", "password"],
+  "additionalProperties": false
 }
 

--- a/catalog-rest-service/src/main/resources/json/schema/type/paging.json
+++ b/catalog-rest-service/src/main/resources/json/schema/type/paging.json
@@ -19,5 +19,6 @@
       "type" : "integer"
     }
   },
-  "required": ["total"]
+  "required": ["total"],
+  "additionalProperties": false
 }

--- a/catalog-rest-service/src/main/resources/json/schema/type/usageDetails.json
+++ b/catalog-rest-service/src/main/resources/json/schema/type/usageDetails.json
@@ -50,5 +50,6 @@
   "required": [
     "dailyStats",
     "date"
-  ]
+  ],
+  "additionalProperties": false
 }


### PR DESCRIPTION
### Describe your changes :
This PR fixes https://github.com/open-metadata/OpenMetadata/issues/1293.

In https://github.com/open-metadata/OpenMetadata/pull/1292 we noticed how the `codegen` tool was not properly importing all necessary `pydantic` classes. This miss in the automatic generation made it impossible to use specific modules such as `location` without fixing manually the missing classes.

As the missing class was `Extra`, in order to configure pydantic with `Extra.forbid`, a way to force the `codegen` tool to add the import is to update the JSON schemas adding the `additionalProperties: false`.

This has been a good opportunity to review all the schemas and disable random properties in the files that were missing this definition.

Thanks!

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@sureshms @harshach @amiorin if you could please take a look!

Thanks 🙏 
