### PR TITLE
Fix #3993 Selecting a service type filter should only list the databases that belong to the service type

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/EntityList/EntityList.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/EntityList/EntityList.tsx
@@ -47,7 +47,7 @@ const EntityList: FunctionComponent<Prop> = ({
                     className="tw-font-medium tw-pl-2"
                     to={getEntityLink(item.index, item.fullyQualifiedName)}>
                     <button
-                      className="tw-text-grey-body hover:tw-text-primary-hover hover:tw-underline tw-w-52 tw-truncate"
+                      className="tw-text-grey-body hover:tw-text-primary-hover hover:tw-underline tw-w-52 tw-truncate tw-text-left"
                       title={item.name}>
                       {item.name}
                     </button>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/Explore.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/Explore.component.tsx
@@ -54,6 +54,7 @@ import {
   INITIAL_SORT_FIELD,
   INITIAL_SORT_ORDER,
   tabsInfo,
+  UPDATABLE_AGGREGATION,
   ZERO_SIZE,
 } from '../../constants/explore.constants';
 import { SearchIndex } from '../../enums/search.enum';
@@ -185,21 +186,25 @@ const Explore: React.FC<ExploreProps> = ({
       for (const newAgg of newAggregations) {
         for (const oldAgg of oldAggs) {
           if (newAgg.title === oldAgg.title) {
-            const buckets = cloneDeep(oldAgg.buckets)
-              .map((item) => {
-                // eslint-disable-next-line @typescript-eslint/camelcase
-                return { ...item, doc_count: 0 };
-              })
-              .concat(newAgg.buckets);
-            const bucketHashmap = buckets.reduce((obj, item) => {
-              obj[item.key]
-                ? // eslint-disable-next-line @typescript-eslint/camelcase
-                  (obj[item.key].doc_count += item.doc_count)
-                : (obj[item.key] = { ...item });
+            if (UPDATABLE_AGGREGATION.includes(newAgg.title)) {
+              const buckets = cloneDeep(oldAgg.buckets)
+                .map((item) => {
+                  // eslint-disable-next-line @typescript-eslint/camelcase
+                  return { ...item, doc_count: 0 };
+                })
+                .concat(newAgg.buckets);
+              const bucketHashmap = buckets.reduce((obj, item) => {
+                obj[item.key]
+                  ? // eslint-disable-next-line @typescript-eslint/camelcase
+                    (obj[item.key].doc_count += item.doc_count)
+                  : (obj[item.key] = { ...item });
 
-              return obj;
-            }, {} as { [key: string]: Bucket });
-            oldAgg.buckets = Object.values(bucketHashmap);
+                return obj;
+              }, {} as { [key: string]: Bucket });
+              oldAgg.buckets = Object.values(bucketHashmap);
+            } else {
+              oldAgg.buckets = newAgg.buckets;
+            }
           }
         }
       }

--- a/openmetadata-ui/src/main/resources/ui/src/constants/explore.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/explore.constants.ts
@@ -24,6 +24,8 @@ export const INITIAL_FROM = 1;
 export const ZERO_SIZE = 0;
 export const emptyValue = '';
 
+export const UPDATABLE_AGGREGATION = ['Service', 'Tier', 'Tags'];
+
 export const getBucketList = (buckets: Array<Bucket>) => {
   let bucketList: Array<Bucket> = [...tiers];
   buckets.forEach((el) => {


### PR DESCRIPTION
Fixes #3993 

### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on issue #3993 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement


#
### Frontend Preview (Screenshots) :


https://user-images.githubusercontent.com/59080942/162582297-a2139920-1788-4786-9ace-e85e1f5b62e7.mov





#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya, @vivekratnavel -->
<!--- Backend: @sureshms @harshach, @vivekratnavel -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
