### PR TITLE
Hot reload module for UI 

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/webpack.config.dev.js
+++ b/openmetadata-ui/src/main/resources/ui/webpack.config.dev.js
@@ -27,7 +27,14 @@ module.exports = {
   mode: 'development',
 
   // Input configuration
-  entry: ['@babel/polyfill', path.join(__dirname, 'src/index.js')],
+  entry: [
+    '@babel/polyfill',
+    // Runtime code for hot module replacement
+    'webpack/hot/dev-server.js',
+    // Dev server client for web socket transport, hot and live reload logic
+    'webpack-dev-server/client/index.js?hot=true&live-reload=true',
+    path.join(__dirname, 'src/index.js'),
+  ],
 
   // Output configuration
   output: {
@@ -208,12 +215,15 @@ module.exports = {
       process: 'process/browser',
       Buffer: ['buffer', 'Buffer'],
     }),
+    // Plugin for hot module replacement
+    new webpack.HotModuleReplacementPlugin(),
   ],
 
   // webpack-dev-server
   devServer: {
     contentBase: outputPath,
     compress: true,
+    hot: true,
     port: 3000,
     // Route all requests to index.html so that app gets to handle all copy pasted deep links
     historyApiFallback: {

--- a/openmetadata-ui/src/main/resources/ui/webpack.config.dev.js
+++ b/openmetadata-ui/src/main/resources/ui/webpack.config.dev.js
@@ -225,6 +225,7 @@ module.exports = {
     compress: true,
     hot: true,
     port: 3000,
+    open: true,
     // Route all requests to index.html so that app gets to handle all copy pasted deep links
     historyApiFallback: {
       disableDotRule: true,


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I have added a hot reload module for UI, it will reload the browser automatically when there are changes in the codebase for the frontend. it is helpful for checking changes related to the frontend in the browser without refreshing the browser manually.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement
- [x] New feature


#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
@open-metadata/ui 