### PR TITLE
Fix issue-4951: Unwanted entries for My Data section on User Profile page 

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/TeamDetails/TeamDetails.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TeamDetails/TeamDetails.tsx
@@ -37,7 +37,7 @@ import { useAuth } from '../../hooks/authHooks';
 import { TeamDetailsProp } from '../../interface/teamsAndUsers.interface';
 import UserCard from '../../pages/teams/UserCard';
 import { hasEditAccess } from '../../utils/CommonUtils';
-import { getInfoElements } from '../../utils/EntityUtils';
+import { filterEntityAssets, getInfoElements } from '../../utils/EntityUtils';
 import SVGIcons from '../../utils/SvgUtils';
 import { Button } from '../buttons/Button/Button';
 import Description from '../common/description/Description';
@@ -119,7 +119,7 @@ const TeamDetails = ({
       name: 'Assets',
       isProtected: false,
       position: 2,
-      count: currentTeam?.owns?.length,
+      count: filterEntityAssets(currentTeam?.owns || []).length,
     },
     {
       name: 'Roles',
@@ -407,7 +407,9 @@ const TeamDetails = ({
    * @returns - dataset cards
    */
   const getDatasetCards = () => {
-    if ((currentTeam?.owns?.length as number) <= 0) {
+    const ownData = filterEntityAssets(currentTeam?.owns || []);
+
+    if (ownData.length <= 0) {
       return (
         <div className="tw-flex tw-flex-col tw-items-center tw-place-content-center tw-mt-40 tw-gap-1">
           <p>Your team does not have any dataset</p>
@@ -431,7 +433,7 @@ const TeamDetails = ({
           className="tw-grid xxl:tw-grid-cols-4 md:tw-grid-cols-3 tw-gap-4"
           data-testid="dataset-card">
           {' '}
-          {currentTeam?.owns?.map((dataset, index) => {
+          {ownData.map((dataset, index) => {
             const Dataset = {
               displayName: dataset.displayName || dataset.name || '',
               type: dataset.type,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
@@ -41,6 +41,7 @@ import {
   getExploreLinkByFilter,
   getNonDeletedTeams,
 } from '../../utils/CommonUtils';
+import { filterEntityAssets } from '../../utils/EntityUtils';
 import SVGIcons, { Icons } from '../../utils/SvgUtils';
 import { showErrorToast } from '../../utils/ToastUtils';
 import ActivityFeedList from '../ActivityFeed/ActivityFeedList/ActivityFeedList';
@@ -628,14 +629,16 @@ const Users = ({
   }, [userData]);
 
   const getRightPanel = useCallback(() => {
+    const ownData = filterEntityAssets(userData?.owns || []);
+
     return (
       <div className="tw-mt-4" data-testid="right-pannel">
         <EntityList
-          entityList={userData?.owns as unknown as FormatedTableData[]}
+          entityList={ownData as unknown as FormatedTableData[]}
           headerText={
             <div className="tw-flex tw-justify-between tw-items-center">
               My Data
-              {userData?.owns?.length ? (
+              {ownData.length ? (
                 <Link
                   className="tw-ml-1"
                   data-testid="my-data"
@@ -645,7 +648,7 @@ const Users = ({
                     AppState.nonSecureUserDetails
                   )}>
                   <span className="link-text tw-font-normal tw-text-xs">
-                    View All <span>({userData?.owns?.length})</span>
+                    View All <span>({ownData.length})</span>
                   </span>
                 </Link>
               ) : null}

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityUtils.tsx
@@ -23,7 +23,7 @@ import {
   getServiceDetailsPath,
   getTeamAndUserDetailsPath,
 } from '../constants/constants';
-import { EntityType, FqnPart } from '../enums/entity.enum';
+import { AssetsType, EntityType, FqnPart } from '../enums/entity.enum';
 import { ServiceCategory } from '../enums/service.enum';
 import { PrimaryTableDataTypes } from '../enums/table.enum';
 import { Dashboard } from '../generated/entity/data/dashboard';
@@ -544,4 +544,10 @@ export const isColumnTestSupported = (dataType: string) => {
 
 export const getTitleCase = (text?: string) => {
   return text ? startCase(text) : '';
+};
+
+export const filterEntityAssets = (data: EntityReference[]) => {
+  const includedEntity = Object.values(AssetsType);
+
+  return data.filter((d) => includedEntity.includes(d.type as AssetsType));
 };


### PR DESCRIPTION

### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Closes #4951 Unwanted entries for the My Data section on the User Profile page and assets tab on the team's page

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement


#
### Frontend Preview (Screenshots) :

https://user-images.githubusercontent.com/71748675/169297005-ba3a082d-b20b-473d-9f68-0d706da3dc06.mov


https://user-images.githubusercontent.com/71748675/169297371-48a27b56-f86e-49b2-ab68-4c8c017de8a9.mov




#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
@open-metadata/ui 