### PR TITLE
Fix #5826 UI : Add Error Boundaries

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/package.json
+++ b/openmetadata-ui/src/main/resources/ui/package.json
@@ -72,6 +72,7 @@
     "react-copy-to-clipboard": "^5.0.4",
     "react-dom": "^16.14.0",
     "react-draft-wysiwyg": "^1.14.7",
+    "react-error-boundary": "^3.1.4",
     "react-flow-renderer": "^10.3.6",
     "react-google-login": "^5.2.2",
     "react-markdown": "^8.0.2",

--- a/openmetadata-ui/src/main/resources/ui/src/App.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/App.tsx
@@ -31,6 +31,7 @@ import 'react-toastify/dist/ReactToastify.min.css';
 import { AuthProvider } from './authentication/auth-provider/AuthProvider';
 import WebSocketProvider from './components/web-scoket/web-scoket.provider';
 import { toastOptions } from './constants/toast.constants';
+import ErrorBoundry from './ErrorBoundry/ErrorBoundry';
 import AppRouter from './router/AppRouter';
 
 const App: FunctionComponent = () => {
@@ -51,11 +52,13 @@ const App: FunctionComponent = () => {
     <div className="main-container">
       <div className="content-wrapper" data-testid="content-wrapper">
         <Router>
-          <WebSocketProvider>
-            <AuthProvider childComponentType={AppRouter}>
-              <AppRouter />
-            </AuthProvider>
-          </WebSocketProvider>
+          <ErrorBoundry>
+            <WebSocketProvider>
+              <AuthProvider childComponentType={AppRouter}>
+                <AppRouter />
+              </AuthProvider>
+            </WebSocketProvider>
+          </ErrorBoundry>
         </Router>
         <ToastContainer {...toastOptions} newestOnTop />
       </div>

--- a/openmetadata-ui/src/main/resources/ui/src/ErrorBoundry/ErrorBoundry.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/ErrorBoundry/ErrorBoundry.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+import { useHistory } from 'react-router-dom';
+import { ROUTES } from '../constants/constants';
+import ErrorFallback from './ErrorFallback';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+const ErrorBoundry: React.FC<Props> = ({ children }) => {
+  const history = useHistory();
+
+  const onErrorReset = () => {
+    history.push(ROUTES.HOME);
+  };
+
+  return (
+    <ErrorBoundary FallbackComponent={ErrorFallback} onReset={onErrorReset}>
+      {children}
+    </ErrorBoundary>
+  );
+};
+
+export default ErrorBoundry;

--- a/openmetadata-ui/src/main/resources/ui/src/ErrorBoundry/ErrorFallback.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/ErrorBoundry/ErrorFallback.tsx
@@ -1,0 +1,27 @@
+import { Button, Result } from 'antd';
+import React from 'react';
+import { FallbackProps } from 'react-error-boundary';
+import { ERROR500 } from '../constants/constants';
+
+const ErrorFallback: React.FC<FallbackProps> = ({
+  error,
+  resetErrorBoundary,
+}) => {
+  return (
+    <Result
+      extra={
+        <Button
+          className="ant-btn-primary-custom"
+          type="primary"
+          onClick={resetErrorBoundary}>
+          Home
+        </Button>
+      }
+      status="404"
+      subTitle={error.message}
+      title={ERROR500}
+    />
+  );
+};
+
+export default ErrorFallback;

--- a/openmetadata-ui/src/main/resources/ui/yarn.lock
+++ b/openmetadata-ui/src/main/resources/ui/yarn.lock
@@ -11809,6 +11809,13 @@ react-error-boundary@^3.1.0:
   dependencies:
     "@babel/runtime" "^7.12.5"
 
+react-error-boundary@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-flow-renderer@^10.3.6:
   version "10.3.6"
   resolved "https://registry.yarnpkg.com/react-flow-renderer/-/react-flow-renderer-10.3.6.tgz#9b6a963fdb68f99800207bea835316f3339ed11f"


### PR DESCRIPTION
Fixes #5826 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on issue #5826 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement


#
### Frontend Preview (Screenshots) :
![image](https://user-images.githubusercontent.com/59080942/177012756-e649627e-e313-4b53-8b34-279f9e5e6c15.png)


As a normal user, I was just playing with the application and then I visited an error-prone page and it crashed, instead of getting a blank page I'm getting a fallback page that tells me what is the exact error and I can go back.

https://user-images.githubusercontent.com/59080942/177012768-7547e9d8-e61e-42dc-a1ad-34849a705c82.mov


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
