### PR TITLE
Fix softDelete should not sent hardDelete true

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/constants/entity.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/entity.constants.ts
@@ -14,5 +14,5 @@
 export const ENTITY_DELETE_STATE = {
   loading: 'initial',
   state: false,
-  softDelete: false,
+  softDelete: true,
 };


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on fixing soft delete should not be sent hard delete true on teams and users' page

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
