### PR TITLE
Fix #4718 UI: Link in the @mention of user refreshes the whole page

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/rich-text-editor/RichTextEditorPreviewer.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/rich-text-editor/RichTextEditorPreviewer.tsx
@@ -15,8 +15,10 @@ import classNames from 'classnames';
 import React, { useEffect, useState } from 'react';
 // Markdown Parser and plugin imports
 import MarkdownParser from 'react-markdown';
+import { Link } from 'react-router-dom';
 import rehypeRaw from 'rehype-raw';
 import remarkGfm from 'remark-gfm';
+import { isExternalUrl } from '../../../utils/StringsUtils';
 import { BlurLayout } from './BlurLayout';
 import { PreviewerProp } from './RichTextEditor.interface';
 
@@ -95,6 +97,14 @@ const RichTextEditorPreviewer = ({
                 {children}
               </code>
             );
+          },
+          a: ({ children, ...props }) => {
+            const href = props.href;
+            if (isExternalUrl(href)) {
+              return <a {...props}>{children}</a>;
+            } else {
+              return <Link to={props.href || ''}>{children}</Link>;
+            }
           },
         }}
         rehypePlugins={[rehypeRaw]}

--- a/openmetadata-ui/src/main/resources/ui/src/constants/feed.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/feed.constants.ts
@@ -22,7 +22,7 @@ export const entityLinkRegEx = /<#E::([^<>]+?)::([^<>]+?)>/g;
 export const entityRegex = /<#E::([^<>]+?)::([^<>]+?)\|(\[(.+?)?\]\((.+?)?\))>/;
 
 export const entityUrlMap = {
-  team: 'teams',
+  team: 'teams-and-users',
   user: 'users',
 };
 

--- a/openmetadata-ui/src/main/resources/ui/src/utils/FeedUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/FeedUtils.tsx
@@ -41,6 +41,7 @@ import {
 } from '../constants/feed.constants';
 import { getEntityPlaceHolder } from './CommonUtils';
 import { ENTITY_LINK_SEPARATOR } from './EntityUtils';
+import { getEncodedFqn } from './StringsUtils';
 import { getRelativeDateByTimeStamp } from './TimeUtils';
 
 export const getEntityType = (entityLink: string) => {
@@ -158,9 +159,9 @@ export async function suggestions(searchTerm: string, mentionChar: string) {
             `@${hit._source.name ?? hit._source.display_name}`,
             hit._source.deleted
           ),
-          link: `${document.location.protocol}//${document.location.host}/${
-            entityUrlMap[entityType as keyof typeof entityUrlMap]
-          }/${hit._source.name}`,
+          link: `/${entityUrlMap[entityType as keyof typeof entityUrlMap]}/${
+            hit._source.name
+          }`,
         };
       });
     } else {
@@ -176,9 +177,9 @@ export async function suggestions(searchTerm: string, mentionChar: string) {
             `@${hit._source.name ?? hit._source.display_name}`,
             hit._source.deleted
           ),
-          link: `${document.location.protocol}//${document.location.host}/${
-            entityUrlMap[entityType as keyof typeof entityUrlMap]
-          }/${hit._source.name}`,
+          link: `/${entityUrlMap[entityType as keyof typeof entityUrlMap]}/${
+            hit._source.name
+          }`,
         };
       });
     }
@@ -196,7 +197,7 @@ export async function suggestions(searchTerm: string, mentionChar: string) {
         return {
           id: hit._id,
           value: `#${entityType}/${hit._source.name}`,
-          link: `${document.location.protocol}//${document.location.host}/${entityType}/${hit._source.fqdn}`,
+          link: `/${entityType}/${getEncodedFqn(hit._source.fqdn)}`,
         };
       });
     } else {
@@ -209,7 +210,7 @@ export async function suggestions(searchTerm: string, mentionChar: string) {
         return {
           id: hit._id,
           value: `#${entityType}/${hit._source.name}`,
-          link: `${document.location.protocol}//${document.location.host}/${entityType}/${hit._source.fqdn}`,
+          link: `/${entityType}/${getEncodedFqn(hit._source.fqdn)}`,
         };
       });
     }

--- a/openmetadata-ui/src/main/resources/ui/src/utils/StringsUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/StringsUtils.ts
@@ -131,3 +131,12 @@ export const getErrorText = (
 export const getEncodedFqn = (fqn: string) => {
   return encodeURIComponent(fqn);
 };
+
+/**
+ *
+ * @param url - Url to be check
+ * @returns - True if url is external otherwise false
+ */
+export const isExternalUrl = (url = '') => {
+  return /^https?:\/\//.test(url);
+};


### PR DESCRIPTION
Fixes #4718 
Fixes #4991 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on fixing these two issues.

- [x] [UI: Link in the @mention of user refreshes the whole page](https://github.com/open-metadata/OpenMetadata/issues/4718)

- [x] [UI : Team and Entity with a slash (/) is broken in activity feed.](https://github.com/open-metadata/OpenMetadata/issues/4991)

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement


#
### Frontend Preview (Screenshots) :

https://user-images.githubusercontent.com/59080942/168733480-3a44f2eb-3d96-41e2-bb3d-a195a7b60253.mov



#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
