### PR TITLE
Update missing FQN

### DIFF
--- a/bootstrap/sql/com.mysql.cj.jdbc.Driver/v003__create_db_connection_info.sql
+++ b/bootstrap/sql/com.mysql.cj.jdbc.Driver/v003__create_db_connection_info.sql
@@ -1,2 +1,59 @@
 DELETE from ingestion_pipeline_entity where 1=1;
 DELETE from entity_relationship where toEntity = 'ingestionPipeline';
+
+-- 0.10 had empty FQNs for services, users and teams
+UPDATE dbservice_entity
+SET json = JSON_INSERT(
+         json,
+        '$.fullyQualifiedName',
+        JSON_EXTRACT(json, '$.name')
+    )
+WHERE JSON_EXTRACT(json, '$.fullyQualifiedName') is NULL;
+
+UPDATE dashboard_service_entity
+SET json = JSON_INSERT(
+         json,
+        '$.fullyQualifiedName',
+        JSON_EXTRACT(json, '$.name')
+    )
+WHERE JSON_EXTRACT(json, '$.fullyQualifiedName') is NULL;
+
+UPDATE messaging_service_entity
+SET json = JSON_INSERT(
+         json,
+        '$.fullyQualifiedName',
+        JSON_EXTRACT(json, '$.name')
+    )
+WHERE JSON_EXTRACT(json, '$.fullyQualifiedName') is NULL;
+
+UPDATE pipeline_service_entity
+SET json = JSON_INSERT(
+         json,
+        '$.fullyQualifiedName',
+        JSON_EXTRACT(json, '$.name')
+    )
+WHERE JSON_EXTRACT(json, '$.fullyQualifiedName') is NULL;
+
+UPDATE storage_service_entity
+SET json = JSON_INSERT(
+         json,
+        '$.fullyQualifiedName',
+        JSON_EXTRACT(json, '$.name')
+    )
+WHERE JSON_EXTRACT(json, '$.fullyQualifiedName') is NULL;
+
+UPDATE team_entity
+SET json = JSON_INSERT(
+         json,
+        '$.fullyQualifiedName',
+        JSON_EXTRACT(json, '$.name')
+    )
+WHERE JSON_EXTRACT(json, '$.fullyQualifiedName') is NULL;
+
+UPDATE user_entity
+SET json = JSON_INSERT(
+         json,
+        '$.fullyQualifiedName',
+        JSON_EXTRACT(json, '$.name')
+    )
+WHERE JSON_EXTRACT(json, '$.fullyQualifiedName') is NULL;

--- a/bootstrap/sql/org.postgresql.Driver/v003__create_db_connection_info.sql
+++ b/bootstrap/sql/org.postgresql.Driver/v003__create_db_connection_info.sql
@@ -1,2 +1,31 @@
 DELETE from ingestion_pipeline_entity where 1=1;
 DELETE from entity_relationship where toEntity = 'ingestionPipeline';
+
+-- 0.10 had empty FQNs for services, users and teams
+UPDATE dbservice_entity
+SET json = jsonb_set(json, '{fullyQualifiedName}', json#>'{name}')
+WHERE json#>'{fullyQualifiedName}' is NULL;
+
+UPDATE dashboard_service_entity
+SET json = jsonb_set(json, '{fullyQualifiedName}', json#>'{name}')
+WHERE json#>'{fullyQualifiedName}' is NULL;
+
+UPDATE messaging_service_entity
+SET json = jsonb_set(json, '{fullyQualifiedName}', json#>'{name}')
+WHERE json#>'{fullyQualifiedName}' is NULL;
+
+UPDATE pipeline_service_entity
+SET json = jsonb_set(json, '{fullyQualifiedName}', json#>'{name}')
+WHERE json#>'{fullyQualifiedName}' is NULL;
+
+UPDATE storage_service_entity
+SET json = jsonb_set(json, '{fullyQualifiedName}', json#>'{name}')
+WHERE json#>'{fullyQualifiedName}' is NULL;
+
+UPDATE team_entity
+SET json = jsonb_set(json, '{fullyQualifiedName}', json#>'{name}')
+WHERE json#>'{fullyQualifiedName}' is NULL;
+
+UPDATE user_entity
+SET json = jsonb_set(json, '{fullyQualifiedName}', json#>'{name}')
+WHERE json#>'{fullyQualifiedName}' is NULL;


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
In 0.11 we added FQN to users and teams, while the migrations missed that step.

Also, 0.10 did not add FQN on the services, making the `list` API miss the pagination. Here we are adding the missing information.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [x] New feature
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
