### PR TITLE
Fix migration script for migrations to 0.11

### DIFF
--- a/bootstrap/sql/com.mysql.cj.jdbc.Driver/v002__create_db_connection_info.sql
+++ b/bootstrap/sql/com.mysql.cj.jdbc.Driver/v002__create_db_connection_info.sql
@@ -28,7 +28,7 @@ CREATE TABLE IF NOT EXISTS mlmodel_service_entity (
     UNIQUE (name)
 );
 
-UPDATE thread_entity SET json = JSON_SET(json, '$.type', 'Conversation');
+UPDATE thread_entity SET json = JSON_SET(json, '$.type', 'Conversation', '$.reactions', JSON_ARRAY());
 
 ALTER TABLE thread_entity
 ADD type VARCHAR(64) GENERATED ALWAYS AS (json ->> '$.type'),

--- a/bootstrap/sql/org.postgresql.Driver/v002__create_db_connection_info.sql
+++ b/bootstrap/sql/org.postgresql.Driver/v002__create_db_connection_info.sql
@@ -30,6 +30,9 @@ CREATE TABLE IF NOT EXISTS mlmodel_service_entity (
 UPDATE thread_entity
 SET json = jsonb_set(json, '{type}', '"Conversation"', true);
 
+update thread_entity
+SET json = jsonb_set(json, '{reactions}', '[]'::jsonb, true);
+
 ALTER TABLE thread_entity
     ADD type VARCHAR(64) GENERATED ALWAYS AS (json ->> 'type') STORED NOT NULL,
     ADD taskId INT GENERATED ALWAYS AS ((json#>'{task,id}')::integer) STORED,

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/FeedRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/FeedRepository.java
@@ -720,6 +720,7 @@ public class FeedRepository {
     restorePatchAttributes(original, updated);
 
     if (!updated.getReactions().isEmpty()) {
+      populateUserReactions(updated.getReactions());
       updated
           .getReactions()
           .forEach(


### PR DESCRIPTION
### Describe your changes :

- Fixed migration of database from 0.10.3 to 0.11 for activity feed and reactions for both Mysql and Postgres

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

