### PR TITLE
Fixes #3463 -- Implement Custom SQL Data Quality Tests

### DIFF
--- a/catalog-rest-service/src/main/resources/json/schema/tests/table/tableCustomSQLQuery.json
+++ b/catalog-rest-service/src/main/resources/json/schema/tests/table/tableCustomSQLQuery.json
@@ -1,0 +1,17 @@
+{
+    "$id": "https://open-metadata.org/schema/tests/table/tableCustomSQLQuery.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "tableCustomSQLQuery",
+    "description": "This schema defines the test TableCustomSQLQuery. Test if a custom SQL returns 1 or 0 row.",
+    "type": "object",
+    "javaType": "org.openmetadata.catalog.tests.table.TableCustomSQLQuery",
+    "properties": {
+      "sqlExpression": {
+        "description": "SQL expression to run against the table",
+        "type": "string"
+      }
+    },
+    "required": ["sqlExpression"],
+    "additionalProperties": false
+  }
+  

--- a/catalog-rest-service/src/main/resources/json/schema/tests/tableTest.json
+++ b/catalog-rest-service/src/main/resources/json/schema/tests/tableTest.json
@@ -30,6 +30,9 @@
             },
             {
               "$ref": "./table/tableColumnToMatchSet.json"
+            },
+            {
+              "$ref": "./table/tableCustomSQLQuery.json"
             }
           ]
         },
@@ -40,7 +43,8 @@
             "tableColumnCountToEqual",
             "tableColumnCountToBeBetween",
             "tableColumnToMatchSet",
-            "tableColumnNameToExist"
+            "tableColumnNameToExist",
+            "tableCustomSQLQuery"
           ]
         }
       },

--- a/ingestion/src/metadata/orm_profiler/processor/orm_profiler.py
+++ b/ingestion/src/metadata/orm_profiler/processor/orm_profiler.py
@@ -312,7 +312,9 @@ class OrmProfilerProcessor(Processor[Table]):
             )
             return None
 
