### PR TITLE
fix: Update make core_generate to run on ubuntu as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,8 +132,8 @@ core_clean:  ## Clean the ingestion-core generated files
 .PHONY: core_generate
 core_generate:  ## Generate the pydantic models from the JSON Schemas to the ingestion-core module
 	$(MAKE) core_install_dev
-	mkdir -p ingestion-core/src/metadata/generated
-	. ingestion-core/venv/bin/activate
+	mkdir -p ingestion-core/src/metadata/generated; \
+	. ingestion-core/venv/bin/activate; \
 	datamodel-codegen --input catalog-rest-service/src/main/resources/json  --input-file-type jsonschema --output ingestion-core/src/metadata/generated
 
 .PHONY: core_bump_version_dev


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Following #2345 and #2359, makefile updated for core_generate recipe which fails CI on Ubuntu with datamodel-codegen module not found error.
Ref - https://github.com/open-metadata/OpenMetadata/runs/4918139776?check_suite_focus=true

Steps to reproduce the CI issue - 
- `docker pull ubuntu:latest`
- `docker run -it -v OpenMetadata:/openmetadata ubuntu:latest`
- Inside docker:
  - Install python3, python3-dev, python3-venv
  - cd /openmetadata
  - run `make core_generate`

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.