### PR TITLE
Fixed #3247: Drop-down arrow in glossary page appears only on click

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryV1.component.tsx
@@ -11,6 +11,7 @@
  *  limitations under the License.
  */
 
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import classNames from 'classnames';
 import { isEmpty } from 'lodash';
 import { GlossaryTermAssets, LoadingState } from 'Models';
@@ -38,7 +39,6 @@ import GlossaryDetails from '../GlossaryDetails/GlossaryDetails.component';
 import GlossaryTermsV1 from '../GlossaryTerms/GlossaryTermsV1.component';
 import Loader from '../Loader/Loader';
 import ConfirmationModal from '../Modals/ConfirmationModal/ConfirmationModal';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 type Props = {
   assetData: GlossaryTermAssets;
@@ -48,8 +48,9 @@ type Props = {
   glossaryList: ModifiedGlossaryData[];
   selectedKey: string;
   expandedKey: string[];
+  loadingKey: string[];
   handleExpandedKey: (key: string[]) => void;
-  handleSelectedKey: (key: string) => void;
+  handleSelectedKey?: (key: string) => void;
   searchText: string;
   selectedData: Glossary | GlossaryTerm;
   isGlossaryActive: boolean;
@@ -57,7 +58,11 @@ type Props = {
   handleAddGlossaryTermClick: () => void;
   updateGlossary: (value: Glossary) => void;
   handleGlossaryTermUpdate: (value: GlossaryTerm) => void;
-  handleSelectedData: (data: Glossary | GlossaryTerm, pos: string) => void;
+  handleSelectedData: (
+    data: Glossary | GlossaryTerm,
+    pos: string,
+    key: string
+  ) => void;
   handleChildLoading: (status: boolean) => void;
   handleSearchText: (text: string) => void;
   onGlossaryDelete: (id: string) => void;
@@ -82,8 +87,8 @@ const GlossaryV1 = ({
   glossaryList,
   selectedKey,
   expandedKey,
+  loadingKey,
   handleExpandedKey,
-  handleSelectedKey,
   searchText,
   selectedData,
   isGlossaryActive,
@@ -155,17 +160,17 @@ Props) => {
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
     node: EventDataNode
   ) => {
-    handleChildLoading(true);
     const key = node.key as string;
-    const breadCrumbData = (treeRef.current?.state.keyEntities[key].nodes ||
-      []) as ModifiedDataNode[];
-    const pos = treeRef.current?.state.keyEntities[key].pos;
-    handleSelectedData(
-      breadCrumbData[breadCrumbData.length - 1].data,
-      pos as string
-    );
+    if (selectedKey !== key) {
+      handleChildLoading(true);
+      const breadCrumbData = (treeRef.current?.state.keyEntities[key].nodes ||
+        []) as ModifiedDataNode[];
+      const selData = breadCrumbData[breadCrumbData.length - 1].data;
+      const pos = treeRef.current?.state.keyEntities[key].pos;
+      handleSelectedData(selData, pos as string, key);
+    }
     // handlePathChange(key.split('.')[0], key);
-    handleSelectedKey(key);
+    // handleSelectedKey(key);
   };
 
   useEffect(() => {
@@ -221,6 +226,7 @@ Props) => {
                   expandedKeys={expandedKey}
                   handleClick={handleTreeClick}
                   handleExpand={(key) => handleExpandedKey(key as string[])}
+                  loadingKey={loadingKey}
                   ref={treeRef}
                   selectedKeys={[selectedKey]}
                   treeData={treeData}

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/TreeView/TreeView.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/TreeView/TreeView.interface.ts
@@ -6,6 +6,7 @@ export interface TreeViewProps {
   showIcon?: boolean;
   selectedKeys?: string[];
   expandedKeys?: string[];
+  loadingKey?: string[];
   handleClick?: (
     event: React.MouseEvent<HTMLElement>,
     node: EventDataNode

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/TreeView/treeView.css
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/TreeView/treeView.css
@@ -9,8 +9,12 @@
   background-image: none !important;
 }
 
-.rc-tree-node-content-wrapper {
-  margin-left: 3px !important;
+.rc-tree:not(.show-switcher) .rc-tree-switcher {
+  display: none !important;
+}
+
+.rc-tree .rc-tree-treenode span.rc-tree-iconEle {
+  margin-right: 5px !important;
 }
 
 .rc-tree-node-content-wrapper:hover {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/GlossaryPage/GlossaryPageV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/GlossaryPage/GlossaryPageV1.component.tsx
@@ -27,10 +27,8 @@ import { useAuthContext } from '../../auth-provider/AuthProvider';
 import {
   deleteGlossary,
   deleteGlossaryTerm,
-  getGlossaries,
   getGlossariesByName,
   getGlossaryTermByFQN,
-  getGlossaryTerms,
   patchGlossaries,
   patchGlossaryTerm,
 } from '../../axiosAPIs/glossaryAPI';
@@ -51,6 +49,8 @@ import { useAuth } from '../../hooks/authHooks';
 import useToastContext from '../../hooks/useToastContext';
 import { formatDataResponse } from '../../utils/APIUtils';
 import {
+  getChildGlossaryTerms,
+  getGlossariesWithRootTerms,
   getHierarchicalKeysByFQN,
   updateGlossaryListBySearchedTerms,
 } from '../../utils/GlossaryUtils';
@@ -75,6 +75,7 @@ const GlossaryPageV1 = () => {
   >([]);
   const [selectedKey, setSelectedKey] = useState<string>('');
   const [expandedKey, setExpandedKey] = useState<string[]>([]);
+  const [loadingKey, setLoadingKey] = useState<string[]>([]);
   const [selectedData, setSelectedData] = useState<Glossary | GlossaryTerm>();
   const [isGlossaryActive, setIsGlossaryActive] = useState(true);
   const [searchText, setSearchText] = useState('');
@@ -91,50 +92,12 @@ const GlossaryPageV1 = () => {
     setIsChildLoading(status);
   };
 
-  const fetchGlossaryTermsData = (id?: string) => {
-    getGlossaryTerms(id, 100, ['children', 'relatedTerms', 'reviewers', 'tags'])
-      .then((res: AxiosResponse) => {
-        const { data } = res.data;
+  const handleSelectedKey = (key: string) => {
+    setSelectedKey(key);
+  };
 
-        // Filtering root level terms from glossary
-        const updatedData = data.filter((d: GlossaryTerm) => !d.parent);
-
-        setGlossariesList((pre) => {
-          return pre.map((d) => {
-            let data = d;
-            if (d.id === id) {
-              let { children } = d;
-              children = ((updatedData as GlossaryTerm[]) || [])?.reduce(
-                (prev, curr) => {
-                  const data = prev.find((item) => {
-                    const itemFQN = item.fullyQualifiedName || item.name;
-                    const currFQN = curr.fullyQualifiedName || curr.name;
-
-                    return itemFQN === currFQN;
-                  });
-
-                  return data ? [...prev] : [...prev, curr];
-                },
-                children || []
-              );
-              data = { ...d, children };
-            }
-
-            return data;
-          });
-        });
-      })
-      .catch((err: AxiosError) => {
-        showToast({
-          variant: 'error',
-          body:
-            err.response?.data?.message ??
-            'Error while fetching glossary terms!',
-        });
-      })
-      .finally(() => {
-        setIsLoading(false);
-      });
+  const handleExpandedKey = (key: string[]) => {
+    setExpandedKey(key);
   };
 
   const initSelectGlossary = (data: Glossary, noSetData = false) => {
@@ -144,22 +107,20 @@ const GlossaryPageV1 = () => {
       setSelectedKey(data.name);
     }
     setExpandedKey([data.name]);
-    fetchGlossaryTermsData(data.id);
   };
 
   const fetchGlossaryList = (pagin = '') => {
     setIsLoading(true);
-    getGlossaries(pagin, 100, ['owner', 'tags', 'reviewers'])
-      .then((res: AxiosResponse) => {
-        const { data } = res.data;
+    getGlossariesWithRootTerms(pagin, 100, ['owner', 'tags', 'reviewers'])
+      .then((data: ModifiedGlossaryData[]) => {
         if (data?.length) {
           setGlossaries(data);
           setGlossariesList(data);
           initSelectGlossary(data[0]);
         } else {
           setGlossariesList([]);
-          setIsLoading(false);
         }
+        setIsLoading(false);
       })
       .catch((err: AxiosError) => {
         showToast({
@@ -173,14 +134,18 @@ const GlossaryPageV1 = () => {
       });
   };
 
-  const fetchGlossaryTermByName = (name: string, pos: string[]) => {
+  const fetchGlossaryTermByName = (
+    name: string,
+    pos: string[],
+    key?: string
+  ) => {
     getGlossaryTermByFQN(name, [
       'children',
       'relatedTerms',
       'reviewers',
       'tags',
     ])
-      .then((res: AxiosResponse) => {
+      .then(async (res: AxiosResponse) => {
         const { data } = res;
         if (data) {
           const clonedGlossaryList = cloneDeep(glossariesList);
@@ -193,24 +158,44 @@ const GlossaryPageV1 = () => {
             }
           }
 
-          let children = [...(treeNode.children || [])];
+          let children = [...(treeNode.children || [])] as GlossaryTerm[];
 
-          children = (
-            (data.children as ModifiedGlossaryData['children']) || []
-          )?.reduce((prev, curr) => {
-            const data = prev.find((item) => {
+          let childTerms = [] as GlossaryTerm[];
+          if (data.children?.length) {
+            childTerms = await getChildGlossaryTerms(
+              (data.children as GlossaryTerm[]).map(
+                (item) => item.fullyQualifiedName || item.name
+              )
+            );
+          }
+
+          children = childTerms.reduce((prev, curr) => {
+            let arrData = [] as GlossaryTerm[];
+            for (let i = 0; i < prev.length; i++) {
+              const item = prev[i];
               const itemFQN = item.fullyQualifiedName || item.name;
               const currFQN = curr.fullyQualifiedName || curr.name;
 
-              return itemFQN === currFQN;
-            });
+              if (itemFQN === currFQN) {
+                if (item.children?.length !== curr.children?.length) {
+                  arrData = [...prev.slice(0, i), curr, ...prev.slice(i + 1)];
+                } else {
+                  arrData = [...prev];
+                }
 
-            return data ? [...prev] : [...prev, curr];
+                break;
+              }
+            }
+
+            return arrData.length ? arrData : [...prev, curr];
           }, children);
 
           extend(treeNode, { ...data, children });
 
           setSelectedData(data);
+          if (key) {
+            handleSelectedKey(key);
+          }
           setGlossariesList(clonedGlossaryList);
           setIsGlossaryActive(false);
         }
@@ -223,7 +208,12 @@ const GlossaryPageV1 = () => {
             'Error while fetching glossary terms!',
         });
       })
-      .finally(() => handleChildLoading(false));
+      .finally(() => {
+        handleChildLoading(false);
+        setLoadingKey((pre) => {
+          return pre.filter((item) => item !== key);
+        });
+      });
   };
 
   const getSearchedGlossaries = (
@@ -429,14 +419,6 @@ const GlossaryPageV1 = () => {
     }
   };
 
-  const handleSelectedKey = (key: string) => {
-    setSelectedKey(key);
-  };
-
-  const handleExpandedKey = (key: string[]) => {
-    setExpandedKey(key);
-  };
-
   const fetchGlossaryTermAssets = (data: GlossaryTerm, forceReset = false) => {
     if (data?.fullyQualifiedName || data?.name) {
       const tagName = data?.fullyQualifiedName || data?.name; // Incase fqn is not fetched yet.
@@ -487,19 +469,27 @@ const GlossaryPageV1 = () => {
     setAssetData((pre) => ({ ...pre, currPage: page }));
   };
 
-  const handleSelectedData = (data: Glossary | GlossaryTerm, pos: string) => {
+  const handleSelectedData = (
+    data: Glossary | GlossaryTerm,
+    pos: string,
+    key: string
+  ) => {
     handleChildLoading(true);
     const hierarchy = pos.split('-').splice(1);
     // console.log(hierarchy);
     if (hierarchy.length < 2) {
       setSelectedData(data);
-      fetchGlossaryTermsData(data.id);
+      handleSelectedKey(key);
       setIsGlossaryActive(true);
       handleChildLoading(false);
     } else {
+      setLoadingKey((pre) => {
+        return !pre.includes(key) ? [...pre, key] : pre;
+      });
       fetchGlossaryTermByName(
         (data as GlossaryTerm)?.fullyQualifiedName || data?.name,
-        hierarchy
+        hierarchy,
+        key
       );
       fetchGlossaryTermAssets(data as GlossaryTerm, true);
     }
@@ -538,11 +528,11 @@ const GlossaryPageV1 = () => {
           handleGlossaryTermUpdate={handleGlossaryTermUpdate}
           handleSearchText={handleSearchText}
           handleSelectedData={handleSelectedData}
-          handleSelectedKey={handleSelectedKey}
           isChildLoading={isChildLoading}
           isGlossaryActive={isGlossaryActive}
           isHasAccess={!isAdminUser && !isAuthDisabled}
           isSearchResultEmpty={isSearchResultEmpty}
+          loadingKey={loadingKey}
           searchText={searchText}
           selectedData={selectedData as Glossary | GlossaryTerm}
           selectedKey={selectedKey}


### PR DESCRIPTION
### Describe your changes :
Closes #3247 
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the preemptive child data loading for glossary and glossary terms

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Frontend Preview (Screenshots) :
<p align="center">
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@shahsank3t @Sachin-chaurasiya @vivekratnavel 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
