### PR TITLE
Fix #4821 - Validate Server and Client versions

### DIFF
--- a/ingestion/src/metadata/ingestion/ometa/mixins/server_mixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/server_mixin.py
@@ -1,0 +1,90 @@
+#  Copyright 2021 Collate
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Mixin class containing Server and client specific methods
+
+To be used by OpenMetadata class
+"""
+import re
+from importlib.metadata import version
+
+from metadata.ingestion.ometa.client import REST
+from metadata.utils.logger import ometa_logger
+
+logger = ometa_logger()
+
+
+class VersionParsingException(Exception):
+    """
+    Used when we cannot parse version information from a string
+    """
+
+
+class VersionMismatchException(Exception):
+    """
+    Used when server and client versions do not match
+    """
+
+
+class OMetaServerMixin:
+    """
+    OpenMetadata API methods related to the Pipeline Entity
+
+    To be inherited by OpenMetadata
+    """
+
+    client: REST
+
+    @staticmethod
+    def get_version_from_string(raw_version: str) -> str:
+        """
+        Given a raw version string, such as `0.10.1.dev0` or
+        `0.11.0-SNAPSHOT`, we should extract the major.minor.patch
+        :param raw_version: raw string with version info
+        :return: Clean version string
+        """
+        try:
+            return re.match(r"\d+.\d+.\d+", raw_version).group(0)
+        except AttributeError as err:
+            raise VersionParsingException(
+                f"Can't extract version from {raw_version} - {err}"
+            )
+
+    def get_server_version(self) -> str:
+        """
+        Run endpoint /version to check server version
+        :return: Server version
+        """
+        raw_version = self.client.get("/version")["version"]
+        return self.get_version_from_string(raw_version)
+
+    def get_client_version(self) -> str:
+        """
+        Get openmetadata-ingestion module version
+        :return: client version
+        """
+        raw_version = version("openmetadata-ingestion")
+        return self.get_version_from_string(raw_version)
+
+    def validate_versions(self) -> None:
+        """
+        Validate Server & Client versions. They should match.
+        Otherwise, raise VersionMismatchException
+        """
+        logger.debug("Validating client and server versions")
+
+        server_version = self.get_server_version()
+        client_version = self.get_client_version()
+
+        if not server_version == client_version:
+            raise VersionMismatchException(
+                f"Server version is {server_version} vs. Client version {client_version}. Both should match."
+            )

--- a/ingestion/src/metadata/ingestion/ometa/ometa_api.py
+++ b/ingestion/src/metadata/ingestion/ometa/ometa_api.py
@@ -58,6 +58,7 @@ from metadata.ingestion.ometa.mixins.es_mixin import ESMixin
 from metadata.ingestion.ometa.mixins.glossary_mixin import GlossaryMixin
 from metadata.ingestion.ometa.mixins.mlmodel_mixin import OMetaMlModelMixin
 from metadata.ingestion.ometa.mixins.pipeline_mixin import OMetaPipelineMixin
+from metadata.ingestion.ometa.mixins.server_mixin import OMetaServerMixin
 from metadata.ingestion.ometa.mixins.service_mixin import OMetaServiceMixin
 from metadata.ingestion.ometa.mixins.table_mixin import OMetaTableMixin
 from metadata.ingestion.ometa.mixins.tag_mixin import OMetaTagMixin
@@ -121,6 +122,7 @@ class OpenMetadata(
     GlossaryMixin,
     OMetaServiceMixin,
     ESMixin,
+    OMetaServerMixin,
     Generic[T, C],
 ):
     """
@@ -165,6 +167,8 @@ class OpenMetadata(
         )
         self.client = REST(client_config)
         self._use_raw_data = raw_data
+
+        self.validate_versions()
 
     def get_suffix(self, entity: Type[T]) -> str:  # pylint: disable=R0911,R0912
         """

--- a/ingestion/tests/unit/test_server_mixin.py
+++ b/ingestion/tests/unit/test_server_mixin.py
@@ -1,0 +1,41 @@
+#  Copyright 2021 Collate
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Validate Server Mixin version methods
+"""
+
+from unittest import TestCase
+
+from metadata.ingestion.ometa.mixins.server_mixin import OMetaServerMixin
+
+
+class OMetaServerTest(TestCase):
+    """
+    Check version methods
+    """
+
+    mixin = OMetaServerMixin()
+
+    def test_get_version_from_string(self):
+        """
+        We should be able to parse regular version responses
+        """
+        self.assertEqual("0.11.0", self.mixin.get_version_from_string("0.11.0.dev0"))
+        self.assertEqual("0.11.0", self.mixin.get_version_from_string("0.11.0"))
+        self.assertEqual(
+            "1111.11.111", self.mixin.get_version_from_string("1111.11.111")
+        )
+        self.assertEqual(
+            "1111.11.111", self.mixin.get_version_from_string("1111.11.111-SNAPSHOT")
+        )
+        self.assertEqual(
+            "0.11.1", self.mixin.get_version_from_string("0.11.1.0.0.1.patch")
+        )


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Fix #4821 - Validate Server and Client versions

Now, whenever the `OpenMetadata` client is initialised, it will compare the `openmetadata-ingestion` version vs. the server version. This raises an exception if they don't match. The validation is currently an equality of `MAJOR.MINOR.PATCH`.

We can evolve this if necessary

Thanks

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [x] New feature
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
