### PR TITLE
Add IF NOT EXISTS checks to postgres migration

### DIFF
--- a/bootstrap/sql/org.postgresql.Driver/v001__create_db_connection_info.sql
+++ b/bootstrap/sql/org.postgresql.Driver/v001__create_db_connection_info.sql
@@ -1,4 +1,4 @@
-CREATE FUNCTION to_tz_timestamp(text) RETURNS TIMESTAMP WITH TIME ZONE AS
+CREATE OR REPLACE FUNCTION to_tz_timestamp(text) RETURNS TIMESTAMP WITH TIME ZONE AS
 $$
 select to_timestamp($1, '%Y-%m-%dT%T.%fZ')::timestamptz;
 $$
@@ -19,9 +19,9 @@ CREATE TABLE IF NOT EXISTS entity_relationship (
     PRIMARY KEY (fromId, toId, relation)
 );
 
-CREATE INDEX entity_relationship_edge_index ON entity_relationship(fromId, toId, relation);
-CREATE INDEX entity_relationship_from_index ON entity_relationship(fromId, relation);
-CREATE INDEX entity_relationship_to_index ON entity_relationship(toId, relation);
+CREATE INDEX IF NOT EXISTS entity_relationship_edge_index ON entity_relationship(fromId, toId, relation);
+CREATE INDEX IF NOT EXISTS entity_relationship_from_index ON entity_relationship(fromId, relation);
+CREATE INDEX IF NOT EXISTS entity_relationship_to_index ON entity_relationship(toId, relation);
 
 --
 -- Table that captures all the relationships between field of an entity to a field of another entity
@@ -39,8 +39,8 @@ CREATE TABLE IF NOT EXISTS field_relationship (
     PRIMARY KEY (fromFQN, toFQN, relation)
 );
 
-CREATE INDEX field_relationship_from_index ON field_relationship(fromFQN, relation);
-CREATE INDEX field_relationship_to_index ON field_relationship(toFQN, relation);
+CREATE INDEX IF NOT EXISTS field_relationship_from_index ON field_relationship(fromFQN, relation);
+CREATE INDEX IF NOT EXISTS field_relationship_to_index ON field_relationship(toFQN, relation);
 
 --
 -- Used for storing additional metadata for an entity
@@ -392,9 +392,9 @@ CREATE TABLE IF NOT EXISTS change_event (
     json JSONB NOT NULL
 );
 
-CREATE INDEX change_event_event_type_index ON change_event(eventType);
-CREATE INDEX change_event_entity_type_index ON change_event(entityType);
-CREATE INDEX change_event_event_time_index ON change_event(eventTime);
+CREATE INDEX IF NOT EXISTS change_event_event_type_index ON change_event(eventType);
+CREATE INDEX IF NOT EXISTS change_event_entity_type_index ON change_event(entityType);
+CREATE INDEX IF NOT EXISTS change_event_event_time_index ON change_event(eventTime);
 
 CREATE TABLE IF NOT EXISTS webhook_entity (
     id VARCHAR(36) GENERATED ALWAYS AS (json ->> 'id') STORED NOT NULL,


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
For the postgres migration script `CREATE INDEX` and `CREATE FUNCTION` clauses are missing `IF NOT EXISTS` checks which can cause problems.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
@open-metadata/backend
<!--- Ingestion: @open-metadata/ingestion -->
