### PR TITLE
Fix #6091: Fix Datalake arrays must be of the same length

### DIFF
--- a/ingestion/src/metadata/utils/s3_utils.py
+++ b/ingestion/src/metadata/utils/s3_utils.py
@@ -8,50 +8,43 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import json
+from io import BytesIO, StringIO
+from typing import Any
+
+import pandas as pd
+from pandas import DataFrame
 
 
-def read_csv_from_s3(client, key, bucket_name):
-    from io import StringIO
-
-    import pandas as pd
-
+def read_csv_from_s3(client: Any, key: dict, bucket_name: str) -> DataFrame:
     csv_obj = client.get_object(Bucket=bucket_name, Key=key["Key"])
     body = csv_obj["Body"]
     csv_string = body.read().decode("utf-8")
     df = pd.read_csv(StringIO(csv_string))
+    return df
+
+
+def read_tsv_from_s3(client: Any, key: dict, bucket_name: str) -> DataFrame:
+    tsv_obj = client.get_object(Bucket=bucket_name, Key=key["Key"])
+    body = tsv_obj["Body"]
+    tsv_string = body.read().decode("utf-8")
+    df = pd.read_csv(StringIO(tsv_string), sep="\t")
 
     return df
 
 
-def read_tsv_from_s3(client, key, bucket_name):
-    from io import StringIO
-
-    import pandas as pd
-
-    csv_obj = client.get_object(Bucket=bucket_name, Key=key["Key"])
-    body = csv_obj["Body"]
-    csv_string = body.read().decode("utf-8")
-    df = pd.read_csv(StringIO(csv_string), sep="\t")
-
-    return df
-
-
-def read_json_from_s3(client, key, bucket_name):
-    import json
-
-    import pandas as pd
-
+def read_json_from_s3(client: Any, key: dict, bucket_name: str) -> DataFrame:
     obj = client.get_object(Bucket=bucket_name, Key=key["Key"])
     json_text = obj["Body"].read().decode("utf-8")
     data = json.loads(json_text)
-    df = pd.DataFrame.from_dict(data)
-
+    if isinstance(data, list):
+        df = pd.DataFrame.from_dict(data)
+    else:
+        df = pd.DataFrame.from_dict(dict([(k, pd.Series(v)) for k, v in data.items()]))
     return df
 
 
-def read_parquet_from_s3(client, key, bucket_name):
-    import dask.dataframe as dd
-
-    df = dd.read_parquet(f"s3://{bucket_name}/{key['Key']}")
-
+def read_parquet_from_s3(client: Any, key: dict, bucket_name: str) -> DataFrame:
+    obj = client.get_object(Bucket=bucket_name, Key=key["Key"])
+    df = pd.read_parquet(BytesIO(obj["Body"].read()))
     return df


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Fix #6091: Fix Datalake arrays must be of the same length

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
@open-metadata/ingestion 
