### PR TITLE
Fix Fernet no_encryption_at_rest ignored for encryptOrDecrypt

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/fernet/Fernet.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/fernet/Fernet.java
@@ -136,6 +136,7 @@ public class Fernet {
       DatabaseConnection databaseConnection,
       CreateDatabaseService.DatabaseServiceType databaseServiceType,
       Boolean encrypt) {
+    if (!isKeyDefined()) return;
     try {
       Object connectionConfig = databaseConnection.getConfig();
       String clazzName =
@@ -166,6 +167,7 @@ public class Fernet {
       DashboardConnection dashboardConnection,
       CreateDashboardService.DashboardServiceType dashboardServiceType,
       Boolean encrypt) {
+    if (!isKeyDefined()) return;
     try {
       Object connectionConfig = dashboardConnection.getConfig();
       String clazzName =
@@ -196,6 +198,7 @@ public class Fernet {
       PipelineConnection pipelineConnection,
       CreatePipelineService.PipelineServiceType pipelineServiceType,
       Boolean encrypt) {
+    if (!isKeyDefined()) return;
     try {
       Object connectionConfig = pipelineConnection.getConfig();
       String clazzName =


### PR DESCRIPTION
### Describe your changes :

Disabled Fernet encryption causes exceptions. This skips encryption/decryption when the key is not set.

#
### Type of change :
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
Backend: @open-metadata/backend
<!--- Ingestion: @open-metadata/ingestion -->
