### PR TITLE
UI :Add meta information in explore entity cards

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/table-data-card/TableDataCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/table-data-card/TableDataCard.tsx
@@ -25,6 +25,7 @@ import { CurrentTourPageType } from '../../../enums/tour.enum';
 import { TableType } from '../../../generated/entity/data/table';
 import { TagLabel } from '../../../generated/type/tagLabel';
 import { serviceTypeLogo } from '../../../utils/ServiceUtils';
+import { stringToHTML } from '../../../utils/StringsUtils';
 import { getEntityLink, getUsagePercentile } from '../../../utils/TableUtils';
 import TableDataCardBody from './TableDataCardBody';
 
@@ -63,6 +64,10 @@ const TableDataCard: FunctionComponent<Props> = ({
   matches,
   tableType,
   deleted = false,
+  service,
+  database,
+  databaseSchema,
+  name,
 }: Props) => {
   const location = useLocation();
   const history = useHistory();
@@ -94,7 +99,28 @@ const TableDataCard: FunctionComponent<Props> = ({
       showLabel: true,
     });
   }
+  if (service) {
+    OtherDetails.push({
+      key: 'Service',
+      value: service,
+      showLabel: true,
+    });
+  }
 
+  if (database) {
+    OtherDetails.push({
+      key: 'Database',
+      value: database,
+      showLabel: true,
+    });
+  }
+  if (databaseSchema) {
+    OtherDetails.push({
+      key: 'Schema',
+      value: databaseSchema,
+      showLabel: true,
+    });
+  }
   const getAssetTags = () => {
     const assetTags = [...(tags as Array<TagLabel>)];
     if (tier && !isUndefined(tier)) {
@@ -130,7 +156,7 @@ const TableDataCard: FunctionComponent<Props> = ({
               data-testid="table-link"
               id={`${id}Title`}
               onClick={handleLinkClick}>
-              {fullyQualifiedName}
+              {stringToHTML(name)}
             </button>
           </h6>
           {deleted && (


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
explore entity cards to display meta information like `service`, `database` and `databaseSchema`

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Frontend Preview (Screenshots) :
<p align="center">
<img width="709" alt="Screenshot 2022-04-24 at 4 51 03 AM" src="https://user-images.githubusercontent.com/59080942/164959800-48240bbc-b343-4b31-bd4e-67a4e524450a.png">

</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
