### PR TITLE
Fix #4768 - Add Location path

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/LocationRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/LocationRepository.java
@@ -42,9 +42,9 @@ import org.openmetadata.catalog.util.ResultList;
 
 public class LocationRepository extends EntityRepository<Location> {
   // Location fields that can be patched in a PATCH request
-  private static final String LOCATION_PATCH_FIELDS = "owner,tags";
+  private static final String LOCATION_PATCH_FIELDS = "owner,tags,path";
   // Location fields that can be updated in a PUT request
-  private static final String LOCATION_UPDATE_FIELDS = "owner,tags";
+  private static final String LOCATION_UPDATE_FIELDS = "owner,tags,path";
 
   public LocationRepository(CollectionDAO dao) {
     super(
@@ -60,6 +60,7 @@ public class LocationRepository extends EntityRepository<Location> {
   @Override
   public Location setFields(Location location, Fields fields) throws IOException {
     location.setService(getService(location));
+    location.setPath(location.getPath());
     location.setOwner(fields.contains(FIELD_OWNER) ? getOwner(location) : null);
     location.setFollowers(fields.contains(FIELD_FOLLOWERS) ? getFollowers(location) : null);
     location.setTags(fields.contains(FIELD_TAGS) ? getTags(location.getFullyQualifiedName()) : null);
@@ -379,6 +380,7 @@ public class LocationRepository extends EntityRepository<Location> {
     @Override
     public void entitySpecificUpdate() throws IOException {
       recordChange("locationType", original.getEntity().getLocationType(), updated.getEntity().getLocationType());
+      recordChange("path", original.getEntity().getPath(), updated.getEntity().getPath());
     }
   }
 }

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/locations/LocationResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/locations/LocationResource.java
@@ -93,7 +93,7 @@ public class LocationResource extends EntityResource<Location, LocationRepositor
     }
   }
 
-  static final String FIELDS = "owner,followers,tags";
+  static final String FIELDS = "owner,followers,tags,path";
 
   @GET
   @Operation(
@@ -448,6 +448,7 @@ public class LocationResource extends EntityResource<Location, LocationRepositor
     return new Location()
         .withId(UUID.randomUUID())
         .withName(create.getName())
+        .withPath(create.getPath())
         .withDescription(create.getDescription())
         .withService(create.getService())
         .withLocationType(create.getLocationType())

--- a/catalog-rest-service/src/main/resources/json/schema/api/data/createLocation.json
+++ b/catalog-rest-service/src/main/resources/json/schema/api/data/createLocation.json
@@ -10,7 +10,7 @@
       "$ref": "../../type/basic.json#/definitions/entityName"
     },
     "path": {
-      "description": "Location full path",
+      "description": "Location full path.",
       "type": "string"
     },
     "description": {

--- a/catalog-rest-service/src/main/resources/json/schema/api/data/createLocation.json
+++ b/catalog-rest-service/src/main/resources/json/schema/api/data/createLocation.json
@@ -7,7 +7,11 @@
   "properties": {
     "name": {
       "description": "Name that identifies this Location.",
-      "$ref": "../../entity/data/location.json#/definitions/locationName"
+      "$ref": "../../type/basic.json#/definitions/entityName"
+    },
+    "path": {
+      "description": "Location full path",
+      "type": "string"
     },
     "description": {
       "description": "Description of the location instance.",

--- a/catalog-rest-service/src/main/resources/json/schema/entity/data/location.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/data/location.json
@@ -6,10 +6,6 @@
   "type": "object",
   "javaType": "org.openmetadata.catalog.entity.data.Location",
   "definitions": {
-    "locationName": {
-      "description": "Local name (not fully qualified name) of a location.",
-      "$ref": "../../type/basic.json#/definitions/entityName"
-    },
     "locationType": {
       "javaType": "org.openmetadata.catalog.type.LocationType",
       "description": "This schema defines the type used for describing different types of Location.",
@@ -40,8 +36,12 @@
       "$ref": "../../type/basic.json#/definitions/uuid"
     },
     "name": {
-      "description": "Name of a location without the service. For example s3://bucket/path1/path2.",
-      "$ref": "#/definitions/locationName"
+      "description": "Name of a location",
+      "$ref": "../../type/basic.json#/definitions/entityName"
+    },
+    "path": {
+      "description": "Location full path",
+      "type": "string"
     },
     "displayName": {
       "description": "Display Name that identifies this table. It could be title or label from the source services.",

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/locations/LocationResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/locations/LocationResourceTest.java
@@ -63,6 +63,7 @@ public class LocationResourceTest extends EntityResourceTest<Location, CreateLoc
   public CreateLocation createRequest(String name, String description, String displayName, EntityReference owner) {
     return new CreateLocation()
         .withName(name)
+        .withPath(name)
         .withService(getContainer())
         .withDescription(description)
         .withOwner(owner);
@@ -81,7 +82,7 @@ public class LocationResourceTest extends EntityResourceTest<Location, CreateLoc
         createRequest.getDescription(),
         TestUtils.getPrincipal(authHeaders),
         createRequest.getOwner());
-
+    assertEquals(createRequest.getPath(), location.getPath());
     // Validate service
     EntityReference expectedService = createRequest.getService();
     if (expectedService != null) {
@@ -172,7 +173,6 @@ public class LocationResourceTest extends EntityResourceTest<Location, CreateLoc
     // Create location for each service and test APIs
     for (EntityReference service : differentServices) {
       createAndCheckEntity(createRequest(test).withService(service), ADMIN_AUTH_HEADERS);
-
       // List locations by filtering on service name and ensure right locations are returned
       Map<String, String> queryParams = new HashMap<>();
       queryParams.put("service", service.getName());

--- a/ingestion/examples/sample_data/locations/locations.json
+++ b/ingestion/examples/sample_data/locations/locations.json
@@ -1,20 +1,23 @@
 {
   "locations": [
     {
-      "name": "s3://bucket-a",
-      "displayName": "s3://bucket-a",
+      "name": "bucket_a",
+      "path": "s3://bucket-a",
+      "displayName": "Bucket A",
       "description": "Bucket A",
       "locationType": "Bucket"
     },
     {
-      "name": "s3://bucket-b",
-      "displayName": "s3://bucket-b",
+      "name": "bucket_b",
+      "path": "s3://bucket-b",
+      "displayName": "Bucket B",
       "description": "Bucket B",
       "locationType": "Bucket"
     },
     {
-      "name": "s3://bucket-a/user/hive/dwh",
-      "displayName": "s3://bucket-a/user/hive/dwh",
+      "name": "hive_dwh",
+      "path": "s3://bucket-a/user/hive/dwh",
+      "displayName": "Hive DWH",
       "description": "Bucket A prefix",
       "locationType": "Prefix"
     }

--- a/ingestion/src/metadata/ingestion/sink/metadata_rest.py
+++ b/ingestion/src/metadata/ingestion/sink/metadata_rest.py
@@ -384,6 +384,7 @@ class MetadataRestSink(Sink[Entity]):
     def _create_location(self, location: Location) -> Location:
         location_request = CreateLocationRequest(
             name=location.name,
+            path=location.path,
             description=location.description,
             locationType=location.locationType,
             tags=location.tags,

--- a/ingestion/src/metadata/ingestion/source/gcs.py
+++ b/ingestion/src/metadata/ingestion/source/gcs.py
@@ -89,12 +89,13 @@ class GcsSource(Source[Entity]):
         try:
             for bucket in self.gcs.list_buckets():
                 self.status.scanned(bucket.name)
-                location_name = self._get_bucket_name_with_prefix(bucket.name)
+                location_path = self._get_bucket_name_with_prefix(bucket.name)
                 location_id = uuid.uuid4()
                 location = Location(
                     id=location_id,
-                    name=location_name,
-                    displayName=location_name,
+                    name=bucket.name,
+                    path=location_path,
+                    displayName=bucket.name,
                     locationType=LocationType.Bucket,
                     service=EntityReference(
                         id=self.service.id,

--- a/ingestion/src/metadata/ingestion/source/glue.py
+++ b/ingestion/src/metadata/ingestion/source/glue.py
@@ -186,7 +186,8 @@ class GlueSource(Source[Entity]):
 
                 table_columns = self.get_columns(table["StorageDescriptor"])
                 location_entity = Location(
-                    name=table["StorageDescriptor"]["Location"],
+                    name=table["Name"][:128],  # set location name as table name
+                    path=table["StorageDescriptor"]["Location"],
                     locationType=location_type,
                     service=EntityReference(
                         id=self.storage_service.id, type="storageService"

--- a/ingestion/src/metadata/ingestion/source/s3.py
+++ b/ingestion/src/metadata/ingestion/source/s3.py
@@ -77,12 +77,13 @@ class S3Source(Source[Entity]):
             for bucket in buckets_response["Buckets"]:
                 bucket_name = bucket["Name"]
                 self.status.scanned(bucket_name)
-                location_name = self._get_bucket_name_with_prefix(bucket_name)
+                location_path = self._get_bucket_name_with_prefix(bucket_name)
                 location_id = uuid.uuid4()
                 location = Location(
                     id=location_id,
-                    name=location_name,
-                    displayName=location_name,
+                    name=bucket_name,
+                    path=location_path,
+                    displayName=bucket_name,
                     locationType=LocationType.Bucket,
                     service=EntityReference(
                         id=self.service.id,

--- a/ingestion/src/metadata/ingestion/source/sample_data.py
+++ b/ingestion/src/metadata/ingestion/source/sample_data.py
@@ -377,6 +377,7 @@ class SampleDataSource(Source[Entity]):
             location_ev = Location(
                 id=uuid.uuid4(),
                 name=location["name"],
+                path=location["path"],
                 displayName=location["displayName"],
                 description=location["description"],
                 locationType=location["locationType"],
@@ -420,7 +421,8 @@ class SampleDataSource(Source[Entity]):
                 )
             location_metadata = Location(
                 id=uuid.uuid4(),
-                name="s3://glue_bucket/dwh/schema/" + table["name"],
+                name=table["name"],
+                path="s3://glue_bucket/dwh/schema/" + table["name"],
                 description=table["description"],
                 locationType=location_type,
                 service=EntityReference(


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
We were using `name` to store the location path. That easily overflowed the 128 characters.

This PR fixes #4768 and adds the property `path` to location.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [x] New feature
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
