### PR TITLE
Fix #5384 Use `displayName` instead of  `name` for pipeline listing page

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/service/index.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/service/index.tsx
@@ -60,6 +60,7 @@ import { Pipeline } from '../../generated/entity/data/pipeline';
 import { Topic } from '../../generated/entity/data/topic';
 import { DatabaseService } from '../../generated/entity/services/databaseService';
 import { IngestionPipeline } from '../../generated/entity/services/ingestionPipelines/ingestionPipeline';
+import { EntityReference } from '../../generated/type/entityReference';
 import { Paging } from '../../generated/type/paging';
 import { useAuth } from '../../hooks/authHooks';
 import { ServiceDataObj } from '../../interface/service.interface';
@@ -950,11 +951,9 @@ const ServicePage: FunctionComponent = () => {
                                     to={getLinkForFqn(
                                       dataObj.fullyQualifiedName || ''
                                     )}>
-                                    {serviceName ===
-                                      ServiceCategory.DASHBOARD_SERVICES &&
-                                    (dataObj as Dashboard).displayName
-                                      ? (dataObj as Dashboard).displayName
-                                      : dataObj.name}
+                                    {getEntityName(
+                                      dataObj as unknown as EntityReference
+                                    )}
                                   </Link>
                                 </td>
                                 <td className="tableBody-cell">


### PR DESCRIPTION
Fixes #5384 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on issue #5384 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement


#
### Frontend Preview (Screenshots) :
<img width="1435" alt="image" src="https://user-images.githubusercontent.com/59080942/173077478-d3e2e732-fb02-413c-a34d-ed97c3e9937a.png">


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
