### PR TITLE
Fix #4780 & #4739 - ConnectionArguments with inner dict

### DIFF
--- a/catalog-rest-service/src/main/resources/json/schema/entity/services/connections/connectionBasicType.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/services/connections/connectionBasicType.json
@@ -6,10 +6,10 @@
   "definitions": {
     "connectionOptions": {
       "javaType": "org.openmetadata.catalog.services.connections.database.ConnectionOptions",
-      "description": "Additional connection options that can be sent to service during the connection.",
+      "description": "Additional connection options to build the URL that can be sent to service during the connection.",
       "type": "object",
       "additionalProperties": {
-        ".{1,}": { "type": "string" }
+        "type": "string"
       }
     },
     "connectionArguments": {

--- a/ingestion/src/metadata/utils/connections.py
+++ b/ingestion/src/metadata/utils/connections.py
@@ -95,9 +95,7 @@ def create_generic_connection(connection, verbose: bool = False) -> Engine:
     :param verbose: debugger or not
     :return: SQAlchemy Engine
     """
-    options = connection.connectionOptions
-    if not options:
-        options = ConnectionOptions()
+    options = connection.connectionOptions or ConnectionOptions()
 
     engine = create_engine(
         get_connection_url(connection),

--- a/ingestion/src/metadata/utils/source_connections.py
+++ b/ingestion/src/metadata/utils/source_connections.py
@@ -207,10 +207,7 @@ def _(connection: PrestoConnection):
 
 @singledispatch
 def get_connection_args(connection):
-    if connection.connectionArguments:
-        return connection.connectionArguments
-    else:
-        return {}
+    return connection.connectionArguments or {}
 
 
 @get_connection_args.register


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
This PR fixes #4780 and fixes #4739

![image](https://user-images.githubusercontent.com/35870520/167384527-4ac15b8e-69e6-4eec-951b-4bf62e131fca.png)

Resolution:
- ConnectionOptions are used to add parameters to the connection URL -> values should be string
- ConnectionArguments are being passed to `connect_args` in SQLAlchemy -> In there we are passing the data as-is.
#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [x] New feature
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
