### PR TITLE
Fixed issue: 3333 Data Quality - Check tests being supported in Date but not Timestamp

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/TableProfiler.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/TableProfiler.component.tsx
@@ -11,6 +11,7 @@
  *  limitations under the License.
  */
 
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import classNames from 'classnames';
 import React, { FC, Fragment } from 'react';
 import { Link } from 'react-router-dom';
@@ -29,7 +30,6 @@ import { Button } from '../buttons/Button/Button';
 import NonAdminAction from '../common/non-admin-action/NonAdminAction';
 import PopOver from '../common/popover/PopOver';
 import RichTextEditorPreviewer from '../common/rich-text-editor/RichTextEditorPreviewer';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 type Props = {
   tableProfiles: Table['tableProfile'];
@@ -290,7 +290,7 @@ const TableProfiler: FC<Props> = ({
                           `No tests available`
                         )}
                         <div className="tw-self-center tw-ml-5">
-                          {col.name.colType.length > 25 ? (
+                          {col.name.colType.includes('struct') ? (
                             <span>Not supported</span>
                           ) : (
                             <NonAdminAction

--- a/openmetadata-ui/src/main/resources/ui/src/styles/fonts.css
+++ b/openmetadata-ui/src/main/resources/ui/src/styles/fonts.css
@@ -12,7 +12,7 @@
  */
 
 @font-face {
-    font-family: "Inter";
-    src: url("../fonts/Inter/Inter-VariableFont_slnt,wght.ttf") format("truetype");
-    font-weight: normal;
+  font-family: 'Inter';
+  src: url('../fonts/Inter/Inter-VariableFont_slnt,wght.ttf') format('truetype');
+  font-weight: normal;
 }

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityUtils.tsx
@@ -499,7 +499,8 @@ export const filteredColumnTestOption = (dataType: string) => {
         (test) => test !== ColumnTestType.columnValuesToBeBetween
       );
 
-    case 'timestamp': {
+    case 'timestamp':
+    case 'date': {
       const excluded = [
         ColumnTestType.columnValuesToBeNotInSet,
         ColumnTestType.columnValueLengthsToBeBetween,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TableUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TableUtils.tsx
@@ -11,6 +11,7 @@
  *  limitations under the License.
  */
 
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import classNames from 'classnames';
 import { upperCase } from 'lodash';
 import { EntityTags, TableDetail } from 'Models';
@@ -36,7 +37,6 @@ import { TagLabel } from '../generated/type/tagLabel';
 import { ModifiedTableColumn } from '../interface/dataQuality.interface';
 import { ordinalize } from './StringsUtils';
 import SVGIcons from './SvgUtils';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 export const getBadgeName = (tableType?: string) => {
   switch (tableType) {
@@ -295,6 +295,8 @@ export const getDataTypeString = (dataType: string): string => {
     case DataType.Timestamp:
     case DataType.Time:
       return 'timestamp';
+    case DataType.Date:
+      return 'date';
     case DataType.Int:
     case DataType.Float:
     case DataType.Smallint:


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Closes #3333
1. Work on fixing timestamp issue were its not allow to add test from profiler when `timestamp is without time zone`.
2. Added support to filter column test options for `DATE` datatype

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement

#
### Frontend Preview (Screenshots) :
<img width="1460" alt="image" src="https://user-images.githubusercontent.com/71748675/158159318-5fb7d9e3-90ad-41ec-8f26-eb35b3b5495c.png">


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->

@Sachin-chaurasiya @darth-coder00 @shahsank3t 