### PR TITLE
Fix 3377: Logs to be printed only once

### DIFF
--- a/ingestion/src/metadata/cli/docker.py
+++ b/ingestion/src/metadata/cli/docker.py
@@ -10,16 +10,6 @@ import click
 import requests as requests
 
 logger = logging.getLogger(__name__)
-
-logging.getLogger("urllib3").setLevel(logging.WARN)
-handler = logging.StreamHandler()
-handler.setFormatter(
-    logging.Formatter(
-        "[%(asctime)s] %(levelname)-8s {%(name)s:%(lineno)d} - %(message)s"
-    )
-)
-logger.addHandler(handler)
-
 calc_gb = 1024 * 1024 * 1000
 min_memory_limit = 6 * calc_gb
 


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Logs currently before this fix were printing twice.
Changed those to once.
Fix #3377

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
@harshach @akash-jain-10 