### PR TITLE
Fix #2432 Need a way to delete recently searched item on the main page.

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/RecentSearchedTerms/RecentSearchedTerms.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/RecentSearchedTerms/RecentSearchedTerms.tsx
@@ -11,14 +11,30 @@
  *  limitations under the License.
  */
 
-import React, { FunctionComponent } from 'react';
+import { RecentlySearchedData } from 'Models';
+import React, { FunctionComponent, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { getExplorePathWithSearch } from '../../constants/constants';
-import { getRecentlySearchedData } from '../../utils/CommonUtils';
+import {
+  getRecentlySearchedData,
+  removeRecentSearchTerm,
+} from '../../utils/CommonUtils';
+import SVGIcons from '../../utils/SvgUtils';
 import PopOver from '../common/popover/PopOver';
 
 const RecentSearchedTerms: FunctionComponent = () => {
-  const recentlySearchedTerms = getRecentlySearchedData();
+  const [recentlySearchedTerms, setRecentlySearchTerms] = useState<
+    RecentlySearchedData[]
+  >([]);
+
+  const onRemove = (term: string) => {
+    removeRecentSearchTerm(term);
+    setRecentlySearchTerms(getRecentlySearchedData());
+  };
+
+  useEffect(() => {
+    setRecentlySearchTerms(getRecentlySearchedData());
+  }, []);
 
   return (
     <>
@@ -29,32 +45,43 @@ const RecentSearchedTerms: FunctionComponent = () => {
         recentlySearchedTerms.map((item, index) => {
           return (
             <div
-              className="tw-flex tw-items-center tw-justify-between tw-mb-2"
+              className="tw-flex tw-items-center tw-justify-between tw-mb-2 tw-group"
               data-testid={`Recently-Search-${item.term}`}
               key={index}>
               <div className="tw-flex">
                 <i className="fa fa-search tw-text-grey-muted tw-pr-2 tw-self-center" />
-                <Link
-                  className="tw-font-medium"
-                  to={getExplorePathWithSearch(item.term)}>
-                  <button className="tw-text-grey-body hover:tw-text-primary-hover hover:tw-underline">
-                    {item.term.length > 20 ? (
-                      <PopOver
-                        html={
-                          <div className="tw-flex tw-flex-nowrap">
-                            {item.term}
-                          </div>
-                        }
-                        position="top"
-                        size="regular"
-                        trigger="mouseenter">
-                        <span>{item.term.slice(0, 20)}...</span>
-                      </PopOver>
-                    ) : (
-                      item.term
-                    )}
+                <div className="tw-flex tw-justify-between">
+                  <Link
+                    className="tw-font-medium"
+                    to={getExplorePathWithSearch(item.term)}>
+                    <button className="tw-text-grey-body hover:tw-text-primary-hover hover:tw-underline">
+                      {item.term.length > 20 ? (
+                        <PopOver
+                          html={
+                            <div className="tw-flex tw-flex-nowrap">
+                              {item.term}
+                            </div>
+                          }
+                          position="top"
+                          size="regular"
+                          trigger="mouseenter">
+                          <span>{item.term.slice(0, 20)}...</span>
+                        </PopOver>
+                      ) : (
+                        item.term
+                      )}
+                    </button>
+                  </Link>
+                  <button
+                    className="tw-opacity-0 group-hover:tw-opacity-100 tw-ml-2"
+                    onClick={() => onRemove(item.term)}>
+                    <SVGIcons
+                      alt="delete"
+                      icon="icon-times-circle"
+                      width="12"
+                    />
                   </button>
-                </Link>
+                </div>
               </div>
             </div>
           );

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CommonUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CommonUtils.tsx
@@ -238,6 +238,18 @@ export const addToRecentSearched = (searchTerm: string): void => {
   }
 };
 
+export const removeRecentSearchTerm = (searchTerm: string) => {
+  const recentlySearch: RecentlySearched = reactLocalStorage.getObject(
+    LOCALSTORAGE_RECENTLY_SEARCHED
+  ) as RecentlySearched;
+  if (recentlySearch?.data) {
+    const arrData = recentlySearch.data.filter(
+      (item) => item.term !== searchTerm
+    );
+    setRecentlySearchedData(arrData);
+  }
+};
+
 export const addToRecentViewed = (eData: RecentlyViewedData): void => {
   const entityData = { ...eData, timestamp: Date.now() };
   let recentlyViewed: RecentlyViewed = reactLocalStorage.getObject(


### PR DESCRIPTION
Fixes #2432 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on issue #2432 to add support for removing recently searched terms.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement


#
### Frontend Preview (Screenshots) :

https://user-images.githubusercontent.com/59080942/152358247-4a00fadd-73c1-4714-b22f-7781b07f7348.mov



#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
 @shahsank3t, @darth-coder00

<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
