### PR TITLE
Fix #5248 UI : Confirmation modal is showing wrong tables count on database page

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/axiosAPIs/tableAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/axiosAPIs/tableAPI.ts
@@ -12,7 +12,7 @@
  */
 
 import { AxiosResponse } from 'axios';
-import { isNil } from 'lodash';
+import { isNil, isUndefined } from 'lodash';
 import { Table } from 'Models';
 import { CreateColumnTest } from '../generated/api/tests/createColumnTest';
 import { CreateTableTest } from '../generated/api/tests/createTableTest';
@@ -62,12 +62,17 @@ export const getTableDetailsByFQN: Function = (
 
 export const getAllTables = (
   arrQueryFields?: string,
-  limit?: number
+  limit?: number,
+  database?: string
 ): Promise<AxiosResponse> => {
   const searchParams = new URLSearchParams();
 
   if (!isNil(limit)) {
     searchParams.set('limit', `${limit}`);
+  }
+
+  if (!isUndefined(database)) {
+    searchParams.set('database', database);
   }
 
   const url = getURLWithQueryFields(

--- a/openmetadata-ui/src/main/resources/ui/src/pages/database-details/index.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/database-details/index.tsx
@@ -538,7 +538,7 @@ const DatabaseDetails: FunctionComponent = () => {
 
   const fetchTablesCount = () => {
     // limit=0 will fetch empty data list with total count
-    getAllTables('', 0)
+    getAllTables('', 0, databaseFQN)
       .then((res: AxiosResponse) => {
         if (res.data) {
           setTableInstanceCount(res.data.paging.total);


### PR DESCRIPTION

### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on issue #5248 
#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :

Here we have 15 tables in `ecommerce_db `

<img width="1438" alt="image" src="https://user-images.githubusercontent.com/59080942/171368853-733d6ff7-28cc-44c5-8d21-1bf4ae698f05.png">

Same count, we have while deleting the `ecommerce_db`

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/59080942/171368935-3e980ebe-bba7-45ed-8248-b3527a54d59a.png">


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
