### PR TITLE
Backend: Soft deleting a user is causing the page to not load

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/FeedRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/FeedRepository.java
@@ -26,6 +26,8 @@ import static org.openmetadata.catalog.type.Relationship.REPLIED_TO;
 import static org.openmetadata.catalog.util.ChangeEventParser.getPlaintextDiff;
 import static org.openmetadata.catalog.util.EntityUtil.compareEntityReference;
 import static org.openmetadata.catalog.util.EntityUtil.populateEntityReferences;
+import static org.openmetadata.catalog.util.RestUtil.DELETED_TEAM_DISPLAY;
+import static org.openmetadata.catalog.util.RestUtil.DELETED_TEAM_NAME;
 import static org.openmetadata.catalog.util.RestUtil.DELETED_USER_DISPLAY;
 import static org.openmetadata.catalog.util.RestUtil.DELETED_USER_NAME;
 
@@ -895,8 +897,13 @@ public class FeedRepository {
         } catch (EntityNotFoundException exception) {
           // mark the not found user as deleted user since
           // user will not be found in case of permanent deletion of user or team
-          ref.setName(DELETED_USER_NAME);
-          ref.setDisplayName(DELETED_USER_DISPLAY);
+          if (ref.getType().equals(Entity.TEAM)) {
+            ref.setName(DELETED_TEAM_NAME);
+            ref.setDisplayName(DELETED_TEAM_DISPLAY);
+          } else {
+            ref.setName(DELETED_USER_NAME);
+            ref.setDisplayName(DELETED_USER_DISPLAY);
+          }
         } catch (IOException ioException) {
           throw new RuntimeException(ioException);
         }

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/util/RestUtil.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/util/RestUtil.java
@@ -38,6 +38,8 @@ public final class RestUtil {
   public static final String ENTITY_NO_CHANGE = "entityNoChange";
   public static final String ENTITY_SOFT_DELETED = "entitySoftDeleted";
   public static final String ENTITY_DELETED = "entityDeleted";
+  public static final String DELETED_USER_NAME = "DeletedUser";
+  public static final String DELETED_USER_DISPLAY = "User was deleted";
   public static final String SIGNATURE_HEADER = "X-OM-Signature";
 
   public static final DateFormat DATE_TIME_FORMAT;

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/util/RestUtil.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/util/RestUtil.java
@@ -40,6 +40,8 @@ public final class RestUtil {
   public static final String ENTITY_DELETED = "entityDeleted";
   public static final String DELETED_USER_NAME = "DeletedUser";
   public static final String DELETED_USER_DISPLAY = "User was deleted";
+  public static final String DELETED_TEAM_NAME = "DeletedTeam";
+  public static final String DELETED_TEAM_DISPLAY = "Team was deleted";
   public static final String SIGNATURE_HEADER = "X-OM-Signature";
 
   public static final DateFormat DATE_TIME_FORMAT;


### PR DESCRIPTION
### Describe your changes :
 - Instead of throwing an exception for hard deleted users, now showing deletedUser in case of deleted user.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :
<img width="1051" alt="Screen Shot 2022-07-19 at 3 58 38 PM" src="https://user-images.githubusercontent.com/1051198/179862169-b98ca819-01ce-4b71-989c-075fe33bcff2.png">
<img width="1055" alt="Screen Shot 2022-07-19 at 4 07 33 PM" src="https://user-images.githubusercontent.com/1051198/179863065-59234439-4e78-4bda-9a65-e9c73f35c85e.png">


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
