### PR TITLE
Fix #4208: Owner of a team should be able to delete a user

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/teams/UserCard.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/teams/UserCard.test.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { findByTestId, render } from '@testing-library/react';
+import { findByTestId, fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import UserCard from './UserCard';
@@ -100,5 +100,26 @@ describe('Test userCard component', () => {
 
     expect(svgIcon).toBeInTheDocument();
     expect(datasetLink).toBeInTheDocument();
+  });
+
+  it('If isOwner is passed it should allow delete action', async () => {
+    const { container } = render(
+      <UserCard
+        isActionVisible
+        isOwner
+        item={mockItem}
+        onRemove={mockRemove}
+      />,
+      {
+        wrapper: MemoryRouter,
+      }
+    );
+
+    const remove = await findByTestId(container, 'remove');
+
+    fireEvent.click(remove);
+
+    expect(remove).toBeInTheDocument();
+    expect(mockRemove).toBeCalled();
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/pages/teams/UserCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/teams/UserCard.tsx
@@ -42,6 +42,7 @@ interface Props {
   isIconVisible?: boolean;
   isDataset?: boolean;
   isCheckBoxes?: boolean;
+  isOwner?: boolean;
   onSelect?: (value: string) => void;
   onRemove?: (value: string) => void;
 }
@@ -52,6 +53,7 @@ const UserCard = ({
   isIconVisible = false,
   isDataset = false,
   isCheckBoxes = false,
+  isOwner = false,
   onSelect,
   onRemove,
 }: Props) => {
@@ -202,6 +204,7 @@ const UserCard = ({
           ) : (
             <NonAdminAction
               html={<>You do not have permission to update the team.</>}
+              isOwner={isOwner}
               permission={Operation.UpdateTeam}
               position="bottom">
               <span
@@ -209,6 +212,7 @@ const UserCard = ({
                   'tw-opacity-40':
                     !isAdminUser &&
                     !isAuthDisabled &&
+                    !isOwner &&
                     !userPermissions[Operation.UpdateTeam],
                 })}
                 data-testid="remove"

--- a/openmetadata-ui/src/main/resources/ui/src/pages/teams/index.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/teams/index.tsx
@@ -439,6 +439,7 @@ const TeamsPage = () => {
           <p>There are no users added yet.</p>
           {isAdminUser ||
           isAuthDisabled ||
+          isOwner() ||
           userPermissions[Operation.UpdateTeam] ? (
             <>
               <p>Would like to start adding some?</p>
@@ -476,6 +477,7 @@ const TeamsPage = () => {
               <UserCard
                 isActionVisible
                 isIconVisible
+                isOwner={isOwner()}
                 item={User}
                 key={index}
                 onRemove={deleteUserHandler}


### PR DESCRIPTION
Closes #4208 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the teams page to allow owners to remove users from team

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<p align="center">

https://user-images.githubusercontent.com/86726556/164063373-27ae8f99-ddb2-49d5-aef8-7ee5c52c1bea.mov


</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@harshach @open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya, @vivekratnavel -->
<!--- Backend: @sureshms @harshach, @vivekratnavel -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
