### PR TITLE
Direct users to the install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,7 @@ OpenMetadata includes the following:
 Visit our demo at [http://sandbox.open-metadata.org](http://sandbox.open-metadata.org)
 
 ## Install and run OpenMetadata
-Get up and running in few mins
-
-```sh
-git clone https://github.com/open-metadata/OpenMetadata
-cd OpenMetadata/docker/metadata
-docker-compose up -d
-```
-Then visit [http://localhost:8585](http://localhost:8585)
-
-For more details on running OpenMetadata on your local machine or in production, see our [Install Doc](https://docs.open-metadata.org/install/run-openmetadata).
+Get up and running in few minutes. See the OpenMetadata documentation for [installation instructions](https://docs.open-metadata.org/install/run-openmetadata).
 
 ## Documentation and Support
 


### PR DESCRIPTION
Users seem to be having difficulty getting up and running with docker-compose. In any case our installation instructions in the readme are inconsistent with what's in the docs.

### Describe your changes :
I am proposing a change to the readme to direct users to our installation docs for running OpenMetadata locally.

#
### Type of change :
- [x] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x ] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.

#
### Reviewers
@harshach
