### PR TITLE
See #2287: The data access should not throw WebException with HTTP Status code 404

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/airflow/AirflowUtils.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/airflow/AirflowUtils.java
@@ -17,7 +17,6 @@ import static org.openmetadata.catalog.Entity.DATABASE_SERVICE;
 import static org.openmetadata.catalog.Entity.helper;
 
 import java.io.IOException;
-import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -61,8 +60,8 @@ public final class AirflowUtils {
   private AirflowUtils() {}
 
   public static OpenMetadataIngestionComponent makeOpenMetadataDatasourceComponent(AirflowPipeline airflowPipeline)
-      throws IOException, ParseException {
-    DatabaseService databaseService = helper(airflowPipeline).findEntity("service", DATABASE_SERVICE);
+      throws IOException {
+    DatabaseService databaseService = helper(airflowPipeline).getContainer(DATABASE_SERVICE).toEntity();
     DatabaseConnection databaseConnection = databaseService.getDatabaseConnection();
     PipelineConfig pipelineConfig = airflowPipeline.getPipelineConfig();
     Map<String, Object> dbConfig = new HashMap<>();
@@ -125,7 +124,7 @@ public final class AirflowUtils {
   }
 
   public static OpenMetadataIngestionConfig buildDatabaseIngestion(
-      AirflowPipeline airflowPipeline, AirflowConfiguration airflowConfiguration) throws IOException, ParseException {
+      AirflowPipeline airflowPipeline, AirflowConfiguration airflowConfiguration) throws IOException {
     return OpenMetadataIngestionConfig.builder()
         .source(makeOpenMetadataDatasourceComponent(airflowPipeline))
         .sink(makeOpenMetadataSinkComponent(airflowPipeline))
@@ -134,7 +133,7 @@ public final class AirflowUtils {
   }
 
   public static IngestionAirflowPipeline toIngestionPipeline(
-      AirflowPipeline airflowPipeline, AirflowConfiguration airflowConfiguration) throws IOException, ParseException {
+      AirflowPipeline airflowPipeline, AirflowConfiguration airflowConfiguration) throws IOException {
     Map<String, Object> taskParams = new HashMap<>();
     taskParams.put("workflow_config", buildDatabaseIngestion(airflowPipeline, airflowConfiguration));
     IngestionTaskConfig taskConfig = IngestionTaskConfig.builder().opKwargs(taskParams).build();

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/exception/CatalogExceptionMessage.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/exception/CatalogExceptionMessage.java
@@ -14,12 +14,28 @@
 package org.openmetadata.catalog.exception;
 
 import java.util.UUID;
+import org.openmetadata.catalog.type.EntityReference;
 
 public final class CatalogExceptionMessage {
   public static final String ENTITY_ALREADY_EXISTS = "Entity already exists";
   public static final String ENTITY_NAME_EMPTY = "Entity name can't be empty";
 
   private CatalogExceptionMessage() {}
+
+  public static String containerNotFound(EntityReference entityReference) {
+    return String.format("Container for %s %s not found", entityReference.getType(), entityReference.getId());
+  }
+
+  public static String danglingLink(EntityReference source, EntityReference target) {
+    return String.format(
+        "Dead link for %s %s, %s %s not found", source.getType(), source.getId(), target.getType(), target.getId());
+  }
+
+  public static String multipleSomethingFound(String something, EntityReference entityReference) {
+    return String.format(
+        "Consistency problem, multiple %s found for %s %s",
+        something, entityReference.getType(), entityReference.getId());
+  }
 
   public static String entityNotFound(String entityType, String id) {
     return String.format("%s instance for %s not found", entityType, id);
@@ -33,12 +49,26 @@ public final class CatalogExceptionMessage {
     return String.format("%s attribute %s can't be modified", entityType, attribute);
   }
 
+  public static String entityNotFound(EntityReference entityReference) {
+    return entityNotFound(entityReference.getType(), entityReference.getId());
+  }
+
+  public static String entityNotFound(String targetEntityType, String relationship, String sourceEntityType, UUID id) {
+    return String.format(
+        "The %s instance %s doesn't have a %s that `%s` it",
+        sourceEntityType, id.toString(), targetEntityType, relationship);
+  }
+
   public static String invalidField(String field) {
     return String.format("Invalid field name %s", field);
   }
 
   public static String entityTypeNotFound(String entityType) {
     return String.format("Entity type %s not found", entityType);
+  }
+
+  public static String wrongEntityType(String entity) {
+    return String.format("Entity type %s cannot be used here", entity);
   }
 
   public static String fieldIsNull(String field) {

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/exception/CatalogGenericExceptionMapper.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/exception/CatalogGenericExceptionMapper.java
@@ -25,7 +25,6 @@ import java.sql.SQLIntegrityConstraintViolationException;
 import java.util.concurrent.ThreadLocalRandom;
 import javax.ws.rs.Path;
 import javax.ws.rs.ProcessingException;
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
@@ -65,6 +64,11 @@ public class CatalogGenericExceptionMapper implements ExceptionMapper<Throwable>
           .type(MediaType.APPLICATION_JSON_TYPE)
           .entity(new ErrorMessage(BAD_REQUEST.getStatusCode(), ex.getMessage()))
           .build();
+    } else if (ex instanceof BadRequestException) {
+      return Response.status(BAD_REQUEST)
+          .type(MediaType.APPLICATION_JSON_TYPE)
+          .entity(new ErrorMessage(BAD_REQUEST.getStatusCode(), ex.getMessage()))
+          .build();
     } else if (ex instanceof AuthenticationException) {
       return Response.status(UNAUTHORIZED)
           .type(MediaType.APPLICATION_JSON_TYPE)
@@ -76,7 +80,7 @@ public class CatalogGenericExceptionMapper implements ExceptionMapper<Throwable>
           .entity(new ErrorMessage(FORBIDDEN.getStatusCode(), ex.getMessage()))
           .build();
     } else if (ex instanceof WebServiceException) {
-      final Response response = ((WebApplicationException) ex).getResponse();
+      final Response response = ((WebServiceException) ex).getResponse();
       Family family = response.getStatusInfo().getFamily();
       if (family.equals(Response.Status.Family.REDIRECTION)) {
         return response;

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/exception/DeserializationException.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/exception/DeserializationException.java
@@ -1,0 +1,14 @@
+package org.openmetadata.catalog.exception;
+
+import javax.ws.rs.core.Response.Status;
+
+public class DeserializationException extends WebServiceException {
+
+  private DeserializationException(String msg, Throwable cause) {
+    super(Status.INTERNAL_SERVER_ERROR, msg, cause);
+  }
+
+  public static DeserializationException message(String msg, Throwable cause) {
+    return new DeserializationException(msg, cause);
+  }
+}

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/exception/EntityNotFoundCheckedExeception.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/exception/EntityNotFoundCheckedExeception.java
@@ -1,0 +1,12 @@
+package org.openmetadata.catalog.exception;
+
+public class EntityNotFoundCheckedExeception extends Exception {
+
+  public EntityNotFoundCheckedExeception(String message) {
+    super(message);
+  }
+
+  public static EntityNotFoundCheckedExeception message(String message) {
+    return new EntityNotFoundCheckedExeception(message);
+  }
+}

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/exception/EntityNotFoundException.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/exception/EntityNotFoundException.java
@@ -13,10 +13,13 @@
 
 package org.openmetadata.catalog.exception;
 
+import java.util.UUID;
 import javax.ws.rs.core.Response;
+import org.openmetadata.catalog.type.EntityReference;
 
 public class EntityNotFoundException extends WebServiceException {
   private static final String BY_ID_MESSAGE = "Entity with id [%s] not found.";
+  private static final String BY_ENTITY_REFERENCE_MESSAGE = "Entity with id [%s] and type [%s] not found.";
   private static final String BY_NAME_MESSAGE = "Entity with name [%s] not found.";
   private static final String BY_FILTER_MESSAGE = "Entity not found for query params [%s].";
   private static final String BY_VERSION_MESSAGE = "Entity with id [%s] and version [%s] not found.";
@@ -30,12 +33,16 @@ public class EntityNotFoundException extends WebServiceException {
     super(Response.Status.NOT_FOUND, message, cause);
   }
 
-  public static EntityNotFoundException byId(String id) {
+  public static EntityNotFoundException byId(UUID id) {
     return new EntityNotFoundException(buildMessageByID(id));
   }
 
-  public static EntityNotFoundException byId(String id, Throwable cause) {
+  public static EntityNotFoundException byId(UUID id, Throwable cause) {
     return new EntityNotFoundException(buildMessageByID(id), cause);
+  }
+
+  public static EntityNotFoundException byEntityReference(EntityReference entityReference, Throwable cause) {
+    return new EntityNotFoundException(buildMessageByEntityReference(entityReference), cause);
   }
 
   public static EntityNotFoundException byMessage(String msg) {
@@ -74,8 +81,12 @@ public class EntityNotFoundException extends WebServiceException {
     return new EntityNotFoundException(buildMessageByParserSchema(id), cause);
   }
 
-  private static String buildMessageByID(String id) {
-    return String.format(BY_ID_MESSAGE, id);
+  private static String buildMessageByID(UUID id) {
+    return String.format(BY_ID_MESSAGE, id.toString());
+  }
+
+  public static String buildMessageByEntityReference(EntityReference entityReference) {
+    return String.format(BY_ENTITY_REFERENCE_MESSAGE, entityReference.getId().toString(), entityReference.getType());
   }
 
   private static String buildMessageByName(String name) {

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/exception/EntityTypeNotFoundExeception.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/exception/EntityTypeNotFoundExeception.java
@@ -1,0 +1,12 @@
+package org.openmetadata.catalog.exception;
+
+public class EntityTypeNotFoundExeception extends Exception {
+
+  public EntityTypeNotFoundExeception(String message) {
+    super(message);
+  }
+
+  public static EntityTypeNotFoundExeception message(String message) {
+    return new EntityTypeNotFoundExeception(message);
+  }
+}

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/AirflowPipelineRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/AirflowPipelineRepository.java
@@ -19,17 +19,14 @@ import static org.openmetadata.catalog.Entity.helper;
 
 import java.io.IOException;
 import java.net.URI;
-import java.text.ParseException;
 import java.util.List;
 import java.util.UUID;
-import org.jdbi.v3.sqlobject.transaction.Transaction;
 import org.openmetadata.catalog.Entity;
 import org.openmetadata.catalog.operations.pipelines.AirflowPipeline;
 import org.openmetadata.catalog.resources.operations.AirflowPipelineResource;
 import org.openmetadata.catalog.type.ChangeDescription;
 import org.openmetadata.catalog.type.EntityReference;
 import org.openmetadata.catalog.util.EntityInterface;
-import org.openmetadata.catalog.util.EntityUtil;
 import org.openmetadata.catalog.util.EntityUtil.Fields;
 
 public class AirflowPipelineRepository extends EntityRepository<AirflowPipeline> {
@@ -56,13 +53,8 @@ public class AirflowPipelineRepository extends EntityRepository<AirflowPipeline>
     return (airflowPipeline.getService().getName() + "." + airflowPipeline.getName());
   }
 
-  @Transaction
-  public EntityReference getOwnerReference(AirflowPipeline airflowPipeline) throws IOException {
-    return EntityUtil.populateOwner(daoCollection.userDAO(), daoCollection.teamDAO(), airflowPipeline.getOwner());
-  }
-
   @Override
-  public AirflowPipeline setFields(AirflowPipeline airflowPipeline, Fields fields) throws IOException, ParseException {
+  public AirflowPipeline setFields(AirflowPipeline airflowPipeline, Fields fields) throws IOException {
     airflowPipeline.setDisplayName(airflowPipeline.getDisplayName());
     airflowPipeline.setService(getService(airflowPipeline));
     airflowPipeline.setPipelineConfig(airflowPipeline.getPipelineConfig());
@@ -80,13 +72,12 @@ public class AirflowPipelineRepository extends EntityRepository<AirflowPipeline>
   }
 
   @Override
-  public void prepare(AirflowPipeline airflowPipeline) throws IOException, ParseException {
+  public void prepare(AirflowPipeline airflowPipeline) throws IOException {
     EntityReference entityReference =
-        helper(helper(airflowPipeline).findEntity("service", List.of(DATABASE_SERVICE, DASHBOARD_SERVICE)))
-            .toEntityReference();
+        helper(airflowPipeline).get("service", List.of(DATABASE_SERVICE, DASHBOARD_SERVICE)).toEntityReference();
     airflowPipeline.setService(entityReference);
     airflowPipeline.setFullyQualifiedName(getFQN(airflowPipeline));
-    airflowPipeline.setOwner(helper(airflowPipeline).validateOwnerOrNull());
+    helper(airflowPipeline).populateOwner();
   }
 
   @Override
@@ -124,8 +115,10 @@ public class AirflowPipelineRepository extends EntityRepository<AirflowPipeline>
     return new AirflowPipelineUpdater(original, updated, operation);
   }
 
-  private EntityReference getService(AirflowPipeline airflowPipeline) throws IOException, ParseException {
-    return helper(airflowPipeline).getContainer(List.of(Entity.DATABASE_SERVICE, Entity.DASHBOARD_SERVICE));
+  private EntityReference getService(AirflowPipeline airflowPipeline) throws IOException {
+    return helper(airflowPipeline)
+        .getContainer(List.of(Entity.DATABASE_SERVICE, Entity.DASHBOARD_SERVICE))
+        .toEntityReference();
   }
 
   public static class AirflowPipelineEntityInterface implements EntityInterface<AirflowPipeline> {

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/ChartRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/ChartRepository.java
@@ -19,7 +19,6 @@ import static org.openmetadata.catalog.Entity.helper;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
 import java.net.URI;
-import java.text.ParseException;
 import java.util.List;
 import java.util.UUID;
 import org.openmetadata.catalog.Entity;
@@ -56,12 +55,12 @@ public class ChartRepository extends EntityRepository<Chart> {
   }
 
   @Override
-  public void prepare(Chart chart) throws IOException, ParseException {
-    DashboardService dashboardService = helper(chart).findEntity("service", DASHBOARD_SERVICE);
+  public void prepare(Chart chart) throws IOException {
+    DashboardService dashboardService = helper(chart).get("service", DASHBOARD_SERVICE).toEntity();
     chart.setService(helper(dashboardService).toEntityReference());
     chart.setServiceType(dashboardService.getServiceType());
     chart.setFullyQualifiedName(getFQN(chart));
-    chart.setOwner(helper(chart).validateOwnerOrNull());
+    helper(chart).populateOwner();
     chart.setTags(EntityUtil.addDerivedTags(daoCollection.tagDAO(), chart.getTags()));
   }
 
@@ -97,7 +96,7 @@ public class ChartRepository extends EntityRepository<Chart> {
   }
 
   @Override
-  public Chart setFields(Chart chart, Fields fields) throws IOException, ParseException {
+  public Chart setFields(Chart chart, Fields fields) throws IOException {
     chart.setService(getService(chart));
     chart.setOwner(fields.contains("owner") ? getOwner(chart) : null);
     chart.setFollowers(fields.contains("followers") ? getFollowers(chart) : null);
@@ -120,8 +119,8 @@ public class ChartRepository extends EntityRepository<Chart> {
     return new ChartEntityInterface(entity);
   }
 
-  private EntityReference getService(Chart chart) throws IOException, ParseException {
-    return helper(chart).getContainer(DASHBOARD_SERVICE);
+  private EntityReference getService(Chart chart) throws IOException {
+    return helper(chart).getContainer(DASHBOARD_SERVICE).toEntityReference();
   }
 
   public static class ChartEntityInterface implements EntityInterface<Chart> {

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/DashboardRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/DashboardRepository.java
@@ -19,13 +19,11 @@ import static org.openmetadata.catalog.util.EntityUtil.toBoolean;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
 import java.net.URI;
-import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import org.jdbi.v3.sqlobject.transaction.Transaction;
 import org.openmetadata.catalog.Entity;
 import org.openmetadata.catalog.entity.data.Dashboard;
 import org.openmetadata.catalog.entity.services.DashboardService;
@@ -66,13 +64,8 @@ public class DashboardRepository extends EntityRepository<Dashboard> {
     return new DashboardEntityInterface(entity);
   }
 
-  @Transaction
-  public EntityReference getOwnerReference(Dashboard dashboard) throws IOException {
-    return EntityUtil.populateOwner(daoCollection.userDAO(), daoCollection.teamDAO(), dashboard.getOwner());
-  }
-
   @Override
-  public Dashboard setFields(Dashboard dashboard, Fields fields) throws IOException, ParseException {
+  public Dashboard setFields(Dashboard dashboard, Fields fields) throws IOException {
     dashboard.setDisplayName(dashboard.getDisplayName());
     dashboard.setService(getService(dashboard));
     dashboard.setOwner(fields.contains("owner") ? getOwner(dashboard) : null);
@@ -97,8 +90,8 @@ public class DashboardRepository extends EntityRepository<Dashboard> {
         .withId(original.getId());
   }
 
-  private EntityReference getService(Dashboard dashboard) throws IOException, ParseException {
-    return helper(dashboard).getContainer(Entity.DASHBOARD_SERVICE);
+  private EntityReference getService(Dashboard dashboard) throws IOException {
+    return helper(dashboard).getContainer(Entity.DASHBOARD_SERVICE).toEntityReference();
   }
 
   private void populateService(Dashboard dashboard) throws IOException {
@@ -133,7 +126,7 @@ public class DashboardRepository extends EntityRepository<Dashboard> {
   public void prepare(Dashboard dashboard) throws IOException {
     populateService(dashboard);
     dashboard.setFullyQualifiedName(getFQN(dashboard));
-    EntityUtil.populateOwner(daoCollection.userDAO(), daoCollection.teamDAO(), dashboard.getOwner()); // Validate owner
+    helper(dashboard).populateOwner();
     dashboard.setTags(EntityUtil.addDerivedTags(daoCollection.tagDAO(), dashboard.getTags()));
     dashboard.setCharts(getCharts(dashboard.getCharts()));
   }

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/DatabaseRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/DatabaseRepository.java
@@ -20,7 +20,6 @@ import static org.openmetadata.catalog.util.EntityUtil.toBoolean;
 
 import java.io.IOException;
 import java.net.URI;
-import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -72,9 +71,7 @@ public class DatabaseRepository extends EntityRepository<Database> {
   public void prepare(Database database) throws IOException {
     populateService(database);
     database.setFullyQualifiedName(getFQN(database));
-    database.setOwner(
-        EntityUtil.populateOwner(
-            daoCollection.userDAO(), daoCollection.teamDAO(), database.getOwner())); // Validate owner
+    helper(database).populateOwner();
   }
 
   @Override
@@ -130,7 +127,7 @@ public class DatabaseRepository extends EntityRepository<Database> {
     return tables;
   }
 
-  public Database setFields(Database database, Fields fields) throws IOException, ParseException {
+  public Database setFields(Database database, Fields fields) throws IOException {
     database.setService(getService(database));
     database.setOwner(fields.contains("owner") ? getOwner(database) : null);
     database.setTables(fields.contains("tables") ? getTables(database) : null);
@@ -177,8 +174,8 @@ public class DatabaseRepository extends EntityRepository<Database> {
     }
   }
 
-  private EntityReference getService(Database database) throws IOException, ParseException {
-    return helper(database).getContainer(DATABASE_SERVICE);
+  private EntityReference getService(Database database) throws IOException {
+    return helper(database).getContainer(DATABASE_SERVICE).toEntityReference();
   }
 
   private void populateService(Database database) throws IOException {

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/MetricsRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/MetricsRepository.java
@@ -18,7 +18,6 @@ import static org.openmetadata.catalog.Entity.helper;
 
 import java.io.IOException;
 import java.net.URI;
-import java.text.ParseException;
 import java.util.List;
 import java.util.UUID;
 import org.openmetadata.catalog.Entity;
@@ -54,7 +53,7 @@ public class MetricsRepository extends EntityRepository<Metrics> {
   }
 
   @Override
-  public Metrics setFields(Metrics metrics, Fields fields) throws IOException, ParseException {
+  public Metrics setFields(Metrics metrics, Fields fields) throws IOException {
     metrics.setService(getService(metrics)); // service is a default field
     metrics.setOwner(fields.contains("owner") ? getOwner(metrics) : null);
     metrics.setUsageSummary(
@@ -75,7 +74,7 @@ public class MetricsRepository extends EntityRepository<Metrics> {
   @Override
   public void prepare(Metrics metrics) throws IOException {
     metrics.setFullyQualifiedName(getFQN(metrics));
-    EntityUtil.populateOwner(daoCollection.userDAO(), daoCollection.teamDAO(), metrics.getOwner()); // Validate owner
+    helper(metrics).populateOwner();
     metrics.setService(getService(metrics.getService()));
     metrics.setTags(EntityUtil.addDerivedTags(daoCollection.tagDAO(), metrics.getTags()));
   }
@@ -110,8 +109,8 @@ public class MetricsRepository extends EntityRepository<Metrics> {
     applyTags(metrics);
   }
 
-  private EntityReference getService(Metrics metrics) throws IOException, ParseException { // Get service by metrics ID
-    return helper(metrics).getContainer(DASHBOARD_SERVICE);
+  private EntityReference getService(Metrics metrics) throws IOException { // Get service by metrics ID
+    return helper(metrics).getContainer(DASHBOARD_SERVICE).toEntityReference();
   }
 
   private EntityReference getService(EntityReference service) throws IOException { // Get service by service ID

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/MlModelRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/MlModelRepository.java
@@ -13,6 +13,7 @@
 
 package org.openmetadata.catalog.jdbi3;
 
+import static org.openmetadata.catalog.Entity.helper;
 import static org.openmetadata.catalog.util.EntityUtil.entityReferenceMatch;
 import static org.openmetadata.catalog.util.EntityUtil.mlFeatureMatch;
 import static org.openmetadata.catalog.util.EntityUtil.mlHyperParameterMatch;
@@ -21,12 +22,10 @@ import static org.openmetadata.catalog.util.EntityUtil.toBoolean;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
 import java.net.URI;
-import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
-import org.jdbi.v3.sqlobject.transaction.Transaction;
 import org.openmetadata.catalog.Entity;
 import org.openmetadata.catalog.entity.data.MlModel;
 import org.openmetadata.catalog.resources.mlmodels.MlModelResource;
@@ -69,13 +68,8 @@ public class MlModelRepository extends EntityRepository<MlModel> {
     return (model.getName());
   }
 
-  @Transaction
-  public EntityReference getOwnerReference(MlModel mlModel) throws IOException {
-    return EntityUtil.populateOwner(daoCollection.userDAO(), daoCollection.teamDAO(), mlModel.getOwner());
-  }
-
   @Override
-  public MlModel setFields(MlModel mlModel, Fields fields) throws IOException, ParseException {
+  public MlModel setFields(MlModel mlModel, Fields fields) throws IOException {
     mlModel.setDisplayName(mlModel.getDisplayName());
     mlModel.setOwner(fields.contains("owner") ? getOwner(mlModel) : null);
     mlModel.setDashboard(fields.contains("dashboard") ? getDashboard(mlModel) : null);
@@ -153,8 +147,8 @@ public class MlModelRepository extends EntityRepository<MlModel> {
       setMlFeatureFQN(mlModel.getFullyQualifiedName(), mlModel.getMlFeatures());
     }
 
-    // Check if owner is valid and set the relationship
-    mlModel.setOwner(EntityUtil.populateOwner(daoCollection.userDAO(), daoCollection.teamDAO(), mlModel.getOwner()));
+    // Populate the owner
+    helper(mlModel).populateOwner();
 
     // Check that the dashboard exists
     if (mlModel.getDashboard() != null) {

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/ReportRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/ReportRepository.java
@@ -17,7 +17,6 @@ import static org.openmetadata.catalog.Entity.helper;
 
 import java.io.IOException;
 import java.net.URI;
-import java.text.ParseException;
 import java.util.List;
 import java.util.UUID;
 import org.openmetadata.catalog.Entity;
@@ -48,7 +47,7 @@ public class ReportRepository extends EntityRepository<Report> {
   }
 
   @Override
-  public Report setFields(Report report, Fields fields) throws IOException, ParseException {
+  public Report setFields(Report report, Fields fields) throws IOException {
     report.setService(getService(report)); // service is a default field
     report.setOwner(fields.contains("owner") ? getOwner(report) : null);
     report.setUsageSummary(
@@ -65,9 +64,9 @@ public class ReportRepository extends EntityRepository<Report> {
   }
 
   @Override
-  public void prepare(Report report) throws IOException, ParseException {
-    report.setService(helper(helper(report).findEntity("service")).toEntityReference());
-    report.setOwner(helper(report).validateOwnerOrNull());
+  public void prepare(Report report) throws IOException {
+    report.setService(helper(report).get("service").toEntityReference());
+    helper(report).populateOwner();
   }
 
   @Override
@@ -91,9 +90,9 @@ public class ReportRepository extends EntityRepository<Report> {
     applyTags(report);
   }
 
-  private EntityReference getService(Report report) throws IOException, ParseException {
+  private EntityReference getService(Report report) throws IOException {
     // TODO What are the report services?
-    return helper(report).getContainer();
+    return helper(report).getContainer().toEntityReference();
   }
 
   public static class ReportEntityInterface implements EntityInterface<Report> {

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/WebhookRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/WebhookRepository.java
@@ -21,7 +21,6 @@ import com.lmax.disruptor.LifecycleAware;
 import java.io.IOException;
 import java.net.URI;
 import java.net.UnknownHostException;
-import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -79,7 +78,7 @@ public class WebhookRepository extends EntityRepository<Webhook> {
   }
 
   @Override
-  public Webhook setFields(Webhook entity, Fields fields) throws IOException, ParseException {
+  public Webhook setFields(Webhook entity, Fields fields) throws IOException {
     return entity; // No fields to set
   }
 

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/bots/BotsResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/bots/BotsResource.java
@@ -21,7 +21,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
-import java.text.ParseException;
 import java.util.List;
 import java.util.UUID;
 import javax.validation.constraints.Max;
@@ -93,7 +92,7 @@ public class BotsResource {
       @Parameter(description = "Returns list of bots after this cursor", schema = @Schema(type = "string"))
           @QueryParam("after")
           String after)
-      throws IOException, GeneralSecurityException, ParseException {
+      throws IOException, GeneralSecurityException {
     RestUtil.validateCursors(before, after);
 
     ResultList<Bots> list;
@@ -119,7 +118,7 @@ public class BotsResource {
         @ApiResponse(responseCode = "404", description = "Bot for instance {id} is not found")
       })
   public Bots get(@Context UriInfo uriInfo, @Context SecurityContext securityContext, @PathParam("id") String id)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.get(uriInfo, id, Fields.EMPTY_FIELDS);
   }
 
@@ -136,7 +135,7 @@ public class BotsResource {
         @ApiResponse(responseCode = "400", description = "Bad request")
       })
   public Response create(@Context UriInfo uriInfo, @Context SecurityContext securityContext, Bots bot)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminRole(authorizer, securityContext);
     bot.withId(UUID.randomUUID())
         .withUpdatedBy(securityContext.getUserPrincipal().getName())

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/charts/ChartResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/charts/ChartResource.java
@@ -25,7 +25,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.GeneralSecurityException;
-import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -154,7 +153,7 @@ public class ChartResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, GeneralSecurityException, ParseException {
+      throws IOException, GeneralSecurityException {
     RestUtil.validateCursors(before, after);
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
 
@@ -183,7 +182,7 @@ public class ChartResource {
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
       @Parameter(description = "Chart Id", schema = @Schema(type = "string")) @PathParam("id") String id)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.listVersions(id);
   }
 
@@ -215,7 +214,7 @@ public class ChartResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
     return addHref(uriInfo, dao.get(uriInfo, id, fields, include));
   }
@@ -248,7 +247,7 @@ public class ChartResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
     Chart chart = dao.getByName(uriInfo, fqn, fields, include);
     addHref(uriInfo, chart);
@@ -279,7 +278,7 @@ public class ChartResource {
               schema = @Schema(type = "string", example = "0.1 or 1.1"))
           @PathParam("version")
           String version)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.getVersion(id, version);
   }
 
@@ -296,7 +295,7 @@ public class ChartResource {
         @ApiResponse(responseCode = "400", description = "Bad request")
       })
   public Response create(@Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateChart create)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     Chart chart = getChart(securityContext, create);
     chart = addHref(uriInfo, dao.create(uriInfo, chart));
@@ -324,7 +323,7 @@ public class ChartResource {
                         @ExampleObject("[" + "{op:remove, path:/a}," + "{op:add, path: /b, value: val}" + "]")
                       }))
           JsonPatch patch)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, FIELDS);
     Chart chart = dao.get(uriInfo, id, fields);
     SecurityUtil.checkAdminRoleOrPermissions(
@@ -349,7 +348,7 @@ public class ChartResource {
       })
   public Response createOrUpdate(
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateChart create)
-      throws IOException, ParseException {
+      throws IOException {
 
     Chart chart = getChart(securityContext, create);
     PutResponse<Chart> response = dao.createOrUpdate(uriInfo, chart);
@@ -408,7 +407,7 @@ public class ChartResource {
         @ApiResponse(responseCode = "404", description = "Chart for instance {id} is not found")
       })
   public Response delete(@Context UriInfo uriInfo, @Context SecurityContext securityContext, @PathParam("id") String id)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     DeleteResponse<Chart> response = dao.delete(securityContext.getUserPrincipal().getName(), id);
     return response.toResponse();

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/dashboards/DashboardResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/dashboards/DashboardResource.java
@@ -25,7 +25,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.GeneralSecurityException;
-import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -159,7 +158,7 @@ public class DashboardResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, GeneralSecurityException, ParseException {
+      throws IOException, GeneralSecurityException {
     RestUtil.validateCursors(before, after);
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
 
@@ -189,7 +188,7 @@ public class DashboardResource {
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
       @Parameter(description = "Dashboard Id", schema = @Schema(type = "string")) @PathParam("id") String id)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.listVersions(id);
   }
 
@@ -221,7 +220,7 @@ public class DashboardResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
     return addHref(uriInfo, dao.get(uriInfo, id, fields, include));
   }
@@ -254,7 +253,7 @@ public class DashboardResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
     Dashboard dashboard = dao.getByName(uriInfo, fqn, fields, include);
     return addHref(uriInfo, dashboard);
@@ -284,7 +283,7 @@ public class DashboardResource {
               schema = @Schema(type = "string", example = "0.1 or 1.1"))
           @PathParam("version")
           String version)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.getVersion(id, version);
   }
 
@@ -303,7 +302,7 @@ public class DashboardResource {
       })
   public Response create(
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateDashboard create)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     Dashboard dashboard = getDashboard(securityContext, create);
     dashboard = addHref(uriInfo, dao.create(uriInfo, dashboard));
@@ -331,7 +330,7 @@ public class DashboardResource {
                         @ExampleObject("[" + "{op:remove, path:/a}," + "{op:add, path: /b, value: val}" + "]")
                       }))
           JsonPatch patch)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, FIELDS);
     Dashboard dashboard = dao.get(uriInfo, id, fields);
     SecurityUtil.checkAdminRoleOrPermissions(
@@ -358,7 +357,7 @@ public class DashboardResource {
       })
   public Response createOrUpdate(
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateDashboard create)
-      throws IOException, ParseException {
+      throws IOException {
     Dashboard dashboard = getDashboard(securityContext, create);
     PutResponse<Dashboard> response = dao.createOrUpdate(uriInfo, dashboard);
     addHref(uriInfo, response.getEntity());
@@ -416,7 +415,7 @@ public class DashboardResource {
         @ApiResponse(responseCode = "404", description = "Dashboard for instance {id} is not found")
       })
   public Response delete(@Context UriInfo uriInfo, @Context SecurityContext securityContext, @PathParam("id") String id)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     DeleteResponse<Dashboard> response = dao.delete(securityContext.getUserPrincipal().getName(), id);
     return response.toResponse();

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/databases/DatabaseResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/databases/DatabaseResource.java
@@ -25,7 +25,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.GeneralSecurityException;
-import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -165,7 +164,7 @@ public class DatabaseResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, GeneralSecurityException, ParseException {
+      throws IOException, GeneralSecurityException {
     RestUtil.validateCursors(before, after);
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
 
@@ -198,7 +197,7 @@ public class DatabaseResource {
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
       @Parameter(description = "database Id", schema = @Schema(type = "string")) @PathParam("id") String id)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.listVersions(id);
   }
 
@@ -230,7 +229,7 @@ public class DatabaseResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
     Database database = dao.get(uriInfo, id, fields, include);
     addHref(uriInfo, database);
@@ -265,7 +264,7 @@ public class DatabaseResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
     Database database = dao.getByName(uriInfo, fqn, fields, include);
     addHref(uriInfo, database);
@@ -296,7 +295,7 @@ public class DatabaseResource {
               schema = @Schema(type = "string", example = "0.1 or 1.1"))
           @PathParam("version")
           String version)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.getVersion(id, version);
   }
 
@@ -315,7 +314,7 @@ public class DatabaseResource {
       })
   public Response create(
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateDatabase create)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     Database database = getDatabase(securityContext, create);
     database = addHref(uriInfo, dao.create(uriInfo, database));
@@ -343,7 +342,7 @@ public class DatabaseResource {
                         @ExampleObject("[" + "{op:remove, path:/a}," + "{op:add, path: /b, value: val}" + "]")
                       }))
           JsonPatch patch)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, FIELDS);
     Database database = dao.get(uriInfo, id, fields);
     SecurityUtil.checkAdminRoleOrPermissions(
@@ -368,7 +367,7 @@ public class DatabaseResource {
       })
   public Response createOrUpdate(
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateDatabase create)
-      throws IOException, ParseException {
+      throws IOException {
     Database database = getDatabase(securityContext, create);
     PutResponse<Database> response = dao.createOrUpdate(uriInfo, database);
     addHref(uriInfo, response.getEntity());
@@ -382,7 +381,7 @@ public class DatabaseResource {
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
       @Parameter(description = "Id of the database", schema = @Schema(type = "string")) @PathParam("id") String id)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, "location");
     dao.deleteLocation(id);
     Database database = dao.get(uriInfo, id, fields);
@@ -407,7 +406,7 @@ public class DatabaseResource {
           @QueryParam("recursive")
           boolean recursive,
       @PathParam("id") String id)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     DeleteResponse<Database> response = dao.delete(securityContext.getUserPrincipal().getName(), id, recursive);
     return response.toResponse();

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/databases/TableResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/databases/TableResource.java
@@ -13,8 +13,6 @@
 
 package org.openmetadata.catalog.resources.databases;
 
-import static org.openmetadata.catalog.Entity.helper;
-
 import io.swagger.annotations.Api;
 import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
@@ -157,7 +155,7 @@ public class TableResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException, GeneralSecurityException {
+      throws IOException, GeneralSecurityException {
     RestUtil.validateCursors(before, after);
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
 
@@ -199,7 +197,7 @@ public class TableResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
     return addHref(uriInfo, dao.get(uriInfo, id, fields, include));
   }
@@ -233,7 +231,7 @@ public class TableResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
     return addHref(uriInfo, dao.getByName(uriInfo, fqn, fields, include));
   }
@@ -254,7 +252,7 @@ public class TableResource {
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
       @Parameter(description = "table Id", schema = @Schema(type = "string")) @PathParam("id") String id)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.listVersions(id);
   }
 
@@ -282,7 +280,7 @@ public class TableResource {
               schema = @Schema(type = "string", example = "0.1 or 1.1"))
           @PathParam("version")
           String version)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.getVersion(id, version);
   }
 
@@ -299,7 +297,7 @@ public class TableResource {
         @ApiResponse(responseCode = "400", description = "Bad request")
       })
   public Response create(@Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateTable create)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     Table table = getTable(securityContext, create);
     table = addHref(uriInfo, dao.create(uriInfo, validateNewTable(table)));
@@ -320,9 +318,9 @@ public class TableResource {
       })
   public Response createOrUpdate(
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateTable create)
-      throws IOException, ParseException {
+      throws IOException {
     Table table = getTable(securityContext, create);
-    SecurityUtil.checkAdminRoleOrPermissions(authorizer, securityContext, helper(table).validateOwnerOrNull());
+    SecurityUtil.checkAdminRoleOrPermissions(authorizer, securityContext, table.getOwner());
     PutResponse<Table> response = dao.createOrUpdate(uriInfo, validateNewTable(table));
     addHref(uriInfo, response.getEntity());
     return response.toResponse();
@@ -349,7 +347,7 @@ public class TableResource {
                         @ExampleObject("[" + "{op:remove, path:/a}," + "{op:add, path: /b, value: val}" + "]")
                       }))
           JsonPatch patch)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, FIELDS);
     Table table = dao.get(uriInfo, id, fields);
     SecurityUtil.checkAdminRoleOrPermissions(
@@ -375,7 +373,7 @@ public class TableResource {
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
       @Parameter(description = "Id of the table", schema = @Schema(type = "string")) @PathParam("id") String id)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     DeleteResponse<Table> response = dao.delete(securityContext.getUserPrincipal().getName(), id);
     return response.toResponse();
@@ -434,7 +432,7 @@ public class TableResource {
       @Context SecurityContext securityContext,
       @Parameter(description = "Id of the table", schema = @Schema(type = "string")) @PathParam("id") String id,
       TableData tableData)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     Table table = dao.addSampleData(UUID.fromString(id), tableData);
     return addHref(uriInfo, table);
@@ -448,7 +446,7 @@ public class TableResource {
       @Context SecurityContext securityContext,
       @Parameter(description = "Id of the table", schema = @Schema(type = "string")) @PathParam("id") String id,
       TableProfile tableProfile)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     Table table = dao.addTableProfileData(UUID.fromString(id), tableProfile);
     return addHref(uriInfo, table);
@@ -469,7 +467,7 @@ public class TableResource {
       @Context SecurityContext securityContext,
       @Parameter(description = "Id of the table", schema = @Schema(type = "string")) @PathParam("id") String id,
       @Parameter(description = "Id of the location to be added", schema = @Schema(type = "string")) String locationId)
-      throws IOException, ParseException {
+      throws IOException {
     Table table = dao.addLocation(UUID.fromString(id), UUID.fromString(locationId));
     return Response.ok().entity(table).build();
   }
@@ -482,7 +480,7 @@ public class TableResource {
       @Context SecurityContext securityContext,
       @Parameter(description = "Id of the table", schema = @Schema(type = "string")) @PathParam("id") String id,
       SQLQuery sqlQuery)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     Table table = dao.addQuery(UUID.fromString(id), sqlQuery);
     return addHref(uriInfo, table);
@@ -499,7 +497,7 @@ public class TableResource {
       @Context SecurityContext securityContext,
       @Parameter(description = "Id of the table", schema = @Schema(type = "string")) @PathParam("id") String id,
       DataModel dataModel)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     Table table = dao.addDataModel(UUID.fromString(id), dataModel);
     return addHref(uriInfo, table);
@@ -531,7 +529,7 @@ public class TableResource {
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
       @Parameter(description = "Id of the table", schema = @Schema(type = "string")) @PathParam("id") String id)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, "location");
     dao.deleteLocation(id);
     Table table = dao.get(uriInfo, id, fields);

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/events/EventResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/events/EventResource.java
@@ -22,7 +22,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.GeneralSecurityException;
-import java.text.ParseException;
 import java.util.List;
 import java.util.Objects;
 import javax.validation.Valid;
@@ -113,7 +112,7 @@ public class EventResource {
               schema = @Schema(type = "long", example = "1426349294842"))
           @QueryParam("timestamp")
           long timestamp)
-      throws IOException, GeneralSecurityException, ParseException {
+      throws IOException, GeneralSecurityException {
     List<String> entityCreatedList = EntityList.getEntityList("entityCreated", entityCreated);
     List<String> entityUpdatedList = EntityList.getEntityList("entityUpdated", entityUpdated);
     List<String> entityDeletedList = EntityList.getEntityList("entityDeleted", entityDeleted);

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/events/WebhookResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/events/WebhookResource.java
@@ -22,7 +22,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.GeneralSecurityException;
-import java.text.ParseException;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -121,7 +120,7 @@ public class WebhookResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException, GeneralSecurityException {
+      throws IOException, GeneralSecurityException {
     RestUtil.validateCursors(before, after);
     ResultList<Webhook> webhooks;
     if (before != null) { // Reverse paging
@@ -156,7 +155,7 @@ public class WebhookResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, GeneralSecurityException, ParseException {
+      throws IOException, GeneralSecurityException {
     return dao.get(uriInfo, id, Fields.EMPTY_FIELDS, include);
   }
 
@@ -183,7 +182,7 @@ public class WebhookResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.getByName(uriInfo, fqn, Fields.EMPTY_FIELDS, include);
   }
 
@@ -203,7 +202,7 @@ public class WebhookResource {
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
       @Parameter(description = "webhook Id", schema = @Schema(type = "string")) @PathParam("id") String id)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.listVersions(id);
   }
 
@@ -231,7 +230,7 @@ public class WebhookResource {
               schema = @Schema(type = "string", example = "0.1 or 1.1"))
           @PathParam("version")
           String version)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.getVersion(id, version);
   }
 
@@ -249,7 +248,7 @@ public class WebhookResource {
       })
   public Response createWebhook(
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateWebhook create)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     Webhook webhook = getWebhook(securityContext, create);
     webhook.setStatus(Boolean.TRUE.equals(webhook.getEnabled()) ? Status.STARTED : Status.NOT_STARTED);
@@ -272,7 +271,7 @@ public class WebhookResource {
       })
   public Response updateWebhook(
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateWebhook create)
-      throws IOException, ParseException, InterruptedException {
+      throws IOException, InterruptedException {
     // TODO
     //    SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     //    Table table = getTable(securityContext, create);
@@ -301,7 +300,7 @@ public class WebhookResource {
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
       @Parameter(description = "webhook Id", schema = @Schema(type = "string")) @PathParam("id") String id)
-      throws IOException, GeneralSecurityException, ParseException, InterruptedException {
+      throws IOException, GeneralSecurityException, InterruptedException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     DeleteResponse<Webhook> response = dao.delete(securityContext.getUserPrincipal().getName(), id);
     dao.deleteWebhookPublisher(UUID.fromString(id));

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/feeds/FeedResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/feeds/FeedResource.java
@@ -20,7 +20,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
-import java.text.ParseException;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -131,7 +130,7 @@ public class FeedResource {
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = CreateThread.class))),
         @ApiResponse(responseCode = "400", description = "Bad request")
       })
-  public Response create(@Context UriInfo uriInfo, @Valid CreateThread cr) throws IOException, ParseException {
+  public Response create(@Context UriInfo uriInfo, @Valid CreateThread cr) throws IOException {
     Thread thread =
         new Thread().withId(UUID.randomUUID()).withThreadTs(System.currentTimeMillis()).withAbout(cr.getAbout());
     // For now redundantly storing everything in json (that includes fromEntity, addressedTo entity)

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/locations/LocationResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/locations/LocationResource.java
@@ -25,7 +25,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.GeneralSecurityException;
-import java.text.ParseException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -148,7 +147,7 @@ public class LocationResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, GeneralSecurityException, ParseException {
+      throws IOException, GeneralSecurityException {
     RestUtil.validateCursors(before, after);
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
 
@@ -178,7 +177,7 @@ public class LocationResource {
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
       @Parameter(description = "location Id", schema = @Schema(type = "string")) @PathParam("id") String id)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.listVersions(id);
   }
 
@@ -210,7 +209,7 @@ public class LocationResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
     return addHref(uriInfo, dao.get(uriInfo, id, fields, include));
   }
@@ -255,7 +254,7 @@ public class LocationResource {
       @Parameter(description = "Returns list of locations after this cursor", schema = @Schema(type = "string"))
           @QueryParam("after")
           String after)
-      throws IOException, GeneralSecurityException, ParseException {
+      throws IOException, GeneralSecurityException {
     RestUtil.validateCursors(before, after);
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
 
@@ -301,7 +300,7 @@ public class LocationResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
     return addHref(uriInfo, dao.getByName(uriInfo, fqn, fields, include));
   }
@@ -330,7 +329,7 @@ public class LocationResource {
               schema = @Schema(type = "string", example = "0.1 or 1.1"))
           @PathParam("version")
           String version)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.getVersion(id, version);
   }
 
@@ -348,7 +347,7 @@ public class LocationResource {
       })
   public Response create(
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateLocation create)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     Location location = getLocation(securityContext, create);
     location = addHref(uriInfo, dao.create(uriInfo, location));
@@ -369,9 +368,9 @@ public class LocationResource {
       })
   public Response createOrUpdate(
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateLocation create)
-      throws IOException, ParseException {
+      throws IOException {
     Location location = getLocation(securityContext, create);
-    SecurityUtil.checkAdminRoleOrPermissions(authorizer, securityContext, dao.getOwnerReference(location));
+    SecurityUtil.checkAdminRoleOrPermissions(authorizer, securityContext, location.getOwner());
     PutResponse<Location> response = dao.createOrUpdate(uriInfo, validateNewLocation(location));
     addHref(uriInfo, response.getEntity());
     return response.toResponse();
@@ -398,7 +397,8 @@ public class LocationResource {
                         @ExampleObject("[" + "{op:remove, path:/a}," + "{op:add, path: /b, value: val}" + "]")
                       }))
           JsonPatch patch)
-      throws IOException, ParseException {
+      throws IOException {
+
     Fields fields = new Fields(FIELD_LIST, FIELDS);
     Location location = dao.get(uriInfo, id, fields);
     SecurityUtil.checkAdminRoleOrPermissions(
@@ -424,7 +424,7 @@ public class LocationResource {
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
       @Parameter(description = "Id of the location", schema = @Schema(type = "string")) @PathParam("id") String id)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     DeleteResponse<Location> response = dao.delete(securityContext.getUserPrincipal().getName(), id);
     return response.toResponse();

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/metrics/MetricsResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/metrics/MetricsResource.java
@@ -21,7 +21,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
-import java.text.ParseException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -102,7 +101,7 @@ public class MetricsResource {
       @Parameter(description = "Returns list of metrics after this cursor", schema = @Schema(type = "string"))
           @QueryParam("after")
           String after)
-      throws IOException, GeneralSecurityException, ParseException {
+      throws IOException, GeneralSecurityException {
     RestUtil.validateCursors(before, after);
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
 
@@ -134,7 +133,7 @@ public class MetricsResource {
               schema = @Schema(type = "string", example = FIELDS))
           @QueryParam("fields")
           String fieldsParam)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
     return dao.get(uriInfo, id, fields);
   }
@@ -152,7 +151,7 @@ public class MetricsResource {
         @ApiResponse(responseCode = "400", description = "Bad request")
       })
   public Response create(@Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid Metrics metrics)
-      throws IOException, ParseException {
+      throws IOException {
     addToMetrics(securityContext, metrics);
     dao.create(uriInfo, metrics);
     return Response.created(metrics.getHref()).entity(metrics).build();
@@ -171,8 +170,7 @@ public class MetricsResource {
         @ApiResponse(responseCode = "400", description = "Bad request")
       })
   public Response createOrUpdate(
-      @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid Metrics metrics)
-      throws IOException, ParseException {
+      @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid Metrics metrics) throws IOException {
     addToMetrics(securityContext, metrics);
     PutResponse<Metrics> response = dao.createOrUpdate(uriInfo, metrics);
     return response.toResponse();

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/mlmodels/MlModelResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/mlmodels/MlModelResource.java
@@ -25,7 +25,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.GeneralSecurityException;
-import java.text.ParseException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -148,7 +147,7 @@ public class MlModelResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, GeneralSecurityException, ParseException {
+      throws IOException, GeneralSecurityException {
     RestUtil.validateCursors(before, after);
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
 
@@ -190,7 +189,7 @@ public class MlModelResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
     return addHref(uriInfo, dao.get(uriInfo, id, fields, include));
   }
@@ -223,7 +222,7 @@ public class MlModelResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
     return addHref(uriInfo, dao.getByName(uriInfo, fqn, fields, include));
   }
@@ -242,7 +241,7 @@ public class MlModelResource {
       })
   public Response create(
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateMlModel create)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     MlModel mlModel = getMlModel(securityContext, create);
     mlModel = addHref(uriInfo, dao.create(uriInfo, mlModel));
@@ -270,7 +269,7 @@ public class MlModelResource {
                         @ExampleObject("[" + "{op:remove, path:/a}," + "{op:add, path: /b, value: val}" + "]")
                       }))
           JsonPatch patch)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, FIELDS);
     MlModel mlModel = dao.get(uriInfo, id, fields);
     SecurityUtil.checkAdminRoleOrPermissions(
@@ -296,9 +295,9 @@ public class MlModelResource {
       })
   public Response createOrUpdate(
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateMlModel create)
-      throws IOException, ParseException {
+      throws IOException {
     MlModel mlModel = getMlModel(securityContext, create);
-    SecurityUtil.checkAdminRoleOrPermissions(authorizer, securityContext, dao.getOwnerReference(mlModel));
+    SecurityUtil.checkAdminRoleOrPermissions(authorizer, securityContext, mlModel.getOwner());
     PutResponse<MlModel> response = dao.createOrUpdate(uriInfo, mlModel);
     addHref(uriInfo, response.getEntity());
     return response.toResponse();
@@ -360,7 +359,7 @@ public class MlModelResource {
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
       @Parameter(description = "ML Model Id", schema = @Schema(type = "string")) @PathParam("id") String id)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.listVersions(id);
   }
 
@@ -388,7 +387,7 @@ public class MlModelResource {
               schema = @Schema(type = "string", example = "0.1 or 1.1"))
           @PathParam("version")
           String version)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.getVersion(id, version);
   }
 
@@ -406,7 +405,7 @@ public class MlModelResource {
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
       @Parameter(description = "Id of the ML Model", schema = @Schema(type = "string")) @PathParam("id") String id)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     DeleteResponse<MlModel> response = dao.delete(securityContext.getUserPrincipal().getName(), id);
     return response.toResponse();

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/operations/AirflowPipelineResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/operations/AirflowPipelineResource.java
@@ -25,7 +25,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.GeneralSecurityException;
-import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -174,7 +173,7 @@ public class AirflowPipelineResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, GeneralSecurityException, ParseException {
+      throws IOException, GeneralSecurityException {
     RestUtil.validateCursors(before, after);
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
 
@@ -207,7 +206,7 @@ public class AirflowPipelineResource {
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
       @Parameter(description = "AirflowPipeline Id", schema = @Schema(type = "string")) @PathParam("id") String id)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.listVersions(id);
   }
 
@@ -240,7 +239,7 @@ public class AirflowPipelineResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
     AirflowPipeline airflowPipeline = dao.get(uriInfo, id, fields, include);
     if (fieldsParam != null && fieldsParam.contains("status")) {
@@ -274,7 +273,7 @@ public class AirflowPipelineResource {
               schema = @Schema(type = "string", example = "0.1 or 1.1"))
           @PathParam("version")
           String version)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.getVersion(id, version);
   }
 
@@ -307,7 +306,7 @@ public class AirflowPipelineResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
     AirflowPipeline airflowPipeline = dao.getByName(uriInfo, fqn, fields, include);
     if (fieldsParam != null && fieldsParam.contains("status")) {
@@ -333,7 +332,7 @@ public class AirflowPipelineResource {
       })
   public Response create(
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateAirflowPipeline create)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     AirflowPipeline airflowPipeline = getAirflowPipeline(securityContext, create);
     airflowPipeline = addHref(uriInfo, dao.create(uriInfo, airflowPipeline));
@@ -362,7 +361,7 @@ public class AirflowPipelineResource {
                         @ExampleObject("[" + "{op:remove, path:/a}," + "{op:add, path: /b, value: val}" + "]")
                       }))
           JsonPatch patch)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, FIELDS);
     AirflowPipeline airflowPipeline = dao.get(uriInfo, id, fields);
     SecurityUtil.checkAdminRoleOrPermissions(
@@ -389,7 +388,7 @@ public class AirflowPipelineResource {
       })
   public Response createOrUpdate(
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateAirflowPipeline create)
-      throws IOException, ParseException {
+      throws IOException {
     AirflowPipeline airflowPipeline = getAirflowPipeline(securityContext, create);
     PutResponse<AirflowPipeline> response = dao.createOrUpdate(uriInfo, airflowPipeline);
     deploy(airflowPipeline);
@@ -413,7 +412,7 @@ public class AirflowPipelineResource {
       })
   public AirflowPipeline triggerIngestion(
       @Context UriInfo uriInfo, @PathParam("id") String id, @Context SecurityContext securityContext)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, "owner");
     AirflowPipeline pipeline = dao.get(uriInfo, id, fields);
     airflowRESTClient.runPipeline(pipeline.getName());
@@ -431,7 +430,7 @@ public class AirflowPipelineResource {
         @ApiResponse(responseCode = "404", description = "ingestion for instance {id} is not found")
       })
   public Response delete(@Context UriInfo uriInfo, @Context SecurityContext securityContext, @PathParam("id") String id)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     DeleteResponse<AirflowPipeline> response = dao.delete(securityContext.getUserPrincipal().getName(), id);
     return response.toResponse();

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/pipelines/PipelineResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/pipelines/PipelineResource.java
@@ -25,7 +25,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.GeneralSecurityException;
-import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -159,7 +158,7 @@ public class PipelineResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, GeneralSecurityException, ParseException {
+      throws IOException, GeneralSecurityException {
     RestUtil.validateCursors(before, after);
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
 
@@ -188,7 +187,7 @@ public class PipelineResource {
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
       @Parameter(description = "pipeline Id", schema = @Schema(type = "string")) @PathParam("id") String id)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.listVersions(id);
   }
 
@@ -220,7 +219,7 @@ public class PipelineResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
     return addHref(uriInfo, dao.get(uriInfo, id, fields, include));
   }
@@ -253,7 +252,7 @@ public class PipelineResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
     Pipeline pipeline = dao.getByName(uriInfo, fqn, fields, include);
     return addHref(uriInfo, pipeline);
@@ -283,7 +282,7 @@ public class PipelineResource {
               schema = @Schema(type = "string", example = "0.1 or 1.1"))
           @PathParam("version")
           String version)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.getVersion(id, version);
   }
 
@@ -302,7 +301,7 @@ public class PipelineResource {
       })
   public Response create(
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreatePipeline create)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     Pipeline pipeline = getPipeline(securityContext, create);
     pipeline = addHref(uriInfo, dao.create(uriInfo, pipeline));
@@ -330,7 +329,7 @@ public class PipelineResource {
                         @ExampleObject("[" + "{op:remove, path:/a}," + "{op:add, path: /b, value: val}" + "]")
                       }))
           JsonPatch patch)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, FIELDS);
     Pipeline pipeline = dao.get(uriInfo, id, fields);
     SecurityUtil.checkAdminRoleOrPermissions(
@@ -357,7 +356,7 @@ public class PipelineResource {
       })
   public Response createOrUpdate(
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreatePipeline create)
-      throws IOException, ParseException {
+      throws IOException {
     Pipeline pipeline = getPipeline(securityContext, create);
     PutResponse<Pipeline> response = dao.createOrUpdate(uriInfo, pipeline);
     addHref(uriInfo, response.getEntity());
@@ -415,7 +414,7 @@ public class PipelineResource {
         @ApiResponse(responseCode = "404", description = "Pipeline for instance {id} is not found")
       })
   public Response delete(@Context UriInfo uriInfo, @Context SecurityContext securityContext, @PathParam("id") String id)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     DeleteResponse<Pipeline> response = dao.delete(securityContext.getUserPrincipal().getName(), id);
     return response.toResponse();

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/policies/PolicyResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/policies/PolicyResource.java
@@ -25,7 +25,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.GeneralSecurityException;
-import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -164,7 +163,7 @@ public class PolicyResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, GeneralSecurityException, ParseException {
+      throws IOException, GeneralSecurityException {
     RestUtil.validateCursors(before, after);
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
 
@@ -205,7 +204,7 @@ public class PolicyResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
     return addHref(uriInfo, dao.get(uriInfo, id, fields, include));
   }
@@ -238,7 +237,7 @@ public class PolicyResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
     Policy policy = dao.getByName(uriInfo, fqn, fields, include);
     return addHref(uriInfo, policy);
@@ -260,7 +259,7 @@ public class PolicyResource {
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
       @Parameter(description = "policy Id", schema = @Schema(type = "string")) @PathParam("id") String id)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.listVersions(id);
   }
 
@@ -288,7 +287,7 @@ public class PolicyResource {
               schema = @Schema(type = "string", example = "0.1 or 1.1"))
           @PathParam("version")
           String version)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.getVersion(id, version);
   }
 
@@ -305,7 +304,7 @@ public class PolicyResource {
         @ApiResponse(responseCode = "400", description = "Bad request")
       })
   public Response create(@Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreatePolicy create)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     Policy policy = getPolicy(securityContext, create);
     policy = addHref(uriInfo, dao.create(uriInfo, policy));
@@ -333,10 +332,10 @@ public class PolicyResource {
                         @ExampleObject("[" + "{op:remove, path:/a}," + "{op:add, path: /b, value: val}" + "]")
                       }))
           JsonPatch patch)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, FIELDS);
     Policy policy = dao.get(uriInfo, id, fields);
