### PR TITLE
Fix: #2590 not allow users (even if they own the entity) to update lineage without the "Update Lineage" permission.

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/EntityLineage/EntityLineage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/EntityLineage/EntityLineage.component.tsx
@@ -89,7 +89,6 @@ const Entitylineage: FunctionComponent<EntityLineageProp> = ({
   addLineageHandler,
   removeLineageHandler,
   entityLineageHandler,
-  isOwner,
 }: EntityLineageProp) => {
   const showToast = useToastContext();
   const { userPermissions, isAuthDisabled, isAdminUser } = useAuth();
@@ -670,7 +669,6 @@ const Entitylineage: FunctionComponent<EntityLineageProp> = ({
                           <p>You do not have permission to edit the lineage</p>
                         </>
                       }
-                      isOwner={isOwner}
                       permission={Operation.UpdateLineage}>
                       <ControlButton
                         className={classNames(
@@ -683,8 +681,7 @@ const Entitylineage: FunctionComponent<EntityLineageProp> = ({
                             'tw-opacity-40':
                               !userPermissions[Operation.UpdateLineage] &&
                               !isAuthDisabled &&
-                              !isAdminUser &&
-                              !isOwner,
+                              !isAdminUser,
                           }
                         )}
                         onClick={() => {


### PR DESCRIPTION
Closes #2590 

### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the lineage editor to only allow edit if the user has permission `Update Lineage` 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@shahsank3t, @darth-coder00
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
