### PR TITLE
fixed issue: Error handling not present for add/delete/update Webhook

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/AddWebhook/WebhookConstants.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AddWebhook/WebhookConstants.tsx
@@ -22,6 +22,6 @@ export const UPDATE_EVENTS_DEFAULT_VALUE = {
 };
 
 export const DELETE_EVENTS_DEFAULT_VALUE = {
-  eventType: '"entityDeleted"',
+  eventType: 'entityDeleted',
   entities: ['*', 'table', 'topic', 'dashboard', 'pipeline'],
 };

--- a/openmetadata-ui/src/main/resources/ui/src/pages/AddWebhookPage/AddWebhookPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/AddWebhookPage/AddWebhookPage.component.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { AxiosError } from 'axios';
+import { AxiosError, AxiosResponse } from 'axios';
 import { LoadingState } from 'Models';
 import React, { FunctionComponent, useState } from 'react';
 import { useHistory } from 'react-router-dom';
@@ -43,12 +43,16 @@ const AddWebhookPage: FunctionComponent = () => {
   const handleSave = (data: CreateWebhook) => {
     setStatus('waiting');
     addWebhook(data)
-      .then(() => {
-        setStatus('success');
-        setTimeout(() => {
-          setStatus('initial');
-          goToWebhooks();
-        }, 500);
+      .then((res: AxiosResponse) => {
+        if (res.data) {
+          setStatus('success');
+          setTimeout(() => {
+            setStatus('initial');
+            goToWebhooks();
+          }, 500);
+        } else {
+          throw jsonData['api-error-messages']['unexpected-error'];
+        }
       })
       .catch((err: AxiosError) => {
         showErrorToast(err, jsonData['api-error-messages']['unexpected-error']);

--- a/openmetadata-ui/src/main/resources/ui/src/pages/EditWebhookPage/EditWebhookPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/EditWebhookPage/EditWebhookPage.component.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { AxiosError } from 'axios';
+import { AxiosError, AxiosResponse } from 'axios';
 import { LoadingState } from 'Models';
 import React, { FunctionComponent, useEffect, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
@@ -46,7 +46,11 @@ const EditWebhookPage: FunctionComponent = () => {
     setIsLoading(true);
     getWebhookByName(webhookName)
       .then((res) => {
-        setWebhookData(res.data);
+        if (res.data) {
+          setWebhookData(res.data);
+        } else {
+          throw jsonData['api-error-messages']['unexpected-error'];
+        }
       })
       .catch((err: AxiosError) => {
         showErrorToast(err, jsonData['api-error-messages']['unexpected-error']);
@@ -66,12 +70,16 @@ const EditWebhookPage: FunctionComponent = () => {
     setStatus('waiting');
     const { name, secretKey } = webhookData || data;
     updateWebhook({ ...data, name, secretKey })
-      .then(() => {
-        setStatus('success');
-        setTimeout(() => {
-          setStatus('initial');
-          goToWebhooks();
-        }, 500);
+      .then((res: AxiosResponse) => {
+        if (res.data) {
+          setStatus('success');
+          setTimeout(() => {
+            setStatus('initial');
+            goToWebhooks();
+          }, 500);
+        } else {
+          throw jsonData['api-error-messages']['unexpected-error'];
+        }
       })
       .catch((err: AxiosError) => {
         showErrorToast(err, jsonData['api-error-messages']['unexpected-error']);
@@ -82,9 +90,13 @@ const EditWebhookPage: FunctionComponent = () => {
   const handleDelete = (id: string) => {
     setDeleteStatus('waiting');
     deleteWebhook(id)
-      .then(() => {
-        setDeleteStatus('initial');
-        goToWebhooks();
+      .then((res: AxiosResponse) => {
+        if (res.data) {
+          setDeleteStatus('initial');
+          goToWebhooks();
+        } else {
+          throw jsonData['api-error-messages']['unexpected-error'];
+        }
       })
       .catch((err: AxiosError) => {
         showErrorToast(err, jsonData['api-error-messages']['unexpected-error']);

--- a/openmetadata-ui/src/main/resources/ui/src/pages/EditWebhookPage/EditWebhookPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/EditWebhookPage/EditWebhookPage.test.tsx
@@ -134,10 +134,44 @@ describe('Test DatasetDetails page', () => {
       expect(addWebhookComponent).toBeInTheDocument();
     });
 
+    it('Show error message on empty response of getWebhookByName api', async () => {
+      (getWebhookByName as jest.Mock).mockImplementationOnce(() =>
+        Promise.resolve({
+          response: { data: '' },
+        })
+      );
+      const { container } = render(<EditWebhookPage />, {
+        wrapper: MemoryRouter,
+      });
+      const addWebhookComponent = await findByText(
+        container,
+        /AddWebhookComponent/i
+      );
+
+      expect(addWebhookComponent).toBeInTheDocument();
+    });
+
     it('Show error message on failing of deleteWebhook api', async () => {
       (deleteWebhook as jest.Mock).mockImplementationOnce(() =>
         Promise.reject({
           response: { data: { message: 'Error!' } },
+        })
+      );
+      const { container } = render(<EditWebhookPage />, {
+        wrapper: MemoryRouter,
+      });
+      const addWebhookComponent = await findByText(
+        container,
+        /AddWebhookComponent/i
+      );
+
+      expect(addWebhookComponent).toBeInTheDocument();
+    });
+
+    it('Show error message on on empty response of deleteWebhook api', async () => {
+      (deleteWebhook as jest.Mock).mockImplementationOnce(() =>
+        Promise.resolve({
+          response: { data: '' },
         })
       );
       const { container } = render(<EditWebhookPage />, {


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the 
-  Error handling not present for add/delete/update Webhook -> Closes #3945
- Backend is throwing an error while creating webhook -> Closes #5908

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement


#
### Frontend Preview (Screenshots) :

https://user-images.githubusercontent.com/71748675/177714302-7f67cd39-dc29-4484-9449-e9cf3306106e.mov



#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