-    SecurityUtil.checkAdminRoleOrPermissions(authorizer, securityContext, dao.getOwnerReference(policy));
+    SecurityUtil.checkAdminRoleOrPermissions(authorizer, securityContext, policy.getOwner());
 
     PatchResponse<Policy> response =
         dao.patch(uriInfo, UUID.fromString(id), securityContext.getUserPrincipal().getName(), patch);
@@ -358,7 +357,7 @@ public class PolicyResource {
       })
   public Response createOrUpdate(
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreatePolicy create)
-      throws IOException, ParseException {
+      throws IOException {
     Policy policy = getPolicy(securityContext, create);
     PutResponse<Policy> response = dao.createOrUpdate(uriInfo, policy);
     addHref(uriInfo, response.getEntity());
@@ -376,7 +375,7 @@ public class PolicyResource {
         @ApiResponse(responseCode = "404", description = "policy for instance {id} is not found")
       })
   public Response delete(@Context UriInfo uriInfo, @Context SecurityContext securityContext, @PathParam("id") String id)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     DeleteResponse<Policy> response = dao.delete(securityContext.getUserPrincipal().getName(), id);
     return response.toResponse();

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/reports/ReportResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/reports/ReportResource.java
@@ -21,7 +21,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
-import java.text.ParseException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -91,7 +90,7 @@ public class ReportResource {
               schema = @Schema(type = "string", example = FIELDS))
           @QueryParam("fields")
           String fieldsParam)
