### PR TITLE
Fix missing SonarCloud decorator in PR when triggering GH workflow for py3.9

### DIFF
--- a/.github/workflows/py-tests-3_9.yml
+++ b/.github/workflows/py-tests-3_9.yml
@@ -77,8 +77,26 @@ jobs:
         # fix coverage xml report for github
         sed -i 's/src\/metadata/\/github\/workspace\/ingestion\/src\/metadata/g' ingestion/ci-coverage.xml
 
+    # we have to pass these args values since we are working with the 'pull_request_target' trigger
+    - name: Push Results in PR to Sonar
+      uses: sonarsource/sonarcloud-github-action@master
+      if: ${{ github.event_name == 'pull_request_target' }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.INGESTION_SONAR_SECRET }}
+      with:
+        projectBaseDir: ingestion/
+        args: >
+          -Dproject.settings=ingestion/sonar-project.properties
+          -Dsonar.pullrequest.key=${{ github.event.pull_request.number }}
+          -Dsonar.pullrequest.branch=${{ github.head_ref }}
+          -Dsonar.pullrequest.github.repository=OpenMetadata
+          -Dsonar.scm.revision=${{ github.event.pull_request.head.sha }}
+          -Dsonar.pullrequest.provider=github
+
     - name: Push Results to Sonar
       uses: sonarsource/sonarcloud-github-action@master
+      if: ${{ github.event_name == 'push' }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.INGESTION_SONAR_SECRET }}


### PR DESCRIPTION
### Describe your changes :
We stop receiving the SonarCloud summary in the PR after updating the GH workflow for py3.9.
The 'pull_request_target' workflow trigger must pass some extra arguments to the Sonar Cloud GH action.

### Type of change :
- [x] Bug fix

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@pmbrull 
Ingestion: @open-metadata/ingestion
