### PR TITLE
Fix #5240 Display database name and table name in activity feed.

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/FeedCardHeader/FeedCardHeader.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/FeedCardHeader/FeedCardHeader.test.tsx
@@ -21,6 +21,10 @@ import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import FeedCardHeader from './FeedCardHeader';
 
+const FQN = 'service.database.schema.table';
+const type = 'table';
+const expectedDisplayName = 'database.schema.table';
+
 jest.mock('../../../axiosAPIs/userAPI', () => ({
   getUserByName: jest.fn().mockReturnValue({}),
 }));
@@ -29,6 +33,9 @@ jest.mock('../../../utils/CommonUtils', () => ({
   getPartialNameFromFQN: jest.fn().mockReturnValue('feedcard'),
   getNonDeletedTeams: jest.fn().mockReturnValue([]),
   getEntityName: jest.fn().mockReturnValue('entityname'),
+  getPartialNameFromTableFQN: jest.fn().mockImplementation(() => {
+    return expectedDisplayName;
+  }),
 }));
 
 jest.mock('../../../utils/TableUtils', () => ({
@@ -45,7 +52,7 @@ jest.mock('../../common/ProfilePicture/ProfilePicture', () => {
 
 const mockFeedHeaderProps = {
   createdBy: 'xyz',
-  entityFQN: 'x.y.z',
+  entityFQN: 'x.y.v.z',
   entityField: 'z',
   entityType: 'y',
   isEntityFeed: true,
@@ -102,5 +109,29 @@ describe('Test Feedheader Component', () => {
     expect(entityTypeElement).toBeInTheDocument();
     expect(entityLinkElement).toBeInTheDocument();
     expect(timeStampElement).toBeInTheDocument();
+  });
+
+  it('Should show link text as `database.schema.table` if entity type is table', async () => {
+    const { container } = render(
+      <FeedCardHeader
+        {...mockFeedHeaderProps}
+        entityFQN={FQN}
+        entityType={type}
+        isEntityFeed={false}
+      />,
+      {
+        wrapper: MemoryRouter,
+      }
+    );
+
+    const entityTypeElement = await findByTestId(container, 'entityType');
+    const entityLinkElement = await findByTestId(container, 'entitylink');
+
+    expect(entityTypeElement).toBeInTheDocument();
+    expect(entityLinkElement).toBeInTheDocument();
+
+    expect(entityTypeElement).toHaveTextContent(type);
+
+    expect(entityLinkElement).toHaveTextContent(expectedDisplayName);
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/FeedCardHeader/FeedCardHeader.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/FeedCardHeader/FeedCardHeader.tsx
@@ -172,7 +172,11 @@ const FeedCardHeader: FC<FeedHeaderProp> = ({
   const entityDisplayName = () => {
     let displayName;
     if (entityType === EntityType.TABLE) {
-      displayName = getPartialNameFromTableFQN(entityFQN, [FqnPart.Table]);
+      displayName = getPartialNameFromTableFQN(
+        entityFQN,
+        [FqnPart.Database, FqnPart.Schema, FqnPart.Table],
+        '.'
+      );
     } else if (entityType === EntityType.DATABASE_SCHEMA) {
       displayName = getPartialNameFromTableFQN(entityFQN, [FqnPart.Schema]);
     } else if (


### PR DESCRIPTION
Fixes #5240 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on issue #5240 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] Improvement

#
### Frontend Preview (Screenshots) :
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/59080942/172136212-476a7335-357c-4746-bbcb-fd8739de4468.png">


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui  
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
