### PR TITLE
Fix #1407 PUT method for service APIs give 405 Method not allowed exception.

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/axiosAPIs/serviceAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/axiosAPIs/serviceAPI.ts
@@ -48,10 +48,10 @@ export const postService: Function = (
 
 export const updateService: Function = (
   serviceName: string,
-  id: string,
+  _id: string,
   options: ServiceOption
 ): Promise<AxiosResponse> => {
-  return APIClient.put(`/services/${serviceName}/${id}`, options);
+  return APIClient.put(`/services/${serviceName}`, options);
 };
 
 export const deleteService: Function = (


### PR DESCRIPTION
Fixes #1407 

### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the Service API call because need to change how we are making put request. 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@shahsank3t, @darth-coder00
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
