### PR TITLE
Fix #4696 - Only store URL suffixes when extracting metadata

### DIFF
--- a/catalog-rest-service/src/main/resources/json/schema/api/data/createChart.json
+++ b/catalog-rest-service/src/main/resources/json/schema/api/data/createChart.json
@@ -23,9 +23,8 @@
       "$ref": "../../entity/data/chart.json#/definitions/chartType"
     },
     "chartUrl": {
-      "description": "Chart URL, pointing to its own Service URL",
-      "type": "string",
-      "format": "uri"
+      "description": "Chart URL suffix from its service.",
+      "type": "string"
     },
     "tables": {
       "description": "Link to tables used in this chart.",

--- a/catalog-rest-service/src/main/resources/json/schema/api/data/createDashboard.json
+++ b/catalog-rest-service/src/main/resources/json/schema/api/data/createDashboard.json
@@ -20,9 +20,8 @@
       "$ref": "../../type/basic.json#/definitions/markdown"
     },
     "dashboardUrl": {
-      "description": "Dashboard URL",
-      "type": "string",
-      "format": "uri"
+      "description": "Dashboard URL suffix from its service.",
+      "type": "string"
     },
     "charts": {
       "description": "All the charts included in this Dashboard.",

--- a/catalog-rest-service/src/main/resources/json/schema/entity/data/chart.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/data/chart.json
@@ -94,9 +94,8 @@
       "$ref": "#/definitions/chartType"
     },
     "chartUrl": {
-      "description": "Chart URL, pointing to its own Service URL.",
-      "type": "string",
-      "format": "uri"
+      "description": "Chart URL suffix from its service.",
+      "type": "string"
     },
     "href": {
       "description": "Link to the resource corresponding to this entity.",

--- a/catalog-rest-service/src/main/resources/json/schema/entity/data/dashboard.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/data/dashboard.json
@@ -40,9 +40,8 @@
       "type": "string"
     },
     "dashboardUrl": {
-      "description": "Dashboard URL.",
-      "type": "string",
-      "format": "uri"
+      "description": "Dashboard URL suffix from its service.",
+      "type": "string"
     },
     "charts": {
       "description": "All the charts included in this Dashboard.",

--- a/ingestion/src/airflow_provider_openmetadata/lineage/utils.py
+++ b/ingestion/src/airflow_provider_openmetadata/lineage/utils.py
@@ -155,12 +155,9 @@ def create_or_update_pipeline(  # pylint: disable=too-many-locals
     :param metadata: OpenMetadata API client
     :return: PipelineEntity
     """
-    pipeline_service_url = conf.get("webserver", "base_url")
-    dag_url = f"{pipeline_service_url}/tree?dag_id={dag.dag_id}"
-    task_url = (
-        f"{pipeline_service_url}/taskinstance/list/"
-        + f"?flt1_dag_id_equals={dag.dag_id}&_flt_3_task_id={operator.task_id}"
-    )
+    dag_url = f"/tree?dag_id={dag.dag_id}"
+    task_url = f"/taskinstance/list/?flt1_dag_id_equals={dag.dag_id}&_flt_3_task_id={operator.task_id}"
+
     dag_start_date = dag.start_date.isoformat() if dag.start_date else None
     task_start_date = (
         task_instance.start_date.isoformat() if task_instance.start_date else None

--- a/ingestion/src/metadata/ingestion/source/dashboard/looker.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/looker.py
@@ -104,7 +104,7 @@ class LookerSource(DashboardSourceService):
         ]
         return self.client.dashboard(dashboard_id=dashboard.id, fields=",".join(fields))
 
-    def get_dashboard_entity(self, dashboard_details: object) -> Dashboard:
+    def get_dashboard_entity(self, dashboard_details) -> Dashboard:
         """
         Method to Get Dashboard Entity
         """
@@ -114,25 +114,25 @@ class LookerSource(DashboardSourceService):
             displayName=dashboard_details.title,
             description=dashboard_details.description or "",
             charts=self.chart_names,
-            url=f"{self.service_connection.hostPort}/dashboards/{dashboard_details.id}",
+            url=f"/dashboards/{dashboard_details.id}",
             service=EntityReference(id=self.service.id, type="dashboardService"),
         )
 
-    def get_lineage(self, dashboard_details: object) -> AddLineageRequest:
+    def get_lineage(self, dashboard_details) -> Optional[AddLineageRequest]:
         """
         Get lineage between dashboard and data sources
         """
         logger.info("Lineage not implemented for Looker")
+        return None
 
     def process_charts(self) -> Optional[Iterable[Chart]]:
         """
         Get lineage between dashboard and data sources
         """
         logger.info("Fetch Charts Not implemented for Looker")
+        return None
 
-    def fetch_dashboard_charts(
-        self, dashboard_details: object
-    ) -> Optional[Iterable[Chart]]:
+    def fetch_dashboard_charts(self, dashboard_details) -> Optional[Iterable[Chart]]:
         """
         Metod to fetch charts linked to dashboard
         """
@@ -151,7 +151,7 @@ class LookerSource(DashboardSourceService):
                     displayName=dashboard_elements.title or "",
                     description="",
                     chart_type=dashboard_elements.type,
-                    url=f"{self.service_connection.hostPort}/dashboard_elements/{dashboard_elements.id}",
+                    url=f"/dashboard_elements/{dashboard_elements.id}",
                     service=EntityReference(
                         id=self.service.id, type="dashboardService"
                     ),

--- a/ingestion/src/metadata/ingestion/source/dashboard/powerbi.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/powerbi.py
@@ -101,6 +101,7 @@ class PowerbiSource(DashboardSourceService):
         yield from self.fetch_dashboard_charts(dashboard_details)
         yield Dashboard(
             name=dashboard_details["id"],
+            # PBI has no hostPort property. All URL details are present in the webUrl property.
             url=dashboard_details["webUrl"],
             displayName=dashboard_details["displayName"],
             description="",
@@ -193,7 +194,8 @@ class PowerbiSource(DashboardSourceService):
                     name=chart["id"],
                     displayName=chart["title"],
                     description="",
-                    chart_type="",
+                    chart_type="",  # Fix this with https://github.com/open-metadata/OpenMetadata/issues/1673
+                    # PBI has no hostPort property. All URL details are present in the webUrl property.
                     url=chart["embedUrl"],
                     service=EntityReference(
                         id=self.service.id, type="dashboardService"

--- a/ingestion/src/metadata/ingestion/source/dashboard/redash.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/redash.py
@@ -103,7 +103,6 @@ class RedashSource(DashboardSourceService):
         if dashboard_id is not None:
             self.status.item_scanned_status()
             dashboard_data = self.client.get_dashboard(dashboard_id)
-            dashboard_url = f"{self.service_connection.hostPort}/dashboard/{dashboard_data.get('slug', '')}"
             dashboard_description = ""
             for widgets in dashboard_data.get("widgets", []):
                 dashboard_description = widgets.get("text")
@@ -115,7 +114,7 @@ class RedashSource(DashboardSourceService):
                 charts=self.dashboards_to_charts[dashboard_id],
                 usageSummary=None,
                 service=EntityReference(id=self.service.id, type="dashboardService"),
-                url=dashboard_url,
+                url=f"/dashboard/{dashboard_data.get('slug', '')}",
             )
 
     def get_lineage(self, dashboard_details: dict) -> Optional[AddLineageRequest]:
@@ -123,6 +122,7 @@ class RedashSource(DashboardSourceService):
         Get lineage between dashboard and data sources
         """
         logger.info("Lineage not implemented for redash")
+        return None
 
     def process_charts(self) -> Optional[Iterable[Chart]]:
         """
@@ -173,9 +173,7 @@ class RedashSource(DashboardSourceService):
                     service=EntityReference(
                         id=self.service.id, type="dashboardService"
                     ),
-                    url=(
-                        f"{self.service_connection.hostPort}/dashboard/{dashboard_data.get('slug', '')}"
-                    ),
+                    url=f"/dashboard/{dashboard_data.get('slug', '')}",
                     description=visualization["description"] if visualization else "",
                 )
 

--- a/ingestion/src/metadata/utils/helpers.py
+++ b/ingestion/src/metadata/utils/helpers.py
@@ -8,7 +8,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
+import re
 from datetime import datetime, timedelta
 from typing import Any, Dict, Iterable
 
@@ -21,16 +21,12 @@ from metadata.generated.schema.api.services.createDatabaseService import (
 from metadata.generated.schema.api.services.createMessagingService import (
     CreateMessagingServiceRequest,
 )
-from metadata.generated.schema.api.services.createPipelineService import (
-    CreatePipelineServiceRequest,
-)
 from metadata.generated.schema.api.services.createStorageService import (
     CreateStorageServiceRequest,
 )
 from metadata.generated.schema.entity.services.dashboardService import DashboardService
 from metadata.generated.schema.entity.services.databaseService import DatabaseService
 from metadata.generated.schema.entity.services.messagingService import MessagingService
-from metadata.generated.schema.entity.services.pipelineService import PipelineService
 from metadata.generated.schema.entity.services.storageService import StorageService
 from metadata.generated.schema.metadataIngestion.workflow import (
     Source as WorkflowSource,
@@ -197,3 +193,13 @@ def get_raw_extract_iter(alchemy_helper) -> Iterable[Dict[str, Any]]:
     rows = alchemy_helper.execute_query()
     for row in rows:
         yield row
+
+
+def replace_special_with(raw: str, replacement: str) -> str:
+    """
+    Replace special characters in a string by a hyphen
+    :param raw: raw string to clean
+    :param replacement: string used to replace
+    :return: clean string
+    """
+    return re.sub(r"[^a-zA-Z0-9]", replacement, raw)

--- a/ingestion/tests/integration/lineage/airflow/test_airflow_lineage.py
+++ b/ingestion/tests/integration/lineage/airflow/test_airflow_lineage.py
@@ -298,13 +298,20 @@ class AirflowLineageTest(TestCase):
                 },
             )
 
-        pipeline = self.metadata.get_by_name(
-            entity=Pipeline, fqn="local_airflow_3.task_group_lineage", fields=["tasks"]
+        pipeline: Pipeline = self.metadata.get_by_name(
+            entity=Pipeline, fqn="airflow.task_group_lineage", fields=["tasks"]
         )
         self.assertIsNotNone(pipeline)
         self.assertIn("group1.task1", {task.name for task in pipeline.tasks})
         self.assertIn("group1.task2", {task.name for task in pipeline.tasks})
         self.assertIn("end", {task.name for task in pipeline.tasks})
+
+        # Validate URL building
+        self.assertEqual("/tree?dag_id=task_group_lineage", pipeline.pipelineUrl)
+        self.assertIn(
+            "/taskinstance/list/?flt1_dag_id_equals=task_group_lineage&_flt_3_task_id=end",
+            {task.taskUrl for task in pipeline.tasks},
+        )
 
     def test_clean_tasks(self):
         """


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Fix #4696 - Only store URL suffixes when extracting metadata

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
