### PR TITLE
Fix #3501: Having more than one instance behind a load balancer w/o stickiness breaks API pagination

### DIFF
--- a/common/src/main/java/org/openmetadata/common/utils/CipherText.java
+++ b/common/src/main/java/org/openmetadata/common/utils/CipherText.java
@@ -13,15 +13,14 @@
 
 package org.openmetadata.common.utils;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.InvalidKeyException;
-import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Base64;
-import java.util.Random;
 import javax.crypto.Cipher;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.spec.SecretKeySpec;
@@ -29,15 +28,12 @@ import javax.crypto.spec.SecretKeySpec;
 /** Class that uses AEC encryption to encrypt and decrypt plain text */
 public final class CipherText {
   private static CipherText instance = null;
-  private static SecretKeySpec secretKey;
+  private final String key = "nYznHcz+l04TmsCMYGQxANTjNtwiWDQ7IfDkqW1wb1U=";
+  private SecretKeySpec secretKey;
 
-  private CipherText() throws NoSuchAlgorithmException, InvalidKeyException, NoSuchPaddingException {
-    // Generate random set of bytes to be used as secret key
-    byte[] bytes = new byte[16];
-    new Random().nextBytes(bytes);
-
-    // Generate secret key from random bytes
-    bytes = MessageDigest.getInstance("SHA-1").digest(bytes);
+  @VisibleForTesting
+  CipherText() {
+    byte[] bytes = Base64.getDecoder().decode(key);
     secretKey = new SecretKeySpec(Arrays.copyOf(bytes, 16), "AES");
   }
 

--- a/common/src/main/java/org/openmetadata/common/utils/CipherText.java
+++ b/common/src/main/java/org/openmetadata/common/utils/CipherText.java
@@ -28,13 +28,12 @@ import javax.crypto.spec.SecretKeySpec;
 /** Class that uses AEC encryption to encrypt and decrypt plain text */
 public final class CipherText {
   private static CipherText instance = null;
-  private final String key = "nYznHcz+l04TmsCMYGQxANTjNtwiWDQ7IfDkqW1wb1U=";
+  private final String key = "OpenMetadata";
   private SecretKeySpec secretKey;
 
   @VisibleForTesting
   CipherText() {
-    byte[] bytes = Base64.getDecoder().decode(key);
-    secretKey = new SecretKeySpec(Arrays.copyOf(bytes, 16), "AES");
+    secretKey = new SecretKeySpec(Arrays.copyOf(key.getBytes(StandardCharsets.UTF_8), 16), "AES");
   }
 
   public static CipherText instance() throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException {

--- a/common/src/test/java/org/openmetadata/common/utils/CipherTextTest.java
+++ b/common/src/test/java/org/openmetadata/common/utils/CipherTextTest.java
@@ -29,4 +29,14 @@ public class CipherTextTest {
       assertEquals(str, cipherText.decrypt(encryptedStr));
     }
   }
+
+  @Test
+  void encryptTwiceTest() throws GeneralSecurityException, UnsupportedEncodingException {
+    CipherText cipher1 = new CipherText();
+    CipherText cipher2 = new CipherText();
+    String str = "foobar";
+    String token = cipher1.encrypt(str);
+    String clear = cipher2.decrypt(token);
+    assertEquals(str, clear);
+  }
 }


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
See #3501 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [x] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.