-      throws IOException, GeneralSecurityException, ParseException {
+      throws IOException, GeneralSecurityException {
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
     return dao.listAfter(uriInfo, fields, null, 10000, null, Include.NON_DELETED);
   }
@@ -117,7 +116,7 @@ public class ReportResource {
               schema = @Schema(type = "string", example = FIELDS))
           @QueryParam("fields")
           String fieldsParam)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
     return dao.get(uriInfo, id, fields);
   }
@@ -135,7 +134,7 @@ public class ReportResource {
         @ApiResponse(responseCode = "400", description = "Bad request")
       })
   public Response create(@Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid Report report)
-      throws IOException, ParseException {
+      throws IOException {
     addToReport(securityContext, report);
     dao.create(uriInfo, report);
     return Response.created(report.getHref()).entity(report).build();
@@ -154,8 +153,7 @@ public class ReportResource {
         @ApiResponse(responseCode = "400", description = "Bad request")
       })
   public Response createOrUpdate(
-      @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid Report report)
-      throws IOException, ParseException {
+      @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid Report report) throws IOException {
     addToReport(securityContext, report);
     PutResponse<Report> response = dao.createOrUpdate(uriInfo, report);
     return response.toResponse();

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/dashboard/DashboardServiceResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/dashboard/DashboardServiceResource.java
@@ -22,7 +22,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.GeneralSecurityException;
-import java.text.ParseException;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -116,7 +115,7 @@ public class DashboardServiceResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, GeneralSecurityException, ParseException {
+      throws IOException, GeneralSecurityException {
     RestUtil.validateCursors(before, after);
 
     if (before != null) { // Reverse paging
@@ -150,7 +149,7 @@ public class DashboardServiceResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.get(uriInfo, id, null, include);
   }
 
@@ -178,7 +177,7 @@ public class DashboardServiceResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.getByName(uriInfo, name, null, include);
   }
 
@@ -198,7 +197,7 @@ public class DashboardServiceResource {
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
       @Parameter(description = "dashboard service Id", schema = @Schema(type = "string")) @PathParam("id") String id)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.listVersions(id);
   }
 
@@ -227,7 +226,7 @@ public class DashboardServiceResource {
               schema = @Schema(type = "string", example = "0.1 or 1.1"))
           @PathParam("version")
           String version)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.getVersion(id, version);
   }
 
