### PR TITLE
fix: Use venv instead of virtualenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,10 +116,10 @@ yarn_start_dev_ui:  ## Run the UI locally with Yarn
 
 ## Ingestion Core
 .PHONY: core_install_dev
-core_install_dev:  ## Prepare a virtualenv for the ingestion-core module
+core_install_dev:  ## Prepare a venv for the ingestion-core module
 	cd ingestion-core; \
 		rm -rf venv; \
-		python -m virtualenv venv; \
+		python -m venv venv; \
 		. venv/bin/activate; \
 		python -m pip install ".[dev]"
 


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Following #2345 and #2359, makefile updated for ingestion core to use `venv` instead of `virtualenv` as CI fails to find module for `virtualenv`.

```
/opt/hostedtoolcache/Python/3.9.9/x64/bin/python: No module named virtualenv
```


#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
