### PR TITLE
Fixed lineage issue for double schema name

### DIFF
--- a/ingestion/src/metadata/ingestion/ometa/mixins/lineage_mixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/lineage_mixin.py
@@ -245,3 +245,4 @@ class OMetaLineageMixin(Generic[T]):
         except Exception as err:
             logger.debug(str(err))
             logger.error(f"Ingesting lineage failed")
+        return False

--- a/ingestion/src/metadata/ingestion/sink/metadata_rest.py
+++ b/ingestion/src/metadata/ingestion/sink/metadata_rest.py
@@ -538,9 +538,12 @@ class MetadataRestSink(Sink[Entity]):
         try:
             parser = Parser(db_schema_and_table.table.viewDefinition.__root__)
             to_table_name = db_schema_and_table.table.name.__root__
+
             for from_table_name in parser.tables:
+                if "." not in from_table_name:
+                    from_table_name = f"{db_schema.name.__root__}.{from_table_name}"
                 self.metadata._create_lineage_by_table_name(
-                    f"{db_schema.name.__root__}.{from_table_name}",
+                    from_table_name,
                     f"{db_schema.name.__root__}.{to_table_name}",
                     db.service.name,
                     db_schema_and_table.database.name.__root__,


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Lineage was not getting created when schema name was was appearing twice. Added a condition to handle the use case

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya, @vivekratnavel -->
<!--- Backend: @sureshms @harshach, @vivekratnavel -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
@harshach @ayush-shah @pmbrull 