### PR TITLE
fix(ui): add ellipses for text overflow

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/TreeView/treeView.css
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/TreeView/treeView.css
@@ -40,6 +40,7 @@
   margin-left: 8px !important;
   display: flex !important;
   align-items: center;
+  overflow: hidden;
 }
 
 .rc-tree-node-content-wrapper:hover {
@@ -48,4 +49,9 @@
 
 .rc-tree-node-content-wrapper:not(.rc-tree-node-selected):hover .rc-tree-title {
   text-decoration: underline !important;
+}
+
+.rc-tree-title {
+  overflow: auto;
+  text-overflow: ellipsis;
 }


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
- Worked on fixing text-overflow for glossary page navigation 
- Closed: #5988 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
<img width="681" alt="Screenshot 2022-07-14 at 5 35 22 PM" src="https://user-images.githubusercontent.com/12962843/178979255-380c4330-0f00-4950-897e-9e9868849b9c.png">

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @open-metadata/ui
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
