### PR TITLE
Fix issue-3406 wrong toast on UI for editing tests, issue-3452 config value is not getting display in edit mode

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/AddDataQualityTest/Forms/TableTestForm.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AddDataQualityTest/Forms/TableTestForm.tsx
@@ -64,7 +64,7 @@ const TableTestForm = ({
     data?.testCase?.config?.maxValue
   );
   const [value, setValue] = useState<number | undefined>(
-    data?.testCase.config?.value
+    data?.testCase.config?.value || data?.testCase.config?.columnCount
   );
   const [frequency, setFrequency] = useState<TestCaseExecutionFrequency>(
     data?.executionFrequency

--- a/openmetadata-ui/src/main/resources/ui/src/constants/DatasetDetails.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/DatasetDetails.constants.ts
@@ -1,0 +1,14 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+export const TEST_DELETE_MSG = 'Test deleted successfully.';

--- a/openmetadata-ui/src/main/resources/ui/src/constants/constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/constants.ts
@@ -31,6 +31,8 @@ export const imageTypes = {
   image512: 's512-c',
   image72: 's72-c',
 };
+
+export const COMMON_ERROR_MSG = 'Something went wrong.';
 export const TOUR_SEARCH_TERM = 'dim_a';
 export const ERROR404 = 'No data found';
 export const ERROR500 = 'Something went wrong';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatasetDetailsPage/DatasetDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatasetDetailsPage/DatasetDetailsPage.component.tsx
@@ -54,11 +54,13 @@ import {
 } from '../../components/EntityLineage/EntityLineage.interface';
 import Loader from '../../components/Loader/Loader';
 import {
+  COMMON_ERROR_MSG,
   getDatabaseDetailsPath,
   getServiceDetailsPath,
   getTableTabPath,
   getVersionPath,
 } from '../../constants/constants';
+import { TEST_DELETE_MSG } from '../../constants/DatasetDetails.constants';
 import { ColumnTestType } from '../../enums/columnTest.enum';
 import { EntityType, TabSpecificField } from '../../enums/entity.enum';
 import { ServiceCategory } from '../../enums/service.enum';
@@ -661,13 +663,13 @@ const DatasetDetailsPage: FunctionComponent = () => {
           variant: 'success',
           body: `Test ${data.testCase.tableTestType} for ${name} has been ${
             itsNewTest ? 'added' : 'updated'
-          }.`,
+          } successfully.`,
         });
       })
       .catch(() => {
         showToast({
           variant: 'error',
-          body: 'Something went wrong.',
+          body: COMMON_ERROR_MSG,
         });
       });
   };
@@ -705,13 +707,13 @@ const DatasetDetailsPage: FunctionComponent = () => {
           variant: 'success',
           body: `Test ${data.testCase.columnTestType} for ${
             data.columnName
-          } has been ${itsNewTest ? 'added' : 'updated'}.`,
+          } has been ${itsNewTest ? 'added' : 'updated'} successfully.`,
         });
       })
       .catch(() => {
         showToast({
           variant: 'error',
-          body: 'Something went wrong.',
+          body: COMMON_ERROR_MSG,
         });
       });
   };
@@ -725,13 +727,13 @@ const DatasetDetailsPage: FunctionComponent = () => {
         setTableTestCase(updatedTest);
         showToast({
           variant: 'success',
-          body: `Test successfully deleted.`,
+          body: TEST_DELETE_MSG,
         });
       })
       .catch(() => {
         showToast({
           variant: 'error',
-          body: 'Something went wrong.',
+          body: COMMON_ERROR_MSG,
         });
       });
   };
@@ -760,13 +762,13 @@ const DatasetDetailsPage: FunctionComponent = () => {
         setColumns(updatedColumns);
         showToast({
           variant: 'success',
-          body: `Test successfully deleted.`,
+          body: TEST_DELETE_MSG,
         });
       })
       .catch(() => {
         showToast({
           variant: 'error',
-          body: 'Something went wrong.',
+          body: COMMON_ERROR_MSG,
         });
       });
   };

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatasetDetailsPage/DatasetDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatasetDetailsPage/DatasetDetailsPage.component.tsx
@@ -659,7 +659,9 @@ const DatasetDetailsPage: FunctionComponent = () => {
         handleShowTestForm(false);
         showToast({
           variant: 'success',
-          body: `Test ${data.testCase.tableTestType} for ${name} has been added.`,
+          body: `Test ${data.testCase.tableTestType} for ${name} has been ${
+            itsNewTest ? 'added' : 'updated'
+          }.`,
         });
       })
       .catch(() => {
@@ -673,6 +675,7 @@ const DatasetDetailsPage: FunctionComponent = () => {
   const handleAddColumnTestCase = (data: ColumnTest) => {
     addColumnTestCase(tableDetails.id, data)
       .then((res: AxiosResponse) => {
+        let itsNewTest = true;
         const columnTestRes = res.data.columns.find(
           (d: Column) => d.name === data.columnName
         );
@@ -682,6 +685,10 @@ const DatasetDetailsPage: FunctionComponent = () => {
               (d as ModifiedTableColumn)?.columnTests?.filter(
                 (test) => test.id !== columnTestRes.columnTests[0].id
               ) || [];
+
+            itsNewTest =
+              oldTest.length ===
+              (d as ModifiedTableColumn)?.columnTests?.length;
 
             return {
               ...d,
@@ -696,7 +703,9 @@ const DatasetDetailsPage: FunctionComponent = () => {
         setSelectedColumn(undefined);
         showToast({
           variant: 'success',
-          body: `Test ${data.testCase.columnTestType} for ${data.columnName} has been added.`,
+          body: `Test ${data.testCase.columnTestType} for ${
+            data.columnName
+          } has been ${itsNewTest ? 'added' : 'updated'}.`,
         });
       })
       .catch(() => {
@@ -714,6 +723,10 @@ const DatasetDetailsPage: FunctionComponent = () => {
           (d) => d.testCase.tableTestType !== testType
         );
         setTableTestCase(updatedTest);
+        showToast({
+          variant: 'success',
+          body: `Test successfully deleted.`,
+        });
       })
       .catch(() => {
         showToast({
@@ -745,6 +758,10 @@ const DatasetDetailsPage: FunctionComponent = () => {
           return d;
         });
         setColumns(updatedColumns);
+        showToast({
+          variant: 'success',
+          body: `Test successfully deleted.`,
+        });
       })
       .catch(() => {
         showToast({


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Closes #3406 
Changed toast message for adding and editing test, also added toast notification for deleting test successfully. to keep consistent ui as we are showing toast notification for edit and add

Closes #3452 
Config value is not getting display in edit mode for `columnCoun`

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement

#
### Frontend Preview (Screenshots) :

#3406

https://user-images.githubusercontent.com/71748675/158559188-541ccea3-7b8e-4e91-ac23-966836d01df4.mov




#3452 

https://user-images.githubusercontent.com/71748675/158558397-b04b5798-33ce-4bd1-8543-7b27443217ab.mov



#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->

@harshach @vivekratnavel @Sachin-chaurasiya @shahsank3t @darth-coder00 