### PR TITLE
Fix #1236 Version Summary for owner change is missing data.

### DIFF
--- a/catalog-rest-service/src/main/resources/ui/src/utils/EntityVersionUtils.tsx
+++ b/catalog-rest-service/src/main/resources/ui/src/utils/EntityVersionUtils.tsx
@@ -169,6 +169,8 @@ export const summaryFormatter = (v: FieldChange) => {
     return `columns ${value?.map((val: any) => val?.name).join(', ')}`;
   } else if (v.name === 'tags' || v.name?.endsWith('tags')) {
     return `tags ${value?.map((val: any) => val?.tagFQN)?.join(', ')}`;
+  } else if (v.name === 'owner') {
+    return `${v.name} ${value.name}`;
   } else {
     return v.name;
   }
@@ -183,17 +185,17 @@ export const getSummary = (changeDescription: ChangeDescription) => {
     <Fragment>
       {fieldsAdded?.length > 0 ? (
         <p className="tw-mb-2">
-          {fieldsAdded?.map(summaryFormatter)} has been added
+          {fieldsAdded?.map(summaryFormatter).join(', ')} has been added
         </p>
       ) : null}
       {fieldsUpdated?.length ? (
         <p className="tw-mb-2">
-          {fieldsUpdated?.map(summaryFormatter)} has been updated
+          {fieldsUpdated?.map(summaryFormatter).join(', ')} has been updated
         </p>
       ) : null}
       {fieldsDeleted?.length ? (
         <p className="tw-mb-2">
-          {fieldsDeleted?.map(summaryFormatter)} has been deleted
+          {fieldsDeleted?.map(summaryFormatter).join(', ')} has been deleted
         </p>
       ) : null}
     </Fragment>


### PR DESCRIPTION
Fixes #1236 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the version side panel because the owner changed data is missing from the version summary.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :
![image](https://user-images.githubusercontent.com/59080942/142805099-35993add-c975-4e68-9aae-b6220580b32e.png)

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@shahsank3t, @darth-coder00

<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
