### PR TITLE
Fix issue-4276: UI: Filter Schema once added unable to remove

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/react-select-component/ReactSelectMultiInput.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/react-select-component/ReactSelectMultiInput.tsx
@@ -13,6 +13,7 @@
 
 import { isUndefined } from 'lodash';
 import React, { KeyboardEventHandler, useState } from 'react';
+import { MultiValue } from 'react-select';
 import CreatableSelect from 'react-select/creatable';
 import { reactSelectCustomStyle } from './reactSelectCustomStyle';
 
@@ -52,6 +53,12 @@ const ReactSelectMultiInput = ({
     setinputValue(input);
   };
 
+  const handleChange = (newValue: MultiValue<unknown>) => {
+    const data = newValue as Option[];
+    setValues(data);
+    getTagValue(data.map((v) => v.value));
+  };
+
   const handleKeyDown: KeyboardEventHandler<HTMLDivElement> = (event) => {
     if (!inputValue) return;
     switch (event.key) {
@@ -76,6 +83,7 @@ const ReactSelectMultiInput = ({
       placeholder={placeholder}
       styles={reactSelectCustomStyle}
       value={values}
+      onChange={handleChange}
       onInputChange={handleInputChange}
       onKeyDown={handleKeyDown}
     />


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Now we can remove the filter pattern if we want.
Closes #4276 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :


#

https://user-images.githubusercontent.com/71748675/164446681-2884d351-3b98-4b52-b69b-ad2da6efe993.mov


### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya, @vivekratnavel -->
<!--- Backend: @sureshms @harshach, @vivekratnavel -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
@open-metadata/ui 