### PR TITLE
[issue-1834] - Prepare MlModel lineage

### DIFF
--- a/ingestion/src/metadata/ingestion/ometa/mixins/mlModelMixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/mlModelMixin.py
@@ -1,0 +1,60 @@
+"""
+Mixin class containing Lineage specific methods
+
+To be used by OpenMetadata class
+"""
+import logging
+from typing import Any, Dict
+
+from metadata.generated.schema.api.lineage.addLineage import AddLineage
+from metadata.generated.schema.entity.data.mlmodel import MlModel
+from metadata.generated.schema.type.entityLineage import EntitiesEdge
+from metadata.generated.schema.type.entityReference import EntityReference
+from metadata.ingestion.ometa.client import REST
+from metadata.ingestion.ometa.mixins.lineageMixin import OMetaLineageMixin
+
+logger = logging.getLogger(__name__)
+
+
+class OMetaMlModelMixin(OMetaLineageMixin):
+    """
+    OpenMetadata API methods related to MlModel.
+
+    To be inherited by OpenMetadata
+    """
+
+    client: REST
+
+    def add_mlmodel_lineage(self, model: MlModel) -> Dict[str, Any]:
+        """
+        Iterates over MlModel's Feature Sources and
+        add the lineage information.
+        :param model: MlModel containing EntityReferences
+        :return: List of added lineage information
+        """
+
+        # Fetch all informed dataSource values
+        refs = [
+            source.dataSource
+            for feature in model.mlFeatures
+            if model.mlFeatures
+            for source in feature.featureSources
+            if feature.featureSources
+            if source.dataSource
+        ]
+
+        # Iterate on the references to add lineage
+        for entity_ref in refs:
+            self.add_lineage(
+                AddLineage(
+                    description="MlModel uses FeatureSource",
+                    edge=EntitiesEdge(
+                        fromEntity=EntityReference(id=model.id, type="mlmodel"),
+                        toEntity=entity_ref,
+                    ),
+                )
+            )
+
+        mlmodel_lineage = self.get_lineage_by_id(MlModel, str(model.id.__root__))
+
+        return mlmodel_lineage

--- a/ingestion/src/metadata/ingestion/ometa/ometa_api.py
+++ b/ingestion/src/metadata/ingestion/ometa/ometa_api.py
@@ -39,6 +39,7 @@ from metadata.generated.schema.type.entityHistory import EntityVersionHistory
 from metadata.ingestion.ometa.auth_provider import AuthenticationProvider
 from metadata.ingestion.ometa.client import REST, APIError, ClientConfig
 from metadata.ingestion.ometa.mixins.lineageMixin import OMetaLineageMixin
+from metadata.ingestion.ometa.mixins.mlModelMixin import OMetaMlModelMixin
 from metadata.ingestion.ometa.mixins.tableMixin import OMetaTableMixin
 from metadata.ingestion.ometa.openmetadata_rest import (
     Auth0AuthenticationProvider,
@@ -75,7 +76,7 @@ class EntityList(Generic[T], BaseModel):
     after: str = None
 
 
-class OpenMetadata(OMetaLineageMixin, OMetaTableMixin, Generic[T, C]):
+class OpenMetadata(OMetaMlModelMixin, OMetaTableMixin, Generic[T, C]):
     """
     Generic interface to the OpenMetadata API
 


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
This PR fixes https://github.com/open-metadata/OpenMetadata/issues/1834

To have the complete view of a MlModel inside a Data Platform, we had already added the possibility to have an `EntityReference` as the `dataSource` of a `MlFeatureSource`.

In this PR, we are updating the Python API to easily ingest the lineage for a given MlModel.

Thanks!

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation


#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
@harshach @ayush-shah