@@ -248,7 +247,7 @@ public class DashboardServiceResource {
       })
   public Response create(
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateDashboardService create)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     DashboardService service = getService(create, securityContext);
     dao.create(uriInfo, service);
@@ -272,7 +271,7 @@ public class DashboardServiceResource {
       })
   public Response update(
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateDashboardService update)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     DashboardService service = getService(update, securityContext);
     PutResponse<DashboardService> response = dao.createOrUpdate(uriInfo, service, true);
@@ -299,7 +298,7 @@ public class DashboardServiceResource {
           boolean recursive,
       @Parameter(description = "Id of the dashboard service", schema = @Schema(type = "string")) @PathParam("id")
           String id)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     DeleteResponse<DashboardService> response = dao.delete(securityContext.getUserPrincipal().getName(), id, recursive);
     return response.toResponse();

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/database/DatabaseServiceResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/database/DatabaseServiceResource.java
@@ -22,7 +22,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.GeneralSecurityException;
-import java.text.ParseException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -123,7 +122,7 @@ public class DatabaseServiceResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, GeneralSecurityException, ParseException {
+      throws IOException, GeneralSecurityException {
     RestUtil.validateCursors(before, after);
     EntityUtil.Fields fields = new EntityUtil.Fields(FIELD_LIST, fieldsParam);
     if (before != null) {
@@ -161,7 +160,7 @@ public class DatabaseServiceResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     EntityUtil.Fields fields = new EntityUtil.Fields(FIELD_LIST, fieldsParam);
     return dao.get(uriInfo, id, fields, include);
   }
@@ -195,7 +194,7 @@ public class DatabaseServiceResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     EntityUtil.Fields fields = new EntityUtil.Fields(FIELD_LIST, fieldsParam);
     return dao.getByName(uriInfo, name, fields, include);
   }
@@ -216,7 +215,7 @@ public class DatabaseServiceResource {
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
       @Parameter(description = "database service Id", schema = @Schema(type = "string")) @PathParam("id") String id)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.listVersions(id);
   }
 
