### PR TITLE
Fix:- Tags drop-down menu is getting overlapped by another elements for tags page

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/tags/index.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/tags/index.tsx
@@ -293,7 +293,7 @@ const TagsPage = () => {
             {isLoading ? (
               <Loader />
             ) : (
-              <div data-testid="tags-container">
+              <div className="full-height" data-testid="tags-container">
                 {currentCategory && (
                   <div
                     className="tw-flex tw-justify-between tw-items-center"
@@ -336,9 +336,7 @@ const TagsPage = () => {
                   />
                 </div>
                 <div className="tw-bg-white">
-                  <table
-                    className="tw-w-full tw-overflow-x-auto"
-                    data-testid="table">
+                  <table className="tw-table-responsive" data-testid="table">
                     <thead>
                       <tr className="tableHead-row">
                         <th

--- a/openmetadata-ui/src/main/resources/ui/src/styles/x-master.css
+++ b/openmetadata-ui/src/main/resources/ui/src/styles/x-master.css
@@ -763,6 +763,10 @@ body .profiler-graph .recharts-active-dot circle {
   overflow-y: hidden;
 }
 
+.full-height {
+  height: calc(100vh - 110px);
+}
+
 #left-panel {
   grid-area: leftsidebar;
 }


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Tags drop-down menu is getting overlapped by another elements for tags page.
Closes #2044 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
![image](https://user-images.githubusercontent.com/71748675/150274638-81acdfca-802c-4d57-8a8f-d5f78aef7f0b.png)
![image](https://user-images.githubusercontent.com/71748675/150274676-fec4ba87-5e79-4f9c-973f-fac340ee298e.png)


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
 Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya 
