### PR TITLE
Upgrade RS SQL statement query

### DIFF
--- a/ingestion/src/metadata/utils/sql_queries.py
+++ b/ingestion/src/metadata/utils/sql_queries.py
@@ -1,26 +1,56 @@
 import textwrap
 
 REDSHIFT_SQL_STATEMENT = """
-        SELECT DISTINCT ss.userid,
-            ss.query query_type,
-            sui.usename user_name,
-            ss.tbl,
-            sq.querytxt query_text,
-            sti.database database_name,
-            sti.schema schema_name,
-            sti.table,
-            sq.starttime start_time,
-            sq.endtime end_time,
-            sq.aborted aborted
-        FROM stl_scan ss
-            JOIN svv_table_info sti ON ss.tbl = sti.table_id
-            JOIN stl_query sq ON ss.query = sq.query
-            JOIN svl_user_info sui ON sq.userid = sui.usesysid
-        WHERE ss.starttime >= '{start_time}'
-            AND ss.starttime < '{end_time}'
-            AND sq.aborted = 0
-        ORDER BY ss.endtime DESC;
-    """
+  WITH
+  queries AS (
+    SELECT *
+      FROM pg_catalog.stl_query
+     WHERE userid > 1
+          -- Filter out all automated & cursor queries
+          AND querytxt NOT ILIKE 'fetch %'
+          AND querytxt NOT ILIKE 'padb_fetch_sample: %'
+          AND querytxt NOT ILIKE 'Undoing % transactions on table % with current xid%'
+          AND aborted = 0
+          AND starttime >= '{start_time}'
+          AND starttime < '{end_time}'
+  ),
+  full_queries AS (
+    SELECT
+          query,
+          LISTAGG(CASE WHEN LEN(RTRIM(text)) = 0 THEN text ELSE RTRIM(text) END, '')
+            WITHIN GROUP (ORDER BY sequence) AS query_text
+      FROM pg_catalog.stl_querytext
+      WHERE sequence < 327	-- each chunk contains up to 200, RS has a maximum str length of 65535.
+    GROUP BY query
+  ),
+  scans AS (
+    -- We have one row per table per slice so we need to get rid of the dupes
+    SELECT distinct query, tbl
+      FROM pg_catalog.stl_scan
+  )
+  SELECT DISTINCT
+        q.userid,
+        s.query AS query_id,
+        RTRIM(u.usename) AS user_name,
+        s.tbl,
+        fq.query_text,
+        sti.database AS database_name,
+        sti.schema AS schema_name,
+        sti.table,
+        q.starttime AS start_time,
+        q.endtime AS end_time,
+        q.aborted AS aborted
+    FROM scans AS s
+        INNER JOIN pg_catalog.svv_table_info AS sti
+          ON (s.tbl)::oid = sti.table_id
+        INNER JOIN queries AS q
+          ON s.query = q.query
+        INNER JOIN full_queries AS fq
+          ON s.query = fq.query
+        INNER JOIN pg_catalog.pg_user AS u
+          ON q.userid = u.usesysid
+    ORDER BY s.endtime DESC;
+"""
 
 REDSHIFT_GET_ALL_RELATION_INFO = """
         SELECT


### PR DESCRIPTION
### Describe your changes :
Upgrading the RS SQL statement query as explained [here](https://github.com/open-metadata/OpenMetadata/issues/6162) to  use [STL_QUERYTXT](https://docs.aws.amazon.com/redshift/latest/dg/r_STL_QUERYTEXT.html) to extract the sql source and apply some optimizations to reduce the number of output columns:
 * Extract full query text for most queries. Truncated at 65535 characters due to RS string type limitation.
 * Limit the queries extracted to the following statements:
    * SELECT, SELECT INTO
    * INSERT, UPDATE, DELETE
    * COPY
    * UNLOAD
    * CREATE TABLE AS (CTAS)
 * Don't fanout queries by table as it's never used downstream and it creates one copy of the query per table scanned. This should help reduce the number of rows ouput.
 * Misc query optimizations to avoid large intermediate results.

Cursors have been excluded for now as they require a completely different query to extract.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [] New feature
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

