### PR TITLE
Fix #3862 UI Search: Select a filter and go to a entity page and hitting back on the browser will reset the previous search results including selected filters

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/AppState.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/AppState.ts
@@ -52,6 +52,7 @@ class AppState {
       updateUserRole: action,
       updateUsers: action,
       updateUserPermissions: action,
+      updateExplorePageTab: action,
     });
   }
 
@@ -81,6 +82,9 @@ class AppState {
   }
   updateUserPermissions(permissions: UserPermissions) {
     this.userPermissions = permissions;
+  }
+  updateExplorePageTab(tab: string) {
+    this.explorePageTab = tab;
   }
 }
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/Explore.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/Explore.component.tsx
@@ -457,6 +457,10 @@ const Explore: React.FC<ExploreProps> = ({
     }
   };
 
+  /**
+   * on filter change , change the route
+   * @param filters - filter object
+   */
   const handleFilterChange = (filters: FilterObject) => {
     const params = prepareQueryParams(filters);
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/Explore.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/Explore.component.tsx
@@ -11,6 +11,11 @@
  *  limitations under the License.
  */
 
+import {
+  faSortAmountDownAlt,
+  faSortAmountUpAlt,
+} from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import classNames from 'classnames';
 import { cloneDeep, isEmpty } from 'lodash';
 import {
@@ -59,15 +64,14 @@ import {
 } from '../../utils/AggregationUtils';
 import { formatDataResponse } from '../../utils/APIUtils';
 import { getCountBadge } from '../../utils/CommonUtils';
-import { getFilterCount, getFilterString } from '../../utils/FilterUtils';
+import {
+  getFilterCount,
+  getFilterString,
+  prepareQueryParams,
+} from '../../utils/FilterUtils';
 import { dropdownIcon as DropDownIcon } from '../../utils/svgconstant';
 import PageLayout from '../containers/PageLayout';
 import { ExploreProps } from './explore.interface';
-import {
-  faSortAmountDownAlt,
-  faSortAmountUpAlt,
-} from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 const Explore: React.FC<ExploreProps> = ({
   tabCounts,
@@ -130,10 +134,12 @@ const Explore: React.FC<ExploreProps> = ({
         }
         setIsFilterSet(true);
 
-        return {
+        const updatedFilters = {
           ...prevState,
           [type]: [...prevState[type], selectedFilter],
         };
+
+        return updatedFilters;
       });
     } else {
       if (searchTag.includes(selectedFilter)) {
@@ -145,8 +151,9 @@ const Explore: React.FC<ExploreProps> = ({
       setFilters((prevState) => {
         const selectedFilterCount = getFilterCount(prevState);
         setIsFilterSet(selectedFilterCount >= 1);
+        const updatedFilters = { ...prevState, [type]: filter };
 
-        return { ...prevState, [type]: filter };
+        return updatedFilters;
       });
     }
   };
@@ -450,6 +457,17 @@ const Explore: React.FC<ExploreProps> = ({
     }
   };
 
+  const handleFilterChange = (filters: FilterObject) => {
+    const params = prepareQueryParams(filters);
+
+    const explorePath = getExplorePathWithSearch(searchQuery);
+
+    history.push({
+      pathname: explorePath,
+      search: params,
+    });
+  };
+
   useEffect(() => {
     handleSearchText(searchQuery || emptyValue);
     setCurrentPage(1);
@@ -536,6 +554,9 @@ const Explore: React.FC<ExploreProps> = ({
       getData();
     } else {
       setCurrentPage(1);
+    }
+    if (!isMounting.current) {
+      handleFilterChange(filters);
     }
   }, [filters]);
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/Explore.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/Explore.component.tsx
@@ -134,12 +134,10 @@ const Explore: React.FC<ExploreProps> = ({
         }
         setIsFilterSet(true);
 
-        const updatedFilters = {
+        return {
           ...prevState,
           [type]: [...prevState[type], selectedFilter],
         };
-
-        return updatedFilters;
       });
     } else {
       if (searchTag.includes(selectedFilter)) {
@@ -151,9 +149,8 @@ const Explore: React.FC<ExploreProps> = ({
       setFilters((prevState) => {
         const selectedFilterCount = getFilterCount(prevState);
         setIsFilterSet(selectedFilterCount >= 1);
-        const updatedFilters = { ...prevState, [type]: filter };
 
-        return updatedFilters;
+        return { ...prevState, [type]: filter };
       });
     }
   };
@@ -459,10 +456,10 @@ const Explore: React.FC<ExploreProps> = ({
 
   /**
    * on filter change , change the route
-   * @param filters - filter object
+   * @param filtersObj - filter object
    */
-  const handleFilterChange = (filters: FilterObject) => {
-    const params = prepareQueryParams(filters);
+  const handleFilterChange = (filtersObj: FilterObject) => {
+    const params = prepareQueryParams(filtersObj);
 
     const explorePath = getExplorePathWithSearch(searchQuery);
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/explore.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/explore.interface.ts
@@ -40,6 +40,7 @@ export interface ExploreProps {
   error: string;
   searchQuery: string;
   showDeleted: boolean;
+  searchResult: ExploreSearchData | undefined;
   fetchCount: () => void;
   handlePathChange: (path: string) => void;
   handleSearchText: (text: string) => void;
@@ -50,5 +51,4 @@ export interface ExploreProps {
   updateDbtModelCount: (count: number) => void;
   fetchData: (value: SearchDataFunctionType[]) => void;
   onShowDeleted: (checked: boolean) => void;
-  searchResult: ExploreSearchData | undefined;
 }

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/facetfilter/FacetFilter.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/facetfilter/FacetFilter.tsx
@@ -57,8 +57,24 @@ const FacetFilter: FunctionComponent<FacetProp> = ({
   const sortBuckets = (buckets: Array<Bucket>) => {
     return buckets.sort((a, b) => (a.key > b.key ? 1 : -1));
   };
-  const getBuckets = (buckets: Array<Bucket>, state: boolean) => {
-    return sortBuckets(buckets).slice(0, state ? buckets.length : LIST_SIZE);
+
+  const sortBucketbyCount = (buckets: Array<Bucket>) => {
+    return buckets.sort((a, b) => (a.doc_count < b.doc_count ? 1 : -1));
+  };
+
+  const getBuckets = (
+    buckets: Array<Bucket>,
+    state: boolean,
+    sortBycount = false
+  ) => {
+    if (sortBycount) {
+      return sortBucketbyCount(buckets).slice(
+        0,
+        state ? buckets.length : LIST_SIZE
+      );
+    } else {
+      return sortBuckets(buckets).slice(0, state ? buckets.length : LIST_SIZE);
+    }
   };
 
   const getLinkTextByTitle = (title: string, bucketLength: number) => {
@@ -79,13 +95,14 @@ const FacetFilter: FunctionComponent<FacetProp> = ({
   const getBucketsByTitle = (title: string, buckets: Array<Bucket>) => {
     switch (title) {
       case 'Service':
-        return getBuckets(buckets, showAllServices);
+        return getBuckets(buckets, showAllServices, true);
       case 'Tags':
-        return getBuckets(buckets, showAllTags);
+        return getBuckets(buckets, showAllTags, true);
+
       case 'Tier':
         return getBuckets(buckets, showAllTier);
       case 'Database':
-        return getBuckets(buckets, showAllDatabase);
+        return getBuckets(buckets, showAllDatabase, true);
       default:
         return [];
     }

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/table-data-card/TableDataCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/table-data-card/TableDataCard.tsx
@@ -77,7 +77,6 @@ const TableDataCard: FunctionComponent<Props> = ({
 
   const OtherDetails: Array<ExtraInfo> = [
     { key: 'Owner', value: owner },
-    // { key: 'Service', value: serviceType },
     { key: 'Tier', value: getTier() },
   ];
   if (indexType !== SearchIndex.DASHBOARD && usage !== undefined) {
@@ -96,6 +95,7 @@ const TableDataCard: FunctionComponent<Props> = ({
       showLabel: true,
     });
   }
+  OtherDetails.push({ key: 'Service', value: serviceType, showLabel: true });
   if (database) {
     OtherDetails.push({
       key: 'Database',

--- a/openmetadata-ui/src/main/resources/ui/src/pages/explore/ExplorePage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/explore/ExplorePage.component.tsx
@@ -13,7 +13,7 @@
 
 import { AxiosError } from 'axios';
 import { Bucket, SearchDataFunctionType, SearchResponse } from 'Models';
-import React, { FunctionComponent, useEffect, useState } from 'react';
+import React, { Fragment, FunctionComponent, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import AppState from '../../AppState';
 import { searchData } from '../../axiosAPIs/miscAPI';
@@ -87,7 +87,7 @@ const ExplorePage: FunctionComponent = () => {
   };
 
   const handlePathChange = (path: string) => {
-    AppState.explorePageTab = path;
+    AppState.updateExplorePageTab(path);
   };
 
   const fetchCounts = () => {
@@ -209,7 +209,7 @@ const ExplorePage: FunctionComponent = () => {
   }, [searchText, showDeleted]);
 
   useEffect(() => {
-    AppState.explorePageTab = tab;
+    AppState.updateExplorePageTab(tab);
   }, [tab]);
 
   useEffect(() => {
@@ -254,7 +254,7 @@ const ExplorePage: FunctionComponent = () => {
   }, []);
 
   return (
-    <>
+    <Fragment>
       {isLoading || isLoadingForData ? (
         <Loader />
       ) : (
@@ -287,7 +287,7 @@ const ExplorePage: FunctionComponent = () => {
           />
         </PageContainerV1>
       )}
-    </>
+    </Fragment>
   );
 };
 

--- a/openmetadata-ui/src/main/resources/ui/src/utils/FilterUtils.js
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/FilterUtils.js
@@ -50,6 +50,11 @@ export const getFilterKey = (key) => {
   return key === 'service_type' ? 'service' : key;
 };
 
+/**
+ * Check for filters and return the filters in query param format
+ * @param filters - filter object
+ * @returns query param format
+ */
 export const prepareQueryParams = (filters) => {
   const entries = Object.entries(filters);
 

--- a/openmetadata-ui/src/main/resources/ui/src/utils/FilterUtils.js
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/FilterUtils.js
@@ -49,3 +49,14 @@ export const getFilterCount = (filterData) => {
 export const getFilterKey = (key) => {
   return key === 'service_type' ? 'service' : key;
 };
+
+export const prepareQueryParams = (filters) => {
+  const entries = Object.entries(filters);
+
+  const params = entries
+    .filter((entry) => entry[1].length)
+    .map((entry) => `${entry[0]}=${entry[1].join(',')}`)
+    .join('&');
+
+  return params;
+};

--- a/openmetadata-ui/src/main/resources/ui/src/utils/FilterUtils.js
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/FilterUtils.js
@@ -58,10 +58,8 @@ export const getFilterKey = (key) => {
 export const prepareQueryParams = (filters) => {
   const entries = Object.entries(filters);
 
-  const params = entries
+  return entries
     .filter((entry) => entry[1].length)
     .map((entry) => `${entry[0]}=${entry[1].join(',')}`)
     .join('&');
-
-  return params;
 };


### PR DESCRIPTION
Fixes #3862 

### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on issue #3862 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :

https://user-images.githubusercontent.com/59080942/162573598-a1b8e4ef-96ce-44b0-8b6c-2cc9031d3965.mov




#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya, @vivekratnavel -->
<!--- Backend: @sureshms @harshach, @vivekratnavel -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
