### PR TITLE
Fix #3112 - col profile safety & sample data

### DIFF
--- a/catalog-rest-service/src/main/resources/json/schema/tests/column/columnValuesToBeNotInSet.json
+++ b/catalog-rest-service/src/main/resources/json/schema/tests/column/columnValuesToBeNotInSet.json
@@ -8,7 +8,10 @@
   "properties": {
     "values": {
       "description": "An Array of values.",
-      "type": "array"
+      "type": "array",
+      "items": {
+        "type": ["string", "number"]
+      }
     }
   },
   "required": ["values"],

--- a/catalog-rest-service/src/main/resources/json/schema/tests/column/columnValuesToBeNotInSet.json
+++ b/catalog-rest-service/src/main/resources/json/schema/tests/column/columnValuesToBeNotInSet.json
@@ -6,7 +6,7 @@
   "type": "object",
   "javaType": "org.openmetadata.catalog.tests.column.ColumnValuesToBeNotInSet",
   "properties": {
-    "values": {
+    "forbiddenValues": {
       "description": "An Array of values.",
       "type": "array",
       "items": {
@@ -14,6 +14,6 @@
       }
     }
   },
-  "required": ["values"],
+  "required": ["forbiddenValues"],
   "additionalProperties": false
 }

--- a/ingestion-core/src/metadata/_version.py
+++ b/ingestion-core/src/metadata/_version.py
@@ -7,5 +7,5 @@ Provides metadata version information.
 
 from incremental import Version
 
-__version__ = Version("metadata", 0, 9, 0, dev=18)
+__version__ = Version("metadata", 0, 9, 0, dev=19)
 __all__ = ["__version__"]

--- a/ingestion/examples/sample_data/datasets/tableTests.json
+++ b/ingestion/examples/sample_data/datasets/tableTests.json
@@ -266,6 +266,44 @@
           "testCaseStatus": "Success",
           "result": "Found min=1.0 vs. the expected min=0"
         }
+      },
+      {
+        "columnName": "last_name",
+        "description": "We have reserved last names",
+        "testCase": {
+          "config": {
+            "forbiddenValues": [
+              "forbidden",
+              "random"
+            ]
+          },
+          "columnTestType": "columnValuesToBeNotInSet"
+        },
+        "executionFrequency": "Daily",
+        "result": {
+          "executionTime": 1646220190,
+          "testCaseStatus": "Success",
+          "result": "Found countInSet=0"
+        }
+      },
+      {
+        "columnName": "last_name",
+        "description": "We have reserved last names",
+        "testCase": {
+          "config": {
+            "forbiddenValues": [
+              "forbidden",
+              "random"
+            ]
+          },
+          "columnTestType": "columnValuesToBeNotInSet"
+        },
+        "executionFrequency": "Daily",
+        "result": {
+          "executionTime": 1646221199,
+          "testCaseStatus": "Success",
+          "result": "Found countInSet=0"
+        }
       }
     ]
   }

--- a/ingestion/examples/sample_data/datasets/tableTests.json
+++ b/ingestion/examples/sample_data/datasets/tableTests.json
@@ -46,6 +46,38 @@
           "testCaseStatus": "Success",
           "result": "Found 5.0 columns vs. the expected 5"
         }
