### PR TITLE
Fix #5092: Allow tag names to be 64 chars in length

### DIFF
--- a/catalog-rest-service/src/main/resources/json/schema/entity/tags/tagCategory.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/tags/tagCategory.json
@@ -11,7 +11,7 @@
       "description": "Name of the tag.",
       "type": "string",
       "minLength": 2,
-      "maxLength": 25
+      "maxLength": 64
     },
     "tagCategoryType": {
       "description": "Type of tag category.",

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/tags/TagResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/tags/TagResourceTest.java
@@ -313,13 +313,13 @@ public class TagResourceTest extends CatalogApplicationTest {
     assertResponseContains(
         () -> createPrimaryTag(USER_TAG_CATEGORY.getName(), create, ADMIN_AUTH_HEADERS),
         BAD_REQUEST,
-        "name size must be between 2 and 25");
+        "name size must be between 2 and 64");
 
     // Long secondary tag name
     assertResponseContains(
         () -> createSecondaryTag(USER_TAG_CATEGORY.getName(), ADDRESS_TAG.getName(), create, ADMIN_AUTH_HEADERS),
         BAD_REQUEST,
-        "name size must be between 2 and 25");
+        "name size must be between 2 and 64");
   }
 
   @Test
@@ -417,7 +417,7 @@ public class TagResourceTest extends CatalogApplicationTest {
     assertResponseContains(
         () -> updatePrimaryTag(USER_TAG_CATEGORY.getName(), ADDRESS_TAG.getName(), create, ADMIN_AUTH_HEADERS),
         BAD_REQUEST,
-        "name size must be between 2 and 25");
+        "name size must be between 2 and 64");
 
     // Long secondary tag name
     assertResponseContains(
@@ -425,7 +425,7 @@ public class TagResourceTest extends CatalogApplicationTest {
             updateSecondaryTag(
                 USER_TAG_CATEGORY.getName(), ADDRESS_TAG.getName(), "Secondary", create, ADMIN_AUTH_HEADERS),
         BAD_REQUEST,
-        "name size must be between 2 and 25");
+        "name size must be between 2 and 64");
   }
 
   private TagCategory createAndCheckCategory(CreateTagCategory create, Map<String, String> authHeaders)

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/tags/TagResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/tags/TagResourceTest.java
@@ -374,7 +374,7 @@ public class TagResourceTest extends CatalogApplicationTest {
     assertResponseContains(
         () -> updateCategory(USER_TAG_CATEGORY.getName(), create, ADMIN_AUTH_HEADERS),
         BAD_REQUEST,
-        "name size must be between 2 and 25");
+        "name size must be between 2 and 64");
   }
 
   @Test

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/tags/TagResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/tags/TagResourceTest.java
@@ -273,7 +273,7 @@ public class TagResourceTest extends CatalogApplicationTest {
     // Long name
     create.withName(TestUtils.LONG_ENTITY_NAME).withCategoryType(TagCategoryType.Descriptive);
     assertResponseContains(
-        () -> createAndCheckCategory(create, ADMIN_AUTH_HEADERS), BAD_REQUEST, "name size must be between 2 and 25");
+        () -> createAndCheckCategory(create, ADMIN_AUTH_HEADERS), BAD_REQUEST, "name size must be between 2 and 64");
   }
 
   @Order(1)


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the ..... because ...

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