@@ -245,7 +244,7 @@ public class DatabaseServiceResource {
               schema = @Schema(type = "string", example = "0.1 or 1.1"))
           @PathParam("version")
           String version)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.getVersion(id, version);
   }
 
@@ -266,7 +265,7 @@ public class DatabaseServiceResource {
       })
   public Response create(
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateDatabaseService create)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     DatabaseService service = getService(create, securityContext);
     dao.create(uriInfo, service);
@@ -290,7 +289,7 @@ public class DatabaseServiceResource {
       })
   public Response update(
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateDatabaseService update)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     DatabaseService service = getService(update, securityContext);
     PutResponse<DatabaseService> response = dao.createOrUpdate(uriInfo, service, true);
@@ -317,7 +316,7 @@ public class DatabaseServiceResource {
           boolean recursive,
       @Parameter(description = "Id of the database service", schema = @Schema(type = "string")) @PathParam("id")
           String id)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     DeleteResponse<DatabaseService> response = dao.delete(securityContext.getUserPrincipal().getName(), id, recursive);
     return response.toResponse();

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/messaging/MessagingServiceResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/messaging/MessagingServiceResource.java
@@ -22,7 +22,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.GeneralSecurityException;
-import java.text.ParseException;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -119,7 +118,7 @@ public class MessagingServiceResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException, GeneralSecurityException {
+      throws IOException, GeneralSecurityException {
     RestUtil.validateCursors(before, after);
     if (before != null) { // Reverse paging
       return dao.listBefore(uriInfo, null, null, limitParam, before, include);
@@ -152,7 +151,7 @@ public class MessagingServiceResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.get(uriInfo, id, null, include);
   }
 
@@ -180,7 +179,7 @@ public class MessagingServiceResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.getByName(uriInfo, name, null, include);
   }
 
@@ -200,7 +199,7 @@ public class MessagingServiceResource {
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
       @Parameter(description = "messaging service Id", schema = @Schema(type = "string")) @PathParam("id") String id)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.listVersions(id);
   }
 
