### PR TITLE
Fix #790 Make assertResponse & assertResponseContains shorter on all …

### DIFF
--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/dashboards/DashboardResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/dashboards/DashboardResourceTest.java
@@ -18,7 +18,6 @@ import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openmetadata.catalog.exception.CatalogExceptionMessage.invalidServiceEntity;
 import static org.openmetadata.catalog.util.TestUtils.ADMIN_AUTH_HEADERS;
@@ -107,10 +106,8 @@ public class DashboardResourceTest extends EntityResourceTest<Dashboard, CreateD
   @Test
   void post_DashboardWithInvalidService_4xx(TestInfo test) {
     CreateDashboard create = createRequest(test).withService(SUPERSET_INVALID_SERVICE_REFERENCE);
-    HttpResponseException exception =
-        assertThrows(HttpResponseException.class, () -> createEntity(create, ADMIN_AUTH_HEADERS));
     assertResponse(
-        exception,
+        () -> createEntity(create, ADMIN_AUTH_HEADERS),
         BAD_REQUEST,
         invalidServiceEntity(SUPERSET_INVALID_SERVICE_REFERENCE.getType(), Entity.DASHBOARD, Entity.DASHBOARD_SERVICE));
   }

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/databases/DatabaseResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/databases/DatabaseResourceTest.java
@@ -16,10 +16,11 @@ package org.openmetadata.catalog.resources.databases;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.openmetadata.catalog.util.TestUtils.ADMIN_AUTH_HEADERS;
 import static org.openmetadata.catalog.util.TestUtils.assertListNotNull;
 import static org.openmetadata.catalog.util.TestUtils.assertListNull;
+import static org.openmetadata.catalog.util.TestUtils.assertResponse;
+import static org.openmetadata.catalog.util.TestUtils.assertResponseContains;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -70,7 +71,7 @@ public class DatabaseResourceTest extends EntityResourceTest<Database, CreateDat
     CreateDatabase create = createRequest(test);
     EntityReference invalidService = new EntityReference().withId(SNOWFLAKE_REFERENCE.getId()).withType("invalid");
     create.withService(invalidService);
