### PR TITLE
Fix #1876: Allow dots in entity names

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/AirflowPipelineRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/AirflowPipelineRepository.java
@@ -84,6 +84,7 @@ public class AirflowPipelineRepository extends EntityRepository<AirflowPipeline>
 
   @Override
   public void prepare(AirflowPipeline airflowPipeline) throws IOException, ParseException {
+    EntityUtil.escapeReservedChars(getEntityInterface(airflowPipeline));
     EntityReference entityReference =
         helper(helper(airflowPipeline).findEntity("service", List.of(DATABASE_SERVICE, DASHBOARD_SERVICE)))
             .toEntityReference();
@@ -145,6 +146,11 @@ public class AirflowPipelineRepository extends EntityRepository<AirflowPipeline>
     @Override
     public String getDisplayName() {
       return entity.getDisplayName();
+    }
+
+    @Override
+    public String getName() {
+      return entity.getName();
     }
 
     @Override
@@ -222,6 +228,11 @@ public class AirflowPipelineRepository extends EntityRepository<AirflowPipeline>
     @Override
     public void setDisplayName(String displayName) {
       entity.setDisplayName(displayName);
+    }
+
+    @Override
+    public void setName(String name) {
+      entity.setName(name);
     }
 
     @Override

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/BotsRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/BotsRepository.java
@@ -55,9 +55,7 @@ public class BotsRepository extends EntityRepository<Bots> {
   }
 
   @Override
-  public void prepare(Bots entity) {
-    /* Nothing to do */
-  }
+  public void prepare(Bots entity) {}
 
   @Override
   public void storeEntity(Bots entity, boolean update) throws IOException {
@@ -89,6 +87,11 @@ public class BotsRepository extends EntityRepository<Bots> {
     @Override
     public String getDisplayName() {
       return entity.getDisplayName();
+    }
+
+    @Override
+    public String getName() {
+      return entity.getName();
     }
 
     @Override
@@ -159,6 +162,11 @@ public class BotsRepository extends EntityRepository<Bots> {
     @Override
     public void setDisplayName(String displayName) {
       entity.setDisplayName(displayName);
+    }
+
+    @Override
+    public void setName(String name) {
+      entity.setName(name);
     }
 
     @Override

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/ChartRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/ChartRepository.java
@@ -60,6 +60,7 @@ public class ChartRepository extends EntityRepository<Chart> {
 
   @Override
   public void prepare(Chart chart) throws IOException, ParseException {
+    EntityUtil.escapeReservedChars(getEntityInterface(chart));
     DashboardService dashboardService = helper(chart).findEntity("service", DASHBOARD_SERVICE);
     chart.setService(helper(dashboardService).toEntityReference());
     chart.setServiceType(dashboardService.getServiceType());
@@ -143,6 +144,11 @@ public class ChartRepository extends EntityRepository<Chart> {
     }
 
     @Override
+    public String getName() {
+      return entity.getName();
+    }
+
+    @Override
     public Boolean isDeleted() {
       return entity.getDeleted();
     }
@@ -220,6 +226,11 @@ public class ChartRepository extends EntityRepository<Chart> {
     @Override
     public void setDisplayName(String displayName) {
       entity.setDisplayName(displayName);
+    }
+
+    @Override
+    public void setName(String name) {
+      entity.setName(name);
     }
 
     @Override

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/DashboardRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/DashboardRepository.java
@@ -128,6 +128,7 @@ public class DashboardRepository extends EntityRepository<Dashboard> {
 
   @Override
   public void prepare(Dashboard dashboard) throws IOException {
+    EntityUtil.escapeReservedChars(getEntityInterface(dashboard));
     populateService(dashboard);
     dashboard.setFullyQualifiedName(getFQN(dashboard));
     EntityUtil.populateOwner(daoCollection.userDAO(), daoCollection.teamDAO(), dashboard.getOwner()); // Validate owner
@@ -244,6 +245,11 @@ public class DashboardRepository extends EntityRepository<Dashboard> {
     }
 
     @Override
+    public String getName() {
+      return entity.getName();
+    }
+
+    @Override
     public Boolean isDeleted() {
       return entity.getDeleted();
     }
@@ -324,6 +330,11 @@ public class DashboardRepository extends EntityRepository<Dashboard> {
     @Override
     public void setDisplayName(String displayName) {
       entity.setDisplayName(displayName);
+    }
+
+    @Override
+    public void setName(String name) {
+      entity.setName(name);
     }
 
     @Override

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/DashboardServiceRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/DashboardServiceRepository.java
@@ -116,6 +116,11 @@ public class DashboardServiceRepository extends EntityRepository<DashboardServic
     }
 
     @Override
+    public String getName() {
+      return entity.getName();
+    }
+
+    @Override
     public Boolean isDeleted() {
       return entity.getDeleted();
     }
@@ -183,6 +188,11 @@ public class DashboardServiceRepository extends EntityRepository<DashboardServic
     @Override
     public void setDisplayName(String displayName) {
       entity.setDisplayName(displayName);
+    }
+
+    @Override
+    public void setName(String name) {
+      entity.setName(name);
     }
 
     @Override

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/DatabaseRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/DatabaseRepository.java
@@ -73,6 +73,7 @@ public class DatabaseRepository extends EntityRepository<Database> {
 
   @Override
   public void prepare(Database database) throws IOException {
+    EntityUtil.escapeReservedChars(getEntityInterface(database));
     populateService(database);
     database.setFullyQualifiedName(getFQN(database));
     database.setOwner(
@@ -211,6 +212,11 @@ public class DatabaseRepository extends EntityRepository<Database> {
     }
 
     @Override
+    public String getName() {
+      return entity.getName();
+    }
+
+    @Override
     public Boolean isDeleted() {
       return entity.getDeleted();
     }
@@ -280,6 +286,11 @@ public class DatabaseRepository extends EntityRepository<Database> {
     @Override
     public void setDisplayName(String displayName) {
       entity.setDisplayName(displayName);
+    }
+
+    @Override
+    public void setName(String name) {
+      entity.setName(name);
     }
 
     @Override

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/DatabaseServiceRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/DatabaseServiceRepository.java
@@ -175,6 +175,11 @@ public class DatabaseServiceRepository extends EntityRepository<DatabaseService>
     }
 
     @Override
+    public String getName() {
+      return entity.getName();
+    }
+
+    @Override
     public EntityReference getOwner() {
       return entity.getOwner();
     }
@@ -242,6 +247,11 @@ public class DatabaseServiceRepository extends EntityRepository<DatabaseService>
     @Override
     public void setDisplayName(String displayName) {
       entity.setDisplayName(displayName);
+    }
+
+    @Override
+    public void setName(String name) {
+      entity.setName(name);
     }
 
     @Override

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/GlossaryRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/GlossaryRepository.java
@@ -137,6 +137,11 @@ public class GlossaryRepository extends EntityRepository<Glossary> {
     }
 
     @Override
+    public String getName() {
+      return entity.getName();
+    }
+
+    @Override
     public Boolean isDeleted() {
       return entity.getDeleted();
     }
@@ -214,6 +219,11 @@ public class GlossaryRepository extends EntityRepository<Glossary> {
     @Override
     public void setDisplayName(String displayName) {
       entity.setDisplayName(displayName);
+    }
+
+    @Override
+    public void setName(String name) {
+      entity.setName(name);
     }
 
     @Override

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/GlossaryTermRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/GlossaryTermRepository.java
@@ -253,6 +253,11 @@ public class GlossaryTermRepository extends EntityRepository<GlossaryTerm> {
     }
 
     @Override
+    public String getName() {
+      return entity.getName();
+    }
+
+    @Override
     public Boolean isDeleted() {
       return entity.getDeleted();
     }
@@ -330,6 +335,11 @@ public class GlossaryTermRepository extends EntityRepository<GlossaryTerm> {
     @Override
     public void setDisplayName(String displayName) {
       entity.setDisplayName(displayName);
+    }
+
+    @Override
+    public void setName(String name) {
+      entity.setName(name);
     }
 
     @Override

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/LocationRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/LocationRepository.java
@@ -177,6 +177,7 @@ public class LocationRepository extends EntityRepository<Location> {
 
   @Override
   public void prepare(Location location) throws IOException {
+    EntityUtil.escapeReservedChars(getEntityInterface(location));
     StorageService storageService = getService(location.getService().getId(), location.getService().getType());
     location.setService(
         new StorageServiceRepository.StorageServiceEntityInterface(storageService).getEntityReference());
@@ -258,6 +259,11 @@ public class LocationRepository extends EntityRepository<Location> {
     @Override
     public String getDisplayName() {
       return entity.getDisplayName();
+    }
+
+    @Override
+    public String getName() {
+      return entity.getName();
     }
 
     @Override
@@ -345,6 +351,11 @@ public class LocationRepository extends EntityRepository<Location> {
     @Override
     public void setDisplayName(String displayName) {
       entity.setDisplayName(displayName);
+    }
+
+    @Override
+    public void setName(String name) {
+      entity.setName(name);
     }
 
     @Override

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/MessagingServiceRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/MessagingServiceRepository.java
@@ -120,6 +120,11 @@ public class MessagingServiceRepository extends EntityRepository<MessagingServic
     }
 
     @Override
+    public String getName() {
+      return entity.getName();
+    }
+
+    @Override
     public Boolean isDeleted() {
       return entity.getDeleted();
     }
@@ -187,6 +192,11 @@ public class MessagingServiceRepository extends EntityRepository<MessagingServic
     @Override
     public void setDisplayName(String displayName) {
       entity.setDisplayName(displayName);
+    }
+
+    @Override
+    public void setName(String name) {
+      entity.setName(name);
     }
 
     @Override

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/MetricsRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/MetricsRepository.java
@@ -75,6 +75,7 @@ public class MetricsRepository extends EntityRepository<Metrics> {
 
   @Override
   public void prepare(Metrics metrics) throws IOException {
+    EntityUtil.escapeReservedChars(getEntityInterface(metrics));
     metrics.setFullyQualifiedName(getFQN(metrics));
     EntityUtil.populateOwner(daoCollection.userDAO(), daoCollection.teamDAO(), metrics.getOwner()); // Validate owner
     metrics.setService(getService(metrics.getService()));
@@ -137,6 +138,11 @@ public class MetricsRepository extends EntityRepository<Metrics> {
     @Override
     public String getDisplayName() {
       return entity.getDisplayName();
+    }
+
+    @Override
+    public String getName() {
+      return entity.getName();
     }
 
     @Override
@@ -217,6 +223,11 @@ public class MetricsRepository extends EntityRepository<Metrics> {
     @Override
     public void setDisplayName(String displayName) {
       entity.setDisplayName(displayName);
+    }
+
+    @Override
+    public void setName(String name) {
+      entity.setName(name);
     }
 
     @Override

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/MlModelRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/MlModelRepository.java
@@ -147,6 +147,7 @@ public class MlModelRepository extends EntityRepository<MlModel> {
 
   @Override
   public void prepare(MlModel mlModel) throws IOException {
+    EntityUtil.escapeReservedChars(getEntityInterface(mlModel));
     mlModel.setFullyQualifiedName(getFQN(mlModel));
 
     if (mlModel.getMlFeatures() != null && !mlModel.getMlFeatures().isEmpty()) {
@@ -251,6 +252,11 @@ public class MlModelRepository extends EntityRepository<MlModel> {
     }
 
     @Override
+    public String getName() {
+      return entity.getName();
+    }
+
+    @Override
     public Boolean isDeleted() {
       return entity.getDeleted();
     }
@@ -333,6 +339,11 @@ public class MlModelRepository extends EntityRepository<MlModel> {
     @Override
     public void setDisplayName(String displayName) {
       entity.setDisplayName(displayName);
+    }
+
+    @Override
+    public void setName(String name) {
+      entity.setName(name);
     }
 
     @Override

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/PipelineRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/PipelineRepository.java
@@ -163,6 +163,8 @@ public class PipelineRepository extends EntityRepository<Pipeline> {
 
   @Override
   public void prepare(Pipeline pipeline) throws IOException {
+    EntityUtil.escapeReservedChars(getEntityInterface(pipeline));
+    EntityUtil.escapeReservedChars(pipeline.getTasks());
     populateService(pipeline);
     pipeline.setFullyQualifiedName(getFQN(pipeline));
     EntityUtil.populateOwner(daoCollection.userDAO(), daoCollection.teamDAO(), pipeline.getOwner()); // Validate owner
@@ -240,6 +242,11 @@ public class PipelineRepository extends EntityRepository<Pipeline> {
     @Override
     public String getDisplayName() {
       return entity.getDisplayName();
+    }
+
+    @Override
+    public String getName() {
+      return entity.getName();
     }
 
     @Override
@@ -322,6 +329,11 @@ public class PipelineRepository extends EntityRepository<Pipeline> {
     @Override
     public void setDisplayName(String displayName) {
       entity.setDisplayName(displayName);
+    }
+
+    @Override
+    public void setName(String name) {
+      entity.setName(name);
     }
 
     @Override

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/PipelineServiceRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/PipelineServiceRepository.java
@@ -116,6 +116,11 @@ public class PipelineServiceRepository extends EntityRepository<PipelineService>
     }
 
     @Override
+    public String getName() {
+      return entity.getName();
+    }
+
+    @Override
     public Boolean isDeleted() {
       return entity.getDeleted();
     }
@@ -183,6 +188,11 @@ public class PipelineServiceRepository extends EntityRepository<PipelineService>
     @Override
     public void setDisplayName(String displayName) {
       entity.setDisplayName(displayName);
+    }
+
+    @Override
+    public void setName(String name) {
+      entity.setName(name);
     }
 
     @Override

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/PolicyRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/PolicyRepository.java
@@ -286,6 +286,11 @@ public class PolicyRepository extends EntityRepository<Policy> {
     }
 
     @Override
+    public String getName() {
+      return entity.getName();
+    }
+
+    @Override
     public Boolean isDeleted() {
       return entity.getDeleted();
     }
@@ -352,6 +357,11 @@ public class PolicyRepository extends EntityRepository<Policy> {
     @Override
     public void setDisplayName(String displayName) {
       entity.setDisplayName(displayName);
+    }
+
+    @Override
+    public void setName(String name) {
+      entity.setName(name);
     }
 
     @Override

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/ReportRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/ReportRepository.java
@@ -113,6 +113,11 @@ public class ReportRepository extends EntityRepository<Report> {
     }
 
     @Override
+    public String getName() {
+      return entity.getName();
+    }
+
+    @Override
     public Boolean isDeleted() {
       return entity.getDeleted();
     }
@@ -190,6 +195,11 @@ public class ReportRepository extends EntityRepository<Report> {
     @Override
     public void setDisplayName(String displayName) {
       entity.setDisplayName(displayName);
+    }
+
+    @Override
+    public void setName(String name) {
+      entity.setName(name);
     }
 
     @Override

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/RoleRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/RoleRepository.java
@@ -202,6 +202,11 @@ public class RoleRepository extends EntityRepository<Role> {
     }
 
     @Override
+    public String getName() {
+      return entity.getName();
+    }
+
+    @Override
     public Boolean isDeleted() {
       return entity.getDeleted();
     }
@@ -260,6 +265,11 @@ public class RoleRepository extends EntityRepository<Role> {
     @Override
     public void setDisplayName(String displayName) {
       entity.setDisplayName(displayName);
+    }
+
+    @Override
+    public void setName(String name) {
+      entity.setName(name);
     }
 
     @Override

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/StorageServiceRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/StorageServiceRepository.java
@@ -109,6 +109,11 @@ public class StorageServiceRepository extends EntityRepository<StorageService> {
     }
 
     @Override
+    public String getName() {
+      return entity.getName();
+    }
+
+    @Override
     public Boolean isDeleted() {
       return entity.getDeleted();
     }
@@ -176,6 +181,11 @@ public class StorageServiceRepository extends EntityRepository<StorageService> {
     @Override
     public void setDisplayName(String displayName) {
       entity.setDisplayName(displayName);
+    }
+
+    @Override
+    public void setName(String name) {
+      entity.setName(name);
     }
 
     @Override

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/TableRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/TableRepository.java
@@ -302,6 +302,9 @@ public class TableRepository extends EntityRepository<Table> {
 
   @Override
   public void prepare(Table table) throws IOException, ParseException {
+    EntityUtil.escapeReservedChars(getEntityInterface(table));
+    EntityUtil.escapeReservedChars(table.getColumns());
+    EntityUtil.escapeReservedChars(table.getTableConstraints());
     Database database = helper(table).findEntity("database", DATABASE);
     table.setDatabase(helper(database).toEntityReference());
     DatabaseService databaseService = helper(database).findEntity("service", DATABASE_SERVICE);
@@ -391,6 +394,7 @@ public class TableRepository extends EntityRepository<Table> {
     return new Column()
         .withDescription(column.getDescription())
         .withName(column.getName())
+        .withDisplayName(column.getDisplayName())
         .withFullyQualifiedName(column.getFullyQualifiedName())
         .withArrayDataType(column.getArrayDataType())
         .withConstraint(column.getConstraint())
@@ -660,6 +664,11 @@ public class TableRepository extends EntityRepository<Table> {
     }
 
     @Override
+    public String getName() {
+      return entity.getName();
+    }
+
+    @Override
     public Boolean isDeleted() {
       return entity.getDeleted();
     }
@@ -742,6 +751,11 @@ public class TableRepository extends EntityRepository<Table> {
     @Override
     public void setDisplayName(String displayName) {
       entity.setDisplayName(displayName);
+    }
+
+    @Override
+    public void setName(String name) {
+      entity.setName(name);
     }
 
     @Override

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/TeamRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/TeamRepository.java
@@ -165,6 +165,11 @@ public class TeamRepository extends EntityRepository<Team> {
     }
 
     @Override
+    public String getName() {
+      return entity.getName();
+    }
+
+    @Override
     public Boolean isDeleted() {
       return entity.getDeleted();
     }
@@ -223,6 +228,11 @@ public class TeamRepository extends EntityRepository<Team> {
     @Override
     public void setDisplayName(String displayName) {
       entity.setDisplayName(displayName);
+    }
+
+    @Override
+    public void setName(String name) {
+      entity.setName(name);
     }
 
     @Override

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/TopicRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/TopicRepository.java
@@ -68,6 +68,7 @@ public class TopicRepository extends EntityRepository<Topic> {
 
   @Override
   public void prepare(Topic topic) throws IOException, ParseException {
+    EntityUtil.escapeReservedChars(getEntityInterface(topic));
     MessagingService messagingService = helper(topic).findEntity("service", MESSAGING_SERVICE);
     topic.setService(helper(messagingService).toEntityReference());
     topic.setServiceType(messagingService.getServiceType());
@@ -157,6 +158,11 @@ public class TopicRepository extends EntityRepository<Topic> {
     }
 
     @Override
+    public String getName() {
+      return entity.getName();
+    }
+
+    @Override
     public Boolean isDeleted() {
       return entity.getDeleted();
     }
@@ -234,6 +240,11 @@ public class TopicRepository extends EntityRepository<Topic> {
     @Override
     public void setDisplayName(String displayName) {
       entity.setDisplayName(displayName);
+    }
+
+    @Override
+    public void setName(String name) {
+      entity.setName(name);
     }
 
     @Override

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/UserRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/UserRepository.java
@@ -220,6 +220,11 @@ public class UserRepository extends EntityRepository<User> {
     }
 
     @Override
+    public String getName() {
+      return entity.getName();
+    }
+
+    @Override
     public Boolean isDeleted() {
       return entity.getDeleted();
     }
@@ -278,6 +283,11 @@ public class UserRepository extends EntityRepository<User> {
     @Override
     public void setDisplayName(String displayName) {
       entity.setDisplayName(displayName);
+    }
+
+    @Override
+    public void setName(String name) {
+      entity.setName(name);
     }
 
     @Override

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/WebhookRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/WebhookRepository.java
@@ -84,9 +84,7 @@ public class WebhookRepository extends EntityRepository<Webhook> {
   }
 
   @Override
-  public void prepare(Webhook entity) throws IOException {
-    // Nothing to prepare
-  }
+  public void prepare(Webhook entity) throws IOException {}
 
   @Override
   public void storeEntity(Webhook entity, boolean update) throws IOException {
@@ -185,6 +183,11 @@ public class WebhookRepository extends EntityRepository<Webhook> {
 
     @Override
     public String getDisplayName() {
+      return entity.getDisplayName();
+    }
+
+    @Override
+    public String getName() {
       return entity.getName();
     }
 
@@ -250,7 +253,12 @@ public class WebhookRepository extends EntityRepository<Webhook> {
 
     @Override
     public void setDisplayName(String displayName) {
-      /* No display name */
+      entity.setDisplayName(displayName);
+    }
+
+    @Override
+    public void setName(String name) {
+      entity.setName(name);
     }
 
     @Override

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/util/EntityInterface.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/util/EntityInterface.java
@@ -28,6 +28,8 @@ public interface EntityInterface<T> {
 
   String getDisplayName();
 
+  String getName();
+
   Boolean isDeleted();
 
   default EntityReference getOwner() {
@@ -71,6 +73,8 @@ public interface EntityInterface<T> {
   };
 
   void setDisplayName(String displayName);
+
+  void setName(String name);
 
   void setUpdateDetails(String updatedBy, long updatedAt);
 

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/util/EntityUtil.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/util/EntityUtil.java
@@ -476,4 +476,32 @@ public final class EntityUtil {
                     .withEventType(EventType.ENTITY_SOFT_DELETED)
                     .withEntities(eventFilter.getEntities())));
   }
+
+  public static void escapeReservedChars(EntityInterface entityInterface) {
+    entityInterface.setDisplayName(
+        entityInterface.getDisplayName() != null ? entityInterface.getDisplayName() : entityInterface.getName());
+    entityInterface.setName(entityInterface.getName().replace(".", "_DOT_"));
+  }
+
+  public static void escapeReservedChars(List<?> collection) {
+    if (collection == null || collection.isEmpty()) {
+      return;
+    }
+    for (Object object : collection) {
+      if (object instanceof Column) {
+        Column column = (Column) object;
+        column.setDisplayName(column.getDisplayName() != null ? column.getDisplayName() : column.getName());
+        column.setName(column.getName().replace(".", "_DOT_"));
+        escapeReservedChars(column.getChildren());
+      } else if (object instanceof TableConstraint) {
+        TableConstraint constraint = (TableConstraint) object;
+        constraint.setColumns(
+            constraint.getColumns().stream().map(s -> s.replace(".", "_DOT_")).collect(Collectors.toList()));
+      } else if (object instanceof Task) {
+        Task task = (Task) object;
+        task.setDisplayName(task.getDisplayName() != null ? task.getDisplayName() : task.getName());
+        task.setName(task.getName().replace(".", "_DOT_"));
+      }
+    }
+  }
 }

--- a/catalog-rest-service/src/main/resources/json/schema/api/services/createDashboardService.json
+++ b/catalog-rest-service/src/main/resources/json/schema/api/services/createDashboardService.json
@@ -9,7 +9,8 @@
       "description": "Name that identifies the this entity instance uniquely",
       "type": "string",
       "minLength": 1,
-      "maxLength": 128
+      "maxLength": 128,
+      "pattern": "^[^.]*$"
     },
     "description": {
       "description": "Description of dashboard service entity.",

--- a/catalog-rest-service/src/main/resources/json/schema/api/services/createDatabaseService.json
+++ b/catalog-rest-service/src/main/resources/json/schema/api/services/createDatabaseService.json
@@ -10,7 +10,8 @@
       "description": "Name that identifies the this entity instance uniquely",
       "type": "string",
       "minLength": 1,
-      "maxLength": 128
+      "maxLength": 128,
+      "pattern": "^[^.]*$"
     },
     "description": {
       "description": "Description of Database entity.",

--- a/catalog-rest-service/src/main/resources/json/schema/api/services/createMessagingService.json
+++ b/catalog-rest-service/src/main/resources/json/schema/api/services/createMessagingService.json
@@ -9,7 +9,8 @@
       "description": "Name that identifies the this entity instance uniquely",
       "type": "string",
       "minLength": 1,
-      "maxLength": 128
+      "maxLength": 128,
+      "pattern": "^[^.]*$"
     },
     "description": {
       "description": "Description of messaging service entity.",

--- a/catalog-rest-service/src/main/resources/json/schema/api/services/createPipelineService.json
+++ b/catalog-rest-service/src/main/resources/json/schema/api/services/createPipelineService.json
@@ -9,7 +9,8 @@
       "description": "Name that identifies the this entity instance uniquely",
       "type": "string",
       "minLength": 1,
-      "maxLength": 128
+      "maxLength": 128,
+      "pattern": "^[^.]*$"
     },
     "description": {
       "description": "Description of pipeline service entity.",

--- a/catalog-rest-service/src/main/resources/json/schema/api/services/createStorageService.json
+++ b/catalog-rest-service/src/main/resources/json/schema/api/services/createStorageService.json
@@ -9,7 +9,8 @@
       "description": "Name that identifies the this entity instance uniquely",
       "type": "string",
       "minLength": 1,
-      "maxLength": 128
+      "maxLength": 128,
+      "pattern": "^[^.]*$"
     },
     "description": {
       "description": "Description of Storage entity.",

--- a/catalog-rest-service/src/main/resources/json/schema/entity/data/database.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/data/database.json
@@ -10,8 +10,7 @@
       "description": "Name that identifies the database.",
       "type": "string",
       "minLength": 1,
-      "maxLength": 128,
-      "pattern": "^[^.]*$"
+      "maxLength": 128
     }
   },
   "properties": {

--- a/catalog-rest-service/src/main/resources/json/schema/entity/data/table.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/data/table.json
@@ -103,15 +103,13 @@
       "description": "Local name (not fully qualified name) of the column. ColumnName is `-` when the column is not named in struct dataType. For example, BigQuery supports struct with unnamed fields.",
       "type": "string",
       "minLength": 1,
-      "maxLength": 128,
-      "pattern": "^[^.]*$"
+      "maxLength": 128
     },
     "tableName": {
-      "description": "Local name (not fully qualified name) of a table.",
+      "description": "Local name (not fully qualified name) of a table. Dots will be escaped automatically",
       "type": "string",
       "minLength": 1,
-      "maxLength": 128,
-      "pattern": "^[^.]*$"
+      "maxLength": 128
     },
     "fullyQualifiedColumnName": {
       "description": "Fully qualified name of the column that includes `serviceName.databaseName.tableName.columnName[.nestedColumnName]`. When columnName is null for dataType struct fields, `field_#` where `#` is field index is used. For map dataType, for key the field name `key` is used and for the value field `value` is used.",
@@ -126,6 +124,10 @@
       "properties": {
         "name": {
           "$ref": "#/definitions/columnName"
+        },
+        "displayName": {
+          "description": "Display Name that identifies this column name.",
+          "type": "string"
         },
         "dataType": {
           "description": "Data type of the column (int, date etc.).",

--- a/catalog-rest-service/src/main/resources/json/schema/entity/data/topic.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/data/topic.json
@@ -10,8 +10,7 @@
       "type": "string",
       "javaType": "org.openmetadata.catalog.type.topic.TopicName",
       "minLength": 1,
-      "maxLength": 128,
-      "pattern": "^[^.]*$"
+      "maxLength": 128
     },
     "schemaType": {
       "description": "Schema type used for the message.",

--- a/catalog-rest-service/src/main/resources/json/schema/entity/events/webhook.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/events/webhook.json
@@ -16,6 +16,10 @@
       "minLength": 1,
       "maxLength": 128
     },
+    "displayName": {
+      "description": "Display Name that identifies this webhook.",
+      "type": "string"
+    },
     "description": {
       "description": "Description of the application.",
       "type": "string"

--- a/catalog-rest-service/src/main/resources/json/schema/entity/services/dashboardService.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/services/dashboardService.json
@@ -37,7 +37,8 @@
       "description": "Name that identifies this dashboard service.",
       "type": "string",
       "minLength": 1,
-      "maxLength": 128
+      "maxLength": 128,
+      "pattern": "^[^.]*$"
     },
     "displayName": {
       "description": "Display Name that identifies this dashboard service.",

--- a/catalog-rest-service/src/main/resources/json/schema/entity/services/databaseService.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/services/databaseService.json
@@ -139,7 +139,8 @@
       "description": "Name that identifies this database service.",
       "type": "string",
       "minLength": 1,
-      "maxLength": 128
+      "maxLength": 128,
+      "pattern": "^[^.]*$"
     },
     "displayName": {
       "description": "Display Name that identifies this database service.",

--- a/catalog-rest-service/src/main/resources/json/schema/entity/services/messagingService.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/services/messagingService.json
@@ -36,7 +36,8 @@
       "description": "Name that identifies this messaging service.",
       "type": "string",
       "minLength": 1,
-      "maxLength": 128
+      "maxLength": 128,
+      "pattern": "^[^.]*$"
     },
     "serviceType": {
       "description": "Type of messaging service such as Kafka or Pulsar...",

--- a/catalog-rest-service/src/main/resources/json/schema/entity/services/pipelineService.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/services/pipelineService.json
@@ -31,7 +31,8 @@
       "description": "Name that identifies this pipeline service.",
       "type": "string",
       "minLength": 1,
-      "maxLength": 128
+      "maxLength": 128,
+      "pattern": "^[^.]*$"
     },
     "serviceType": {
       "description": "Type of pipeline service such as Airflow or Prefect...",

--- a/catalog-rest-service/src/main/resources/json/schema/entity/services/storageService.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/services/storageService.json
@@ -14,7 +14,8 @@
       "description": "Name that identifies this storage service.",
       "type": "string",
       "minLength": 1,
-      "maxLength": 128
+      "maxLength": 128,
+      "pattern": "^[^.]*$"
     },
     "displayName": {
       "description": "Display Name that identifies this storage service.",

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/EntityOperationsResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/EntityOperationsResourceTest.java
@@ -28,7 +28,8 @@ public abstract class EntityOperationsResourceTest<T, K> extends EntityResourceT
       boolean supportsFollowers,
       boolean supportsOwner,
       boolean supportsTags,
-      boolean supportsAuthorizedMetadataOperations) {
+      boolean supportsAuthorizedMetadataOperations,
+      boolean supportsDots) {
     super(
         entityType,
         entityClass,
@@ -38,7 +39,8 @@ public abstract class EntityOperationsResourceTest<T, K> extends EntityResourceT
         supportsFollowers,
         supportsOwner,
         supportsTags,
-        supportsAuthorizedMetadataOperations);
+        supportsAuthorizedMetadataOperations,
+        supportsDots);
   }
 
   // Override the resource path name of regular entities api/v1/<entities> to api/operations/v1/<operations>

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/charts/ChartResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/charts/ChartResourceTest.java
@@ -45,7 +45,7 @@ import org.openmetadata.catalog.util.TestUtils;
 public class ChartResourceTest extends EntityResourceTest<Chart, CreateChart> {
 
   public ChartResourceTest() {
-    super(Entity.CHART, Chart.class, ChartList.class, "charts", ChartResource.FIELDS, true, true, true, true);
+    super(Entity.CHART, Chart.class, ChartList.class, "charts", ChartResource.FIELDS, true, true, true, true, true);
   }
 
   @BeforeAll

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/dashboards/DashboardResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/dashboards/DashboardResourceTest.java
@@ -68,6 +68,7 @@ public class DashboardResourceTest extends EntityResourceTest<Dashboard, CreateD
         true,
         true,
         true,
+        true,
         true);
   }
 

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/databases/DatabaseResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/databases/DatabaseResourceTest.java
@@ -57,6 +57,7 @@ public class DatabaseResourceTest extends EntityResourceTest<Database, CreateDat
         false,
         true,
         false,
+        true,
         true);
   }
 

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/events/WebhookResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/events/WebhookResourceTest.java
@@ -64,7 +64,7 @@ public class WebhookResourceTest extends EntityResourceTest<Webhook, CreateWebho
   }
 
   public WebhookResourceTest() {
-    super(Entity.WEBHOOK, Webhook.class, WebhookList.class, "webhook", "", false, false, false, false);
+    super(Entity.WEBHOOK, Webhook.class, WebhookList.class, "webhook", "", false, false, false, false, false);
     supportsPatch = false;
   }
 

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/glossary/GlossaryResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/glossary/GlossaryResourceTest.java
@@ -44,7 +44,8 @@ public class GlossaryResourceTest extends EntityResourceTest<Glossary, CreateGlo
         false,
         true,
         true,
-        true);
+        true,
+        false);
   }
 
   @BeforeAll

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/glossary/GlossaryTermResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/glossary/GlossaryTermResourceTest.java
@@ -76,6 +76,7 @@ public class GlossaryTermResourceTest extends EntityResourceTest<GlossaryTerm, C
         false,
         false,
         true,
+        false,
         false);
   }
 

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/locations/LocationResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/locations/LocationResourceTest.java
@@ -58,6 +58,7 @@ public class LocationResourceTest extends EntityResourceTest<Location, CreateLoc
         true,
         true,
         true,
+        true,
         true);
   }
 

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/mlmodels/MlModelResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/mlmodels/MlModelResourceTest.java
@@ -103,7 +103,17 @@ public class MlModelResourceTest extends EntityResourceTest<MlModel, CreateMlMod
           new MlHyperParameter().withName("random").withValue("hello"));
 
   public MlModelResourceTest() {
-    super(Entity.MLMODEL, MlModel.class, MlModelList.class, "mlmodels", MlModelResource.FIELDS, true, true, true, true);
+    super(
+        Entity.MLMODEL,
+        MlModel.class,
+        MlModelList.class,
+        "mlmodels",
+        MlModelResource.FIELDS,
+        true,
+        true,
+        true,
+        true,
+        true);
   }
 
   @BeforeAll

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/operations/AirflowPipelineResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/operations/AirflowPipelineResourceTest.java
@@ -97,6 +97,7 @@ public class AirflowPipelineResourceTest extends EntityOperationsResourceTest<Ai
         false,
         true,
         false,
+        true,
         true);
   }
 
@@ -149,7 +150,6 @@ public class AirflowPipelineResourceTest extends EntityOperationsResourceTest<Ai
         createRequest.getDescription(),
         TestUtils.getPrincipal(authHeaders),
         createRequest.getOwner());
-    assertEquals(createRequest.getDisplayName(), ingestion.getDisplayName());
     assertEquals(createRequest.getConcurrency(), ingestion.getConcurrency());
     validatePipelineConfig(createRequest.getPipelineConfig(), ingestion.getPipelineConfig());
   }

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/policies/PolicyResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/policies/PolicyResourceTest.java
@@ -66,7 +66,17 @@ public class PolicyResourceTest extends EntityResourceTest<Policy, CreatePolicy>
   private static Location location;
 
   public PolicyResourceTest() {
-    super(Entity.POLICY, Policy.class, PolicyList.class, "policies", PolicyResource.FIELDS, false, true, false, false);
+    super(
+        Entity.POLICY,
+        Policy.class,
+        PolicyList.class,
+        "policies",
+        PolicyResource.FIELDS,
+        false,
+        true,
+        false,
+        false,
+        false);
   }
 
   @BeforeAll

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/DashboardServiceResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/DashboardServiceResourceTest.java
@@ -57,6 +57,7 @@ public class DashboardServiceResourceTest extends EntityResourceTest<DashboardSe
         false,
         true,
         false,
+        false,
         false);
     this.supportsPatch = false;
   }

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/DatabaseServiceResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/DatabaseServiceResourceTest.java
@@ -75,6 +75,7 @@ public class DatabaseServiceResourceTest extends EntityResourceTest<DatabaseServ
         false,
         true,
         false,
+        false,
         false);
     this.supportsPatch = false;
   }

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/MessagingServiceResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/MessagingServiceResourceTest.java
@@ -64,6 +64,7 @@ public class MessagingServiceResourceTest extends EntityResourceTest<MessagingSe
         false,
         true,
         false,
+        false,
         false);
     supportsPatch = false;
   }

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/PipelineServiceResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/PipelineServiceResourceTest.java
@@ -61,6 +61,7 @@ public class PipelineServiceResourceTest extends EntityResourceTest<PipelineServ
         false,
         true,
         false,
+        false,
         false);
     this.supportsPatch = false;
   }

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/StorageServiceResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/StorageServiceResourceTest.java
@@ -46,6 +46,7 @@ public class StorageServiceResourceTest extends EntityResourceTest<StorageServic
         false,
         true,
         false,
+        false,
         false);
     this.supportsPatch = false;
   }

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/teams/RoleResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/teams/RoleResourceTest.java
@@ -46,7 +46,7 @@ import org.openmetadata.catalog.util.TestUtils;
 public class RoleResourceTest extends EntityResourceTest<Role, CreateRole> {
 
   public RoleResourceTest() {
-    super(Entity.ROLE, Role.class, RoleList.class, "roles", null, false, false, false, false);
+    super(Entity.ROLE, Role.class, RoleList.class, "roles", null, false, false, false, false, false);
   }
 
   @Test
@@ -141,8 +141,6 @@ public class RoleResourceTest extends EntityResourceTest<Role, CreateRole> {
   public void validateCreatedEntity(Role role, CreateRole createRequest, Map<String, String> authHeaders) {
     validateCommonEntityFields(
         getEntityInterface(role), createRequest.getDescription(), TestUtils.getPrincipal(authHeaders), null);
-
-    assertEquals(createRequest.getDisplayName(), role.getDisplayName());
   }
 
   @Override

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/teams/TeamResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/teams/TeamResourceTest.java
@@ -65,7 +65,7 @@ public class TeamResourceTest extends EntityResourceTest<Team, CreateTeam> {
   final Profile PROFILE = new Profile().withImages(new ImageList().withImage(URI.create("http://image.com")));
 
   public TeamResourceTest() {
-    super(Entity.TEAM, Team.class, TeamList.class, "teams", TeamResource.FIELDS, false, false, false, false);
+    super(Entity.TEAM, Team.class, TeamList.class, "teams", TeamResource.FIELDS, false, false, false, false, false);
   }
 
   @Test
@@ -251,7 +251,6 @@ public class TeamResourceTest extends EntityResourceTest<Team, CreateTeam> {
     validateCommonEntityFields(
         getEntityInterface(team), createRequest.getDescription(), TestUtils.getPrincipal(authHeaders), null);
 
-    assertEquals(createRequest.getDisplayName(), team.getDisplayName());
     assertEquals(createRequest.getProfile(), team.getProfile());
 
     List<EntityReference> expectedUsers = new ArrayList<>();

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/teams/UserResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/teams/UserResourceTest.java
@@ -83,7 +83,7 @@ public class UserResourceTest extends EntityResourceTest<User, CreateUser> {
   final Profile PROFILE = new Profile().withImages(new ImageList().withImage(URI.create("http://image.com")));
 
   public UserResourceTest() {
-    super(Entity.USER, User.class, UserList.class, "users", UserResource.FIELDS, false, false, false, false);
+    super(Entity.USER, User.class, UserList.class, "users", UserResource.FIELDS, false, false, false, false, false);
   }
 
   @Test

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/topics/TopicResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/topics/TopicResourceTest.java
@@ -51,7 +51,7 @@ import org.openmetadata.catalog.util.TestUtils.UpdateType;
 public class TopicResourceTest extends EntityResourceTest<Topic, CreateTopic> {
 
   public TopicResourceTest() {
-    super(Entity.TOPIC, Topic.class, TopicList.class, "topics", TopicResource.FIELDS, true, true, true, true);
+    super(Entity.TOPIC, Topic.class, TopicList.class, "topics", TopicResource.FIELDS, true, true, true, true, true);
   }
 
   @Test

--- a/ingestion-core/src/metadata/_version.py
+++ b/ingestion-core/src/metadata/_version.py
@@ -7,5 +7,5 @@ Provides metadata version information.
 
 from incremental import Version
 
-__version__ = Version("metadata", 0, 9, 0, dev=6)
+__version__ = Version("metadata", 0, 9, 0, dev=7)
 __all__ = ["__version__"]


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
See #1876

# Requirements
1. Users can ingest entities containing dots in their names.
2. Entity services MUST not have dots in their entity names. OM will throw a validation error.
3. User must provide the FQN encoded with `_DOT_`. For example `service.sche.ma.tab.le` needs to searched as `service.sche_DOT_ma.tab_DOT_le`

## Entites escaping dots
1. AirflowPipeline
2. Chart
3. Dashboard
4. Database
5. Location
6. Metrics
7. MlModel
8. Pipeline
9. Table
10. Topic

## Entities rejecting dots
1. Database Service
2. Dashboard Service
3. Messaging Service
4. Pipeline Service
5. Storage Service

## Entities accepting dots
1. Bots
2. Policy
3. Report
4. Role
5. Team
6. User
7. Webhook

## Fields escaping dots
1. Column
2. Task

# Progress
- [x] Implement escaping for field column
- [x] for Task
- [x] for TableData (addSampleData, skipped because the user should use the column name received after the POST)
- [x] for TableConstraint
- [x] for ColumnConstraint (skipped because it's just an ENUM)
- [x] for ColumnJoin and TableJoin (addJoins, skipped because the user should use the column name received after the POST)
- [x] for ColumnProfile (addDataProfiler, skipped because the user should use the column name received after the POST)
- [x] Remove the other Python code. It will code in a second PR.

# Limitations
1. TableJoin works only with columns and not with nested columns. Trino supports joins on nested columns.
2. ColumnProfile works only with columns and not with nested columns. It's very likely that our users need support for nested column profiles, checks, and alerts.

# Solution
1. Create[Entity] should only allow specifying the entity `name` but not the entity `displayName`.
1. We escape `.` with `_DOT_`.

# Notes
## Joins
It has been tested that Trino supports joins on fields of structs.
```sql
select * from t1 join t2 on t1.customer.id = t2.customer[1];
```
## Unnamed fields in structs
Structs in Trino and BigQuery can have unnamed fields that can be accessed with the `[]` notation.

## Repeated
BigQuery doesn't support arrays of arrays. Repeated is a struct that can be repeated multiple times. This is the `create` statement for Trino of the table used in the BigQuery [examples](https://cloud.google.com/blog/topics/developers-practitioners/bigquery-explained-working-joins-nested-repeated-data).

```sql
create table memory.default.t1 as
SELECT *
FROM (
         VALUES (1, 'a',
                 cast(row(1, 'Joe', 'New York') as row(id bigint, name varchar, location varchar)),
                 array[cast(row(1, 1, 2) as row(sku bigint, quantity bigint, price bigint))])
     ) AS t (order_id, order_time, customer, product);
```

# Q&A
Q: Why are we not replacing the `_DOT_` with `~` like in JSON Pointer.
A: To avoid breaking with the past.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.