### PR TITLE
Fix #4745 UI: For scrolling the content in the middle column, the cursor needs to be in the middle column .

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/containers/PageLayout.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/containers/PageLayout.tsx
@@ -12,7 +12,7 @@
  */
 
 import classNames from 'classnames';
-import React, { FC, ReactNode } from 'react';
+import React, { FC, Fragment, ReactNode } from 'react';
 import { PageLayoutType } from '../../enums/layout.enum';
 
 interface PageLayoutProp {
@@ -32,13 +32,39 @@ const PageLayout: FC<PageLayoutProp> = ({
   layout = PageLayoutType['3Col'],
   classes = '',
 }: PageLayoutProp) => {
+  const getLeftPanel = () => {
+    return (
+      leftPanel && (
+        <div>
+          <div className="tw-pr-4 tw-py-1" id="left-panel">
+            {leftPanel}
+          </div>
+          <div />
+        </div>
+      )
+    );
+  };
+
+  const getRightPanel = () => {
+    return (
+      rightPanel && (
+        <div>
+          <div className="tw-px-2 tw-py-1" id="right-panel">
+            {rightPanel}
+          </div>
+          <div />
+        </div>
+      )
+    );
+  };
+
   const get3ColLayout = () => {
     return (
-      <>
+      <Fragment>
         {header && <div className="tw-px-6">{header}</div>}
         <div
           className={classNames(
-            'page-layout-container l3-col tw-gap-x-3 tw-px-6 tw-overflow-y-auto centered-layout',
+            'page-layout-container l3-col tw-gap-x-3 tw-px-6 centered-layout',
             classes,
             {
               'page-layout-container-left-center-right':
@@ -54,14 +80,10 @@ const PageLayout: FC<PageLayoutProp> = ({
               'page-layout-container-center': !leftPanel && !rightPanel,
             }
           )}>
-          {leftPanel && (
-            <div className="tw-overflow-y-auto tw-pr-4 tw-py-1" id="left-panel">
-              {leftPanel}
-            </div>
-          )}
+          {getLeftPanel()}
           <div
             className={classNames(
-              'tw-overflow-y-auto tw-py-1',
+              'tw-py-1',
               {
                 'tw-pl-2': leftPanel,
               },
@@ -72,50 +94,40 @@ const PageLayout: FC<PageLayoutProp> = ({
             id="center">
             {children}
           </div>
-          {rightPanel && (
-            <div
-              className="tw-overflow-y-auto tw-px-2 tw-py-1"
-              id="right-panel">
-              {rightPanel}
-            </div>
-          )}
+          {getRightPanel()}
         </div>
-      </>
+      </Fragment>
     );
   };
 
   const get2ColLTRLayout = () => {
     return (
-      <>
+      <Fragment>
         {header && <div className="tw-px-6">{header}</div>}
         <div
           className={classNames(
-            'page-layout-container l2-ltr-col tw-gap-x-3 tw-px-6 tw-overflow-y-auto centered-layout',
+            'page-layout-container l2-ltr-col tw-gap-x-3 tw-px-6 centered-layout',
             classes,
             leftPanel
               ? 'page-layout-container-left-center'
               : 'page-layout-container-center'
           )}>
-          {leftPanel && (
-            <div className="tw-overflow-y-auto tw-pr-4 tw-py-1" id="left-panel">
-              {leftPanel}
-            </div>
-          )}
+          {getLeftPanel()}
           <div
-            className={classNames('tw-overflow-y-auto tw-py-1', {
+            className={classNames('tw-py-1', {
               'tw-pl-8': leftPanel,
             })}
             id="center">
             {children}
           </div>
         </div>
-      </>
+      </Fragment>
     );
   };
 
   const get2ColRTLLayout = () => {
     return (
-      <>
+      <Fragment>
         {header && (
           <div className="page-layout-container tw-gap-x-3 tw-px-6 centered-layout tw-max-w-full-hd tw-pt-4">
             {header}
@@ -123,28 +135,22 @@ const PageLayout: FC<PageLayoutProp> = ({
         )}
         <div
           className={classNames(
-            'page-layout-container l2-rtl-col tw-gap-x-3 tw-px-6 tw-overflow-y-auto centered-layout',
+            'page-layout-container l2-rtl-col tw-gap-x-3 tw-px-6 centered-layout',
             classes,
             rightPanel
               ? 'page-layout-container-center-right'
               : 'page-layout-container-center'
           )}>
           <div
-            className={classNames('tw-overflow-y-auto tw-py-1', {
+            className={classNames('tw-py-1', {
               'tw-pr-10': rightPanel,
             })}
             id="center">
             {children}
           </div>
-          {rightPanel && (
-            <div
-              className="tw-overflow-y-auto tw-px-2 tw-py-1"
-              id="right-panel">
-              {rightPanel}
-            </div>
-          )}
+          {getRightPanel()}
         </div>
-      </>
+      </Fragment>
     );
   };
 

--- a/openmetadata-ui/src/main/resources/ui/src/styles/x-master.css
+++ b/openmetadata-ui/src/main/resources/ui/src/styles/x-master.css
@@ -760,7 +760,7 @@ body .profiler-graph .recharts-active-dot circle {
   align-content: flex-start;
   position: relative;
   height: calc(100% - 70px);
-  overflow-y: hidden;
+  overflow-y: scroll;
 }
 
 .full-height {
@@ -769,13 +769,23 @@ body .profiler-graph .recharts-active-dot circle {
 
 #left-panel {
   grid-area: leftsidebar;
+  position: sticky;
+  position: -webkit-sticky;
+  top: 0;
+  left: 0;
+  overflow-y: scroll;
 }
 #right-panel {
   grid-area: rightsidebar;
+  position: sticky;
+  position: -webkit-sticky;
+  top: 0;
+  left: 0;
+  overflow-y: scroll;
 }
 #center {
   grid-area: centerarea;
-  overflow-y: auto;
+  overflow-y: inherit;
 }
 
 /* Hide scrollbar for Chrome, Safari and Opera */
@@ -796,6 +806,7 @@ body .profiler-graph .recharts-active-dot circle {
 .page-layout-container {
   display: grid;
   grid-auto-flow: column;
+  position: relative;
 }
 .page-layout-container.l3-col {
   grid-template-columns: 256px auto 256px;


### PR DESCRIPTION
Fixes #4745 

### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on issue #4745 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement


#
### Frontend Preview (Screenshots) :


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
