### PR TITLE
Fix: Query Parser

### DIFF
--- a/ingestion/src/metadata/ingestion/processor/query_parser.py
+++ b/ingestion/src/metadata/ingestion/processor/query_parser.py
@@ -82,7 +82,7 @@ class QueryParserProcessor(Processor):
             start_date = record.analysis_date
             if isinstance(record.analysis_date, str):
                 start_date = datetime.datetime.strptime(
-                    record.analysis_date, "%Y-%m-%d %H:%M:%S"
+                    str(record.analysis_date), "%Y-%m-%d %H:%M:%S"
                 ).date()
             parser = Parser(record.sql)
             columns_dict = {} if parser.columns_dict is None else parser.columns_dict


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
User was facing 

        [2022-03-04 16:40:24,291] INFO     {metadata.ingestion.source.sql_source_common:33} - Table Scanned:
        [2022-03-04 16:40:24,291] ERROR    {metadata.ingestion.processor.query_parser:74} - strptime() argument 1 must be str, not datetime.datetime
Strptime expecting str got datetime fix
#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
@harshach @pmbrull 