### PR TITLE
lower model references to match between dbt and database (spark)

### DIFF
--- a/ingestion/src/metadata/ingestion/source/sql_source.py
+++ b/ingestion/src/metadata/ingestion/source/sql_source.py
@@ -200,7 +200,7 @@ class SQLSource(Source[OMetaDatabaseAndTable]):
         yield inspect(self.engine)
 
     def get_table_fqn(self, service_name, schema, table_name) -> str:
-        return f"{service_name}.{schema}.{table_name}"
+        return f"{service_name}.{schema}.{table_name}".lower()
 
     def next_record(self) -> Iterable[Entity]:
         inspectors = self.get_databases()
@@ -418,7 +418,7 @@ class SQLSource(Source[OMetaDatabaseAndTable]):
                         columns=columns,
                         upstream=upstream_nodes,
                     )
-                    model_fqdn = f"{schema}.{model_name}"
+                    model_fqdn = f"{schema}.{model_name}".lower()
                 except Exception as err:
                     logger.debug(traceback.print_exc())
                     logger.error(err)


### PR DESCRIPTION
Add lower on model_fqn and get_table_fqn to increase matching between dbt and database references on Spark.

### Describe your changes :
Experienced that we did not get matching between dbt manifest/catalog and table metadata from database. Saw that we have defined all our dbt models with casing and that Databricks SQL (Spark) always returns all table and view casings as lower. Added lower() to increase matching between dbt and database schemas in case insensitive database table/view names. 

Should ideally be expanded to handle database dialect specifically and not do .lower() on databases/sources which are case sensitive. 

#
### Type of change :
- [x] Bug fix

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@ayush-shah
