### PR TITLE
Fix #3080: Activity Feed: Blank feed on my-data page for updating user's role or team

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/Entity.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/Entity.java
@@ -106,6 +106,11 @@ public final class Entity {
   public static final String AIRFLOW_PIPELINE = "airflowPipeline";
   public static final String WEBHOOK = "webhook";
 
+  //
+  // List of entities whose changes should not be published to the Activity Feed
+  //
+  public static final List<String> ACTIVITY_FEED_EXCLUDED_ENTITIES = List.of(USER, TEAM, ROLE, POLICY, BOTS);
+
   private Entity() {}
 
   public static <T> void registerEntity(
@@ -183,6 +188,16 @@ public final class Entity {
   public static boolean shouldHaveOwner(@NonNull String entityType) {
     // Team does not have an owner. (yet?)
     return !entityType.equals(TEAM);
+  }
+
+  /**
+   * Returns true if the change events of the given entity type should be published to the activity feed.
+   *
+   * @param entityType Type of the entity.
+   * @return true if change events of the entity should be published to activity feed, false otherwise
+   */
+  public static boolean shouldDisplayEntityChangeOnFeed(@NonNull String entityType) {
+    return !ACTIVITY_FEED_EXCLUDED_ENTITIES.contains(entityType);
   }
 
   public static <T> EntityInterface<T> getEntityInterface(T entity) {

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/events/ChangeEventHandler.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/events/ChangeEventHandler.java
@@ -72,8 +72,7 @@ public class ChangeEventHandler implements EventHandler {
 
         // Add a new thread to the entity for every change event
         // for the event to appear in activity feeds
-        // Skip creating threads for user or team related changes for now
-        if (!Entity.USER.equals(changeEvent.getEntityType()) && !Entity.TEAM.equals(changeEvent.getEntityType())) {
+        if (Entity.shouldDisplayEntityChangeOnFeed(changeEvent.getEntityType())) {
           List<Thread> threads = getThreads(responseContext);
           if (threads != null) {
             for (var thread : threads) {

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/events/ChangeEventHandler.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/events/ChangeEventHandler.java
@@ -72,10 +72,16 @@ public class ChangeEventHandler implements EventHandler {
 
         // Add a new thread to the entity for every change event
         // for the event to appear in activity feeds
-        List<Thread> threads = getThreads(responseContext, changeEvent);
-        if (threads != null) {
-          for (var thread : threads) {
-            feedDao.create(thread);
+        // Skip creating threads for user or team related changes for now
+        if (!Entity.USER.equals(changeEvent.getEntityType()) && !Entity.TEAM.equals(changeEvent.getEntityType())) {
+          List<Thread> threads = getThreads(responseContext);
+          if (threads != null) {
+            for (var thread : threads) {
+              // Don't create a thread if there is no message
+              if (!thread.getMessage().isEmpty()) {
+                feedDao.create(thread);
+              }
+            }
           }
         }
       }
@@ -171,7 +177,7 @@ public class ChangeEventHandler implements EventHandler {
         .withCurrentVersion(changeEvent.getCurrentVersion());
   }
 
-  private List<Thread> getThreads(ContainerResponseContext responseContext, ChangeEvent changeEvent) {
+  private List<Thread> getThreads(ContainerResponseContext responseContext) {
     Object entity = responseContext.getEntity();
     if (entity == null) {
       return null; // Response has no entity to produce change event from
@@ -184,14 +190,14 @@ public class ChangeEventHandler implements EventHandler {
       return null;
     }
 
-    return getThreads(entity, entityInterface.getChangeDescription(), changeEvent);
+    return getThreads(entity, entityInterface.getChangeDescription());
   }
 
-  private List<Thread> getThreads(Object entity, ChangeDescription changeDescription, ChangeEvent changeEvent) {
+  private List<Thread> getThreads(Object entity, ChangeDescription changeDescription) {
     List<Thread> threads = new ArrayList<>();
     var entityInterface = Entity.getEntityInterface(entity);
 
-    Map<EntityLink, String> messages = ChangeEventParser.getFormattedMessages(changeDescription, entity, changeEvent);
+    Map<EntityLink, String> messages = ChangeEventParser.getFormattedMessages(changeDescription, entity);
 
     // Create an automated thread
     for (var link : messages.keySet()) {

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/util/ChangeEventParser.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/util/ChangeEventParser.java
@@ -32,7 +32,6 @@ import org.apache.commons.lang.StringUtils;
 import org.openmetadata.catalog.Entity;
 import org.openmetadata.catalog.resources.feeds.MessageParser.EntityLink;
 import org.openmetadata.catalog.type.ChangeDescription;
-import org.openmetadata.catalog.type.ChangeEvent;
 import org.openmetadata.catalog.type.EntityReference;
 import org.openmetadata.catalog.type.FieldChange;
 
@@ -46,8 +45,7 @@ public final class ChangeEventParser {
     DELETE
   }
 
-  public static Map<EntityLink, String> getFormattedMessages(
-      ChangeDescription changeDescription, Object entity, ChangeEvent changeEvent) {
+  public static Map<EntityLink, String> getFormattedMessages(ChangeDescription changeDescription, Object entity) {
     // Store a map of entityLink -> message
     Map<EntityLink, String> messages;
 
@@ -82,7 +80,7 @@ public final class ChangeEventParser {
   }
 
   private static String getFieldValue(Object fieldValue) {
-    if (fieldValue != null) {
+    if (fieldValue != null && !fieldValue.toString().isEmpty()) {
       try {
         // Check if field value is a json string
         JsonValue json = JsonUtils.readJson(fieldValue.toString());

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/util/ChangeEventParserTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/util/ChangeEventParserTest.java
@@ -33,7 +33,6 @@ import org.openmetadata.catalog.CatalogApplicationTest;
 import org.openmetadata.catalog.resources.databases.TableResourceTest;
 import org.openmetadata.catalog.resources.feeds.MessageParser.EntityLink;
 import org.openmetadata.catalog.type.ChangeDescription;
-import org.openmetadata.catalog.type.ChangeEvent;
 import org.openmetadata.catalog.type.EntityReference;
 import org.openmetadata.catalog.type.FieldChange;
 import org.openmetadata.catalog.type.TagLabel;
@@ -57,16 +56,14 @@ public class ChangeEventParserTest extends CatalogApplicationTest {
   @Test
   void testFormattedMessages() throws JsonProcessingException {
     ChangeDescription changeDescription = new ChangeDescription();
-    ChangeEvent changeEvent = new ChangeEvent();
     // Simulate updating tags of an entity from tag1 -> tag2
     FieldChange addTag = new FieldChange();
     addTag.withName("tags").withNewValue("tag2");
     FieldChange deleteTag = new FieldChange();
     deleteTag.withName("tags").withOldValue("tag1");
     changeDescription.withFieldsAdded(List.of(addTag)).withFieldsDeleted(List.of(deleteTag)).withPreviousVersion(1.0);
-    changeEvent.withChangeDescription(changeDescription).withPreviousVersion(1.0).withCurrentVersion(1.1);
 
-    Map<EntityLink, String> messages = ChangeEventParser.getFormattedMessages(changeDescription, TABLE, changeEvent);
+    Map<EntityLink, String> messages = ChangeEventParser.getFormattedMessages(changeDescription, TABLE);
     assertEquals(1, messages.size());
 
     TagLabel tag1 = new TagLabel();
@@ -78,8 +75,7 @@ public class ChangeEventParserTest extends CatalogApplicationTest {
     addTag.withNewValue(JsonUtils.pojoToJson(List.of(tag2)));
     deleteTag.withOldValue(JsonUtils.pojoToJson(List.of(tag1)));
 
-    Map<EntityLink, String> jsonMessages =
-        ChangeEventParser.getFormattedMessages(changeDescription, TABLE, changeEvent);
+    Map<EntityLink, String> jsonMessages = ChangeEventParser.getFormattedMessages(changeDescription, TABLE);
     assertEquals(1, jsonMessages.size());
 
     // The entity links and values of both the messages should be the same
@@ -89,7 +85,6 @@ public class ChangeEventParserTest extends CatalogApplicationTest {
   @Test
   void testEntityReferenceFormat() throws JsonProcessingException {
     ChangeDescription changeDescription = new ChangeDescription();
-    ChangeEvent changeEvent = new ChangeEvent();
     // Simulate adding owner to a table
     EntityReference entityReference = new EntityReference();
     entityReference.withId(UUID.randomUUID()).withName("user1").withDisplayName("User One");
@@ -97,9 +92,8 @@ public class ChangeEventParserTest extends CatalogApplicationTest {
     addOwner.withName("owner").withNewValue(JsonUtils.pojoToJson(entityReference));
 
     changeDescription.withFieldsAdded(List.of(addOwner)).withPreviousVersion(1.0);
-    changeEvent.withChangeDescription(changeDescription).withPreviousVersion(1.0).withCurrentVersion(1.1);
 
-    Map<EntityLink, String> messages = ChangeEventParser.getFormattedMessages(changeDescription, TABLE, changeEvent);
+    Map<EntityLink, String> messages = ChangeEventParser.getFormattedMessages(changeDescription, TABLE);
     assertEquals(1, messages.size());
 
     assertEquals("Added **owner**: `User One`", messages.values().iterator().next());
@@ -108,15 +102,13 @@ public class ChangeEventParserTest extends CatalogApplicationTest {
   @Test
   void testUpdateOfString() {
     ChangeDescription changeDescription = new ChangeDescription();
-    ChangeEvent changeEvent = new ChangeEvent();
     // Simulate a change of description in table
     FieldChange updateDescription = new FieldChange();
     updateDescription.withName("description").withNewValue("new description").withOldValue("old description");
 
     changeDescription.withFieldsUpdated(List.of(updateDescription)).withPreviousVersion(1.0);
-    changeEvent.withChangeDescription(changeDescription).withPreviousVersion(0.1).withCurrentVersion(1.1);
 
-    Map<EntityLink, String> messages = ChangeEventParser.getFormattedMessages(changeDescription, TABLE, changeEvent);
+    Map<EntityLink, String> messages = ChangeEventParser.getFormattedMessages(changeDescription, TABLE);
     assertEquals(1, messages.size());
 
     assertEquals(
@@ -135,11 +127,8 @@ public class ChangeEventParserTest extends CatalogApplicationTest {
         .withFieldsDeleted(List.of(deleteDescription))
         .withPreviousVersion(1.0);
 
-    changeEvent.withChangeDescription(changeDescription).withPreviousVersion(0.1).withCurrentVersion(1.1);
-
     // now test if both the type of updates give the same message
-    Map<EntityLink, String> updatedMessages =
-        ChangeEventParser.getFormattedMessages(changeDescription, TABLE, changeEvent);
+    Map<EntityLink, String> updatedMessages = ChangeEventParser.getFormattedMessages(changeDescription, TABLE);
     assertEquals(1, updatedMessages.size());
 
     assertEquals(messages.keySet().iterator().next(), updatedMessages.keySet().iterator().next());
@@ -149,7 +138,6 @@ public class ChangeEventParserTest extends CatalogApplicationTest {
   @Test
   void testMajorSchemaChange() {
     ChangeDescription changeDescription = new ChangeDescription();
-    ChangeEvent changeEvent = new ChangeEvent();
     // Simulate a change of column name in table
     FieldChange addColumn = new FieldChange();
     addColumn
@@ -167,9 +155,8 @@ public class ChangeEventParserTest extends CatalogApplicationTest {
         .withFieldsAdded(List.of(addColumn))
         .withFieldsDeleted(List.of(deleteColumn))
         .withPreviousVersion(1.3);
-    changeEvent.withChangeDescription(changeDescription).withPreviousVersion(0.1).withCurrentVersion(2.3);
 
-    Map<EntityLink, String> messages = ChangeEventParser.getFormattedMessages(changeDescription, TABLE, changeEvent);
+    Map<EntityLink, String> messages = ChangeEventParser.getFormattedMessages(changeDescription, TABLE);
     assertEquals(1, messages.size());
 
     assertEquals(
@@ -186,9 +173,8 @@ public class ChangeEventParserTest extends CatalogApplicationTest {
         .withFieldsAdded(List.of(addColumn))
         .withFieldsDeleted(List.of(deleteColumn))
         .withPreviousVersion(1.3);
-    changeEvent.withChangeDescription(changeDescription).withPreviousVersion(0.1).withCurrentVersion(2.3);
 
-    messages = ChangeEventParser.getFormattedMessages(changeDescription, TABLE, changeEvent);
+    messages = ChangeEventParser.getFormattedMessages(changeDescription, TABLE);
     assertEquals(1, messages.size());
 
     assertEquals(
@@ -205,9 +191,8 @@ public class ChangeEventParserTest extends CatalogApplicationTest {
         .withFieldsAdded(List.of(addColumn))
         .withFieldsDeleted(List.of(deleteColumn))
         .withPreviousVersion(1.4);
-    changeEvent.withChangeDescription(changeDescription).withPreviousVersion(0.1).withCurrentVersion(2.4);
 
-    messages = ChangeEventParser.getFormattedMessages(changeDescription, TABLE, changeEvent);
+    messages = ChangeEventParser.getFormattedMessages(changeDescription, TABLE);
     assertEquals(1, messages.size());
 
     assertEquals(


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
See #3080 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [ ] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
