### PR TITLE
Fix #2153 - Lineage date parsing

### DIFF
--- a/ingestion/src/airflow_provider_openmetadata/lineage/utils.py
+++ b/ingestion/src/airflow_provider_openmetadata/lineage/utils.py
@@ -13,9 +13,8 @@
 OpenMetadata Airflow Lineage Backend
 """
 
-import ast
 import traceback
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
 from airflow.configuration import conf
 
@@ -98,13 +97,11 @@ def get_properties(
     :return: properties dict
     """
 
-    props: Dict[str, str] = {
-        key: repr(value) for (key, value) in serializer(obj).items()
-    }
+    props: Dict[str, str] = {key: value for (key, value) in serializer(obj).items()}
 
     for key in obj.get_serialized_fields():
         if key not in props:
-            props[key] = repr(getattr(obj, key))
+            props[key] = getattr(obj, key)
 
     return {key: value for (key, value) in props.items() if key in allowed_keys}
 
@@ -136,17 +133,44 @@ def get_xlets(
     return None
 
 
-def get_iso_start_date(props: Dict[str, Any]) -> Optional[str]:
+def iso_dag_start_date(props: Dict[str, Any]) -> Optional[str]:
     """
     Given a properties dict, return the start_date
     as an iso string if start_date is informed
     :param props: properties dict
     :return: iso start_date or None
     """
-    if "start_date" in props:
+
+    # DAG start date comes as `float`
+    if props.get("start_date"):
         return convert_epoch_to_iso(int(float(props["start_date"])))
 
     return None
+
+
+def iso_task_start_end_date(
+    props: Dict[str, Any]
+) -> Tuple[Optional[str], Optional[str]]:
+    """
+    Given the attributes of a Task Instance, return
+    the task start date and task end date as
+    ISO format
+    :param props: task instance attributes
+    :return: task start and end date
+    """
+
+    task_start_date = (
+        convert_epoch_to_iso(int(props["start_date"].timestamp()))
+        if props.get("start_date")
+        else None
+    )
+    task_end_date = (
+        convert_epoch_to_iso(int(props["end_date"].timestamp()))
+        if props.get("end_date")
+        else None
+    )
+
+    return task_start_date, task_end_date
 
 
 def create_pipeline_entity(
@@ -174,24 +198,14 @@ def create_pipeline_entity(
         f"{pipeline_service_url}/taskinstance/list/"
         + f"?flt1_dag_id_equals={dag.dag_id}&_flt_3_task_id={operator.task_id}"
     )
-    dag_start_date = get_iso_start_date(dag_properties)
+    dag_start_date = iso_dag_start_date(dag_properties)
+    task_start_date, task_end_date = iso_task_start_end_date(task_properties)
 
     downstream_tasks = []
-    if "_downstream_task_ids" in task_properties:
-        downstream_tasks = ast.literal_eval(task_properties["_downstream_task_ids"])
+    if task_properties.get("_downstream_task_ids"):
+        downstream_tasks = task_properties["_downstream_task_ids"]
 
     operator.log.info(f"downstream tasks {downstream_tasks}")
-
-    task_start_date = (
-        task_properties["start_date"].isoformat()
-        if "start_time" in task_properties
-        else None
-    )
-    task_end_date = (
-        task_properties["end_date"].isoformat()
-        if "end_time" in task_properties
-        else None
-    )
 
     task = Task(
         name=task_properties["task_id"],

--- a/ingestion/src/airflow_provider_openmetadata/lineage/utils.py
+++ b/ingestion/src/airflow_provider_openmetadata/lineage/utils.py
@@ -136,6 +136,19 @@ def get_xlets(
     return None
 
 
+def get_iso_start_date(props: Dict[str, Any]) -> Optional[str]:
+    """
+    Given a properties dict, return the start_date
+    as an iso string if start_date is informed
+    :param props: properties dict
+    :return: iso start_date or None
+    """
+    if "start_date" in props:
+        return convert_epoch_to_iso(int(float(props["start_date"])))
+
+    return None
+
+
 def create_pipeline_entity(
     dag_properties: Dict[str, str],
     task_properties: Dict[str, str],
@@ -161,7 +174,7 @@ def create_pipeline_entity(
         f"{pipeline_service_url}/taskinstance/list/"
         + f"?flt1_dag_id_equals={dag.dag_id}&_flt_3_task_id={operator.task_id}"
     )
-    dag_start_date = convert_epoch_to_iso(int(float(dag_properties["start_date"])))
+    dag_start_date = get_iso_start_date(dag_properties)
 
     downstream_tasks = []
     if "_downstream_task_ids" in task_properties:


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
This PR fixes https://github.com/open-metadata/OpenMetadata/issues/2153#issuecomment-1019701270

The main issue was that `start_date` is not a required property when defining a DAG. We are now allowing the key to not exist in the DAG properties and pass that as `None`.

While checking the date conversion, we also fixed the keys for the task start and end dates. Although they are already `datetime`, we use our custom `convert_epoch_to_iso` to have the final format match both for the DAG and tasks.

Moreover, we are no longer picking up the attributes of the serialized objects from `repr`, as that forces the transformation to string and we need to transform it back with `ast.literal_eval`. The `literal_eval` does not function properly when the node is a call, which is the case for the tasks `start_date` and `end_date`.

Removing `ast` simplifies a bit the logic and helps us extract the required values.

We have added tests on the date parsing and ran the full integration tests in `airflow standalone`

![image](https://user-images.githubusercontent.com/35870520/150835659-02497922-94b9-49af-91b4-59557f5edab4.png)

Thanks!

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have performed a self-review of my own. 
- [ ] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
@harshach @ayush-shah
