### PR TITLE
Fix #4332 - Athena LEN & hist concat cast + disable

### DIFF
--- a/ingestion/src/metadata/orm_profiler/metrics/static/histogram.py
+++ b/ingestion/src/metadata/orm_profiler/metrics/static/histogram.py
@@ -91,6 +91,7 @@ class Histogram(QueryMetric):
                 ).label("boundaries"),
                 func.count().label("frequencies"),
             )
+            .select_from(ranges_cte)
             .group_by(
                 ranges_cte.c.bin_floor,
                 ranges_cte.c.bin_ceil,

--- a/ingestion/src/metadata/orm_profiler/metrics/static/histogram.py
+++ b/ingestion/src/metadata/orm_profiler/metrics/static/histogram.py
@@ -86,17 +86,17 @@ class Histogram(QueryMetric):
 
         hist = (
             session.query(
-                ConcatFn(str(ranges_cte.c.bin_floor), " to ", str(ranges_cte.c.bin_ceil)).label(
-                    "boundaries"
-                ),
+                ConcatFn(
+                    str(ranges_cte.c.bin_floor), " to ", str(ranges_cte.c.bin_ceil)
+                ).label("boundaries"),
                 func.count().label("frequencies"),
             )
             .group_by(
                 ranges_cte.c.bin_floor,
                 ranges_cte.c.bin_ceil,
-                ConcatFn(str(ranges_cte.c.bin_floor), " to ", str(ranges_cte.c.bin_ceil)).label(
-                    "boundaries"
-                ),
+                ConcatFn(
+                    str(ranges_cte.c.bin_floor), " to ", str(ranges_cte.c.bin_ceil)
+                ).label("boundaries"),
             )
             .order_by("boundaries")
         )

--- a/ingestion/src/metadata/orm_profiler/metrics/static/histogram.py
+++ b/ingestion/src/metadata/orm_profiler/metrics/static/histogram.py
@@ -86,7 +86,7 @@ class Histogram(QueryMetric):
 
         hist = (
             session.query(
-                ConcatFn(ranges_cte.c.bin_floor, " to ", ranges_cte.c.bin_ceil).label(
+                ConcatFn(str(ranges_cte.c.bin_floor), " to ", str(ranges_cte.c.bin_ceil)).label(
                     "boundaries"
                 ),
                 func.count().label("frequencies"),
@@ -94,7 +94,7 @@ class Histogram(QueryMetric):
             .group_by(
                 ranges_cte.c.bin_floor,
                 ranges_cte.c.bin_ceil,
-                ConcatFn(ranges_cte.c.bin_floor, " to ", ranges_cte.c.bin_ceil).label(
+                ConcatFn(str(ranges_cte.c.bin_floor), " to ", str(ranges_cte.c.bin_ceil)).label(
                     "boundaries"
                 ),
             )

--- a/ingestion/src/metadata/orm_profiler/orm/functions/length.py
+++ b/ingestion/src/metadata/orm_profiler/orm/functions/length.py
@@ -38,5 +38,6 @@ def _(element, compiler, **kw):
 @compiles(LenFn, Dialects.Databricks)
 @compiles(LenFn, Dialects.MySQL)
 @compiles(LenFn, Dialects.MariaDB)
+@compiles(LenFn, Dialects.Athena)
 def _(element, compiler, **kw):
     return "LENGTH(%s)" % compiler.process(element.clauses, **kw)

--- a/ingestion/src/metadata/orm_profiler/orm/registry.py
+++ b/ingestion/src/metadata/orm_profiler/orm/registry.py
@@ -42,7 +42,7 @@ class Dialects(Enum):
     Snowflake = "snowflake"
     MSSQL = "mssql"
     Oracle = "oracle"
-    Athena = "athena"
+    Athena = "awsathena"
     Presto = "presto"
     Trino = "Trino"
     Vertica = "vertica"

--- a/ingestion/src/metadata/orm_profiler/profiler/default.py
+++ b/ingestion/src/metadata/orm_profiler/profiler/default.py
@@ -44,7 +44,7 @@ def get_default_metrics(table: DeclarativeMeta) -> List[Metric]:
         Metrics.SUM.value,
         Metrics.UNIQUE_COUNT.value,
         Metrics.UNIQUE_RATIO.value,
-        Metrics.HISTOGRAM.value,
+        # Metrics.HISTOGRAM.value,  # TODO: enable it back after #4368
     ]
 
 

--- a/ingestion/tests/unit/profiler/test_profiler.py
+++ b/ingestion/tests/unit/profiler/test_profiler.py
@@ -102,9 +102,9 @@ class ProfilerTest(TestCase):
             variance=None,
             distinctCount=2.0,
             distinctProportion=1.0,
-            histogram=Histogram(
-                boundaries=["30.0 to 30.25", "31.0 to 31.25"], frequencies=[1, 1]
-            ),
+            # histogram=Histogram(
+            #     boundaries=["30.0 to 30.25", "31.0 to 31.25"], frequencies=[1, 1]
+            # ),
         )
 
     def test_required_metrics(self):

--- a/openmetadata-airflow-apis/setup.py
+++ b/openmetadata-airflow-apis/setup.py
@@ -22,7 +22,7 @@ def get_long_description():
 
 
 base_requirements = {
-    "openmetadata-ingestion[airflow-container]~=0.10",
+    "openmetadata-ingestion[airflow-container]~=0.9",
     "PyYAML<6.0",  # pycln requires < 6
     "pendulum~=2.1.2",
     "packaging~=21.2",

--- a/openmetadata-airflow-apis/setup.py
+++ b/openmetadata-airflow-apis/setup.py
@@ -22,7 +22,7 @@ def get_long_description():
 
 
 base_requirements = {
-    "openmetadata-ingestion[airflow-container]~=0.9",
+    "openmetadata-ingestion[airflow-container]~=0.10",
     "PyYAML<6.0",  # pycln requires < 6
     "pendulum~=2.1.2",
     "packaging~=21.2",
@@ -44,7 +44,7 @@ dev_requirements = {
 
 setup(
     name="openmetadata-airflow-managed-apis",
-    version="0.1.3",
+    version="0.10.0.dev0",
     url="https://open-metadata.org/",
     author="OpenMetadata Committers",
     license="Apache License 2.0",


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Fix #4332

Aside from a couple of fixes, this PR also disabled the Histogram from the default profiler. We are currently not showing that metric in the profiler view and its giving us some issues in different dialects. Opened https://github.com/open-metadata/OpenMetadata/issues/4368 to improve how we compute it

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [x] New feature
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @shahsank3t, @darth-coder00, @Sachin-chaurasiya, @vivekratnavel -->
<!--- Backend: @sureshms @harshach, @vivekratnavel -->
<!--- Ingestion: @harshach @ayush-shah @pmbrull -->
