### PR TITLE
Fix #4258 - Check dag bag and discard run id search

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/airflow/AirflowRESTClient.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/airflow/AirflowRESTClient.java
@@ -171,7 +171,10 @@ public class AirflowRESTClient {
       if (response.statusCode() == 200) {
         List<PipelineStatus> statuses = JsonUtils.readObjects(response.body(), PipelineStatus.class);
         ingestionPipeline.setPipelineStatuses(statuses);
+        ingestionPipeline.setDeployed(true);
         return ingestionPipeline;
+      } else if (response.statusCode() == 404) {
+        ingestionPipeline.setDeployed(false);
       }
 
       throw AirflowException.byMessage(

--- a/catalog-rest-service/src/main/resources/json/schema/entity/services/ingestionPipelines/ingestionPipeline.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/services/ingestionPipelines/ingestionPipeline.json
@@ -166,6 +166,10 @@
       },
       "default": null
     },
+    "deployed": {
+      "description": "Indicates if the workflow has been successfully deployed to Airflow.",
+      "type": "boolean"
+    },
     "nextExecutionDate": {
       "description": "Next execution date from the underlying pipeline platform once the pipeline scheduled.",
       "$ref": "../../../type/basic.json#/definitions/date"

--- a/openmetadata-airflow-apis/src/openmetadata/api/apis_metadata.py
+++ b/openmetadata-airflow-apis/src/openmetadata/api/apis_metadata.py
@@ -55,7 +55,7 @@ APIS_METADATA = [
     },
     {
         "name": "dag_status",
-        "description": "Get the status of a dag run",
+        "description": "Get the status of a dag's latest runs",
         "http_method": "GET",
         "arguments": [
             {
@@ -63,12 +63,6 @@ APIS_METADATA = [
                 "description": "The id of the dag",
                 "form_input_type": "text",
                 "required": True,
-            },
-            {
-                "name": "run_id",
-                "description": "The id of the dagRun",
-                "form_input_type": "text",
-                "required": False,
             },
         ],
     },

--- a/openmetadata-airflow-apis/src/openmetadata/api/rest_api.py
+++ b/openmetadata-airflow-apis/src/openmetadata/api/rest_api.py
@@ -218,16 +218,15 @@ class REST_API(AppBuilderBaseView):
         Check the status of a DAG runs
         """
         dag_id: str = self.get_request_arg(request, "dag_id")
-        run_id: Optional[str] = self.get_request_arg(request, "run_id")
 
         try:
-            return status(dag_id, run_id)
+            return status(dag_id)
 
         except Exception as exc:
-            logging.info(f"Failed to get dag {dag_id} {run_id} status")
+            logging.info(f"Failed to get dag {dag_id} status")
             return ApiResponse.error(
                 status=ApiResponse.STATUS_SERVER_ERROR,
-                error=f"Failed to get status for {dag_id} {run_id} due to {exc} - {traceback.format_exc()}",
+                error=f"Failed to get status for {dag_id} due to {exc} - {traceback.format_exc()}",
             )
 
     def delete_dag(self) -> Response:


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Fix #4258 

- Return 404 if DAG is not in the DagBag
- Return empty if the DAG has not been run yet
- Discard searching for specific runId, as it is not used from UI

Added `deployed` field to IngestionPipeline which gets informed as true/false from `pipelineStatus` query param

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [x] New feature
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya, @vivekratnavel -->
<!--- Backend: @sureshms @harshach, @vivekratnavel -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