-    TestUtils.assertResponse(
+    assertResponse(
         () -> createEntity(create, ADMIN_AUTH_HEADERS),
         BAD_REQUEST,
         CatalogExceptionMessage.invalidServiceEntity("invalid", Entity.DATABASE, Entity.DATABASE_SERVICE));
@@ -99,9 +100,7 @@ public class DatabaseResourceTest extends EntityResourceTest<Database, CreateDat
   @Test
   void post_databaseWithoutRequiredService_4xx(TestInfo test) {
     CreateDatabase create = createRequest(test).withService(null);
-    HttpResponseException exception =
-        assertThrows(HttpResponseException.class, () -> createEntity(create, ADMIN_AUTH_HEADERS));
-    TestUtils.assertResponseContains(exception, BAD_REQUEST, "service must not be null");
+    assertResponseContains(() -> createEntity(create, ADMIN_AUTH_HEADERS), BAD_REQUEST, "service must not be null");
   }
 
   @Test

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/lineage/LineageResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/lineage/LineageResourceTest.java
@@ -16,7 +16,6 @@ package org.openmetadata.catalog.resources.lineage;
 import static javax.ws.rs.core.Response.Status.FORBIDDEN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openmetadata.catalog.security.SecurityUtil.authHeaders;
 import static org.openmetadata.catalog.util.TestUtils.ADMIN_AUTH_HEADERS;
@@ -107,16 +106,12 @@ public class LineageResourceTest extends CatalogApplicationTest {
     Map<String, String> authHeaders = authHeaders(userName + "@open-metadata.org");
 
     if (shouldThrowException) {
-      HttpResponseException exception =
-          assertThrows(HttpResponseException.class, () -> addEdge(TABLES.get(1), TABLES.get(2), authHeaders));
       assertResponse(
-          exception,
+          () -> addEdge(TABLES.get(1), TABLES.get(2), authHeaders),
           FORBIDDEN,
           String.format("Principal: CatalogPrincipal{name='%s'} does not have permission to UpdateLineage", userName));
-      exception =
-          assertThrows(HttpResponseException.class, () -> deleteEdge(TABLES.get(1), TABLES.get(2), authHeaders));
       assertResponse(
-          exception,
+          () -> deleteEdge(TABLES.get(1), TABLES.get(2), authHeaders),
           FORBIDDEN,
           String.format("Principal: CatalogPrincipal{name='%s'} does not have permission to UpdateLineage", userName));
       return;

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/locations/LocationResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/locations/LocationResourceTest.java
@@ -16,7 +16,6 @@ package org.openmetadata.catalog.resources.locations;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.openmetadata.catalog.util.TestUtils.ADMIN_AUTH_HEADERS;
 import static org.openmetadata.catalog.util.TestUtils.assertListNotNull;
 import static org.openmetadata.catalog.util.TestUtils.assertResponse;
@@ -177,16 +176,16 @@ public class LocationResourceTest extends EntityResourceTest<Location, CreateLoc
 
   @Test
   void post_locationWithoutRequiredFields_4xx(TestInfo test) {
-    HttpResponseException exception =
-        assertThrows(
-            HttpResponseException.class, () -> createEntity(createRequest(test).withName(null), ADMIN_AUTH_HEADERS));
-    assertResponse(exception, BAD_REQUEST, "[name must not be null]");
+    assertResponse(
+        () -> createEntity(createRequest(test).withName(null), ADMIN_AUTH_HEADERS),
+        BAD_REQUEST,
+        "[name must not be null]");
 
     // Service is required field
-    exception =
-        assertThrows(
-            HttpResponseException.class, () -> createEntity(createRequest(test).withService(null), ADMIN_AUTH_HEADERS));
-    assertResponse(exception, BAD_REQUEST, "[service must not be null]");
+    assertResponse(
+        () -> createEntity(createRequest(test).withService(null), ADMIN_AUTH_HEADERS),
+        BAD_REQUEST,
+        "[service must not be null]");
   }
 
   @Test

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/operations/AirflowPipelineResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/operations/AirflowPipelineResourceTest.java
@@ -32,6 +32,7 @@ import static org.openmetadata.catalog.fernet.Fernet.decryptIfTokenized;
 import static org.openmetadata.catalog.util.TestUtils.ADMIN_AUTH_HEADERS;
 import static org.openmetadata.catalog.util.TestUtils.UpdateType.MINOR_UPDATE;
 import static org.openmetadata.catalog.util.TestUtils.assertListNotNull;
+import static org.openmetadata.catalog.util.TestUtils.assertResponseContains;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -204,9 +205,7 @@ public class AirflowPipelineResourceTest extends EntityOperationsResourceTest<Ai
   @Test
   void post_AirflowPipelineWithoutRequiredService_4xx(TestInfo test) {
     CreateAirflowPipeline create = createRequest(test).withService(null);
-    HttpResponseException exception =
-        assertThrows(HttpResponseException.class, () -> createEntity(create, ADMIN_AUTH_HEADERS));
-    TestUtils.assertResponseContains(exception, BAD_REQUEST, "service must not be null");
+    assertResponseContains(() -> createEntity(create, ADMIN_AUTH_HEADERS), BAD_REQUEST, "service must not be null");
   }
 
   @Test

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/pipelines/PipelineResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/pipelines/PipelineResourceTest.java
@@ -360,11 +360,10 @@ public class PipelineResourceTest extends EntityResourceTest<Pipeline, CreatePip
             .withExecutionDate(format.parse("2022-01-16").getTime())
             .withTaskStatus(taskStatus);
 
-    HttpResponseException exception =
-        assertThrows(
-            HttpResponseException.class,
-            () -> putPipelineStatusData(pipeline.getId(), pipelineStatus, ADMIN_AUTH_HEADERS));
-    TestUtils.assertResponseContains(exception, BAD_REQUEST, "Invalid task name invalidTask");
+    assertResponseContains(
+        () -> putPipelineStatusData(pipeline.getId(), pipelineStatus, ADMIN_AUTH_HEADERS),
+        BAD_REQUEST,
+        "Invalid task name invalidTask");
   }
 
   @Test

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/pipelines/PipelineResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/pipelines/PipelineResourceTest.java
@@ -18,10 +18,10 @@ import static javax.ws.rs.core.Response.Status.OK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.openmetadata.catalog.util.TestUtils.ADMIN_AUTH_HEADERS;
 import static org.openmetadata.catalog.util.TestUtils.UpdateType.MINOR_UPDATE;
 import static org.openmetadata.catalog.util.TestUtils.assertListNotNull;
+import static org.openmetadata.catalog.util.TestUtils.assertResponseContains;
 
 import java.io.IOException;
 import java.net.URI;
@@ -184,9 +184,7 @@ public class PipelineResourceTest extends EntityResourceTest<Pipeline, CreatePip
   @Test
   void post_PipelineWithoutRequiredService_4xx(TestInfo test) {
     CreatePipeline create = createRequest(test).withService(null);
-    HttpResponseException exception =
-        assertThrows(HttpResponseException.class, () -> createEntity(create, ADMIN_AUTH_HEADERS));
-    TestUtils.assertResponseContains(exception, BAD_REQUEST, "service must not be null");
+    assertResponseContains(() -> createEntity(create, ADMIN_AUTH_HEADERS), BAD_REQUEST, "service must not be null");
   }
 
   @Test

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/policies/PolicyResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/policies/PolicyResourceTest.java
@@ -17,7 +17,6 @@ import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.openmetadata.catalog.util.TestUtils.ADMIN_AUTH_HEADERS;
 import static org.openmetadata.catalog.util.TestUtils.UpdateType.MINOR_UPDATE;
@@ -130,9 +129,7 @@ public class PolicyResourceTest extends EntityResourceTest<Policy, CreatePolicy>
   @Test
   void post_PolicyWithoutPolicyType_400_badRequest(TestInfo test) {
     CreatePolicy create = createRequest(test).withPolicyType(null);
-    HttpResponseException exception =
-        assertThrows(HttpResponseException.class, () -> createEntity(create, ADMIN_AUTH_HEADERS));
-    assertResponse(exception, BAD_REQUEST, "[policyType must not be null]");
+    assertResponse(() -> createEntity(create, ADMIN_AUTH_HEADERS), BAD_REQUEST, "[policyType must not be null]");
   }
 
   @Test
@@ -160,10 +157,8 @@ public class PolicyResourceTest extends EntityResourceTest<Policy, CreatePolicy>
     rules.add(
         PolicyUtils.accessControlRule("rule21", null, null, null, MetadataOperation.UpdateDescription, true, 0, true));
     CreatePolicy create = createAccessControlPolicyWithRules(getEntityName(test), rules);
-    HttpResponseException exception =
-        assertThrows(HttpResponseException.class, () -> createEntity(create, ADMIN_AUTH_HEADERS));
     assertResponseContains(
-        exception,
+        () -> createEntity(create, ADMIN_AUTH_HEADERS),
         BAD_REQUEST,
         String.format(
             "Found invalid rule rule21 within policy %s. Please ensure that at least one among the user "
@@ -184,37 +179,41 @@ public class PolicyResourceTest extends EntityResourceTest<Policy, CreatePolicy>
         PolicyUtils.accessControlRule(
             "rule3", null, null, "DataConsumer", MetadataOperation.UpdateTags, true, 1, true));
     CreatePolicy create = createAccessControlPolicyWithRules(getEntityName(test), rules);
-    HttpResponseException exception =
-        assertThrows(HttpResponseException.class, () -> createEntity(create, ADMIN_AUTH_HEADERS));
     assertResponseContains(
-        exception,
+        () -> createEntity(create, ADMIN_AUTH_HEADERS),
         BAD_REQUEST,
         String.format(
-            "Found multiple rules with operation UpdateTags within policy %s. Please ensure that operation across all rules within the policy are distinct",
+            "Found multiple rules with operation UpdateTags within policy %s. "
+                + "Please ensure that operation across all rules within the policy are distinct",
             getEntityName(test)));
   }
 
   @Test
   void get_PolicyListWithInvalidLimitOffset_4xx() {
     // Limit must be >= 1 and <= 1000,000
-    HttpResponseException exception =
-        assertThrows(HttpResponseException.class, () -> listPolicies(null, -1, null, null, ADMIN_AUTH_HEADERS));
-    assertResponse(exception, BAD_REQUEST, "[query param limit must be greater than or equal to 1]");
+    assertResponse(
+        () -> listPolicies(null, -1, null, null, ADMIN_AUTH_HEADERS),
+        BAD_REQUEST,
+        "[query param limit must be greater than or equal to 1]");
 
-    exception = assertThrows(HttpResponseException.class, () -> listPolicies(null, 0, null, null, ADMIN_AUTH_HEADERS));
-    assertResponse(exception, BAD_REQUEST, "[query param limit must be greater than or equal to 1]");
+    assertResponse(
+        () -> listPolicies(null, 0, null, null, ADMIN_AUTH_HEADERS),
+        BAD_REQUEST,
+        "[query param limit must be greater than or equal to 1]");
 
-    exception =
-        assertThrows(HttpResponseException.class, () -> listPolicies(null, 1000001, null, null, ADMIN_AUTH_HEADERS));
-    assertResponse(exception, BAD_REQUEST, "[query param limit must be less than or equal to 1000000]");
+    assertResponse(
+        () -> listPolicies(null, 1000001, null, null, ADMIN_AUTH_HEADERS),
+        BAD_REQUEST,
+        "[query param limit must be less than or equal to 1000000]");
   }
 
   @Test
   void get_PolicyListWithInvalidPaginationCursors_4xx() {
     // Passing both before and after cursors is invalid
-    HttpResponseException exception =
-        assertThrows(HttpResponseException.class, () -> listPolicies(null, 1, "", "", ADMIN_AUTH_HEADERS));
-    assertResponse(exception, BAD_REQUEST, "Only one of before or after query parameter allowed");
+    assertResponse(
+        () -> listPolicies(null, 1, "", "", ADMIN_AUTH_HEADERS),
+        BAD_REQUEST,
+        "Only one of before or after query parameter allowed");
   }
 
   @Test

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/DashboardServiceResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/DashboardServiceResourceTest.java
@@ -16,8 +16,9 @@ package org.openmetadata.catalog.resources.services;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.openmetadata.catalog.util.TestUtils.ADMIN_AUTH_HEADERS;
+import static org.openmetadata.catalog.util.TestUtils.assertResponse;
+import static org.openmetadata.catalog.util.TestUtils.assertResponseContains;
 import static org.openmetadata.catalog.util.TestUtils.getPrincipal;
 
 import java.io.IOException;
@@ -63,18 +64,16 @@ public class DashboardServiceResourceTest extends EntityResourceTest<DashboardSe
   @Test
   void post_withoutRequiredFields_400_badRequest(TestInfo test) {
     // Create dashboard with mandatory serviceType field empty
-    HttpResponseException exception =
-        assertThrows(
-            HttpResponseException.class,
-            () -> createEntity(createRequest(test).withServiceType(null), ADMIN_AUTH_HEADERS));
-    TestUtils.assertResponse(exception, BAD_REQUEST, "[serviceType must not be null]");
+    assertResponse(
+        () -> createEntity(createRequest(test).withServiceType(null), ADMIN_AUTH_HEADERS),
+        BAD_REQUEST,
+        "[serviceType must not be null]");
 
     // Create dashboard with mandatory dashboardUrl field empty
-    exception =
-        assertThrows(
-            HttpResponseException.class,
-            () -> createEntity(createRequest(test).withDashboardUrl(null), ADMIN_AUTH_HEADERS));
-    TestUtils.assertResponse(exception, BAD_REQUEST, "[dashboardUrl must not be null]");
+    assertResponse(
+        () -> createEntity(createRequest(test).withDashboardUrl(null), ADMIN_AUTH_HEADERS),
+        BAD_REQUEST,
+        "[dashboardUrl must not be null]");
   }
 
   @Test
@@ -94,31 +93,27 @@ public class DashboardServiceResourceTest extends EntityResourceTest<DashboardSe
 
     // Invalid format
     create.withIngestionSchedule(schedule.withRepeatFrequency("INVALID"));
-    HttpResponseException exception =
-        assertThrows(HttpResponseException.class, () -> createEntity(create, ADMIN_AUTH_HEADERS));
-    TestUtils.assertResponse(exception, BAD_REQUEST, "Invalid ingestion repeatFrequency INVALID");
+    assertResponse(
+        () -> createEntity(create, ADMIN_AUTH_HEADERS), BAD_REQUEST, "Invalid ingestion repeatFrequency INVALID");
 
     // Duration that contains years, months and seconds are not allowed
     create.withIngestionSchedule(schedule.withRepeatFrequency("P1Y"));
-    exception = assertThrows(HttpResponseException.class, () -> createEntity(create, ADMIN_AUTH_HEADERS));
-    TestUtils.assertResponse(
-        exception,
+    assertResponse(
+        () -> createEntity(create, ADMIN_AUTH_HEADERS),
         BAD_REQUEST,
-        "Ingestion repeatFrequency can only contain Days, Hours, " + "and Minutes - example P{d}DT{h}H{m}M");
+        "Ingestion repeatFrequency can only contain Days, Hours, and Minutes - example P{d}DT{h}H{m}M");
 
     create.withIngestionSchedule(schedule.withRepeatFrequency("P1M"));
-    exception = assertThrows(HttpResponseException.class, () -> createEntity(create, ADMIN_AUTH_HEADERS));
-    TestUtils.assertResponse(
-        exception,
+    assertResponse(
+        () -> createEntity(create, ADMIN_AUTH_HEADERS),
         BAD_REQUEST,
-        "Ingestion repeatFrequency can only contain Days, Hours, " + "and Minutes - example P{d}DT{h}H{m}M");
+        "Ingestion repeatFrequency can only contain Days, Hours, and Minutes - example P{d}DT{h}H{m}M");
 
     create.withIngestionSchedule(schedule.withRepeatFrequency("PT1S"));
-    exception = assertThrows(HttpResponseException.class, () -> createEntity(create, ADMIN_AUTH_HEADERS));
-    TestUtils.assertResponse(
-        exception,
+    assertResponse(
+        () -> createEntity(create, ADMIN_AUTH_HEADERS),
         BAD_REQUEST,
-        "Ingestion repeatFrequency can only contain Days, Hours, " + "and Minutes - example P{d}DT{h}H{m}M");
+        "Ingestion repeatFrequency can only contain Days, Hours, and Minutes - example P{d}DT{h}H{m}M");
   }
 
   @Test
@@ -140,15 +135,16 @@ public class DashboardServiceResourceTest extends EntityResourceTest<DashboardSe
     Schedule schedule = new Schedule().withStartDate(new Date()).withRepeatFrequency("P1D");
     CreateDashboardService create = createRequest(test).withIngestionSchedule(schedule);
     create.withIngestionSchedule(schedule.withRepeatFrequency("PT1M")); // Repeat every 0 seconds
-    HttpResponseException exception =
-        assertThrows(HttpResponseException.class, () -> createEntity(create, ADMIN_AUTH_HEADERS));
-    TestUtils.assertResponseContains(
-        exception, BAD_REQUEST, "Ingestion repeatFrequency is too short and must be more than 60 minutes");
+    assertResponseContains(
+        () -> createEntity(create, ADMIN_AUTH_HEADERS),
+        BAD_REQUEST,
+        "Ingestion repeatFrequency is too short and must be more than 60 minutes");
 
     create.withIngestionSchedule(schedule.withRepeatFrequency("PT59M")); // Repeat every 50 minutes 59 seconds
-    exception = assertThrows(HttpResponseException.class, () -> createEntity(create, ADMIN_AUTH_HEADERS));
-    TestUtils.assertResponse(
-        exception, BAD_REQUEST, "Ingestion repeatFrequency is too short and must " + "be more than 60 minutes");
+    assertResponse(
+        () -> createEntity(create, ADMIN_AUTH_HEADERS),
+        BAD_REQUEST,
+        "Ingestion repeatFrequency is too short and must be more than 60 minutes");
   }
 
   @Test

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/DatabaseServiceResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/DatabaseServiceResourceTest.java
@@ -18,10 +18,10 @@ import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.openmetadata.catalog.Entity.helper;
 import static org.openmetadata.catalog.util.TestUtils.ADMIN_AUTH_HEADERS;
 import static org.openmetadata.catalog.util.TestUtils.TEST_AUTH_HEADERS;
