### PR TITLE
Fix:  #1745 Two arrows seem unnecessary In details page breadcrumb.

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/title-breadcrumb/title-breadcrumb.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/title-breadcrumb/title-breadcrumb.component.tsx
@@ -42,7 +42,7 @@ const TitleBreadcrumb: FunctionComponent<TitleBreadcrumbProps> = ({
                     {link.name}
                   </Link>
                   <span className="tw-px-2">
-                    <i className="fas fa-angle-double-right tw-text-xs tw-cursor-default tw-text-gray-400 tw-align-middle" />
+                    <i className="fas fa-angle-right tw-text-xs tw-cursor-default tw-text-gray-400 tw-align-middle" />
                   </span>
                 </>
               ) : link.url ? (


### PR DESCRIPTION
Closes #1745 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the details page breadcrumb because need to replace the two arrow with single arrow.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement


#
### Frontend Preview (Screenshots) :
![image](https://user-images.githubusercontent.com/59080942/146922710-5310d944-9f14-4120-8347-36af8f925508.png)


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@shahsank3t, @darth-coder00
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
