### PR TITLE
Fixes #5964 -- Trino Median function and columnValuesToMatchRegex wording

### DIFF
--- a/ingestion/src/metadata/orm_profiler/orm/functions/median.py
+++ b/ingestion/src/metadata/orm_profiler/orm/functions/median.py
@@ -46,6 +46,7 @@ def _(elements, compiler, **kwargs):
     col, _ = [compiler.process(element, **kwargs) for element in elements.clauses]
     return "median(%s)" % col
 
+
 @compiles(MedianFn, Dialects.Trino)
 @compiles(MedianFn, Dialects.Presto)
 def _(elements, compiler, **kwargs):

--- a/ingestion/src/metadata/orm_profiler/orm/functions/median.py
+++ b/ingestion/src/metadata/orm_profiler/orm/functions/median.py
@@ -46,11 +46,11 @@ def _(elements, compiler, **kwargs):
     col, _ = [compiler.process(element, **kwargs) for element in elements.clauses]
     return "median(%s)" % col
 
-
+@compiles(MedianFn, Dialects.Trino)
 @compiles(MedianFn, Dialects.Presto)
 def _(elements, compiler, **kwargs):
     col, _ = [compiler.process(element, **kwargs) for element in elements.clauses]
-    return "approx_percentile(%s, 0.5, 0.99)" % col
+    return "approx_percentile(%s, 0.5)" % col
 
 
 @compiles(MedianFn, Dialects.SQLite)

--- a/ingestion/src/metadata/orm_profiler/validations/column/column_values_to_match_regex.py
+++ b/ingestion/src/metadata/orm_profiler/validations/column/column_values_to_match_regex.py
@@ -87,7 +87,7 @@ def column_values_to_match_regex(
         if col_profile.valuesCount == like_count_res
         else TestCaseStatus.Failed
     )
-    result = f"Found {like_count_res} value(s) matching regex pattern vs {int(col_profile.valuesCount)} value(s) in the table."
+    result = f"Found {like_count_res} value(s) matching regex pattern vs {int(col_profile.valuesCount)} value(s) in the column."
 
     return TestCaseResult(
         executionTime=execution_date.timestamp(), testCaseStatus=status, result=result

--- a/ingestion/src/metadata/orm_profiler/validations/column/column_values_to_match_regex.py
+++ b/ingestion/src/metadata/orm_profiler/validations/column/column_values_to_match_regex.py
@@ -87,7 +87,7 @@ def column_values_to_match_regex(
         if col_profile.valuesCount == like_count_res
         else TestCaseStatus.Failed
     )
-    result = f"Found likeCount={like_count_res} & valuesCount={col_profile.valuesCount}. They should be equal."
+    result = f"Found {like_count_res} value(s) matching regex pattern vs {int(col_profile.valuesCount)} value(s) in the table."
 
     return TestCaseResult(
         executionTime=execution_date.timestamp(), testCaseStatus=status, result=result

--- a/ingestion/tests/unit/profiler/test_session_validations.py
+++ b/ingestion/tests/unit/profiler/test_session_validations.py
@@ -148,7 +148,7 @@ class MetricsTest(TestCase):
         assert res_ok == TestCaseResult(
             executionTime=EXECUTION_DATE.timestamp(),
             testCaseStatus=TestCaseStatus.Success,
-            result="Found 2 value(s) matching regex pattern vs 2 value(s) in the table.",
+            result="Found 2 value(s) matching regex pattern vs 2 value(s) in the column.",
         )
 
         res_ko = validate(
@@ -162,7 +162,7 @@ class MetricsTest(TestCase):
         assert res_ko == TestCaseResult(
             executionTime=EXECUTION_DATE.timestamp(),
             testCaseStatus=TestCaseStatus.Failed,
-            result="Found 1 value(s) matching regex pattern vs 2 value(s) in the table.",
+            result="Found 1 value(s) matching regex pattern vs 2 value(s) in the column.",
         )
 
         res_aborted = validate(

--- a/ingestion/tests/unit/profiler/test_session_validations.py
+++ b/ingestion/tests/unit/profiler/test_session_validations.py
@@ -148,7 +148,7 @@ class MetricsTest(TestCase):
         assert res_ok == TestCaseResult(
             executionTime=EXECUTION_DATE.timestamp(),
             testCaseStatus=TestCaseStatus.Success,
-            result="Found likeCount=2 & valuesCount=2.0. They should be equal.",
+            result="Found 2 value(s) matching regex pattern vs 2 value(s) in the table.",
         )
 
         res_ko = validate(
@@ -162,7 +162,7 @@ class MetricsTest(TestCase):
         assert res_ko == TestCaseResult(
             executionTime=EXECUTION_DATE.timestamp(),
             testCaseStatus=TestCaseStatus.Failed,
-            result="Found likeCount=1 & valuesCount=2.0. They should be equal.",
+            result="Found 1 value(s) matching regex pattern vs 2 value(s) in the table.",
         )
 
         res_aborted = validate(


### PR DESCRIPTION
### Describe your changes :
Fixes #5964 where trino median function is not compiled correctly. It also updates the wording for `columnValuesToMatchRegex ` to make it explicit as to what is being tested.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [x] New feature
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
Ingestion: @open-metadata/ingestion
