### PR TITLE
Fix #2144: Only "space" as name is allowed by createService and createTeam apis

### DIFF
--- a/catalog-rest-service/src/main/resources/json/schema/entity/data/location.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/data/location.json
@@ -8,7 +8,9 @@
   "definitions": {
     "locationName": {
       "description": "Local name (not fully qualified name) of a location.",
-      "$ref": "../../type/basic.json#/definitions/entityName"
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128
     },
     "locationType": {
       "javaType": "org.openmetadata.catalog.type.LocationType",

--- a/catalog-rest-service/src/main/resources/json/schema/type/basic.json
+++ b/catalog-rest-service/src/main/resources/json/schema/type/basic.json
@@ -64,11 +64,11 @@
       "pattern": "^<#E/\\S+/\\S+>$"
     },
     "entityName": {
-      "description": "Name that identifies this dashboard service.",
+      "description": "Name that identifies this dashboard service. All reserved and unsafe url characters but dot are not allowed.",
       "type": "string",
       "minLength": 1,
       "maxLength": 128,
-      "pattern": "^[^\\s]*$"
+      "pattern": "^[^\\s&$+,/:;=?@#<>\\[\\]{}|\\\\^%]*$"
     },
     "fullyQualifiedEntityName": {
       "description": "A unique name that identifies an entity. Example for table 'DatabaseService:Database:Table'.",

--- a/catalog-rest-service/src/main/resources/json/schema/type/basic.json
+++ b/catalog-rest-service/src/main/resources/json/schema/type/basic.json
@@ -67,7 +67,8 @@
       "description": "Name that identifies this dashboard service.",
       "type": "string",
       "minLength": 1,
-      "maxLength": 128
+      "maxLength": 128,
+      "pattern": "^[^\\s]*$"
     },
     "fullyQualifiedEntityName": {
       "description": "A unique name that identifies an entity. Example for table 'DatabaseService:Database:Table'.",

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/events/WebhookResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/events/WebhookResourceTest.java
@@ -295,14 +295,14 @@ public class WebhookResourceTest extends EntityResourceTest<Webhook, CreateWebho
     String baseUri = "http://localhost:" + APP.getLocalPort() + "/api/v1/test/webhook/filterBased";
 
     // Create webhook with endpoint api/v1/test/webhook/entityCreated/<entity> to receive entityCreated events
-    String name = EventType.ENTITY_CREATED + ":" + entity;
+    String name = EventType.ENTITY_CREATED + "_" + entity;
     String uri = baseUri + "/" + EventType.ENTITY_CREATED + "/" + entity;
     List<EventFilter> filters =
         List.of(new EventFilter().withEventType(EventType.ENTITY_CREATED).withEntities(List.of(entity)));
     createWebhook(name, uri, filters);
 
     // Create webhook with endpoint api/v1/test/webhook/entityUpdated/<entity> to receive entityUpdated events
-    name = EventType.ENTITY_UPDATED + ":" + entity;
+    name = EventType.ENTITY_UPDATED + "_" + entity;
     uri = baseUri + "/" + EventType.ENTITY_UPDATED + "/" + entity;
     filters = List.of(new EventFilter().withEventType(EventType.ENTITY_UPDATED).withEntities(List.of(entity)));
     createWebhook(name, uri, filters);


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
See #2144.

#### Implementation details
Don't allow space and [other unsafe and reserved chars](https://stackoverflow.com/a/695467) inside `entityName`. We need to support Cyrillic and other charsets.
Location name can be anything (see S3 specs).

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>
<img width="426" alt="image" src="https://user-images.githubusercontent.com/32617/161976594-03eb69a0-765d-4161-807d-f716d54c4598.png">
<img width="417" alt="image" src="https://user-images.githubusercontent.com/32617/161976674-29755444-03d7-4f42-9d0b-282bbecb1b77.png">


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.
