### PR TITLE
Fixed : Add bots tab to group users with isBot set to true.

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/UserDetailsModal/UserDetailsModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/UserDetailsModal/UserDetailsModal.tsx
@@ -81,7 +81,7 @@ const UserDetailsModal = ({
               Role: {userData.isAdmin ? 'Admin' : 'User'}
             </p>
             {userData.teams && <div className="tw-filter-seperator tw-w-5/6" />}
-            <p className="tw-w-4/5 tw-mx-auto">
+            <div className="tw-w-4/5 tw-mx-auto">
               <span className="tw-flex tw-justify-center tw-flex-wrap">
                 {userData.teams && userData.teams.length > 0 ? (
                   userData.teams.map((team, i) => (
@@ -95,7 +95,7 @@ const UserDetailsModal = ({
                   <p>This user is not a part of any team!</p>
                 )}
               </span>
-            </p>
+            </div>
           </div>
         </div>
         <div className="tw-modal-footer" data-testid="cta-container">

--- a/openmetadata-ui/src/main/resources/ui/src/components/UserList/UserList.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/UserList/UserList.tsx
@@ -16,6 +16,7 @@ import { isUndefined, lowerCase } from 'lodash';
 import React, { FunctionComponent, useEffect, useState } from 'react';
 import PageLayout from '../../components/containers/PageLayout';
 import Loader from '../../components/Loader/Loader';
+import { UserType } from '../../enums/user.enum';
 import { Team } from '../../generated/entity/teams/team';
 import { User } from '../../generated/entity/teams/user';
 import { getCountBadge } from '../../utils/CommonUtils';
@@ -39,17 +40,58 @@ const UserList: FunctionComponent<Props> = ({
   const [userList, setUserList] = useState<Array<User>>(allUsers);
   const [users, setUsers] = useState<Array<User>>([]);
   const [admins, setAdmins] = useState<Array<User>>([]);
+  const [bots, setBots] = useState<Array<User>>([]);
   const [currentTeam, setCurrentTeam] = useState<Team>();
   const [currentTab, setCurrentTab] = useState<number>(1);
   const [selectedUser, setSelectedUser] = useState<User>();
   const [searchText, setSearchText] = useState('');
 
-  if (selectedUser) {
-    selectedUser;
-  }
-
   const handleSearchAction = (searchValue: string) => {
     setSearchText(searchValue);
+  };
+
+  const isIncludes = (name: string) => {
+    return lowerCase(name).includes(searchText);
+  };
+
+  const setCurrentTabList = (tab: number) => {
+    switch (tab) {
+      case 2:
+        setAdmins(
+          userList.filter(
+            (user) => user.isAdmin && isIncludes(user.displayName || user.name)
+          )
+        );
+
+        break;
+
+      case 3:
+        setBots(
+          userList.filter(
+            (user) => user.isBot && isIncludes(user.displayName || user.name)
+          )
+        );
+
+        break;
+      case 1:
+      default:
+        setUsers(
+          userList.filter(
+            (user) =>
+              !user.isAdmin &&
+              !user.isBot &&
+              isIncludes(user.displayName || user.name)
+          )
+        );
+
+        break;
+    }
+  };
+
+  const setAllTabList = () => {
+    setUsers(userList.filter((user) => !user.isAdmin && !user.isBot));
+    setAdmins(userList.filter((user) => user.isAdmin));
+    setBots(userList.filter((user) => user.isBot));
   };
 
   const selectTeam = (team?: Team) => {
@@ -106,11 +148,7 @@ const UserList: FunctionComponent<Props> = ({
   const handleTabChange = (tab: number) => {
     setSearchText('');
     setCurrentTab(tab);
-    if (tab === 1) {
-      setAdmins(userList.filter((user) => user.isAdmin));
-    } else {
-      setUsers(userList.filter((user) => !user.isAdmin));
-    }
+    setAllTabList();
   };
 
   const getTabs = () => {
@@ -138,6 +176,15 @@ const UserList: FunctionComponent<Props> = ({
               Admins
               {getCountBadge(admins.length, '', currentTab === 2)}
             </button>
+            <button
+              className={`tw-pb-2 tw-px-4 tw-gh-tabs ${getActiveTabClass(3)}`}
+              data-testid="assets"
+              onClick={() => {
+                handleTabChange(3);
+              }}>
+              Bots
+              {getCountBadge(bots.length, '', currentTab === 3)}
+            </button>
           </div>
           <div className="tw-w-4/12 tw-pt-2">
             <Searchbar
@@ -154,42 +201,23 @@ const UserList: FunctionComponent<Props> = ({
   };
 
   useEffect(() => {
-    setUsers(userList.filter((user) => !user.isAdmin));
-    setAdmins(userList.filter((user) => user.isAdmin));
+    setAllTabList();
   }, [userList]);
 
   useEffect(() => {
-    if (!currentTeam) {
+    if (currentTeam) {
+      const userIds = (currentTeam.users || []).map((userData) => userData.id);
+      const filteredUsers = allUsers.filter((user) =>
+        userIds.includes(user.id)
+      );
+      setUserList(filteredUsers);
+    } else {
       setUserList(allUsers);
     }
   }, [allUsers]);
 
-  const isIncludes = (name: string) => {
-    return lowerCase(name).includes(searchText);
-  };
-
   useEffect(() => {
-    if (currentTab === 1) {
-      setUsers(
-        userList.filter((user) => {
-          if (!user.isAdmin && isIncludes(user.displayName || user.name)) {
-            return true;
-          }
-
-          return false;
-        })
-      );
-    } else {
-      setAdmins(
-        userList.filter((user) => {
-          if (user.isAdmin && isIncludes(user.displayName || user.name)) {
-            return true;
-          }
-
-          return false;
-        })
-      );
-    }
+    setCurrentTabList(currentTab);
   }, [searchText]);
 
   const getLeftPanel = () => {
@@ -236,8 +264,24 @@ const UserList: FunctionComponent<Props> = ({
     );
   };
 
-  const getUserCards = (isAdmin = false) => {
-    const listUserData = isAdmin ? admins : users;
+  const getUserCards = (type: UserType) => {
+    let listUserData: Array<User> = [];
+
+    switch (type) {
+      case UserType.ISADMIN:
+        listUserData = admins;
+
+        break;
+      case UserType.ISBOT:
+        listUserData = bots;
+
+        break;
+      case UserType.ISUSER:
+      default:
+        listUserData = users;
+
+        break;
+    }
 
     return (
       <>
@@ -269,8 +313,9 @@ const UserList: FunctionComponent<Props> = ({
       {!isLoading ? (
         <>
           {getTabs()}
-          {currentTab === 1 && getUserCards()}
-          {currentTab === 2 && getUserCards(true)}
+          {currentTab === 1 && getUserCards(UserType.ISUSER)}
+          {currentTab === 2 && getUserCards(UserType.ISADMIN)}
+          {currentTab === 3 && getUserCards(UserType.ISBOT)}
           {!isUndefined(selectedUser) && (
             <UserDetailsModal
               header="User Details"

--- a/openmetadata-ui/src/main/resources/ui/src/enums/user.enum.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/enums/user.enum.ts
@@ -1,0 +1,18 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+export enum UserType {
+  ISBOT = 'isBot',
+  ISADMIN = 'isAdmin',
+  ISUSER = 'user',
+}


### PR DESCRIPTION
Fixes #2171 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the user listing page because of the need to add a separate tab for `bots`.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] Improvement


#
### Frontend Preview (Screenshots) :
![image](https://user-images.githubusercontent.com/59080942/149504325-9e3ff664-cc6a-45c5-a2ef-fe1502758a9e.png)


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@shahsank3t, @darth-coder00
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
