### PR TITLE
[WIP] Fix #4610 - Pipeline Tasks removal

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/PipelineRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/PipelineRepository.java
@@ -400,7 +400,6 @@ public class PipelineRepository extends EntityRepository<Pipeline> {
       if (newTasks || removedTasks) {
         List<Task> added = new ArrayList<>();
         List<Task> deleted = new ArrayList<>();
-        majorVersionChange = majorVersionChange || !newTasks || !removedTasks;
         recordListChange("tasks", origTasks, updatedTasks, added, deleted, taskMatch);
       }
     }

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/PipelineRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/PipelineRepository.java
@@ -400,6 +400,7 @@ public class PipelineRepository extends EntityRepository<Pipeline> {
       if (newTasks || removedTasks) {
         List<Task> added = new ArrayList<>();
         List<Task> deleted = new ArrayList<>();
+        majorVersionChange = majorVersionChange || !newTasks || !removedTasks;
         recordListChange("tasks", origTasks, updatedTasks, added, deleted, taskMatch);
       }
     }

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/PipelineRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/PipelineRepository.java
@@ -395,7 +395,9 @@ public class PipelineRepository extends EntityRepository<Pipeline> {
         updateTaskDescription(stored, updated);
       }
 
-      if (newTasks) {
+      boolean removedTasks = updatedTasks.size() < origTasks.size();
+
+      if (newTasks || removedTasks) {
         List<Task> added = new ArrayList<>();
         List<Task> deleted = new ArrayList<>();
         recordListChange("tasks", origTasks, updatedTasks, added, deleted, taskMatch);

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/pipelines/PipelineResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/pipelines/PipelineResourceTest.java
@@ -484,11 +484,24 @@ public class PipelineResourceTest extends EntityResourceTest<Pipeline, CreatePip
             ADMIN_AUTH_HEADERS,
             MINOR_UPDATE,
             change);
-    // TODO update this once task removal is figured out
-    // remove a task
-    // TASKS.remove(0);
-    // change = getChangeDescription(pipeline.getVersion()).withFieldsUpdated(singletonList("tasks"));
-    // updateAndCheckEntity(request.withTasks(TASKS), OK, ADMIN_AUTH_HEADERS, MINOR_UPDATE, change);
+
+    assertEquals(3, pipeline.getTasks().size());
+
+    List<Task> new_tasks = new ArrayList<>();
+    for (int i = 1; i < 3; i++) { // remove task0
+      Task task =
+          new Task()
+              .withName("task" + i)
+              .withDescription("description")
+              .withDisplayName("displayName")
+              .withTaskUrl(new URI("http://localhost:0"));
+      new_tasks.add(task);
+    }
+
+    change = getChangeDescription(pipeline.getVersion());
+    change.getFieldsUpdated().add(new FieldChange().withNewValue(new_tasks).withOldValue(TASKS));
+    pipeline = updateEntity(request, OK, ADMIN_AUTH_HEADERS);
+    assertEquals(2, pipeline.getTasks().size());
   }
 
   @Override

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/pipelines/PipelineResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/pipelines/PipelineResourceTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openmetadata.catalog.util.TestUtils.ADMIN_AUTH_HEADERS;
+import static org.openmetadata.catalog.util.TestUtils.UpdateType.MAJOR_UPDATE;
 import static org.openmetadata.catalog.util.TestUtils.UpdateType.MINOR_UPDATE;
 import static org.openmetadata.catalog.util.TestUtils.UpdateType.NO_CHANGE;
 import static org.openmetadata.catalog.util.TestUtils.assertListNotNull;
@@ -259,6 +260,9 @@ public class PipelineResourceTest extends EntityResourceTest<Pipeline, CreatePip
     change = getChangeDescription(pipeline.getVersion());
     // create a request with same tasks we shouldn't see any change
     updateAndCheckEntity(request.withTasks(updatedTasks), OK, ADMIN_AUTH_HEADERS, NO_CHANGE, change);
+    // create new request with few tasks removed
+    updatedTasks.remove(taskEmptyDesc);
+    pipeline = updateAndCheckEntity(request.withTasks(updatedTasks), OK, ADMIN_AUTH_HEADERS, MAJOR_UPDATE, change);
   }
 
   @Test

--- a/ingestion/tests/integration/ometa/test_ometa_pipeline_api.py
+++ b/ingestion/tests/integration/ometa/test_ometa_pipeline_api.py
@@ -340,8 +340,14 @@ class OMetaPipelineTest(TestCase):
 
         pipeline = self.metadata.create_or_update(data=create_pipeline)
 
-        updated_pipeline = self.metadata.clean_pipeline_tasks(
+        self.metadata.clean_pipeline_tasks(
             pipeline=pipeline, task_ids=["task3", "task4"]
+        )
+
+        updated_pipeline = self.metadata.get_by_name(
+            entity=Pipeline,
+            fqdn="test-service-pipeline.pipeline-test",
+            fields=["tasks"],
         )
 
         assert len(updated_pipeline.tasks) == 2


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->

Fix #4610

Running a PUT updating a Pipeline Entity with a specific list of tasks, returns the Pipeline Entity with that list only. However, running a GET again returns the list with the old + new tasks.

Updated the tests to cover this scenario

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [x] New feature
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
