### PR TITLE
Fix #6175 UI : show "Close with comment" for  task creator, assignees, owners and admins

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/TaskDetailPage/TaskDetailPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/TaskDetailPage/TaskDetailPage.tsx
@@ -641,50 +641,55 @@ const TaskDetailPage = () => {
                   task={taskDetail.task}
                 />
               )}
-              {hasEditAccess() && !isTaskClosed && (
-                <div
-                  className="tw-flex tw-justify-end"
-                  data-testid="task-cta-buttons">
+
+              <div
+                className="tw-flex tw-justify-end"
+                data-testid="task-cta-buttons">
+                {(hasEditAccess() || isCreator) && !isTaskClosed && (
                   <Button
                     className="ant-btn-link-custom"
                     type="link"
                     onClick={() => setModalVisible(true)}>
                     Close with comment
                   </Button>
+                )}
 
-                  {taskDetail.task?.suggestion ? (
-                    <Dropdown.Button
-                      className="ant-btn-primary-dropdown"
-                      icon={
-                        <FontAwesomeIcon
-                          className="tw-text-sm"
-                          icon={faChevronDown}
-                        />
-                      }
-                      overlay={
-                        <Menu
-                          selectable
-                          items={TASK_ACTION_LIST}
-                          selectedKeys={[taskAction.key]}
-                          onClick={(info) => onTaskActionChange(info.key)}
-                        />
-                      }
-                      trigger={['click']}
-                      type="primary"
-                      onClick={onTaskResolve}>
-                      {taskAction.label}
-                    </Dropdown.Button>
-                  ) : (
-                    <Button
-                      className="ant-btn-primary-custom"
-                      disabled={!suggestion}
-                      type="primary"
-                      onClick={onTaskResolve}>
-                      Add Description
-                    </Button>
-                  )}
-                </div>
-              )}
+                {hasEditAccess() && !isTaskClosed && (
+                  <Fragment>
+                    {taskDetail.task?.suggestion ? (
+                      <Dropdown.Button
+                        className="ant-btn-primary-dropdown"
+                        icon={
+                          <FontAwesomeIcon
+                            className="tw-text-sm"
+                            icon={faChevronDown}
+                          />
+                        }
+                        overlay={
+                          <Menu
+                            selectable
+                            items={TASK_ACTION_LIST}
+                            selectedKeys={[taskAction.key]}
+                            onClick={(info) => onTaskActionChange(info.key)}
+                          />
+                        }
+                        trigger={['click']}
+                        type="primary"
+                        onClick={onTaskResolve}>
+                        {taskAction.label}
+                      </Dropdown.Button>
+                    ) : (
+                      <Button
+                        className="ant-btn-primary-custom"
+                        disabled={!suggestion}
+                        type="primary"
+                        onClick={onTaskResolve}>
+                        Add Description
+                      </Button>
+                    )}
+                  </Fragment>
+                )}
+              </div>
 
               {isTaskClosed && <ClosedTask task={taskDetail.task} />}
             </Card>


### PR DESCRIPTION
Closes #6175 

### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on changing logic to show "Close with comment" for  task creators, assignees, owners and admins

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] Improvement


#
### Frontend Preview (Screenshots) :
<img width="1437" alt="image" src="https://user-images.githubusercontent.com/59080942/179722274-a2cf75ad-6d00-466d-a465-0509f34c4eac.png">


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
