### PR TITLE
fixed issue-4516 UI: Remove popover for ingestion status if there is no details available

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Ingestion/Ingestion.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Ingestion/Ingestion.component.tsx
@@ -271,7 +271,19 @@ const Ingestion: React.FC<IngestionProps> = ({
       .slice(Math.max(ingestion.pipelineStatuses.length - 5, 0));
 
     return lastFiveIngestions?.map((r, i) => {
-      return (
+      const status =
+        i === lastFiveIngestions.length - 1 ? (
+          <p
+            className={`tw-h-5 tw-w-16 tw-rounded-sm tw-bg-status-${r.state} tw-mr-1 tw-px-1 tw-text-white tw-text-center`}>
+            {capitalize(r.state)}
+          </p>
+        ) : (
+          <p
+            className={`tw-w-4 tw-h-5 tw-rounded-sm tw-bg-status-${r.state} tw-mr-1`}
+          />
+        );
+
+      return r?.endDate || r?.startDate ? (
         <PopOver
           html={
             <div className="tw-text-left">
@@ -287,17 +299,10 @@ const Ingestion: React.FC<IngestionProps> = ({
           position="bottom"
           theme="light"
           trigger="mouseenter">
-          {i === lastFiveIngestions.length - 1 ? (
-            <p
-              className={`tw-h-5 tw-w-16 tw-rounded-sm tw-bg-status-${r.state} tw-mr-1 tw-px-1 tw-text-white tw-text-center`}>
-              {capitalize(r.state)}
-            </p>
-          ) : (
-            <p
-              className={`tw-w-4 tw-h-5 tw-rounded-sm tw-bg-status-${r.state} tw-mr-1`}
-            />
-          )}
+          {status}
         </PopOver>
+      ) : (
+        status
       );
     });
   };


### PR DESCRIPTION

### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Closes #4516 UI: Remove popover for ingestion status if there is no details available

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :

https://user-images.githubusercontent.com/71748675/165513344-929aec01-0baf-4145-96af-a9ee2943cf74.mov



#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
@open-metadata/ui 