### PR TITLE
Fix issue-4575: UI: Add total count of user owned or following data entities in profile page and home page

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/EntityList/EntityList.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/EntityList/EntityList.tsx
@@ -46,10 +46,13 @@ const EntityList: FunctionComponent<Prop> = ({
                 )}`}
                 key={index}>
                 <div className="tw-flex">
-                  {getEntityIcon(item.index)}
+                  {getEntityIcon(item.index || item.type || '')}
                   <Link
                     className="tw-font-medium tw-pl-2"
-                    to={getEntityLink(item.index, item.fullyQualifiedName)}>
+                    to={getEntityLink(
+                      item.index || item.type || '',
+                      item.fullyQualifiedName
+                    )}>
                     <button
                       className="tw-text-grey-body hover:tw-text-primary-hover hover:tw-underline tw-w-52 tw-truncate tw-text-left"
                       title={getEntityName(item as unknown as EntityReference)}>

--- a/openmetadata-ui/src/main/resources/ui/src/components/MyData/MyData.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MyData/MyData.component.tsx
@@ -140,7 +140,7 @@ const MyData: React.FC<MyDataProps> = ({
                   data-testid="my-data"
                   to={getLinkByFilter(Ownership.OWNER)}>
                   <span className="link-text tw-font-normal tw-text-xs">
-                    View All
+                    View All <span>({ownedData.length})</span>
                   </span>
                 </Link>
               ) : null}
@@ -160,7 +160,7 @@ const MyData: React.FC<MyDataProps> = ({
                   data-testid="following-data"
                   to={getLinkByFilter(Ownership.FOLLOWERS)}>
                   <span className="link-text tw-font-normal tw-text-xs">
-                    View All
+                    View All <span>({followedData.length})</span>
                   </span>
                 </Link>
               ) : null}

--- a/openmetadata-ui/src/main/resources/ui/src/components/MyData/MyData.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MyData/MyData.component.tsx
@@ -53,6 +53,8 @@ const MyData: React.FC<MyDataProps> = ({
   followedData,
   feedData,
   feedFilter,
+  ownedDataCount,
+  followedDataCount,
   feedFilterHandler,
   isFeedLoading,
   postFeedHandler,
@@ -140,7 +142,7 @@ const MyData: React.FC<MyDataProps> = ({
                   data-testid="my-data"
                   to={getLinkByFilter(Ownership.OWNER)}>
                   <span className="link-text tw-font-normal tw-text-xs">
-                    View All <span>({ownedData.length})</span>
+                    View All <span>({ownedDataCount})</span>
                   </span>
                 </Link>
               ) : null}
@@ -160,7 +162,7 @@ const MyData: React.FC<MyDataProps> = ({
                   data-testid="following-data"
                   to={getLinkByFilter(Ownership.FOLLOWERS)}>
                   <span className="link-text tw-font-normal tw-text-xs">
-                    View All <span>({followedData.length})</span>
+                    View All <span>({followedDataCount})</span>
                   </span>
                 </Link>
               ) : null}

--- a/openmetadata-ui/src/main/resources/ui/src/components/MyData/MyData.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MyData/MyData.interface.ts
@@ -26,6 +26,8 @@ export interface MyDataProps {
   countTables: number;
   countTopics: number;
   countDashboards: number;
+  followedDataCount: number;
+  ownedDataCount: number;
   countPipelines: number;
   userDetails?: User;
   ownedData: Array<FormatedTableData>;

--- a/openmetadata-ui/src/main/resources/ui/src/components/MyData/MyData.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MyData/MyData.test.tsx
@@ -319,6 +319,8 @@ const mockProp = {
   countServices: 0,
   countTables: 10,
   countTopics: 5,
+  followedDataCount: 5,
+  ownedDataCount: 5,
   error: '',
   feedData: formatDataResponse(mockData.data.hits.hits),
   feedFilter: FeedFilter.ALL,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
@@ -40,7 +40,6 @@ import { Paging } from '../../generated/type/paging';
 import { useInfiniteScroll } from '../../hooks/useInfiniteScroll';
 import jsonData from '../../jsons/en';
 import {
-  getCountBadge,
   getEntityName,
   getNonDeletedTeams,
   getOwnerIds,
@@ -619,17 +618,14 @@ const Users = ({
             <div className="tw-flex tw-justify-between tw-items-center">
               My Data
               {userData?.owns?.length ? (
-                <div>
-                  {/* {getCountBadge(userData?.owns?.length || 0, '', false)} */}
-                  <Link
-                    className="tw-ml-1"
-                    data-testid="my-data"
-                    to={getLinkByFilter(Ownership.OWNER)}>
-                    <span className="link-text tw-font-normal tw-text-xs">
-                      View All <span>({userData?.owns?.length})</span>
-                    </span>
-                  </Link>
-                </div>
+                <Link
+                  className="tw-ml-1"
+                  data-testid="my-data"
+                  to={getLinkByFilter(Ownership.OWNER)}>
+                  <span className="link-text tw-font-normal tw-text-xs">
+                    View All <span>({userData?.owns?.length})</span>
+                  </span>
+                </Link>
               ) : null}
             </div>
           }
@@ -643,17 +639,14 @@ const Users = ({
             <div className="tw-flex tw-justify-between">
               Following
               {userData?.follows?.length ? (
-                <div>
-                  {getCountBadge(userData?.follows?.length || 0, '', false)}
-                  <Link
-                    className="tw-ml-1"
-                    data-testid="following-data"
-                    to={getLinkByFilter(Ownership.FOLLOWERS)}>
-                    <span className="link-text tw-font-normal tw-text-xs">
-                      View All
-                    </span>
-                  </Link>
-                </div>
+                <Link
+                  className="tw-ml-1"
+                  data-testid="following-data"
+                  to={getLinkByFilter(Ownership.FOLLOWERS)}>
+                  <span className="link-text tw-font-normal tw-text-xs">
+                    View All <span>({userData?.follows?.length})</span>
+                  </span>
+                </Link>
               ) : null}
             </div>
           }

--- a/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
@@ -40,6 +40,7 @@ import { Paging } from '../../generated/type/paging';
 import { useInfiniteScroll } from '../../hooks/useInfiniteScroll';
 import jsonData from '../../jsons/en';
 import {
+  getCountBadge,
   getEntityName,
   getNonDeletedTeams,
   getOwnerIds,
@@ -615,16 +616,20 @@ const Users = ({
         <EntityList
           entityList={userData?.owns as unknown as FormatedTableData[]}
           headerText={
-            <div className="tw-flex tw-justify-between">
+            <div className="tw-flex tw-justify-between tw-items-center">
               My Data
               {userData?.owns?.length ? (
-                <Link
-                  data-testid="my-data"
-                  to={getLinkByFilter(Ownership.OWNER)}>
-                  <span className="link-text tw-font-normal tw-text-xs">
-                    View All
-                  </span>
-                </Link>
+                <div>
+                  {/* {getCountBadge(userData?.owns?.length || 0, '', false)} */}
+                  <Link
+                    className="tw-ml-1"
+                    data-testid="my-data"
+                    to={getLinkByFilter(Ownership.OWNER)}>
+                    <span className="link-text tw-font-normal tw-text-xs">
+                      View All <span>({userData?.owns?.length})</span>
+                    </span>
+                  </Link>
+                </div>
               ) : null}
             </div>
           }
@@ -638,13 +643,17 @@ const Users = ({
             <div className="tw-flex tw-justify-between">
               Following
               {userData?.follows?.length ? (
-                <Link
-                  data-testid="following-data"
-                  to={getLinkByFilter(Ownership.FOLLOWERS)}>
-                  <span className="link-text tw-font-normal tw-text-xs">
-                    View All
-                  </span>
-                </Link>
+                <div>
+                  {getCountBadge(userData?.follows?.length || 0, '', false)}
+                  <Link
+                    className="tw-ml-1"
+                    data-testid="following-data"
+                    to={getLinkByFilter(Ownership.FOLLOWERS)}>
+                    <span className="link-text tw-font-normal tw-text-xs">
+                      View All
+                    </span>
+                  </Link>
+                </div>
               ) : null}
             </div>
           }

--- a/openmetadata-ui/src/main/resources/ui/src/interface/types.d.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/interface/types.d.ts
@@ -222,6 +222,7 @@ declare module 'Models' {
       name: string[];
     };
     index: string;
+    type?: string;
     database?: string;
     databaseSchema?: string;
     deleted?: boolean;

--- a/openmetadata-ui/src/main/resources/ui/src/pages/MyDataPage/MyDataPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/MyDataPage/MyDataPage.component.tsx
@@ -55,6 +55,8 @@ const MyDataPage = () => {
 
   const [ownedData, setOwnedData] = useState<Array<FormatedTableData>>();
   const [followedData, setFollowedData] = useState<Array<FormatedTableData>>();
+  const [ownedDataCount, setOwnedDataCount] = useState(0);
+  const [followedDataCount, setFollowedDataCount] = useState(0);
 
   const [feedFilter, setFeedFilter] = useState<FeedFilter>(FeedFilter.ALL);
   const [entityThread, setEntityThread] = useState<EntityThread[]>([]);
@@ -203,8 +205,10 @@ const MyDataPage = () => {
       .then(([resOwnedEntity, resFollowedEntity]) => {
         if (resOwnedEntity.status === 'fulfilled') {
           setOwnedData(formatDataResponse(resOwnedEntity.value.data.hits.hits));
+          setOwnedDataCount(resOwnedEntity.value.data.hits.total.value);
         }
         if (resFollowedEntity.status === 'fulfilled') {
+          setFollowedDataCount(resFollowedEntity.value.data.hits.total.value);
           setFollowedData(
             formatDataResponse(resFollowedEntity.value.data.hits.hits)
           );
@@ -353,8 +357,10 @@ const MyDataPage = () => {
             feedFilterHandler={feedFilterHandler}
             fetchFeedHandler={getFeedData}
             followedData={followedData || []}
+            followedDataCount={followedDataCount}
             isFeedLoading={isFeedLoading}
             ownedData={ownedData || []}
+            ownedDataCount={ownedDataCount}
             paging={paging}
             postFeedHandler={postFeedHandler}
           />

--- a/openmetadata-ui/src/main/resources/ui/src/pages/tour-page/TourPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/tour-page/TourPage.component.tsx
@@ -133,8 +133,10 @@ const TourPage = () => {
             }}
             fetchFeedHandler={handleOnClick}
             followedData={[]}
+            followedDataCount={1}
             isFeedLoading={false}
             ownedData={[]}
+            ownedDataCount={1}
             paging={{} as Paging}
             postFeedHandler={handleOnClick}
             userDetails={AppState.userDetails}


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Closes #4575 UI: Add total count of user owned or following data entities in profile page and home page

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [x] New feature


#
### Frontend Preview (Screenshots) :
Home Page:-
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/71748675/166418977-aff1256e-4f11-428f-b418-6a8769aae845.png">

User Page:-
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/71748675/166247111-29672597-ef09-4c02-8d26-b58061134558.png">



#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
@open-metadata/ui 