### PR TITLE
Excluding db2 from all plugins

### DIFF
--- a/ingestion/setup.py
+++ b/ingestion/setup.py
@@ -183,7 +183,11 @@ setup(
         **{plugin: list(dependencies) for (plugin, dependencies) in plugins.items()},
         "all": list(
             base_requirements.union(
-                *[requirements for plugin, requirements in plugins.items()]
+                *[
+                    requirements
+                    for plugin, requirements in plugins.items()
+                    if plugin != "db2"
+                ]
             )
         ),
     },


### PR DESCRIPTION

### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Excluding db2 from all plugins, as it causes `_arch` issues on some os platforms
#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have performed a self-review of my own. 
- [ ] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
@harshach @akash-jain-10 @pmbrull 