### PR TITLE
fix issue: 5134 -  protected users and admin route with admin protection

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/constants/constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/constants.ts
@@ -169,6 +169,8 @@ export const ROUTES = {
   SQL_BUILDER: '/sql-builder',
   TEAMS_AND_USERS: '/teams-and-users',
   TEAMS_AND_USERS_DETAILS: `/teams-and-users/${PLACEHOLDER_ROUTE_TEAM_AND_USER}`,
+  TEAMS_AND_USERS_USERS: `/teams-and-users/users`,
+  TEAMS_AND_USERS_ADMINS: `/teams-and-users/admins`,
   SETTINGS: '/settings',
   STORE: '/store',
   FEEDS: '/feeds',

--- a/openmetadata-ui/src/main/resources/ui/src/router/AuthenticatedAppRouter.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/router/AuthenticatedAppRouter.tsx
@@ -62,6 +62,16 @@ const AuthenticatedAppRouter: FunctionComponent = () => {
         component={TeamsAndUsersPage}
         path={ROUTES.TEAMS_AND_USERS}
       />
+      <AdminProtectedRoute
+        exact
+        component={TeamsAndUsersPage}
+        path={ROUTES.TEAMS_AND_USERS_USERS}
+      />
+      <AdminProtectedRoute
+        exact
+        component={TeamsAndUsersPage}
+        path={ROUTES.TEAMS_AND_USERS_ADMINS}
+      />
       <Route
         exact
         component={TeamsAndUsersPage}


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Closes #5134 
I have made changes related to users' and admins routes, now non-admin will not have access to routes via URL

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :


https://user-images.githubusercontent.com/71748675/171604386-7aeed9d7-99b7-411e-b8e3-b75b150f4325.mov



#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
