### PR TITLE
Fix #6255 Backend: Ignore dashboard usage summary in activity feed

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/events/ChangeEventHandler.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/events/ChangeEventHandler.java
@@ -91,7 +91,8 @@ public class ChangeEventHandler implements EventHandler {
       if (Entity.shouldDisplayEntityChangeOnFeed(changeEvent.getEntityType())) {
         // ignore usageSummary updates in the feed
         boolean shouldIgnore = false;
-        if (Entity.TABLE.equals(changeEvent.getEntityType()) && changeEvent.getChangeDescription() != null) {
+        if (List.of(Entity.TABLE, Entity.DASHBOARD).contains(changeEvent.getEntityType())
+            && changeEvent.getChangeDescription() != null) {
           List<FieldChange> fields = changeEvent.getChangeDescription().getFieldsUpdated();
           shouldIgnore = fields.stream().anyMatch(field -> field.getName().equals("usageSummary"));
         }


### PR DESCRIPTION
### Describe your changes :
See #6255 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement

