### PR TITLE
fix(ui): owner search issue and show total count on load

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/ManageTab/ManageTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ManageTab/ManageTab.component.tsx
@@ -165,7 +165,7 @@ const ManageTab: FunctionComponent<ManageProps> = ({
       searchFormattedUsersAndTeams(searchQuery, from)
         .then((res) => {
           const { users, teams } = res;
-          setListOwners(getOwnerList(users, teams));
+          setListOwners(getOwnerList(users, teams, true));
         })
         .catch(() => {
           setListOwners([]);
@@ -180,13 +180,11 @@ const ManageTab: FunctionComponent<ManageProps> = ({
   const getOwnerSuggestion = useCallback(
     (qSearchText = '') => {
       setIsUserLoading(true);
+      setListOwners([]);
       suggestFormattedUsersAndTeams(qSearchText)
         .then((res) => {
           const { users, teams } = res;
-          setListOwners(getOwnerList(users, teams));
-        })
-        .catch(() => {
-          setListOwners([]);
+          setListOwners(getOwnerList(users, teams, true));
         })
         .finally(() => {
           setIsUserLoading(false);

--- a/openmetadata-ui/src/main/resources/ui/src/components/ManageTab/ManageTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ManageTab/ManageTab.component.tsx
@@ -165,7 +165,7 @@ const ManageTab: FunctionComponent<ManageProps> = ({
       searchFormattedUsersAndTeams(searchQuery, from)
         .then((res) => {
           const { users, teams } = res;
-          setListOwners(getOwnerList(users, teams, true));
+          setListOwners(getOwnerList(users, teams));
         })
         .catch(() => {
           setListOwners([]);

--- a/openmetadata-ui/src/main/resources/ui/src/components/dropdown/DropDownList.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/dropdown/DropDownList.tsx
@@ -36,6 +36,7 @@ const DropDownList: FunctionComponent<DropDownListProp> = ({
   domPosition,
   className = '',
   widthClass = 'tw-w-52',
+  getTotalCountForGroup,
 }: DropDownListProp) => {
   const { height: windowHeight } = useWindowDimensions();
   const isMounted = useRef<boolean>(false);
@@ -87,6 +88,17 @@ const DropDownList: FunctionComponent<DropDownListProp> = ({
     return searchedList.filter((item) => {
       return groupName ? item.group === groupName : !item.group;
     });
+  };
+
+  const getGroupCount = (groupName?: string): number => {
+    let count = 0;
+    if (controlledSearchStr === '' && getTotalCountForGroup && groupName) {
+      count = getTotalCountForGroup(groupName);
+    } else {
+      count = getSearchedListByGroup(groupName)?.length;
+    }
+
+    return count;
   };
 
   const getDropDownElement = (item: DropDownListItem, index: number) => {
@@ -278,7 +290,7 @@ const DropDownList: FunctionComponent<DropDownListProp> = ({
                         onClick={() => setActiveTab(index + 1)}>
                         {grp}
                         {getCountBadge(
-                          getSearchedListByGroup(grp).length,
+                          getGroupCount(grp),
                           '',
                           activeTab === index + 1
                         )}

--- a/openmetadata-ui/src/main/resources/ui/src/components/dropdown/types.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/dropdown/types.ts
@@ -59,6 +59,7 @@ export type DropDownListProp = {
   domPosition?: DOMRect;
   isLoading?: boolean;
   widthClass?: string;
+  getTotalCountForGroup?: (groupName: string) => number;
 };
 
 export type DropDownProp = {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ManageUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ManageUtils.ts
@@ -16,9 +16,16 @@ import AppState from '../AppState';
 import { EntityReference } from '../generated/type/entityUsage';
 import { getEntityName } from './CommonUtils';
 
+/**
+ * @param listUsers - List of users
+ * @param listTeams - List of teams
+ * @param excludeCurrentUser - Wether to exclude current user to be on list. Needed when calls from searching
+ * @returns List of user or team
+ */
 export const getOwnerList = (
   listUsers?: FormattedUsersData[],
-  listTeams?: FormattedTeamsData[]
+  listTeams?: FormattedTeamsData[],
+  excludeCurrentUser?: boolean
 ) => {
   const userDetails = AppState.getCurrentUserDetails();
 
@@ -47,17 +54,21 @@ export const getOwnerList = (
     }));
 
     return [
-      {
-        name: getEntityName(userDetails as unknown as EntityReference),
-        value: userDetails.id,
-        group: 'Users',
-        type: 'user',
-      },
+      ...(!excludeCurrentUser
+        ? [
+            {
+              name: getEntityName(userDetails as unknown as EntityReference),
+              value: userDetails.id,
+              group: 'Users',
+              type: 'user',
+            },
+          ]
+        : []),
       ...users,
       ...teams,
     ];
   } else {
-    return userDetails
+    return userDetails && !excludeCurrentUser
       ? [
           {
             name: getEntityName(userDetails as unknown as EntityReference),


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
- Fetch total count for Users & Teams
- Serach should work correctly 
- update count on searching 

Closed: #5892 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :

https://user-images.githubusercontent.com/12962843/177803350-c815a5ee-d79b-4e79-b12f-0f9f0ece997c.mov


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @open-metadata/ui
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
