### PR TITLE
Minor changes to API docs - fix grouping of delete policy and consist…

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/permissions/PermissionsResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/permissions/PermissionsResource.java
@@ -45,7 +45,7 @@ public class PermissionsResource {
 
   @GET
   @Operation(
-      summary = "Retrieves permissions for logged in user",
+      summary = "Get permissions for logged in user",
       tags = "general",
       responses = {
         @ApiResponse(

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/policies/PolicyResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/policies/PolicyResource.java
@@ -336,7 +336,7 @@ public class PolicyResource extends EntityResource<Policy, PolicyRepository> {
   @Path("/{id}")
   @Operation(
       summary = "Delete a Policy",
-      tags = "policy",
+      tags = "policies",
       description = "Delete a policy by `id`.",
       responses = {
         @ApiResponse(responseCode = "200", description = "OK"),


### PR DESCRIPTION
…ent documentation

### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Fix API docs:
1. DELETE policy is not grouped under rest of the policy APIs because of incorrect tags set to `policy` instead of `polcies`.
2. Change the text for GET user permissions API to be consistent with rest of the API documentation. Use Get xxx instead of Retreivex xxx.
3. 
#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [] I have commented on my code, particularly in hard-to-understand areas.
- [] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

