### PR TITLE
Fix #1626 Profiler should show primary key, non null column information in profiler tab

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DatasetDetails/DatasetDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DatasetDetails/DatasetDetails.component.tsx
@@ -394,7 +394,10 @@ const DatasetDetails: React.FC<DatasetDetailsProps> = ({
             {activeTab === 2 && (
               <div className="tw-mt-4">
                 <TableProfiler
-                  columns={columns.map((col) => col.name)}
+                  columns={columns.map((col) => ({
+                    constraint: col.constraint as string,
+                    colName: col.name,
+                  }))}
                   tableProfiles={tableProfile}
                 />
               </div>

--- a/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/TableProfiler.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/TableProfiler.component.tsx
@@ -15,11 +15,12 @@ import classNames from 'classnames';
 import React, { Fragment, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Table, TableProfile } from '../../generated/entity/data/table';
+import { getConstraintIcon } from '../../utils/TableUtils';
 import TableProfilerGraph from './TableProfilerGraph.component';
 
 type Props = {
   tableProfiles: Table['tableProfile'];
-  columns: Array<string>;
+  columns: Array<{ constraint: string; colName: string }>;
 };
 
 type ProfilerGraphData = Array<{
@@ -45,7 +46,7 @@ const TableProfiler = ({ tableProfiles, columns }: Props) => {
   const columnSpecificData = columns.map((column) => {
     const data = modifiedData?.map((md) => {
       const currentColumn = md.columnProfile?.find(
-        (colProfile) => colProfile.name === column
+        (colProfile) => colProfile.name === column.colName
       );
 
       return { profilDate: md.profileDate, ...currentColumn, rows: md.rows };
@@ -85,19 +86,19 @@ const TableProfiler = ({ tableProfiles, columns }: Props) => {
                     <td
                       className="tw-relative tableBody-cell"
                       data-testid="tableBody-cell">
-                      <p className="tw-flex">
+                      <div className="tw-flex">
                         <span
                           className="tw-mr-2 tw-cursor-pointer"
                           onClick={() =>
                             setExpandedColumn((prevState) => ({
-                              name: col.name,
+                              name: col.name.colName,
                               isExpanded:
-                                prevState.name === col.name
+                                prevState.name === col.name.colName
                                   ? !prevState.isExpanded
                                   : true,
                             }))
                           }>
-                          {expandedColumn.name === col.name ? (
+                          {expandedColumn.name === col.name.colName ? (
                             expandedColumn.isExpanded ? (
                               <i className="fas fa-caret-down" />
                             ) : (
@@ -107,8 +108,13 @@ const TableProfiler = ({ tableProfiles, columns }: Props) => {
                             <i className="fas fa-caret-right" />
                           )}
                         </span>
-                        <span>{col.name}</span>
-                      </p>
+                        {colIndex === 0 && (
+                          <span className="tw-mr-3 tw--ml-2">
+                            {getConstraintIcon('PRIMARY_KEY', 'tw-relative')}
+                          </span>
+                        )}
+                        <span>{col.name.colName}</span>
+                      </div>
                     </td>
                     <td className="tw-relative tableBody-cell profiler-graph">
                       <TableProfilerGraph
@@ -151,47 +157,50 @@ const TableProfiler = ({ tableProfiles, columns }: Props) => {
                     </td>
                   </tr>
                 </tbody>
-                {expandedColumn.name === col.name && expandedColumn.isExpanded && (
-                  <tbody>
-                    {col.data?.map((colData, index) => (
-                      <tr
-                        className={classNames(
-                          'tableBody-row tw-border-0 tw-border-l tw-border-r',
-                          {
-                            'tw-border-b':
-                              columnSpecificData.length - 1 === colIndex &&
-                              col.data?.length === index + 1,
-                          }
-                        )}
-                        key={index}>
-                        <td className="tw-relative tableBody-cell">
-                          <span className="tw-pl-6">{colData.profilDate}</span>
-                        </td>
-                        <td className="tw-relative tableBody-cell">
-                          <span className="tw-pl-6">{colData.rows}</span>
-                        </td>
-                        <td className="tw-relative tableBody-cell">
-                          {colData.uniqueProportion ?? 0}
-                        </td>
-                        <td className="tw-relative tableBody-cell">
-                          {colData.nullProportion ?? 0}
-                        </td>
-                        <td className="tw-relative tableBody-cell">
-                          {colData.min ?? 0}
-                        </td>
-                        <td className="tw-relative tableBody-cell">
-                          {colData.max ?? 0}
-                        </td>
-                        <td className="tw-relative tableBody-cell">
-                          {colData.median ?? 0}
-                        </td>
-                        <td className="tw-relative tableBody-cell">
-                          {colData.stddev ?? 0}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                )}
+                {expandedColumn.name === col.name.colName &&
+                  expandedColumn.isExpanded && (
+                    <tbody>
+                      {col.data?.map((colData, index) => (
+                        <tr
+                          className={classNames(
+                            'tableBody-row tw-border-0 tw-border-l tw-border-r',
+                            {
+                              'tw-border-b':
+                                columnSpecificData.length - 1 === colIndex &&
+                                col.data?.length === index + 1,
+                            }
+                          )}
+                          key={index}>
+                          <td className="tw-relative tableBody-cell">
+                            <span className="tw-pl-6">
+                              {colData.profilDate}
+                            </span>
+                          </td>
+                          <td className="tw-relative tableBody-cell">
+                            <span className="tw-pl-6">{colData.rows}</span>
+                          </td>
+                          <td className="tw-relative tableBody-cell">
+                            {colData.uniqueProportion ?? 0}
+                          </td>
+                          <td className="tw-relative tableBody-cell">
+                            {colData.nullProportion ?? 0}
+                          </td>
+                          <td className="tw-relative tableBody-cell">
+                            {colData.min ?? 0}
+                          </td>
+                          <td className="tw-relative tableBody-cell">
+                            {colData.max ?? 0}
+                          </td>
+                          <td className="tw-relative tableBody-cell">
+                            {colData.median ?? 0}
+                          </td>
+                          <td className="tw-relative tableBody-cell">
+                            {colData.stddev ?? 0}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  )}
               </Fragment>
             );
           })}

--- a/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/TableProfiler.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/TableProfiler.component.tsx
@@ -110,7 +110,10 @@ const TableProfiler = ({ tableProfiles, columns }: Props) => {
                         </span>
                         {colIndex === 0 && (
                           <span className="tw-mr-3 tw--ml-2">
-                            {getConstraintIcon('PRIMARY_KEY', 'tw-relative')}
+                            {getConstraintIcon(
+                              col.name.constraint,
+                              'tw-relative'
+                            )}
                           </span>
                         )}
                         <span>{col.name.colName}</span>

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TableUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TableUtils.tsx
@@ -11,6 +11,7 @@
  *  limitations under the License.
  */
 
+import classNames from 'classnames';
 import { EntityTags, TableDetail } from 'Models';
 import React from 'react';
 import AppState from '../AppState';
@@ -144,7 +145,7 @@ export const getFollowerDetail = (id: string) => {
   return follower;
 };
 
-export const getConstraintIcon = (constraint = '') => {
+export const getConstraintIcon = (constraint = '', className = '') => {
   let title: string, icon: string;
   switch (constraint) {
     case ConstraintTypes.PRIMARY_KEY:
@@ -174,7 +175,7 @@ export const getConstraintIcon = (constraint = '') => {
 
   return (
     <PopOver
-      className="tw-absolute tw-left-2"
+      className={classNames('tw-absolute tw-left-2', className)}
       position="bottom"
       size="small"
       title={title}


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the table profiler because the need to show Profiler should show primary key, non null column information in profiler tab

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] Improvement


#
### Frontend Preview (Screenshots) :
![image](https://user-images.githubusercontent.com/59080942/145428156-10446e02-512c-4cc4-ae5e-fcb7145b030b.png)

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@shahsank3t, @darth-coder00
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
