### PR TITLE
Refactor Trino Connector and allow proxy setup in trino connection config

### DIFF
--- a/catalog-rest-service/src/main/resources/json/schema/entity/services/connections/database/trinoConnection.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/services/connections/database/trinoConnection.json
@@ -31,7 +31,7 @@
       "default": "trino"
     },
     "username": {
-      "description": "username to connect  to the Snowflake. This user should have privileges to read all the metadata in Snowflake.",
+      "description": "username to connect to Trino. This user should have privileges to read all the metadata in Trino.",
       "type": "string"
     },
     "password": {
@@ -43,6 +43,10 @@
       "description": "Host and port of the data source.",
       "type": "string"
     },
+    "catalog": {
+      "description": "Catalog of the data source.",
+      "type": "string"
+    },
     "database": {
       "description": "Database of the data source. This is optional parameter, if you would like to restrict the metadata reading to a single database. When left blank , OpenMetadata Ingestion attempts to scan all the databases in Trino.",
       "type": "string"
@@ -52,6 +56,14 @@
     },
     "connectionArguments": {
       "$ref": "connectionBasicType.json#/definitions/connectionArguments"
+    },
+    "proxies": {
+      "description": "Proxies for the connection to Trino data source",
+      "type": "object"
+    },
+    "params": {
+      "description": "URL parameters for connection to the Trino data source",
+      "type": "object"
     },
     "supportedPipelineTypes": {
       "description": "Supported Metadata Extraction Pipelines.",

--- a/catalog-rest-service/src/main/resources/json/schema/entity/services/connections/database/trinoConnection.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/services/connections/database/trinoConnection.json
@@ -48,7 +48,7 @@
       "type": "string"
     },
     "database": {
-      "description": "Database of the data source. This is optional parameter, if you would like to restrict the metadata reading to a single database. When left blank , OpenMetadata Ingestion attempts to scan all the databases in Trino.",
+      "description": "Database of the data source. This is optional parameter, if you would like to restrict the metadata reading to a single database. When left blank , OpenMetadata Ingestion attempts to scan all the databases in the selected catalog in Trino.",
       "type": "string"
     },
     "connectionOptions": {

--- a/docs/integrations/connectors/trino.md
+++ b/docs/integrations/connectors/trino.md
@@ -415,9 +415,9 @@ Then re-run the install command in [Step 2](trino.md#2.-install-the-python-modul
 If you encounter the following error when attempting to run the ingestion workflow in Step 12, this is probably because there is no OpenMetadata server running at http://localhost:8585.
 
 ```
-requests.exceptions.ConnectionError: HTTPConnectionPool(host='localhost', port=8585): 
-Max retries exceeded with url: /api/v1/services/databaseServices/name/local_trino 
-(Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x1031fa310>: 
+requests.exceptions.ConnectionError: HTTPConnectionPool(host='localhost', port=8585):
+Max retries exceeded with url: /api/v1/services/databaseServices/name/local_trino
+(Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x1031fa310>:
 Failed to establish a new connection: [Errno 61] Connection refused'))
 ```
 

--- a/docs/integrations/connectors/trino.md
+++ b/docs/integrations/connectors/trino.md
@@ -184,6 +184,14 @@ To specify a single database to ingest metadata from, provide the name of the da
 "database": "trino_db"
 ```
 
+#### **proxies (optional)**
+
+You can set a proxy for the connection with trino. If this field is not included, no proxy is set.
+
+```javascript
+"proxies": {"http": "<http proxy>", "https": "<https proxy>"}
+```
+
 ### **5. Enable/disable the data profiler**
 
 The data profiler ingests usage information for tables. This enables you to assess the frequency of use, reliability, and other details.

--- a/ingestion/src/metadata/ingestion/source/trino.py
+++ b/ingestion/src/metadata/ingestion/source/trino.py
@@ -33,6 +33,10 @@ from metadata.generated.schema.entity.services.connections.database.trinoConnect
 
 class TrinoConfig(TrinoConnection, SQLConnectionConfig):
     params: Optional[dict] = None
+<<<<<<< HEAD
+=======
+    proxies: dict = {}
+>>>>>>> make proxies optional
 
     def get_connection_url(self):
         url = f"{self.scheme}://"

--- a/ingestion/src/metadata/ingestion/source/trino.py
+++ b/ingestion/src/metadata/ingestion/source/trino.py
@@ -35,9 +35,13 @@ from metadata.generated.schema.entity.services.connections.database.trinoConnect
 class TrinoConfig(TrinoConnection, SQLConnectionConfig):
     params: Optional[dict] = None
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
     proxies: dict = {}
 >>>>>>> make proxies optional
+=======
+    proxies: Optional[dict] = None
+>>>>>>> make proxies of optional type
 
     def get_connection_url(self):
         url = f"{self.scheme}://"

--- a/ingestion/src/metadata/ingestion/source/trino.py
+++ b/ingestion/src/metadata/ingestion/source/trino.py
@@ -15,6 +15,7 @@ from typing import Iterable, Optional
 from urllib.parse import quote_plus
 
 import click
+from requests import Session
 from sqlalchemy.inspection import inspect
 
 from metadata.generated.schema.metadataIngestion.workflow import (

--- a/ingestion/src/metadata/ingestion/source/trino.py
+++ b/ingestion/src/metadata/ingestion/source/trino.py
@@ -19,18 +19,19 @@ from sqlalchemy.inspection import inspect
 from metadata.generated.schema.metadataIngestion.workflow import (
     OpenMetadataServerConfig,
 )
+from metadata.ingestion.api.source import InvalidSourceException
 from metadata.ingestion.models.ometa_table_db import OMetaDatabaseAndTable
 from metadata.ingestion.source.sql_source import SQLSource
-from metadata.ingestion.api.source import InvalidSourceException
 
 logger = logging.getLogger(__name__)
 
+from metadata.generated.schema.entity.services.connections.database.trinoConnection import (
+    TrinoConnection,
+)
 from metadata.generated.schema.metadataIngestion.workflow import (
     Source as WorkflowSource,
 )
-from metadata.generated.schema.entity.services.connections.database.trinoConnection import (
-    TrinoConnection
-)
+
 
 class TrinoSource(SQLSource):
     def __init__(self, config, metadata_config):

--- a/ingestion/src/metadata/ingestion/source/trino.py
+++ b/ingestion/src/metadata/ingestion/source/trino.py
@@ -15,7 +15,6 @@ from typing import Iterable, Optional
 from urllib.parse import quote_plus
 
 import click
-from requests import Session
 from sqlalchemy.inspection import inspect
 
 from metadata.generated.schema.metadataIngestion.workflow import (
@@ -34,14 +33,7 @@ from metadata.generated.schema.entity.services.connections.database.trinoConnect
 
 class TrinoConfig(TrinoConnection, SQLConnectionConfig):
     params: Optional[dict] = None
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-    proxies: dict = {}
->>>>>>> make proxies optional
-=======
     proxies: Optional[dict] = None
->>>>>>> make proxies of optional type
 
     def get_connection_url(self):
         url = f"{self.scheme}://"

--- a/ingestion/src/metadata/utils/engines.py
+++ b/ingestion/src/metadata/utils/engines.py
@@ -22,7 +22,7 @@ from sqlalchemy.orm.session import Session
 from metadata.generated.schema.metadataIngestion.workflow import (
     Source as WorkflowSource,
 )
-from metadata.utils.source_connections import get_connection_url
+from metadata.utils.source_connections import get_connection_args, get_connection_url
 
 logger = logging.getLogger("Utils")
 
@@ -36,13 +36,10 @@ def get_engine(workflow_source: WorkflowSource, verbose: bool = False) -> Engine
     options = service_connection_config.connectionOptions
     if not options:
         options = {}
-    connect_args = service_connection_config.connectionArguments
-    if not connect_args:
-        connect_args = {}
     engine = create_engine(
         get_connection_url(service_connection_config),
         **options,
-        connect_args=connect_args,
+        connect_args=get_connection_args(service_connection_config),
         echo=verbose,
     )
 

--- a/ingestion/src/metadata/utils/source_connections.py
+++ b/ingestion/src/metadata/utils/source_connections.py
@@ -132,7 +132,7 @@ def get_connection_args(connection):
 
 
 @get_connection_args.register
-def _(connection: TrinoConnection):
+def get_connection_args(connection: TrinoConnection):
     if connection.proxies:
         session = Session()
         session.proxies = connection.proxies

--- a/ingestion/src/metadata/utils/source_connections.py
+++ b/ingestion/src/metadata/utils/source_connections.py
@@ -97,7 +97,7 @@ def _(connection: SQLiteConnection):
 
 
 @get_connection_url.register
-def get_connection_url(connection: TrinoConnection):
+def _(connection: TrinoConnection):
     url = f"{connection.scheme}://"
     if connection.username:
         url += f"{quote_plus(connection.username)}"
@@ -132,7 +132,7 @@ def get_connection_args(connection):
 
 
 @get_connection_args.register
-def get_connection_args(connection: TrinoConnection):
+def _(connection: TrinoConnection):
     if connection.proxies:
         session = Session()
         session.proxies = connection.proxies

--- a/ingestion/src/metadata/utils/source_connections.py
+++ b/ingestion/src/metadata/utils/source_connections.py
@@ -115,6 +115,7 @@ def _(connection: TrinoConnection):
         url = f"{url}?{params}"
     return url
 
+
 @get_connection_url.register
 def _(connection: DatabricksConnection):
     url = f"{connection.scheme.value}://token:{connection.token}@{connection.hostPort}"

--- a/ingestion/src/metadata/utils/source_connections.py
+++ b/ingestion/src/metadata/utils/source_connections.py
@@ -98,7 +98,7 @@ def _(connection: SQLiteConnection):
 
 @get_connection_url.register
 def _(connection: TrinoConnection):
-    url = f"{connection.scheme}://"
+    url = f"{connection.scheme.value}://"
     if connection.username:
         url += f"{quote_plus(connection.username)}"
         if connection.password:
@@ -115,8 +115,8 @@ def _(connection: TrinoConnection):
         url = f"{url}?{params}"
     return url
 
-
-def get_connection_url(connection: DatabricksConnection):
+@get_connection_url.register
+def _(connection: DatabricksConnection):
     url = f"{connection.scheme.value}://token:{connection.token}@{connection.hostPort}"
     if connection.database:
         url += f"/{connection.database}"
@@ -136,6 +136,9 @@ def _(connection: TrinoConnection):
     if connection.proxies:
         session = Session()
         session.proxies = connection.proxies
-        return {**connection.connectionArguments, "http_session": session}
+        if connection.connectionArguments:
+            return {**connection.connectionArguments, "http_session": session}
+        else:
+            return {"http_session": session}
     else:
         return connection.connectionArguments

--- a/ingestion/src/metadata/utils/source_connections.py
+++ b/ingestion/src/metadata/utils/source_connections.py
@@ -95,6 +95,7 @@ def _(connection: SQLiteConnection):
 
     return f"{connection.scheme.value}:///:memory:"
 
+
 @get_connection_url.register
 def get_connection_url(connection: TrinoConnection):
     url = f"{connection.scheme}://"
@@ -113,6 +114,7 @@ def get_connection_url(connection: TrinoConnection):
         )
         url = f"{url}?{params}"
     return url
+
 
 def get_connection_url(connection: DatabricksConnection):
     url = f"{connection.scheme.value}://token:{connection.token}@{connection.hostPort}"

--- a/ingestion/tests/unit/source_connection/test_trino_connection.py
+++ b/ingestion/tests/unit/source_connection/test_trino_connection.py
@@ -14,51 +14,46 @@ from unittest import TestCase
 
 from metadata.generated.schema.entity.services.connections.database.trinoConnection import (
     TrinoConnection,
-    TrinoScheme
+    TrinoScheme,
 )
-from metadata.utils.source_connections import get_connection_url, get_connection_args
+from metadata.utils.source_connections import get_connection_args, get_connection_url
 
 
 class TrinoConnectionTest(TestCase):
     def test_connection_url_without_params(self):
-        expected_url = (
-            "trino://username:pass@localhost:443/catalog"
-        )
+        expected_url = "trino://username:pass@localhost:443/catalog"
         trino_conn_obj = TrinoConnection(
             scheme=TrinoScheme.trino,
             hostPort="localhost:443",
             username="username",
             password="pass",
-            catalog="catalog"
+            catalog="catalog",
         )
         assert expected_url == get_connection_url(trino_conn_obj)
 
     def test_connection_url_with_params(self):
-        expected_url = (
-            "trino://username:pass@localhost:443/catalog?param=value"
-        )
+        expected_url = "trino://username:pass@localhost:443/catalog?param=value"
         trino_conn_obj = TrinoConnection(
             scheme=TrinoScheme.trino,
             hostPort="localhost:443",
             username="username",
             password="pass",
             catalog="catalog",
-            params = {"param": "value"}
+            params={"param": "value"},
         )
         assert expected_url == get_connection_url(trino_conn_obj)
 
     def test_connection_with_proxies(self):
-        test_proxies = (
-            {"http": "http_proxy", "https": "https_proxy"}
-        )
+        test_proxies = {"http": "http_proxy", "https": "https_proxy"}
         trino_conn_obj = TrinoConnection(
             scheme=TrinoScheme.trino,
             hostPort="localhost:443",
             username="username",
             password="pass",
             catalog="catalog",
-            proxies=test_proxies
+            proxies=test_proxies,
         )
-        assert test_proxies == get_connection_args(trino_conn_obj).get("http_session").proxies
-
-
+        assert (
+            test_proxies
+            == get_connection_args(trino_conn_obj).get("http_session").proxies
+        )

--- a/ingestion/tests/unit/source_connection/test_trino_connection.py
+++ b/ingestion/tests/unit/source_connection/test_trino_connection.py
@@ -1,0 +1,64 @@
+#  Copyright 2021 Collate
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+from unittest import TestCase
+
+from metadata.generated.schema.entity.services.connections.database.trinoConnection import (
+    TrinoConnection,
+    TrinoScheme
+)
+from metadata.utils.source_connections import get_connection_url, get_connection_args
+
+
+class TrinoConnectionTest(TestCase):
+    def test_connection_url_without_params(self):
+        expected_url = (
+            "trino://username:pass@localhost:443/catalog"
+        )
+        trino_conn_obj = TrinoConnection(
+            scheme=TrinoScheme.trino,
+            hostPort="localhost:443",
+            username="username",
+            password="pass",
+            catalog="catalog"
+        )
+        assert expected_url == get_connection_url(trino_conn_obj)
+
+    def test_connection_url_with_params(self):
+        expected_url = (
+            "trino://username:pass@localhost:443/catalog?param=value"
+        )
+        trino_conn_obj = TrinoConnection(
+            scheme=TrinoScheme.trino,
+            hostPort="localhost:443",
+            username="username",
+            password="pass",
+            catalog="catalog",
+            params = {"param": "value"}
+        )
+        assert expected_url == get_connection_url(trino_conn_obj)
+
+    def test_connection_with_proxies(self):
+        test_proxies = (
+            {"http": "http_proxy", "https": "https_proxy"}
+        )
+        trino_conn_obj = TrinoConnection(
+            scheme=TrinoScheme.trino,
+            hostPort="localhost:443",
+            username="username",
+            password="pass",
+            catalog="catalog",
+            proxies=test_proxies
+        )
+        assert test_proxies == get_connection_args(trino_conn_obj).get("http_session").proxies
+
+

--- a/ingestion/tests/unit/test_source_url.py
+++ b/ingestion/tests/unit/test_source_url.py
@@ -58,3 +58,4 @@ class TestConfig(TestCase):
         )
         url_without_db = get_connection_url(connection_without_db)
         assert url_without_db == "redshift+psycopg2://username:password@localhost:1234"
+

--- a/ingestion/tests/unit/test_source_url.py
+++ b/ingestion/tests/unit/test_source_url.py
@@ -58,4 +58,3 @@ class TestConfig(TestCase):
         )
         url_without_db = get_connection_url(connection_without_db)
         assert url_without_db == "redshift+psycopg2://username:password@localhost:1234"
-


### PR DESCRIPTION
### Describe your changes :
Refactor trino connection to use  Json Schema definition
Allow proxies for the trino ingestion connection via the optional `proxies` field in TrinoConfig

Trino python client allows to setup proxies via `proxies` key in `http_session` field.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation

#

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya, @vivekratnavel -->
<!--- Backend: @sureshms @harshach, @vivekratnavel -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
