### PR TITLE
fix: openmetadata-security.yaml jdbc-option

### DIFF
--- a/conf/openmetadata-security.yaml
+++ b/conf/openmetadata-security.yaml
@@ -23,7 +23,7 @@ server:
       port: 8586
 
 # Above configuration for running http is fine for dev and testing.
-# For production setup, where UI app will hit apis through DPS it 
+# For production setup, where UI app will hit apis through DPS it
 # is strongly recommended to run https instead. Note that only
 # keyStorePath and keyStorePassword are mandatory properties. Values
 # for other properties are defaults
@@ -31,7 +31,7 @@ server:
   #applicationConnectors:
   #  - type: https
   #    port: 8585
-  #    keyStorePath: ./conf/keystore.jks 
+  #    keyStorePath: ./conf/keystore.jks
   #    keyStorePassword: changeit
   #    keyStoreType: JKS
   #    keyStoreProvider:
@@ -55,12 +55,12 @@ server:
   #    supportedCipherSuites: TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
   #    allowRenegotiation: true
   #    endpointIdentificationAlgorithm: (none)
- 
+
   #adminConnectors:
   #  - type: https
   #    port: 8586
-  #    keyStorePath: ./conf/keystore.jks 
-  #    keyStorePassword: changeit 
+  #    keyStorePath: ./conf/keystore.jks
+  #    keyStorePassword: changeit
   #    keyStoreType: JKS
   #    keyStoreProvider:
   #    trustStorePath: /path/to/file
@@ -109,7 +109,7 @@ database:
   user: openmetadata_user
   password: openmetadata_password
   # the JDBC URL; the database is called openmetadata_db
-  url: jdbc:mysql://localhost/openmetadata_db?useSSL=false&serverTimezone=UTC
+  url: jdbc:mysql://localhost/openmetadata_db?allowPublicKeyRetrieval=true&useSSL=false&serverTimezone=UTC
 
 
 # Authorizer Configuration
@@ -129,7 +129,7 @@ authenticationConfiguration:
   authority: "https://accounts.google.com"
   clientId: "261867039324-neb92r2147i6upchb78tv29idk079bps.apps.googleusercontent.com"
   callbackUrl: "http://localhost:8585/callback"
-  
+
 elasticsearch:
   host: localhost
   port: 9200
@@ -160,4 +160,3 @@ health:
         downtimeInterval: 10s
         failureAttempts: 2
         successAttempts: 1
-


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
There is an error in the mysql jdbc option information in `openmetadata-security.yaml` provided as an example.
Using mysql 8.x, only `useSSL=false` option exists and `allowPublicKeyRetrieval=true` option does not exist.
A runtime error occurs.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [x] New feature
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have performed a self-review of my own. 
- [ ] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
