### PR TITLE
Assign default role to new users being created

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/Entity.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/Entity.java
@@ -211,6 +211,7 @@ public final class Entity {
   }
 
   public static <T> EntityRepository<T> getEntityRepositoryForClass(@NonNull Class<T> clazz) {
+    @SuppressWarnings("unchecked")
     EntityRepository<T> entityRepository = (EntityRepository<T>) CLASS_ENTITY_REPOSITORY_MAP.get(clazz);
     if (entityRepository == null) {
       throw new UnhandledServerException(

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/CollectionDAO.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/CollectionDAO.java
@@ -991,6 +991,9 @@ public interface CollectionDAO {
       return "name";
     }
 
+    @SqlQuery("SELECT id FROM role_entity WHERE `default` = TRUE")
+    List<String> getDefaultRolesIds();
+
     @SqlQuery("SELECT json FROM role_entity WHERE `default` = TRUE")
     List<String> getDefaultRoles();
 

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/EntityRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/EntityRepository.java
@@ -200,7 +200,7 @@ public abstract class EntityRepository<T> {
    *
    * @see TableRepository#storeRelationships(Table) for an example implementation
    */
-  public abstract void storeRelationships(T entity);
+  public abstract void storeRelationships(T entity) throws IOException;
 
   /**
    * PATCH operations can't overwrite certain fields, such as entity ID, fullyQualifiedNames etc. Instead of throwing an

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/UserRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/UserRepository.java
@@ -25,9 +25,12 @@ import java.net.URI;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.jdbi.v3.sqlobject.transaction.Transaction;
 import org.openmetadata.catalog.Entity;
@@ -82,7 +85,7 @@ public class UserRepository extends EntityRepository<User> {
   }
 
   @Override
-  public void storeRelationships(User user) {
+  public void storeRelationships(User user) throws IOException {
     assignRoles(user, user.getRoles());
     assignTeams(user, user.getTeams());
   }
@@ -138,11 +141,15 @@ public class UserRepository extends EntityRepository<User> {
   }
 
   public List<EntityReference> validateRoles(List<UUID> roleIds) throws IOException {
-    if (roleIds == null) {
-      return Collections.emptyList(); // Return an empty roles list
+    // Populate default roles.
+    Set<UUID> roleIdsSet =
+        daoCollection.roleDAO().getDefaultRolesIds().stream().map(UUID::fromString).collect(Collectors.toSet());
+    if (roleIds != null) {
+      roleIdsSet.addAll(new HashSet<>(roleIds));
     }
+
     List<EntityReference> validatedRoles = new ArrayList<>();
-    for (UUID roleId : roleIds) {
+    for (UUID roleId : roleIdsSet) {
       validatedRoles.add(daoCollection.roleDAO().findEntityReferenceById(roleId));
     }
     return validatedRoles;
@@ -195,7 +202,6 @@ public class UserRepository extends EntityRepository<User> {
   }
 
   private void assignTeams(User user, List<EntityReference> teams) {
-    // Query - add team to the user
     teams = Optional.ofNullable(teams).orElse(Collections.emptyList());
     for (EntityReference team : teams) {
       daoCollection

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/teams/UserResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/teams/UserResourceTest.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import javax.json.JsonPatch;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.client.HttpResponseException;
@@ -90,6 +91,34 @@ public class UserResourceTest extends EntityResourceTest<User, CreateUser> {
   public void post_entity_as_non_admin_401(TestInfo test) {
     // Override the method as a User can create a User entity for himself
     // during first time login without being an admin
+  }
+
+  @Test
+  void post_userWithDefaultRole(TestInfo test) throws IOException {
+    // Given no default role has been set, when a user is created, then no role should be assigned.
+    CreateUser create = createRequest(test, 1);
+    createUserAndCheckRoles(create, Collections.emptyList());
+
+    RoleResourceTest roleResourceTest = new RoleResourceTest();
+    Role defaultRole = roleResourceTest.createRolesAndSetDefault(test, 7);
+    List<Role> roles = roleResourceTest.listEntities(Collections.emptyMap(), ADMIN_AUTH_HEADERS).getData();
+    UUID nonDefaultRoleId = roles.stream().filter(role -> !role.getDefault()).findAny().orElseThrow().getId();
+    UUID defaultRoleId = defaultRole.getId();
+
+    // Given a default role has been set, when a user is created without any roles, then the default role should be
+    // assigned.
+    create = createRequest(test, 2);
+    createUserAndCheckRoles(create, Arrays.asList(defaultRoleId));
+
+    // Given a default role has been set, when a user is created with a non default role, then the default role should
+    // be assigned along with the non default role.
+    create = createRequest(test, 3).withRoles(List.of(nonDefaultRoleId));
+    createUserAndCheckRoles(create, Arrays.asList(nonDefaultRoleId, defaultRoleId));
+
+    // Given a default role has been set, when a user is created with both default and non-default role, then both
+    // roles should be assigned.
+    create = createRequest(test, 4).withRoles(List.of(nonDefaultRoleId, defaultRoleId));
+    createUserAndCheckRoles(create, Arrays.asList(nonDefaultRoleId, defaultRoleId));
   }
 
   @Test
@@ -481,6 +510,15 @@ public class UserResourceTest extends EntityResourceTest<User, CreateUser> {
     assertResponse(exception, NOT_FOUND, CatalogExceptionMessage.entityNotFound("user", user.getId()));
 
     // TODO deactivated user can't be made owner
+  }
+
+  private void createUserAndCheckRoles(CreateUser create, List<UUID> expectedRolesIds) throws HttpResponseException {
+    User user = createEntity(create, ADMIN_AUTH_HEADERS);
+    user = getEntity(user.getId(), ADMIN_AUTH_HEADERS);
+    List<UUID> actualRolesIds =
+        user.getRoles().stream().map(EntityReference::getId).sorted().collect(Collectors.toList());
+    Collections.sort(expectedRolesIds);
+    assertEquals(expectedRolesIds, actualRolesIds);
   }
 
   private User patchUser(UUID userId, String originalJson, User updated, Map<String, String> headers)


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->

When a new user is created, the default role is assigned to the user automatically by the backend.

See #2460

This is a stacked PR that builds on top of #2631

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
Backend: @sureshms @harshach 
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
