### PR TITLE
Fix #1729: Connector Trino works with username.

### DIFF
--- a/ingestion/examples/workflows/trino.json
+++ b/ingestion/examples/workflows/trino.json
@@ -4,8 +4,9 @@
     "config": {
       "service_name": "local_trino",
       "host_port": "localhost:8080",
-      "catalog": "catalog_name",
-      "schema_name": "schema_name"
+      "username": "user",
+      "catalog": "tpcds",
+      "database": "tiny"
     }
   },
   "sink": {

--- a/ingestion/tests/unit/trino_test.py
+++ b/ingestion/tests/unit/trino_test.py
@@ -1,0 +1,43 @@
+import json
+from unittest import TestCase
+
+from metadata.ingestion.api.workflow import Workflow
+
+config = """
+{
+  "source": {
+    "type": "trino",
+    "config": {
+      "service_name": "local_trino",
+      "host_port": "localhost:8080",
+      "username": "user",
+      "catalog": "tpcds",
+      "database": "tiny"
+    }
+  },
+  "sink": {
+    "type": "metadata-rest",
+    "config": {}
+  },
+  "metadata_server": {
+    "type": "metadata-server",
+    "config": {
+      "api_endpoint": "http://localhost:8585/api",
+      "auth_provider_type": "no-auth"
+    }
+  }
+}
+"""
+
+
+class WorkflowTest(TestCase):
+    def test_execute_200(self):
+        """
+        stage/file.py must be compatible with source/sample_data.py,
+        this test try to catch if one becomes incompatible with the other
+        by running a workflow that includes both of them.
+        """
+        workflow = Workflow.create(json.loads(config))
+        workflow.execute()
+        workflow.stop()
+        self.assertTrue(True)


### PR DESCRIPTION
### Implementation details
I have decided to rename ```schema_name``` to ```database``` and make it mandatory. Without ```database``` there is an error while scanning all available tables. The connector doesn't support multiple databases at the moment. It has to be tested with passwords. Trino requires SSL if you use passwords. It has to be tested with impersonation. I have removed quote_plus because I don't think it's needed.

- [x] Support username
- [ ] There is an integration test
- [ ] Support impersonation
- [ ] Support passwords
- [ ] Support tokens
- [ ] Support multiple databases

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@harshach @ayush-shah @pmbrull
