### PR TITLE
Fix #2439: Slack Event publisher do not throw errors when an event unpublished , fix bug for entity created events

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/events/AbstractEventPublisher.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/events/AbstractEventPublisher.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.extern.slf4j.Slf4j;
-import org.openmetadata.catalog.events.errors.EventPublisherException;
 import org.openmetadata.catalog.events.errors.RetriableException;
 import org.openmetadata.catalog.resources.events.EventResource.ChangeEventList;
 import org.openmetadata.catalog.type.ChangeEvent;
@@ -56,8 +55,6 @@ public abstract class AbstractEventPublisher implements EventPublisher {
     } catch (RetriableException ex) {
       setNextBackOff();
       Thread.sleep(currentBackoffTime);
-    } catch (EventPublisherException e) {
-      LOG.error("Failed to publish event {}", changeEvent);
     } catch (Exception e) {
       LOG.error("Failed to publish event {}", changeEvent);
     }

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/slack/SlackWebhookEventPublisher.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/slack/SlackWebhookEventPublisher.java
@@ -53,7 +53,6 @@ public class SlackWebhookEventPublisher extends AbstractEventPublisher {
   @Override
   public void publish(ChangeEventList events) throws EventPublisherException {
     for (ChangeEvent event : events.getData()) {
-      LOG.info("log event {}", event);
       try {
         SlackMessage slackMessage = buildSlackMessage(event);
         Response response =
@@ -65,8 +64,7 @@ public class SlackWebhookEventPublisher extends AbstractEventPublisher {
           throw new SlackRetriableException(response.getStatusInfo().getReasonPhrase());
         }
       } catch (Exception e) {
-        LOG.error("Failed to publish event {} to slack ", event);
-        throw new EventPublisherException(e.getMessage());
+        LOG.error("Failed to publish event {} to slack due to {} ", event, e.getMessage());
       }
     }
   }
@@ -106,7 +104,9 @@ public class SlackWebhookEventPublisher extends AbstractEventPublisher {
   private List<SlackAttachment> getAddedEventsText(ChangeEvent event) {
     List<SlackAttachment> attachments = new ArrayList<>();
     ChangeDescription changeDescription = event.getChangeDescription();
-    if (changeDescription.getFieldsAdded() != null && !changeDescription.getFieldsAdded().isEmpty()) {
+    if (changeDescription != null
+        && changeDescription.getFieldsAdded() != null
+        && !changeDescription.getFieldsAdded().isEmpty()) {
       for (FieldChange fieldChange : changeDescription.getFieldsAdded()) {
         SlackAttachment attachment = new SlackAttachment();
         StringBuilder title = new StringBuilder();
@@ -135,7 +135,9 @@ public class SlackWebhookEventPublisher extends AbstractEventPublisher {
   private List<SlackAttachment> getUpdatedEventsText(ChangeEvent event) {
     List<SlackAttachment> attachments = new ArrayList<>();
     ChangeDescription changeDescription = event.getChangeDescription();
-    if (changeDescription.getFieldsUpdated() != null && !changeDescription.getFieldsUpdated().isEmpty()) {
+    if (changeDescription != null
+        && changeDescription.getFieldsUpdated() != null
+        && !changeDescription.getFieldsUpdated().isEmpty()) {
       for (FieldChange fieldChange : changeDescription.getFieldsUpdated()) {
         // when the entity is deleted we will get deleted set as true. We do not need to parse this for slack messages.
         if (!fieldChange.getName().equals("deleted")) {
@@ -156,7 +158,9 @@ public class SlackWebhookEventPublisher extends AbstractEventPublisher {
   private List<SlackAttachment> getDeletedEventsText(ChangeEvent event) {
     List<SlackAttachment> attachments = new ArrayList<>();
     ChangeDescription changeDescription = event.getChangeDescription();
-    if (changeDescription.getFieldsDeleted() != null && !changeDescription.getFieldsDeleted().isEmpty()) {
+    if (changeDescription != null
+        && changeDescription.getFieldsDeleted() != null
+        && !changeDescription.getFieldsDeleted().isEmpty()) {
       for (FieldChange fieldChange : changeDescription.getFieldsDeleted()) {
         SlackAttachment attachment = new SlackAttachment();
         StringBuilder title = new StringBuilder();


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the ..... because ...

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have performed a self-review of my own. 
- [ ] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
