### PR TITLE
fix(ui): #5836 User profile should show user related activity only

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
@@ -54,10 +54,7 @@ import { dropdownIcon as DropDownIcon } from '../../utils/svgconstant';
 import SVGIcons, { Icons } from '../../utils/SvgUtils';
 import { showErrorToast } from '../../utils/ToastUtils';
 import ActivityFeedList from '../ActivityFeed/ActivityFeedList/ActivityFeedList';
-import {
-  filterList,
-  filterListTasks,
-} from '../ActivityFeed/ActivityFeedList/ActivityFeedList.util';
+import { filterListTasks } from '../ActivityFeed/ActivityFeedList/ActivityFeedList.util';
 import { Button } from '../buttons/Button/Button';
 import Description from '../common/description/Description';
 import ProfilePicture from '../common/ProfilePicture/ProfilePicture';
@@ -67,6 +64,7 @@ import PageLayout, { leftPanelAntCardStyle } from '../containers/PageLayout';
 import DropDownList from '../dropdown/DropDownList';
 import Loader from '../Loader/Loader';
 import { Option, Props } from './Users.interface';
+import { userPageFilterList } from './Users.util';
 
 const Users = ({
   userData,
@@ -673,7 +671,7 @@ const Users = ({
             onClick={() => setShowFilterList((visible) => !visible)}>
             <span className="tw-font-medium tw-text-grey">
               {
-                (activeTab === 1 ? filterList : filterListTasks).find(
+                (activeTab === 1 ? userPageFilterList : filterListTasks).find(
                   (f) => f.value === feedFilter
                 )?.name
               }
@@ -682,7 +680,9 @@ const Users = ({
           </Button>
           {showFilterList && (
             <DropDownList
-              dropDownList={activeTab === 1 ? filterList : filterListTasks}
+              dropDownList={
+                activeTab === 1 ? userPageFilterList : filterListTasks
+              }
               value={feedFilter}
               onSelect={handleFilterDropdownChange}
             />

--- a/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
@@ -14,7 +14,7 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Card } from 'antd';
 import { AxiosError, AxiosResponse } from 'axios';
-import { isEmpty, isNil, toLower } from 'lodash';
+import { capitalize, isEmpty, isNil, toLower } from 'lodash';
 import { observer } from 'mobx-react';
 import React, {
   Fragment,
@@ -134,8 +134,8 @@ const Users = ({
   };
 
   const activeTabHandler = (tabNum: number) => {
+    setFeedFilter(tabNum === 1 ? FeedFilter.ALL : FeedFilter.OWNER);
     setActiveTab(tabNum);
-    setFeedFilter(FeedFilter.ALL);
     // To reset search params appends from other page for proper navigation
     location.search = '';
     if (profileInfo[tabNum - 1].path !== tab) {
@@ -670,11 +670,9 @@ const Users = ({
             variant="link"
             onClick={() => setShowFilterList((visible) => !visible)}>
             <span className="tw-font-medium tw-text-grey">
-              {
-                (activeTab === 1 ? userPageFilterList : filterListTasks).find(
-                  (f) => f.value === feedFilter
-                )?.name
-              }
+              {(activeTab === 1 ? userPageFilterList : filterListTasks).find(
+                (f) => f.value === feedFilter
+              )?.name || capitalize(feedFilter)}
             </span>
             <DropDownIcon />
           </Button>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.util.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.util.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import SVGIcons, { Icons } from '../../utils/SvgUtils';
+
+export const userPageFilterList = [
+  {
+    name: 'My Data',
+    value: 'OWNER',
+    icon: <SVGIcons alt="" icon={Icons.FOLDER} width="16px" />,
+  },
+  {
+    name: 'Mentions',
+    value: 'MENTIONS',
+    icon: <SVGIcons alt="" icon={Icons.MENTIONS} width="16px" />,
+  },
+  {
+    name: 'Following',
+    value: 'FOLLOWS',
+    icon: <SVGIcons alt="" icon={Icons.STAR} width="16px" />,
+  },
+];

--- a/openmetadata-ui/src/main/resources/ui/src/pages/UserPage/UserPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/UserPage/UserPage.component.tsx
@@ -260,11 +260,12 @@ const UserPage = () => {
     if (userData.id) {
       const threadType =
         tab === 'tasks' ? ThreadType.Task : ThreadType.Conversation;
+
       const newFeedFilter =
         (searchParams.get('feedFilter') as FeedFilter) ??
-        threadType === ThreadType.Conversation
+        (threadType === ThreadType.Conversation
           ? FeedFilter.OWNER
-          : FeedFilter.ALL;
+          : FeedFilter.ALL);
       setFeedFilter(newFeedFilter);
       setEntityThread([]);
       getFeedData(threadType, undefined, newFeedFilter);

--- a/openmetadata-ui/src/main/resources/ui/src/pages/UserPage/UserPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/UserPage/UserPage.component.tsx
@@ -261,7 +261,10 @@ const UserPage = () => {
       const threadType =
         tab === 'tasks' ? ThreadType.Task : ThreadType.Conversation;
       const newFeedFilter =
-        (searchParams.get('feedFilter') as FeedFilter) ?? FeedFilter.ALL;
+        (searchParams.get('feedFilter') as FeedFilter) ??
+        threadType === ThreadType.Conversation
+          ? FeedFilter.OWNER
+          : FeedFilter.ALL;
       setFeedFilter(newFeedFilter);
       setEntityThread([]);
       getFeedData(threadType, undefined, newFeedFilter);


### PR DESCRIPTION
### Describe your changes :
> Update the default filter to "My Data" instead "All Activity" for the User profile page

Closes: [#5836](https://github.com/open-metadata/OpenMetadata/issues/5836)

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
<img width="1680" alt="Screenshot 2022-07-05 at 11 41 26 PM" src="https://user-images.githubusercontent.com/12962843/177389763-38125332-5ac6-4608-bea1-32a5ea99ecb3.png">


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @open-metadata/ui
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
