### PR TITLE
add cast to text before length()

### DIFF
--- a/ingestion/src/metadata/orm_profiler/orm/functions/length.py
+++ b/ingestion/src/metadata/orm_profiler/orm/functions/length.py
@@ -34,7 +34,6 @@ def _(element, compiler, **kw):
 @compiles(LenFn, Dialects.SQLite)
 @compiles(LenFn, Dialects.Vertica)
 @compiles(LenFn, Dialects.Hive)
-@compiles(LenFn, Dialects.Postgres)
 @compiles(LenFn, Dialects.Databricks)
 @compiles(LenFn, Dialects.MySQL)
 @compiles(LenFn, Dialects.MariaDB)
@@ -43,3 +42,8 @@ def _(element, compiler, **kw):
 @compiles(LenFn, Dialects.Presto)
 def _(element, compiler, **kw):
     return "LENGTH(%s)" % compiler.process(element.clauses, **kw)
+
+
+@compiles(LenFn, Dialects.Postgres)
+def _(element, compiler, **kw):
+    return "LENGTH(CAST(%s AS text))" % compiler.process(element.clauses, **kw)


### PR DESCRIPTION
### Cast Postgres types to TEXT before calling length() when profiling.

I think there is a Data Profiling issue with Postgres datasource.
For some Postgres data types the length() function does not work without casting to text, so expressions used by profiling queries stop working. This breaks data profiling for some columns.
To reproduce, create this nonstandard column in your db and look for errors in profiling logs.
Following error comes from regtype but you will get same with xml or inet datatype:
```

[2022-05-10 08:19:35,092] {logging_mixin.py:109} WARNING - /usr/local/lib/python3.9/site-packages/metadata/ingestion/source/sql_source.py:630 SAWarning: Did not recognize type 'regtype' of column 'column_type'
[2022-05-10 08:19:35,094] {sql_source.py:689} WARNING - Unknown type NullType() mapped to VARCHAR: column_type
[2022-05-10 08:19:35,095] {sql_source.py:230} INFO - select * from _timescaledb_catalog.dimension limit 50
[2022-05-10 08:19:35,128] {core.py:231} WARNING - Error trying to compute column profile for column_type - (psycopg2.errors.UndefinedFunction) function length(regtype) does not exist
LINE 1: SELECT avg(LENGTH(column_type)) AS mean, count(column_type) ...
                   ^
HINT:  No function matches the given name and argument types. You might need to add explicit type casts. 
```

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] All new and existing tests passed.
