### PR TITLE
Fix #1749: Location is missing some fields

### DIFF
--- a/ingestion/src/metadata/ingestion/sink/metadata_rest.py
+++ b/ingestion/src/metadata/ingestion/sink/metadata_rest.py
@@ -162,6 +162,8 @@ class MetadataRestSink(Sink[Entity]):
                 location_request = CreateLocationEntityRequest(
                     name=db_and_table.location.name,
                     description=db_and_table.location.description.strip(),
+                    locationType=db_and_table.location.locationType,
+                    owner=db_and_table.location.owner,
                     service=EntityReference(
                         id=db_and_table.location.service.id,
                         type="storageService",
@@ -288,7 +290,6 @@ class MetadataRestSink(Sink[Entity]):
                 name=location.name,
                 description=location.description,
                 locationType=location.locationType,
-                tags=location.tags,
                 owner=location.owner,
                 service=location.service,
             )


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the ingestion framework because the locationType was missing from the Glue example. I have added the owner field and removed the tags because the other entities didn't have them.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@harshach @ayush-shah @pmbrull