@@ -229,7 +228,7 @@ public class MessagingServiceResource {
               schema = @Schema(type = "string", example = "0.1 or 1.1"))
           @PathParam("version")
           String version)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.getVersion(id, version);
   }
 
@@ -250,7 +249,7 @@ public class MessagingServiceResource {
       })
   public Response create(
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateMessagingService create)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     MessagingService service = getService(create, securityContext);
     dao.create(uriInfo, service);
@@ -278,7 +277,7 @@ public class MessagingServiceResource {
       @Parameter(description = "Id of the messaging service", schema = @Schema(type = "string")) @PathParam("id")
           String id,
       @Valid CreateMessagingService update)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     MessagingService service = getService(update, securityContext);
     PutResponse<MessagingService> response = dao.createOrUpdate(uriInfo, service, true);
@@ -304,7 +303,7 @@ public class MessagingServiceResource {
           boolean recursive,
       @Parameter(description = "Id of the messaging service", schema = @Schema(type = "string")) @PathParam("id")
           String id)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     DeleteResponse<MessagingService> response = dao.delete(securityContext.getUserPrincipal().getName(), id, recursive);
     return response.toResponse();

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/pipeline/PipelineServiceResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/pipeline/PipelineServiceResource.java
@@ -22,7 +22,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.GeneralSecurityException;
-import java.text.ParseException;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -124,7 +123,7 @@ public class PipelineServiceResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, GeneralSecurityException, ParseException {
+      throws IOException, GeneralSecurityException {
     RestUtil.validateCursors(before, after);
 
     if (before != null) { // Reverse paging
@@ -158,7 +157,7 @@ public class PipelineServiceResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.get(uriInfo, id, null, include);
   }
 
@@ -186,7 +185,7 @@ public class PipelineServiceResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.getByName(uriInfo, name, null, include);
   }
 
@@ -206,7 +205,7 @@ public class PipelineServiceResource {
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
       @Parameter(description = "pipeline service Id", schema = @Schema(type = "string")) @PathParam("id") String id)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.listVersions(id);
   }
 
@@ -235,7 +234,7 @@ public class PipelineServiceResource {
               schema = @Schema(type = "string", example = "0.1 or 1.1"))
           @PathParam("version")
           String version)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.getVersion(id, version);
   }
 
@@ -256,7 +255,7 @@ public class PipelineServiceResource {
       })
   public Response create(
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreatePipelineService create)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     PipelineService service = getService(create, securityContext);
     dao.create(uriInfo, service);
@@ -280,7 +279,7 @@ public class PipelineServiceResource {
       })
   public Response update(
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreatePipelineService update)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     PipelineService service = getService(update, securityContext);
     PutResponse<PipelineService> response = dao.createOrUpdate(uriInfo, service, true);
@@ -307,7 +306,7 @@ public class PipelineServiceResource {
           boolean recursive,
       @Parameter(description = "Id of the pipeline service", schema = @Schema(type = "string")) @PathParam("id")
           String id)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     DeleteResponse<PipelineService> response = dao.delete(securityContext.getUserPrincipal().getName(), id, recursive);
     return response.toResponse();

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/storage/StorageServiceResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/storage/StorageServiceResource.java
@@ -22,7 +22,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.GeneralSecurityException;
-import java.text.ParseException;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -119,7 +118,7 @@ public class StorageServiceResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, GeneralSecurityException, ParseException {
+      throws IOException, GeneralSecurityException {
     RestUtil.validateCursors(before, after);
     if (before != null) { // Reverse paging
       return dao.listBefore(uriInfo, null, null, limitParam, before, include);
@@ -152,7 +151,7 @@ public class StorageServiceResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.get(uriInfo, id, null, include);
   }
 
@@ -180,7 +179,7 @@ public class StorageServiceResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.getByName(uriInfo, name, null, include);
   }
 
@@ -200,7 +199,7 @@ public class StorageServiceResource {
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
       @Parameter(description = "storage service Id", schema = @Schema(type = "string")) @PathParam("id") String id)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.listVersions(id);
   }
 
