### PR TITLE
[TASK-6140] Add OMeta header to SQLAlchemy-based queries

### DIFF
--- a/ingestion/src/metadata/utils/connections.py
+++ b/ingestion/src/metadata/utils/connections.py
@@ -23,10 +23,10 @@ from typing import Union
 import requests
 from sqlalchemy import create_engine
 from sqlalchemy.engine.base import Engine
+from sqlalchemy.event import listen
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm.session import Session
-from sqlalchemy.event import listen
 
 from metadata.generated.schema.entity.services.connections.connectionBasicType import (
     ConnectionArguments,
@@ -127,14 +127,8 @@ class SourceConnectionException(Exception):
     Raised when we cannot connect to the source
     """
 
-def inject_query_header(
-    conn,
-    cursor,
-    statement,
-    parameters,
-    context,
-    executemany
-):
+
+def inject_query_header(conn, cursor, statement, parameters, context, executemany):
     header_obj = {"app": "OpenMetadata", "version": "0.0.0"}
     statement_with_header = f"/* {json.dumps(header_obj)} */ \n" + statement
     return statement_with_header, parameters

--- a/ingestion/src/metadata/utils/connections.py
+++ b/ingestion/src/metadata/utils/connections.py
@@ -20,6 +20,7 @@ from distutils.command.config import config
 from functools import singledispatch
 from typing import Union
 
+import pkg_resources
 import requests
 from sqlalchemy import create_engine
 from sqlalchemy.engine.base import Engine
@@ -128,9 +129,14 @@ class SourceConnectionException(Exception):
     """
 
 
+def render_query_header(ometa_version: str) -> str:
+    header_obj = {"app": "OpenMetadata", "version": ometa_version}
+    return f"/* {json.dumps(header_obj)} */\n"
+
+
 def inject_query_header(conn, cursor, statement, parameters, context, executemany):
-    header_obj = {"app": "OpenMetadata", "version": "0.0.0"}
-    statement_with_header = f"/* {json.dumps(header_obj)} */ \n" + statement
+    version = pkg_resources.require("openmetadata-ingestion")[0].version
+    statement_with_header = render_query_header(version) + statement
     return statement_with_header, parameters
 
 

--- a/ingestion/src/metadata/utils/connections.py
+++ b/ingestion/src/metadata/utils/connections.py
@@ -131,12 +131,12 @@ class SourceConnectionException(Exception):
 
 def render_query_header(ometa_version: str) -> str:
     header_obj = {"app": "OpenMetadata", "version": ometa_version}
-    return f"/* {json.dumps(header_obj)} */\n"
+    return f"/* {json.dumps(header_obj)} */"
 
 
 def inject_query_header(conn, cursor, statement, parameters, context, executemany):
     version = pkg_resources.require("openmetadata-ingestion")[0].version
-    statement_with_header = render_query_header(version) + statement
+    statement_with_header = render_query_header(version) + "\n" + statement
     return statement_with_header, parameters
 
 

--- a/ingestion/src/metadata/utils/sql_queries.py
+++ b/ingestion/src/metadata/utils/sql_queries.py
@@ -10,9 +10,12 @@ REDSHIFT_SQL_STATEMENT = """
           AND querytxt NOT ILIKE 'fetch %%'
           AND querytxt NOT ILIKE 'padb_fetch_sample: %%'
           AND querytxt NOT ILIKE 'Undoing %% transactions on table %% with current xid%%'
+          AND querytxt NOT LIKE '/* {"app": "OpenMetadata", %%} */%%'
+          AND querytxt NOT LIKE '/* {"app": "OpenMetadata", %%} */%%'
           AND aborted = 0
           AND starttime >= '{start_time}'
           AND starttime < '{end_time}'
+          
   ),
   full_queries AS (
     SELECT
@@ -185,7 +188,9 @@ SNOWFLAKE_SQL_STATEMENT = """
             RESULT_LIMIT => {result_limit}
             )
         )
