### PR TITLE
Fix #4595: newKey and New Value on database connection

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/ServiceConfig/ConnectionConfigForm.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ServiceConfig/ConnectionConfigForm.tsx
@@ -35,7 +35,7 @@ import { ConfigData } from '../../interface/service.interface';
 import jsonData from '../../jsons/en';
 import { getDashboardConfig } from '../../utils/DashboardServiceUtils';
 import { getDatabaseConfig } from '../../utils/DatabaseServiceUtils';
-import { escapeBackwardSlashChar } from '../../utils/JSONSchemaFormUtils';
+import { FormatFormDataForSubmit } from '../../utils/JSONSchemaFormUtils';
 import { getMessagingConfig } from '../../utils/MessagingServiceUtils';
 import { getPipelineConfig } from '../../utils/PipelineServiceUtils';
 import { showErrorToast } from '../../utils/ToastUtils';
@@ -71,12 +71,12 @@ const ConnectionConfigForm: FunctionComponent<Props> = ({
     : ({} as ConfigData);
 
   const handleSave = (data: ISubmitEvent<ConfigData>) => {
-    const updatedFormData = escapeBackwardSlashChar(data.formData);
+    const updatedFormData = FormatFormDataForSubmit(data.formData);
     onSave({ ...data, formData: updatedFormData });
   };
 
   const handleTestConnection = (formData: ConfigData) => {
-    const updatedFormData = escapeBackwardSlashChar(formData);
+    const updatedFormData = FormatFormDataForSubmit(formData);
 
     return new Promise<void>((resolve, reject) => {
       TestConnection(updatedFormData, 'Database')

--- a/openmetadata-ui/src/main/resources/ui/src/utils/JSONSchemaFormUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/JSONSchemaFormUtils.ts
@@ -30,3 +30,28 @@ export function escapeBackwardSlashChar<T>(formData: T): T {
 
   return formData;
 }
+
+export function removeAddnFieldsWithDefVal<T>(formData: T): T {
+  for (const key in formData) {
+    if (typeof formData[key as keyof T] === 'object') {
+      removeAddnFieldsWithDefVal(formData[key as keyof T]);
+    } else {
+      const data = formData[key as keyof T];
+      if (
+        key.startsWith('newKey') &&
+        data === ('New Value' as unknown as T[keyof T])
+      ) {
+        delete formData[key];
+      }
+    }
+  }
+
+  return formData;
+}
+
+export function FormatFormDataForSubmit<T>(formData: T): T {
+  escapeBackwardSlashChar(formData);
+  removeAddnFieldsWithDefVal(formData);
+
+  return formData;
+}


### PR DESCRIPTION

### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on 

- Filtering out default key and value for additional properties in json-schema form.
- `newKey` and `New Value` added for additionalProperties, will be filtered out from api payload, unless user changes it.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<p align="center">
<img width="1792" alt="Screenshot 2022-05-05 at 3 20 46 PM" src="https://user-images.githubusercontent.com/86726556/166900437-f746cc6f-f0ba-4485-8d43-78680e1c57c9.png">
<img width="1792" alt="Screenshot 2022-05-05 at 3 21 15 PM" src="https://user-images.githubusercontent.com/86726556/166900454-4c5299f6-6882-4e4f-a444-ff93940d896e.png">

</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui @harshach @shahsank3t 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
