### PR TITLE
Usage Engine Connection Fix

### DIFF
--- a/ingestion/src/metadata/ingestion/source/clickhouse_usage.py
+++ b/ingestion/src/metadata/ingestion/source/clickhouse_usage.py
@@ -43,7 +43,7 @@ class ClickhouseUsageSource(Source[TableQuery]):
             start_time=start, end_time=end
         )
         self.report = SQLSourceStatus()
-        self.engine = get_engine(self.config.serviceConnection)
+        self.engine = get_engine(self.connection)
 
     @classmethod
     def create(cls, config_dict, metadata_config: WorkflowConfig):

--- a/ingestion/src/metadata/ingestion/source/mssql_usage.py
+++ b/ingestion/src/metadata/ingestion/source/mssql_usage.py
@@ -40,7 +40,7 @@ class MssqlUsageSource(Source[TableQuery]):
         self.analysis_date = start
         self.sql_stmt = MSSQL_SQL_USAGE_STATEMENT.format(start_date=start, end_date=end)
         self.report = SQLSourceStatus()
-        self.engine = get_engine(self.config.serviceConnection)
+        self.engine = get_engine(self.connection)
 
     @classmethod
     def create(cls, config_dict, metadata_config: WorkflowConfig):

--- a/ingestion/src/metadata/ingestion/source/redshift_usage.py
+++ b/ingestion/src/metadata/ingestion/source/redshift_usage.py
@@ -64,7 +64,7 @@ class RedshiftUsageSource(Source[TableQuery]):
         self._extract_iter: Union[None, Iterator] = None
         self._database = "redshift"
         self.status = SQLSourceStatus()
-        self.engine = get_engine(self.config.serviceConnection)
+        self.engine = get_engine(self.service_connection)
 
     @classmethod
     def create(cls, config_dict, metadata_config: WorkflowConfig):

--- a/ingestion/src/metadata/ingestion/source/snowflake_usage.py
+++ b/ingestion/src/metadata/ingestion/source/snowflake_usage.py
@@ -70,7 +70,7 @@ class SnowflakeUsageSource(Source[TableQuery]):
         self._extract_iter: Union[None, Iterator] = None
         self._database = "Snowflake"
         self.report = SQLSourceStatus()
-        self.engine = get_engine(self.config.serviceConnection)
+        self.engine = get_engine(self.service_connection)
 
     @classmethod
     def create(cls, config_dict, metadata_config: WorkflowConfig):


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the ..... because ...
```
Traceback (most recent call last):
  File "/Users/mayursingal/Desktop/ulixius1/OpenMetadata/venv/bin/metadata", line 8, in <module>
    sys.exit(metadata())
  File "/Users/mayursingal/Desktop/ulixius1/OpenMetadata/venv/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/mayursingal/Desktop/ulixius1/OpenMetadata/venv/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/mayursingal/Desktop/ulixius1/OpenMetadata/venv/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/mayursingal/Desktop/ulixius1/OpenMetadata/venv/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/mayursingal/Desktop/ulixius1/OpenMetadata/venv/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/mayursingal/Desktop/ulixius1/OpenMetadata/venv/lib/python3.8/site-packages/metadata/cmd.py", line 90, in ingest
    workflow = Workflow.create(workflow_config)
  File "/Users/mayursingal/Desktop/ulixius1/OpenMetadata/venv/lib/python3.8/site-packages/metadata/ingestion/api/workflow.py", line 138, in create
    return cls(config)
  File "/Users/mayursingal/Desktop/ulixius1/OpenMetadata/venv/lib/python3.8/site-packages/metadata/ingestion/api/workflow.py", line 58, in __init__
    self.source: Source = source_class.create(
  File "/Users/mayursingal/Desktop/ulixius1/OpenMetadata/venv/lib/python3.8/site-packages/metadata/ingestion/source/snowflake_usage.py", line 83, in create
    return cls(config, metadata_config)
  File "/Users/mayursingal/Desktop/ulixius1/OpenMetadata/venv/lib/python3.8/site-packages/metadata/ingestion/source/snowflake_usage.py", line 73, in __init__
    self.engine = get_engine(self.config.serviceConnection)
  File "/Users/mayursingal/Desktop/ulixius1/OpenMetadata/venv/lib/python3.8/site-packages/metadata/utils/engines.py", line 43, in get_engine
    options = connection.connectionOptions
AttributeError: 'ServiceConnection' object has no attribute 'connectionOptions'
```

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya, @vivekratnavel -->
<!--- Backend: @sureshms @harshach, @vivekratnavel -->
@harshach @ayush-shah @pmbrull 
