### PR TITLE
Fix issue-3473: we need to show only assets in owned and following tab.

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { EntityType } from '../../enums/entity.enum';
+import { AssetsType } from '../../enums/entity.enum';
 import { EntityReference, User } from '../../generated/entity/teams/user';
 import UserCard from '../../pages/teams/UserCard';
 import SVGIcons, { Icons } from '../../utils/SvgUtils';
@@ -43,10 +43,10 @@ const Users = ({ userData }: Props) => {
     },
   ];
 
-  const getEntityDetails = (data: EntityReference[]) => {
-    const includedEntity = Object.values(EntityType);
+  const getAssets = (data: EntityReference[]) => {
+    const includedEntity = Object.values(AssetsType);
 
-    return data.filter((d) => includedEntity.includes(d.type as EntityType));
+    return data.filter((d) => includedEntity.includes(d.type as AssetsType));
   };
 
   const fetchLeftPanel = () => {
@@ -142,14 +142,14 @@ const Users = ({ userData }: Props) => {
       <div>
         {activeTab === 1 &&
           getEntityData(
-            getEntityDetails(userData?.owns || []),
+            getAssets(userData?.owns || []),
             `${
               userData?.displayName || userData?.name || 'User'
             } does not own anything yet`
           )}
         {activeTab === 2 &&
           getEntityData(
-            getEntityDetails(userData?.follows || []),
+            getAssets(userData?.follows || []),
             `${
               userData?.displayName || userData?.name || 'User'
             } does not follow anything yet`

--- a/openmetadata-ui/src/main/resources/ui/src/enums/entity.enum.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/enums/entity.enum.ts
@@ -27,6 +27,13 @@ export enum EntityType {
   WEBHOOK = 'webhook',
 }
 
+export enum AssetsType {
+  TABLE = 'table',
+  TOPIC = 'topic',
+  DASHBOARD = 'dashboard',
+  PIPELINE = 'pipeline',
+}
+
 export enum ChangeType {
   ADDED = 'Added',
   UPDATED = 'Updated',

--- a/openmetadata-ui/src/main/resources/ui/src/pages/teams/UserCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/teams/UserCard.tsx
@@ -18,6 +18,7 @@ import { Link } from 'react-router-dom';
 import { useAuthContext } from '../../auth-provider/AuthProvider';
 import Avatar from '../../components/common/avatar/Avatar';
 import NonAdminAction from '../../components/common/non-admin-action/NonAdminAction';
+import { AssetsType } from '../../enums/entity.enum';
 import { SearchIndex } from '../../enums/search.enum';
 import { Operation } from '../../generated/entity/policies/accessControl/rule';
 import { useAuth } from '../../hooks/authHooks';
@@ -35,13 +36,6 @@ type Props = {
   onRemove?: (value: string) => void;
 };
 
-enum DatasetType {
-  TABLE = 'table',
-  TOPIC = 'topic',
-  DASHBOARD = 'dashboard',
-  PIPELINE = 'pipeline',
-}
-
 const UserCard = ({
   item,
   isActionVisible = false,
@@ -57,10 +51,10 @@ const UserCard = ({
     type: string
   ): Array<'service' | 'database' | 'table' | 'column'> => {
     switch (type) {
-      case DatasetType.TABLE:
+      case AssetsType.TABLE:
         return ['database', 'table'];
-      case DatasetType.TOPIC:
-      case DatasetType.DASHBOARD:
+      case AssetsType.TOPIC:
+      case AssetsType.DASHBOARD:
       default:
         return ['service', 'database', 'table'];
     }
@@ -69,19 +63,19 @@ const UserCard = ({
   const getDatasetIcon = (type: string) => {
     let icon = '';
     switch (type) {
-      case DatasetType.TOPIC:
+      case AssetsType.TOPIC:
         icon = Icons.TOPIC;
 
         break;
-      case DatasetType.DASHBOARD:
+      case AssetsType.DASHBOARD:
         icon = Icons.DASHBOARD;
 
         break;
-      case DatasetType.PIPELINE:
+      case AssetsType.PIPELINE:
         icon = Icons.PIPELINE;
 
         break;
-      case DatasetType.TABLE:
+      case AssetsType.TABLE:
       default:
         icon = Icons.TABLE;
 
@@ -92,7 +86,7 @@ const UserCard = ({
       <SVGIcons
         alt="icon"
         className={classNames('tw-h-4 tw-w-4', {
-          'tw-mt-0.5': type !== DatasetType.DASHBOARD,
+          'tw-mt-0.5': type !== AssetsType.DASHBOARD,
         })}
         icon={icon}
       />
@@ -102,15 +96,19 @@ const UserCard = ({
   const getDatasetTitle = (type: string, fqn: string) => {
     let link = '';
     switch (type) {
-      case DatasetType.TOPIC:
+      case AssetsType.TOPIC:
         link = getEntityLink(SearchIndex.TOPIC, fqn);
 
         break;
-      case DatasetType.DASHBOARD:
+      case AssetsType.PIPELINE:
+        link = getEntityLink(SearchIndex.PIPELINE, fqn);
+
+        break;
+      case AssetsType.DASHBOARD:
         link = getEntityLink(SearchIndex.DASHBOARD, fqn);
 
         break;
-      case DatasetType.TABLE:
+      case AssetsType.TABLE:
       default:
         link = getEntityLink(SearchIndex.TABLE, fqn);
 


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I have filter out the other entity except data assets.
Closes #3473 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/71748675/158773025-46125c2c-4058-4a7a-9c9a-3e4960de4f6e.png">


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
@harshach @vivekratnavel @darth-coder00 @Sachin-chaurasiya 