### PR TITLE
Fix: Search bar is searching in last active tab

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/explore/ExplorePage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/explore/ExplorePage.component.tsx
@@ -201,6 +201,10 @@ const ExplorePage: FunctionComponent = () => {
   }, [searchText]);
 
   useEffect(() => {
+    AppState.explorePageTab = tab;
+  }, [tab]);
+
+  useEffect(() => {
     fetchData([
       {
         queryString: searchText,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DatasetDetailsUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DatasetDetailsUtils.ts
@@ -17,6 +17,10 @@ export const datasetTableTabs = [
     path: 'schema',
   },
   {
+    name: 'Sample Data',
+    path: 'sample_data',
+  },
+  {
     name: 'Profiler',
     path: 'profiler',
   },
@@ -29,10 +33,6 @@ export const datasetTableTabs = [
     path: 'dbt',
   },
   {
-    name: 'Sample Data',
-    path: 'sample_data',
-  },
-  {
     name: 'Manage',
     path: 'manage',
   },
@@ -41,20 +41,22 @@ export const datasetTableTabs = [
 export const getCurrentDatasetTab = (tab: string) => {
   let currentTab = 1;
   switch (tab) {
-    case 'profiler':
+    case 'sample_data':
       currentTab = 2;
 
       break;
-    case 'lineage':
+
+    case 'profiler':
       currentTab = 3;
 
       break;
-    case 'dbt':
+
+    case 'lineage':
       currentTab = 4;
 
       break;
 
-    case 'sample_data':
+    case 'dbt':
       currentTab = 5;
 
       break;


### PR DESCRIPTION
### Describe your changes :
Closes #2029 
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the Search functionality to fix ambiguous tab switching

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<p align="center">
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@shahsank3t @Sachin-chaurasiya 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
