### PR TITLE
Fix #4732 - Glue clean and paginate

### DIFF
--- a/ingestion/src/metadata/ingestion/source/glue.py
+++ b/ingestion/src/metadata/ingestion/source/glue.py
@@ -11,9 +11,8 @@
 
 import traceback
 import uuid
-from typing import Iterable
+from typing import Iterable, List
 
-from metadata.config.common import FQDN_SEPARATOR
 from metadata.generated.schema.entity.data.database import Database
 from metadata.generated.schema.entity.data.databaseSchema import DatabaseSchema
 from metadata.generated.schema.entity.data.location import Location, LocationType
@@ -98,36 +97,30 @@ class GlueSource(Source[Entity]):
     def prepare(self):
         pass
 
-    def assign_next_token_db(self, glue_db_resp):
-        if "NextToken" in glue_db_resp:
-            self.next_db_token = glue_db_resp["NextToken"]
-        else:
-            self.next_db_token = "break"
-
     def next_record(self) -> Iterable[Entity]:
-        while True:
-            if self.next_db_token == "break":
-                break
-            elif self.next_db_token:
-                glue_db_resp = self.glue.get_databases(
-                    NextToken=self.next_db_token, ResourceShareType="ALL"
-                )
-                self.assign_next_token_db(glue_db_resp)
-            else:
-                glue_db_resp = self.glue.get_databases(ResourceShareType="ALL")
-                self.assign_next_token_db(glue_db_resp)
-            for db in glue_db_resp["DatabaseList"]:
 
+        yield from self.ingest_catalog()
+        yield from self.ingest_pipelines()
+
+    def ingest_catalog(self) -> Iterable[Entity]:
+        """
+        Ingest db and table data
+        """
+        paginator = self.glue.get_paginator("get_databases")
+        paginator_response = paginator.paginate()
+
+        for page in paginator_response:
+            for db in page["DatabaseList"]:
                 if filter_by_schema(
                     schema_filter_pattern=self.config.sourceConfig.config.schemaFilterPattern,
                     schema_name=db["Name"],
                 ):
-                    self.source_status.filter(db["Name"], "Schema pattern not allowed")
+                    self.status.filter(db["Name"], "Schema pattern not allowed")
                     continue
 
-                self.database_name = db["Name"]
-                yield from self.ingest_tables()
-        yield from self.ingest_pipelines()
+                yield from self.ingest_tables(
+                    catalog_id=db["CatalogId"], database_name=db["Name"]
+                )
 
     def get_columns(self, column_data):
         for column in column_data["Columns"]:
@@ -144,15 +137,20 @@ class GlueSource(Source[Entity]):
             parsed_string["dataLength"] = parsed_string.get("dataLength", 1)
             yield Column(**parsed_string)
 
-    def ingest_tables(self, next_tables_token=None) -> Iterable[OMetaDatabaseAndTable]:
+    def ingest_tables(
+        self, catalog_id: str, database_name: str
+    ) -> Iterable[OMetaDatabaseAndTable]:
         try:
-            if next_tables_token is not None:
-                glue_resp = self.glue.get_tables(
-                    DatabaseName=self.database_name, NextToken=next_tables_token
-                )
-            else:
-                glue_resp = self.glue.get_tables(DatabaseName=self.database_name)
-            for table in glue_resp["TableList"]:
+
+            all_tables: List[dict] = []
+
+            paginator = self.glue.get_paginator("get_tables")
+            paginator_response = paginator.paginate(DatabaseName=database_name)
+
+            for page in paginator_response:
+                all_tables += page["TableList"]
+
+            for table in all_tables:
 
                 if filter_by_table(
                     self.config.sourceConfig.config.tableFilterPattern,
@@ -165,7 +163,7 @@ class GlueSource(Source[Entity]):
                     continue
                 database_entity = Database(
                     id=uuid.uuid4(),
-                    name="default",
+                    name=catalog_id,
                     service=EntityReference(id=self.service.id, type="databaseService"),
                 )
 
@@ -175,8 +173,6 @@ class GlueSource(Source[Entity]):
                     database=EntityReference(id=database_entity.id, type="database"),
                     service=EntityReference(id=self.service.id, type="databaseService"),
                 )
-                table_name = table["Name"][:255]
-                fqn = f"{self.config.serviceName}{FQDN_SEPARATOR}{self.database_name}{FQDN_SEPARATOR}{table_name}"
                 parameters = table.get("Parameters")
                 location_type = LocationType.Table
                 if parameters:
@@ -188,7 +184,6 @@ class GlueSource(Source[Entity]):
                         else LocationType.Iceberg
                     )
 
-                self.dataset_name = fqn
                 table_columns = self.get_columns(table["StorageDescriptor"])
                 location_entity = Location(
                     name=table["StorageDescriptor"]["Location"],
@@ -211,7 +206,6 @@ class GlueSource(Source[Entity]):
                     description=table["Description"]
                     if hasattr(table, "Description")
                     else "",
-                    fullyQualifiedName=fqn[:128],
                     columns=table_columns,
                     tableType=table_type,
                 )
@@ -222,8 +216,7 @@ class GlueSource(Source[Entity]):
                     location=location_entity,
                 )
                 yield table_and_db
-            if "NextToken" in glue_resp:
-                yield from self.ingest_tables(glue_resp["NextToken"])
+
         except Exception as err:
             logger.debug(traceback.format_exc())
             logger.error(err)
@@ -291,4 +284,4 @@ class GlueSource(Source[Entity]):
         return self.status
 
     def test_connection(self) -> None:
-        pass
+        test_connection(self.connection)


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
We were using manual iterations and token retrieval to paginate data instead of the supported `paginate` methods.

I was not able to replicate the issue where not all dbs were ingested (getting the same data before and now), but yet again, we do not have much data in our Glue and I'm missing permissions.

This patch might get rid of the issue, we'll need to test it further.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [x] New feature
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
