### PR TITLE
Fix #5498: Column comparator should ignore case

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/util/EntityUtil.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/util/EntityUtil.java
@@ -101,12 +101,12 @@ public final class EntityUtil {
 
   public static final BiPredicate<Column, Column> columnMatch =
       (column1, column2) ->
-          column1.getName().equals(column2.getName())
+          column1.getName().equalsIgnoreCase(column2.getName())
               && column1.getDataType() == column2.getDataType()
               && column1.getArrayDataType() == column2.getArrayDataType();
 
   public static final BiPredicate<Column, Column> columnNameMatch =
-      (column1, column2) -> column1.getName().equals(column2.getName());
+      (column1, column2) -> column1.getName().equalsIgnoreCase(column2.getName());
 
   public static final BiPredicate<TableConstraint, TableConstraint> tableConstraintMatch =
       (constraint1, constraint2) ->

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/databases/TableResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/databases/TableResourceTest.java
@@ -379,6 +379,19 @@ public class TableResourceTest extends EntityResourceTest<Table, CreateTable> {
     origColumns.remove(3);
     origColumns.add(3, column3.withDataType(INT));
     assertColumns(origColumns, updatedTable.getColumns());
+
+    // Change the case of the column name and it should't update
+    updateColumn2 = getColumn("COLUMN2", INT, null).withOrdinalPosition(2).withDescription("");
+    columns = new ArrayList<>();
+    columns.add(updateColumn1);
+    columns.add(updateColumn2);
+    columns.add(updateColumn4);
+    columns.add(updateColumn3);
+    create.setColumns(columns);
+    create.setTableConstraints(List.of(constraint));
+    prevVersion = updatedTable.getVersion();
+    updatedTable = updateEntity(create, OK, ADMIN_AUTH_HEADERS);
+    TestUtils.validateUpdate(prevVersion, updatedTable.getVersion(), NO_CHANGE);
   }
 
   public static Column getColumn(String name, ColumnDataType columnDataType, TagLabel tag) {


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the ..... because ...

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
