### PR TITLE
Fix #1821: PyHive registers the trino:// schema too

### DIFF
--- a/ingestion/src/metadata/cmd.py
+++ b/ingestion/src/metadata/cmd.py
@@ -14,10 +14,9 @@ import os
 import pathlib
 import subprocess
 import sys
+import tempfile
 import time
 import traceback
-import tempfile
-import pathlib
 from datetime import timedelta
 
 import click
@@ -47,9 +46,11 @@ def check() -> None:
 
 @click.group()
 @click.version_option(get_metadata_version())
-@click.option("--debug/--no-debug", default=False)
+@click.option(
+    "--debug/--no-debug", default=lambda: os.environ.get("METADATA_DEBUG", False)
+)
 def metadata(debug: bool) -> None:
-    if os.getenv("METADATA_DEBUG", False):
+    if debug:
         logging.getLogger().setLevel(logging.INFO)
         logging.getLogger("metadata").setLevel(logging.DEBUG)
     else:
@@ -160,6 +161,7 @@ def docker(start, stop, clean, type, path) -> None:
 
     try:
         import docker as sys_docker
+
         from metadata.ingestion.ometa.ometa_api import OpenMetadata
         from metadata.ingestion.ometa.openmetadata_rest import MetadataServerConfig
 

--- a/ingestion/src/metadata/ingestion/source/trino.py
+++ b/ingestion/src/metadata/ingestion/source/trino.py
@@ -8,15 +8,19 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
+import logging
+import sys
 from typing import Iterable
 from urllib.parse import quote_plus
 
+import click
 from sqlalchemy.inspection import inspect
 
 from metadata.ingestion.models.ometa_table_db import OMetaDatabaseAndTable
 from metadata.ingestion.ometa.openmetadata_rest import MetadataServerConfig
 from metadata.ingestion.source.sql_source import SQLConnectionConfig, SQLSource
+
+logger = logging.getLogger(__name__)
 
 
 class TrinoConfig(SQLConnectionConfig):
@@ -53,6 +57,18 @@ class TrinoConfig(SQLConnectionConfig):
 
 class TrinoSource(SQLSource):
     def __init__(self, config, metadata_config, ctx):
+        try:
+            from sqlalchemy_trino import dbapi
+        except ModuleNotFoundError:
+            click.secho(
+                "Trino source dependencies are missing. Please run\n"
+                + "$ pip install --upgrade 'openmetadata-ingestion[trino]'",
+                fg="red",
+            )
+            if logger.isEnabledFor(logging.DEBUG):
+                raise
+            else:
+                sys.exit(1)
         super().__init__(config, metadata_config, ctx)
 
     @classmethod


### PR DESCRIPTION
### Describe your changes :
Both PyHive and sqlalchemy-trino were installed in my venv. I removed accidentaly sqlalchemy-trino.

Instead of getting
```
sqlalchemy.exc.NoSuchModuleError: Can't load plugin: sqlalchemy.dialects:trino
```

I got
```
[2021-12-19 18:36:54,665] INFO     {metadata.ingestion.source.sql_source:361} - Parsing Data Models
[2021-12-19 18:36:57,887] INFO     {metadata.ingestion.source.sql_source:64} - Table Scanned: local_trino.call_center
[2021-12-19 18:36:57,887] ERROR    {metadata.ingestion.source.sql_source:148} - Table Description Error :
/Users/amiorin/.pyenv/versions/3.9.7/envs/test2/lib/python3.9/site-packages/pyhive/sqlalchemy_presto.py:151: SAWarning: Did not recognize type 'char(16)' of column 'cc_call_center_id'
  util.warn("Did not recognize type '%s' of column '%s'" % (row.Type, row.Column))
```

And this can make our users think that there is a bug in our code instead of a misconfiguration.

see also #1835 and #1847

#
### Implementation details

I have fixed a bug in how we treat the METADATA_DEBUG and --debug. If debug is enabled, we print the backtrace. If debug is disabled we print the remedy in plain English.
#
![image](https://user-images.githubusercontent.com/32617/147129126-fc123e29-4dde-4394-a11e-ecbcbe9efb4f.png)
#
![image](https://user-images.githubusercontent.com/32617/147129186-f36cdff9-11dc-44aa-abbb-7911caf44ed0.png)


#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Reviewers
@harshach @ayush-shah @pmbrull
