### PR TITLE
Fix #4931: Add multiple database support in Clickhouse

### DIFF
--- a/ingestion/src/metadata/ingestion/source/clickhouse.py
+++ b/ingestion/src/metadata/ingestion/source/clickhouse.py
@@ -8,7 +8,9 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+"""Clickhouse source module"""
 import enum
+from typing import Iterable
 
 from clickhouse_sqlalchemy.drivers.base import ClickHouseDialect
 from clickhouse_sqlalchemy.drivers.http.transport import RequestsTransport, _get_type
@@ -17,6 +19,8 @@ from sqlalchemy import exc, schema, text
 from sqlalchemy import types as sqltypes
 from sqlalchemy import util as sa_util
 from sqlalchemy.engine import reflection
+from sqlalchemy.engine.reflection import Inspector
+from sqlalchemy.inspection import inspect
 from sqlalchemy.util import warn
 
 from metadata.generated.schema.entity.services.connections.database.clickhouseConnection import (
@@ -30,6 +34,11 @@ from metadata.generated.schema.metadataIngestion.workflow import (
 )
 from metadata.ingestion.api.source import InvalidSourceException
 from metadata.ingestion.source.sql_source import SQLSource
+from metadata.utils.connections import get_connection
+from metadata.utils.filters import filter_by_database
+from metadata.utils.logger import ingestion_logger
+
+logger = ingestion_logger()
 
 
 @reflection.cache
@@ -172,3 +181,31 @@ class ClickhouseSource(SQLSource):
             )
 
         return cls(config, metadata_config)
+
+    def get_databases(self) -> Iterable[Inspector]:
+        if self.service_connection.database:
+            yield from super().get_databases()
+        else:
+            query = "show databases"
+            results = self.connection.execute(query)
+            db_list = []
+
+            for res in results:
+                db_list.append(list(res))
+
+            for row in db_list:
+                try:
+                    if filter_by_database(
+                        self.source_config.databaseFilterPattern, database_name=row[0]
+                    ):
+                        self.status.filter(row[0], "Database pattern not allowed")
+                        continue
+                    logger.info(f"Ingesting from database: {row[0]}")
+                    self.service_connection.database = row[0]
+                    self.engine = get_connection(
+                        self.config.serviceConnection.__root__.config
+                    )
+                    self.engine.connect()
+                    yield inspect(self.engine)
+                except Exception as err:
+                    logger.error(f"Failed to Connect: {row[0]} due to error {err}")

--- a/ingestion/src/metadata/ingestion/source/clickhouse.py
+++ b/ingestion/src/metadata/ingestion/source/clickhouse.py
@@ -188,10 +188,7 @@ class ClickhouseSource(SQLSource):
         else:
             query = "show databases"
             results = self.connection.execute(query)
-            db_list = []
-
-            for res in results:
-                db_list.append(list(res))
+            db_list = [list(res) for res in results]
 
             for row in db_list:
                 try:


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on Adding multiple database support in Clickhouse.
Befor : Clickhouse picks up default database when not specified in the config file.
Now: When database is not specified in the config, all available databases  ingest.
Fix #4931 


#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement


### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