-        WHERE QUERY_TYPE NOT IN ('ROLLBACK','CREATE_USER','CREATE_ROLE','CREATE_NETWORK_POLICY','ALTER_ROLE','ALTER_NETWORK_POLICY','ALTER_ACCOUNT','DROP_SEQUENCE','DROP_USER','DROP_ROLE','DROP_NETWORK_POLICY','REVOKE','UNLOAD','USE','DELETE','DROP','TRUNCATE_TABLE','ALTER_SESSION','COPY','UPDATE','COMMIT','SHOW','ALTER','DESCRIBE','CREATE_TABLE','PUT_FILES','GET_FILES');
+        WHERE QUERY_TYPE NOT IN ('ROLLBACK','CREATE_USER','CREATE_ROLE','CREATE_NETWORK_POLICY','ALTER_ROLE','ALTER_NETWORK_POLICY','ALTER_ACCOUNT','DROP_SEQUENCE','DROP_USER','DROP_ROLE','DROP_NETWORK_POLICY','REVOKE','UNLOAD','USE','DELETE','DROP','TRUNCATE_TABLE','ALTER_SESSION','COPY','UPDATE','COMMIT','SHOW','ALTER','DESCRIBE','CREATE_TABLE','PUT_FILES','GET_FILES')
+          AND query_text NOT LIKE '/* {"app": "OpenMetadata", %%} */%%'
+          AND query_text NOT LIKE '/* {"app": "dbt", %%} */%%';
         """
 SNOWFLAKE_SESSION_TAG_QUERY = 'ALTER SESSION SET QUERY_TAG="{query_tag}"'
 
@@ -332,6 +337,8 @@ MSSQL_SQL_USAGE_STATEMENT = """
       INNER JOIN sys.databases db
         ON db.database_id = t.dbid
       WHERE s.last_execution_time between '{start_time}' and '{end_time}'
+          AND t.text NOT LIKE '/* {"app": "OpenMetadata", %%} */%%'
+          AND t.text NOT LIKE '/* {"app": "dbt", %%} */%%';
       ORDER BY s.last_execution_time DESC;
 """
 
@@ -350,6 +357,8 @@ CLICKHOUSE_SQL_USAGE_STATEMENT = """
         Where start_time between '{start_time}' and '{end_time}'
         and CAST(type,'Int8') <> 3
         and CAST(type,'Int8') <> 4
+        and query NOT LIKE '/* {"app": "OpenMetadata", %%} */%%'
+        and query NOT LIKE '/* {"app": "dbt", %%} */%%'
         and (`type`='QueryFinish' or `type`='QueryStart')
 """
 
@@ -391,6 +400,8 @@ WHERE creation_time BETWEEN "{start_time}" AND "{end_time}"
   AND job_type = "QUERY"
   AND state = "DONE"
   AND IFNULL(statement_type, "NO") not in ("NO", "DROP_TABLE", "CREATE_TABLE")
+  AND text NOT LIKE '/* {"app": "OpenMetadata", %%} */%%'
+  AND text NOT LIKE '/* {"app": "dbt", %%} */%%'
 """
 
 

--- a/ingestion/src/metadata/utils/sql_queries.py
+++ b/ingestion/src/metadata/utils/sql_queries.py
@@ -11,7 +11,7 @@ REDSHIFT_SQL_STATEMENT = """
           AND querytxt NOT ILIKE 'padb_fetch_sample: %%'
           AND querytxt NOT ILIKE 'Undoing %% transactions on table %% with current xid%%'
           AND querytxt NOT LIKE '/* {"app": "OpenMetadata", %%} */%%'
-          AND querytxt NOT LIKE '/* {"app": "OpenMetadata", %%} */%%'
+          AND querytxt NOT LIKE '/* {"app": "dbt", %%} */%%'
           AND aborted = 0
           AND starttime >= '{start_time}'
           AND starttime < '{end_time}'

--- a/ingestion/tests/unit/test_ometa_utils.py
+++ b/ingestion/tests/unit/test_ometa_utils.py
@@ -17,6 +17,7 @@ from unittest import TestCase
 from metadata.generated.schema.entity.data.mlmodel import MlModel
 from metadata.generated.schema.type import basic
 from metadata.ingestion.ometa.utils import format_name, get_entity_type, model_str
+from metadata.utils.connections import render_query_header
 
 
 class OMetaUtilsTest(TestCase):
@@ -53,4 +54,10 @@ class OMetaUtilsTest(TestCase):
         )
         self.assertEqual(
             model_str(basic.FullyQualifiedEntityName(__root__="FQDN")), "FQDN"
+        )
+
+    def test_render_query_headers_builds_the_right_string(self) -> None:
+        assert (
+            render_query_header("0.0.1")
+            == '/* {"app": "OpenMetadata", "version": "0.0.1"} */'
         )


### PR DESCRIPTION
https://github.com/open-metadata/OpenMetadata/issues/6140

### Describe your changes :
We wanted to add a header to all openmetadata queries in order to identify & filter them. We've achieved that by using [SQLAlchemy's event listeners](https://docs.sqlalchemy.org/en/14/core/event.html) to intercept and alter all statements from the engine in `CommonDbSourceService`. Seem to work on the inspector when inspecting connections derived from the same engine too. Example query extracted from the Redshift's system tables:

![image](https://user-images.githubusercontent.com/9376816/180577680-1d60c136-10b4-4c9e-9c62-56814756b373.png)

We've also filtered all queries with the OpenMetadata & dbt headers as per the issue.

I only have access for a working setup of Redshift so we as we've modified several queries for other systems if we have some battery of integration tests it would be safer to run them.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
N/A

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ingestion 
