### PR TITLE
Add error handling for charts in superset

### DIFF
--- a/ingestion/src/metadata/ingestion/source/superset.py
+++ b/ingestion/src/metadata/ingestion/source/superset.py
@@ -359,7 +359,11 @@ class SupersetSource(Source[Entity]):
             charts = self.client.fetch_charts(current_page, page_size)
             current_page += 1
             for chart_json in charts["result"]:
-                yield from self._build_chart(chart_json)
+                try:
+                    yield from self._build_chart(chart_json)
+                except Exception as err:
+                    logger.debug(traceback.format_exc())
+                    logger.error(err)
 
     def get_status(self):
         return self.status


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
fix #4586 
I was not able to reproduce the error but if the attributes of charts are not set, it won't stop the ingestion.
It will skip the corrupt charts and move on ingesting other charts

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
