### PR TITLE
Fix #1385: python -m metadata should work

### DIFF
--- a/ingestion/src/metadata/__main__.py
+++ b/ingestion/src/metadata/__main__.py
@@ -1,0 +1,4 @@
+from metadata.cmd import metadata
+
+if __name__ == "__main__":
+    metadata()


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on this because some setups of Python are broken.
```python``` is install as admin and ```pip``` is installed as user. The ```PATH``` is misconfigured. They have to do ```python -m install openmetadata-ingestion``` but ```metadata``` CLI will not be found. With this patch they will be able to do ```python -m metadata docker --start``` to work around the misconfiguration of Python.

#
### Type of change :
- [x] Improvement

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
Ingestion: @harshach @ayush-shah @pmbrull
