### PR TITLE
[issue-1284] - Add MlStore and Server to MlModel

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/MlModelRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/MlModelRepository.java
@@ -43,7 +43,7 @@ import java.util.UUID;
 public class MlModelRepository extends EntityRepository<MlModel> {
   private static final Logger LOG = LoggerFactory.getLogger(MlModelRepository.class);
   private static final Fields MODEL_UPDATE_FIELDS = new Fields(MlModelResource.FIELD_LIST,
-          "owner,algorithm,dashboard,mlHyperParameters,mlFeatures,tags");
+          "owner,algorithm,dashboard,mlHyperParameters,mlFeatures,mlStore,server,tags");
   private static final Fields MODEL_PATCH_FIELDS = new Fields(MlModelResource.FIELD_LIST,
           "owner,algorithm,dashboard,mlHyperParameters,mlFeatures,tags");
   private final CollectionDAO dao;
@@ -77,6 +77,8 @@ public class MlModelRepository extends EntityRepository<MlModel> {
     mlModel.setDashboard(fields.contains("dashboard") ? getDashboard(mlModel) : null);
     mlModel.setMlFeatures(fields.contains("mlFeatures") ? mlModel.getMlFeatures(): null);
     mlModel.setMlHyperParameters(fields.contains("mlHyperParameters") ? mlModel.getMlHyperParameters(): null);
+    mlModel.setMlStore(fields.contains("mlStore") ? mlModel.getMlStore(): null);
+    mlModel.setServer(fields.contains("server") ? mlModel.getServer(): null);
     mlModel.setFollowers(fields.contains("followers") ? getFollowers(mlModel) : null);
     mlModel.setTags(fields.contains("tags") ? getTags(mlModel.getFullyQualifiedName()) : null);
     mlModel.setUsageSummary(fields.contains("usageSummary") ? EntityUtil.getLatestUsage(dao.usageDAO(),
@@ -338,6 +340,8 @@ public class MlModelRepository extends EntityRepository<MlModel> {
       updateDashboard(origMlModel, updatedMlModel);
       updateMlFeatures(origMlModel, updatedMlModel);
       updateMlHyperParameters(origMlModel, updatedMlModel);
+      updateMlStore(origMlModel, updatedMlModel);
+      updateServer(origMlModel, updatedMlModel);
     }
 
     private void updateAlgorithm(MlModel origModel, MlModel updatedModel) throws JsonProcessingException {
@@ -350,6 +354,14 @@ public class MlModelRepository extends EntityRepository<MlModel> {
 
     private void updateMlHyperParameters(MlModel origModel, MlModel updatedModel) throws JsonProcessingException {
       recordChange("mlHyperParameters", origModel.getMlHyperParameters(), updatedModel.getMlHyperParameters());
+    }
+
+    private void updateMlStore(MlModel origModel, MlModel updatedModel) throws JsonProcessingException {
+      recordChange("mlStore", origModel.getMlStore(), updatedModel.getMlStore(), true);
+    }
+
+    private void updateServer(MlModel origModel, MlModel updatedModel) throws JsonProcessingException {
+      recordChange("server", origModel.getServer(), updatedModel.getServer());
     }
 
     private void updateDashboard(MlModel origModel, MlModel updatedModel) throws JsonProcessingException {

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/mlmodels/MlModelResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/mlmodels/MlModelResource.java
@@ -110,7 +110,8 @@ public class MlModelResource {
     }
   }
 
-  static final String FIELDS = "owner,dashboard,algorithm,mlFeatures,mlHyperParameters,followers,tags,usageSummary";
+  static final String FIELDS = "owner,dashboard,algorithm,mlFeatures,mlHyperParameters,mlStore,server," +
+          "followers,tags,usageSummary";
   public static final List<String> FIELD_LIST = Arrays.asList(FIELDS.replaceAll(" ", "")
           .split(","));
 
@@ -357,6 +358,8 @@ public class MlModelResource {
               .withAlgorithm(create.getAlgorithm())
               .withMlFeatures(create.getMlFeatures())
               .withMlHyperParameters(create.getMlHyperParameters())
+              .withMlStore(create.getMlStore())
+              .withServer(create.getServer())
               .withTags(create.getTags())
               .withOwner(create.getOwner())
               .withUpdatedBy(securityContext.getUserPrincipal().getName())

--- a/catalog-rest-service/src/main/resources/json/schema/api/data/createMlModel.json
+++ b/catalog-rest-service/src/main/resources/json/schema/api/data/createMlModel.json
@@ -43,6 +43,14 @@
       "description": "Performance Dashboard URL to track metric evolution",
       "$ref" : "../../type/entityReference.json"
     },
+    "mlStore": {
+      "description": "Location containing the ML Model. It can be a storage layer and/or a container repository.",
+      "$ref": "../../entity/data/mlmodel.json#/definitions/mlStore"
+    },
+    "server": {
+      "description": "Endpoint that makes the ML Model available, e.g,. a REST API serving the data or computing predictions.",
+      "$ref": "../../type/basic.json#/definitions/href"
+    },
     "tags": {
       "description": "Tags for this ML Model",
       "type": "array",

--- a/catalog-rest-service/src/main/resources/json/schema/entity/data/mlmodel.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/data/mlmodel.json
@@ -155,6 +155,22 @@
           "type": "string"
         }
       }
+    },
+    "mlStore": {
+      "type": "object",
+      "javaType": "org.openmetadata.catalog.type.MlStore",
+      "description": "Location containing the ML Model. It can be a storage layer and/or a container repository.",
+      "additionalProperties": false,
+      "properties": {
+        "storage": {
+          "description": "Storage Layer containing the ML Model data.",
+          "$ref": "../../type/basic.json#/definitions/href"
+        },
+        "imageRepository": {
+          "description": "Container Repository with the ML Model image.",
+          "$ref": "../../type/basic.json#/definitions/href"
+        }
+      }
     }
   },
   "properties" : {
@@ -205,6 +221,14 @@
     "dashboard" : {
       "description": "Performance Dashboard URL to track metric evolution.",
       "$ref" : "../../type/entityReference.json"
+    },
+    "mlStore": {
+      "description": "Location containing the ML Model. It can be a storage layer and/or a container repository.",
+      "$ref": "#/definitions/mlStore"
+    },
+    "server": {
+      "description": "Endpoint that makes the ML Model available, e.g,. a REST API serving the data or computing predictions.",
+      "$ref": "../../type/basic.json#/definitions/href"
     },
     "href": {
       "description": "Link to the resource corresponding to this entity.",


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
This PR fixes https://github.com/open-metadata/OpenMetadata/issues/1284.

It adds the following properties to the ML Model entity:
- MlStore: to indicate where the trained model file (e.g., pkl) is stored and/or where to find the Docker image
- Server: endpoint where users/integrations can access the model data or run live prediction services

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
