### PR TITLE
Fix #1694: Add parameter team to filter the list of users

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/UserRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/UserRepository.java
@@ -252,10 +252,10 @@ public class UserRepository extends EntityRepository<User> {
     public void setId(UUID id) { entity.setId(id); }
 
     @Override
-    public void setDescription(String description) { entity.setDescription(description);}
+    public void setDescription(String description) { entity.setDescription(description); }
 
     @Override
-    public void setDisplayName(String displayName) { entity.setDisplayName(displayName);}
+    public void setDisplayName(String displayName) { entity.setDisplayName(displayName); }
 
     @Override
     public void setUpdateDetails(String updatedBy, Date updatedAt) {

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/teams/UserResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/teams/UserResource.java
@@ -126,6 +126,9 @@ public class UserResource {
                                @Parameter(description = "Fields requested in the returned resource",
                                        schema = @Schema(type = "string", example = FIELDS))
                                @QueryParam("fields") String fieldsParam,
+                               @Parameter(description = "Filter users by team",
+                                       schema = @Schema(type = "string", example = "Legal"))
+                               @QueryParam("team") String teamParam,
                                @Parameter(description = "Limit the number users returned. (1 to 1000000, default = 10)")
                                @DefaultValue("10")
                                @Min(1)
@@ -143,9 +146,9 @@ public class UserResource {
 
     ResultList<User> users;
     if (before != null) { // Reverse paging
-      users = dao.listBefore(uriInfo, fields, null, limitParam, before);
+      users = dao.listBefore(uriInfo, fields, teamParam, limitParam, before);
     } else { // Forward paging or first page
-      users = dao.listAfter(uriInfo, fields, null, limitParam, after);
+      users = dao.listAfter(uriInfo, fields, teamParam, limitParam, after);
     }
     Optional.ofNullable(users.getData()).orElse(Collections.emptyList()).forEach(u -> addHref(uriInfo, u));
     return users;


### PR DESCRIPTION
### Describe your changes :
UI needs an API to get all the users filtered by team name.

#### Implementation details
I couldn't reuse the default list implementation because the team name is in another table. A user may not have a team and this required a LEFT JOIN. A user may have multiple teams and this requires distinct. I have implemented the distinct with a group as suggested by one of our users @francescomucio.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improve

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@sureshms @harshach