### PR TITLE
Fix #4870: Return empty response if the bot token is not available

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/teams/UserResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/teams/UserResource.java
@@ -446,7 +446,8 @@ public class UserResource extends EntityResource<User, UserRepository> {
     }
     SecurityUtil.authorizeAdmin(authorizer, securityContext, ADMIN);
     AuthenticationMechanism authenticationMechanism = user.getAuthenticationMechanism();
-    if (authenticationMechanism.getConfig() != null
+    if (authenticationMechanism != null
+        && authenticationMechanism.getConfig() != null
         && authenticationMechanism.getAuthType() == AuthenticationMechanism.AuthType.JWT) {
       return JsonUtils.convertValue(authenticationMechanism.getConfig(), JWTAuthMechanism.class);
     }


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the ..... because ...

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
