### PR TITLE
Close #2006: The MySql connector sample configuration file lacks `host_port` 

### DIFF
--- a/docs/openmetadata/connectors/mysql.md
+++ b/docs/openmetadata/connectors/mysql.md
@@ -110,6 +110,7 @@ Note: The `source.config` field in the configuration JSON will include the major
   "source": {
     "type": "mysql",
     "config": {
+      "host_port": "hostname.domain.com:5439",
       "username": "openmetadata_user",
       "password": "openmetadata_password",
       "database": "openmetadata_db",


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the MySql connector documentation because an option was missing in the sample connector file and I had to spend some time to figure out what was missing, with this other people will save a bit of time.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have performed a self-review of my own. 
- [ ] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
@harshach