### PR TITLE
Fix: Turned-off welcome message when a new user signs up

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/auth-provider/AuthProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/auth-provider/AuthProvider.tsx
@@ -15,7 +15,6 @@ import { AxiosResponse } from 'axios';
 import { CookieStorage } from 'cookie-storage';
 import { isEmpty, isNil } from 'lodash';
 import { observer } from 'mobx-react';
-import { NewUser } from 'Models';
 import { UserManager, WebStorageStateStore } from 'oidc-client';
 import React, {
   ComponentType,
@@ -36,7 +35,6 @@ import axiosClient from '../axiosAPIs';
 import { fetchAuthorizerConfig } from '../axiosAPIs/miscAPI';
 import { getLoggedInUser, getUserByName } from '../axiosAPIs/userAPI';
 import Loader from '../components/Loader/Loader';
-import { FirstTimeUserModal } from '../components/Modals/FirstTimeUserModal/FirstTimeUserModal';
 import { COOKIE_VERSION } from '../components/Modals/WhatsNewModal/whatsNewData';
 import { oidcTokenKey, ROUTES } from '../constants/constants';
 import { ClientErrors } from '../enums/axios.enum';
@@ -72,13 +70,9 @@ const AuthProvider: FunctionComponent<AuthProviderProps> = ({
   const location = useLocation();
   const history = useHistory();
   const showToast = useToastContext();
-  const {
-    isAuthenticatedRoute,
-    isFirstTimeUser,
-    isSignedIn,
-    isSigningIn,
-    isSignedOut,
-  } = useAuth(location.pathname);
+  const { isFirstTimeUser, isSignedIn, isSigningIn, isSignedOut } = useAuth(
+    location.pathname
+  );
 
   const oidcUserToken = cookieStorage.getItem(oidcTokenKey);
   const [loading, setLoading] = useState(true);
@@ -187,14 +181,14 @@ const AuthProvider: FunctionComponent<AuthProviderProps> = ({
       });
   };
 
-  const handleFirstTourModal = (skip: boolean) => {
-    appState.newUser = {} as NewUser;
-    if (skip) {
-      history.push(ROUTES.HOME);
-    } else {
-      // TODO: Route to tour page
-    }
-  };
+  // const handleFirstTourModal = (skip: boolean) => {
+  //   appState.newUser = {} as NewUser;
+  //   if (skip) {
+  //     history.push(ROUTES.HOME);
+  //   } else {
+  //     // TODO: Route to tour page
+  //   }
+  // };
 
   useEffect(() => {
     fetchAuthConfig();
@@ -276,12 +270,13 @@ const AuthProvider: FunctionComponent<AuthProviderProps> = ({
               <AppWithAuth />
             )}
           </Switch>
-          {isAuthenticatedRoute && isFirstTimeUser ? (
+          {/* TODO: Uncomment below lines to show Welcome modal on Sign-up */}
+          {/* {isAuthenticatedRoute && isFirstTimeUser ? (
             <FirstTimeUserModal
               onCancel={() => handleFirstTourModal(true)}
               onSave={() => handleFirstTourModal(false)}
             />
-          ) : null}
+          ) : null} */}
         </>
       ) : null}
     </>

--- a/openmetadata-ui/src/main/resources/ui/src/components/app-bar/Appbar.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/app-bar/Appbar.tsx
@@ -62,9 +62,7 @@ const Appbar: React.FC = (): JSX.Element => {
   const searchQuery = match?.params?.searchQuery;
   const [searchValue, setSearchValue] = useState(searchQuery);
   const [isOpen, setIsOpen] = useState<boolean>(true);
-  const [isFeatureModalOpen, setIsFeatureModalOpen] = useState<boolean>(() => {
-    return !isFirstTimeUser && cookieStorage.getItem(COOKIE_VERSION) !== 'true';
-  });
+  const [isFeatureModalOpen, setIsFeatureModalOpen] = useState<boolean>(false);
 
   const [version, setVersion] = useState<string>('');
 
@@ -143,7 +141,8 @@ const Appbar: React.FC = (): JSX.Element => {
 
   useEffect(() => {
     setIsFeatureModalOpen(
-      !isFirstTimeUser && cookieStorage.getItem(COOKIE_VERSION) !== 'true'
+      // TODO: Add !isFirstTimeUser to condition if showing Welcome Modal
+      cookieStorage.getItem(COOKIE_VERSION) !== 'true'
     );
   }, [isFirstTimeUser]);
 

--- a/openmetadata-ui/src/main/resources/ui/src/utils/APIUtils.js
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/APIUtils.js
@@ -46,7 +46,6 @@ export const formatDataResponse = (hits) => {
     newData.entityType = hit._source.entity_type;
     newData.changeDescriptions = hit._source.change_descriptions;
 
-
     return newData;
   });
 


### PR DESCRIPTION
### Describe your changes :
Closes #1632 
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the removing Welcome modal for new users as it shows up after every clean-up post new release when user has to sign-up again

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Frontend Preview (Screenshots) :
<p align="center">
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@shahsank3t @Sachin-chaurasiya 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
