### PR TITLE
Fixes #3497 API fails to return assets and users belonging to team when the team is deleted

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/DatabaseRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/DatabaseRepository.java
@@ -15,6 +15,7 @@ package org.openmetadata.catalog.jdbi3;
 
 import static javax.ws.rs.core.Response.Status.CREATED;
 import static org.openmetadata.catalog.Entity.FIELD_OWNER;
+import static org.openmetadata.catalog.type.Include.ALL;
 
 import java.io.IOException;
 import java.net.URI;
@@ -139,7 +140,7 @@ public class DatabaseRepository extends EntityRepository<Database> {
     List<String> result = findTo(database.getId(), Entity.DATABASE, Relationship.HAS, Entity.LOCATION);
     if (result.size() == 1) {
       String locationId = result.get(0);
-      return daoCollection.locationDAO().findEntityReferenceById(UUID.fromString(locationId));
+      return daoCollection.locationDAO().findEntityReferenceById(UUID.fromString(locationId), ALL);
     } else {
       return null;
     }

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/DatabaseServiceRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/DatabaseServiceRepository.java
@@ -89,7 +89,7 @@ public class DatabaseServiceRepository extends EntityRepository<DatabaseService>
     List<EntityReference> airflowPipelines = new ArrayList<>();
     for (String airflowPipelineId : airflowPipelineIds) {
       airflowPipelines.add(
-          daoCollection.airflowPipelineDAO().findEntityReferenceById(UUID.fromString(airflowPipelineId)));
+          daoCollection.airflowPipelineDAO().findEntityReferenceById(UUID.fromString(airflowPipelineId), Include.ALL));
     }
     return airflowPipelines;
   }

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/GlossaryTermRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/GlossaryTermRepository.java
@@ -17,6 +17,7 @@
 package org.openmetadata.catalog.jdbi3;
 
 import static org.openmetadata.catalog.Entity.GLOSSARY_TERM;
+import static org.openmetadata.catalog.type.Include.ALL;
 import static org.openmetadata.catalog.util.EntityUtil.stringMatch;
 import static org.openmetadata.catalog.util.EntityUtil.termReferenceMatch;
 import static org.openmetadata.common.utils.CommonUtil.listOrEmpty;
