### PR TITLE
Fix #1602 Team page goes blank if there is not team in params.

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/teams/index.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/teams/index.tsx
@@ -355,15 +355,15 @@ const TeamsPage = () => {
   };
 
   useEffect(() => {
-    fetchTeams();
-  }, []);
-
-  useEffect(() => {
     setUserList(AppState.users);
   }, [AppState.users]);
 
   useEffect(() => {
-    fetchCurrentTeam(team);
+    if (team) {
+      fetchCurrentTeam(team);
+    } else {
+      fetchTeams();
+    }
     setCurrentTab(1);
   }, [team]);
 


### PR DESCRIPTION
Fixes #1602 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the Teams page because the team's page goes blank if there is no team in params.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@shahsank3t, @darth-coder00
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