+      },
+      {
+        "description": "Rows should always be 100 because of something",
+        "testCase": {
+          "config": {
+            "minValue": 100,
+            "maxValue": 200
+          },
+          "tableTestType": "tableRowCountToBeBetween"
+        },
+        "executionFrequency": "Daily",
+        "result": {
+          "executionTime": 1646220190,
+          "testCaseStatus": "Success",
+          "result": "Found 120.0 rows vs. the expected range [100, 200]"
+        }
+      },
+      {
+        "description": "Rows should always be 100 because of something",
+        "testCase": {
+          "config": {
+            "minValue": 100,
+            "maxValue": 200
+          },
+          "tableTestType": "tableRowCountToBeBetween"
+        },
+        "executionFrequency": "Daily",
+        "result": {
+          "executionTime": 1646221199,
+          "testCaseStatus": "Success",
+          "result": "Found 120.0 rows vs. the expected range [100, 200]"
+        }
       }
     ],
     "columnTests": [
@@ -90,9 +122,149 @@
         },
         "executionFrequency": "Daily",
         "result": {
+          "executionTime": 1646220190,
+          "testCaseStatus": "Success",
+          "result": "Found uniqueCount=100.0 vs. valuesCount=100.0"
+        }
+      },
+      {
+        "columnName": "email",
+        "description": "emails should be unique",
+        "testCase": {
+          "config": {},
+          "columnTestType": "columnValuesToBeUnique"
+        },
+        "executionFrequency": "Daily",
+        "result": {
           "executionTime": 1646221199,
           "testCaseStatus": "Success",
           "result": "Found uniqueCount=100.0 vs. valuesCount=100.0"
+        }
+      },
+      {
+        "columnName": "user_id",
+        "description": "user_id should be not null",
+        "testCase": {
+          "config": {},
+          "columnTestType": "columnValuesToBeNotNull"
+        },
+        "executionFrequency": "Daily",
+        "result": {
+          "executionTime": 1646220190,
+          "testCaseStatus": "Success",
+          "result": "Found nullCount=0"
+        }
+      },
+      {
+        "columnName": "user_id",
+        "description": "user_id should be not null",
+        "testCase": {
+          "config": {},
+          "columnTestType": "columnValuesToBeNotNull"
+        },
+        "executionFrequency": "Daily",
+        "result": {
+          "executionTime": 1646221199,
+          "testCaseStatus": "Success",
+          "result": "Found nullCount=0"
+        }
+      },
+      {
+        "columnName": "last_name",
+        "description": "last_name should match a regex",
+        "testCase": {
+          "config": {
+            "regex": "%something%"
+          },
+          "columnTestType": "columnValuesToMatchRegex"
+        },
+        "executionFrequency": "Daily",
+        "result": {
+          "executionTime": 1646220190,
+          "testCaseStatus": "Failed",
+          "result": "Found likeCount=0. Nothing matches %something%"
+        }
+      },
+      {
+        "columnName": "last_name",
+        "description": "last_name should match a regex",
+        "testCase": {
+          "config": {
+            "regex": "%something%"
+          },
+          "columnTestType": "columnValuesToMatchRegex"
+        },
+        "executionFrequency": "Daily",
+        "result": {
+          "executionTime": 1646221199,
+          "testCaseStatus": "Failed",
+          "result": "Found likeCount=0. Nothing matches %something%"
+        }
+      },
+      {
+        "columnName": "first_name",
+        "description": "Some description...",
+        "testCase": {
+          "config": {
+            "missingCountValue": 10
+          },
+          "columnTestType": "columnValuesMissingCountToBeEqual"
+        },
+        "executionFrequency": "Daily",
+        "result": {
+          "executionTime": 1646220190,
+          "testCaseStatus": "Failed",
+          "result": "Found nullCount=0.0 vs. the expected nullCount=10"
+        }
+      },
+      {
+        "columnName": "first_name",
+        "description": "Some description...",
+        "testCase": {
+          "config": {
+            "missingCountValue": 10
+          },
+          "columnTestType": "columnValuesMissingCountToBeEqual"
+        },
+        "executionFrequency": "Daily",
+        "result": {
+          "executionTime": 1646221199,
+          "testCaseStatus": "Failed",
+          "result": "Found nullCount=0.0 vs. the expected nullCount=10"
+        }
+      },
+      {
+        "columnName": "email",
+        "description": "email should have a fixed length",
+        "testCase": {
+          "config": {
+            "minValue": 6,
+            "maxValue": 30
+          },
+          "columnTestType": "columnValuesToBeBetween"
+        },
+        "executionFrequency": "Daily",
+        "result": {
+          "executionTime": 1646221199,
+          "testCaseStatus": "Success",
+          "result": "Found min=1.0 vs. the expected min=0"
+        }
+      },
+      {
+        "columnName": "email",
+        "description": "email should have a fixed length",
+        "testCase": {
+          "config": {
+            "minValue": 6,
+            "maxValue": 30
+          },
+          "columnTestType": "columnValuesToBeBetween"
+        },
+        "executionFrequency": "Daily",
+        "result": {
+          "executionTime": 1646220190,
+          "testCaseStatus": "Success",
+          "result": "Found min=1.0 vs. the expected min=0"
         }
       }
     ]

