### PR TITLE
Fix #5207 UI - Team Assets display table full address

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/teams/UserCard.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/teams/UserCard.test.tsx
@@ -18,7 +18,7 @@ import UserCard from './UserCard';
 
 const mockItem = {
   displayName: 'description1',
-  fqn: 'name1',
+  fqn: 'service.database.databaseSchema.table',
   id: 'id1',
   type: 'table',
 };
@@ -102,6 +102,7 @@ describe('Test userCard component', () => {
 
     expect(svgIcon).toBeInTheDocument();
     expect(datasetLink).toBeInTheDocument();
+    expect(datasetLink).toHaveTextContent('database/databaseSchema/table');
   });
 
   it('If isOwner is passed it should allow delete action', async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/teams/UserCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/teams/UserCard.tsx
@@ -73,6 +73,7 @@ const UserCard = ({
       case AssetsType.TABLE:
         return getPartialNameFromTableFQN(fqn, [
           FqnPart.Database,
+          FqnPart.Schema,
           FqnPart.Table,
         ]);
 


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on issue #5207 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] Improvement


#
### Frontend Preview (Screenshots) :
<img width="1435" alt="image" src="https://user-images.githubusercontent.com/59080942/170956610-c788fa53-aa0a-4c33-9128-c93380ae9a96.png">

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
