### PR TITLE
dbServiceName field move from serviceConnection to sourceConfig

### DIFF
--- a/ingestion/examples/workflows/metabase.yaml
+++ b/ingestion/examples/workflows/metabase.yaml
@@ -7,9 +7,9 @@ source:
       username: username
       password: password
       hostPort: http://hostPort
-      dbServiceName: Database Service Name to create Lineage
   sourceConfig:
     config:
+      dbServiceName: Database Service Name to create Lineage
       dashboardFilterPattern: {}
       chartFilterPattern: {}
 sink:


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
In Yaml file dbServiceName field move from serviceConnection to sourceConfig

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement

### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