--- a/ingestion/src/metadata/orm_profiler/profiles/core.py
+++ b/ingestion/src/metadata/orm_profiler/profiles/core.py
@@ -341,7 +341,8 @@ class Profiler(Generic[MetricType]):
             # Let's filter those out.
             computed_profiles = [
                 ColumnProfile(**self.column_results.get(col.name))
-                for col in self.columns if self.column_results.get(col.name)
+                for col in self.columns
+                if self.column_results.get(col.name)
             ]
 
             profile = TableProfile(

--- a/ingestion/src/metadata/orm_profiler/profiles/core.py
+++ b/ingestion/src/metadata/orm_profiler/profiles/core.py
@@ -335,14 +335,20 @@ class Profiler(Generic[MetricType]):
         We need to transform it to TableProfile
         """
         try:
+
+            # There are columns that we might have skipped from
+            # computing metrics, if the type is not supported.
+            # Let's filter those out.
+            computed_profiles = [
+                ColumnProfile(**self.column_results.get(col.name))
+                for col in self.columns if self.column_results.get(col.name)
+            ]
+
             profile = TableProfile(
                 profileDate=self.profile_date.strftime("%Y-%m-%d"),
-                columnCount=self._table_results.get("columnCount"),  # TODO IMPLEMENT
+                columnCount=self._table_results.get("columnCount"),
                 rowCount=self._table_results.get(RowCount.name()),
-                columnProfile=[
-                    ColumnProfile(**self._column_results.get(col.name))
-                    for col in self.columns
-                ],
+                columnProfile=computed_profiles,
             )
 
             return profile

--- a/ingestion/src/metadata/orm_profiler/validations/column/column_values_not_in_set.py
+++ b/ingestion/src/metadata/orm_profiler/validations/column/column_values_not_in_set.py
@@ -49,7 +49,7 @@ def column_values_not_in_set(
     :return: TestCaseResult with status and results
     """
 
-    set_count = add_props(values=test_case.values)(Metrics.COUNT_IN_SET.value)
+    set_count = add_props(values=test_case.forbiddenValues)(Metrics.COUNT_IN_SET.value)
 
     try:
         col = next(

--- a/ingestion/tests/unit/profiler/test_session_validations.py
+++ b/ingestion/tests/unit/profiler/test_session_validations.py
@@ -81,7 +81,7 @@ class MetricsTest(TestCase):
         column_profile = ColumnProfile(name="name")  # column name
 
         res_ok = validate(
-            ColumnValuesToBeNotInSet(values=["random", "forbidden"]),
+            ColumnValuesToBeNotInSet(forbiddenValues=["random", "forbidden"]),
             col_profile=column_profile,
             execution_date=EXECUTION_DATE,
             session=self.session,
@@ -95,7 +95,7 @@ class MetricsTest(TestCase):
         )
 
         res_ko = validate(
-            ColumnValuesToBeNotInSet(values=["John", "forbidden"]),
+            ColumnValuesToBeNotInSet(forbiddenValues=["John", "forbidden"]),
             col_profile=column_profile,
             execution_date=EXECUTION_DATE,
             session=self.session,
@@ -109,7 +109,7 @@ class MetricsTest(TestCase):
         )
 
         res_aborted = validate(
-            ColumnValuesToBeNotInSet(values=["John", "forbidden"]),
+            ColumnValuesToBeNotInSet(forbiddenValues=["John", "forbidden"]),
             col_profile=ColumnProfile(name="random"),
             execution_date=EXECUTION_DATE,
             session=self.session,


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
This PR fixes https://github.com/open-metadata/OpenMetadata/issues/3112

We have:
- Added some safety when getting column profile data
- Constrained a bit more a test type value
- Added sample tests
- Changed the name of columnValuesToBeNotInSet from `values` to `forbiddenValues`, otherwise pydantic was having a hard time with the parsing. This should fix https://github.com/open-metadata/OpenMetadata/issues/3143


Thanks

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [x] New feature
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have performed a self-review of my own. 
- [ ] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
