### PR TITLE
Fix #3612 Team Patch API is not updating isJoinable field

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/TeamRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/TeamRepository.java
@@ -274,6 +274,7 @@ public class TeamRepository extends EntityRepository<Team> {
     @Override
     public void entitySpecificUpdate() throws IOException {
       recordChange("profile", original.getEntity().getProfile(), updated.getEntity().getProfile());
+      recordChange("isJoinable", original.getEntity().getIsJoinable(), updated.getEntity().getIsJoinable());
       updateUsers(original.getEntity(), updated.getEntity());
       updateDefaultRoles(original.getEntity(), updated.getEntity());
     }

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/teams/TeamResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/teams/TeamResourceTest.java
@@ -257,6 +257,29 @@ public class TeamResourceTest extends EntityResourceTest<Team, CreateTeam> {
   }
 
   @Test
+  void patch_isJoinable_200(TestInfo test) throws IOException {
+    CreateTeam create =
+        createRequest(getEntityName(test), "description", "displayName", null)
+            .withProfile(PROFILE)
+            .withIsJoinable(false);
+    Team team = createAndCheckEntity(create, ADMIN_AUTH_HEADERS);
+
+    // patch the team with isJoinable set to true
+    String json = JsonUtils.pojoToJson(team);
+    team.setIsJoinable(true);
+    ChangeDescription change = getChangeDescription(team.getVersion());
+    change.getFieldsUpdated().add(new FieldChange().withName("isJoinable").withOldValue(false).withNewValue(true));
+    team = patchEntityAndCheck(team, json, ADMIN_AUTH_HEADERS, UpdateType.MINOR_UPDATE, change);
+
+    // set isJoinable to false and check
+    json = JsonUtils.pojoToJson(team);
+    team.setIsJoinable(false);
+    change = getChangeDescription(team.getVersion());
+    change.getFieldsUpdated().add(new FieldChange().withName("isJoinable").withOldValue(true).withNewValue(false));
+    patchEntityAndCheck(team, json, ADMIN_AUTH_HEADERS, UpdateType.MINOR_UPDATE, change);
+  }
+
+  @Test
   void patch_deleteUserAndDefaultRoleFromTeam_200(TestInfo test) throws IOException {
     UserResourceTest userResourceTest = new UserResourceTest();
     final int totalUsers = 20;


### PR DESCRIPTION
### Describe your changes :
See #3612 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have performed a self-review of my own. 
- [ ] I have tagged my reviewers below.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

