### PR TITLE
Fix #4414 User Profile Roles are missing Admin option in dropdown

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.test.tsx
@@ -139,6 +139,7 @@ const mockProp = {
   paging: mockPaging,
   postFeedHandler: postFeed,
   isAdminUser: false,
+  isLoggedinUser: false,
   updateUserDetails,
 };
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
@@ -396,7 +396,7 @@ const Users = ({
     }));
     if (!userData.isAdmin) {
       userRolesOption.push({
-        label: 'Admin',
+        label: TERM_ADMIN,
         value: 'admin',
       });
     }
@@ -632,7 +632,7 @@ const Users = ({
     ];
     if (userData.isAdmin) {
       defaultRoles.push({
-        label: 'Admin',
+        label: TERM_ADMIN,
         value: 'admin',
       });
     }

--- a/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
@@ -93,6 +93,7 @@ const Users = ({
   paging,
   updateUserDetails,
   isAdminUser,
+  isLoggedinUser,
 }: Props) => {
   const [activeTab, setActiveTab] = useState(1);
   const [fieldListVisible, setFieldListVisible] = useState<boolean>(false);
@@ -205,7 +206,7 @@ const Users = ({
   };
 
   const getDisplayNameComponent = () => {
-    if (isAdminUser) {
+    if (isAdminUser || isLoggedinUser) {
       return (
         <div className="tw-mt-4 tw-w-full tw-text-center">
           {isDisplayNameEdit ? (
@@ -271,7 +272,7 @@ const Users = ({
   };
 
   const getDescriptionComponent = () => {
-    if (isAdminUser) {
+    if (isAdminUser || isLoggedinUser) {
       return (
         <Description
           description={userData.description || ''}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
@@ -390,6 +390,17 @@ const Users = ({
   };
 
   const getRolesComponent = () => {
+    const userRolesOption = roles?.map((role) => ({
+      label: getEntityName(role as unknown as EntityReference),
+      value: role.id,
+    }));
+    if (!userData.isAdmin) {
+      userRolesOption.push({
+        label: 'Admin',
+        value: 'admin',
+      });
+    }
+
     const rolesElement = (
       <Fragment>
         {userData.isAdmin && (
@@ -444,10 +455,7 @@ const Users = ({
                   aria-label="Select roles"
                   className="tw-ml-1"
                   isSearchable={false}
-                  options={roles?.map((role) => ({
-                    label: getEntityName(role as unknown as EntityReference),
-                    value: role.id,
-                  }))}
+                  options={userRolesOption}
                   placeholder="Roles..."
                   styles={reactSingleSelectCustomStyle}
                   value={selectedRoles}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
@@ -13,7 +13,7 @@
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { AxiosError, AxiosResponse } from 'axios';
-import { isNil } from 'lodash';
+import { isNil, toLower } from 'lodash';
 import { observer } from 'mobx-react';
 import React, { Fragment, RefObject, useEffect, useState } from 'react';
 import Select, { MultiValue } from 'react-select';
@@ -156,10 +156,14 @@ const Users = ({
 
   const handleRolesChange = () => {
     // filter out the roles , and exclude the admin one
-    const updatedRoles = selectedRoles.filter((role) => role.value !== 'admin');
+    const updatedRoles = selectedRoles.filter(
+      (role) => role.value !== toLower(TERM_ADMIN)
+    );
 
     // get the admin role and send it as boolean value `iaAdmin=Boolean(isAdmin)
-    const isAdmin = selectedRoles.find((role) => role.value === 'admin');
+    const isAdmin = selectedRoles.find(
+      (role) => role.value === toLower(TERM_ADMIN)
+    );
     updateUserDetails({
       roles: updatedRoles.map((role) => role.value),
       isAdmin: Boolean(isAdmin),
@@ -397,7 +401,7 @@ const Users = ({
     if (!userData.isAdmin) {
       userRolesOption.push({
         label: TERM_ADMIN,
-        value: 'admin',
+        value: toLower(TERM_ADMIN),
       });
     }
 
@@ -633,7 +637,7 @@ const Users = ({
     if (userData.isAdmin) {
       defaultRoles.push({
         label: TERM_ADMIN,
-        value: 'admin',
+        value: toLower(TERM_ADMIN),
       });
     }
     setSelectedRoles(defaultRoles);

--- a/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.interface.ts
@@ -30,6 +30,7 @@ export interface Props {
   paging: Paging;
   isFeedLoading: boolean;
   isAdminUser: boolean;
+  isLoggedinUser: boolean;
   updateUserDetails: (data: UserDetails) => void;
   feedFilterHandler: (v: FeedFilter) => void;
   fetchFeedHandler: (filterType: FeedFilter, after?: string) => void;

--- a/openmetadata-ui/src/main/resources/ui/src/pages/UserPage/UserPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/UserPage/UserPage.component.tsx
@@ -195,6 +195,7 @@ const UserPage = () => {
           fetchFeedHandler={getFeedData}
           isAdminUser={Boolean(isAdminUser)}
           isFeedLoading={isFeedLoading}
+          isLoggedinUser={isLoggedinUser(username)}
           paging={paging}
           postFeedHandler={postFeedHandler}
           updateUserDetails={updateUserDetails}


### PR DESCRIPTION
Fixes #4414 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on issue #4414 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/59080942/164916669-a3d061e4-37ad-45a1-8ced-78325e340985.png">

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
