### PR TITLE
Fixed #2238 #2241 Lineage: In view mode, the main node is not highlighted and Two nodes for same table in lineage.

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/EntityLineage/EntityLineage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/EntityLineage/EntityLineage.component.tsx
@@ -118,6 +118,14 @@ const Entitylineage: FunctionComponent<EntityLineageProp> = ({
     status: 'initial',
   });
 
+  const getNodeClass = (node: FlowElement) => {
+    return `${
+      node.id.includes(entityLineage.entity.id) && !isEditMode
+        ? 'leaf-node core'
+        : 'leaf-node'
+    }`;
+  };
+
   const selectedEntityHandler = (entity: EntityReference) => {
     setSelectedEntity(entity);
   };
@@ -232,7 +240,10 @@ const Entitylineage: FunctionComponent<EntityLineageProp> = ({
     setElements((prevElements) => {
       return prevElements.map((el) => {
         if (el.id === selectedNode.id) {
-          return { ...el, className: 'leaf-node' };
+          return {
+            ...el,
+            className: getNodeClass(el),
+          };
         } else {
           return el;
         }
@@ -317,7 +328,10 @@ const Entitylineage: FunctionComponent<EntityLineageProp> = ({
           if (preEl.id === el.id) {
             return { ...preEl, className: `${preEl.className} selected-node` };
           } else {
-            return { ...preEl, className: 'leaf-node' };
+            return {
+              ...preEl,
+              className: getNodeClass(preEl),
+            };
           }
         });
       });
@@ -337,7 +351,10 @@ const Entitylineage: FunctionComponent<EntityLineageProp> = ({
             data: { ...preEl.data, columns: tableColumns },
           };
         } else {
-          return { ...preEl, className: 'leaf-node' };
+          return {
+            ...preEl,
+            className: getNodeClass(preEl),
+          };
         }
       })
     );

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageUtils.tsx
@@ -140,7 +140,7 @@ export const getLineageData = (
     const [xVal, yVal] = [positionX * 2 * depth, y + positionY * posDepth];
 
     return {
-      id: `node-${node.id}-${depth}`,
+      id: `${node.id}`,
       sourcePosition: Position.Right,
       targetPosition: Position.Left,
       type: 'default',
@@ -174,14 +174,14 @@ export const getLineageData = (
             UPStreamNodes.push(makeNode(node, 'from', depth, upDepth));
             lineageEdges.push({
               id: `edge-${up.fromEntity}-${id}-${depth}`,
-              source: `node-${node.id}-${depth}`,
-              target: edg ? edg.id : `node-${id}-${depth}`,
+              source: `${node.id}`,
+              target: edg ? edg.id : `${id}`,
               type: isEditMode ? edgeType : 'custom',
               arrowHeadType: ArrowHeadType.ArrowClosed,
               data: {
                 id: `edge-${up.fromEntity}-${id}-${depth}`,
-                source: `node-${node.id}-${depth}`,
-                target: edg ? edg.id : `node-${id}-${depth}`,
+                source: `${node.id}`,
+                target: edg ? edg.id : `${id}`,
                 sourceType: node.type,
                 targetType: edg?.data?.entityType,
                 onEdgeClick,
@@ -216,14 +216,14 @@ export const getLineageData = (
             DOWNStreamNodes.push(makeNode(node, 'to', depth, downDepth));
             lineageEdges.push({
               id: `edge-${id}-${down.toEntity}`,
-              source: edg ? edg.id : `node-${id}-${depth}`,
-              target: `node-${node.id}-${depth}`,
+              source: edg ? edg.id : `${id}`,
+              target: `${node.id}`,
               type: isEditMode ? edgeType : 'custom',
               arrowHeadType: ArrowHeadType.ArrowClosed,
               data: {
                 id: `edge-${id}-${down.toEntity}`,
-                source: edg ? edg.id : `node-${id}-${depth}`,
-                target: `node-${node.id}-${depth}`,
+                source: edg ? edg.id : `${id}`,
+                target: `${node.id}`,
                 sourceType: edg?.data?.entityType,
                 targetType: node.type,
                 onEdgeClick,
@@ -291,7 +291,7 @@ export const getLineageData = (
 
   const lineageData = [
     {
-      id: `node-${mainNode.id}-1`,
+      id: `${mainNode.id}`,
       sourcePosition: 'right',
       targetPosition: 'left',
       type:


### PR DESCRIPTION
Fixes #2238
Fixes #2241 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the Lineage editor to fix the main node highlighting and Two nodes for the same table in lineage.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@shahsank3t, @darth-coder00
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
