### PR TITLE
Docker cli TypeError fixed

### DIFF
--- a/ingestion/src/metadata/cli/docker.py
+++ b/ingestion/src/metadata/cli/docker.py
@@ -12,7 +12,6 @@ import requests as requests
 logger = logging.getLogger(__name__)
 
 logging.getLogger("urllib3").setLevel(logging.WARN)
-# Configure logger.
 handler = logging.StreamHandler()
 handler.setFormatter(
     logging.Formatter(
@@ -147,7 +146,7 @@ def run_docker(start, stop, pause, resume, clean, file_path):
     except MemoryError:
         click.secho(
             f"Please Allocate More memory to Docker.\nRecommended: 4GB\nCurrent: "
-            f"{round(float(docker_info['MemTotal']) / calc_gb, 2)}",
+            f"{round(float(dict(docker_info).get('mem_total')) / calc_gb, 2)}",
             fg="red",
         )
     except Exception as err:


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
If the user has memory allocated less than the expected amount, it should throw an MemoryError.
As the package changed from docker-sdk to python-on-whales, the attributes and the object changed from where we fetched the allocated memory, which throws a TypeError.
Fixed that with the current PR. 
#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
@harshach @akash-jain-10 