@@ -229,7 +228,7 @@ public class StorageServiceResource {
               schema = @Schema(type = "string", example = "0.1 or 1.1"))
           @PathParam("version")
           String version)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.getVersion(id, version);
   }
 
@@ -248,7 +247,7 @@ public class StorageServiceResource {
       })
   public Response create(
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateStorageService create)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     StorageService databaseService = getService(create, securityContext);
     dao.create(uriInfo, databaseService);
@@ -270,7 +269,7 @@ public class StorageServiceResource {
       })
   public Response update(
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateStorageService update)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     StorageService databaseService = getService(update, securityContext);
     PutResponse<StorageService> response = dao.createOrUpdate(uriInfo, databaseService);
@@ -296,7 +295,7 @@ public class StorageServiceResource {
           boolean recursive,
       @Parameter(description = "Id of the storage service", schema = @Schema(type = "string")) @PathParam("id")
           String id)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     DeleteResponse<StorageService> response = dao.delete(securityContext.getUserPrincipal().getName(), id, recursive);
     return response.toResponse();

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/teams/RoleResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/teams/RoleResource.java
@@ -26,7 +26,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.GeneralSecurityException;
-import java.text.ParseException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -147,7 +146,7 @@ public class RoleResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, GeneralSecurityException, ParseException {
+      throws IOException, GeneralSecurityException {
     RestUtil.validateCursors(before, after);
     EntityUtil.Fields fields = new EntityUtil.Fields(FIELD_LIST, fieldsParam);
 
@@ -177,7 +176,7 @@ public class RoleResource {
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
       @Parameter(description = "role Id", schema = @Schema(type = "string")) @PathParam("id") String id)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.listVersions(id);
   }
 
@@ -210,7 +209,7 @@ public class RoleResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     EntityUtil.Fields fields = new EntityUtil.Fields(FIELD_LIST, fieldsParam);
     return addHref(uriInfo, dao.get(uriInfo, id, fields, include));
   }
@@ -244,7 +243,7 @@ public class RoleResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     EntityUtil.Fields fields = new EntityUtil.Fields(FIELD_LIST, fieldsParam);
     return addHref(uriInfo, dao.getByName(uriInfo, name, fields, include));
   }
@@ -273,7 +272,7 @@ public class RoleResource {
               schema = @Schema(type = "string", example = "0.1 or 1.1"))
           @PathParam("version")
           String version)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.getVersion(id, version);
   }
 
@@ -291,7 +290,7 @@ public class RoleResource {
       })
   public Response create(
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateRole createRole)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     Role role = getRole(createRole, securityContext);
     role = addHref(uriInfo, dao.create(uriInfo, role));
@@ -312,7 +311,7 @@ public class RoleResource {
       })
   public Response createOrUpdateRole(
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateRole createRole)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     Role role = getRole(createRole, securityContext);
     RestUtil.PutResponse<Role> response = dao.createOrUpdate(uriInfo, role);
@@ -341,7 +340,7 @@ public class RoleResource {
                         @ExampleObject("[" + "{op:remove, path:/a}," + "{op:add, path: /b, value: val}" + "]")
                       }))
           JsonPatch patch)
-      throws IOException, ParseException {
+      throws IOException {
 
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     PatchResponse<Role> response =
@@ -361,7 +360,7 @@ public class RoleResource {
         @ApiResponse(responseCode = "404", description = "Role for instance {id} is not found")
       })
   public Response delete(@Context UriInfo uriInfo, @Context SecurityContext securityContext, @PathParam("id") String id)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     // A role has a strong relationship with a policy. Recursively delete the policy that the role contains, to avoid
     // leaving a dangling policy without a role.

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/teams/TeamResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/teams/TeamResource.java
@@ -26,7 +26,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.GeneralSecurityException;
-import java.text.ParseException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -142,7 +141,7 @@ public class TeamResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, GeneralSecurityException, ParseException {
+      throws IOException, GeneralSecurityException {
     RestUtil.validateCursors(before, after);
     EntityUtil.Fields fields = new EntityUtil.Fields(FIELD_LIST, fieldsParam);
 
@@ -172,7 +171,7 @@ public class TeamResource {
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
       @Parameter(description = "team Id", schema = @Schema(type = "string")) @PathParam("id") String id)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.listVersions(id);
   }
 
@@ -205,7 +204,7 @@ public class TeamResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     EntityUtil.Fields fields = new EntityUtil.Fields(FIELD_LIST, fieldsParam);
     return addHref(uriInfo, dao.get(uriInfo, id, fields, include));
   }
@@ -239,7 +238,7 @@ public class TeamResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     EntityUtil.Fields fields = new EntityUtil.Fields(FIELD_LIST, fieldsParam);
     return addHref(uriInfo, dao.getByName(uriInfo, name, fields, include));
   }
@@ -268,7 +267,7 @@ public class TeamResource {
               schema = @Schema(type = "string", example = "0.1 or 1.1"))
           @PathParam("version")
           String version)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.getVersion(id, version);
   }
 
@@ -285,7 +284,7 @@ public class TeamResource {
         @ApiResponse(responseCode = "400", description = "Bad request")
       })
   public Response create(@Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateTeam ct)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     Team team = getTeam(ct, securityContext);
     addHref(uriInfo, dao.create(uriInfo, team));
@@ -305,8 +304,7 @@ public class TeamResource {
         @ApiResponse(responseCode = "400", description = "Bad request")
       })
   public Response createOrUpdateTeam(
-      @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateTeam ct)
-      throws IOException, ParseException {
+      @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateTeam ct) throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     Team team = getTeam(ct, securityContext);
     RestUtil.PutResponse<Team> response = dao.createOrUpdate(uriInfo, team);
@@ -335,7 +333,7 @@ public class TeamResource {
                         @ExampleObject("[" + "{op:remove, path:/a}," + "{op:add, path: /b, value: val}" + "]")
                       }))
           JsonPatch patch)
-      throws IOException, ParseException {
+      throws IOException {
 
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     PatchResponse<Team> response =
@@ -355,7 +353,7 @@ public class TeamResource {
         @ApiResponse(responseCode = "404", description = "Team for instance {id} is not found")
       })
   public Response delete(@Context UriInfo uriInfo, @Context SecurityContext securityContext, @PathParam("id") String id)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     DeleteResponse<Team> response = dao.delete(securityContext.getUserPrincipal().getName(), id);
     return response.toResponse();

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/teams/UserResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/teams/UserResource.java
@@ -26,7 +26,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.GeneralSecurityException;
-import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -154,7 +153,7 @@ public class UserResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, GeneralSecurityException, ParseException {
+      throws IOException, GeneralSecurityException {
     RestUtil.validateCursors(before, after);
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
 
@@ -184,7 +183,7 @@ public class UserResource {
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
       @Parameter(description = "user Id", schema = @Schema(type = "string")) @PathParam("id") String id)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.listVersions(id);
   }
 
@@ -217,7 +216,7 @@ public class UserResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
     User user = dao.get(uriInfo, id, fields, include);
     return addHref(uriInfo, user);
@@ -252,7 +251,7 @@ public class UserResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
     User user = dao.getByName(uriInfo, name, fields, include);
     return addHref(uriInfo, user);
@@ -280,7 +279,7 @@ public class UserResource {
               schema = @Schema(type = "string", example = FIELDS))
           @QueryParam("fields")
           String fieldsParam)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
     String currentUserName = securityContext.getUserPrincipal().getName();
     User user = dao.getByName(uriInfo, currentUserName, fields);
@@ -311,7 +310,7 @@ public class UserResource {
               schema = @Schema(type = "string", example = "0.1 or 1.1"))
           @PathParam("version")
           String version)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.getVersion(id, version);
   }
 
@@ -328,8 +327,7 @@ public class UserResource {
         @ApiResponse(responseCode = "400", description = "Bad request")
       })
   public Response createUser(
-      @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateUser create)
-      throws IOException, ParseException {
+      @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateUser create) throws IOException {
     if (create.getIsAdmin() != null && create.getIsAdmin()) {
       SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     }
@@ -351,8 +349,7 @@ public class UserResource {
         @ApiResponse(responseCode = "400", description = "Bad request")
       })
   public Response createOrUpdateUser(
-      @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateUser create)
-      throws IOException, ParseException {
+      @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateUser create) throws IOException {
     if ((create.getIsAdmin() != null && create.getIsAdmin()) || (create.getIsBot() != null && create.getIsBot())) {
       SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     }
@@ -385,7 +382,7 @@ public class UserResource {
                         @ExampleObject("[" + "{op:remove, path:/a}," + "{op:add, path: /b, value: val}" + "]")
                       }))
           JsonPatch patch)
-      throws IOException, ParseException {
+      throws IOException {
     for (JsonValue patchOp : patch.toJsonArray()) {
       JsonObject patchOpObject = patchOp.asJsonObject();
       if (patchOpObject.containsKey("path") && patchOpObject.containsKey("value")) {
@@ -415,7 +412,7 @@ public class UserResource {
         @ApiResponse(responseCode = "404", description = "User for instance {id} is not found")
       })
   public Response delete(@Context UriInfo uriInfo, @Context SecurityContext securityContext, @PathParam("id") String id)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     DeleteResponse<User> response = dao.delete(securityContext.getUserPrincipal().getName(), id);
     return response.toResponse();

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/topics/TopicResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/topics/TopicResource.java
@@ -26,7 +26,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.security.GeneralSecurityException;
-import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -157,7 +156,7 @@ public class TopicResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, GeneralSecurityException, ParseException {
+      throws IOException, GeneralSecurityException {
     RestUtil.validateCursors(before, after);
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
 
@@ -186,7 +185,7 @@ public class TopicResource {
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
       @Parameter(description = "Topic Id", schema = @Schema(type = "string")) @PathParam("id") String id)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.listVersions(id);
   }
 
@@ -218,7 +217,7 @@ public class TopicResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
     return addHref(uriInfo, dao.get(uriInfo, id, fields, include));
   }
@@ -251,7 +250,7 @@ public class TopicResource {
           @QueryParam("include")
           @DefaultValue("non-deleted")
           Include include)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, fieldsParam);
     Topic topic = dao.getByName(uriInfo, fqn, fields, include);
     addHref(uriInfo, topic);
@@ -282,7 +281,7 @@ public class TopicResource {
               schema = @Schema(type = "string", example = "0.1 or 1.1"))
           @PathParam("version")
           String version)
-      throws IOException, ParseException {
+      throws IOException {
     return dao.getVersion(id, version);
   }
 
@@ -299,7 +298,7 @@ public class TopicResource {
         @ApiResponse(responseCode = "400", description = "Bad request")
       })
   public Response create(@Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateTopic create)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     Topic topic = getTopic(securityContext, create);
 
@@ -328,7 +327,7 @@ public class TopicResource {
                         @ExampleObject("[" + "{op:remove, path:/a}," + "{op:add, path: /b, value: val}" + "]")
                       }))
           JsonPatch patch)