+import static org.openmetadata.catalog.util.TestUtils.assertResponseContains;
 import static org.openmetadata.catalog.util.TestUtils.getPrincipal;
 
 import io.dropwizard.db.DataSourceFactory;
@@ -91,9 +91,8 @@ public class DatabaseServiceResourceTest extends EntityResourceTest<DatabaseServ
   void post_invalidDatabaseServiceNoJdbc_4xx(TestInfo test) {
     // No jdbc connection set
     CreateDatabaseService create = createRequest(test).withDatabaseConnection(null);
-    HttpResponseException exception =
-        assertThrows(HttpResponseException.class, () -> createEntity(create, ADMIN_AUTH_HEADERS));
-    TestUtils.assertResponseContains(exception, BAD_REQUEST, "databaseConnection must not be null");
+    assertResponseContains(
+        () -> createEntity(create, ADMIN_AUTH_HEADERS), BAD_REQUEST, "databaseConnection must not be null");
   }
 
   @Test

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/MessagingServiceResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/MessagingServiceResourceTest.java
@@ -16,9 +16,10 @@ package org.openmetadata.catalog.resources.services;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openmetadata.catalog.util.TestUtils.ADMIN_AUTH_HEADERS;
+import static org.openmetadata.catalog.util.TestUtils.assertResponse;
+import static org.openmetadata.catalog.util.TestUtils.assertResponseContains;
 
 import java.io.IOException;
 import java.net.URI;
