### PR TITLE
Fixes #4935 -- Profiler Error with ClickHouse empty tables

### DIFF
--- a/ingestion/src/metadata/orm_profiler/metrics/static/column_names.py
+++ b/ingestion/src/metadata/orm_profiler/metrics/static/column_names.py
@@ -14,6 +14,7 @@ Table Column Count Metric definition
 """
 # pylint: disable=duplicate-code
 
+import sqlalchemy
 from sqlalchemy import inspect, literal
 from sqlalchemy.orm import DeclarativeMeta
 
@@ -56,4 +57,4 @@ class ColumnNames(StaticMetric):
             )
 
         col_names = ",".join(inspect(self.table).c.keys())
-        return literal(col_names)
+        return literal(col_names, type_=sqlalchemy.types.String)

--- a/ingestion/src/metadata/orm_profiler/metrics/static/mean.py
+++ b/ingestion/src/metadata/orm_profiler/metrics/static/mean.py
@@ -15,13 +15,31 @@ AVG Metric definition
 # pylint: disable=duplicate-code
 
 from sqlalchemy import column, func
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.sql.functions import GenericFunction
 
-from metadata.orm_profiler.metrics.core import StaticMetric, _label
+from metadata.orm_profiler.metrics.core import CACHE, StaticMetric, _label
 from metadata.orm_profiler.orm.functions.length import LenFn
-from metadata.orm_profiler.orm.registry import is_concatenable, is_quantifiable
+from metadata.orm_profiler.orm.registry import (
+    Dialects,
+    is_concatenable,
+    is_quantifiable,
+)
 from metadata.utils.logger import profiler_logger
 
 logger = profiler_logger()
+
+
+class avg(GenericFunction):
+    name = "avg"
+    inherit_cache = CACHE
+
+
+@compiles(avg, Dialects.ClickHouse)
+def _(element, compiler, **kw):
+    """Handle case for empty table. If empty, clickhouse returns NaN"""
+    proc = compiler.process(element.clauses, **kw)
+    return "if(isNaN(avg(%s)), null, avg(%s)" % ((proc,) * 2)
 
 
 class Mean(StaticMetric):

--- a/ingestion/src/metadata/orm_profiler/metrics/static/stddev.py
+++ b/ingestion/src/metadata/orm_profiler/metrics/static/stddev.py
@@ -51,6 +51,15 @@ def _(element, compiler, **kw):
     return "AVG(%s * %s) - AVG(%s) * AVG(%s)" % ((proc,) * 4)
 
 
+@compiles(StdDevFn, Dialects.ClickHouse)
+def _(element, compiler, **kw):
+    """Returns stdv for clickhouse database and handle empty tables.
+    If table is empty, clickhouse returns NaN.
+    """
+    proc = compiler.process(element.clauses, **kw)
+    return "if(isNaN(stddevPop(%s)), null, 'stddevPop(%s))" % ((proc,) * 2)
+
+
 class StdDev(StaticMetric):
     """
     STD Metric

--- a/ingestion/src/metadata/orm_profiler/orm/functions/length.py
+++ b/ingestion/src/metadata/orm_profiler/orm/functions/length.py
@@ -51,3 +51,9 @@ def _(element, compiler, **kw):
 @compiles(LenFn, Dialects.Postgres)
 def _(element, compiler, **kw):
     return "LENGTH(CAST(%s AS text))" % compiler.process(element.clauses, **kw)
+
+
+@compiles(LenFn, Dialects.ClickHouse)
+def _(element, compiler, **kw):
+    """Handles lenght function for ClickHouse"""
+    return "length(%s)" % compiler.process(element.clauses, **kw)

--- a/ingestion/src/metadata/orm_profiler/orm/functions/modulo.py
+++ b/ingestion/src/metadata/orm_profiler/orm/functions/modulo.py
@@ -54,3 +54,10 @@ def _(element, compiler, **kw):
 
     value, base = validate_and_compile(element, compiler, **kw)
     return f"MOD({value}, {base})"
+
+
+@compiles(ModuloFn, Dialects.ClickHouse)
+def _(element, compiler, **kw):
+    """Handles modulo function for ClickHouse"""
+    value, base = validate_and_compile(element, compiler, **kw)
+    return f"modulo({value}, {base})"

--- a/ingestion/src/metadata/orm_profiler/orm/functions/random_num.py
+++ b/ingestion/src/metadata/orm_profiler/orm/functions/random_num.py
@@ -68,3 +68,12 @@ def _(*_, **__):
     use it for a random sample.
     """
     return "ABS(CHECKSUM(NewId()))"
+
+
+@compiles(RandomNumFn, Dialects.ClickHouse)
+def _(*_, **__):
+    """
+    ClickHouse random returns a number between 0 and 4,294,967,295.
+    We need to divide it by 4294967295 to get a number between 0 and 1.
+    """
+    return "toInt8(RAND(10)/4294967295*100)"


### PR DESCRIPTION
### Describe your changes :
This PR fixes #4935 implementing:
- logic to handle click modulo function
- logic to generate random sample
- logic to return `None` if mean or std function return `NaN`

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
Ingestion: @open-metadata/ingestion
