### PR TITLE
Fix airflow lineage config auth scopes

### DIFF
--- a/ingestion/src/airflow_provider_openmetadata/lineage/config/providers.py
+++ b/ingestion/src/airflow_provider_openmetadata/lineage/config/providers.py
@@ -69,7 +69,7 @@ def load_okta_auth() -> OktaSSOClientConfig:
         orgURL=conf.get(LINEAGE, "org_url"),
         privateKey=conf.get(LINEAGE, "private_key"),
         email=conf.get(LINEAGE, "email"),
-        scopes=conf.get(LINEAGE, "scopes", fallback=[]),
+        scopes=conf.getjson(LINEAGE, "scopes", fallback=[]),
     )
 
 
@@ -94,7 +94,7 @@ def load_azure_auth() -> AzureSSOClientConfig:
         clientSecret=conf.get(LINEAGE, "client_secret"),
         authority=conf.get(LINEAGE, "authority"),
         clientId=conf.get(LINEAGE, "client_id"),
-        scopes=conf.get(LINEAGE, "scopes", fallback=[]),
+        scopes=conf.getjson(LINEAGE, "scopes", fallback=[]),
     )
 
 


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
The airflow method `conf.get` on airflow only returns strings.
The scope parameter needs to be a list, by switching to `conf.getjson` it will try to parse to a list.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [] Improvement
- [] New feature
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
