### PR TITLE
fix: Adding deprecated publicKey field as short term fix

### DIFF
--- a/conf/openmetadata-security.yaml
+++ b/conf/openmetadata-security.yaml
@@ -126,6 +126,7 @@ authorizerConfiguration:
 
 authenticationConfiguration:
   provider: "google"
+  publicKey: https://www.googleapis.com/oauth2/v3/certs
   publicKeyUrls: 
     - "https://www.googleapis.com/oauth2/v3/certs"
   authority: "https://accounts.google.com"

--- a/conf/openmetadata.yaml
+++ b/conf/openmetadata.yaml
@@ -125,6 +125,7 @@ authorizerConfiguration:
 
 authenticationConfiguration:
   provider: ${AUTHENTICATION_PROVIDER:-no-auth}
+  publicKey: ${AUTHENTICATION_PUBLIC_KEY:-https://www.googleapis.com/oauth2/v3/certs}
   publicKeyUrls: 
     - ${AUTHENTICATION_PUBLIC_KEY:-https://www.googleapis.com/oauth2/v3/certs}
   authority: ${AUTHENTICATION_AUTHORITY:-https://accounts.google.com}


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Adding deprecated `publicKey` field as short term fix. Long term is Front End Auth SSO libraries should utilize `publicKeyUrls` in favour of this.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya, @vivekratnavel -->
<!--- Backend: @sureshms @harshach, @vivekratnavel -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