@@ -76,17 +77,16 @@ public class MessagingServiceResourceTest extends EntityResourceTest<MessagingSe
   @Test
   void post_withoutRequiredFields_400_badRequest(TestInfo test) {
     // Create messaging with mandatory serviceType field empty
-    HttpResponseException exception =
-        assertThrows(
-            HttpResponseException.class,
-            () -> createEntity(createRequest(test).withServiceType(null), ADMIN_AUTH_HEADERS));
-    TestUtils.assertResponse(exception, BAD_REQUEST, "[serviceType must not be null]");
+    assertResponse(
+        () -> createEntity(createRequest(test).withServiceType(null), ADMIN_AUTH_HEADERS),
+        BAD_REQUEST,
+        "[serviceType must not be null]");
 
     // Create messaging with mandatory brokers field empty
-    exception =
-        assertThrows(
-            HttpResponseException.class, () -> createEntity(createRequest(test).withBrokers(null), ADMIN_AUTH_HEADERS));
-    TestUtils.assertResponse(exception, BAD_REQUEST, "[brokers must not be null]");
+    assertResponse(
+        () -> createEntity(createRequest(test).withBrokers(null), ADMIN_AUTH_HEADERS),
+        BAD_REQUEST,
+        "[brokers must not be null]");
   }
 
   @Test
@@ -106,31 +106,27 @@ public class MessagingServiceResourceTest extends EntityResourceTest<MessagingSe
 
     // Invalid format
     create.withIngestionSchedule(schedule.withRepeatFrequency("INVALID"));
-    HttpResponseException exception =
-        assertThrows(HttpResponseException.class, () -> createEntity(create, ADMIN_AUTH_HEADERS));
-    TestUtils.assertResponse(exception, BAD_REQUEST, "Invalid ingestion repeatFrequency INVALID");
+    assertResponse(
+        () -> createEntity(create, ADMIN_AUTH_HEADERS), BAD_REQUEST, "Invalid ingestion repeatFrequency INVALID");
 
     // Duration that contains years, months and seconds are not allowed
     create.withIngestionSchedule(schedule.withRepeatFrequency("P1Y"));
-    exception = assertThrows(HttpResponseException.class, () -> createEntity(create, ADMIN_AUTH_HEADERS));
-    TestUtils.assertResponse(
-        exception,
+    assertResponse(
+        () -> createEntity(create, ADMIN_AUTH_HEADERS),
         BAD_REQUEST,
-        "Ingestion repeatFrequency can only contain Days, Hours, " + "and Minutes - example P{d}DT{h}H{m}M");
+        "Ingestion repeatFrequency can only contain Days, Hours, and Minutes - example P{d}DT{h}H{m}M");
 
     create.withIngestionSchedule(schedule.withRepeatFrequency("P1M"));
-    exception = assertThrows(HttpResponseException.class, () -> createEntity(create, ADMIN_AUTH_HEADERS));
-    TestUtils.assertResponse(
-        exception,
+    assertResponse(
+        () -> createEntity(create, ADMIN_AUTH_HEADERS),
         BAD_REQUEST,
-        "Ingestion repeatFrequency can only contain Days, Hours, " + "and Minutes - example P{d}DT{h}H{m}M");
+        "Ingestion repeatFrequency can only contain Days, Hours, and Minutes - example P{d}DT{h}H{m}M");
 
     create.withIngestionSchedule(schedule.withRepeatFrequency("PT1S"));
-    exception = assertThrows(HttpResponseException.class, () -> createEntity(create, ADMIN_AUTH_HEADERS));
-    TestUtils.assertResponse(
-        exception,
+    assertResponse(
+        () -> createEntity(create, ADMIN_AUTH_HEADERS),
         BAD_REQUEST,
-        "Ingestion repeatFrequency can only contain Days, Hours, " + "and Minutes - example P{d}DT{h}H{m}M");
+        "Ingestion repeatFrequency can only contain Days, Hours, and Minutes - example P{d}DT{h}H{m}M");
   }
 
   @Test
@@ -152,15 +148,16 @@ public class MessagingServiceResourceTest extends EntityResourceTest<MessagingSe
     Schedule schedule = new Schedule().withStartDate(new Date()).withRepeatFrequency("P1D");
     CreateMessagingService create = createRequest(test).withIngestionSchedule(schedule);
     create.withIngestionSchedule(schedule.withRepeatFrequency("PT1M")); // Repeat every 0 seconds
