### PR TITLE
Fix #4855  Glossary Term has redundant button for `Add Reviewer`

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/GlossaryTerms/GlossaryTermsV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/GlossaryTerms/GlossaryTermsV1.component.tsx
@@ -385,15 +385,10 @@ const GlossaryTermsV1 = ({
   };
 
   const getTabPaneButton = () => {
-    switch (activeTab) {
-      case 1: {
-        return relatedTerms.length ? AddRelatedTermButton() : undefined;
-      }
-      case 3: {
-        return glossaryTerm.reviewers?.length ? AddReviewerButton() : undefined;
-      }
-      default:
-        return;
+    if (activeTab === 1) {
+      return relatedTerms.length ? AddRelatedTermButton() : undefined;
+    } else {
+      return;
     }
   };
 


### PR DESCRIPTION
Closes #4855 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on issue #4855 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/59080942/167790890-c61c9884-1d67-47e6-a078-8690cf6c3686.png">


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
