### PR TITLE
Add to docs how to setup lineage callbacks by default on airflow

### DIFF
--- a/docs/integrations/airflow/airflow-lineage.md
+++ b/docs/integrations/airflow/airflow-lineage.md
@@ -132,6 +132,8 @@ and pass them as an argument for `on_failure_callback` and `on_success_callback`
 
 This can be set both at DAG and Task level, giving us flexibility on how (and if) we want to handle lineage on failure.
 
+If you want to track all DAGs, Tasks or specifics operators from airflow, considere to use the [Airflow Cluster Policies](https://airflow.apache.org/docs/apache-airflow/stable/concepts/cluster-policies.html) to wrap the OpenMetadata lineage callbacks by default.
+
 ### On Failure Callback
 
 This function handles the end-to-end logic:


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Added a note explaining how airflow users can set the OpenMetadata lineage callbacks by default for all DAGs, Tasks or specifics operators. 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [] Bug fix
- [] Improvement
- [] New feature
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
