### PR TITLE
[TASK-6241] Cache ES ingestion when ingesting usage

### DIFF
--- a/ingestion/src/metadata/ingestion/ometa/mixins/table_mixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/table_mixin.py
@@ -31,8 +31,11 @@ from metadata.generated.schema.entity.data.table import (
 from metadata.generated.schema.type.usageRequest import UsageRequest
 from metadata.ingestion.ometa.client import REST
 from metadata.ingestion.ometa.utils import ometa_logger
+from metadata.utils.lru_cache import LRUCache
 
 logger = ometa_logger()
+
+LRU_CACHE_SIZE = 4096
 
 
 class OMetaTableMixin:
@@ -128,14 +131,14 @@ class OMetaTableMixin:
         :param table: Table Entity to update
         :param table_queries: SqlQuery to add
         """
-        seen_queries = set()
+        seen_queries = LRUCache(LRU_CACHE_SIZE)
         for query in table_queries:
             if not query.query in seen_queries:
                 self.client.put(
                     f"{self.get_suffix(Table)}/{table.id.__root__}/tableQuery",
                     data=query.json(),
                 )
-                seen_queries.add(query.query)
+                seen_queries.put(query.query, None)
 
     def publish_table_usage(
         self, table: Table, table_usage_request: UsageRequest

--- a/ingestion/src/metadata/ingestion/ometa/mixins/table_mixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/table_mixin.py
@@ -133,7 +133,7 @@ class OMetaTableMixin:
         """
         seen_queries = LRUCache(LRU_CACHE_SIZE)
         for query in table_queries:
-            if not query.query in seen_queries:
+            if query.query not in seen_queries:
                 self.client.put(
                     f"{self.get_suffix(Table)}/{table.id.__root__}/tableQuery",
                     data=query.json(),

--- a/ingestion/src/metadata/ingestion/ometa/mixins/table_mixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/table_mixin.py
@@ -128,11 +128,14 @@ class OMetaTableMixin:
         :param table: Table Entity to update
         :param table_queries: SqlQuery to add
         """
+        seen_queries = set()
         for query in table_queries:
-            self.client.put(
-                f"{self.get_suffix(Table)}/{table.id.__root__}/tableQuery",
-                data=query.json(),
-            )
+            if not query.query in seen_queries:
+                self.client.put(
+                    f"{self.get_suffix(Table)}/{table.id.__root__}/tableQuery",
+                    data=query.json(),
+                )
+                seen_queries.add(query.query)
 
     def publish_table_usage(
         self, table: Table, table_usage_request: UsageRequest

--- a/ingestion/src/metadata/ingestion/ometa/ometa_api.py
+++ b/ingestion/src/metadata/ingestion/ometa/ometa_api.py
@@ -172,9 +172,9 @@ class OpenMetadata(
         self._auth_provider = auth_provider_fn(self.config)
 
         # Load the secrets' manager client
-        self.secrets_manager_client = get_secrets_manager(
-            config.secretsManagerProvider, config.secretsManagerCredentials
-        )
+        # self.secrets_manager_client = get_secrets_manager(
+        #     config.secretsManagerProvider, config.secretsManagerCredentials
+        # )
 
         client_config: ClientConfig = ClientConfig(
             base_url=self.config.hostPort,

--- a/ingestion/src/metadata/ingestion/ometa/ometa_api.py
+++ b/ingestion/src/metadata/ingestion/ometa/ometa_api.py
@@ -172,9 +172,9 @@ class OpenMetadata(
         self._auth_provider = auth_provider_fn(self.config)
 
         # Load the secrets' manager client
-        # self.secrets_manager_client = get_secrets_manager(
-        #     config.secretsManagerProvider, config.secretsManagerCredentials
-        # )
+        self.secrets_manager_client = get_secrets_manager(
+            config.secretsManagerProvider, config.secretsManagerCredentials
+        )
 
         client_config: ClientConfig = ClientConfig(
             base_url=self.config.hostPort,

--- a/ingestion/src/metadata/ingestion/source/database/usage_source.py
+++ b/ingestion/src/metadata/ingestion/source/database/usage_source.py
@@ -86,13 +86,14 @@ class UsageSource(Source[TableQuery], ABC):
         if self.config.sourceConfig.config.queryLogFilePath:
             query_list = []
             with open(self.config.sourceConfig.config.queryLogFilePath, "r") as fin:
-                for i in csv.DictReader(fin):
+                records = csv.DictReader(fin)
+                for i in [next(records) for _ in range(10000)]:
                     query_dict = dict(i)
                     analysis_date = (
                         datetime.utcnow()
                         if not query_dict.get("start_time")
                         else datetime.strptime(
-                            query_dict.get("start_time"), "%Y-%m-%d %H:%M:%S"
+                            query_dict.get("start_time"), "%Y-%m-%d %H:%M:%S.%f"
                         )
                     )
                     query_list.append(
@@ -101,7 +102,7 @@ class UsageSource(Source[TableQuery], ABC):
                             userName=query_dict.get("user_name", ""),
                             startTime=query_dict.get("start_time", ""),
                             endTime=query_dict.get("end_time", ""),
-                            analysisDate=analysis_date.date(),
+                            analysisDate=analysis_date,
                             aborted=self.get_aborted_status(query_dict),
                             databaseName=self.get_database_name(query_dict),
                             serviceName=self.config.serviceName,
@@ -124,6 +125,7 @@ class UsageSource(Source[TableQuery], ABC):
                         )
                     )
                     queries = []
+                    rows = [next(rows) for _ in range(2000)]
                     for row in rows:
                         row = dict(row)
                         try:

--- a/ingestion/src/metadata/ingestion/source/database/usage_source.py
+++ b/ingestion/src/metadata/ingestion/source/database/usage_source.py
@@ -86,8 +86,7 @@ class UsageSource(Source[TableQuery], ABC):
         if self.config.sourceConfig.config.queryLogFilePath:
             query_list = []
             with open(self.config.sourceConfig.config.queryLogFilePath, "r") as fin:
-                records = csv.DictReader(fin)
-                for i in [next(records) for _ in range(10000)]:
+                for i in csv.DictReader(fin):
                     query_dict = dict(i)
                     analysis_date = (
                         datetime.utcnow()
@@ -125,7 +124,6 @@ class UsageSource(Source[TableQuery], ABC):
                         )
                     )
                     queries = []
-                    rows = [next(rows) for _ in range(2000)]
                     for row in rows:
                         row = dict(row)
                         try:

--- a/ingestion/src/metadata/utils/lru_cache.py
+++ b/ingestion/src/metadata/utils/lru_cache.py
@@ -1,0 +1,43 @@
+"""
+LRU cache
+"""
+
+from collections import OrderedDict
+
+
+class LRUCache:
+    """Least Recently Used cache"""
+
+    def __init__(self, capacity: int) -> None:
+        self._cache = OrderedDict()
+        self.capacity = capacity
+
+    def get(self, key):
+        """
+        Returns the value associated to `key` if it exists,
+        updating the cache usage.
+        Raises `KeyError` if `key doesn't exist in the cache.
+        """
+        self._cache.move_to_end(key)
+        return self._cache[key]
+
+    def put(self, key, value) -> None:
+        """
+        Assigns `value` to `key`, overwriting `key` if it already exists
+        in the cache and updating the cache usage.
+        If the size of the cache grows above capacity, pops the least used
+        element.
+        """
+        self._cache[key] = value
+        self._cache.move_to_end(key)
+        if len(self._cache) > self.capacity:
+            self._cache.popitem(last=False)
+
+    def __contains__(self, key) -> bool:
+        if key not in self._cache:
+            return False
+        self._cache.move_to_end(key)
+        return True
+
+    def __len__(self) -> int:
+        return len(self._cache)

--- a/ingestion/src/metadata/utils/sql_lineage.py
+++ b/ingestion/src/metadata/utils/sql_lineage.py
@@ -183,7 +183,6 @@ def _create_lineage_by_table_name(
     """
 
     try:
-        
         from_table_entities = get_table_entities_from_query(
             metadata=metadata,
             service_name=service_name,
@@ -280,7 +279,6 @@ def get_lineage_by_query(
     DictConfigurator.configure = configure
     column_lineage_map.clear()
     
-
     try:
         result = LineageRunner(query)
 

--- a/ingestion/src/metadata/utils/sql_lineage.py
+++ b/ingestion/src/metadata/utils/sql_lineage.py
@@ -55,6 +55,7 @@ def get_column_fqn(table_entity: Table, column: str) -> Optional[str]:
 
 search_cache = {}
 
+
 def search_table_entities(
     metadata: OpenMetadata,
     service_name: str,
@@ -278,7 +279,7 @@ def get_lineage_by_query(
     # Reverting changes after import is done
     DictConfigurator.configure = configure
     column_lineage_map.clear()
-    
+
     try:
         result = LineageRunner(query)
 

--- a/ingestion/src/metadata/utils/sql_lineage.py
+++ b/ingestion/src/metadata/utils/sql_lineage.py
@@ -28,9 +28,12 @@ from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.utils import fqn
 from metadata.utils.helpers import get_formatted_entity_name
 from metadata.utils.logger import utils_logger
+from metadata.utils.lru_cache import LRUCache
 
 logger = utils_logger()
 column_lineage_map = {}
+
+LRU_CACHE_SIZE = 4096
 
 
 def split_raw_table_name(database: str, raw_name: str) -> dict:
@@ -53,7 +56,7 @@ def get_column_fqn(table_entity: Table, column: str) -> Optional[str]:
             return tbl_column.fullyQualifiedName.__root__
 
 
-search_cache = {}
+search_cache = LRUCache(LRU_CACHE_SIZE)
 
 
 def search_table_entities(
@@ -70,7 +73,7 @@ def search_table_entities(
     """
     search_tuple = (service_name, database, database_schema, table)
     if search_tuple in search_cache:
-        return search_cache[search_tuple]
+        return search_cache.get(search_tuple)
     else:
         try:
             table_fqns = fqn.build(
@@ -87,7 +90,7 @@ def search_table_entities(
                 table_entity: Table = metadata.get_by_name(Table, fqn=table_fqn)
                 if table_entity:
                     table_entities.append(table_entity)
-            search_cache[search_tuple] = table_entities
+            search_cache.put(search_tuple, table_entities)
             return table_entities
         except Exception as err:
             logger.debug(traceback.format_exc())

--- a/ingestion/tests/unit/metadata/utils/test_lru_cache.py
+++ b/ingestion/tests/unit/metadata/utils/test_lru_cache.py
@@ -1,0 +1,50 @@
+"""Tests for the LRU cache class"""
+
+import pytest
+
+from metadata.utils.lru_cache import LRUCache
+
+
+class TestLRUCache:
+    def test_create_cache(self) -> None:
+        cache = LRUCache(2)
+        cache.put(1, 1)
+
+    def test_get_fails_if_key_doesnt_exist(self) -> None:
+        cache = LRUCache(2)
+        with pytest.raises(KeyError):
+            cache.get(1)
+
+    def test_putting_an_element_increases_cache_size(self) -> None:
+        cache = LRUCache(2)
+        assert len(cache) == 0
+        cache.put(1, None)
+        cache.put(2, None)
+        assert len(cache) == 2
+
+    def test_contains_determines_if_an_element_exists(self) -> None:
+        cache = LRUCache(2)
+        cache.put(1, 1)
+        assert 1 in cache
+        assert 2 not in cache
+
+    def test_putting_over_capacity_rotates_cache(self) -> None:
+        cache = LRUCache(2)
+        cache.put(1, None)
+        cache.put(2, None)
+        cache.put(3, None)
+        assert 1 not in cache
+
+    def test_interacting_with_a_key_makes_it_used(self) -> None:
+        cache = LRUCache(2)
+        cache.put(1, None)
+        cache.put(2, None)
+        1 in cache
+        cache.put(3, None)
+        assert 1 in cache
+        assert 2 not in cache
+
+    def test_getting_an_existing_key_returns_the_associated_element(self) -> None:
+        cache = LRUCache(2)
+        cache.put(1, 2)
+        assert cache.get(1) == 2


### PR DESCRIPTION
### Describe your changes :
As explained on #6241, we've identified that the database usage ingestion does a very large amount of repeated requests to elastisearch and the backend tables for every query/table processed. This PR is a first effort to improve usage ingestion performance by implementing caches/checks in three stages of the process:
 * `metadata_usage` & `table_mixin`: For each table, avoid ingesting the same query more than once as it will add no new information and most of the repetaed queries are created by previous stages in the process. 
 * `sql_usage` cache the result of `search_table_entities` that does one query to ES and potentially many to backend and was one of the main sources of the slowdown. I wasn't able to find a nice place to put the cache due to the way the code is structured so I ended up creating it as a module-level variable. This is far from ideal but for a nicer setup we'll need to do some restructuring.


We did some experiments to evaluate the impact in performance and obtained the results below. Note that to reduce variability we extracted an entire day's worth of queries (~52.5k queries, 57 MB)  from RS into a csv file and loaded them from there. All runs below include the sql parsing step which was not optimized:

**Not optimized**
 - 1000 records, no optimization -> 88.63s user 5.92s system 32% cpu 4:53.97 total
 - 5000 records, no optimization -> 676.88s user 12.21s system 59% cpu 19:25.03 total
 - 10000 records, no optimization -> 1276.32s user 21.37s system 60% cpu 35:47.41 total
**Optimized**
 - 1000 records, optimized -> 33.79s user 1.01s system 54% cpu 1:03.41 total
 - 5000 records, optimized -> 357.55s user 2.50s system 79% cpu 7:32.33 total
 - 10000 record, optimized -> 566.22s user 4.54s system 75% cpu 12:34.00 total


![image](https://user-images.githubusercontent.com/9376816/180441956-714a3489-dfc1-4b2f-a2cd-703654694c11.png)

The chart above suggests that the imroved version has a lower complexity, although due to the many parts involved in the execution of each iteration of the ingestion this might be difficult to measure.

There's still plenty of room for improvement as the ones propoed are quite hamfisted and we could greatly reduce the amount of records we generate ourselves but it's a good indicator of how things can improve.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [] Bug fix
- [x] Improvement
- [] New feature
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation

#
### Frontend Preview (Screenshots) :
N/A

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
 @open-metadata/ingestion
