### PR TITLE
fixed issue-3312: filter out the owned object with entities

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { EntityType } from '../../enums/entity.enum';
 import { EntityReference, User } from '../../generated/entity/teams/user';
 import UserCard from '../../pages/teams/UserCard';
 import SVGIcons, { Icons } from '../../utils/SvgUtils';
@@ -41,6 +42,12 @@ const Users = ({ userData }: Props) => {
       position: 2,
     },
   ];
+
+  const getEntityDetails = (data: EntityReference[]) => {
+    const includedEntity = Object.values(EntityType);
+
+    return data.filter((d) => includedEntity.includes(d.type as EntityType));
+  };
 
   const fetchLeftPanel = () => {
     return (
@@ -135,14 +142,14 @@ const Users = ({ userData }: Props) => {
       <div>
         {activeTab === 1 &&
           getEntityData(
-            userData?.owns || [],
+            getEntityDetails(userData?.owns || []),
             `${
               userData?.displayName || userData?.name || 'User'
             } does not own anything yet`
           )}
         {activeTab === 2 &&
           getEntityData(
-            userData?.follows || [],
+            getEntityDetails(userData?.follows || []),
             `${
               userData?.displayName || userData?.name || 'User'
             } does not follow anything yet`

--- a/openmetadata-ui/src/main/resources/ui/src/pages/teams/UserCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/teams/UserCard.tsx
@@ -125,7 +125,7 @@ const UserCard = ({
     <div
       className={classNames(
         'tw-card tw-flex tw-justify-between tw-py-2 tw-px-3 tw-group',
-        { 'tw-py-5': isDataset }
+        { 'tw-py-5 tw-items-center': isDataset }
       )}
       data-testid="user-card-container">
       <div className={`tw-flex ${isCheckBoxes ? 'tw-mr-2' : 'tw-gap-1'}`}>

--- a/openmetadata-ui/src/main/resources/ui/src/pages/teams/UserCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/teams/UserCard.tsx
@@ -39,6 +39,7 @@ enum DatasetType {
   TABLE = 'table',
   TOPIC = 'topic',
   DASHBOARD = 'dashboard',
+  PIPELINE = 'pipeline',
 }
 
 const UserCard = ({
@@ -74,6 +75,10 @@ const UserCard = ({
         break;
       case DatasetType.DASHBOARD:
         icon = Icons.DASHBOARD;
+
+        break;
+      case DatasetType.PIPELINE:
+        icon = Icons.PIPELINE;
 
         break;
       case DatasetType.TABLE:


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Closes #3312 
I worked filter out the owned object with entities in user profile and alignment issue fixed.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement

#
### Frontend Preview (Screenshots) :
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/71748675/157470136-2e903fb3-7474-4f5d-8d62-005935abaf1c.png">


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
 Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya 
