### PR TITLE
Fix #4827 UI : Show Expiry date for JWT token on bots details page.

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/axiosAPIs/userAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/axiosAPIs/userAPI.ts
@@ -130,9 +130,13 @@ export const getUserToken: Function = (id: string): Promise<AxiosResponse> => {
 
 export const generateUserToken: Function = (
   id: string,
-  data: Record<string, string>
+  expiry: string
 ): Promise<AxiosResponse> => {
-  return APIClient.put(`/users/generateToken/${id}`, data);
+  const configOptions = {
+    headers: { 'Content-type': 'application/json' },
+  };
+
+  return APIClient.put(`/users/generateToken/${id}`, expiry, configOptions);
 };
 
 export const revokeUserToken: Function = (

--- a/openmetadata-ui/src/main/resources/ui/src/components/BotsDetail/BotsDetail.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BotsDetail/BotsDetail.component.tsx
@@ -61,6 +61,7 @@ const BotsDetail: FC<BotsDetailProp> = ({
   const [isDisplayNameEdit, setIsDisplayNameEdit] = useState(false);
   const [isDescriptionEdit, setIsDescriptionEdit] = useState(false);
   const [botsToken, setBotsToken] = useState<string>('');
+  const [botsTokenExpiry, setBotsTokenExpiry] = useState<string>();
   const [isRevokingToken, setIsRevokingToken] = useState<boolean>(false);
   const [isRegeneratingToken, setIsRegeneratingToken] =
     useState<boolean>(false);
@@ -103,19 +104,21 @@ const BotsDetail: FC<BotsDetailProp> = ({
   const fetchBotsToken = () => {
     getUserToken(botsData.id)
       .then((res: AxiosResponse) => {
-        const { JWTToken } = res.data;
+        const { JWTToken, JWTTokenExpiresAt } = res.data;
         setBotsToken(JWTToken);
+        setBotsTokenExpiry(JWTTokenExpiresAt);
       })
       .catch((err: AxiosError) => {
         showErrorToast(err);
       });
   };
 
-  const generateBotsToken = (data: Record<string, string>) => {
+  const generateBotsToken = (data: string) => {
     generateUserToken(botsData.id, data)
       .then((res: AxiosResponse) => {
-        const { JWTToken } = res.data;
+        const { JWTToken, JWTTokenExpiresAt } = res.data;
         setBotsToken(JWTToken);
+        setBotsTokenExpiry(JWTTokenExpiresAt);
       })
       .catch((err: AxiosError) => {
         showErrorToast(err);
@@ -134,11 +137,7 @@ const BotsDetail: FC<BotsDetailProp> = ({
   };
 
   const handleGenerate = () => {
-    const data = {
-      JWTToken: 'string',
-      JWTTokenExpiry: selectedExpiry,
-    };
-    generateBotsToken(data);
+    generateBotsToken(selectedExpiry);
   };
 
   const onDisplayNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -277,6 +276,18 @@ const BotsDetail: FC<BotsDetailProp> = ({
     }
   };
 
+  const getBotsTokenExpiryDate = () => {
+    if (botsTokenExpiry) {
+      return (
+        <p className="tw-text-grey-muted tw-mt-2 tw-italic">
+          Expires on {moment(botsTokenExpiry).format('ddd Do MMMM, YYYY')}
+        </p>
+      );
+    } else {
+      return null;
+    }
+  };
+
   const centerLayout = () => {
     if (generateToken) {
       return (
@@ -329,6 +340,7 @@ const BotsDetail: FC<BotsDetailProp> = ({
               />
               {getCopyComponent()}
             </div>
+            {getBotsTokenExpiryDate()}
           </Fragment>
         );
       } else {

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/teams/authN/jwtAuth.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/teams/authN/jwtAuth.ts
@@ -21,6 +21,10 @@ export interface JwtAuth {
    */
   JWTToken: string;
   /**
+   * JWT Auth Token expiration time.
+   */
+  JWTTokenExpiresAt?: number;
+  /**
    * JWT Auth Token expiration in days
    */
   JWTTokenExpiry: JWTTokenExpiry;

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/teams/user.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/teams/user.ts
@@ -132,6 +132,10 @@ export interface AuthMechanism {
    */
   JWTToken?: string;
   /**
+   * JWT Auth Token expiration time.
+   */
+  JWTTokenExpiresAt?: number;
+  /**
    * JWT Auth Token expiration in days
    */
   JWTTokenExpiry?: JWTTokenExpiry;

--- a/openmetadata-ui/src/main/resources/ui/src/pages/BotsListpage/BotsListpage.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/BotsListpage/BotsListpage.component.test.tsx
@@ -1,0 +1,36 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import BotsListPage from './BotsListpage.component';
+
+jest.mock('../../components/BotsList/BotsList', () => {
+  return jest.fn().mockReturnValue(<div data-testid="bots-list">BotsList</div>);
+});
+jest.mock('../../axiosAPIs/userAPI', () => ({
+  getUsers: jest.fn().mockImplementation(() => Promise.resolve()),
+}));
+
+describe('Test BotsList Page Component', () => {
+  it('Should render all child elements', async () => {
+    const { findByTestId } = render(<BotsListPage />, {
+      wrapper: MemoryRouter,
+    });
+
+    const botsListComponent = await findByTestId('bots-list');
+
+    expect(botsListComponent).toBeInTheDocument();
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/pages/BotsPage/BotsPage.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/BotsPage/BotsPage.component.test.tsx
@@ -1,0 +1,72 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { getUserByName } from '../../axiosAPIs/userAPI';
+import BotsPage from './BotsPage.component';
+
+const mockUserDetail = {
+  id: 'cb3db26a-5e01-4d14-8f06-bb1040c28ad0',
+  name: 'customermail2020',
+  displayName: '',
+  version: 0.1,
+  updatedAt: 1652179111681,
+  updatedBy: 'anonymous',
+  email: 'customermail2020@gmail.com',
+  href: 'http://localhost:8585/api/v1/users/cb3db26a-5e01-4d14-8f06-bb1040c28ad0',
+  isBot: true,
+  isAdmin: false,
+  deleted: false,
+};
+
+jest.mock('../../components/BotsDetail/BotsDetail.component', () => {
+  return jest
+    .fn()
+    .mockReturnValue(<div data-testid="bots-details">BotsDetails</div>);
+});
+
+jest.mock('../../axiosAPIs/userAPI', () => ({
+  getUserByName: jest.fn().mockImplementation(() => Promise.resolve()),
+  revokeUserToken: jest.fn().mockImplementation(() => Promise.resolve()),
+  updateUserDetail: jest.fn().mockImplementation(() => Promise.resolve()),
+}));
+
+describe('Test BotsPage Component', () => {
+  it('Should render all child elements', async () => {
+    (getUserByName as jest.Mock).mockImplementationOnce(() => {
+      return Promise.resolve({ data: mockUserDetail });
+    });
+    const { findByTestId } = render(<BotsPage />, {
+      wrapper: MemoryRouter,
+    });
+
+    const botsDetailsComponent = await findByTestId('bots-details');
+
+    expect(botsDetailsComponent).toBeInTheDocument();
+  });
+
+  it('Should render error placeholder if API fails', async () => {
+    (getUserByName as jest.Mock).mockImplementationOnce(() => {
+      return Promise.reject();
+    });
+    const { findByTestId } = render(<BotsPage />, {
+      wrapper: MemoryRouter,
+    });
+
+    const errorPlaceholder = await findByTestId('error');
+
+    expect(errorPlaceholder).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #4827 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the Bots details page to show the expiry date of the token and unit tests.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] Improvement
- [x] New feature

#
### Frontend Preview (Screenshots) :
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/59080942/167624829-ef68404e-d111-4f85-945a-e1c048e5057a.png">


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
