### PR TITLE
Fix #4919: Fix elastic search teams indexing

### DIFF
--- a/ingestion/src/metadata/ingestion/sink/elasticsearch.py
+++ b/ingestion/src/metadata/ingestion/sink/elasticsearch.py
@@ -11,7 +11,6 @@
 
 import json
 import ssl
-import traceback
 from datetime import datetime
 from typing import List, Optional
 
@@ -523,7 +522,7 @@ class ElasticsearchSink(Sink[Entity]):
         owns = []
         if team.users:
             for user in team.users.__root__:
-                users.append(user)
+                users.append(user.name)
 
         if team.owns:
             for own in team.owns.__root__:


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Fix #4919 : Fix elastic search teams indexing

```
AttributeError: 'MetadataESConnection' object has no attribute 'includePolicy'
```
This issue was fixed in #4884 
#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
@open-metadata/ingestion
