### PR TITLE
Add text-summary reporting for UI unit test coverage

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/package.json
+++ b/openmetadata-ui/src/main/resources/ui/package.json
@@ -90,7 +90,7 @@
     "mock-api": "node ./mock-api/app.js",
     "test": "jest --passWithNoTests",
     "test:watch": "jest --passWithNoTests --watch",
-    "test:coverage": "jest --passWithNoTests --coverage",
+    "test:coverage": "jest --passWithNoTests --coverage --coverageReporters=\"text-summary\"",
     "lint": "eslint \"./src/**/*.{js,jsx,ts,tsx}\"",
     "lint:fix": "eslint './src/**/*.{js,jsx,ts,tsx}' --fix",
     "pretty": "prettier . --config './.prettierrc' --write",


### PR DESCRIPTION
Added text summary for unit test coverage, that will report coverage like shown below:

```
=============================== Coverage summary ===============================
Statements   : 39.91% ( 7230/18115 )
Branches     : 18.14% ( 2734/15068 )
Functions    : 21.24% ( 794/3738 )
Lines        : 37.56% ( 5871/15632 )
================================================================================
```
