### PR TITLE
Fixes #6078 - DB column named `metadata` conflict with SQA reserved attribute

### DIFF
--- a/ingestion/src/metadata/orm_profiler/orm/converter.py
+++ b/ingestion/src/metadata/orm_profiler/orm/converter.py
@@ -67,6 +67,8 @@ _TYPE_MAP = {
     DataType.UUID: CustomTypes.UUID.value,
 }
 
+SQA_RESERVED_ATTRIBUTES = ["metadata"]
+
 
 def check_snowflake_case_sensitive(table_service_type, table_or_col) -> Optional[bool]:
     """Check whether column or table name are not uppercase for snowflake table.
@@ -118,7 +120,11 @@ def ometa_to_orm(table: Table, metadata: OpenMetadata) -> DeclarativeMeta:
     """
 
     cols = {
-        str(col.name.__root__): build_orm_col(idx, col, table.serviceType)
+        (
+            col.name.__root__ + "_"
+            if col.name.__root__ in SQA_RESERVED_ATTRIBUTES
+            else col.name.__root__
+        ): build_orm_col(idx, col, table.serviceType)
         for idx, col in enumerate(table.columns)
     }
 

--- a/ingestion/src/metadata/orm_profiler/processor/orm_profiler.py
+++ b/ingestion/src/metadata/orm_profiler/processor/orm_profiler.py
@@ -270,7 +270,7 @@ class OrmProfilerProcessor(Processor[Table]):
         Log test case results
         """
         self.status.tested(name)
-        if not result.testCaseStatus == TestCaseStatus.Success:
+        if result.testCaseStatus != TestCaseStatus.Success:
             self.status.failure(f"{name}: {result.result}")
 
     @staticmethod

--- a/ingestion/src/metadata/orm_profiler/profiler/core.py
+++ b/ingestion/src/metadata/orm_profiler/profiler/core.py
@@ -228,7 +228,7 @@ class Profiler(Generic[TMetric]):
         try:
             row = self.profiler_interface.get_static_metrics(col, col_metrics)
             self._column_results[col.name].update(dict(row))
-        except (TimeoutError, Exception) as err:
+        except Exception as err:
             logger.warning(
                 f"Error trying to compute column profile for {col.name} - {err}"
             )
@@ -251,7 +251,7 @@ class Profiler(Generic[TMetric]):
             row = self.profiler_interface.get_table_metrics(table_metrics)
             if row:
                 self._table_results.update(dict(row))
-        except (TimeoutError, Exception) as err:
+        except Exception as err:
             logger.debug(traceback.format_exc())
             logger.error(
                 f"Error while running table metric for: {self.table.__tablename__} - {err}"
@@ -268,7 +268,7 @@ class Profiler(Generic[TMetric]):
                 row = self.profiler_interface.get_query_metrics(col, metric)
                 self._column_results[col.name].update(dict(row))
 
-            except (TimeoutError, Exception) as err:  # pylint: disable=broad-except
+            except Exception as err:  # pylint: disable=broad-except
                 logger.debug(traceback.format_exc())
                 logger.error(
                     f"Error computing query metric {metric.name()} for {self.table.__tablename__}.{col.name} - {err}"

--- a/ingestion/src/metadata/orm_profiler/sink/metadata_rest.py
+++ b/ingestion/src/metadata/orm_profiler/sink/metadata_rest.py
@@ -13,6 +13,7 @@
 OpenMetadata REST Sink implementation for the ORM Profiler results
 """
 import traceback
+from typing import Optional
 
 from metadata.config.common import ConfigModel
 from metadata.generated.schema.entity.services.connections.metadata.openMetadataConnection import (
@@ -29,7 +30,7 @@ logger = profiler_logger()
 
 
 class MetadataRestSinkConfig(ConfigModel):
-    api_endpoint: str = None
+    api_endpoint: Optional[str] = None
 
 
 class MetadataRestSink(Sink[Entity]):

--- a/ingestion/tests/unit/profiler/test_converter.py
+++ b/ingestion/tests/unit/profiler/test_converter.py
@@ -1,0 +1,123 @@
+#  Copyright 2021 Collate
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Test ometa to orm converter
+"""
+
+from unittest.mock import patch
+from uuid import UUID
+
+from pytest import mark
+
+from metadata.generated.schema.entity.data.table import Column, DataType, Table
+from metadata.generated.schema.entity.services.databaseService import (
+    DatabaseServiceType,
+)
+from metadata.orm_profiler.orm.converter import ometa_to_orm
+
+
+@patch("metadata.orm_profiler.orm.converter.get_orm_schema", return_value="schema")
+@mark.parametrize(
+    "column_definition, table_name",
+    [
+        (
+            [
+                (
+                    "CaseSensitive",
+                    DataType.STRING,
+                ),
+                ("UPPER_CASE", DataType.INT),
+            ],
+            "table_1",
+        ),
+        (
+            [
+                (
+                    "all_lower_case",
+                    DataType.STRING,
+                ),
+                ("lower_case", DataType.INT),
+            ],
+            "table_2",
+        ),
+    ],
+)
+def test_snowflake_case_sensitive_orm(mock, column_definition, table_name):
+    """Test that snowflake case sensitive orm table
+    are enforced correctly
+    """
+    columns = [
+        Column(
+            name=name,
+            dataType=type,
+        )
+        for name, type in column_definition
+    ]
+
+    table = Table(
+        id=UUID("1f8c1222-09a0-11ed-871b-ca4e864bb16a"),
+        name=table_name,
+        columns=columns,
+        serviceType=DatabaseServiceType.Snowflake,
+    )
+
+    orm_table = ometa_to_orm(table, None)
+
+    assert orm_table.__table_args__.get("quote")
+    assert [
+        name.lower() for name, _ in column_definition
+    ] == orm_table.__table__.columns.keys()
+    assert orm_table.__tablename__ == table_name
+    assert orm_table.__table_args__["schema"] == "schema"
+    for name, _ in column_definition:
+        assert hasattr(orm_table, name)
+
+
+@patch("metadata.orm_profiler.orm.converter.get_orm_schema", return_value="schema")
+def test_metadata_column(mock):
+    """Test that snowflake case sensitive orm table
+    are enforced correctly
+    """
+    table_name = "foo"
+    column_definition = [
+        (
+            "foo",
+            DataType.STRING,
+        ),
+        ("metadata", DataType.INT),
+    ]
+
+    columns = [
+        Column(
+            name=name,
+            dataType=type,
+        )
+        for name, type in column_definition
+    ]
+
+    table = Table(
+        id=UUID("1f8c1222-09a0-11ed-871b-ca4e864bb16a"),
+        name=table_name,
+        columns=columns,
+        serviceType=DatabaseServiceType.BigQuery,
+    )
+
+    orm_table = ometa_to_orm(table, None)
+
+    assert not orm_table.__table_args__.get("quote")
+    assert [
+        name.lower() for name, _ in column_definition
+    ] == orm_table.__table__.columns.keys()
+    assert orm_table.__tablename__ == table_name
+    assert orm_table.__table_args__["schema"] == "schema"
+    for name, _ in column_definition:
+        assert hasattr(orm_table, name)


### PR DESCRIPTION
### Describe your changes :
Fixes #6078 where DB column named `metadata` conflict with SQA reserved attribute.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
Ingestion: @open-metadata/ingestion
