### PR TITLE
Fix access control rule userRoleAttr to point to roleName

### DIFF
--- a/catalog-rest-service/src/main/resources/json/schema/entity/policies/accessControl/rule.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/policies/accessControl/rule.json
@@ -47,7 +47,7 @@
     },
     "userRoleAttr": {
       "description": "Role of the user that the rule should match on.",
-      "$ref": "../../teams/team.json#/definitions/teamName",
+      "$ref": "../../teams/role.json#/definitions/roleName",
       "default": null
     },
     "operation": {

--- a/ingestion-core/src/metadata/_version.py
+++ b/ingestion-core/src/metadata/_version.py
@@ -7,6 +7,5 @@ Provides metadata version information.
 
 from incremental import Version
 
-
-__version__ = Version("metadata", 0, 9, 0, dev=9)
+__version__ = Version("metadata", 0, 9, 0, dev=10)
 __all__ = ["__version__"]


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on this to fix the schema documentation

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
Backend: @sureshms @harshach 
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
