### PR TITLE
Fixes to connection options in create engine

### DIFF
--- a/ingestion/src/metadata/utils/engines.py
+++ b/ingestion/src/metadata/utils/engines.py
@@ -19,6 +19,9 @@ from sqlalchemy.engine.base import Engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm.session import Session
 
+from metadata.generated.schema.entity.services.connections.connectionBasicType import (
+    ConnectionOptions,
+)
 from metadata.generated.schema.metadataIngestion.workflow import (
     Source as WorkflowSource,
 )
@@ -35,10 +38,10 @@ def get_engine(workflow_source: WorkflowSource, verbose: bool = False) -> Engine
     service_connection_config = workflow_source.serviceConnection.__root__.config
     options = service_connection_config.connectionOptions
     if not options:
-        options = {}
+        options = ConnectionOptions()
     engine = create_engine(
         get_connection_url(service_connection_config),
-        **options,
+        **options.dict(),
         connect_args=get_connection_args(service_connection_config),
         echo=verbose,
     )


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Fix #4032 
create_engine method requires options to be passed as dictionary. The options were assigning as a ConnectionOptions objects so that is needed to be converted to dictionary.
Also previously an empty dictionary was being passed if the options were empty. We can pass. an empty ConnectionOptions object now and it will be converted to dictionary
#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya, @vivekratnavel -->
<!--- Backend: @sureshms @harshach, @vivekratnavel -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
@pmbrull please check the implementation