### PR TITLE
Fix #2379 - CLI backup Import on call

### DIFF
--- a/ingestion/src/metadata/cli/backup.py
+++ b/ingestion/src/metadata/cli/backup.py
@@ -18,9 +18,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Optional, Tuple
 
-import boto3
 import click
-from boto3.exceptions import S3UploadFailedError
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -60,6 +58,16 @@ def upload_backup(endpoint: str, bucket: str, key: str, file: Path) -> None:
     :param key: S3 key to upload the backup file
     :param file: file to upload
     """
+
+    try:
+        import boto3
+        from boto3.exceptions import S3UploadFailedError
+    except ModuleNotFoundError as err:
+        logger.error(
+            "Trying to import boto3 to run the backup upload."
+            + " Please install openmetadata-ingestion[backup]."
+        )
+        raise err
 
     s3_key = Path(key) / file.name
     click.secho(


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
This PR fixes https://github.com/open-metadata/OpenMetadata/issues/2379.

Try to import boto3 only when interested in running the backup command with the upload. This allows normal use of the CLI if backup is not needed.

Thanks

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have performed a self-review of my own. 
- [ ] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
