### PR TITLE
Fix #3626 Add a config API for sandbox mode

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/CatalogApplicationConfig.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/CatalogApplicationConfig.java
@@ -28,7 +28,6 @@ import org.openmetadata.catalog.elasticsearch.ElasticSearchConfiguration;
 import org.openmetadata.catalog.events.EventHandlerConfiguration;
 import org.openmetadata.catalog.fernet.FernetConfiguration;
 import org.openmetadata.catalog.migration.MigrationConfiguration;
-import org.openmetadata.catalog.sandbox.SandboxConfiguration;
 import org.openmetadata.catalog.security.AuthenticationConfiguration;
 import org.openmetadata.catalog.security.AuthorizerConfiguration;
 import org.openmetadata.catalog.slack.SlackPublisherConfiguration;
@@ -94,10 +93,10 @@ public class CatalogApplicationConfig extends Configuration {
   @Setter
   private HealthConfiguration healthConfiguration = new HealthConfiguration();
 
-  @JsonProperty("sandboxConfiguration")
+  @JsonProperty("sandboxModeEnabled")
   @Getter
   @Setter
-  private SandboxConfiguration sandboxConfiguration;
+  private boolean sandboxModeEnabled;
 
   @Override
   public String toString() {

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/CatalogApplicationConfig.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/CatalogApplicationConfig.java
@@ -28,6 +28,7 @@ import org.openmetadata.catalog.elasticsearch.ElasticSearchConfiguration;
 import org.openmetadata.catalog.events.EventHandlerConfiguration;
 import org.openmetadata.catalog.fernet.FernetConfiguration;
 import org.openmetadata.catalog.migration.MigrationConfiguration;
+import org.openmetadata.catalog.sandbox.SandboxConfiguration;
 import org.openmetadata.catalog.security.AuthenticationConfiguration;
 import org.openmetadata.catalog.security.AuthorizerConfiguration;
 import org.openmetadata.catalog.slack.SlackPublisherConfiguration;
@@ -92,6 +93,11 @@ public class CatalogApplicationConfig extends Configuration {
   @Getter
   @Setter
   private HealthConfiguration healthConfiguration = new HealthConfiguration();
+
+  @JsonProperty("sandboxConfiguration")
+  @Getter
+  @Setter
+  private SandboxConfiguration sandboxConfiguration;
 
   @Override
   public String toString() {

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/config/ConfigResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/config/ConfigResource.java
@@ -86,19 +86,19 @@ public class ConfigResource {
   @GET
   @Path(("/sandbox"))
   @Operation(
-      summary = "Get sandbox configuration",
+      summary = "Get sandbox mode",
       tags = "general",
       responses = {
         @ApiResponse(
             responseCode = "200",
-            description = "Sandbox configuration",
+            description = "Sandbox mode",
             content =
                 @Content(mediaType = "application/json", schema = @Schema(implementation = SandboxConfiguration.class)))
       })
-  public SandboxConfiguration getSandboxConfig() {
+  public SandboxConfiguration getSandboxMode() {
     SandboxConfiguration sandboxConfiguration = new SandboxConfiguration();
-    if (catalogApplicationConfig.getSandboxConfiguration() != null) {
-      sandboxConfiguration = catalogApplicationConfig.getSandboxConfiguration();
+    if (catalogApplicationConfig.isSandboxModeEnabled()) {
+      sandboxConfiguration.setSandboxModeEnabled(true);
     }
     return sandboxConfiguration;
   }

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/config/ConfigResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/config/ConfigResource.java
@@ -24,6 +24,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import org.openmetadata.catalog.CatalogApplicationConfig;
 import org.openmetadata.catalog.resources.Collection;
+import org.openmetadata.catalog.sandbox.SandboxConfiguration;
 import org.openmetadata.catalog.security.AuthenticationConfiguration;
 import org.openmetadata.catalog.security.AuthorizerConfiguration;
 
@@ -80,5 +81,25 @@ public class ConfigResource {
       authorizerConfiguration = catalogApplicationConfig.getAuthorizerConfiguration();
     }
     return authorizerConfiguration;
+  }
+
+  @GET
+  @Path(("/sandbox"))
+  @Operation(
+      summary = "Get sandbox configuration",
+      tags = "general",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Sandbox configuration",
+            content =
+                @Content(mediaType = "application/json", schema = @Schema(implementation = SandboxConfiguration.class)))
+      })
+  public SandboxConfiguration getSandboxConfig() {
+    SandboxConfiguration sandboxConfiguration = new SandboxConfiguration();
+    if (catalogApplicationConfig.getSandboxConfiguration() != null) {
+      sandboxConfiguration = catalogApplicationConfig.getSandboxConfiguration();
+    }
+    return sandboxConfiguration;
   }
 }

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/sandbox/SandboxConfiguration.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/sandbox/SandboxConfiguration.java
@@ -1,0 +1,13 @@
+package org.openmetadata.catalog.sandbox;
+
+public class SandboxConfiguration {
+  private boolean isSandboxModeEnabled;
+
+  public boolean isSandboxModeEnabled() {
+    return isSandboxModeEnabled;
+  }
+
+  public void setSandboxModeEnabled(boolean sandboxModeEnabled) {
+    isSandboxModeEnabled = sandboxModeEnabled;
+  }
+}


### PR DESCRIPTION
### Describe your changes :
See #3626 

Now, we can add the following config to openmetadata.yaml to enable sandbox mode
```
sandboxModeEnabled: true
```
And get the value of the config with `/api/v1/config/sandbox` with the following response
```
{
"sandboxModeEnabled": true
}
```

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [ ] I have tagged my reviewers below.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya -->
<!--- Backend: @sureshms @harshach -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
