### PR TITLE
Handle undefined version in GUI

### DIFF
--- a/catalog-rest-service/src/main/resources/ui/src/components/app-bar/Appbar.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/components/app-bar/Appbar.tsx
@@ -290,7 +290,7 @@ const Appbar: React.FC = (): JSX.Element => {
                   {
                     name: (
                       <span className="tw-text-grey-muted tw-cursor-text tw-text-xs">
-                        {`Version ${version.split('-')[0]}`}
+                        {`Version ${(version ? version : '?').split('-')[0]}`}
                         <hr className="tw--mr-12 tw--ml-2 tw-mt-1.5" />
                       </span>
                     ),


### PR DESCRIPTION
When running the GUI in development mode with eg

`npm run start`

the GUI shows a blank screen because of a runtime error (`"_" undefined)`) at `Appbar.tsx:293`

This PR replaces an undefined version with '?'

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix



<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@shahsank3t, @darth-coder00, @Sachin-chaurasiya

