### PR TITLE
[issue-1746] - Add dataSource to MlModel

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -5,5 +5,6 @@
     <file url="file://$PROJECT_DIR$/catalog-rest-service/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/catalog-rest-service/src/main/resources/json/data" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/common/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/openmetadata-ui/src/main/resources/ui/dist" charset="UTF-8" />
   </component>
 </project>

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/MlModelRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/MlModelRepository.java
@@ -149,7 +149,7 @@ public class MlModelRepository extends EntityRepository<MlModel> {
 
   private void validateMlDataSource(MlFeatureSource source) throws IOException {
     if (source.getDataSource() != null) {
-      dao.tableDAO().findEntityReferenceById(source.getDataSource().getId());
+      Entity.getEntityReference(source.getDataSource().getType(), source.getDataSource().getId());
     }
   }
 

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/MlModelRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/MlModelRepository.java
@@ -133,10 +133,7 @@ public class MlModelRepository extends EntityRepository<MlModel> {
         });
   }
 
-  /**
-   * Make sure that all the MlFeatureSources are pointing to correct
-   * EntityReferences in tha Table DAO.
-   */
+  /** Make sure that all the MlFeatureSources are pointing to correct EntityReferences in tha Table DAO. */
   private void validateReferences(List<MlFeature> mlFeatures) throws IOException {
     for (MlFeature feature : mlFeatures) {
       if (feature.getFeatureSources() != null && !feature.getFeatureSources().isEmpty()) {

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/MlModelRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/MlModelRepository.java
@@ -111,11 +111,14 @@ public class MlModelRepository extends EntityRepository<MlModel> {
     return dao.tagDAO().getTags(fqn);
   }
 
-  private void setMlFeatureSourcesFQN(String parentFQN, List<MlFeatureSource> mlSources) {
+  private void setMlFeatureSourcesFQN(List<MlFeatureSource> mlSources) {
     mlSources.forEach(
         s -> {
-          String sourceFqn = parentFQN + "." + s.getName();
-          s.setFullyQualifiedName(sourceFqn);
+          if (s.getDataSource() != null) {
+            s.setFullyQualifiedName(s.getDataSource().getName() + "." + s.getName());
+          } else {
+            s.setFullyQualifiedName(s.getName());
+          }
         });
   }
 
@@ -125,9 +128,29 @@ public class MlModelRepository extends EntityRepository<MlModel> {
           String featureFqn = parentFQN + "." + f.getName();
           f.setFullyQualifiedName(featureFqn);
           if (f.getFeatureSources() != null) {
-            setMlFeatureSourcesFQN(featureFqn, f.getFeatureSources());
+            setMlFeatureSourcesFQN(f.getFeatureSources());
           }
         });
+  }
+
+  /**
+   * Make sure that all the MlFeatureSources are pointing to correct
+   * EntityReferences in tha Table DAO.
+   */
+  private void validateReferences(List<MlFeature> mlFeatures) throws IOException {
+    for (MlFeature feature : mlFeatures) {
+      if (feature.getFeatureSources() != null && !feature.getFeatureSources().isEmpty()) {
+        for (MlFeatureSource source : feature.getFeatureSources()) {
+          validateMlDataSource(source);
+        }
+      }
+    }
+  }
+
+  private void validateMlDataSource(MlFeatureSource source) throws IOException {
+    if (source.getDataSource() != null) {
+      dao.tableDAO().findEntityReferenceById(source.getDataSource().getId());
+    }
   }
 
   @Override
@@ -135,6 +158,7 @@ public class MlModelRepository extends EntityRepository<MlModel> {
     mlModel.setFullyQualifiedName(getFQN(mlModel));
 
     if (mlModel.getMlFeatures() != null && !mlModel.getMlFeatures().isEmpty()) {
+      validateReferences(mlModel.getMlFeatures());
       setMlFeatureFQN(mlModel.getFullyQualifiedName(), mlModel.getMlFeatures());
     }
 

--- a/catalog-rest-service/src/main/resources/json/schema/entity/data/mlmodel.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/data/mlmodel.json
@@ -84,6 +84,10 @@
         "fullyQualifiedName": {
           "$ref": "#/definitions/fullyQualifiedFeatureSourceName"
         },
+        "dataSource": {
+          "description": "Description of the Data Source (e.g., a Table)",
+          "$ref" : "../../type/entityReference.json"
+        },
         "tags": {
           "description": "Tags associated with the feature source.",
           "type": "array",

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/mlmodels/MlModelResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/mlmodels/MlModelResourceTest.java
@@ -41,20 +41,29 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.openmetadata.catalog.Entity;
+import org.openmetadata.catalog.api.data.CreateDatabase;
 import org.openmetadata.catalog.api.data.CreateMlModel;
+import org.openmetadata.catalog.api.data.CreateTable;
 import org.openmetadata.catalog.api.services.CreateDashboardService;
 import org.openmetadata.catalog.api.services.CreateDashboardService.DashboardServiceType;
 import org.openmetadata.catalog.entity.data.Dashboard;
+import org.openmetadata.catalog.entity.data.Database;
 import org.openmetadata.catalog.entity.data.MlModel;
+import org.openmetadata.catalog.entity.data.Table;
 import org.openmetadata.catalog.entity.services.DashboardService;
 import org.openmetadata.catalog.jdbi3.DashboardRepository.DashboardEntityInterface;
 import org.openmetadata.catalog.jdbi3.DashboardServiceRepository.DashboardServiceEntityInterface;
 import org.openmetadata.catalog.jdbi3.MlModelRepository;
+import org.openmetadata.catalog.jdbi3.TableRepository.TableEntityInterface;
 import org.openmetadata.catalog.resources.EntityResourceTest;
 import org.openmetadata.catalog.resources.dashboards.DashboardResourceTest;
+import org.openmetadata.catalog.resources.databases.DatabaseResourceTest;
+import org.openmetadata.catalog.resources.databases.TableResourceTest;
 import org.openmetadata.catalog.resources.mlmodels.MlModelResource.MlModelList;
 import org.openmetadata.catalog.resources.services.DashboardServiceResourceTest;
 import org.openmetadata.catalog.type.ChangeDescription;
+import org.openmetadata.catalog.type.Column;
+import org.openmetadata.catalog.type.ColumnDataType;
 import org.openmetadata.catalog.type.EntityReference;
 import org.openmetadata.catalog.type.FeatureSourceDataType;
 import org.openmetadata.catalog.type.FieldChange;
@@ -74,6 +83,10 @@ public class MlModelResourceTest extends EntityResourceTest<MlModel> {
   public static final String ALGORITHM = "regression";
   public static Dashboard DASHBOARD;
   public static EntityReference DASHBOARD_REFERENCE;
+  public static Database DATABASE;
+  public static List<Column> COLUMNS;
+  public static Table TABLE;
+  public static EntityReference TABLE_REFERENCE;
 
   public static final URI SERVER = URI.create("http://localhost.com/mlModel");
   public static final MlStore ML_STORE =
@@ -124,6 +137,26 @@ public class MlModelResourceTest extends EntityResourceTest<MlModel> {
         dashboardResourceTest.createDashboard(
             dashboardResourceTest.create(test).withService(SUPERSET_REFERENCE), adminAuthHeaders());
     DASHBOARD_REFERENCE = new DashboardEntityInterface(DASHBOARD).getEntityReference();
+
+    DatabaseResourceTest databaseResourceTest = new DatabaseResourceTest();
+    CreateDatabase create = databaseResourceTest.create(test).withService(SNOWFLAKE_REFERENCE);
+    DATABASE = databaseResourceTest.createAndCheckEntity(create, adminAuthHeaders());
+
+    COLUMNS =
+            Collections.singletonList(
+                    new Column()
+                            .withName("age")
+                            .withDataType(ColumnDataType.INT)
+            );
+
+    CreateTable createTable = new CreateTable()
+            .withName("myTable")
+            .withDatabase(DATABASE.getId())
+            .withColumns(COLUMNS);
+
+    TableResourceTest tableResourceTest = new TableResourceTest();
+    TABLE = tableResourceTest.createAndCheckEntity(createTable, adminAuthHeaders());
+    TABLE_REFERENCE = new TableEntityInterface(TABLE).getEntityReference();
   }
 
   public static MlModel createMlModel(CreateMlModel create, Map<String, String> authHeaders)
@@ -223,11 +256,12 @@ public class MlModelResourceTest extends EntityResourceTest<MlModel> {
     CreateMlModel request = create(test);
     // Create a made up dashboard reference by picking up a random UUID
     EntityReference dashboard = new EntityReference().withId(USER1.getId()).withType("dashboard");
-    // MlModel model = createAndCheckEntity(request, adminAuthHeaders());
+
     assertResponse(
         () -> createMlModel(request.withDashboard(dashboard), adminAuthHeaders()),
         Status.NOT_FOUND,
-        String.format("dashboard instance for %s not found", USER1.getId()));
+        String.format("dashboard instance for %s not found", USER1.getId())
+    );
   }
 
   @Test
@@ -288,6 +322,56 @@ public class MlModelResourceTest extends EntityResourceTest<MlModel> {
     change.getFieldsDeleted().add(new FieldChange().withName("mlFeatures").withOldValue(ML_FEATURES));
 
     updateAndCheckEntity(request.withMlFeatures(newFeatures), Status.OK, adminAuthHeaders(), MINOR_UPDATE, change);
+  }
+
+  @Test
+  public void put_MlModelWithDataSource_200(TestInfo test) throws IOException {
+    CreateMlModel request = create(test);
+    MlModel model = createAndCheckEntity(request, adminAuthHeaders());
+
+    MlFeature newMlFeature = new MlFeature()
+            .withName("color")
+            .withDataType(MlFeatureDataType.Categorical)
+            .withFeatureSources(
+                    Collections.singletonList(
+                            new MlFeatureSource()
+                                    .withName("age")
+                                    .withDataType(FeatureSourceDataType.INTEGER)
+                                    .withDataSource(TABLE_REFERENCE)
+                    ));
+    List<MlFeature> newFeatures = Collections.singletonList(newMlFeature);
+
+    ChangeDescription change = getChangeDescription(model.getVersion());
+    change.getFieldsAdded().add(new FieldChange().withName("mlFeatures").withNewValue(newFeatures));
+    change.getFieldsDeleted().add(new FieldChange().withName("mlFeatures").withOldValue(ML_FEATURES));
+
+    updateAndCheckEntity(request.withMlFeatures(newFeatures), Status.OK, adminAuthHeaders(), MINOR_UPDATE, change);
+  }
+
+  @Test
+  public void put_MlModelWithInvalidDataSource_400(TestInfo test) throws IOException {
+    CreateMlModel request = create(test);
+
+    // Create a made up table reference by picking up a random UUID
+    EntityReference invalid_table = new EntityReference().withId(USER1.getId()).withType("table");
+
+    MlFeature newMlFeature = new MlFeature()
+            .withName("color")
+            .withDataType(MlFeatureDataType.Categorical)
+            .withFeatureSources(
+                    Collections.singletonList(
+                            new MlFeatureSource()
+                                    .withName("age")
+                                    .withDataType(FeatureSourceDataType.INTEGER)
+                                    .withDataSource(invalid_table)
+                    ));
+    List<MlFeature> newFeatures = Collections.singletonList(newMlFeature);
+
+    assertResponse(
+            () -> createMlModel(request.withMlFeatures(newFeatures), adminAuthHeaders()),
+            Status.NOT_FOUND,
+            String.format("table instance for %s not found", USER1.getId())
+    );
   }
 
   @Test
@@ -425,6 +509,7 @@ public class MlModelResourceTest extends EntityResourceTest<MlModel> {
         assertEquals(actual.getName(), expected.getName());
         assertEquals(actual.getDescription(), expected.getDescription());
         assertEquals(actual.getDataType(), expected.getDataType());
+        assertEquals(actual.getDataSource(), expected.getDataSource());
       };
 
   private void validateMlFeatureSources(List<MlFeature> expected, List<MlFeature> actual) {

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/mlmodels/MlModelResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/mlmodels/MlModelResourceTest.java
@@ -142,17 +142,9 @@ public class MlModelResourceTest extends EntityResourceTest<MlModel> {
     CreateDatabase create = databaseResourceTest.create(test).withService(SNOWFLAKE_REFERENCE);
     DATABASE = databaseResourceTest.createAndCheckEntity(create, adminAuthHeaders());
 
-    COLUMNS =
-            Collections.singletonList(
-                    new Column()
-                            .withName("age")
-                            .withDataType(ColumnDataType.INT)
-            );
+    COLUMNS = Collections.singletonList(new Column().withName("age").withDataType(ColumnDataType.INT));
 
-    CreateTable createTable = new CreateTable()
-            .withName("myTable")
-            .withDatabase(DATABASE.getId())
-            .withColumns(COLUMNS);
+    CreateTable createTable = new CreateTable().withName("myTable").withDatabase(DATABASE.getId()).withColumns(COLUMNS);
 
     TableResourceTest tableResourceTest = new TableResourceTest();
     TABLE = tableResourceTest.createAndCheckEntity(createTable, adminAuthHeaders());
@@ -260,8 +252,7 @@ public class MlModelResourceTest extends EntityResourceTest<MlModel> {
     assertResponse(
         () -> createMlModel(request.withDashboard(dashboard), adminAuthHeaders()),
         Status.NOT_FOUND,
-        String.format("dashboard instance for %s not found", USER1.getId())
-    );
+        String.format("dashboard instance for %s not found", USER1.getId()));
   }
 
   @Test
@@ -329,16 +320,16 @@ public class MlModelResourceTest extends EntityResourceTest<MlModel> {
     CreateMlModel request = create(test);
     MlModel model = createAndCheckEntity(request, adminAuthHeaders());
 
-    MlFeature newMlFeature = new MlFeature()
+    MlFeature newMlFeature =
+        new MlFeature()
             .withName("color")
             .withDataType(MlFeatureDataType.Categorical)
             .withFeatureSources(
-                    Collections.singletonList(
-                            new MlFeatureSource()
-                                    .withName("age")
-                                    .withDataType(FeatureSourceDataType.INTEGER)
-                                    .withDataSource(TABLE_REFERENCE)
-                    ));
+                Collections.singletonList(
+                    new MlFeatureSource()
+                        .withName("age")
+                        .withDataType(FeatureSourceDataType.INTEGER)
+                        .withDataSource(TABLE_REFERENCE)));
     List<MlFeature> newFeatures = Collections.singletonList(newMlFeature);
 
     ChangeDescription change = getChangeDescription(model.getVersion());
@@ -355,23 +346,22 @@ public class MlModelResourceTest extends EntityResourceTest<MlModel> {
     // Create a made up table reference by picking up a random UUID
     EntityReference invalid_table = new EntityReference().withId(USER1.getId()).withType("table");
 
-    MlFeature newMlFeature = new MlFeature()
+    MlFeature newMlFeature =
+        new MlFeature()
             .withName("color")
             .withDataType(MlFeatureDataType.Categorical)
             .withFeatureSources(
-                    Collections.singletonList(
-                            new MlFeatureSource()
-                                    .withName("age")
-                                    .withDataType(FeatureSourceDataType.INTEGER)
-                                    .withDataSource(invalid_table)
-                    ));
+                Collections.singletonList(
+                    new MlFeatureSource()
+                        .withName("age")
+                        .withDataType(FeatureSourceDataType.INTEGER)
+                        .withDataSource(invalid_table)));
     List<MlFeature> newFeatures = Collections.singletonList(newMlFeature);
 
     assertResponse(
-            () -> createMlModel(request.withMlFeatures(newFeatures), adminAuthHeaders()),
-            Status.NOT_FOUND,
-            String.format("table instance for %s not found", USER1.getId())
-    );
+        () -> createMlModel(request.withMlFeatures(newFeatures), adminAuthHeaders()),
+        Status.NOT_FOUND,
+        String.format("table instance for %s not found", USER1.getId()));
   }
 
   @Test


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
This PR fixes https://github.com/open-metadata/OpenMetadata/issues/1746

By adding the dataSource attribute to the MlFeatureSource we have the required ingredients to iterate on this and have proper lineage information between MlModels and Tables.

I'll prepare a follow-up PR updating the Python API to add the lineage on PUT/POST.

Thanks!

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have performed a self-review of my own. 
- [ ] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers

Backend: @sureshms @harshach
