### PR TITLE
Update docker image tags to 0.6.0

### DIFF
--- a/docker/metadata/docker-compose.yml
+++ b/docker/metadata/docker-compose.yml
@@ -13,7 +13,7 @@ version: "3.9"
 services:
   mysql:
     container_name: openmetadata_mysql
-    image: openmetadata/db:latest
+    image: openmetadata/db:0.6.0
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: password
@@ -40,7 +40,7 @@ services:
   openmetadata-server:
     container_name: openmetadata_server
     restart: always
-    image: openmetadata/server:latest
+    image: openmetadata/server:0.7.0
     expose:
       - 8585
       - 9200
@@ -59,7 +59,7 @@ services:
 
   ingestion:
     container_name: openmetadata_ingestion
-    image: openmetadata/ingestion:latest
+    image: openmetadata/ingestion:0.6.0
     depends_on:
       - mysql
     expose:


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Let's use explicit docker image tags with docker-compose.yaml.
This will make sure the `metadata docker --start` command will always fetch the latest version.
This issue resolves #1429 .

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
