### PR TITLE
ISSUE-2048: Bigquery data profiler uses schema name instead of project id

### DIFF
--- a/ingestion/src/metadata/ingestion/source/sql_source.py
+++ b/ingestion/src/metadata/ingestion/source/sql_source.py
@@ -217,11 +217,16 @@ class SQLSource(Source[OMetaDatabaseAndTable]):
                     logger.error(repr(err))
                     logger.error(err)
 
-                if self._instantiate_profiler():
-                    profile = self.run_data_profiler(table_name, schema)
-                    table_entity.tableProfile = (
-                        [profile] if profile is not None else None
-                    )
+                try:
+                    if self._instantiate_profiler():
+                        profile = self.run_data_profiler(table_name, schema)
+                        table_entity.tableProfile = (
+                            [profile] if profile is not None else None
+                        )
+                # Catch any errors during the profile runner and continue
+                except Exception as err:
+                    logger.error(repr(err))
+                    logger.error(err)
                 # check if we have any model to associate with
                 table_entity.dataModel = self._get_data_model(schema, table_name)
 

--- a/ingestion/src/metadata/profiler/databases/bigquery.py
+++ b/ingestion/src/metadata/profiler/databases/bigquery.py
@@ -23,6 +23,11 @@ class BigquerySQLExpressions(SQLExpressions):
 class Bigquery(DatabaseCommon):
     config: BigQueryConfig = None
     sql_exprs: BigquerySQLExpressions = BigquerySQLExpressions()
+    
+    def get_connection_url(self):
+        if self.config.project_id:
+            return f"{self.config.scheme}://{self.config.project_id}"
+        return f"{self.config.scheme}://"
 
     def __init__(self, config):
         super().__init__(config)
@@ -34,14 +39,6 @@ class Bigquery(DatabaseCommon):
         return cls(config)
 
     def qualify_table_name(self, table_name: str, schema_name: str) -> str:
-        return f"`{self.config.database}.{table_name}`"
-
-    def standardize_schema_table_names(
-        self, schema: str, table: str
-    ) -> Tuple[str, str]:
-        segments = table.split(".")
-        if len(segments) != 2:
-            raise ValueError(f"expected table to contain schema name already {table}")
-        if segments[0] != schema:
-            raise ValueError(f"schema {schema} does not match table {table}")
-        return segments[0], segments[1]
+        if schema_name:
+            return f"`{schema_name}.{table_name}`"
+        return f"{table_name}"

--- a/ingestion/src/metadata/profiler/databases/bigquery.py
+++ b/ingestion/src/metadata/profiler/databases/bigquery.py
@@ -23,7 +23,7 @@ class BigquerySQLExpressions(SQLExpressions):
 class Bigquery(DatabaseCommon):
     config: BigQueryConfig = None
     sql_exprs: BigquerySQLExpressions = BigquerySQLExpressions()
-    
+
     def get_connection_url(self):
         if self.config.project_id:
             return f"{self.config.scheme}://{self.config.project_id}"

--- a/ingestion/src/metadata/profiler/databases/bigquery.py
+++ b/ingestion/src/metadata/profiler/databases/bigquery.py
@@ -9,6 +9,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from typing import Tuple
+
 from metadata.ingestion.source.bigquery import BigQueryConfig
 from metadata.profiler.common.database_common import DatabaseCommon, SQLExpressions
 
@@ -33,3 +35,13 @@ class Bigquery(DatabaseCommon):
 
     def qualify_table_name(self, table_name: str, schema_name: str) -> str:
         return f"`{self.config.database}.{table_name}`"
+
+    def standardize_schema_table_names(
+        self, schema: str, table: str
+    ) -> Tuple[str, str]:
+        segments = table.split(".")
+        if len(segments) != 2:
+            raise ValueError(f"expected table to contain schema name already {table}")
+        if segments[0] != schema:
+            raise ValueError(f"schema {schema} does not match table {table}")
+        return segments[0], segments[1]

--- a/ingestion/src/metadata/profiler/profiler.py
+++ b/ingestion/src/metadata/profiler/profiler.py
@@ -44,6 +44,12 @@ class Profiler:
         self.schema_name = schema_name
         self.excluded_columns = excluded_columns
         self.time = profile_time
+        if "." in table_name:
+            schema_name = table_name.split(".")[0]
+            table_name = "".join(table_name.split(".")[1:])
+            self.table = Table(name=table_name)
+            self.schema_name = schema_name
+
         self.qualified_table_name = self.database.qualify_table_name(
             table_name, schema_name
         )

--- a/ingestion/src/metadata/profiler/profiler_runner.py
+++ b/ingestion/src/metadata/profiler/profiler_runner.py
@@ -13,7 +13,7 @@ import importlib
 import logging
 import traceback
 from datetime import datetime, timezone
-from typing import Type, TypeVar
+from typing import Tuple, Type, TypeVar
 
 from metadata.config.common import ConfigModel, DynamicTypedConfig
 from metadata.ingestion.source.sql_source_common import SQLSourceStatus
@@ -70,6 +70,10 @@ class ProfilerRunner:
         config = ProfilerConfig.parse_obj(config_dict)
         return cls(config)
 
+    @staticmethod
+    def standardize_schema_table_names(schema: str, table: str) -> Tuple[str, str]:
+        return schema, table
+
     def run_profiler(self):
         schema_names = self.database.inspector.get_schema_names()
         results = []
@@ -81,6 +85,9 @@ class ProfilerRunner:
 
             for table_name in tables:
                 try:
+                    schema, table_name = self.standardize_schema_table_names(
+                        schema, table_name
+                    )
                     if not self.sql_config.table_filter_pattern.included(table_name):
                         self.status.filter(
                             f"{self.sql_config.get_service_name()}.{table_name}",

--- a/ingestion/src/metadata/profiler/profiler_runner.py
+++ b/ingestion/src/metadata/profiler/profiler_runner.py
@@ -70,10 +70,6 @@ class ProfilerRunner:
         config = ProfilerConfig.parse_obj(config_dict)
         return cls(config)
 
-    @staticmethod
-    def standardize_schema_table_names(schema: str, table: str) -> Tuple[str, str]:
-        return schema, table
-
     def run_profiler(self):
         schema_names = self.database.inspector.get_schema_names()
         results = []
@@ -85,9 +81,6 @@ class ProfilerRunner:
 
             for table_name in tables:
                 try:
-                    schema, table_name = self.standardize_schema_table_names(
-                        schema, table_name
-                    )
                     if not self.sql_config.table_filter_pattern.included(table_name):
                         self.status.filter(
                             f"{self.sql_config.get_service_name()}.{table_name}",


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Issue #2048 
Bigquery data profiler uses schema name instead of project id

**DRAFT PR - Work under progress**

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have performed a self-review of my own. 
- [ ] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] All new and existing tests passed.

<!-- # !-->
<!-- ### Reviewers !-->
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
