### PR TITLE
Fix#5843  UI : Do not show the request description icon in entities that has no support for tasks yet

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/description/Description.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/description/Description.test.tsx
@@ -14,6 +14,7 @@
 import { findByTestId, queryByTestId, render } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
+import { EntityType } from '../../../enums/entity.enum';
 import Description from './Description';
 
 const mockEntityFieldThreads = [
@@ -59,6 +60,7 @@ jest.mock('../../../hooks/authHooks', () => {
 
 jest.mock('../../../utils/CommonUtils', () => ({
   getHtmlForNonAdminAction: jest.fn(),
+  isTaskSupported: jest.fn().mockReturnValue(true),
 }));
 
 jest.mock('../../../utils/EntityUtils', () => ({
@@ -208,6 +210,7 @@ describe('Test Description Component', () => {
         {...mockDescriptionProp}
         description=""
         entityFieldThreads={[]}
+        entityType={EntityType.TABLE}
       />,
       {
         wrapper: MemoryRouter,

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/description/Description.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/description/Description.tsx
@@ -19,9 +19,11 @@ import React, { FC, Fragment } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useAuthContext } from '../../../authentication/auth-provider/AuthProvider';
 import { EntityField } from '../../../constants/feed.constants';
+import { EntityType } from '../../../enums/entity.enum';
 import { ThreadType } from '../../../generated/entity/feed/thread';
 import { Operation } from '../../../generated/entity/policies/accessControl/rule';
 import { useAuth } from '../../../hooks/authHooks';
+import { isTaskSupported } from '../../../utils/CommonUtils';
 import { getEntityFeedLink } from '../../../utils/EntityUtils';
 import SVGIcons, { Icons } from '../../../utils/SvgUtils';
 import {
@@ -181,10 +183,15 @@ const Description: FC<DescriptionProps> = ({
             <SVGIcons alt="edit" icon="icon-edit" title="Edit" width="16px" />
           </button>
         )}
+        {isTaskSupported(entityType as EntityType) ? (
+          <Fragment>
+            {' '}
+            <RequestDescriptionEl />
+            {getDescriptionTaskElement()}
+          </Fragment>
+        ) : null}
 
-        <RequestDescriptionEl />
         <DescriptionThreadEl descriptionThread={thread} />
-        {getDescriptionTaskElement()}
       </div>
     ) : null;
   };

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CommonUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CommonUtils.tsx
@@ -686,5 +686,10 @@ export const getFeedCounts = (
     });
 };
 
+/**
+ *
+ * @param entityType type of the entity
+ * @returns true if entity type is exists in TASK_ENTITIES otherwise false
+ */
 export const isTaskSupported = (entityType: EntityType) =>
   TASK_ENTITIES.includes(entityType);

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CommonUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CommonUtils.tsx
@@ -689,7 +689,7 @@ export const getFeedCounts = (
 /**
  *
  * @param entityType type of the entity
- * @returns true if entity type is exists in TASK_ENTITIES otherwise false
+ * @returns true if entity type exists in TASK_ENTITIES otherwise false
  */
 export const isTaskSupported = (entityType: EntityType) =>
   TASK_ENTITIES.includes(entityType);

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CommonUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CommonUtils.tsx
@@ -47,6 +47,7 @@ import Fqn from './Fqn';
 import { getExplorePathWithInitFilters } from './RouterUtils';
 import { serviceTypeLogo } from './ServiceUtils';
 import SVGIcons, { Icons } from './SvgUtils';
+import { TASK_ENTITIES } from './TasksUtils';
 import { showErrorToast } from './ToastUtils';
 
 export const arraySorterByKey = (
@@ -684,3 +685,6 @@ export const getFeedCounts = (
       );
     });
 };
+
+export const isTaskSupported = (entityType: EntityType) =>
+  TASK_ENTITIES.includes(entityType);


### PR DESCRIPTION
Fixes #5843 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on issue #5843 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
