### PR TITLE
Fix #4511: Hide the test connection button for Sample Data.

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/AddService/AddService.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AddService/AddService.component.tsx
@@ -214,6 +214,7 @@ const AddService = ({
                   : {}) as DataService
               }
               serviceCategory={serviceCategory}
+              serviceType={selectServiceType}
               status={saveServiceState}
               onCancel={handleConnectionDetailsBackClick}
               onSave={(e) => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/ServiceConfig/ConnectionConfigForm.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ServiceConfig/ConnectionConfigForm.tsx
@@ -24,6 +24,7 @@ import {
 import {
   DatabaseConnection,
   DatabaseService,
+  DatabaseServiceType,
 } from '../../generated/entity/services/databaseService';
 import {
   MessagingConnection,
@@ -44,6 +45,7 @@ interface Props {
   data: DatabaseService | MessagingService | DashboardService | PipelineService;
   okText?: string;
   cancelText?: string;
+  serviceType: string;
   serviceCategory: ServiceCategory;
   status: LoadingState;
   onCancel?: () => void;
@@ -54,6 +56,7 @@ const ConnectionConfigForm: FunctionComponent<Props> = ({
   data,
   okText = 'Save',
   cancelText = 'Cancel',
+  serviceType,
   serviceCategory,
   status,
   onCancel,
@@ -149,7 +152,11 @@ const ConnectionConfigForm: FunctionComponent<Props> = ({
         uiSchema={connSch.uiSchema}
         onCancel={onCancel}
         onSubmit={handleSave}
-        onTestConnection={handleTestConnection}
+        onTestConnection={
+          serviceType !== DatabaseServiceType.SampleData
+            ? handleTestConnection
+            : undefined
+        }
       />
     );
   };

--- a/openmetadata-ui/src/main/resources/ui/src/components/ServiceConfig/ServiceConfig.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ServiceConfig/ServiceConfig.tsx
@@ -24,6 +24,7 @@ import ConnectionConfigForm from './ConnectionConfigForm';
 
 interface ServiceConfigProps {
   serviceCategory: ServiceCategory;
+  serviceType: string;
   data?: ServicesData;
   handleUpdate: (
     data: ConfigData,
@@ -37,6 +38,7 @@ export const Field = ({ children }: { children: React.ReactNode }) => {
 
 const ServiceConfig = ({
   serviceCategory,
+  serviceType,
   data,
   handleUpdate,
 }: ServiceConfigProps) => {
@@ -69,6 +71,7 @@ const ServiceConfig = ({
             | PipelineService
         }
         serviceCategory={serviceCategory}
+        serviceType={serviceType}
         status={status}
         onSave={handleOnSaveClick}
       />

--- a/openmetadata-ui/src/main/resources/ui/src/pages/service/index.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/service/index.tsx
@@ -996,6 +996,7 @@ const ServicePage: FunctionComponent = () => {
                     data={serviceDetails as ServicesData}
                     handleUpdate={handleConfigUpdate}
                     serviceCategory={serviceName as ServiceCategory}
+                    serviceType={serviceDetails?.serviceType || ''}
                   />
                 )}
 


### PR DESCRIPTION
Closes #4511 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the service connection form to hide test connection for SampleData service

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Frontend Preview (Screenshots) :
<p align="center">

https://user-images.githubusercontent.com/86726556/166493781-bf3cd086-8b45-48af-9b4e-a6a68e27cd51.mov

</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui @harshach 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
