### PR TITLE
Feat: UI: Users, Teams and all the entity should support both soft-delete and hard-delete 

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/cypress/integration/Pages/EntityDetails.spec.js
+++ b/openmetadata-ui/src/main/resources/ui/cypress/integration/Pages/EntityDetails.spec.js
@@ -36,7 +36,9 @@ describe('Entity Details Page', () => {
 
     // check for delete section and delete button is available or not
     cy.get('[data-testid="danger-zone"]').scrollIntoView().should('be.visible');
-    cy.get('[data-testid="delete-button"]')
+    cy.get('[data-testid="hard-delete"] > .tw-flex')
+      .scrollIntoView()
+      .find('[data-testid="delete-button"]')
       .should('be.visible')
       .click()
       .as('deleteBtn');

--- a/openmetadata-ui/src/main/resources/ui/cypress/integration/Pages/TeamsAndUsers.spec.js
+++ b/openmetadata-ui/src/main/resources/ui/cypress/integration/Pages/TeamsAndUsers.spec.js
@@ -465,10 +465,16 @@ describe('TeamsAndUsers page', () => {
       .should('not.be.visible')
       .click();
 
-    cy.get('.tw-modal-container').should('be.visible');
-    cy.contains('Are you sure you want to delete').should('be.visible');
-    cy.get('[data-testid="save-button"]').should('be.visible').click();
-    cy.get('.tw-modal-container').should('not.exist');
+    cy.get('[role="dialog"]').should('be.visible');
+    cy.contains(`Delete ${NEW_USER.display_name}`).should('be.visible');
+    cy.get('[data-testid="confirm-button"]')
+      .should('be.visible')
+      .as('confirmBtn');
+    cy.get('@confirmBtn').should('be.disabled');
+    cy.get('[data-testid="confirmation-text-input"]')
+      .should('be.visible')
+      .type(DELETE_TERM);
+    cy.get('@confirmBtn').should('not.be.disabled').click();
 
     cy.reload();
     cy.get('[data-testid="searchbar"]')

--- a/openmetadata-ui/src/main/resources/ui/src/components/DashboardDetails/DashboardDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DashboardDetails/DashboardDetails.component.tsx
@@ -686,6 +686,7 @@ const DashboardDetails = ({
                 <div>
                   <ManageTabComponent
                     allowDelete
+                    allowSoftDelete
                     currentTier={tier?.tagFQN}
                     currentUser={owner}
                     deletEntityMessage={getDeleteEntityMessage()}

--- a/openmetadata-ui/src/main/resources/ui/src/components/DatasetDetails/DatasetDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DatasetDetails/DatasetDetails.component.tsx
@@ -777,6 +777,7 @@ const DatasetDetails: React.FC<DatasetDetailsProps> = ({
                 <div>
                   <ManageTab
                     allowDelete
+                    allowSoftDelete
                     currentTier={tier?.tagFQN}
                     currentUser={owner}
                     entityId={tableDetails.id}

--- a/openmetadata-ui/src/main/resources/ui/src/components/EntityLineage/EntityLineage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/EntityLineage/EntityLineage.component.tsx
@@ -1233,11 +1233,13 @@ const Entitylineage: FunctionComponent<EntityLineageProp> = ({
   };
 
   useEffect(() => {
-    const { node, edge } = getLayoutedElementsV1(setElementsHandleV1());
-    setNodes(node);
-    setEdges(edge);
+    if (!deleted) {
+      const { node, edge } = getLayoutedElementsV1(setElementsHandleV1());
+      setNodes(node);
+      setEdges(edge);
 
-    resetViewEditState();
+      resetViewEditState();
+    }
   }, [lineageData, isNodeLoading, isEditMode]);
 
   useEffect(() => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/MlModelDetail/MlModelDetail.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MlModelDetail/MlModelDetail.component.tsx
@@ -456,6 +456,7 @@ const MlModelDetail: FC<MlModelDetailProp> = ({
                 <div>
                   <ManageTabComponent
                     allowDelete
+                    allowSoftDelete
                     currentTier={mlModelTier?.tagFQN}
                     currentUser={mlModelDetail.owner}
                     entityId={mlModelDetail.id}

--- a/openmetadata-ui/src/main/resources/ui/src/components/PipelineDetails/PipelineDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/PipelineDetails/PipelineDetails.component.tsx
@@ -467,6 +467,7 @@ const PipelineDetails = ({
                 <div>
                   <ManageTabComponent
                     allowDelete
+                    allowSoftDelete
                     currentTier={tier?.tagFQN}
                     currentUser={owner}
                     entityId={pipelineDetails.id}

--- a/openmetadata-ui/src/main/resources/ui/src/components/TopicDetails/TopicDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TopicDetails/TopicDetails.component.tsx
@@ -463,6 +463,7 @@ const TopicDetails: React.FC<TopicDetailsProps> = ({
                 <div>
                   <ManageTabComponent
                     allowDelete
+                    allowSoftDelete
                     currentTier={tier?.tagFQN}
                     currentUser={owner}
                     entityId={topicDetails.id}

--- a/openmetadata-ui/src/main/resources/ui/src/components/UserDetails/UserDetails.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/UserDetails/UserDetails.test.tsx
@@ -189,8 +189,12 @@ jest.mock('../Loader/Loader', () => {
   return jest.fn().mockReturnValue(<p>Loader</p>);
 });
 
-jest.mock('../Modals/ConfirmationModal/ConfirmationModal', () => {
-  return jest.fn().mockReturnValue(<p>ConfirmationModal</p>);
+jest.mock('../common/DeleteWidget/DeleteWidgetV1', () => {
+  return jest
+    .fn()
+    .mockImplementation(({ visible }) =>
+      visible ? <p>DeleteWidgetV1</p> : null
+    );
 });
 
 jest.mock('../UserDataCard/UserDataCard', () => {
@@ -249,13 +253,13 @@ describe('Test UserDetails component', () => {
 
     expect(userDataCard.length).toBe(3);
 
-    expect(queryByText('ConfirmationModal')).toBeNull();
+    expect(queryByText('DeleteWidgetV1')).toBeNull();
 
     act(() => {
       fireEvent.click(handleDeleteUserModal[0]);
     });
 
-    expect(queryByText('ConfirmationModal')).toBeInTheDocument();
+    expect(queryByText('DeleteWidgetV1')).toBeInTheDocument();
   });
 
   it('Checking if Error is displayed when no users present', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/UserDetails/UserDetails.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/UserDetails/UserDetails.test.tsx
@@ -189,11 +189,11 @@ jest.mock('../Loader/Loader', () => {
   return jest.fn().mockReturnValue(<p>Loader</p>);
 });
 
-jest.mock('../common/DeleteWidget/DeleteWidgetV1', () => {
+jest.mock('../common/DeleteWidget/DeleteWidgetModal', () => {
   return jest
     .fn()
     .mockImplementation(({ visible }) =>
-      visible ? <p>DeleteWidgetV1</p> : null
+      visible ? <p>DeleteWidgetModal</p> : null
     );
 });
 
@@ -253,13 +253,13 @@ describe('Test UserDetails component', () => {
 
     expect(userDataCard.length).toBe(3);
 
-    expect(queryByText('DeleteWidgetV1')).toBeNull();
+    expect(queryByText('DeleteWidgetModal')).toBeNull();
 
     act(() => {
       fireEvent.click(handleDeleteUserModal[0]);
     });
 
-    expect(queryByText('DeleteWidgetV1')).toBeInTheDocument();
+    expect(queryByText('DeleteWidgetModal')).toBeInTheDocument();
   });
 
   it('Checking if Error is displayed when no users present', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/UserDetails/UserDetails.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/UserDetails/UserDetails.tsx
@@ -174,18 +174,6 @@ const UserDetails = ({
           totalCount={userPaging.total}
         />
       )}
-      {/* {!isUndefined(deletingUser) && (
-        <ConfirmationModal
-          bodyText={`Are you sure you want to delete ${deletingUser.name}?`}
-          cancelText="Cancel"
-          confirmText="Confirm"
-          header="Delete user"
-          onCancel={() => setDeletingUser(undefined)}
-          onConfirm={() => {
-            onConfirmDeleteUser(deletingUser.id);
-          }}
-        />
-      )} */}
 
       <DeleteWidgetV1
         afterDeleteAction={onConfirmDeleteUser}

--- a/openmetadata-ui/src/main/resources/ui/src/components/UserDetails/UserDetails.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/UserDetails/UserDetails.tsx
@@ -18,7 +18,7 @@ import { getUserPath, PAGE_SIZE_BASE } from '../../constants/constants';
 import { EntityReference, User } from '../../generated/entity/teams/user';
 import { Paging } from '../../generated/type/paging';
 import { getEntityName } from '../../utils/CommonUtils';
-import DeleteWidgetV1 from '../common/DeleteWidget/DeleteWidgetV1';
+import DeleteWidgetModal from '../common/DeleteWidget/DeleteWidgetModal';
 import ErrorPlaceHolder from '../common/error-with-placeholder/ErrorPlaceHolder';
 import NextPrevious from '../common/next-previous/NextPrevious';
 import PopOver from '../common/popover/PopOver';
@@ -175,7 +175,7 @@ const UserDetails = ({
         />
       )}
 
-      <DeleteWidgetV1
+      <DeleteWidgetModal
         afterDeleteAction={onConfirmDeleteUser}
         entityId={deletingUser?.id || ''}
         entityName={deletingUser?.name || ''}

--- a/openmetadata-ui/src/main/resources/ui/src/components/UserDetails/UserDetails.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/UserDetails/UserDetails.tsx
@@ -18,12 +18,12 @@ import { getUserPath, PAGE_SIZE_BASE } from '../../constants/constants';
 import { EntityReference, User } from '../../generated/entity/teams/user';
 import { Paging } from '../../generated/type/paging';
 import { getEntityName } from '../../utils/CommonUtils';
+import DeleteWidgetV1 from '../common/DeleteWidget/DeleteWidgetV1';
 import ErrorPlaceHolder from '../common/error-with-placeholder/ErrorPlaceHolder';
 import NextPrevious from '../common/next-previous/NextPrevious';
 import PopOver from '../common/popover/PopOver';
 import Searchbar from '../common/searchbar/Searchbar';
 import Loader from '../Loader/Loader';
-import ConfirmationModal from '../Modals/ConfirmationModal/ConfirmationModal';
 import UserDataCard from '../UserDataCard/UserDataCard';
 
 export type UserDetailsProps = {
@@ -37,7 +37,7 @@ export type UserDetailsProps = {
     cursorValue: string | number,
     activePage?: number
   ) => void;
-  handleDeleteUser: (id: string) => void;
+  handleDeleteUser: () => void;
 };
 
 interface DeleteUserInfo {
@@ -73,8 +73,8 @@ const UserDetails = ({
     history.push(getUserPath(name));
   };
 
-  const onConfirmDeleteUser = (id: string) => {
-    handleDeleteUser(id);
+  const onConfirmDeleteUser = () => {
+    handleDeleteUser();
     setDeletingUser(undefined);
   };
 
@@ -174,7 +174,7 @@ const UserDetails = ({
           totalCount={userPaging.total}
         />
       )}
-      {!isUndefined(deletingUser) && (
+      {/* {!isUndefined(deletingUser) && (
         <ConfirmationModal
           bodyText={`Are you sure you want to delete ${deletingUser.name}?`}
           cancelText="Cancel"
@@ -185,7 +185,16 @@ const UserDetails = ({
             onConfirmDeleteUser(deletingUser.id);
           }}
         />
-      )}
+      )} */}
+
+      <DeleteWidgetV1
+        afterDeleteAction={onConfirmDeleteUser}
+        entityId={deletingUser?.id || ''}
+        entityName={deletingUser?.name || ''}
+        entityType="user"
+        visible={!isUndefined(deletingUser)}
+        onCancel={() => setDeletingUser(undefined)}
+      />
     </div>
   );
 };

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/DeleteWidget/DeleteWidget.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/DeleteWidget/DeleteWidget.interface.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-export interface DeleteWidgetV1Props {
+export interface DeleteWidgetModalProps {
   visible: boolean;
   onCancel: () => void;
   allowSoftDelete?: boolean;

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/DeleteWidget/DeleteWidget.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/DeleteWidget/DeleteWidget.interface.ts
@@ -1,0 +1,41 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+export interface DeleteWidgetV1Props {
+  visible: boolean;
+  onCancel: () => void;
+  allowSoftDelete?: boolean;
+  entityName: string;
+  entityType: string;
+  isAdminUser?: boolean;
+  entityId: string;
+  isRecursiveDelete?: boolean;
+  afterDeleteAction?: () => void;
+}
+
+export interface DeleteSectionProps {
+  allowSoftDelete?: boolean;
+  entityName: string;
+  entityType: string;
+  deletEntityMessage?: string;
+  hasPermission: boolean;
+  isAdminUser?: boolean;
+  entityId: string;
+  isRecursiveDelete?: boolean;
+  afterDeleteAction?: () => void;
+}
+
+export enum DeleteType {
+  SOFT_DELETE = 'soft-delete',
+  HARD_DELETE = 'hard-delete',
+}

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/DeleteWidget/DeleteWidgetModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/DeleteWidget/DeleteWidgetModal.test.tsx
@@ -14,10 +14,10 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { DeleteWidgetV1Props } from './DeleteWidget.interface';
-import DeleteWidgetV1 from './DeleteWidgetV1';
+import { DeleteWidgetModalProps } from './DeleteWidget.interface';
+import DeleteWidgetModal from './DeleteWidgetModal';
 
-const mockProps: DeleteWidgetV1Props = {
+const mockProps: DeleteWidgetModalProps = {
   visible: true,
   onCancel: jest.fn(),
   entityName: 'entityName',
@@ -27,7 +27,7 @@ const mockProps: DeleteWidgetV1Props = {
 
 describe('Test DeleteWidgetV1 Component', () => {
   it('Component should render properly', async () => {
-    render(<DeleteWidgetV1 {...mockProps} />);
+    render(<DeleteWidgetModal {...mockProps} />);
 
     const deleteModal = await screen.findByTestId('delete-modal');
     const footer = await screen.findByTestId('footer');
@@ -47,7 +47,7 @@ describe('Test DeleteWidgetV1 Component', () => {
   });
 
   it('Delete click should work properly', async () => {
-    render(<DeleteWidgetV1 {...mockProps} />);
+    render(<DeleteWidgetModal {...mockProps} />);
     const inputBox = await screen.findByTestId('confirmation-text-input');
     const confirmButton = await screen.findByTestId('confirm-button');
     const hardDelete = await screen.findByTestId('hard-delete');
@@ -62,7 +62,7 @@ describe('Test DeleteWidgetV1 Component', () => {
   });
 
   it('Discard click should work properly', async () => {
-    render(<DeleteWidgetV1 {...mockProps} />);
+    render(<DeleteWidgetModal {...mockProps} />);
     const discardButton = await screen.findByTestId('discard-button');
 
     userEvent.click(discardButton);

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/DeleteWidget/DeleteWidgetModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/DeleteWidget/DeleteWidgetModal.tsx
@@ -25,7 +25,7 @@ import { getTitleCase } from '../../../utils/EntityUtils';
 import { showErrorToast, showSuccessToast } from '../../../utils/ToastUtils';
 import { Button } from '../../buttons/Button/Button';
 import Loader from '../../Loader/Loader';
-import { DeleteType, DeleteWidgetV1Props } from './DeleteWidget.interface';
+import { DeleteType, DeleteWidgetModalProps } from './DeleteWidget.interface';
 
 const DeleteWidgetV1 = ({
   visible,
@@ -35,7 +35,7 @@ const DeleteWidgetV1 = ({
   entityId,
   isRecursiveDelete,
   afterDeleteAction,
-}: DeleteWidgetV1Props) => {
+}: DeleteWidgetModalProps) => {
   const history = useHistory();
   const [entityDeleteState, setEntityDeleteState] =
     useState<typeof ENTITY_DELETE_STATE>(ENTITY_DELETE_STATE);

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/DeleteWidget/DeleteWidgetV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/DeleteWidget/DeleteWidgetV1.test.tsx
@@ -1,0 +1,72 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { DeleteWidgetV1Props } from './DeleteWidget.interface';
+import DeleteWidgetV1 from './DeleteWidgetV1';
+
+const mockProps: DeleteWidgetV1Props = {
+  visible: true,
+  onCancel: jest.fn(),
+  entityName: 'entityName',
+  entityType: 'entityType',
+  entityId: 'entityId',
+};
+
+describe('Test DeleteWidgetV1 Component', () => {
+  it('Component should render properly', async () => {
+    render(<DeleteWidgetV1 {...mockProps} />);
+
+    const deleteModal = await screen.findByTestId('delete-modal');
+    const footer = await screen.findByTestId('footer');
+    const discardButton = await screen.findByTestId('discard-button');
+    const confirmButton = await screen.findByTestId('confirm-button');
+    const softDelete = await screen.findByTestId('soft-delete');
+    const hardDelete = await screen.findByTestId('hard-delete');
+    const inputBox = await screen.findByTestId('confirmation-text-input');
+
+    expect(deleteModal).toBeInTheDocument();
+    expect(footer).toBeInTheDocument();
+    expect(discardButton).toBeInTheDocument();
+    expect(confirmButton).toBeInTheDocument();
+    expect(softDelete).toBeInTheDocument();
+    expect(hardDelete).toBeInTheDocument();
+    expect(inputBox).toBeInTheDocument();
+  });
+
+  it('Delete click should work properly', async () => {
+    render(<DeleteWidgetV1 {...mockProps} />);
+    const inputBox = await screen.findByTestId('confirmation-text-input');
+    const confirmButton = await screen.findByTestId('confirm-button');
+    const hardDelete = await screen.findByTestId('hard-delete');
+
+    userEvent.click(hardDelete);
+
+    userEvent.type(inputBox, 'DELETE');
+
+    expect(confirmButton).not.toBeDisabled();
+
+    userEvent.click(confirmButton);
+  });
+
+  it('Discard click should work properly', async () => {
+    render(<DeleteWidgetV1 {...mockProps} />);
+    const discardButton = await screen.findByTestId('discard-button');
+
+    userEvent.click(discardButton);
+
+    expect(mockProps.onCancel).toBeCalledTimes(1);
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/DeleteWidget/DeleteWidgetV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/DeleteWidget/DeleteWidgetV1.tsx
@@ -11,9 +11,10 @@
  *  limitations under the License.
  */
 
+import { Modal, Radio, RadioChangeEvent } from 'antd';
 import { AxiosError, AxiosResponse } from 'axios';
 import { startCase } from 'lodash';
-import React, { Fragment, useState } from 'react';
+import React, { ChangeEvent, useCallback, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { deleteEntity } from '../../../axiosAPIs/miscAPI';
 import { ENTITY_DELETE_STATE } from '../../../constants/entity.constants';
@@ -22,24 +23,24 @@ import jsonData from '../../../jsons/en';
 import { getEntityDeleteMessage } from '../../../utils/CommonUtils';
 import { getTitleCase } from '../../../utils/EntityUtils';
 import { showErrorToast, showSuccessToast } from '../../../utils/ToastUtils';
-import EntityDeleteModal from '../../Modals/EntityDeleteModal/EntityDeleteModal';
-import { DeleteSectionProps } from './DeleteWidget.interface';
-import DeleteWidgetBody from './DeleteWidgetBody';
+import { Button } from '../../buttons/Button/Button';
+import Loader from '../../Loader/Loader';
+import { DeleteType, DeleteWidgetV1Props } from './DeleteWidget.interface';
 
-const DeleteWidget = ({
-  allowSoftDelete,
+const DeleteWidgetV1 = ({
+  visible,
   entityName,
   entityType,
-  hasPermission,
-  isAdminUser,
-  deletEntityMessage,
+  onCancel,
   entityId,
   isRecursiveDelete,
   afterDeleteAction,
-}: DeleteSectionProps) => {
+}: DeleteWidgetV1Props) => {
   const history = useHistory();
   const [entityDeleteState, setEntityDeleteState] =
     useState<typeof ENTITY_DELETE_STATE>(ENTITY_DELETE_STATE);
+  const [name, setName] = useState<string>('');
+  const [value, setValue] = useState<DeleteType>(DeleteType.SOFT_DELETE);
 
   const prepareDeleteMessage = (softDelete = false) => {
     const softDeleteText = `Soft deleting will deactivate the ${entityName}. This will disable any discovery, read or write operations on ${entityName}`;
@@ -48,12 +49,32 @@ const DeleteWidget = ({
     return softDelete ? softDeleteText : hardDeleteText;
   };
 
+  const DELETE_OPTION = [
+    {
+      title: `Soft delete ${entityType} “${entityName}”`,
+      description: prepareDeleteMessage(true),
+      type: DeleteType.SOFT_DELETE,
+    },
+    {
+      title: `Delete ${entityType} “${entityName}”`,
+      description: prepareDeleteMessage(),
+      type: DeleteType.HARD_DELETE,
+    },
+  ];
+
+  const handleOnChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setName(e.target.value);
+  };
+
   const handleOnEntityDelete = (softDelete = false) => {
     setEntityDeleteState((prev) => ({ ...prev, state: true, softDelete }));
   };
 
   const handleOnEntityDeleteCancel = () => {
     setEntityDeleteState(ENTITY_DELETE_STATE);
+    setName('');
+    setValue(DeleteType.SOFT_DELETE);
+    onCancel();
   };
 
   const prepareEntityType = () => {
@@ -94,6 +115,7 @@ const DeleteWidget = ({
                 jsonData['api-success-messages']['delete-entity-success']
               )
             );
+
             if (afterDeleteAction) {
               afterDeleteAction();
             } else {
@@ -119,58 +141,97 @@ const DeleteWidget = ({
       });
   };
 
-  const getDeleteModal = () => {
-    if (entityDeleteState.state) {
-      return (
-        <EntityDeleteModal
-          bodyText={
-            deletEntityMessage ||
-            prepareDeleteMessage(entityDeleteState.softDelete)
-          }
-          entityName={entityName}
-          entityType={entityType}
-          loadingState={entityDeleteState.loading}
-          softDelete={entityDeleteState.softDelete}
-          onCancel={handleOnEntityDeleteCancel}
-          onConfirm={handleOnEntityDeleteConfirm}
-        />
-      );
-    } else {
-      return null;
-    }
+  const isNameMatching = useCallback(() => {
+    return (
+      name === 'DELETE' &&
+      (value === DeleteType.SOFT_DELETE || value === DeleteType.HARD_DELETE)
+    );
+  }, [name]);
+
+  const onChange = (e: RadioChangeEvent) => {
+    const value = e.target.value;
+    setValue(value);
+    handleOnEntityDelete(value === DeleteType.SOFT_DELETE);
+  };
+
+  const Footer = () => {
+    return (
+      <div className="tw-justify-end" data-testid="footer">
+        <Button
+          className="tw-mr-2"
+          data-testid="discard-button"
+          disabled={entityDeleteState.loading === 'waiting'}
+          size="regular"
+          theme="primary"
+          variant="text"
+          onClick={handleOnEntityDeleteCancel}>
+          Cancel
+        </Button>
+        {entityDeleteState.loading === 'waiting' ? (
+          <Button
+            disabled
+            className="tw-w-16 tw-h-8 tw-rounded-md disabled:tw-opacity-100"
+            data-testid="loading-button"
+            size="custom"
+            theme="primary"
+            variant="contained">
+            <Loader size="small" type="white" />
+          </Button>
+        ) : (
+          <Button
+            className="tw-h-8 tw-px-3 tw-py-2 tw-rounded-md"
+            data-testid="confirm-button"
+            disabled={!isNameMatching()}
+            size="custom"
+            theme="primary"
+            variant="contained"
+            onClick={handleOnEntityDeleteConfirm}>
+            Confirm
+          </Button>
+        )}
+      </div>
+    );
   };
 
   return (
-    <Fragment>
-      <div className="tw-mt-1 tw-bg-white" data-testid="danger-zone-container">
-        <div className="tw-border tw-border-error-70 tw-rounded tw-mt-3">
-          {allowSoftDelete && (
-            <div className="tw-border-b" data-testid="soft-delete">
-              <DeleteWidgetBody
-                buttonText="Soft delete"
-                description={prepareDeleteMessage(true)}
-                hasPermission={hasPermission}
-                header={`Soft delete ${getTitleCase(entityType)} ${entityName}`}
-                isOwner={isAdminUser}
-                onClick={() => handleOnEntityDelete(true)}
-              />
-            </div>
-          )}
-          <div data-testid="hard-delete">
-            <DeleteWidgetBody
-              buttonText="Delete"
-              description={prepareDeleteMessage()}
-              hasPermission={hasPermission}
-              header={`Delete ${getTitleCase(entityType)} ${entityName}`}
-              isOwner={isAdminUser}
-              onClick={() => handleOnEntityDelete(false)}
-            />
-          </div>
-        </div>
+    <Modal
+      data-testid="delete-modal"
+      footer={Footer()}
+      okText="Delete"
+      title={`Delete ${entityName}`}
+      visible={visible}
+      onCancel={handleOnEntityDeleteCancel}>
+      <Radio.Group value={value} onChange={onChange}>
+        {DELETE_OPTION.map((option) => (
+          <Radio
+            data-testid={option.type}
+            key={option.type}
+            value={option.type}>
+            <p className="tw-text-sm tw-mb-1 tw-font-medium">{option.title}</p>
+            <p className="tw-text-grey-muted tw-text-xs">
+              {option.description}
+            </p>
+          </Radio>
+        ))}
+      </Radio.Group>
+      <div>
+        <p className="tw-mb-2">
+          Type <strong>DELETE</strong> to confirm
+        </p>
+        <input
+          autoComplete="off"
+          className="tw-form-inputs tw-form-inputs-padding"
+          data-testid="confirmation-text-input"
+          disabled={entityDeleteState.loading === 'waiting'}
+          name="entityName"
+          placeholder="DELETE"
+          type="text"
+          value={name}
+          onChange={handleOnChange}
+        />
       </div>
-      {getDeleteModal()}
-    </Fragment>
+    </Modal>
   );
 };
 
-export default DeleteWidget;
+export default DeleteWidgetV1;

--- a/openmetadata-ui/src/main/resources/ui/src/interface/teamsAndUsers.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/interface/teamsAndUsers.interface.ts
@@ -57,7 +57,7 @@ export interface TeamsAndUsersProps {
     [key: string]: string;
   };
   updateTeamHandler: (data: Team) => Promise<void>;
-  handleDeleteUser: (id: string) => void;
+  handleDeleteUser: () => void;
   handleTeamUsersSearchAction: (text: string) => void;
   teamUserPaginHandler: (
     cursorValue: string | number,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DashboardDetailsPage/DashboardDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DashboardDetailsPage/DashboardDetailsPage.component.tsx
@@ -422,7 +422,7 @@ const DashboardDetailsPage = () => {
   const fetchTabSpecificData = (tabField = '') => {
     switch (tabField) {
       case TabSpecificField.LINEAGE: {
-        if (!deleted) {
+        if (!isEmpty(dashboardDetails) && !deleted) {
           if (isEmpty(entityLineage)) {
             getLineageData();
           }

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatasetDetailsPage/DatasetDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatasetDetailsPage/DatasetDetailsPage.component.tsx
@@ -410,7 +410,7 @@ const DatasetDetailsPage: FunctionComponent = () => {
       }
 
       case TabSpecificField.LINEAGE: {
-        if (!deleted) {
+        if (!isEmpty(tableDetails) && !deleted) {
           if (isEmpty(entityLineage)) {
             getLineageData();
           }

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PipelineDetails/PipelineDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PipelineDetails/PipelineDetailsPage.component.tsx
@@ -347,7 +347,7 @@ const PipelineDetailsPage = () => {
   const fetchTabSpecificData = (tabField = '') => {
     switch (tabField) {
       case TabSpecificField.LINEAGE: {
-        if (!deleted) {
+        if (!isEmpty(pipelineDetails) && !deleted) {
           if (isEmpty(entityLineage)) {
             getLineageData();
           }

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TeamsAndUsersPage/TeamsAndUsersPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TeamsAndUsersPage/TeamsAndUsersPage.component.tsx
@@ -27,11 +27,7 @@ import {
   getTeams,
   patchTeamDetail,
 } from '../../axiosAPIs/teamsAPI';
-import {
-  deleteUser,
-  getUsers,
-  updateUserDetail,
-} from '../../axiosAPIs/userAPI';
+import { getUsers, updateUserDetail } from '../../axiosAPIs/userAPI';
 import PageContainerV1 from '../../components/containers/PageContainerV1';
 import Loader from '../../components/Loader/Loader';
 import TeamsAndUsers from '../../components/TeamsAndUsers/TeamsAndUsers.component';
@@ -58,7 +54,6 @@ import { formatUsersResponse } from '../../utils/APIUtils';
 import { isUrlFriendlyName } from '../../utils/CommonUtils';
 import { getErrorText } from '../../utils/StringsUtils';
 import { showErrorToast, showSuccessToast } from '../../utils/ToastUtils';
-import { getAllUsersList } from '../../utils/UserDataUtils';
 
 const TeamsAndUsersPage = () => {
   const { teamAndUser } = useParams<Record<string, string>>();
@@ -245,22 +240,14 @@ const TeamsAndUsersPage = () => {
     history.push(ROUTES.CREATE_USER);
   };
 
-  const handleDeleteUser = (id: string) => {
-    setIsUsersLoading(true);
-    deleteUser(id)
-      .then(() => {
-        getAllUsersList();
-      })
-      .catch((err: AxiosError) => {
-        showErrorToast(
-          err,
-          jsonData['api-error-messages']['delete-user-error']
-        );
-      })
-      .finally(() => {
-        setIsLoading(false);
-        setIsUsersLoading(false);
-      });
+  const handleDeleteUser = () => {
+    setAllTabList(activeUserTab || '');
+    if (activeUserTab === UserType.USERS) {
+      setUsersCount((pre) => pre - 1);
+    }
+    if (activeUserTab === UserType.ADMINS) {
+      setAdminsCount((pre) => pre - 1);
+    }
   };
 
   /**

--- a/openmetadata-ui/src/main/resources/ui/src/styles/x-master.css
+++ b/openmetadata-ui/src/main/resources/ui/src/styles/x-master.css
@@ -1117,6 +1117,15 @@ code {
   padding: 4px 8px;
 }
 
+.ant-modal-content {
+  border-radius: 6px;
+}
+
+.ant-modal-header {
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
+}
+
 /* Feed popover CSS end */
 
 .data-box {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageUtils.tsx
@@ -169,10 +169,7 @@ export const getLineageDataV1 = (
   currentData: { nodes: Node[]; edges: Edge[] }
 ) => {
   const [x, y] = [0, 0];
-  const nodes = [
-    ...(entityLineage['nodes'] as EntityReference[]),
-    entityLineage['entity'],
-  ];
+  const nodes = [...(entityLineage['nodes'] || []), entityLineage['entity']];
   const edgesV1 = [
     ...(entityLineage.downstreamEdges || []),
     ...(entityLineage.upstreamEdges || []),


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the on the issue #5474 UI: Users, Teams and all the entities should support both soft-delete and hard-delete #5600
Closes #5474 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement
- [x] New feature


#
### Frontend Preview (Screenshots) :
added soft-delete support for all the entities
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/71748675/175353752-5c1d96b7-41b5-4c60-80ee-2429c952bc8f.png">

users page delete modal
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/71748675/175354721-fc9c176c-843e-443b-b589-2d7e1bbd2726.png">


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
@open-metadata/ui 