### PR TITLE
Fix: text highlight issue on search

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/searched-data/SearchedData.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/searched-data/SearchedData.tsx
@@ -62,22 +62,15 @@ const SearchedData: React.FC<SearchedDataProp> = ({
   const highlightSearchResult = () => {
     return data.map((table, index) => {
       let tDesc = table.description;
-      const highLightedTexts = !isEmpty(table.highlight?.description)
-        ? table.highlight?.description.join(' ') || ''
-        : '';
-      const highlightTxtMatch = highLightedTexts.match(
-        /<span(.*?)>(.*?)<\/span>/g
-      );
-      if (highlightTxtMatch) {
-        const matchTextArr = highlightTxtMatch.map((val) =>
+      const highLightedTexts = table.highlight?.description || [];
+
+      if (highLightedTexts) {
+        const matchTextArr = highLightedTexts.map((val) =>
           val.replace(/<\/?span(.*?)>/g, '')
         );
-        matchTextArr.forEach((text) => {
-          const regEx = new RegExp(`\\b${text}\\b`, 'g');
-          tDesc = tDesc.replace(
-            regEx,
-            `<span class="text-highlighter">${text}</span>`
-          );
+
+        matchTextArr.forEach((text, i) => {
+          tDesc = tDesc.replace(text, highLightedTexts[i]);
         });
       }
 

--- a/openmetadata-ui/src/main/resources/ui/src/styles/x-master.css
+++ b/openmetadata-ui/src/main/resources/ui/src/styles/x-master.css
@@ -706,7 +706,7 @@ a:focus {
 
 .text-highlighter {
   background-color: #ffc34e40;
-  padding: 0.25rem;
+  padding: 0 0.25rem;
 }
 
 body .profiler-graph .recharts-active-dot circle {


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the text highlight issue because it's applying a duplicate highlight style when there is multiple texts found in a single description.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
![image](https://user-images.githubusercontent.com/71748675/146725606-988f01ca-8cac-450c-845d-3a8cf9b3a0b5.png)


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
 Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya 