-        test_case_result: TestCaseResult = validation_enum_registry.registry[test_case.tableTestType.value](
+        test_case_result: TestCaseResult = validation_enum_registry.registry[
+            test_case.tableTestType.value
+        ](
             test_case.config,
             table_profile=profiler_results,
             execution_date=self.execution_date,
@@ -371,7 +373,9 @@ class OrmProfilerProcessor(Processor[Table]):
                 result=msg,
             )
 
-        test_case_result: TestCaseResult = validation_enum_registry.registry[test_case.columnTestType.value](
+        test_case_result: TestCaseResult = validation_enum_registry.registry[
+            test_case.columnTestType.value
+        ](
             test_case.config,
             col_profile=col_profiler_res,
             execution_date=self.execution_date,

--- a/ingestion/src/metadata/orm_profiler/processor/orm_profiler.py
+++ b/ingestion/src/metadata/orm_profiler/processor/orm_profiler.py
@@ -46,7 +46,7 @@ from metadata.orm_profiler.profiler.handle_partition import (
     is_partitioned,
 )
 from metadata.orm_profiler.profiler.sampler import Sampler
-from metadata.orm_profiler.validations.core import validate
+from metadata.orm_profiler.validations.core import validation_enum_registry
 from metadata.orm_profiler.validations.models import TestDef
 from metadata.utils.helpers import get_start_and_end
 
@@ -312,7 +312,7 @@ class OrmProfilerProcessor(Processor[Table]):
             )
             return None
 
-        test_case_result: TestCaseResult = validate(
+        test_case_result: TestCaseResult = validation_enum_registry.registry[test_case.tableTestType.value](
             test_case.config,
             table_profile=profiler_results,
             execution_date=self.execution_date,
@@ -371,7 +371,7 @@ class OrmProfilerProcessor(Processor[Table]):
                 result=msg,
             )
 
-        test_case_result: TestCaseResult = validate(
+        test_case_result: TestCaseResult = validation_enum_registry.registry[test_case.columnTestType.value](
             test_case.config,
             col_profile=col_profiler_res,
             execution_date=self.execution_date,

--- a/ingestion/src/metadata/orm_profiler/validations/core.py
+++ b/ingestion/src/metadata/orm_profiler/validations/core.py
@@ -20,9 +20,7 @@ mark the test as Failure/Aborted and pass a proper
 result string. The ORM Processor will be the one in charge
 of logging these issues.
 """
-from functools import singledispatch
 
-from metadata.generated.schema.tests.basic import TestCaseResult
 from metadata.orm_profiler.validations.column.column_value_max_to_be_between import (
     column_value_max_to_be_between,
 )
@@ -87,45 +85,35 @@ from metadata.orm_profiler.validations.table.table_row_count_to_equal import (
     table_row_count_to_equal,
 )
 from metadata.utils.logger import profiler_logger
+from metadata.utils.dispatch import enum_register
 
 logger = profiler_logger()
 
-
-@singledispatch
-def validate(test_case, **__) -> TestCaseResult:
-    """
-    Default function to validate test cases.
-
-    Note that the first argument should be a positional argument.
-    """
-    raise NotImplementedError(
-        f"Missing test case validation implementation for {type(test_case)}."
-    )
-
+validation_enum_registry = enum_register()
 
 # Table Tests
-validate.register(table_row_count_to_equal)
-validate.register(table_row_count_to_be_between)
-validate.register(table_column_count_to_equal)
-validate.register(table_column_count_to_be_between)
-validate.register(table_column_to_match_set)
-validate.register(table_column_name_to_exist)
+validation_enum_registry.add("tableRowCountToEqual")(table_row_count_to_equal)
+validation_enum_registry.add("tableRowCountToBeBetween")(table_row_count_to_be_between)
+validation_enum_registry.add("tableColumnCountToEqual")(table_column_count_to_equal)
+validation_enum_registry.add("tableColumnCountToBeBetween")(table_column_count_to_be_between)
+validation_enum_registry.add("tableColumnToMatchSet")(table_column_to_match_set)
+validation_enum_registry.add("tableColumnNameToExist")(table_column_name_to_exist)
 
-# Column Tests
-validate.register(column_values_to_be_between)
-validate.register(column_values_to_be_unique)
-validate.register(column_values_to_be_not_null)
-validate.register(column_value_length_to_be_between)
-validate.register(column_value_max_to_be_between)
-validate.register(column_value_min_to_be_between)
-validate.register(column_values_sum_to_be_between)
-validate.register(column_value_mean_to_be_between)
-validate.register(column_value_median_to_be_between)
-validate.register(column_value_stddev_to_be_between)
-validate.register(column_values_to_not_match_regex)
+# # Column Tests
+validation_enum_registry.add("columnValuesToBeBetween")(column_values_to_be_between)
+validation_enum_registry.add("columnValuesToBeUnique")(column_values_to_be_unique)
+validation_enum_registry.add("columnValuesToBeNotNull")(column_values_to_be_not_null)
+validation_enum_registry.add("columnValueLengthsToBeBetween")(column_value_length_to_be_between)
+validation_enum_registry.add("columnValueMaxToBeBetween")(column_value_max_to_be_between)
+validation_enum_registry.add("columnValueMinToBeBetween")(column_value_min_to_be_between)
+validation_enum_registry.add("columnValuesSumToBeBetween")(column_values_sum_to_be_between)
+validation_enum_registry.add("columnValueMeanToBeBetween")(column_value_mean_to_be_between)
+validation_enum_registry.add("columnValueMedianToBeBetween")(column_value_median_to_be_between)
+validation_enum_registry.add("columnValueStdDevToBeBetween")(column_value_stddev_to_be_between)
 
-# Column Session Tests
-validate.register(column_values_not_in_set)
-validate.register(column_values_in_set)
-validate.register(column_values_to_match_regex)
-validate.register(column_values_missing_count_to_be_equal)
+# # Column Session Tests
+validation_enum_registry.add("columnValuesToBeNotInSet")(column_values_not_in_set)
+validation_enum_registry.add("columnValuesToBeInSet")(column_values_in_set)
+validation_enum_registry.add("columnValuesToMatchRegex")(column_values_to_match_regex)
+validation_enum_registry.add("columnValuesToNotMatchRegex")(column_values_to_not_match_regex)
+validation_enum_registry.add("columnValuesMissingCountToBeEqual")(column_values_missing_count_to_be_equal)

--- a/ingestion/src/metadata/orm_profiler/validations/core.py
+++ b/ingestion/src/metadata/orm_profiler/validations/core.py
@@ -78,14 +78,17 @@ from metadata.orm_profiler.validations.table.table_column_name_to_exist import (
 from metadata.orm_profiler.validations.table.table_column_to_match_set import (
     table_column_to_match_set,
 )
+from metadata.orm_profiler.validations.table.table_custom_sql_query import (
+    table_custom_sql_query,
+)
 from metadata.orm_profiler.validations.table.table_row_count_to_be_between import (
     table_row_count_to_be_between,
 )
 from metadata.orm_profiler.validations.table.table_row_count_to_equal import (
     table_row_count_to_equal,
 )
-from metadata.utils.logger import profiler_logger
 from metadata.utils.dispatch import enum_register
+from metadata.utils.logger import profiler_logger
 
 logger = profiler_logger()
 
@@ -95,25 +98,46 @@ validation_enum_registry = enum_register()
 validation_enum_registry.add("tableRowCountToEqual")(table_row_count_to_equal)
 validation_enum_registry.add("tableRowCountToBeBetween")(table_row_count_to_be_between)
 validation_enum_registry.add("tableColumnCountToEqual")(table_column_count_to_equal)
-validation_enum_registry.add("tableColumnCountToBeBetween")(table_column_count_to_be_between)
+validation_enum_registry.add("tableColumnCountToBeBetween")(
+    table_column_count_to_be_between
+)
 validation_enum_registry.add("tableColumnToMatchSet")(table_column_to_match_set)
 validation_enum_registry.add("tableColumnNameToExist")(table_column_name_to_exist)
+validation_enum_registry.add("tableCustomSQLQuery")(table_custom_sql_query)
 
 # # Column Tests
 validation_enum_registry.add("columnValuesToBeBetween")(column_values_to_be_between)
 validation_enum_registry.add("columnValuesToBeUnique")(column_values_to_be_unique)
 validation_enum_registry.add("columnValuesToBeNotNull")(column_values_to_be_not_null)
-validation_enum_registry.add("columnValueLengthsToBeBetween")(column_value_length_to_be_between)
-validation_enum_registry.add("columnValueMaxToBeBetween")(column_value_max_to_be_between)
-validation_enum_registry.add("columnValueMinToBeBetween")(column_value_min_to_be_between)
-validation_enum_registry.add("columnValuesSumToBeBetween")(column_values_sum_to_be_between)
-validation_enum_registry.add("columnValueMeanToBeBetween")(column_value_mean_to_be_between)
-validation_enum_registry.add("columnValueMedianToBeBetween")(column_value_median_to_be_between)
-validation_enum_registry.add("columnValueStdDevToBeBetween")(column_value_stddev_to_be_between)
+validation_enum_registry.add("columnValueLengthsToBeBetween")(
+    column_value_length_to_be_between
+)
+validation_enum_registry.add("columnValueMaxToBeBetween")(
+    column_value_max_to_be_between
+)
+validation_enum_registry.add("columnValueMinToBeBetween")(
+    column_value_min_to_be_between
+)
+validation_enum_registry.add("columnValuesSumToBeBetween")(
+    column_values_sum_to_be_between
+)
+validation_enum_registry.add("columnValueMeanToBeBetween")(
+    column_value_mean_to_be_between
+)
+validation_enum_registry.add("columnValueMedianToBeBetween")(
+    column_value_median_to_be_between
+)
+validation_enum_registry.add("columnValueStdDevToBeBetween")(
+    column_value_stddev_to_be_between
+)
 
 # # Column Session Tests
 validation_enum_registry.add("columnValuesToBeNotInSet")(column_values_not_in_set)
 validation_enum_registry.add("columnValuesToBeInSet")(column_values_in_set)
 validation_enum_registry.add("columnValuesToMatchRegex")(column_values_to_match_regex)
-validation_enum_registry.add("columnValuesToNotMatchRegex")(column_values_to_not_match_regex)
-validation_enum_registry.add("columnValuesMissingCountToBeEqual")(column_values_missing_count_to_be_equal)
+validation_enum_registry.add("columnValuesToNotMatchRegex")(
+    column_values_to_not_match_regex
+)
+validation_enum_registry.add("columnValuesMissingCountToBeEqual")(
+    column_values_missing_count_to_be_equal
+)

--- a/ingestion/src/metadata/orm_profiler/validations/table/table_custom_sql_query.py
+++ b/ingestion/src/metadata/orm_profiler/validations/table/table_custom_sql_query.py
@@ -1,0 +1,59 @@
+#  Copyright 2021 Collate
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+TableColumnCountToBeBetween validation implementation
+"""
+# pylint: disable=duplicate-code
+
+from datetime import datetime
+
+from sqlalchemy import text
+from sqlalchemy.orm import DeclarativeMeta, Session
+
+from metadata.generated.schema.entity.data.table import TableProfile
+from metadata.generated.schema.tests.basic import TestCaseResult, TestCaseStatus
+from metadata.generated.schema.tests.table.tableCustomSQLQuery import (
+    TableCustomSQLQuery,
+)
+from metadata.utils.logger import profiler_logger
+
+logger = profiler_logger()
+
+
+def table_custom_sql_query(
+    test_case: TableCustomSQLQuery,
+    execution_date: datetime,
+    session: Session,
+    **__,
+) -> TestCaseResult:
+    """
+    Validate custom SQL tests. Tests will fail if number of rows
+    returned is not 0
+
+    Args:
+        test_case: test case type to be ran. Used to dispatch
+        table_profile: table profile results
+        execution_date: datetime of the test execution
+        session: sqlalchemy session
+        table: sqlalchemy declarative meta table
+    Returns:
+        TestCaseResult with status and results
+    """
+
+    rows = session.execute(text(test_case.sqlExpression)).all()
+
+    status = TestCaseStatus.Success if not rows else TestCaseStatus.Failed
+    result = f"Found {len(rows)} row(s). Test query is expected to return 0 row."
+
+    return TestCaseResult(
+        executionTime=execution_date.timestamp(), testCaseStatus=status, result=result
+    )

--- a/ingestion/tests/unit/profiler/test_validations.py
+++ b/ingestion/tests/unit/profiler/test_validations.py
@@ -40,7 +40,7 @@ from metadata.generated.schema.tests.table.tableRowCountToBeBetween import (
 from metadata.generated.schema.tests.table.tableRowCountToEqual import (
     TableRowCountToEqual,
 )
-from metadata.orm_profiler.validations.core import validate
+from metadata.orm_profiler.validations.core import validation_enum_registry
 
 EXECUTION_DATE = datetime.strptime("2021-07-03", "%Y-%m-%d")
 
@@ -54,7 +54,7 @@ def test_table_row_count_to_equal():
         rowCount=100,
     )
 
-    res_ok = validate(
+    res_ok = validation_enum_registry.registry["tableRowCountToEqual"](
         TableRowCountToEqual(value=100),
         table_profile=table_profile,
         execution_date=EXECUTION_DATE,
@@ -65,7 +65,7 @@ def test_table_row_count_to_equal():
         result="Found 100.0 rows vs. the expected 100",
     )
 
-    res_ko = validate(
+    res_ko = validation_enum_registry.registry["tableRowCountToEqual"](
         TableRowCountToEqual(value=50),
         table_profile=table_profile,
         execution_date=EXECUTION_DATE,
@@ -81,7 +81,7 @@ def test_table_row_count_to_equal():
         profileDate=EXECUTION_DATE.strftime("%Y-%m-%d"),
     )
 
-    res_aborted = validate(
+    res_aborted = validation_enum_registry.registry["tableRowCountToEqual"](
         TableRowCountToEqual(value=100),
         table_profile=table_profile_aborted,
         execution_date=EXECUTION_DATE,
@@ -103,7 +103,7 @@ def test_table_row_count_to_be_between():
         rowCount=100,
     )
 
-    res_ok = validate(
+    res_ok = validation_enum_registry.registry["tableRowCountToBeBetween"](
         TableRowCountToBeBetween(minValue=20, maxValue=120),
         table_profile=table_profile,
         execution_date=EXECUTION_DATE,
@@ -114,7 +114,7 @@ def test_table_row_count_to_be_between():
         result="Found 100.0 rows vs. the expected range [20, 120].",
     )
 
-    res_ko = validate(
+    res_ko = validation_enum_registry.registry["tableRowCountToBeBetween"](
         TableRowCountToBeBetween(minValue=120, maxValue=200),
         table_profile=table_profile,
         execution_date=EXECUTION_DATE,
@@ -130,7 +130,7 @@ def test_table_row_count_to_be_between():
         profileDate=EXECUTION_DATE.strftime("%Y-%m-%d"),
     )
 
-    res_aborted = validate(
+    res_aborted = validation_enum_registry.registry["tableRowCountToBeBetween"](
         TableRowCountToBeBetween(minValue=120, maxValue=200),
         table_profile=table_profile_aborted,
         execution_date=EXECUTION_DATE,
@@ -145,14 +145,14 @@ def test_table_row_count_to_be_between():
 
 def test_table_column_count_to_equal():
     """
-    Check TableRowCountToEqual
+    Check TableColumnCountToEqual
     """
     table_profile = TableProfile(
         profileDate=EXECUTION_DATE.strftime("%Y-%m-%d"),
         columnCount=5,
     )
 
-    res_ok = validate(
+    res_ok = validation_enum_registry.registry["tableColumnCountToEqual"](
         TableColumnCountToEqual(columnCount=5),
         table_profile=table_profile,
         execution_date=EXECUTION_DATE,
@@ -163,7 +163,7 @@ def test_table_column_count_to_equal():
         result="Found 5.0 columns vs. the expected 5",
     )
 
-    res_ko = validate(
+    res_ko = validation_enum_registry.registry["tableColumnCountToEqual"](
         TableColumnCountToEqual(columnCount=20),
         table_profile=table_profile,
         execution_date=EXECUTION_DATE,
@@ -179,7 +179,7 @@ def test_table_column_count_to_equal():
         profileDate=EXECUTION_DATE.strftime("%Y-%m-%d"),
     )
 
-    res_aborted = validate(
+    res_aborted = validation_enum_registry.registry["tableColumnCountToEqual"](
         TableColumnCountToEqual(columnCount=5),
         table_profile=table_profile_aborted,
         execution_date=EXECUTION_DATE,
@@ -202,7 +202,7 @@ def test_column_values_to_be_between():
         max=3,
     )
 
-    res_ok = validate(
+    res_ok = validation_enum_registry.registry["columnValuesToBeBetween"](
         ColumnValuesToBeBetween(
             minValue=0,
             maxValue=3,
@@ -216,7 +216,7 @@ def test_column_values_to_be_between():
         result="Found min=1.0, max=3.0 vs. the expected min=0, max=3.",
     )
 
-    res_ko = validate(
+    res_ko = validation_enum_registry.registry["columnValuesToBeBetween"](
         ColumnValuesToBeBetween(
             minValue=0,
             maxValue=2,
@@ -235,7 +235,7 @@ def test_column_values_to_be_between():
         min=1,
     )
 
-    res_aborted = validate(
+    res_aborted = validation_enum_registry.registry["columnValuesToBeBetween"](
         ColumnValuesToBeBetween(
             minValue=0,
             maxValue=3,
@@ -264,7 +264,7 @@ def test_column_values_to_be_unique():
         uniqueCount=10,
     )
 
-    res_ok = validate(
+    res_ok = validation_enum_registry.registry["columnValuesToBeUnique"](
         ColumnValuesToBeUnique(),
         col_profile=column_profile,
         execution_date=EXECUTION_DATE,
@@ -283,7 +283,7 @@ def test_column_values_to_be_unique():
         uniqueCount=5,
     )
 
-    res_ko = validate(
+    res_ko = validation_enum_registry.registry["columnValuesToBeUnique"](
         ColumnValuesToBeUnique(),
         col_profile=column_profile_ko,
         execution_date=EXECUTION_DATE,
@@ -300,7 +300,7 @@ def test_column_values_to_be_unique():
 
     column_profile_aborted = ColumnProfile()
 
-    res_aborted = validate(
+    res_aborted = validation_enum_registry.registry["columnValuesToBeUnique"](
         ColumnValuesToBeUnique(),
         col_profile=column_profile_aborted,
         execution_date=EXECUTION_DATE,
@@ -325,7 +325,7 @@ def test_column_values_to_be_not_null():
         nullCount=0,
     )
 
-    res_ok = validate(
+    res_ok = validation_enum_registry.registry["columnValuesToBeNotNull"](
         ColumnValuesToBeNotNull(),
         col_profile=column_profile,
         execution_date=EXECUTION_DATE,
@@ -340,7 +340,7 @@ def test_column_values_to_be_not_null():
         nullCount=10,
     )
 
-    res_ko = validate(
+    res_ko = validation_enum_registry.registry["columnValuesToBeNotNull"](
         ColumnValuesToBeNotNull(),
         col_profile=column_profile_ko,
         execution_date=EXECUTION_DATE,
@@ -354,7 +354,7 @@ def test_column_values_to_be_not_null():
 
     column_profile_aborted = ColumnProfile()
 
-    res_aborted = validate(
+    res_aborted = validation_enum_registry.registry["columnValuesToBeNotNull"](
         ColumnValuesToBeNotNull(),
         col_profile=column_profile_aborted,
         execution_date=EXECUTION_DATE,
@@ -378,7 +378,7 @@ def test_column_value_length_to_be_between():
         maxLength=16,
     )
 
-    res_ok = validate(
+    res_ok = validation_enum_registry.registry["columnValueLengthsToBeBetween"](
         ColumnValueLengthsToBeBetween(minLength=2, maxLength=20),
         col_profile=col_profile,
         execution_date=EXECUTION_DATE,
@@ -389,7 +389,7 @@ def test_column_value_length_to_be_between():
         result="Found minLength=4.0, maxLength=16.0 vs. the expected minLength=2, maxLength=20.",
     )
 
-    res_ko = validate(
+    res_ko = validation_enum_registry.registry["columnValueLengthsToBeBetween"](
         ColumnValueLengthsToBeBetween(minLength=10, maxLength=20),
         col_profile=col_profile,
         execution_date=EXECUTION_DATE,
@@ -403,7 +403,7 @@ def test_column_value_length_to_be_between():
 
     col_profile_aborted = ColumnProfile(minLength=4)
 
-    res_aborted = validate(
+    res_aborted = validation_enum_registry.registry["columnValueLengthsToBeBetween"](
         ColumnValueLengthsToBeBetween(minLength=2, maxLength=20),
         col_profile=col_profile_aborted,
         execution_date=EXECUTION_DATE,

--- a/openmetadata-ui/src/main/resources/ui/src/components/AddDataQualityTest/Forms/TableTestForm.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AddDataQualityTest/Forms/TableTestForm.tsx
@@ -74,6 +74,9 @@ const TableTestForm = ({
   const [columnNameSet, setcolumnNameSet] = useState<string | undefined>(
     data?.testCase?.config?.columnNames
   );
+  const [sqlExpression, setSqlExpression] = useState<string | undefined>(
+    data?.testCase?.config?.sqlExpression
+  );
   const [columnNameSetOrdered, setcolumnNameSetOrdered] = useState<boolean>(
     data?.testCase?.config?.ordered !== undefined
       ? data?.testCase?.config?.ordered
@@ -88,6 +91,7 @@ const TableTestForm = ({
     columnName: false,
     columnNameSet: false,
     columnNameSetOrdered: false,
+    sqlExpression: false,
   });
   const [testTypeOptions, setTestTypeOptions] = useState<string[]>();
 
@@ -136,6 +140,11 @@ const TableTestForm = ({
 
         break;
 
+      case TableTestType.TableCustomSQLQuery:
+        errMsg.sqlExpression = isEmpty(sqlExpression);
+
+        break;
+
       default:
         errMsg.values = isEmpty(value);
     }
@@ -178,6 +187,11 @@ const TableTestForm = ({
       case TableTestType.TableRowCountToEqual:
         return {
           value: isEmpty(value) ? undefined : value,
+        };
+
+      case TableTestType.TableCustomSQLQuery:
+        return {
+          sqlExpression: isEmpty(sqlExpression) ? undefined : sqlExpression,
         };
 
       default:
@@ -251,6 +265,12 @@ const TableTestForm = ({
 
         break;
 
+      case 'sql-expression':
+        setSqlExpression(value as unknown as string);
+        errorMsg.sqlExpression = false;
+
+        break;
+
       default:
         break;
     }
@@ -279,6 +299,26 @@ const TableTestForm = ({
     );
   };
 
+  const getSQLTextField = () => {
+    return (
+      <Field>
+        <label className="tw-block tw-form-label" htmlFor="value">
+          {requiredField('SQL Expression:')}
+        </label>
+        <input
+          className="tw-form-inputs tw-form-inputs-padding"
+          data-testid="sql-expression"
+          id="sql-expression"
+          name="sql-expression"
+          placeholder="SELECT * FROM dual"
+          type="text"
+          value={sqlExpression}
+          onChange={handleValidation}
+        />
+      </Field>
+    );
+  };
+
   const getValueColTextField = () => {
     return (
       <Field>
@@ -288,7 +328,7 @@ const TableTestForm = ({
         <input
           className="tw-form-inputs tw-form-inputs-padding"
           data-testid="column-name"
-          id="columnn-ame"
+          id="column-name"
           name="column-name"
           placeholder="col1"
           type="text"
@@ -380,6 +420,8 @@ const TableTestForm = ({
         return getValueColTextField();
       case TableTestType.TableColumnToMatchSet:
         return getValueColSetTextField();
+      case TableTestType.TableCustomSQLQuery:
+        return getSQLTextField();
       default:
         return getValueField();
     }


### PR DESCRIPTION
### Describe your changes :
This PR fixes #3463 by implementing the base logic to execute custom SQL tests. The test has been defined as a tableTest as it is technically executed against the whole table. This limits the number of SQL tests to 1. I am suggesting to fix in a second PR (open to suggestion though).

@open-metadata/ui I used a `label` field for the query imput, let me know if you think there is a better element to use.

We also took the opportunity to re-work part of the test dispatch in anticipation of the test case API re-work. 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
![Screenshot 2022-07-08 at 6 07 57 PM](https://user-images.githubusercontent.com/13626425/178032382-dd06e360-a5aa-489e-811e-1e4b7d48817b.png)

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
@open-metadata/ingestion
