### PR TITLE
Fix #1877: Editing services description does not save

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,5 +1,0 @@
-<component name="ProjectCodeStyleConfiguration">
-  <state>
-    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
-  </state>
-</component>

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/dashboard/DashboardServiceResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/dashboard/DashboardServiceResource.java
@@ -275,7 +275,7 @@ public class DashboardServiceResource {
       throws IOException, ParseException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     DashboardService service = getService(update, securityContext);
-    PutResponse<DashboardService> response = dao.createOrUpdate(uriInfo, service);
+    PutResponse<DashboardService> response = dao.createOrUpdate(uriInfo, service, true);
     return response.toResponse();
   }
 

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/database/DatabaseServiceResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/database/DatabaseServiceResource.java
@@ -293,7 +293,7 @@ public class DatabaseServiceResource {
       throws IOException, ParseException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     DatabaseService service = getService(update, securityContext);
-    PutResponse<DatabaseService> response = dao.createOrUpdate(uriInfo, service);
+    PutResponse<DatabaseService> response = dao.createOrUpdate(uriInfo, service, true);
     return response.toResponse();
   }
 

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/messaging/MessagingServiceResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/messaging/MessagingServiceResource.java
@@ -281,7 +281,7 @@ public class MessagingServiceResource {
       throws IOException, ParseException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     MessagingService service = getService(update, securityContext);
-    PutResponse<MessagingService> response = dao.createOrUpdate(uriInfo, service);
+    PutResponse<MessagingService> response = dao.createOrUpdate(uriInfo, service, true);
     return response.toResponse();
   }
 

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/pipeline/PipelineServiceResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/pipeline/PipelineServiceResource.java
@@ -283,7 +283,7 @@ public class PipelineServiceResource {
       throws IOException, ParseException {
     SecurityUtil.checkAdminOrBotRole(authorizer, securityContext);
     PipelineService service = getService(update, securityContext);
-    PutResponse<PipelineService> response = dao.createOrUpdate(uriInfo, service);
+    PutResponse<PipelineService> response = dao.createOrUpdate(uriInfo, service, true);
     return response.toResponse();
   }
 

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/EntityResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/EntityResourceTest.java
@@ -775,8 +775,8 @@ public abstract class EntityResourceTest<T> extends CatalogApplicationTest {
     entity = updateEntity(request, OK, adminAuthHeaders());
     entityInterface = getEntityInterface(entity);
     // For service resources, we allow update of non-empty description via PUT
-    List<Class<?>> services = Arrays.asList(
-            DatabaseService.class, PipelineService.class, DashboardService.class, MessagingService.class);
+    List<Class<?>> services =
+        Arrays.asList(DatabaseService.class, PipelineService.class, DashboardService.class, MessagingService.class);
     if (services.contains(entity.getClass())) {
       assertNotEquals(oldVersion, entityInterface.getVersion()); // Version did change
       assertEquals("updatedDescription", entityInterface.getDescription()); // Description did change

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/EntityResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/EntityResourceTest.java
@@ -49,6 +49,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -79,6 +80,7 @@ import org.openmetadata.catalog.api.services.CreateMessagingService.MessagingSer
 import org.openmetadata.catalog.api.services.CreatePipelineService;
 import org.openmetadata.catalog.api.services.CreatePipelineService.PipelineServiceType;
 import org.openmetadata.catalog.api.services.CreateStorageService;
+import org.openmetadata.catalog.entity.services.DashboardService;
 import org.openmetadata.catalog.entity.services.DatabaseService;
 import org.openmetadata.catalog.entity.services.MessagingService;
 import org.openmetadata.catalog.entity.services.PipelineService;
@@ -772,8 +774,16 @@ public abstract class EntityResourceTest<T> extends CatalogApplicationTest {
     request = createRequest(getEntityName(test), "updatedDescription", "displayName", null);
     entity = updateEntity(request, OK, adminAuthHeaders());
     entityInterface = getEntityInterface(entity);
-    assertEquals(oldVersion, entityInterface.getVersion()); // Version did not change
-    assertEquals("description", entityInterface.getDescription()); // Description did not change
+    // For service resources, we allow update of non-empty description via PUT
+    List<Class<?>> services = Arrays.asList(
+            DatabaseService.class, PipelineService.class, DashboardService.class, MessagingService.class);
+    if (services.contains(entity.getClass())) {
+      assertNotEquals(oldVersion, entityInterface.getVersion()); // Version did change
+      assertEquals("updatedDescription", entityInterface.getDescription()); // Description did change
+    } else {
+      assertEquals(oldVersion, entityInterface.getVersion()); // Version did not change
+      assertEquals("description", entityInterface.getDescription()); // Description did not change
+    }
   }
 
   @Test


### PR DESCRIPTION
### Describe your changes :
I allowed editing services descriptions via PUT API calls.

#
### Type of change :
- [x] Bug fix


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
