### PR TITLE
Fix issue-2044: Tags drop-down menu is getting overlapped by another elements

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/SampleDataTable/SampleDataTable.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/SampleDataTable/SampleDataTable.component.tsx
@@ -82,7 +82,7 @@ const SampleDataTable: FunctionComponent<Props> = ({ sampleData }: Props) => {
         </button>
       ) : null}
 
-      <div className="tw-table-responsive" ref={tableRef}>
+      <div className="tw-table-responsive tw-overflow-x-auto" ref={tableRef}>
         {sampleData?.rows?.length && sampleData?.columns?.length ? (
           <table
             className="tw-min-w-max tw-w-full tw-table-auto"

--- a/openmetadata-ui/src/main/resources/ui/src/styles/tailwind.css
+++ b/openmetadata-ui/src/main/resources/ui/src/styles/tailwind.css
@@ -57,7 +57,7 @@
     @apply tw-border;
   }
   .tw-table-responsive {
-    @apply tw-block tw-w-full tw-overflow-x-auto;
+    @apply tw-block tw-w-full;
   }
   .tw-table-responsive > .tw-table-bordered {
     @apply tw-border-none;


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Tags drop-down menu is getting overlapped by another elements
Closes #2044 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement

#
### Frontend Preview (Screenshots) :
![image](https://user-images.githubusercontent.com/71748675/149941457-fda5d77f-38be-4db9-8bc4-7cd92b7e2127.png)
![image](https://user-images.githubusercontent.com/71748675/149941784-e5bad2c3-a15e-4418-b08b-d574ef1da3b8.png)


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya 