-    HttpResponseException exception =
-        assertThrows(HttpResponseException.class, () -> createEntity(create, ADMIN_AUTH_HEADERS));
-    TestUtils.assertResponseContains(
-        exception, BAD_REQUEST, "Ingestion repeatFrequency is too short and must be more than 60 minutes");
+    assertResponseContains(
+        () -> createEntity(create, ADMIN_AUTH_HEADERS),
+        BAD_REQUEST,
+        "Ingestion repeatFrequency is too short and must be more than 60 minutes");
 
     create.withIngestionSchedule(schedule.withRepeatFrequency("PT59M")); // Repeat every 50 minutes 59 seconds
-    exception = assertThrows(HttpResponseException.class, () -> createEntity(create, ADMIN_AUTH_HEADERS));
-    TestUtils.assertResponse(
-        exception, BAD_REQUEST, "Ingestion repeatFrequency is too short and must " + "be more than 60 minutes");
+    assertResponse(
+        () -> createEntity(create, ADMIN_AUTH_HEADERS),
+        BAD_REQUEST,
+        "Ingestion repeatFrequency is too short and must be more than 60 minutes");
   }
 
   @Test

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/PipelineServiceResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/PipelineServiceResourceTest.java
@@ -16,8 +16,9 @@ package org.openmetadata.catalog.resources.services;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.openmetadata.catalog.util.TestUtils.ADMIN_AUTH_HEADERS;
+import static org.openmetadata.catalog.util.TestUtils.assertResponse;
+import static org.openmetadata.catalog.util.TestUtils.assertResponseContains;
 import static org.openmetadata.catalog.util.TestUtils.getPrincipal;
 
 import java.io.IOException;
@@ -74,18 +75,16 @@ public class PipelineServiceResourceTest extends EntityResourceTest<PipelineServ
   @Test
   void post_withoutRequiredFields_400_badRequest(TestInfo test) {
     // Create pipeline with mandatory serviceType field empty
-    HttpResponseException exception =
-        assertThrows(
-            HttpResponseException.class,
-            () -> createEntity(createRequest(test).withServiceType(null), ADMIN_AUTH_HEADERS));
-    TestUtils.assertResponse(exception, BAD_REQUEST, "[serviceType must not be null]");
+    assertResponse(
+        () -> createEntity(createRequest(test).withServiceType(null), ADMIN_AUTH_HEADERS),
+        BAD_REQUEST,
+        "[serviceType must not be null]");
 
     // Create pipeline with mandatory `brokers` field empty
-    exception =
-        assertThrows(
-            HttpResponseException.class,
-            () -> createEntity(createRequest(test).withPipelineUrl(null), ADMIN_AUTH_HEADERS));
-    TestUtils.assertResponse(exception, BAD_REQUEST, "[pipelineUrl must not be null]");
+    assertResponse(
+        () -> createEntity(createRequest(test).withPipelineUrl(null), ADMIN_AUTH_HEADERS),
+        BAD_REQUEST,
+        "[pipelineUrl must not be null]");
   }
 
   @Test
@@ -105,31 +104,27 @@ public class PipelineServiceResourceTest extends EntityResourceTest<PipelineServ
 
     // Invalid format
     create.withIngestionSchedule(schedule.withRepeatFrequency("INVALID"));
-    HttpResponseException exception =
-        assertThrows(HttpResponseException.class, () -> createEntity(create, ADMIN_AUTH_HEADERS));
-    TestUtils.assertResponse(exception, BAD_REQUEST, "Invalid ingestion repeatFrequency INVALID");
+    assertResponse(
+        () -> createEntity(create, ADMIN_AUTH_HEADERS), BAD_REQUEST, "Invalid ingestion repeatFrequency INVALID");
 
     // Duration that contains years, months and seconds are not allowed
     create.withIngestionSchedule(schedule.withRepeatFrequency("P1Y"));
-    exception = assertThrows(HttpResponseException.class, () -> createEntity(create, ADMIN_AUTH_HEADERS));
-    TestUtils.assertResponse(
-        exception,
+    assertResponse(
+        () -> createEntity(create, ADMIN_AUTH_HEADERS),
         BAD_REQUEST,
-        "Ingestion repeatFrequency can only contain Days, Hours, " + "and Minutes - example P{d}DT{h}H{m}M");
+        "Ingestion repeatFrequency can only contain Days, Hours, and Minutes - example P{d}DT{h}H{m}M");
 
     create.withIngestionSchedule(schedule.withRepeatFrequency("P1M"));
-    exception = assertThrows(HttpResponseException.class, () -> createEntity(create, ADMIN_AUTH_HEADERS));
-    TestUtils.assertResponse(
-        exception,
+    assertResponse(
+        () -> createEntity(create, ADMIN_AUTH_HEADERS),
         BAD_REQUEST,
-        "Ingestion repeatFrequency can only contain Days, Hours, " + "and Minutes - example P{d}DT{h}H{m}M");
+        "Ingestion repeatFrequency can only contain Days, Hours, and Minutes - example P{d}DT{h}H{m}M");
 
     create.withIngestionSchedule(schedule.withRepeatFrequency("PT1S"));
-    exception = assertThrows(HttpResponseException.class, () -> createEntity(create, ADMIN_AUTH_HEADERS));
-    TestUtils.assertResponse(
-        exception,
+    assertResponse(
+        () -> createEntity(create, ADMIN_AUTH_HEADERS),
         BAD_REQUEST,
-        "Ingestion repeatFrequency can only contain Days, Hours, " + "and Minutes - example P{d}DT{h}H{m}M");
+        "Ingestion repeatFrequency can only contain Days, Hours, and Minutes - example P{d}DT{h}H{m}M");
   }
 
   @Test
@@ -151,15 +146,16 @@ public class PipelineServiceResourceTest extends EntityResourceTest<PipelineServ
     Schedule schedule = new Schedule().withStartDate(new Date()).withRepeatFrequency("P1D");
     CreatePipelineService create = createRequest(test).withIngestionSchedule(schedule);
     create.withIngestionSchedule(schedule.withRepeatFrequency("PT1M")); // Repeat every 0 seconds
-    HttpResponseException exception =
-        assertThrows(HttpResponseException.class, () -> createEntity(create, ADMIN_AUTH_HEADERS));
-    TestUtils.assertResponseContains(
-        exception, BAD_REQUEST, "Ingestion repeatFrequency is too short and must be more than 60 minutes");
+    assertResponseContains(
+        () -> createEntity(create, ADMIN_AUTH_HEADERS),
+        BAD_REQUEST,
+        "Ingestion repeatFrequency is too short and must be more than 60 minutes");
 
     create.withIngestionSchedule(schedule.withRepeatFrequency("PT59M")); // Repeat every 50 minutes 59 seconds
