### PR TITLE
Added result limit in DatabaseServiceQueryUsagePipeline

### DIFF
--- a/catalog-rest-service/src/main/resources/json/schema/metadataIngestion/databaseServiceQueryUsagePipeline.json
+++ b/catalog-rest-service/src/main/resources/json/schema/metadataIngestion/databaseServiceQueryUsagePipeline.json
@@ -13,6 +13,11 @@
       "description": "Temporary file name to store the query logs before processing. Absolute file path required.",
       "type": "string",
       "default": "/tmp/query_log"
+    },
+    "resultLimit": {
+      "description": "Configuration to set the limit for query logs",
+      "type": "integer",
+      "default": "100"
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Added result limit in DatabaseServiceQueryUsagePipeline

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya, @vivekratnavel -->
<!--- Backend: @sureshms @harshach, @vivekratnavel -->
@harshach @ayush-shah @pmbrull
