### PR TITLE
Revert "Configure entrypoint for airflow plugin"

### DIFF
--- a/openmetadata-airflow-apis/setup.py
+++ b/openmetadata-airflow-apis/setup.py
@@ -53,13 +53,6 @@ setup(
     package_dir={"": "src"},
     zip_safe=False,
     dependency_links=[],
-    include_package_data=True,
-    package_data={"": ["*.html", "*.j2"]},
-    entry_points={
-        "airflow.plugins": [
-            "openmetadata-airflow-managed-apis = plugins.openmetadata_airflow_apis_plugin:RestApiPlugin"
-        ]
-    },
     project_urls={
         "Documentation": "https://docs.open-metadata.org/",
         "Source": "https://github.com/open-metadata/OpenMetadata",


### PR DESCRIPTION
Reverts open-metadata/OpenMetadata#4733

Having some conflicts with ingestion image. Check thread here https://openmetadata.slack.com/archives/C02B6955S4S/p1651824724328819?thread_ts=1651716288.401759&cid=C02B6955S4S

Thanks