### PR TITLE
FIX 5712: make generate gives different results depending on OS

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/CollectionDAO.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/CollectionDAO.java
@@ -1474,7 +1474,7 @@ public interface CollectionDAO {
         String description1 = r.getString("description1");
         String description2 = r.getString("description2");
         return new TagLabel()
-            .withSource(TagLabel.Source.values()[r.getInt("source")])
+            .withSource(TagLabel.TagSource.values()[r.getInt("source")])
             .withLabelType(TagLabel.LabelType.values()[r.getInt("labelType")])
             .withState(TagLabel.State.values()[r.getInt("state")])
             .withTagFQN(r.getString("tagFQN"))

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/EntityRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/EntityRepository.java
@@ -81,7 +81,7 @@ import org.openmetadata.catalog.type.Include;
 import org.openmetadata.catalog.type.Relationship;
 import org.openmetadata.catalog.type.TagLabel;
 import org.openmetadata.catalog.type.TagLabel.LabelType;
-import org.openmetadata.catalog.type.TagLabel.Source;
+import org.openmetadata.catalog.type.TagLabel.TagSource;
 import org.openmetadata.catalog.util.EntityUtil;
 import org.openmetadata.catalog.util.EntityUtil.Fields;
 import org.openmetadata.catalog.util.FullyQualifiedName;
@@ -741,7 +741,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
 
   /** Get tags associated with a given set of tags */
   private List<TagLabel> getDerivedTags(TagLabel tagLabel) {
-    if (tagLabel.getSource() == Source.GLOSSARY) { // Related tags are only supported for Glossary
+    if (tagLabel.getSource() == TagSource.GLOSSARY) { // Related tags are only supported for Glossary
       List<TagLabel> derivedTags = daoCollection.tagUsageDAO().getTags(tagLabel.getTagFQN());
       derivedTags.forEach(tag -> tag.setLabelType(LabelType.DERIVED));
       return derivedTags;
@@ -759,14 +759,14 @@ public abstract class EntityRepository<T extends EntityInterface> {
   /** Apply tags {@code tagLabels} to the entity or field identified by {@code targetFQN} */
   public void applyTags(List<TagLabel> tagLabels, String targetFQN) {
     for (TagLabel tagLabel : listOrEmpty(tagLabels)) {
-      if (tagLabel.getSource() == Source.TAG) {
+      if (tagLabel.getSource() == TagSource.TAG) {
         Tag tag = daoCollection.tagDAO().findEntityByName(tagLabel.getTagFQN());
         tagLabel.withDescription(tag.getDescription());
-        tagLabel.setSource(Source.TAG);
-      } else if (tagLabel.getSource() == Source.GLOSSARY) {
+        tagLabel.setSource(TagSource.TAG);
+      } else if (tagLabel.getSource() == TagSource.GLOSSARY) {
         GlossaryTerm term = daoCollection.glossaryTermDAO().findEntityByName(tagLabel.getTagFQN(), NON_DELETED);
         tagLabel.withDescription(term.getDescription());
-        tagLabel.setSource(Source.GLOSSARY);
+        tagLabel.setSource(TagSource.GLOSSARY);
       }
 
       // Apply tagLabel to targetFQN that identifies an entity or field

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/GlossaryRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/GlossaryRepository.java
@@ -30,7 +30,7 @@ import org.openmetadata.catalog.resources.glossary.GlossaryResource;
 import org.openmetadata.catalog.type.EntityReference;
 import org.openmetadata.catalog.type.Relationship;
 import org.openmetadata.catalog.type.TagLabel;
-import org.openmetadata.catalog.type.TagLabel.Source;
+import org.openmetadata.catalog.type.TagLabel.TagSource;
 import org.openmetadata.catalog.util.EntityUtil;
 import org.openmetadata.catalog.util.EntityUtil.Fields;
 
@@ -91,7 +91,7 @@ public class GlossaryRepository extends EntityRepository<Glossary> {
   }
 
   private Integer getUsageCount(Glossary glossary) {
-    return daoCollection.tagUsageDAO().getTagCount(Source.GLOSSARY.ordinal(), glossary.getName());
+    return daoCollection.tagUsageDAO().getTagCount(TagSource.GLOSSARY.ordinal(), glossary.getName());
   }
 
   @Override

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/GlossaryTermRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/GlossaryTermRepository.java
@@ -37,7 +37,7 @@ import org.openmetadata.catalog.resources.glossary.GlossaryTermResource;
 import org.openmetadata.catalog.type.EntityReference;
 import org.openmetadata.catalog.type.Relationship;
 import org.openmetadata.catalog.type.TagLabel;
-import org.openmetadata.catalog.type.TagLabel.Source;
+import org.openmetadata.catalog.type.TagLabel.TagSource;
 import org.openmetadata.catalog.util.EntityUtil;
 import org.openmetadata.catalog.util.EntityUtil.Fields;
 import org.openmetadata.catalog.util.FullyQualifiedName;
@@ -71,7 +71,7 @@ public class GlossaryTermRepository extends EntityRepository<GlossaryTerm> {
   }
 
   private Integer getUsageCount(GlossaryTerm term) {
-    return daoCollection.tagUsageDAO().getTagCount(Source.GLOSSARY.ordinal(), term.getFullyQualifiedName());
+    return daoCollection.tagUsageDAO().getTagCount(TagSource.GLOSSARY.ordinal(), term.getFullyQualifiedName());
   }
 
   private EntityReference getParent(GlossaryTerm entity) throws IOException {
@@ -197,7 +197,7 @@ public class GlossaryTermRepository extends EntityRepository<GlossaryTerm> {
   @Override
   protected void postDelete(GlossaryTerm entity) {
     // Cleanup all the tag labels using this glossary term
-    daoCollection.tagUsageDAO().deleteTagLabels(Source.GLOSSARY.ordinal(), entity.getFullyQualifiedName());
+    daoCollection.tagUsageDAO().deleteTagLabels(TagSource.GLOSSARY.ordinal(), entity.getFullyQualifiedName());
   }
 
   /** Handles entity updated from PUT and POST operation. */

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/TagCategoryRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/TagCategoryRepository.java
@@ -28,7 +28,7 @@ import org.openmetadata.catalog.resources.tags.TagResource;
 import org.openmetadata.catalog.type.Include;
 import org.openmetadata.catalog.type.TagCategory;
 import org.openmetadata.catalog.type.TagLabel;
-import org.openmetadata.catalog.type.TagLabel.Source;
+import org.openmetadata.catalog.type.TagLabel.TagSource;
 import org.openmetadata.catalog.util.EntityUtil.Fields;
 import org.openmetadata.catalog.util.FullyQualifiedName;
 import org.openmetadata.catalog.util.JsonUtils;
@@ -103,7 +103,7 @@ public class TagCategoryRepository extends EntityRepository<TagCategory> {
   public void storeRelationships(TagCategory entity) {}
 
   private Integer getUsageCount(TagCategory category) {
-    return daoCollection.tagUsageDAO().getTagCount(Source.TAG.ordinal(), category.getName());
+    return daoCollection.tagUsageDAO().getTagCount(TagSource.TAG.ordinal(), category.getName());
   }
 
   @Transaction
@@ -111,8 +111,8 @@ public class TagCategoryRepository extends EntityRepository<TagCategory> {
     TagCategory category = get(uriInfo, id, Fields.EMPTY_FIELDS, Include.NON_DELETED);
     dao.delete(id);
     daoCollection.tagDAO().deleteTagsByPrefix(category.getName());
-    daoCollection.tagUsageDAO().deleteTagLabels(Source.TAG.ordinal(), category.getName());
-    daoCollection.tagUsageDAO().deleteTagLabelsByPrefix(Source.TAG.ordinal(), category.getName());
+    daoCollection.tagUsageDAO().deleteTagLabels(TagSource.TAG.ordinal(), category.getName());
+    daoCollection.tagUsageDAO().deleteTagLabelsByPrefix(TagSource.TAG.ordinal(), category.getName());
     return category;
   }
 

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/TagRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/TagRepository.java
@@ -25,7 +25,7 @@ import org.openmetadata.catalog.Entity;
 import org.openmetadata.catalog.entity.tags.Tag;
 import org.openmetadata.catalog.resources.tags.TagResource;
 import org.openmetadata.catalog.type.Include;
-import org.openmetadata.catalog.type.TagLabel.Source;
+import org.openmetadata.catalog.type.TagLabel.TagSource;
 import org.openmetadata.catalog.util.EntityUtil.Fields;
 import org.openmetadata.catalog.util.FullyQualifiedName;
 import org.openmetadata.catalog.util.JsonUtils;
@@ -113,7 +113,7 @@ public class TagRepository extends EntityRepository<Tag> {
   @Override
   protected void postDelete(Tag entity) {
     // Cleanup all the tag labels using this tag
-    daoCollection.tagUsageDAO().deleteTagLabels(Source.TAG.ordinal(), entity.getFullyQualifiedName());
+    daoCollection.tagUsageDAO().deleteTagLabels(TagSource.TAG.ordinal(), entity.getFullyQualifiedName());
   }
 
   @Override
@@ -123,7 +123,7 @@ public class TagRepository extends EntityRepository<Tag> {
   }
 
   private Integer getUsageCount(Tag tag) {
-    return daoCollection.tagUsageDAO().getTagCount(Source.TAG.ordinal(), tag.getFullyQualifiedName());
+    return daoCollection.tagUsageDAO().getTagCount(TagSource.TAG.ordinal(), tag.getFullyQualifiedName());
   }
 
   @Transaction
@@ -131,8 +131,8 @@ public class TagRepository extends EntityRepository<Tag> {
     Tag tag = get(uriInfo, id, Fields.EMPTY_FIELDS, Include.NON_DELETED);
     dao.delete(id);
     daoCollection.tagDAO().deleteTagsByPrefix(tag.getFullyQualifiedName());
-    daoCollection.tagUsageDAO().deleteTagLabels(Source.TAG.ordinal(), tag.getFullyQualifiedName());
-    daoCollection.tagUsageDAO().deleteTagLabelsByPrefix(Source.TAG.ordinal(), tag.getFullyQualifiedName());
+    daoCollection.tagUsageDAO().deleteTagLabels(TagSource.TAG.ordinal(), tag.getFullyQualifiedName());
+    daoCollection.tagUsageDAO().deleteTagLabelsByPrefix(TagSource.TAG.ordinal(), tag.getFullyQualifiedName());
     return tag;
   }
 

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/util/EntityUtil.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/util/EntityUtil.java
@@ -62,7 +62,7 @@ import org.openmetadata.catalog.type.MlHyperParameter;
 import org.openmetadata.catalog.type.Schedule;
 import org.openmetadata.catalog.type.TableConstraint;
 import org.openmetadata.catalog.type.TagLabel;
-import org.openmetadata.catalog.type.TagLabel.Source;
+import org.openmetadata.catalog.type.TagLabel.TagSource;
 import org.openmetadata.catalog.type.Task;
 import org.openmetadata.catalog.type.UsageDetails;
 import org.openmetadata.catalog.type.UsageStats;
@@ -370,13 +370,13 @@ public final class EntityUtil {
     return new TagLabel()
         .withTagFQN(term.getFullyQualifiedName())
         .withDescription(term.getDescription())
-        .withSource(Source.GLOSSARY);
+        .withSource(TagSource.GLOSSARY);
   }
 
   public static TagLabel getTagLabel(Tag tag) throws HttpResponseException {
     return new TagLabel()
         .withTagFQN(tag.getFullyQualifiedName())
         .withDescription(tag.getDescription())
-        .withSource(Source.TAG);
+        .withSource(TagSource.TAG);
   }
 }

--- a/catalog-rest-service/src/main/resources/json/schema/type/tagLabel.json
+++ b/catalog-rest-service/src/main/resources/json/schema/type/tagLabel.json
@@ -12,6 +12,7 @@
     },
     "TagSource": {
       "type": "string",
+      "default": "Tag",
       "enum": ["Tag", "Glossary"]
     }
   },

--- a/catalog-rest-service/src/main/resources/json/schema/type/tagLabel.json
+++ b/catalog-rest-service/src/main/resources/json/schema/type/tagLabel.json
@@ -9,6 +9,10 @@
     "tagFQN": {
       "type": "string",
       "maxLength": 45
+    },
+    "TagSource": {
+      "type": "string",
+      "enum": ["Tag", "Glossary"]
     }
   },
   "properties": {
@@ -21,9 +25,7 @@
     },
     "source": {
       "description": "Label is from Tags or Glossary.",
-      "type": "string",
-      "enum": ["Tag", "Glossary"],
-      "default": "Tag"
+      "$ref": "#/definitions/TagSource"
     },
     "labelType": {
       "description": "Label type describes how a tag label was applied. 'Manual' indicates the tag label was applied by a person. 'Derived' indicates a tag label was derived using the associated tag relationship (see TagCategory.json for more details). 'Propagated` indicates a tag label was propagated from upstream based on lineage. 'Automated' is used when a tool was used to determine the tag label.",

--- a/catalog-rest-service/src/main/resources/json/schema/type/tagLabel.json
+++ b/catalog-rest-service/src/main/resources/json/schema/type/tagLabel.json
@@ -12,7 +12,6 @@
     },
     "TagSource": {
       "type": "string",
-      "default": "Tag",
       "enum": ["Tag", "Glossary"]
     }
   },
@@ -26,6 +25,7 @@
     },
     "source": {
       "description": "Label is from Tags or Glossary.",
+      "default": "Tag",
       "$ref": "#/definitions/TagSource"
     },
     "labelType": {

--- a/catalog-rest-service/src/main/resources/json/schema/type/tagLabel.json
+++ b/catalog-rest-service/src/main/resources/json/schema/type/tagLabel.json
@@ -12,6 +12,7 @@
     },
     "TagSource": {
       "type": "string",
+      "default": "Tag",
       "enum": ["Tag", "Glossary"]
     }
   },
@@ -25,7 +26,6 @@
     },
     "source": {
       "description": "Label is from Tags or Glossary.",
-      "default": "Tag",
       "$ref": "#/definitions/TagSource"
     },
     "labelType": {

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/EnumBackwardCompatibilityTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/EnumBackwardCompatibilityTest.java
@@ -19,8 +19,8 @@ import org.junit.jupiter.api.Test;
 import org.openmetadata.catalog.type.Relationship;
 import org.openmetadata.catalog.type.TagLabel;
 import org.openmetadata.catalog.type.TagLabel.LabelType;
-import org.openmetadata.catalog.type.TagLabel.Source;
 import org.openmetadata.catalog.type.TagLabel.State;
+import org.openmetadata.catalog.type.TagLabel.TagSource;
 
 /**
  * Enum ordinal number is stored in the database. New enums must be added at the end to ensure backward compatibility
@@ -64,7 +64,7 @@ class EnumBackwardCompatibilityTest {
    */
   @Test
   void testTagSourceEnumBackwardCompatible() {
-    assertEquals(0, Source.TAG.ordinal());
-    assertEquals(1, Source.GLOSSARY.ordinal());
+    assertEquals(0, TagSource.TAG.ordinal());
+    assertEquals(1, TagSource.GLOSSARY.ordinal());
   }
 }

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/util/TestUtils.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/util/TestUtils.java
@@ -66,7 +66,7 @@ import org.openmetadata.catalog.type.MessagingConnection;
 import org.openmetadata.catalog.type.MlModelConnection;
 import org.openmetadata.catalog.type.PipelineConnection;
 import org.openmetadata.catalog.type.TagLabel;
-import org.openmetadata.catalog.type.TagLabel.Source;
+import org.openmetadata.catalog.type.TagLabel.TagSource;
 
 @Slf4j
 public final class TestUtils {
@@ -337,7 +337,7 @@ public final class TestUtils {
     EntityUtil.mergeTags(updatedExpectedList, expectedList);
 
     for (TagLabel expected : expectedList) {
-      if (expected.getSource() == Source.GLOSSARY) {
+      if (expected.getSource() == TagSource.GLOSSARY) {
         GlossaryTerm glossaryTerm =
             new GlossaryTermResourceTest().getEntityByName(expected.getTagFQN(), null, "tags", ADMIN_AUTH_HEADERS);
         List<TagLabel> derived = new ArrayList<>();

--- a/ingestion/src/metadata/ingestion/source/database/common_db_source.py
+++ b/ingestion/src/metadata/ingestion/source/database/common_db_source.py
@@ -41,7 +41,12 @@ from metadata.generated.schema.metadataIngestion.workflow import (
     Source as WorkflowSource,
 )
 from metadata.generated.schema.type.entityReference import EntityReference
-from metadata.generated.schema.type.tagLabel import LabelType, Source1, State, TagLabel
+from metadata.generated.schema.type.tagLabel import (
+    LabelType,
+    State,
+    TagLabel,
+    TagSource,
+)
 from metadata.ingestion.models.ometa_tag_category import OMetaTagAndCategory
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.database.database_service import (

--- a/ingestion/src/metadata/ingestion/source/database/database_service.py
+++ b/ingestion/src/metadata/ingestion/source/database/database_service.py
@@ -40,7 +40,12 @@ from metadata.generated.schema.metadataIngestion.workflow import (
 )
 from metadata.generated.schema.type import basic
 from metadata.generated.schema.type.basic import EntityName, FullyQualifiedEntityName
-from metadata.generated.schema.type.tagLabel import LabelType, Source1, State, TagLabel
+from metadata.generated.schema.type.tagLabel import (
+    LabelType,
+    State,
+    TagLabel,
+    TagSource,
+)
 from metadata.ingestion.api.source import Source, SourceStatus
 from metadata.ingestion.api.topology_runner import TopologyRunnerMixin
 from metadata.ingestion.models.ometa_tag_category import OMetaTagAndCategory
@@ -314,7 +319,7 @@ class DatabaseServiceSource(DBTMixin, TopologyRunnerMixin, Source, ABC):
                 ),
                 labelType=LabelType.Automated,
                 state=State.Suggested,
-                source=Source1.Tag,
+                source=TagSource.Tag,
             )
             for tag_and_category in self.context.tags or []
             if tag_and_category.fqn.__root__ == entity_fqn

--- a/openmetadata-core/src/main/java/org/openmetadata/core/entity/repository/EntityRepository.java
+++ b/openmetadata-core/src/main/java/org/openmetadata/core/entity/repository/EntityRepository.java
@@ -69,7 +69,7 @@ import org.openmetadata.catalog.type.Include;
 import org.openmetadata.catalog.type.Relationship;
 import org.openmetadata.catalog.type.TagLabel;
 import org.openmetadata.catalog.type.TagLabel.LabelType;
-import org.openmetadata.catalog.type.TagLabel.Source;
+import org.openmetadata.catalog.type.TagLabel.TagSource;
 import org.openmetadata.core.TypeRegistry;
 import org.openmetadata.core.entity.Entity;
 import org.openmetadata.core.entity.interfaces.EntityDAO;
@@ -737,7 +737,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
 
   /** Get tags associated with a given set of tags */
   private List<TagLabel> getDerivedTags(TagLabel tagLabel) {
-    if (tagLabel.getSource() == Source.GLOSSARY) { // Related tags are only supported for Glossary
+    if (tagLabel.getSource() == TagSource.GLOSSARY) { // Related tags are only supported for Glossary
       List<TagLabel> derivedTags = daoCollection.tagUsageDAO().getTags(tagLabel.getTagFQN());
       derivedTags.forEach(tag -> tag.setLabelType(LabelType.DERIVED));
       return derivedTags;
@@ -755,14 +755,14 @@ public abstract class EntityRepository<T extends EntityInterface> {
   /** Apply tags {@code tagLabels} to the entity or field identified by {@code targetFQN} */
   public void applyTags(List<TagLabel> tagLabels, String targetFQN) {
     for (TagLabel tagLabel : listOrEmpty(tagLabels)) {
-      if (tagLabel.getSource() == Source.TAG) {
+      if (tagLabel.getSource() == TagSource.TAG) {
         Tag tag = daoCollection.tagDAO().findEntityByName(tagLabel.getTagFQN());
         tagLabel.withDescription(tag.getDescription());
-        tagLabel.setSource(Source.TAG);
-      } else if (tagLabel.getSource() == Source.GLOSSARY) {
+        tagLabel.setSource(TagSource.TAG);
+      } else if (tagLabel.getSource() == TagSource.GLOSSARY) {
         GlossaryTerm term = daoCollection.glossaryTermDAO().findEntityByName(tagLabel.getTagFQN(), NON_DELETED);
         tagLabel.withDescription(term.getDescription());
-        tagLabel.setSource(Source.GLOSSARY);
+        tagLabel.setSource(TagSource.GLOSSARY);
       }
 
       // Apply tagLabel to targetFQN that identifies an entity or field

--- a/openmetadata-core/src/main/java/org/openmetadata/core/jdbi3/CollectionDAO.java
+++ b/openmetadata-core/src/main/java/org/openmetadata/core/jdbi3/CollectionDAO.java
@@ -1445,7 +1445,7 @@ public interface CollectionDAO {
         String description1 = r.getString("description1");
         String description2 = r.getString("description2");
         return new TagLabel()
-            .withSource(TagLabel.Source.values()[r.getInt("source")])
+            .withSource(TagLabel.TagSource.values()[r.getInt("source")])
             .withLabelType(TagLabel.LabelType.values()[r.getInt("labelType")])
             .withState(TagLabel.State.values()[r.getInt("state")])
             .withTagFQN(r.getString("tagFQN"))

--- a/openmetadata-core/src/main/resources/json/schema/type/tagLabel.json
+++ b/openmetadata-core/src/main/resources/json/schema/type/tagLabel.json
@@ -9,6 +9,11 @@
     "tagFQN": {
       "type": "string",
       "maxLength": 45
+    },
+    "TagSource": {
+      "type": "string",
+      "default": "Tag",
+      "enum": ["Tag", "Glossary"]
     }
   },
   "properties": {
@@ -21,9 +26,7 @@
     },
     "source": {
       "description": "Label is from Tags or Glossary.",
-      "type": "string",
-      "enum": ["Tag", "Glossary"],
-      "default": "Tag"
+      "$ref": "#/definitions/TagSource"
     },
     "labelType": {
       "description": "Label type describes how a tag label was applied. 'Manual' indicates the tag label was applied by a person. 'Derived' indicates a tag label was derived using the associated tag relationship (see TagCategory.json for more details). 'Propagated` indicates a tag label was propagated from upstream based on lineage. 'Automated' is used when a tool was used to determine the tag label.",

--- a/openmetadata-ui/src/main/resources/ui/src/components/GlossaryDetails/GlossaryDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/GlossaryDetails/GlossaryDetails.component.tsx
@@ -27,7 +27,7 @@ import {
 import { Glossary } from '../../generated/entity/data/glossary';
 import { Operation } from '../../generated/entity/policies/policy';
 import { EntityReference } from '../../generated/type/entityReference';
-import { LabelType, Source, State } from '../../generated/type/tagLabel';
+import { LabelType, State, TagSource } from '../../generated/type/tagLabel';
 import { useAuth } from '../../hooks/authHooks';
 import jsonData from '../../jsons/en';
 import { getEntityName, hasEditAccess } from '../../utils/CommonUtils';
@@ -111,7 +111,7 @@ const GlossaryDetails = ({ isHasAccess, glossary, updateGlossary }: props) => {
         .map((tag) => ({
           labelType: LabelType.Manual,
           state: State.Confirmed,
-          source: Source.Tag,
+          source: TagSource.Tag,
           tagFQN: tag,
         }));
       const updatedTags = [...prevTags, ...newTags];

--- a/openmetadata-ui/src/main/resources/ui/src/components/GlossaryTerms/GlossaryTermsV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/GlossaryTerms/GlossaryTermsV1.component.tsx
@@ -31,7 +31,7 @@ import {
   TermReference,
 } from '../../generated/entity/data/glossaryTerm';
 import { EntityReference } from '../../generated/entity/type';
-import { LabelType, Source, State } from '../../generated/type/tagLabel';
+import { LabelType, State, TagSource } from '../../generated/type/tagLabel';
 import jsonData from '../../jsons/en';
 import { getEntityName } from '../../utils/CommonUtils';
 import SVGIcons, { Icons } from '../../utils/SvgUtils';
@@ -187,7 +187,7 @@ const GlossaryTermsV1 = ({
         .map((tag) => ({
           labelType: LabelType.Manual,
           state: State.Confirmed,
-          source: Source.Tag,
+          source: TagSource.Tag,
           tagFQN: tag,
         }));
       const updatedTags = [...prevTags, ...newTags];

--- a/openmetadata-ui/src/main/resources/ui/src/components/SchemaTab/SchemaTab.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/SchemaTab/SchemaTab.test.tsx
@@ -19,9 +19,9 @@ import {
   Column,
   DataType,
   LabelType,
-  Source,
   State,
   Table,
+  TagSource,
 } from '../../generated/entity/data/table';
 import SchemaTab from './SchemaTab.component';
 const mockColumns: Column[] = [
@@ -34,13 +34,13 @@ const mockColumns: Column[] = [
       {
         tagFQN: 'string',
         labelType: LabelType.Manual,
-        source: Source.Tag,
+        source: TagSource.Tag,
         state: State.Confirmed,
       },
       {
         tagFQN: 'string2',
         labelType: LabelType.Derived,
-        source: Source.Tag,
+        source: TagSource.Tag,
         state: State.Confirmed,
       },
     ],

--- a/openmetadata-ui/src/main/resources/ui/src/components/tags-container/tags-container.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/tags-container/tags-container.tsx
@@ -18,7 +18,7 @@ import { EntityTags, TagOption } from 'Models';
 import React, { Fragment, FunctionComponent, useEffect, useState } from 'react';
 import AsyncSelect from 'react-select/async';
 import { FQN_SEPARATOR_CHAR } from '../../constants/char.constants';
-import { Source } from '../../generated/type/tagLabel';
+import { TagSource } from '../../generated/type/tagLabel';
 import { withLoader } from '../../hoc/withLoader';
 import { Button } from '../buttons/Button/Button';
 import Tags from '../tags/tags';
@@ -109,7 +109,7 @@ const TagsContainer: FunctionComponent<TagsContainerProps> = ({
         removeTag={(_e, removedTag: string) => {
           handleTagRemoval(removedTag, index);
         }}
-        showOnlyName={tag.source === Source.Glossary}
+        showOnlyName={tag.source === TagSource.Glossary}
         tag={tag}
         type="border"
       />

--- a/openmetadata-ui/src/main/resources/ui/src/components/tags-viewer/tags-viewer.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/tags-viewer/tags-viewer.tsx
@@ -16,7 +16,7 @@ import { isNil } from 'lodash';
 import { EntityTags } from 'Models';
 import React, { Fragment, FunctionComponent } from 'react';
 import { LIST_SIZE } from '../../constants/constants';
-import { Source } from '../../generated/type/tagLabel';
+import { TagSource } from '../../generated/type/tagLabel';
 import PopOver from '../common/popover/PopOver';
 import Tags from '../tags/tags';
 import { TagsViewerProps } from './tags-viewer.interface';
@@ -39,7 +39,7 @@ const TagsViewer: FunctionComponent<TagsViewerProps> = ({
           { 'diff-added tw-mx-1': tag?.added },
           { 'diff-removed': tag?.removed }
         )}
-        showOnlyName={tag.source === Source.Glossary}
+        showOnlyName={tag.source === TagSource.Glossary}
         startWith={showStartWith ? '#' : undefined}
         tag={tag}
         type={type}

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/TagSuggestion.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/TagSuggestion.tsx
@@ -18,9 +18,9 @@ import React, { useEffect, useState } from 'react';
 import { getTagSuggestions } from '../../../axiosAPIs/miscAPI';
 import {
   LabelType,
-  Source,
   State,
   TagLabel,
+  TagSource,
 } from '../../../generated/type/tagLabel';
 import { showErrorToast } from '../../../utils/ToastUtils';
 
@@ -84,8 +84,8 @@ const TagSuggestion: React.FC<Props> = ({ onChange, selectedTags }) => {
       labelType: LabelType.Manual,
       state: State.Suggested,
       source: isEqual(value['data-sourceType'], 'tag')
-        ? Source.Tag
-        : Source.Glossary,
+        ? TagSource.Tag
+        : TagSource.Glossary,
       tagFQN: value.value,
     }));
     onChange(newTags);


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on fixing make generate gives different results depending on OS
Fix #5712 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement

### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