-    exception = assertThrows(HttpResponseException.class, () -> createEntity(create, ADMIN_AUTH_HEADERS));
-    TestUtils.assertResponse(
-        exception, BAD_REQUEST, "Ingestion repeatFrequency is too short and must " + "be more than 60 minutes");
+    assertResponse(
+        () -> createEntity(create, ADMIN_AUTH_HEADERS),
+        BAD_REQUEST,
+        "Ingestion repeatFrequency is too short and must be more than 60 minutes");
   }
 
   @Test

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/teams/RoleResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/teams/RoleResourceTest.java
@@ -15,7 +15,6 @@ package org.openmetadata.catalog.resources.teams;
 
 import static javax.ws.rs.core.Response.Status.FORBIDDEN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.openmetadata.catalog.util.TestUtils.ADMIN_AUTH_HEADERS;
 import static org.openmetadata.catalog.util.TestUtils.TEST_AUTH_HEADERS;
 import static org.openmetadata.catalog.util.TestUtils.assertListNotNull;
@@ -84,10 +83,10 @@ public class RoleResourceTest extends EntityResourceTest<Role, CreateRole> {
     // Patching as a non-admin should is disallowed
     String originalJson = JsonUtils.pojoToJson(role);
     role.setDisplayName("newDisplayName");
-    HttpResponseException exception =
-        assertThrows(
-            HttpResponseException.class, () -> patchEntity(role.getId(), originalJson, role, TEST_AUTH_HEADERS));
-    assertResponse(exception, FORBIDDEN, "Principal: CatalogPrincipal{name='test'} is not admin");
+    assertResponse(
+        () -> patchEntity(role.getId(), originalJson, role, TEST_AUTH_HEADERS),
+        FORBIDDEN,
+        "Principal: CatalogPrincipal{name='test'} is not admin");
   }
 
   private static void validateRole(

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/teams/TeamResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/teams/TeamResourceTest.java
@@ -18,7 +18,6 @@ import static javax.ws.rs.core.Response.Status.FORBIDDEN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openmetadata.catalog.util.TestUtils.ADMIN_AUTH_HEADERS;
 import static org.openmetadata.catalog.util.TestUtils.TEST_AUTH_HEADERS;
@@ -116,14 +115,16 @@ public class TeamResourceTest extends EntityResourceTest<Team, CreateTeam> {
     Team team = createEntity(create, ADMIN_AUTH_HEADERS);
 
     // Empty query field .../teams?fields=
-    HttpResponseException exception =
-        assertThrows(HttpResponseException.class, () -> getEntity(team.getId(), "test", ADMIN_AUTH_HEADERS));
-    assertResponse(exception, BAD_REQUEST, CatalogExceptionMessage.invalidField("test"));
+    assertResponse(
+        () -> getEntity(team.getId(), "test", ADMIN_AUTH_HEADERS),
+        BAD_REQUEST,
+        CatalogExceptionMessage.invalidField("test"));
 
     // .../teams?fields=invalidField
-    exception =
-        assertThrows(HttpResponseException.class, () -> getEntity(team.getId(), "invalidField", ADMIN_AUTH_HEADERS));
-    assertResponse(exception, BAD_REQUEST, CatalogExceptionMessage.invalidField("invalidField"));
+    assertResponse(
+        () -> getEntity(team.getId(), "invalidField", ADMIN_AUTH_HEADERS),
+        BAD_REQUEST,
+        CatalogExceptionMessage.invalidField("invalidField"));
   }
 
   /**
@@ -152,10 +153,10 @@ public class TeamResourceTest extends EntityResourceTest<Team, CreateTeam> {
     // Patching as a non-admin should is disallowed
     String originalJson = JsonUtils.pojoToJson(team);
     team.setDisplayName("newDisplayName");
-    HttpResponseException exception =
-        assertThrows(
-            HttpResponseException.class, () -> patchEntity(team.getId(), originalJson, team, TEST_AUTH_HEADERS));
-    assertResponse(exception, FORBIDDEN, "Principal: CatalogPrincipal{name='test'} is not admin");
+    assertResponse(
+        () -> patchEntity(team.getId(), originalJson, team, TEST_AUTH_HEADERS),
+        FORBIDDEN,
+        "Principal: CatalogPrincipal{name='test'} is not admin");
   }
 
   @Test

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/teams/UserResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/teams/UserResourceTest.java
@@ -23,8 +23,8 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.openmetadata.catalog.exception.CatalogExceptionMessage.entityNotFound;
 import static org.openmetadata.catalog.security.SecurityUtil.authHeaders;
 import static org.openmetadata.catalog.util.TestUtils.ADMIN_AUTH_HEADERS;
 import static org.openmetadata.catalog.util.TestUtils.TEST_AUTH_HEADERS;
@@ -32,6 +32,7 @@ import static org.openmetadata.catalog.util.TestUtils.UpdateType.MINOR_UPDATE;
 import static org.openmetadata.catalog.util.TestUtils.assertListNotNull;
 import static org.openmetadata.catalog.util.TestUtils.assertListNull;
 import static org.openmetadata.catalog.util.TestUtils.assertResponse;
+import static org.openmetadata.catalog.util.TestUtils.assertResponseContains;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
@@ -96,20 +97,19 @@ public class UserResourceTest extends EntityResourceTest<User, CreateUser> {
   void post_userWithoutEmail_400_badRequest(TestInfo test) {
     // Create user with mandatory email field null
     CreateUser create = createRequest(test).withEmail(null);
-    HttpResponseException exception =
-        assertThrows(HttpResponseException.class, () -> createEntity(create, ADMIN_AUTH_HEADERS));
-    assertResponse(exception, BAD_REQUEST, "[email must not be null]");
+    assertResponse(() -> createEntity(create, ADMIN_AUTH_HEADERS), BAD_REQUEST, "[email must not be null]");
 
     // Create user with mandatory email field empty
     create.withEmail("");
-    exception = assertThrows(HttpResponseException.class, () -> createEntity(create, ADMIN_AUTH_HEADERS));
-    TestUtils.assertResponseContains(exception, BAD_REQUEST, "email must match \"^\\S+@\\S+\\.\\S+$\"");
-    TestUtils.assertResponseContains(exception, BAD_REQUEST, "email size must be between 6 and 127");
+    assertResponseContains(
+        () -> createEntity(create, ADMIN_AUTH_HEADERS), BAD_REQUEST, "email must match \"^\\S+@\\S+\\.\\S+$\"");
+    assertResponseContains(
+        () -> createEntity(create, ADMIN_AUTH_HEADERS), BAD_REQUEST, "email size must be between 6 and 127");
 
     // Create user with mandatory email field with invalid email address
     create.withEmail("invalidEmail");
-    exception = assertThrows(HttpResponseException.class, () -> createEntity(create, ADMIN_AUTH_HEADERS));
-    TestUtils.assertResponseContains(exception, BAD_REQUEST, "[email must match \"^\\S+@\\S+\\.\\S+$\"]");
+    assertResponseContains(
+        () -> createEntity(create, ADMIN_AUTH_HEADERS), BAD_REQUEST, "[email must match \"^\\S+@\\S+\\.\\S+$\"]");
   }
 
   @Test
@@ -117,9 +117,8 @@ public class UserResourceTest extends EntityResourceTest<User, CreateUser> {
     CreateUser create =
         createRequest(test, 6).withDisplayName("displayName").withEmail("test@email.com").withIsAdmin(true);
 
-    HttpResponseException exception =
-        assertThrows(HttpResponseException.class, () -> createAndCheckEntity(create, null));
-    assertResponse(exception, UNAUTHORIZED, "Not authorized; User's Email is not present");
+    assertResponse(
+        () -> createAndCheckEntity(create, null), UNAUTHORIZED, "Not authorized; User's Email is not present");
   }
 
   @Test
@@ -171,9 +170,10 @@ public class UserResourceTest extends EntityResourceTest<User, CreateUser> {
             .withEmail("test@email.com")
             .withIsAdmin(true);
 
-    HttpResponseException exception =
-        assertThrows(HttpResponseException.class, () -> createAndCheckEntity(create, TEST_AUTH_HEADERS));
-    assertResponse(exception, FORBIDDEN, "Principal: CatalogPrincipal{name='test'} is not admin");
+    assertResponse(
+        () -> createAndCheckEntity(create, TEST_AUTH_HEADERS),
+        FORBIDDEN,
+        "Principal: CatalogPrincipal{name='test'} is not admin");
   }
 
   @Test
@@ -275,14 +275,14 @@ public class UserResourceTest extends EntityResourceTest<User, CreateUser> {
     User user = createEntity(createRequest(test), ADMIN_AUTH_HEADERS);
 
     // Empty query field .../users?fields=
-    HttpResponseException exception =
-        assertThrows(HttpResponseException.class, () -> getEntity(user.getId(), "test", ADMIN_AUTH_HEADERS));
-    TestUtils.assertResponseContains(exception, BAD_REQUEST, "Invalid field name");
+    assertResponseContains(
+        () -> getEntity(user.getId(), "test", ADMIN_AUTH_HEADERS), BAD_REQUEST, "Invalid field name");
 
     // .../users?fields=invalidField
-    exception =
-        assertThrows(HttpResponseException.class, () -> getEntity(user.getId(), "invalidField", ADMIN_AUTH_HEADERS));
-    assertResponse(exception, BAD_REQUEST, CatalogExceptionMessage.invalidField("invalidField"));
+    assertResponse(
+        () -> getEntity(user.getId(), "invalidField", ADMIN_AUTH_HEADERS),
+        BAD_REQUEST,
+        CatalogExceptionMessage.invalidField("invalidField"));
   }
 
   /**
@@ -299,9 +299,10 @@ public class UserResourceTest extends EntityResourceTest<User, CreateUser> {
             authHeaders("test23@email.com"));
     String userJson = JsonUtils.pojoToJson(user);
     user.setDisplayName("newName");
-    HttpResponseException exception =
-        assertThrows(HttpResponseException.class, () -> patchUser(userJson, user, authHeaders("test100@email.com")));
-    assertResponse(exception, FORBIDDEN, "Principal: CatalogPrincipal{name='test100'} does not have permissions");
+    assertResponse(
+        () -> patchUser(userJson, user, authHeaders("test100@email.com")),
+        FORBIDDEN,
+        "Principal: CatalogPrincipal{name='test100'} does not have permissions");
   }
 
   @Test
@@ -313,9 +314,10 @@ public class UserResourceTest extends EntityResourceTest<User, CreateUser> {
             authHeaders("test2@email.com"));
     String userJson = JsonUtils.pojoToJson(user);
     user.setIsAdmin(Boolean.TRUE);
-    HttpResponseException exception =
-        assertThrows(HttpResponseException.class, () -> patchUser(userJson, user, authHeaders("test100@email.com")));
-    assertResponse(exception, FORBIDDEN, "Principal: CatalogPrincipal{name='test100'} is not admin");
+    assertResponse(
+        () -> patchUser(userJson, user, authHeaders("test100@email.com")),
+        FORBIDDEN,
+        "Principal: CatalogPrincipal{name='test100'} is not admin");
   }
 
   @Test
@@ -469,11 +471,10 @@ public class UserResourceTest extends EntityResourceTest<User, CreateUser> {
     tableResourceTest.checkFollowerDeleted(table.getId(), user.getId(), ADMIN_AUTH_HEADERS);
 
     // User can no longer follow other entities
-    HttpResponseException exception =
-        assertThrows(
-            HttpResponseException.class,
-            () -> tableResourceTest.addAndCheckFollower(table.getId(), user.getId(), CREATED, 1, ADMIN_AUTH_HEADERS));
-    assertResponse(exception, NOT_FOUND, CatalogExceptionMessage.entityNotFound("user", user.getId()));
+    assertResponse(
+        () -> tableResourceTest.addAndCheckFollower(table.getId(), user.getId(), CREATED, 1, ADMIN_AUTH_HEADERS),
+        NOT_FOUND,
+        entityNotFound("user", user.getId()));
 
     // TODO deactivated user can't be made owner
   }

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/topics/TopicResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/topics/TopicResourceTest.java
@@ -15,7 +15,6 @@ package org.openmetadata.catalog.resources.topics;
 
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.openmetadata.catalog.util.TestUtils.ADMIN_AUTH_HEADERS;
 import static org.openmetadata.catalog.util.TestUtils.assertListNotNull;
 import static org.openmetadata.catalog.util.TestUtils.assertResponse;
@@ -70,23 +69,22 @@ public class TopicResourceTest extends EntityResourceTest<Topic, CreateTopic> {
   @Test
   void post_topicWithoutRequiredFields_4xx(TestInfo test) {
     // Service is required field
-    HttpResponseException exception =
-        assertThrows(
-            HttpResponseException.class, () -> createEntity(createRequest(test).withService(null), ADMIN_AUTH_HEADERS));
-    assertResponse(exception, BAD_REQUEST, "[service must not be null]");
+    assertResponse(
+        () -> createEntity(createRequest(test).withService(null), ADMIN_AUTH_HEADERS),
+        BAD_REQUEST,
+        "[service must not be null]");
 
     // Partitions is required field
-    exception =
-        assertThrows(
-            HttpResponseException.class,
-            () -> createEntity(createRequest(test).withPartitions(null), ADMIN_AUTH_HEADERS));
-    assertResponse(exception, BAD_REQUEST, "[partitions must not be null]");
+    assertResponse(
+        () -> createEntity(createRequest(test).withPartitions(null), ADMIN_AUTH_HEADERS),
+        BAD_REQUEST,
+        "[partitions must not be null]");
 
     // Partitions must be >= 1
-    exception =
-        assertThrows(
-            HttpResponseException.class, () -> createEntity(createRequest(test).withPartitions(0), ADMIN_AUTH_HEADERS));
-    assertResponse(exception, BAD_REQUEST, "[partitions must be greater than or equal to 1]");
+    assertResponse(
+        () -> createEntity(createRequest(test).withPartitions(0), ADMIN_AUTH_HEADERS),
+        BAD_REQUEST,
+        "[partitions must be greater than or equal to 1]");
   }
 
   @Test

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/usage/UsageResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/usage/UsageResourceTest.java
@@ -16,8 +16,9 @@ package org.openmetadata.catalog.resources.usage;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.openmetadata.catalog.Entity.TABLE;
+import static org.openmetadata.catalog.exception.CatalogExceptionMessage.entityNotFound;
+import static org.openmetadata.catalog.exception.CatalogExceptionMessage.entityTypeNotFound;
 import static org.openmetadata.catalog.util.TestUtils.ADMIN_AUTH_HEADERS;
 import static org.openmetadata.catalog.util.TestUtils.NON_EXISTENT_ENTITY;
 import static org.openmetadata.catalog.util.TestUtils.assertResponse;
@@ -47,7 +48,6 @@ import org.openmetadata.catalog.Entity;
 import org.openmetadata.catalog.api.data.CreateTable;
 import org.openmetadata.catalog.entity.data.Database;
 import org.openmetadata.catalog.entity.data.Table;
-import org.openmetadata.catalog.exception.CatalogExceptionMessage;
 import org.openmetadata.catalog.resources.databases.DatabaseResourceTest;
 import org.openmetadata.catalog.resources.databases.TableResourceTest;
 import org.openmetadata.catalog.type.DailyCount;
@@ -76,39 +76,37 @@ public class UsageResourceTest extends CatalogApplicationTest {
 
   @Test
   public void post_usageWithNonExistentEntityId_4xx() {
-    HttpResponseException exception =
-        assertThrows(
-            HttpResponseException.class,
-            () -> reportUsage(TABLE, NON_EXISTENT_ENTITY, usageReport(), ADMIN_AUTH_HEADERS));
-    assertResponse(exception, NOT_FOUND, CatalogExceptionMessage.entityNotFound(TABLE, NON_EXISTENT_ENTITY));
+    assertResponse(
+        () -> reportUsage(TABLE, NON_EXISTENT_ENTITY, usageReport(), ADMIN_AUTH_HEADERS),
+        NOT_FOUND,
+        entityNotFound(TABLE, NON_EXISTENT_ENTITY));
   }
 
   @Test
   public void post_usageInvalidEntityName_4xx() {
     String invalidEntityType = "invalid";
-    HttpResponseException exception =
-        assertThrows(
-            HttpResponseException.class,
-            () -> reportUsage(invalidEntityType, UUID.randomUUID(), usageReport(), ADMIN_AUTH_HEADERS));
-    assertResponse(exception, NOT_FOUND, CatalogExceptionMessage.entityTypeNotFound(invalidEntityType));
+    assertResponse(
+        () -> reportUsage(invalidEntityType, UUID.randomUUID(), usageReport(), ADMIN_AUTH_HEADERS),
+        NOT_FOUND,
+        entityTypeNotFound(invalidEntityType));
   }
 
   @Test
   public void post_usageWithNegativeCountName_4xx() {
     DailyCount dailyCount = usageReport().withCount(-1); // Negative usage count
-    HttpResponseException exception =
-        assertThrows(
-            HttpResponseException.class, () -> reportUsage(TABLE, UUID.randomUUID(), dailyCount, ADMIN_AUTH_HEADERS));
-    assertResponse(exception, BAD_REQUEST, "[count must be greater than or equal to 0]");
+    assertResponse(
+        () -> reportUsage(TABLE, UUID.randomUUID(), dailyCount, ADMIN_AUTH_HEADERS),
+        BAD_REQUEST,
+        "[count must be greater than or equal to 0]");
   }
 
   @Test
   public void post_usageWithoutDate_4xx() {
     DailyCount usageReport = usageReport().withDate(null); // Negative usage count
-    HttpResponseException exception =
-        assertThrows(
-            HttpResponseException.class, () -> reportUsage(TABLE, UUID.randomUUID(), usageReport, ADMIN_AUTH_HEADERS));
-    assertResponse(exception, BAD_REQUEST, "[date must not be null]");
+    assertResponse(
+        () -> reportUsage(TABLE, UUID.randomUUID(), usageReport, ADMIN_AUTH_HEADERS),
+        BAD_REQUEST,
+        "[date must not be null]");
   }
 
   @Test

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/util/TestUtils.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/util/TestUtils.java
@@ -140,19 +140,6 @@ public final class TestUtils {
         expectedReason + " not in actual " + exception.getReasonPhrase());
   }
 
-  public static void assertResponse(HttpResponseException exception, Status expectedCode, String expectedReason) {
-    assertEquals(expectedCode.getStatusCode(), exception.getStatusCode());
-    assertEquals(expectedReason, exception.getReasonPhrase());
-  }
-
-  public static void assertResponseContains(
-      HttpResponseException exception, Status expectedCode, String expectedReason) {
-    assertEquals(expectedCode.getStatusCode(), exception.getStatusCode());
-    assertTrue(
-        exception.getReasonPhrase().contains(expectedReason),
-        expectedReason + " not in actual " + exception.getReasonPhrase());
-  }
-
   public static <T> void assertEntityPagination(List<T> allEntities, ResultList<T> actual, int limit, int offset) {
     assertFalse(actual.getData().isEmpty());
     if (actual.getPaging().getAfter() != null && actual.getPaging().getBefore() != null) {


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
This change makes test code smaller and more readable by using lambda expression when call assertResponse & assertResponseContains

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have performed a self-review of my own. 
- [ ] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
