### PR TITLE
[issue-1700] - Invalid Dashboard and duplicate logic in MlModel

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/MlModelRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/MlModelRepository.java
@@ -135,13 +135,11 @@ public class MlModelRepository extends EntityRepository<MlModel> {
     // Check if owner is valid and set the relationship
     mlModel.setOwner(EntityUtil.populateOwner(dao.userDAO(), dao.teamDAO(), mlModel.getOwner()));
 
-    setDashboard(mlModel, mlModel.getDashboard());
+    // Check that the dashboard exists
     if (mlModel.getDashboard() != null) {
-      // Add relationship from MlModel to Dashboard
-      String dashboardId = mlModel.getDashboard().getId().toString();
-      dao.relationshipDAO().insert(dashboardId, mlModel.getId().toString(), Entity.MLMODEL, Entity.DASHBOARD,
-              Relationship.USES.ordinal());
+      dao.dashboardDAO().findEntityReferenceById(mlModel.getDashboard().getId());
     }
+
     mlModel.setTags(EntityUtil.addDerivedTags(dao.tagDAO(), mlModel.getTags()));
   }
 

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/mlmodels/MlModelResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/mlmodels/MlModelResourceTest.java
@@ -226,6 +226,16 @@ public class MlModelResourceTest extends EntityResourceTest<MlModel> {
   }
 
   @Test
+  public void put_MlModelAddInvalidDashboard_200(TestInfo test) throws IOException {
+    CreateMlModel request = create(test);
+    // Create a made up dashboard reference by picking up a random UUID
+    EntityReference dashboard = new EntityReference().withId(USER1.getId()).withType("dashboard");
+    //MlModel model = createAndCheckEntity(request, adminAuthHeaders());
+    assertResponse(() -> createMlModel(request.withDashboard(dashboard), adminAuthHeaders()), Status.NOT_FOUND,
+            String.format("dashboard instance for %s not found", USER1.getId()));
+  }
+
+  @Test
   public void put_MlModelAddServer_200(TestInfo test) throws IOException {
     CreateMlModel request = create(test);
     MlModel model = createAndCheckEntity(request, adminAuthHeaders());


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
This PR fixes https://github.com/open-metadata/OpenMetadata/issues/1700.

We were duplicating some logic in `prepare` and `storeRelationship` for the MlModel regarding the dashboard href.

We are now validating that the received dashboard indeed exists and keeping the relationship setter at `storeRelationship`.

There is a new test validating that passing an invalid dashboard is flagged as 404.

Thanks!

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers

 @sureshms @harshach 