### PR TITLE
Fix: issue-2789 Unable to expand Tier1,Tier2 and Tier 3 description on breadcrumb

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/tags/tags.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/tags/tags.tsx
@@ -79,7 +79,10 @@ const Tags: FunctionComponent<TagProps> = ({
                 <div className="tw-text-left tw-p-1">
                   {tag.description && (
                     <div className="tw-mb-3">
-                      <RichTextEditorPreviewer markdown={tag.description} />
+                      <RichTextEditorPreviewer
+                        enableSeeMoreVariant={false}
+                        markdown={tag.description}
+                      />
                     </div>
                   )}
                   <p>Set as {tag.labelType}</p>


### PR DESCRIPTION
Closes #2789 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I work on issue-2789 Unable to expand Tier1,Tier2 and Tier 3 description on breadcrumb

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<img width="1800" alt="image" src="https://user-images.githubusercontent.com/71748675/157009017-637d9939-a042-465a-b682-235021387f53.png">
<img width="1800" alt="image" src="https://user-images.githubusercontent.com/71748675/157009123-4df67163-b0b2-4e63-b4be-f3121b20d9fe.png">

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have performed a self-review of my own. 
- [ ] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya 
