### PR TITLE
Fix #2060: java-checkstyle is not working anymore

### DIFF
--- a/.github/workflows/java-checkstyle-ro.yml
+++ b/.github/workflows/java-checkstyle-ro.yml
@@ -9,8 +9,10 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-name: java-checkstyle
+name: Run the java checkstyle
 
+# read-only repo token
+# no access to secrets
 on:
   pull_request_target:
     branches: [ main ]
@@ -27,8 +29,6 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        node-version:
-          - 12.x
 
     steps:
       - name: Checkout
@@ -42,22 +42,26 @@ jobs:
       - name: Run checkstyle
         run: mvn googleformatter:format@reformat-sources
 
-      - name: Save checkstyle outcome
-        id: git
-        continue-on-error: true
+      - name: Save checkstyle outcome and PR number
+        shell: bash {0}
         run: |
+          mkdir -p ./pr
           git diff-files --quiet
+          echo $? > ./pr/checkstyle_exit_code
+          echo ${{ github.event.number }} > ./pr/NR
 
-      - name: Create a comment in the PR with the instructions
-        if: steps.git.outcome != 'success'
-        uses: peter-evans/create-or-update-comment@v1
+      - name: Upload checkstyle outcome and PR number
+        uses: actions/upload-artifact@v2
         with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            The Java checkstyle failed. Please run `mvn googleformatter:format@reformat-sources` in the root
-            of your repository and commit the changes to this PR.
+          name: pr
+          path: pr/
 
-      - name: Java checkstyle failed, check the comment in the PR
-        if: steps.git.outcome != 'success'
-        run: |
-          exit 1
+      - name: Fail if Java checkstyle failed
+        uses: actions/github-script@v3
+        with:
+          script: |
+            var fs = require('fs');
+            var error = Number(fs.readFileSync('./pr/checkstyle_exit_code')) > 0
+            if (error) {
+              process.exit(error)
+            }

--- a/.github/workflows/java-checkstyle-rw.yml
+++ b/.github/workflows/java-checkstyle-rw.yml
@@ -1,0 +1,66 @@
+#  Copyright 2021 Collate
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+name: Comment on the pull request
+
+# read-write repo token
+# access to secrets
+on:
+  workflow_run:
+    workflows: ["Run the java checkstyle"]
+    types:
+      - completed
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: >
+      ${{ github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: 'Download artifact'
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+      - run: unzip pr.zip
+
+      - name: 'Comment on PR'
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            var fs = require('fs');
+            var issue_number = Number(fs.readFileSync('./NR'));
+            var error = Number(fs.readFileSync('./checkstyle_exit_code')) > 0
+            if (error) {
+              await github.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue_number,
+                body: '**The Java checkstyle failed.**\n\nPlease run `mvn googleformatter:format@reformat-sources` in the root of your repository and commit the changes to this PR. You can also use [pre-commit](https://pre-commit.com/) to automate the Java code formatting.'
+              });
+            }


### PR DESCRIPTION
See #2060 

The first version of this PR was reverting java-checkstyle.
Now, the second version of this PR is fixing the bug.

# Description
There are two actions. The first one is executed in the context of the PR to check the style and save the result. The second one is executed after the first one and in the context of the target (OpenMetadata/main) to leave a comment with the instructions for the developer submitting the PR with code failing the java-checkstyle.

# Security
This approach is safe as described in the [Github blog](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) 