### PR TITLE
Fixed #3263: Able to save an empty reference in glossary term

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/GlossaryReferenceModal/GlossaryReferenceModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/GlossaryReferenceModal/GlossaryReferenceModal.test.tsx
@@ -1,0 +1,63 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { findByTestId, fireEvent, render } from '@testing-library/react';
+import React from 'react';
+import GlossaryReferenceModal from './GlossaryReferenceModal';
+
+const mockSave = jest.fn();
+const mockCancel = jest.fn();
+const mockRefs: Array<Record<string, string>> = [];
+
+jest.mock('../../GlossaryReferences/GlossaryReferences', () => {
+  return jest.fn().mockReturnValue(<p>GlossaryReferences</p>);
+});
+
+jest.mock('lodash', () => ({
+  isEqual: jest.fn().mockReturnValue(false),
+  cloneDeep: jest.fn().mockReturnValue(mockRefs),
+}));
+
+describe('Test Ingestion modal component', () => {
+  it('Component Should render', async () => {
+    const { container } = render(
+      <GlossaryReferenceModal
+        header="Reference Modal"
+        referenceList={mockRefs}
+        onCancel={mockCancel}
+        onSave={mockSave}
+      />
+    );
+
+    const glossaryRefModal = await findByTestId(container, 'modal-container');
+    const header = await findByTestId(container, 'header');
+    const cancel = await findByTestId(container, 'cancelButton');
+    const save = await findByTestId(container, 'saveButton');
+
+    expect(glossaryRefModal).toBeInTheDocument();
+    expect(header).toBeInTheDocument();
+    expect(header.textContent).toStrictEqual('Reference Modal');
+    expect(cancel).toBeInTheDocument();
+    expect(cancel.textContent).toStrictEqual('Cancel');
+    expect(save).toBeInTheDocument();
+    expect(save.textContent).toStrictEqual('Save');
+
+    fireEvent.click(cancel);
+
+    expect(mockCancel).toBeCalled();
+
+    fireEvent.click(save);
+
+    expect(mockSave).toBeCalled();
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/GlossaryReferenceModal/GlossaryReferenceModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/GlossaryReferenceModal/GlossaryReferenceModal.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { cloneDeep } from 'lodash';
+import { cloneDeep, isEqual } from 'lodash';
 import React, { useState } from 'react';
 import { TermReference } from '../../../generated/entity/data/glossaryTerm';
 import { errorMsg, isValidUrl } from '../../../utils/CommonUtils';
@@ -62,7 +62,11 @@ const GlossaryReferenceModal = ({
       }))
       .filter((item) => item.name && item.endpoint);
     if (isValid(refList)) {
-      onSave(references);
+      if (!isEqual(referenceList, refList)) {
+        onSave(refList);
+      } else {
+        onCancel();
+      }
     } else {
       setErrMsg('Endpoints should be valid URL.');
     }
@@ -86,6 +90,7 @@ const GlossaryReferenceModal = ({
         </div>
         <div className="tw-modal-footer" data-testid="cta-container">
           <Button
+            data-testid="cancelButton"
             size="regular"
             theme="primary"
             variant="link"


### PR DESCRIPTION
### Describe your changes :
Closes #3263 
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the fixing issue of saving empty references in glossary terms

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<p align="center">
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@vivekratnavel @Sachin-chaurasiya @harshach 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