@@ -79,7 +80,7 @@ public class GlossaryTermRepository extends EntityRepository<GlossaryTerm> {
 
   private EntityReference getParent(GlossaryTerm entity) throws IOException {
     List<String> ids = findFrom(entity.getId(), GLOSSARY_TERM, Relationship.PARENT_OF, GLOSSARY_TERM);
-    return ids.size() == 1 ? Entity.getEntityReferenceById(GLOSSARY_TERM, UUID.fromString(ids.get(0))) : null;
+    return ids.size() == 1 ? Entity.getEntityReferenceById(GLOSSARY_TERM, UUID.fromString(ids.get(0)), ALL) : null;
   }
 
   private List<EntityReference> getChildren(GlossaryTerm entity) throws IOException {
@@ -187,7 +188,7 @@ public class GlossaryTermRepository extends EntityRepository<GlossaryTerm> {
   }
 
   public EntityReference getGlossary(String id) throws IOException {
-    return daoCollection.glossaryDAO().findEntityReferenceById(UUID.fromString(id));
+    return daoCollection.glossaryDAO().findEntityReferenceById(UUID.fromString(id), ALL);
   }
 
   @Override

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/MlModelRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/MlModelRepository.java
@@ -15,6 +15,7 @@ package org.openmetadata.catalog.jdbi3;
 
 import static org.openmetadata.catalog.Entity.FIELD_OWNER;
 import static org.openmetadata.catalog.Entity.MLMODEL;
+import static org.openmetadata.catalog.type.Include.ALL;
 import static org.openmetadata.catalog.util.EntityUtil.entityReferenceMatch;
 import static org.openmetadata.catalog.util.EntityUtil.mlFeatureMatch;
 import static org.openmetadata.catalog.util.EntityUtil.mlHyperParameterMatch;
@@ -192,7 +193,9 @@ public class MlModelRepository extends EntityRepository<MlModel> {
     if (mlModel != null) {
       List<String> ids = findTo(mlModel.getId(), Entity.MLMODEL, Relationship.USES, Entity.DASHBOARD);
       ensureSingleRelationship(MLMODEL, mlModel.getId(), ids, "dashboards", false);
-      return ids.isEmpty() ? null : daoCollection.dashboardDAO().findEntityReferenceById(UUID.fromString(ids.get(0)));
+      return ids.isEmpty()
+          ? null
+          : daoCollection.dashboardDAO().findEntityReferenceById(UUID.fromString(ids.get(0)), ALL);
     }
     return null;
   }

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/RoleRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/RoleRepository.java
@@ -13,6 +13,8 @@
 
 package org.openmetadata.catalog.jdbi3;
 
+import static org.openmetadata.catalog.type.Include.ALL;
+
 import java.io.IOException;
 import java.net.URI;
 import java.security.GeneralSecurityException;
@@ -62,13 +64,13 @@ public class RoleRepository extends EntityRepository<Role> {
 
   @Override
   public Role setFields(Role role, Fields fields) throws IOException {
-    role.setPolicy(fields.contains("policy") ? getPolicyForRole(role) : null);
-    role.setTeams(fields.contains("teams") ? getTeamsForRole(role) : null);
-    role.setUsers(fields.contains("users") ? getUsersForRole(role) : null);
+    role.setPolicy(fields.contains("policy") ? getPolicy(role) : null);
+    role.setTeams(fields.contains("teams") ? getTeams(role) : null);
+    role.setUsers(fields.contains("users") ? getUsers(role) : null);
     return role;
   }
 
-  private EntityReference getPolicyForRole(@NonNull Role role) throws IOException {
+  private EntityReference getPolicy(@NonNull Role role) throws IOException {
     List<String> result = findTo(role.getId(), Entity.ROLE, Relationship.CONTAINS, Entity.POLICY);
     if (result.size() != 1) {
       LOG.warn(
@@ -77,15 +79,15 @@ public class RoleRepository extends EntityRepository<Role> {
           role.getName());
       return null;
     }
-    return Entity.getEntityReferenceById(Entity.POLICY, UUID.fromString(result.get(0)));
+    return Entity.getEntityReferenceById(Entity.POLICY, UUID.fromString(result.get(0)), ALL);
   }
 
-  private List<EntityReference> getUsersForRole(@NonNull Role role) throws IOException {
+  private List<EntityReference> getUsers(@NonNull Role role) throws IOException {
     List<String> ids = findFrom(role.getId(), Entity.ROLE, Relationship.HAS, Entity.USER);
     return EntityUtil.populateEntityReferences(ids, Entity.USER);
   }
 
-  private List<EntityReference> getTeamsForRole(@NonNull Role role) throws IOException {
+  private List<EntityReference> getTeams(@NonNull Role role) throws IOException {
     List<String> ids = findFrom(role.getId(), Entity.ROLE, Relationship.HAS, Entity.TEAM);
     return EntityUtil.populateEntityReferences(ids, Entity.TEAM);
   }

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/EntityResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/EntityResourceTest.java
@@ -92,6 +92,7 @@ import org.openmetadata.catalog.api.services.CreateMessagingService.MessagingSer
 import org.openmetadata.catalog.api.services.CreatePipelineService;
 import org.openmetadata.catalog.api.services.CreatePipelineService.PipelineServiceType;
 import org.openmetadata.catalog.api.services.CreateStorageService;
+import org.openmetadata.catalog.api.teams.CreateTeam;
 import org.openmetadata.catalog.entity.data.Chart;
 import org.openmetadata.catalog.entity.data.Database;
 import org.openmetadata.catalog.entity.data.Glossary;
@@ -845,11 +846,24 @@ public abstract class EntityResourceTest<T, K> extends CatalogApplicationTest {
     if (!supportsOwner) {
       return;
     }
+
+    TeamResourceTest teamResourceTest = new TeamResourceTest();
+    CreateTeam createTeam = teamResourceTest.createRequest(test);
+    Team team = teamResourceTest.createAndCheckEntity(createTeam, ADMIN_AUTH_HEADERS);
+    EntityReference teamReference = new TeamEntityInterface(team).getEntityReference();
+
     // Entity with user as owner is created successfully
     createAndCheckEntity(createRequest(getEntityName(test, 1), "", "", USER_OWNER1), ADMIN_AUTH_HEADERS);
 
     // Entity with team as owner is created successfully
-    createAndCheckEntity(createRequest(getEntityName(test, 2), "", "", TEAM_OWNER1), ADMIN_AUTH_HEADERS);
+    T entity = createAndCheckEntity(createRequest(getEntityName(test, 2), "", "", teamReference), ADMIN_AUTH_HEADERS);
+    EntityInterface<T> entityInterface = getEntityInterface(entity);
+
+    // Delete team and ensure the entity still exists but with owner as deleted
+    teamResourceTest.deleteEntity(team.getId(), ADMIN_AUTH_HEADERS);
+    entity = getEntity(entityInterface.getId(), "owner", ADMIN_AUTH_HEADERS);
+    entityInterface = getEntityInterface(entity);
+    assertTrue(entityInterface.getOwner().getDeleted());
   }
 
   @Test


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
See #3497 for details of the bug. This bus is due to code not handling finding owner for an asset or team for a user due to incorrect method call in the backend to retrieve the data from the database.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
