### PR TITLE
Fix: #1430 Display latest value of number of rows alongside the trendline

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DatasetDetails/DatasetDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DatasetDetails/DatasetDetails.component.tsx
@@ -273,7 +273,9 @@ const DatasetDetails: React.FC<DatasetDetailsProps> = ({
               height={38}
               toolTipPos={{ x: 20, y: -30 }}
             />
-            <span className="tw--ml-6">rows</span>
+            <span className="tw--ml-6">{`${
+              tableProfile[0].rowCount || 0
+            } rows`}</span>
           </div>
         ) : (
           ''


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the rows graph to show total row-count

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Frontend Preview (Screenshots) :
<p align="center">
<img width="1792" alt="Screenshot 2022-01-31 at 8 59 44 PM" src="https://user-images.githubusercontent.com/86726556/151995105-42f99842-5b3b-444d-88ce-456bbb8a4aa1.png">

</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@Sachin-chaurasiya @shahsank3t 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
