### PR TITLE
Fix: Position issue of clear all button

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/Explore.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/Explore.component.tsx
@@ -385,18 +385,21 @@ const Explore: React.FC<ExploreProps> = ({
   const getTabs = () => {
     return (
       <div className="tw-mb-5">
-        <nav className="tw-flex tw-flex-row tw-gh-tabs-container tw-mx-9 xl:tw-pr-64 lg:tw-pr-0">
-          <div className="tw-w-3/12">
-            {isFilterSelected && (
-              <p
-                className="link-text tw-text-sm tw-text-grey-body tw-text-right tw-mt-5 tw-mr-12"
+        <nav className="tw-flex tw-flex-row tw-gh-tabs-container tw-mx-9 xl:tw-pr-64 lg:tw-pr-0 tw-justify-between">
+          <div className="tw-flex">
+            <div className="tw-w-72 tw-flex-shrink-0">
+              <Button
+                className={classNames('tw-underline tw-mt-5 tw-ml-5', {
+                  'tw-invisible': !isFilterSelected,
+                })}
+                size="custom"
+                theme="primary"
+                variant="link"
                 onClick={resetFilters}>
                 Clear All
-              </p>
-            )}
-          </div>
-          <div className="tw-flex tw-justify-between tw-w-9/12">
-            <div className="tw--ml-2.5">
+              </Button>
+            </div>
+            <div>
               {tabsInfo.map((tabDetail, index) => (
                 <button
                   className={`tw-pb-2 tw-pr-6 tw-gh-tabs ${getActiveTabClass(
@@ -423,8 +426,8 @@ const Explore: React.FC<ExploreProps> = ({
                 </button>
               ))}
             </div>
-            {getSortingElements()}
           </div>
+          {getSortingElements()}
         </nav>
       </div>
     );


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the Faceted search Clear All button to fix position issue

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<p align="center">
<img width="1792" alt="Screenshot 2021-12-16 at 12 47 17 PM" src="https://user-images.githubusercontent.com/86726556/146325485-e42c4e13-bf98-413a-a30b-a1e73469e1f5.png">

</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@shahsank3t @Sachin-chaurasiya 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