-      throws IOException, ParseException {
+      throws IOException {
     Fields fields = new Fields(FIELD_LIST, FIELDS);
     Topic topic = dao.get(uriInfo, id, fields);
     SecurityUtil.checkAdminRoleOrPermissions(
@@ -353,7 +352,7 @@ public class TopicResource {
       })
   public Response createOrUpdate(
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateTopic create)
-      throws IOException, ParseException {
+      throws IOException {
 
     Topic topic = getTopic(securityContext, create);
     PutResponse<Topic> response = dao.createOrUpdate(uriInfo, topic);
@@ -412,7 +411,7 @@ public class TopicResource {
         @ApiResponse(responseCode = "404", description = "Topic for instance {id} is not found")
       })
   public Response delete(@Context UriInfo uriInfo, @Context SecurityContext securityContext, @PathParam("id") String id)
-      throws IOException, ParseException {
+      throws IOException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     DeleteResponse<Topic> response = dao.delete(securityContext.getUserPrincipal().getName(), id);
     return response.toResponse();

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/util/EntityUtil.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/util/EntityUtil.java
@@ -34,14 +34,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.joda.time.Period;
 import org.joda.time.format.ISOPeriodFormat;
 import org.openmetadata.catalog.Entity;
-import org.openmetadata.catalog.entity.teams.Team;
 import org.openmetadata.catalog.entity.teams.User;
 import org.openmetadata.catalog.exception.CatalogExceptionMessage;
 import org.openmetadata.catalog.exception.EntityNotFoundException;
 import org.openmetadata.catalog.jdbi3.CollectionDAO.EntityRelationshipDAO;
 import org.openmetadata.catalog.jdbi3.CollectionDAO.EntityVersionPair;
 import org.openmetadata.catalog.jdbi3.CollectionDAO.TagDAO;
-import org.openmetadata.catalog.jdbi3.CollectionDAO.TeamDAO;
 import org.openmetadata.catalog.jdbi3.CollectionDAO.UsageDAO;
 import org.openmetadata.catalog.jdbi3.CollectionDAO.UserDAO;
 import org.openmetadata.catalog.jdbi3.Relationship;
@@ -161,28 +159,6 @@ public final class EntityUtil {
     if (!userDAO.exists(userId)) {
       throw EntityNotFoundException.byMessage(CatalogExceptionMessage.entityNotFound(Entity.USER, userId));
     }
-  }
-
-  public static EntityReference populateOwner(UserDAO userDAO, TeamDAO teamDAO, EntityReference owner)
-      throws IOException {
-    if (owner == null) {
-      return null;
-    }
-    UUID id = owner.getId();
-    if (owner.getType().equalsIgnoreCase("user")) {
-      User ownerInstance = userDAO.findEntityById(id);
-      owner.setName(ownerInstance.getName());
-      if (Optional.ofNullable(ownerInstance.getDeleted()).orElse(false)) {
-        throw new IllegalArgumentException(CatalogExceptionMessage.deactivatedUser(id));
-      }
-    } else if (owner.getType().equalsIgnoreCase("team")) {
-      Team ownerInstance = teamDAO.findEntityById(id);
-      owner.setDescription(ownerInstance.getDescription());
-      owner.setName(ownerInstance.getName());
-    } else {
-      throw new IllegalArgumentException(String.format("Invalid ownerType %s", owner.getType()));
-    }
-    return owner;
   }
 
   public static void setOwner(

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/util/RestUtil.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/util/RestUtil.java
@@ -122,7 +122,7 @@ public final class RestUtil {
     return DATE_FORMAT.parse(date1).compareTo(DATE_FORMAT.parse(date2));
   }
 
-  public static String today(int offsetDays) throws ParseException {
+  public static String today(int offsetDays) {
     Date date = CommonUtil.getDateByOffset(new Date(), offsetDays);
     return DATE_FORMAT.format(date);
   }

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/operations/AirflowPipelineResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/operations/AirflowPipelineResourceTest.java
@@ -37,7 +37,6 @@ import static org.openmetadata.catalog.util.TestUtils.assertResponse;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
@@ -366,7 +365,7 @@ public class AirflowPipelineResourceTest extends EntityOperationsResourceTest<Ai
 
   @Test
   void post_AirflowWithDatabaseServiceMetadata_GeneratedIngestionPipelineConfig_200_ok(TestInfo test)
-      throws IOException, ParseException {
+      throws IOException {
     CreateAirflowPipeline request =
         create(test)
             .withPipelineType(PipelineType.METADATA)
@@ -397,7 +396,7 @@ public class AirflowPipelineResourceTest extends EntityOperationsResourceTest<Ai
     assertEquals(expectedScheduleInterval, ingestion.getScheduleInterval());
     validateGeneratedAirflowPipelineConfig(airflowPipeline);
     // Update and connector orgs and options to database connection
-    DatabaseService databaseService = helper(airflowPipeline).findEntity("service", DATABASE_SERVICE);
+    DatabaseService databaseService = helper(airflowPipeline).getContainer(DATABASE_SERVICE).toEntity();
     DatabaseConnection databaseConnection = databaseService.getDatabaseConnection();
     ConnectionArguments connectionArguments =
         new ConnectionArguments()
@@ -558,10 +557,9 @@ public class AirflowPipelineResourceTest extends EntityOperationsResourceTest<Ai
     }
   }
 
-  private void validateGeneratedAirflowPipelineConfig(AirflowPipeline airflowPipeline)
-      throws IOException, ParseException {
+  private void validateGeneratedAirflowPipelineConfig(AirflowPipeline airflowPipeline) throws IOException {
     IngestionAirflowPipeline ingestionPipeline = AirflowUtils.toIngestionPipeline(airflowPipeline, AIRFLOW_CONFIG);
-    DatabaseService databaseService = helper(airflowPipeline).findEntity("service", DATABASE_SERVICE);
+    DatabaseService databaseService = helper(airflowPipeline).getContainer(DATABASE_SERVICE).toEntity();
     DatabaseConnection databaseConnection = databaseService.getDatabaseConnection();
     DatabaseServiceMetadataPipeline metadataPipeline =
         JsonUtils.convertValue(airflowPipeline.getPipelineConfig(), DatabaseServiceMetadataPipeline.class);
@@ -596,8 +594,8 @@ public class AirflowPipelineResourceTest extends EntityOperationsResourceTest<Ai
     }
   }
 
-  private void listDatabaseServicePipelines(AirflowPipeline airflowPipeline) throws IOException, ParseException {
-    DatabaseService databaseService = helper(airflowPipeline).findEntity("service", DATABASE_SERVICE);
+  private void listDatabaseServicePipelines(AirflowPipeline airflowPipeline) throws IOException {
+    DatabaseService databaseService = helper(airflowPipeline).getContainer(DATABASE_SERVICE).toEntity();
     DatabaseServiceResourceTest.getResource("services/databaseServices");
   }
 }

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/DatabaseServiceResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/DatabaseServiceResourceTest.java
@@ -25,7 +25,6 @@ import static org.openmetadata.catalog.util.TestUtils.getPrincipal;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -134,7 +133,7 @@ public class DatabaseServiceResourceTest extends EntityResourceTest<DatabaseServ
   }
 
   @Test
-  void put_addIngestion_as_admin_2xx(TestInfo test) throws IOException, ParseException {
+  void put_addIngestion_as_admin_2xx(TestInfo test) throws IOException {
     DatabaseService service = createAndCheckEntity(create(test).withDescription(null), adminAuthHeaders());
 
     // Update database description and ingestion service that are null

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/util/TestUtils.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/util/TestUtils.java
@@ -151,7 +151,7 @@ public final class TestUtils {
     assertEquals(expectedCode.getStatusCode(), exception.getStatusCode());
     assertTrue(
         exception.getReasonPhrase().contains(expectedReason),
-        expectedReason + " not in actual " + exception.getReasonPhrase());
+        "`" + expectedReason + "` not in actual `" + exception.getReasonPhrase() + "`");
   }
 
   public static <T> void assertEntityPagination(List<T> allEntities, ResultList<T> actual, int limit, int offset) {

--- a/common/src/main/java/org/openmetadata/common/utils/CommonUtil.java
+++ b/common/src/main/java/org/openmetadata/common/utils/CommonUtil.java
@@ -90,7 +90,7 @@ public final class CommonUtil {
   }
 
   /** Get date after {@code days} from the given date or before i{@code days} when it is negative */
-  public static Date getDateByOffset(Date date, int days) throws ParseException {
+  public static Date getDateByOffset(Date date, int days) {
     Calendar calendar = Calendar.getInstance();
     calendar.setTime(date);
     calendar.add(Calendar.DATE, days);
@@ -98,7 +98,7 @@ public final class CommonUtil {
   }
 
   /** Get date after {@code days} from the given date or before i{@code days} when it is negative */
-  public static Date getDateByOffsetSeconds(Date date, int seconds) throws ParseException {
+  public static Date getDateByOffsetSeconds(Date date, int seconds) {
     Calendar calendar = Calendar.getInstance();
     calendar.setTime(date);
     calendar.add(Calendar.SECOND, seconds);


### PR DESCRIPTION
### Describe your changes :
See #2287 

- [x] remove all useless declared exceptions in the signatures

# Example for table and pipeline
## Goals
* The developer doesn't need to worry about `deleted` or `non-deleted` or the
exception to throw `BAD_REQUEST` or `INTERNAL_ERROR`.
* The developer can provide entity types for validation but the validation is done by the decorator.
* The API is fluent.

## prepare context (write path)
* validate mandatory fields: database and service (from disk).
* `ownerReference` must be augmented to all `entityReference` fields but it can be null.
* `database` must exist.
* `service` must exist.
* `serviceType` must be set.
* `serviceType` is populated in the prepare and saved to disk.
* everything must be **NON_DELETED**.

```java
// all throw BAD_REQUEST
Database database = helper(table).get("database", DATABASE).toEntity();
// Reassigning the `EntityReference` we return more metadata like `name`, `description`, `displayName`.
table.setDatabase(helper(database).toEntityReference());
// this is the one only throwing INTERNAL_ERROR, when creating a table the Database and the DatabaseService must be there
// it will be called 2 times. One time when we do `helper(table).get("database", DATABASE).toEntity() and then again when
// we do `helper(database).getContainer(DATABASE_SERVICE).toEntity()`. We have to do this to get the `ServiceType` that
// it is only available in the Entity and not in the EntityReference.
DatabaseService databaseService = helper(database).getContainer(DATABASE_SERVICE).toEntity();
table.setService(helper(databaseService).toEntityReference());
// we need to populate the serviceType
table.setServiceType(databaseService.getServiceType());
// this is like the previous populateOwner but it calls the setter of `table` and it doesn't require `daoCollection.userDAO(), daoCollection.teamDAO(), metrics.getOwner()` as parameter.
helper(table).populateOwner();
```

## setFields context (read path)
* Because of `table.withOwner(null).withDatabase(null).withHref(null).withTags(null).withService(null);`
we need to look up for these relationships including `location` for `table`.
* relationships must be followed with the **Include** of `table`.
* null is ok for `owner` and `location`.
* database and service must be there.

```java
// all throw INTERNAL_ERROR
Database database = helper(table).getContainer(DATABASE).toEntity();
table.setDatabase(helper(database).toEntityReference());
// the setFields of Database will check the link to DatabaseService
table.setService(database.getService());
// can be NULL
table.setOwner(helper(table).getOwner().toEntityReference());
// can be NULL, `has` is similar to `contains` but a table is contained and therefore we prefered to use `getContainer`.
table.setLocation(helper(table).has(LOCATION).toEntityReference());
```

```java
// pipeLine
ingestion.setService(helper(pipeline).getContainer(List.of(DATABASE_SERVICE, DASHBOARD_SERVICE)).toEntityReference());
pipeline.setOwner(helper(pipeline).getOwner().toEntityReference());
```
