### PR TITLE
Fix #4336: in HA setup, multiple instances of OpenMetadata servers try to create admin users and one of them will fail

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/security/DefaultAuthorizer.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/security/DefaultAuthorizer.java
@@ -64,7 +64,7 @@ public class DefaultAuthorizer implements Authorizer {
           user.setIsAdmin(true);
         }
         addOrUpdateUser(user);
-      } catch (EntityNotFoundException ex) {
+      } catch (EntityNotFoundException | IOException ex) {
         User user =
             new User()
                 .withId(UUID.randomUUID())
@@ -74,8 +74,6 @@ public class DefaultAuthorizer implements Authorizer {
                 .withUpdatedBy(adminUser)
                 .withUpdatedAt(System.currentTimeMillis());
         addOrUpdateUser(user);
-      } catch (IOException e) {
-        LOG.error("Failed to create admin user {}", adminUser, e);
       }
     }
   }
@@ -90,7 +88,7 @@ public class DefaultAuthorizer implements Authorizer {
           user.setIsBot(true);
         }
         addOrUpdateUser(user);
-      } catch (EntityNotFoundException ex) {
+      } catch (EntityNotFoundException | IOException ex) {
         User user =
             new User()
                 .withId(UUID.randomUUID())
@@ -100,8 +98,6 @@ public class DefaultAuthorizer implements Authorizer {
                 .withUpdatedBy(botUser)
                 .withUpdatedAt(System.currentTimeMillis());
         addOrUpdateUser(user);
-      } catch (IOException e) {
-        LOG.error("Failed to create admin user {}", botUser, e);
       }
     }
   }
@@ -251,7 +247,7 @@ public class DefaultAuthorizer implements Authorizer {
     try {
       RestUtil.PutResponse<User> addedUser = userRepository.createOrUpdate(null, user);
       LOG.debug("Added user entry: {}", addedUser);
-    } catch (IOException exception) {
+    } catch (Exception exception) {
       // In HA set up the other server may have already added the user.
       LOG.debug("Caught exception: {}", ExceptionUtils.getStackTrace(exception));
       LOG.debug("User entry: {} already exists.", user);


### PR DESCRIPTION

### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the ..... because ...

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya, @vivekratnavel -->
<!--- Backend: @sureshms @harshach, @vivekratnavel -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
