### PR TITLE
Fix #5108 - Add Map and Struct support for Athena & Block them for profiler

### DIFF
--- a/ingestion/sonar-project.properties
+++ b/ingestion/sonar-project.properties
@@ -7,5 +7,5 @@ sonar.sources=ingestion/src
 sonar.tests=ingestion/tests
 sonar.exclusions=ingestion/src/metadata_server/static/**,ingestion/src/metadata_server/templates/**
 sonar.python.xunit.reportPath=ingestion/junit/test-results-*.xml
-sonar.python.coverage.reportPaths=ingestion/ci-coverage.xml
+sonar.python.coverage.reportPaths=ingestion/coverage.xml
 sonar.python.version=3.7,3.8,3.9

--- a/ingestion/src/metadata/ingestion/source/database/athena.py
+++ b/ingestion/src/metadata/ingestion/source/database/athena.py
@@ -8,7 +8,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import Optional, Tuple
+from typing import Iterable, Optional, Tuple
 
 from pyathena.sqlalchemy_athena import AthenaDialect
 from sqlalchemy import types
@@ -110,7 +110,7 @@ class AthenaSource(CommonDbSourceService):
 
     def get_table_names(
         self, schema: str, inspector: Inspector
-    ) -> Optional[Tuple[str, str]]:
+    ) -> Optional[Iterable[Tuple[str, str]]]:
         if self.source_config.includeTables:
             for table in inspector.get_table_names(schema):
                 yield table, "External"  # All tables in Athena are External

--- a/ingestion/src/metadata/ingestion/source/database/athena.py
+++ b/ingestion/src/metadata/ingestion/source/database/athena.py
@@ -10,6 +10,8 @@
 #  limitations under the License.
 from typing import Optional, Tuple
 
+from pyathena.sqlalchemy_athena import AthenaDialect
+from sqlalchemy import types
 from sqlalchemy.engine import Inspector
 
 from metadata.generated.schema.entity.services.connections.database.athenaConnection import (
@@ -24,10 +26,71 @@ from metadata.generated.schema.metadataIngestion.workflow import (
     Source as WorkflowSource,
 )
 from metadata.ingestion.api.source import InvalidSourceException
+from metadata.ingestion.source import sqa_types
 from metadata.ingestion.source.database.common_db_source import CommonDbSourceService
 from metadata.utils.logger import ingestion_logger
 
 logger = ingestion_logger()
+
+
+def _get_column_type(self, type_):
+    """
+    Function overwritten from AthenaDialect
+    to add custom SQA typing.
+    """
+    match = self._pattern_column_type.match(type_)
+    if match:
+        name = match.group(1).lower()
+        length = match.group(2)
+    else:
+        name = type_.lower()
+        length = None
+
+    args = []
+    if name in ["boolean"]:
+        col_type = types.BOOLEAN
+    elif name in ["float", "double", "real"]:
+        col_type = types.FLOAT
+    elif name in ["tinyint", "smallint", "integer", "int"]:
+        col_type = types.INTEGER
+    elif name in ["bigint"]:
+        col_type = types.BIGINT
+    elif name in ["decimal"]:
+        col_type = types.DECIMAL
+        if length:
+            precision, scale = length.split(",")
+            args = [int(precision), int(scale)]
+    elif name in ["char"]:
+        col_type = types.CHAR
+        if length:
+            args = [int(length)]
+    elif name in ["varchar"]:
+        col_type = types.VARCHAR
+        if length:
+            args = [int(length)]
+    elif name in ["string"]:
+        col_type = types.String
+    elif name in ["date"]:
+        col_type = types.DATE
+    elif name in ["timestamp"]:
+        col_type = types.TIMESTAMP
+    elif name in ["binary", "varbinary"]:
+        col_type = types.BINARY
+    elif name in ["array"]:
+        col_type = types.ARRAY
+    elif name in ["json"]:
+        col_type = types.JSON
+    elif name in ["struct", "row"]:
+        col_type = sqa_types.SQAStruct
+    elif name in ["map"]:
+        col_type = sqa_types.SQAMap
+    else:
+        logger.warn(f"Did not recognize type '{type_}'")
+        col_type = types.NullType
+    return col_type(*args)
+
+
+AthenaDialect._get_column_type = _get_column_type
 
 
 class AthenaSource(CommonDbSourceService):
@@ -46,7 +109,7 @@ class AthenaSource(CommonDbSourceService):
         return cls(config, metadata_config)
 
     def get_table_names(
-            self, schema: str, inspector: Inspector
+        self, schema: str, inspector: Inspector
     ) -> Optional[Tuple[str, str]]:
         if self.source_config.includeTables:
             for table in inspector.get_table_names(schema):

--- a/ingestion/src/metadata/ingestion/source/database/athena.py
+++ b/ingestion/src/metadata/ingestion/source/database/athena.py
@@ -8,6 +8,9 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+from typing import Optional, Tuple
+
+from sqlalchemy.engine import Inspector
 
 from metadata.generated.schema.entity.services.connections.database.athenaConnection import (
     AthenaConnection,
@@ -41,3 +44,13 @@ class AthenaSource(CommonDbSourceService):
             )
 
         return cls(config, metadata_config)
+
+    def get_table_names(
+            self, schema: str, inspector: Inspector
+    ) -> Optional[Tuple[str, str]]:
+        if self.source_config.includeTables:
+            for table in inspector.get_table_names(schema):
+                yield table, "External"  # All tables in Athena are External
+        if self.source_config.includeViews:
+            for view in inspector.get_view_names(schema):
+                yield view, "View"

--- a/ingestion/src/metadata/ingestion/source/database/common_db_source.py
+++ b/ingestion/src/metadata/ingestion/source/database/common_db_source.py
@@ -158,7 +158,7 @@ class CommonDbSourceService(DBTSource, SqlColumnHandler, SqlAlchemySource):
 
     def get_table_names(
         self, schema: str, inspector: Inspector
-    ) -> Optional[Tuple[str, str]]:
+    ) -> Optional[Iterable[Tuple[str, str]]]:
         if self.source_config.includeTables:
             for table in inspector.get_table_names(schema):
                 yield table, "Regular"

--- a/ingestion/src/metadata/ingestion/source/database/sqlalchemy_source.py
+++ b/ingestion/src/metadata/ingestion/source/database/sqlalchemy_source.py
@@ -90,7 +90,9 @@ class SqlAlchemySource(Source, ABC):
         """
 
     @abstractmethod
-    def get_table_names(self, schema: str, inspector: Inspector) -> Optional[List[str]]:
+    def get_table_names(
+        self, schema: str, inspector: Inspector
+    ) -> Optional[Iterable[Tuple[str, str]]]:
         """
         Method to fetch table & view names
         """

--- a/ingestion/src/metadata/ingestion/source/sqa_types.py
+++ b/ingestion/src/metadata/ingestion/source/sqa_types.py
@@ -1,0 +1,28 @@
+#  Copyright 2021 Collate
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Define custom types as wrappers on top of
+existing SQA types to have a bridge between
+SQA dialects and OM rich type system
+"""
+from sqlalchemy import types
+
+
+class SQAMap(types.String):
+    """
+    Custom Map type definition
+    """
+
+
+class SQAStruct(types.String):
+    """
+    Custom Struct type definition
+    """

--- a/ingestion/src/metadata/orm_profiler/orm/registry.py
+++ b/ingestion/src/metadata/orm_profiler/orm/registry.py
@@ -17,6 +17,7 @@ import sqlalchemy
 from sqlalchemy import Integer, Numeric
 from sqlalchemy.sql.sqltypes import Concatenable, Enum
 
+from metadata.ingestion.source import sqa_types
 from metadata.orm_profiler.orm.types.hex_byte_string import HexByteString
 from metadata.orm_profiler.orm.types.uuid import UUIDString
 from metadata.orm_profiler.registry import TypeRegistry
@@ -66,7 +67,8 @@ NOT_COMPUTE = {
     sqlalchemy.types.NullType,
     sqlalchemy.ARRAY,
     sqlalchemy.JSON,
-
+    sqa_types.SQAMap,
+    sqa_types.SQAStruct,
 }
 
 

--- a/ingestion/src/metadata/orm_profiler/orm/registry.py
+++ b/ingestion/src/metadata/orm_profiler/orm/registry.py
@@ -66,6 +66,7 @@ NOT_COMPUTE = {
     sqlalchemy.types.NullType,
     sqlalchemy.ARRAY,
     sqlalchemy.JSON,
+
 }
 
 

--- a/ingestion/src/metadata/utils/column_type_parser.py
+++ b/ingestion/src/metadata/utils/column_type_parser.py
@@ -4,6 +4,8 @@ from typing import Any, Dict, List, Type, Union
 from sqlalchemy.sql import sqltypes as types
 from sqlalchemy.types import TypeEngine
 
+from metadata.ingestion.source import sqa_types
+
 
 def create_sqlalchemy_type(name: str):
     sqlalchemy_type = type(
@@ -45,6 +47,9 @@ class ColumnTypeParser:
         types.Integer: "INT",
         types.BigInteger: "BIGINT",
         types.VARBINARY: "VARBINARY",
+        # Custom wrapper types enriching SQA type system
+        sqa_types.SQAMap: "MAP",
+        sqa_types.SQAStruct: "STRUCT",
     }
 
     _SOURCE_TYPE_TO_OM_TYPE = {


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Fix #5108

The issue was that the profiler was failing for `map` type in Athena. Even though pyathena handles it as a string, the profiler actually needs to run some logic that failed.

By providing wrapper classes on top of SQA types, we can override the pyathena dialect to map source types to our custom definitions. This way, we can properly handle the richer type system that OM has.

Also, athena tables are external by definition, so we updated that as well.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [x] New feature
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
