### PR TITLE
Fix #4453: Remove the Frequency of Test Run field when we add a test

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/AddDataQualityTest/Forms/ColumnTestForm.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AddDataQualityTest/Forms/ColumnTestForm.test.tsx
@@ -27,7 +27,6 @@ describe('Test ColumnTestForm component', () => {
     const columTestType = await findByTestId(container, 'columTestType');
     const cancelButton = await findByTestId(container, 'cancel-test');
     const saveButton = await findByTestId(container, 'save-test');
-    const frequency = await findByTestId(container, 'frequency');
     const description = await findByText(
       container,
       /MarkdownWithPreview component/i
@@ -38,6 +37,5 @@ describe('Test ColumnTestForm component', () => {
     expect(description).toBeInTheDocument();
     expect(cancelButton).toBeInTheDocument();
     expect(saveButton).toBeInTheDocument();
-    expect(frequency).toBeInTheDocument();
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/AddDataQualityTest/Forms/ColumnTestForm.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AddDataQualityTest/Forms/ColumnTestForm.tsx
@@ -17,7 +17,6 @@ import { cloneDeep, isEmpty, isUndefined } from 'lodash';
 import { EditorContentRef } from 'Models';
 import React, { Fragment, useEffect, useRef, useState } from 'react';
 import { ColumnTestType } from '../../../enums/columnTest.enum';
-import { TestCaseExecutionFrequency } from '../../../generated/api/tests/createTableTest';
 import { Table } from '../../../generated/entity/data/table';
 import {
   ColumnTest,
@@ -79,9 +78,6 @@ const ColumnTestForm = ({
     data?.testCase?.config?.maxValue
   );
 
-  const [frequency, setFrequency] = useState<TestCaseExecutionFrequency>(
-    data?.executionFrequency || TestCaseExecutionFrequency.Daily
-  );
   const [forbiddenValues, setForbiddenValues] = useState<(string | number)[]>(
     data?.testCase?.config?.forbiddenValues || ['']
   );
@@ -284,7 +280,6 @@ const ColumnTestForm = ({
       const columnTestObj: ColumnTest = {
         columnName: columnName,
         description: markdownRef.current?.getEditorContent() || undefined,
-        executionFrequency: frequency,
         testCase: {
           config: getTestConfi(),
           columnTestType: columnTest,
@@ -341,11 +336,6 @@ const ColumnTestForm = ({
 
         break;
       }
-
-      case 'frequency':
-        setFrequency(value as TestCaseExecutionFrequency);
-
-        break;
 
       case 'columnName': {
         const selectedColumn = column.find((d) => d.name === value);
@@ -665,25 +655,6 @@ const ColumnTestForm = ({
           </Field>
 
           {getColumnTestConfig()}
-
-          <Field>
-            <label className="tw-block tw-form-label" htmlFor="frequency">
-              Frequency of Test Run:
-            </label>
-            <select
-              className="tw-form-inputs tw-px-3 tw-py-1"
-              data-testid="frequency"
-              id="frequency"
-              name="frequency"
-              value={frequency}
-              onChange={handleValidation}>
-              {Object.values(TestCaseExecutionFrequency).map((option) => (
-                <option key={option} value={option}>
-                  {option}
-                </option>
-              ))}
-            </select>
-          </Field>
         </div>
         <Field>
           <Field className="tw-flex tw-justify-end">

--- a/openmetadata-ui/src/main/resources/ui/src/components/AddDataQualityTest/Forms/TableTestForm.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AddDataQualityTest/Forms/TableTestForm.test.tsx
@@ -26,7 +26,6 @@ describe('Test TableTestForm component', () => {
     const cancelButton = await findByTestId(container, 'cancel-test');
     const saveButton = await findByTestId(container, 'save-test');
     const value = await findByTestId(container, 'value');
-    const frequency = await findByTestId(container, 'frequency');
     const description = await findByText(
       container,
       /MarkdownWithPreview component/i
@@ -37,6 +36,5 @@ describe('Test TableTestForm component', () => {
     expect(value).toBeInTheDocument();
     expect(cancelButton).toBeInTheDocument();
     expect(saveButton).toBeInTheDocument();
-    expect(frequency).toBeInTheDocument();
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/AddDataQualityTest/Forms/TableTestForm.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AddDataQualityTest/Forms/TableTestForm.tsx
@@ -18,7 +18,6 @@ import React, { Fragment, useEffect, useRef, useState } from 'react';
 import {
   CreateTableTest,
   TableTestType,
-  TestCaseExecutionFrequency,
 } from '../../../generated/api/tests/createTableTest';
 import { TableTest } from '../../../generated/tests/tableTest';
 import {
@@ -67,11 +66,6 @@ const TableTestForm = ({
   );
   const [value, setValue] = useState<number | undefined>(
     data?.testCase.config?.value || data?.testCase.config?.columnCount
-  );
-  const [frequency, setFrequency] = useState<TestCaseExecutionFrequency>(
-    data?.executionFrequency
-      ? data.executionFrequency
-      : TestCaseExecutionFrequency.Daily
   );
   const [isShowError, setIsShowError] = useState({
     minOrMax: false,
@@ -153,7 +147,6 @@ const TableTestForm = ({
     if (validateForm()) {
       const createTest: CreateTableTest = {
         description: markdownRef.current?.getEditorContent() || undefined,
-        executionFrequency: frequency,
         testCase: {
           config: getConfigValue(),
           tableTestType: tableTest,
@@ -200,11 +193,6 @@ const TableTestForm = ({
       case 'value':
         setValue(value as unknown as number);
         errorMsg.values = false;
-
-        break;
-
-      case 'frequency':
-        setFrequency(value as TestCaseExecutionFrequency);
 
         break;
 
@@ -330,25 +318,6 @@ const TableTestForm = ({
             {tableTest === TableTestType.TableRowCountToBeBetween
               ? getMinMaxField()
               : getValueField()}
-          </Field>
-
-          <Field>
-            <label className="tw-block tw-form-label" htmlFor="frequency">
-              Frequency of Test Run:
-            </label>
-            <select
-              className="tw-form-inputs tw-px-3 tw-py-1"
-              data-testid="frequency"
-              id="frequency"
-              name="frequency"
-              value={frequency}
-              onChange={handleValidation}>
-              {Object.values(TestCaseExecutionFrequency).map((option) => (
-                <option key={option} value={option}>
-                  {option}
-                </option>
-              ))}
-            </select>
           </Field>
         </div>
         <Field className="tw-flex tw-justify-end">


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the Add test form in Data Quality tab to remove execution frequency from it

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Frontend Preview (Screenshots) :
<p align="center">
Previous UI:
<img width="1433" alt="Screenshot 2022-04-25 at 12 57 33 PM" src="https://user-images.githubusercontent.com/86726556/165046876-6585715d-912b-42e0-b79e-f26ce57891c9.png">

Current UI:
<img width="1442" alt="Screenshot 2022-04-25 at 1 03 28 PM" src="https://user-images.githubusercontent.com/86726556/165046923-48d05064-2b6e-4b24-80c6-c0d4a35db5f9.png">

</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@pmbrull @harshach @open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
