### PR TITLE
fixed issue 6071: Service ingestion workflows should be configurable as scheduled or on-demand

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/cypress/common/common.js
+++ b/openmetadata-ui/src/main/resources/ui/cypress/common/common.js
@@ -87,7 +87,7 @@ export const testServiceCreationAndIngestion = (
   // Test the connection
   cy.get('[data-testid="test-connection-btn"]').should('exist');
   cy.get('[data-testid="test-connection-btn"]').click();
-  cy.wait(500); 
+  cy.wait(500);
   cy.contains('Connection test was successful').should('exist');
   cy.get('[data-testid="submit-btn"]').should('exist').click();
 
@@ -127,6 +127,7 @@ export const testServiceCreationAndIngestion = (
 
   // Schedule & Deploy
   cy.contains('Schedule for Ingestion').should('be.visible');
+  cy.get('[data-testid="ingestion-type"]').should('be.visible').select('hour');
   cy.get('[data-testid="deploy-button"]').should('be.visible').click();
 
   // check success
@@ -216,7 +217,7 @@ export const visitEntityTab = (id) => {
 export const searchEntity = (term) => {
   cy.get('[data-testid="searchBox"]').scrollIntoView().should('be.visible');
   cy.get('[data-testid="searchBox"]').type(`${term}{enter}`);
-  cy.get('[data-testid="suggestion-overlay"]').click(1,1);
+  cy.get('[data-testid="suggestion-overlay"]').click(1, 1);
 };
 
 // add new tag to entity and its table

--- a/openmetadata-ui/src/main/resources/ui/src/components/AddIngestion/AddIngestion.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AddIngestion/AddIngestion.component.tsx
@@ -11,11 +11,10 @@
  *  limitations under the License.
  */
 
-import { isUndefined } from 'lodash';
+import { isEmpty, isUndefined } from 'lodash';
 import { LoadingState } from 'Models';
 import React, { useMemo, useState } from 'react';
 import {
-  INGESTION_SCHEDULER_INITIAL_VALUE,
   INITIAL_FILTER_PATTERN,
   STEPS_FOR_ADD_INGESTION,
 } from '../../constants/ingestion.constant';
@@ -97,7 +96,7 @@ const AddIngestion = ({
   );
   const [description, setDescription] = useState(data?.description ?? '');
   const [repeatFrequency, setRepeatFrequency] = useState(
-    data?.airflowConfig.scheduleInterval ?? INGESTION_SCHEDULER_INITIAL_VALUE
+    data?.airflowConfig.scheduleInterval ?? ''
   );
   const [showDashboardFilter, setShowDashboardFilter] = useState(
     !isUndefined(
@@ -482,7 +481,9 @@ const AddIngestion = ({
   const createNewIngestion = () => {
     const ingestionDetails: CreateIngestionPipeline = {
       airflowConfig: {
-        scheduleInterval: repeatFrequency,
+        scheduleInterval: isEmpty(repeatFrequency)
+          ? undefined
+          : repeatFrequency,
       },
       loggerLevel: enableDebugLog ? LogLevels.Debug : LogLevels.Info,
       name: ingestionName,

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/CronEditor/CronEditor.constant.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/CronEditor/CronEditor.constant.ts
@@ -15,6 +15,11 @@
 export const getPeriodOptions = () => {
   return [
     {
+      label: 'none',
+      value: '',
+      prep: '',
+    },
+    {
       label: 'minutes',
       value: 'minute',
       prep: '',

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/CronEditor/CronEditor.jsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/CronEditor/CronEditor.jsx
@@ -13,6 +13,7 @@
 
 /* eslint-disable */
 
+import { isEmpty } from 'lodash';
 import React, { useState } from 'react';
 import { pluralize } from '../../../utils/CommonUtils';
 import {
@@ -58,7 +59,7 @@ const getCron = (state) => {
     case 'year':
       return getYearCron(selectedYearOption);
     default:
-      return '* * * * *';
+      return '';
   }
 };
 
@@ -74,7 +75,7 @@ const CronEditor = (props) => {
   };
   const getStateValue = (valueStr) => {
     let stateVal = {
-      selectedPeriod: 'week',
+      selectedPeriod: '',
       selectedMinOption: {
         min: 5,
       },
@@ -115,27 +116,29 @@ const CronEditor = (props) => {
 
     stateVal.selectedPeriod = t || stateVal.selectedPeriod;
 
-    const selectedPeriodObj =
-      stateVal[
-        'selected' + (t.charAt(0).toUpperCase() + t.substr(1)) + 'Option'
-      ];
+    if (!isEmpty(t)) {
+      const selectedPeriodObj =
+        stateVal[
+          'selected' + (t.charAt(0).toUpperCase() + t.substr(1)) + 'Option'
+        ];
 
-    let targets = toDisplay[t];
+      let targets = toDisplay[t];
 
-    for (let i = 0; i < targets.length; i++) {
-      let tgt = targets[i];
+      for (let i = 0; i < targets.length; i++) {
+        let tgt = targets[i];
 
-      if (tgt == 'time') {
-        selectedPeriodObj.hour = v.hour;
-        selectedPeriodObj.min = v.min;
-      } else {
-        selectedPeriodObj[tgt] = v[tgt];
+        if (tgt == 'time') {
+          selectedPeriodObj.hour = v.hour;
+          selectedPeriodObj.min = v.min;
+        } else {
+          selectedPeriodObj[tgt] = v[tgt];
+        }
       }
     }
 
     return stateVal;
   };
-  const [value, setCronValue] = useState(props.value || '0 0 * * 0');
+  const [value, setCronValue] = useState(props.value || '');
   const [state, setState] = useState(getStateValue(value));
   const [periodOptions] = useState(getPeriodOptions());
   const [minuteSegmentOptions] = useState(getMinuteSegmentOptions());
@@ -586,6 +589,11 @@ const CronEditor = (props) => {
           {getWeekComponent(cronPeriodString)}
           {getMonthComponent(cronPeriodString)}
           {getYearComponent(cronPeriodString)}
+          {isEmpty(value) && (
+            <p className="tw-col-span-2">
+              Pipeline will only be triggered manually.
+            </p>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the Service ingestion workflows should be configurable as scheduled or on-demand
Closes #6071 
#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement


#
### Frontend Preview (Screenshots) :

https://user-images.githubusercontent.com/71748675/179922593-18657652-7aa0-44f5-8488-1b98a509490e.mov



#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
@open-metadata/ui 