### PR TITLE
fix(ui): refresh authToken for google instead logged out user

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/authentication/auth-provider/AuthProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/authentication/auth-provider/AuthProvider.tsx
@@ -70,6 +70,7 @@ import {
   matchUserDetails,
 } from '../../utils/UserDataUtils';
 import Auth0Authenticator from '../authenticators/Auth0Authenticator';
+import GoogleAuthenticator from '../authenticators/GoogleAuthenticator';
 import MsalAuthenticator from '../authenticators/MsalAuthenticator';
 import OidcAuthenticator from '../authenticators/OidcAuthenticator';
 import OktaAuthenticator from '../authenticators/OktaAuthenticator';
@@ -473,7 +474,23 @@ export const AuthProvider = ({
           </OktaAuthProvider>
         );
       }
-      case AuthTypes.GOOGLE:
+      case AuthTypes.GOOGLE: {
+        return authConfig ? (
+          <GoogleAuthenticator
+            childComponentType={childComponentType}
+            ref={authenticatorRef}
+            userConfig={getUserManagerConfig({
+              ...(authConfig as Record<string, string>),
+            })}
+            onLoginFailure={handleFailedLogin}
+            onLoginSuccess={handleSuccessfulLogin}
+            onLogoutSuccess={handleSuccessfulLogout}>
+            {children}
+          </GoogleAuthenticator>
+        ) : (
+          <Loader />
+        );
+      }
       case AuthTypes.CUSTOM_OIDC:
       case AuthTypes.AWS_COGNITO: {
         return authConfig ? (


### PR DESCRIPTION
### Describe your changes :
- Instead logged out user, refreshed token on session expires 

Fix #2491 


#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @open-metadata/ui 
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
