### PR TITLE
UI: Remove dummy text from manage tab

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/ManageTab/ManageTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ManageTab/ManageTab.component.tsx
@@ -49,7 +49,6 @@ const ManageTab: FunctionComponent<ManageProps> = ({
   allowSoftDelete,
   isRecursiveDelete,
   deletEntityMessage,
-  manageSectionType,
   handleIsJoinable,
 }: ManageProps) => {
   const { userPermissions, isAdminUser } = useAuth();
@@ -302,9 +301,6 @@ const ManageTab: FunctionComponent<ManageProps> = ({
       className="tw-max-w-3xl tw-mx-auto"
       data-testid="manage-tab"
       id="manageTabDetails">
-      <p className="tw-text-base tw-font-medium tw-mt-2">
-        Manage {manageSectionType ? manageSectionType : 'Section'}
-      </p>
       <div
         className={classNames('tw-mt-2 tw-pb-4', {
           'tw-mb-3': !hideTier,

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/DeleteWidget/DeleteWidget.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/DeleteWidget/DeleteWidget.tsx
@@ -136,7 +136,6 @@ const DeleteWidget = ({
 
   return (
     <Fragment>
-      <p className="tw-text-base tw-font-medium">Delete section</p>
       <div className="tw-mt-1 tw-bg-white" data-testid="danger-zone">
         <div className="tw-border tw-border-error tw-rounded tw-mt-3 tw-shadow">
           {allowSoftDelete && (

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/OwnerWidget/OwnerWidget.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/OwnerWidget/OwnerWidget.tsx
@@ -97,8 +97,8 @@ const OwnerWidget = ({
             <div className="tw-w-10/12">
               <p className="tw-text-sm tw-mb-1 tw-font-medium">Owner</p>
               <p className="tw-text-grey-muted tw-text-xs">
-                Lorem ipsum dolor, sit amet consectetur adipisicing elit.
-                Necessitatibus, sint.
+                The Team owner details are found here. Team ownership can be
+                changed
               </p>
             </div>
 
@@ -163,8 +163,8 @@ const OwnerWidget = ({
                   Open to join
                 </p>
                 <p className="tw-text-grey-muted tw-text-xs">
-                  Lorem ipsum dolor, sit amet consectetur adipisicing elit.
-                  Necessitatibus, sint.
+                  Turn on toggle to allow any user to join the team. To restrict
+                  access, keep the toggle off
                 </p>
               </div>
               <div className="tw-flex tw-items-center">


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on removing dummy text from manage tab

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement


#
### Frontend Preview (Screenshots) :
![image](https://user-images.githubusercontent.com/59080942/164928502-4bca05bd-b7d5-4591-8faf-5dfd0bad3cb7.png)


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
