### PR TITLE
feat(ui): refresh token support for OIDC client login

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/authentication/auth-provider/AuthProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/authentication/auth-provider/AuthProvider.tsx
@@ -282,9 +282,11 @@ export const AuthProvider = ({
       ? renewIdToken()
           .then(() => {
             setSilentSignInRetries(0);
+            // eslint-disable-next-line @typescript-eslint/no-use-before-define
             startTokenExpiryTimer();
           })
           .catch((err) => {
+            // eslint-disable-next-line no-console
             console.error('Error while attempting for silent signIn. ', err);
             setSilentSignInRetries((prev) => prev + 1);
             if (silentSignInRetries < 2) {

--- a/openmetadata-ui/src/main/resources/ui/src/authentication/authenticators/OidcAuthenticator.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/authentication/authenticators/OidcAuthenticator.tsx
@@ -146,6 +146,20 @@ const OidcAuthenticator = forwardRef<AuthenticatorRef, Props>(
               </>
             )}
           />
+          <Route
+            path={ROUTES.SILENT_CALLBACK}
+            render={() => (
+              <>
+                <Callback
+                  userManager={userManager}
+                  onSuccess={(user) => {
+                    localStorage.setItem(oidcTokenKey, user.id_token);
+                  }}
+                />
+                <Loader />
+              </>
+            )}
+          />
           {isAuthenticated || isAuthDisabled ? (
             <Fragment>{children}</Fragment>
           ) : !isSigningIn && isEmpty(userDetails) && isEmpty(newUser) ? (

--- a/openmetadata-ui/src/main/resources/ui/src/authentication/authenticators/OidcAuthenticator.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/authentication/authenticators/OidcAuthenticator.tsx
@@ -88,10 +88,13 @@ const OidcAuthenticator = forwardRef<AuthenticatorRef, Props>(
     const logout = () => {
       setLoadingIndicator(true);
       setIsAuthenticated(false);
-      localStorage.removeItem(
-        `oidc.user:${userConfig.authority}:${userConfig.client_id}`
-      );
+      userManager.removeUser();
       onLogoutSuccess();
+    };
+
+    // Performs silent signIn and returns with IDToken
+    const signInSilently = async () => {
+      return userManager.signinSilent().then((user) => user.id_token);
     };
 
     useImperativeHandle(ref, () => ({
@@ -102,62 +105,58 @@ const OidcAuthenticator = forwardRef<AuthenticatorRef, Props>(
         logout();
       },
       renewIdToken() {
-        return Promise.resolve('');
+        return signInSilently();
       },
     }));
 
     const AppWithAuth = getAuthenticator(childComponentType, userManager);
 
-    return (
-      <Fragment>
-        {!loading ? (
-          <>
-            <Appbar />
-            <Switch>
-              <Route exact path={ROUTES.HOME}>
-                {!isAuthDisabled && !isAuthenticated && !isSigningIn ? (
-                  <Redirect to={ROUTES.SIGNIN} />
-                ) : (
-                  <Redirect to={ROUTES.MY_DATA} />
-                )}
-              </Route>
-              <Route exact component={PageNotFound} path={ROUTES.NOT_FOUND} />
-              {!isSigningIn ? (
-                <Route exact component={SigninPage} path={ROUTES.SIGNIN} />
-              ) : null}
-              <Route
-                path={ROUTES.CALLBACK}
-                render={() => (
-                  <>
-                    <Callback
-                      userManager={userManager}
-                      onError={(error) => {
-                        showErrorToast(error?.message);
-                        onLoginFailure();
-                      }}
-                      onSuccess={(user) => {
-                        localStorage.setItem(oidcTokenKey, user.id_token);
-                        setIsAuthenticated(true);
-                        onLoginSuccess(user as OidcUser);
-                      }}
-                    />
-                    <Loader />
-                  </>
-                )}
-              />
-              {isAuthenticated || isAuthDisabled ? (
-                <Fragment>{children}</Fragment>
-              ) : !isSigningIn && isEmpty(userDetails) && isEmpty(newUser) ? (
-                <Redirect to={ROUTES.SIGNIN} />
-              ) : (
-                <AppWithAuth />
-              )}
-            </Switch>
-          </>
-        ) : (
-          <Loader />
-        )}
-      </Fragment>
+    return !loading ? (
+      <>
+        <Appbar />
+        <Switch>
+          <Route exact path={ROUTES.HOME}>
+            {!isAuthDisabled && !isAuthenticated && !isSigningIn ? (
+              <Redirect to={ROUTES.SIGNIN} />
+            ) : (
+              <Redirect to={ROUTES.MY_DATA} />
+            )}
+          </Route>
+          <Route exact component={PageNotFound} path={ROUTES.NOT_FOUND} />
+          {!isSigningIn ? (
+            <Route exact component={SigninPage} path={ROUTES.SIGNIN} />
+          ) : null}
+          <Route
+            path={ROUTES.CALLBACK}
+            render={() => (
+              <>
+                <Callback
+                  userManager={userManager}
+                  onError={(error) => {
+                    showErrorToast(error?.message);
+                    onLoginFailure();
+                  }}
+                  onSuccess={(user) => {
+                    localStorage.setItem(oidcTokenKey, user.id_token);
+                    setIsAuthenticated(true);
+                    onLoginSuccess(user as OidcUser);
+                  }}
+                />
+                <Loader />
+              </>
+            )}
+          />
+          {isAuthenticated || isAuthDisabled ? (
+            <Fragment>{children}</Fragment>
+          ) : !isSigningIn && isEmpty(userDetails) && isEmpty(newUser) ? (
+            <Redirect to={ROUTES.SIGNIN} />
+          ) : (
+            <AppWithAuth />
+          )}
+        </Switch>
+      </>
+    ) : (
+      <Loader />
     );
   }
 );

--- a/openmetadata-ui/src/main/resources/ui/src/constants/constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/constants.ts
@@ -142,6 +142,7 @@ export const facetFilterPlaceholder = [
 export const ROUTES = {
   HOME: '/',
   CALLBACK: '/callback',
+  SILENT_CALLBACK: '/silent-callback',
   NOT_FOUND: '/404',
   MY_DATA: '/my-data',
   TOUR: '/tour',

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AuthProvider.util.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AuthProvider.util.ts
@@ -39,6 +39,12 @@ export const getRedirectUri = (callbackUrl: string) => {
     : `${window.location.origin}/callback`;
 };
 
+export const getSilentRedirectUri = () => {
+  return isDev()
+    ? 'http://localhost:3000/silent-callback'
+    : `${window.location.origin}/silent-callback`;
+};
+
 export const getUserManagerConfig = (
   authClient: Record<string, string> = {}
 ): Record<string, string | boolean | WebStorageStateStore> => {
@@ -52,6 +58,8 @@ export const getUserManagerConfig = (
     response_type: responseType,
     // eslint-disable-next-line @typescript-eslint/camelcase
     redirect_uri: getRedirectUri(callbackUrl),
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    silent_redirect_uri: getSilentRedirectUri(),
     scope,
     userStore: new WebStorageStateStore({ store: localStorage }),
   };

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AuthProvider.util.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AuthProvider.util.ts
@@ -46,7 +46,6 @@ export const getUserManagerConfig = (
 
   return {
     authority,
-    automaticSilentRenew: true,
     // eslint-disable-next-line @typescript-eslint/camelcase
     client_id: clientId,
     // eslint-disable-next-line @typescript-eslint/camelcase


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
- I worked on refreshing auth token before its expiration. 
- Affected SSOs are Google, AWS Cognito, Custom OIDC
- @vivekratnavel We need to support one more redirect URI from SSOs: `/silent-callback` 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :

> Dev testing performed for
1. Should start to try silentSignIn before the token is about to expire ( Before 50 seconds )
2. Should re-try on failure for 3 times after that redirect to login screen
3. Initialise timer on App load & After successful login
4. Re-try attempt consider for consecutive retires, On successful login we will reset the retry count

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @open-metadata/ui
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
