### PR TITLE
Configure entrypoint for airflow plugin

### DIFF
--- a/openmetadata-airflow-apis/setup.py
+++ b/openmetadata-airflow-apis/setup.py
@@ -53,6 +53,15 @@ setup(
     package_dir={"": "src"},
     zip_safe=False,
     dependency_links=[],
+    include_package_data=True,
+    package_data={
+        "": [
+            "*.html", "*.j2"
+        ]
+    },
+    entry_points={
+        "airflow.plugins": ["openmetadata-airflow-managed-apis = plugins.openmetadata_airflow_apis_plugin:RestApiPlugin"]
+    },
     project_urls={
         "Documentation": "https://docs.open-metadata.org/",
         "Source": "https://github.com/open-metadata/OpenMetadata",

--- a/openmetadata-airflow-apis/setup.py
+++ b/openmetadata-airflow-apis/setup.py
@@ -54,13 +54,11 @@ setup(
     zip_safe=False,
     dependency_links=[],
     include_package_data=True,
-    package_data={
-        "": [
-            "*.html", "*.j2"
-        ]
-    },
+    package_data={"": ["*.html", "*.j2"]},
     entry_points={
-        "airflow.plugins": ["openmetadata-airflow-managed-apis = plugins.openmetadata_airflow_apis_plugin:RestApiPlugin"]
+        "airflow.plugins": [
+            "openmetadata-airflow-managed-apis = plugins.openmetadata_airflow_apis_plugin:RestApiPlugin"
+        ]
     },
     project_urls={
         "Documentation": "https://docs.open-metadata.org/",


### PR DESCRIPTION
### Describe your changes :
I worked on the setup.py from the openmetadata airflow api  because  currently we need to donwload the tar release and unpack it to the plugins dir of airflow installation. This process can be made easier by specyfing and entrypoint aiflow.plugin which airflow in runtime picks the plugin and installs it.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [] Bug fix
- [x] Improvement
- [] New feature
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ingestion

