### PR TITLE
Fix: issue-2392 & 2297: Database Services page is not responsive to 1024 resolutions & 404 screen flickers while logging out

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/app-bar/Appbar.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/app-bar/Appbar.tsx
@@ -180,7 +180,7 @@ const Appbar: React.FC = (): JSX.Element => {
     },
     {
       name: 'Logout',
-      to: '#/action-1',
+      to: '',
       disabled: false,
       method: userSignOut,
     },

--- a/openmetadata-ui/src/main/resources/ui/src/pages/services/index.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/services/index.tsx
@@ -533,7 +533,7 @@ const ServicesPage = () => {
                     </NonAdminAction>
                   </div>
                   <div
-                    className="tw-grid tw-grid-cols-4 tw-gap-4 tw-mb-4"
+                    className="tw-grid xl:tw-grid-cols-4 tw-grid-cols-2 tw-gap-4 tw-mb-4"
                     data-testid="data-container">
                     {serviceList.map((service, index) => (
                       <div


### PR DESCRIPTION
Closes #2392 
Closes #2297 

### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Fix: issue-2392 & 2297: Database Services page is not responsive to 1024 resolutions & 404 screen flickers while logging out 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement


#
### Frontend Preview (Screenshots) :
#2392
![image](https://user-images.githubusercontent.com/71748675/151743964-5f1ef2ef-8166-4133-8ef1-3990c60dca42.png)

#2297 

https://user-images.githubusercontent.com/71748675/151779510-8bc92e90-b76f-4477-b0d6-a7835c7b2845.mov





#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya 
