### PR TITLE
fix(ui): do not fallback to polling and use websocket as transport method

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/web-scoket/web-scoket.provider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/web-scoket/web-scoket.provider.tsx
@@ -34,6 +34,10 @@ const WebSocketProvider: FC<Props> = ({ children }: Props) => {
         query: {
           userId: currentUser?.id,
         },
+        // Since we have load balancer in our application
+        // We need to enforce transports to be websocket only
+        // Refer: https://socket.io/docs/v3/using-multiple-nodes/
+        transports: ['websocket'],
       })
     );
   }, [currentUser]);


### PR DESCRIPTION
### Describe your changes :
Fix polling fallback when there's error for websocket & fore to use websocket only

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation

#
### Frontend Preview (Screenshots) :
<img width="1680" alt="Screenshot 2022-06-28 at 6 35 31 PM" src="https://user-images.githubusercontent.com/12962843/176185772-1a9a333f-f910-4784-984d-3588f7b7e7b9.png">

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @open-metadata/ui
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
