### PR TITLE
Fix#5921: Implentation for retrieving auth provider config from Secret Manager

### DIFF
--- a/ingestion/src/metadata/ingestion/ometa/ometa_api.py
+++ b/ingestion/src/metadata/ingestion/ometa/ometa_api.py
@@ -160,6 +160,14 @@ class OpenMetadata(
     def __init__(self, config: OpenMetadataConnection, raw_data: bool = False):
         self.config = config
 
+        # Load the secrets' manager client
+        self.secrets_manager_client = get_secrets_manager(
+            config.secretsManagerProvider, config.secretsManagerCredentials
+        )
+
+        # Load auth provider config from Secret Manager if necessary
+        self.secrets_manager_client.add_auth_provider_security_config(self.config)
+
         # Load the auth provider init from the registry
         auth_provider_fn = auth_provider_registry.registry.get(
             self.config.authProvider.value
@@ -170,11 +178,6 @@ class OpenMetadata(
             )
 
         self._auth_provider = auth_provider_fn(self.config)
-
-        # Load the secrets' manager client
-        self.secrets_manager_client = get_secrets_manager(
-            config.secretsManagerProvider, config.secretsManagerCredentials
-        )
 
         client_config: ClientConfig = ClientConfig(
             base_url=self.config.hostPort,

--- a/ingestion/tests/integration/ometa/test_ometa_api.py
+++ b/ingestion/tests/integration/ometa/test_ometa_api.py
@@ -14,11 +14,8 @@ OpenMetadata API initialization
 """
 from metadata.generated.schema.entity.services.connections.metadata.openMetadataConnection import (
     OpenMetadataConnection,
-    SecretsManagerProvider,
 )
-from metadata.generated.schema.security.credentials.awsCredentials import AWSCredentials
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
-from metadata.utils.secrets_manager import AWSSecretsManager, LocalSecretsManager
 
 
 def test_init_ometa():
@@ -26,17 +23,3 @@ def test_init_ometa():
     metadata = OpenMetadata(server_config)
 
     assert metadata.health_check()
-    assert type(metadata.secrets_manager_client) is LocalSecretsManager
-
-
-def test_init_ometa_with_aws_secret_manager():
-    server_config = OpenMetadataConnection(
-        hostPort="http://localhost:8585/api",
-        secretsManagerProvider=SecretsManagerProvider.aws,
-        secretsManagerCredentials=AWSCredentials(
-            awsRegion="test", awsSecretAccessKey="test"
-        ),
-    )
-    metadata = OpenMetadata(server_config)
-
-    assert type(metadata.secrets_manager_client) is AWSSecretsManager

--- a/ingestion/tests/integration/ometa/test_ometa_secrets_manager.py
+++ b/ingestion/tests/integration/ometa/test_ometa_secrets_manager.py
@@ -1,0 +1,88 @@
+#  Copyright 2022 Collate
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from copy import copy
+from unittest import TestCase
+from unittest.mock import MagicMock, Mock, patch
+
+from metadata.generated.schema.entity.services.connections.metadata.openMetadataConnection import (
+    AuthProvider,
+    OpenMetadataConnection,
+    SecretsManagerProvider,
+)
+from metadata.generated.schema.security.client.googleSSOClientConfig import (
+    GoogleSSOClientConfig,
+)
+from metadata.generated.schema.security.credentials.awsCredentials import AWSCredentials
+from metadata.ingestion.ometa.auth_provider import (
+    GoogleAuthenticationProvider,
+    NoOpAuthenticationProvider,
+)
+from metadata.ingestion.ometa.ometa_api import OpenMetadata
+from metadata.utils.secrets_manager import AWSSecretsManager, LocalSecretsManager
+
+
+class OMetaSecretManagerTest(TestCase):
+    metadata: OpenMetadata
+    aws_server_config: OpenMetadataConnection
+    local_server_config: OpenMetadataConnection
+
+    @classmethod
+    def setUp(cls) -> None:
+        cls.local_server_config = OpenMetadataConnection(
+            hostPort="http://localhost:8585/api",
+            enableVersionValidation=False,
+        )
+        cls.aws_server_config = OpenMetadataConnection(
+            hostPort="http://localhost:8585/api",
+            secretsManagerProvider=SecretsManagerProvider.aws,
+            secretsManagerCredentials=AWSCredentials(
+                awsRegion="test", awsSecretAccessKey="test"
+            ),
+            enableVersionValidation=False,
+        )
+
+    def test_ometa_with_local_secret_manager(self):
+        self._init_local_secret_manager()
+        assert type(self.metadata.secrets_manager_client) is LocalSecretsManager
+        assert type(self.metadata._auth_provider) is NoOpAuthenticationProvider
+
+    def test_ometa_with_local_secret_manager_with_google_auth(self):
+        self.local_server_config.authProvider = AuthProvider.google
+        self.local_server_config.securityConfig = GoogleSSOClientConfig(
+            secretKey="/fake/path"
+        )
+        self._init_local_secret_manager()
+        assert type(self.metadata.secrets_manager_client) is LocalSecretsManager
+        assert type(self.metadata._auth_provider) is GoogleAuthenticationProvider
+
+    def test_ometa_with_aws_secret_manager(self):
+        self._init_aws_secret_manager()
+        assert type(self.metadata.secrets_manager_client) is AWSSecretsManager
+        assert type(self.metadata._auth_provider) is NoOpAuthenticationProvider
+
+    @patch("metadata.ingestion.ometa.ometa_api.get_secrets_manager")
+    def test_ometa_with_aws_secret_manager_with_google_auth(self, secrets_manager_mock):
+        security_config = copy(self.aws_server_config)
+        security_config.securityConfig = GoogleSSOClientConfig(secretKey="/fake/path")
+        secret_client_mock = Mock()
+        secret_client_mock.add_auth_provider_security_config.return_value = (
+            security_config
+        )
+        secrets_manager_mock.return_value = secret_client_mock
+        self.aws_server_config.authProvider = AuthProvider.google
+        self._init_aws_secret_manager()
+        assert type(self.metadata._auth_provider) is GoogleAuthenticationProvider
+
+    def _init_local_secret_manager(self):
+        self.metadata = OpenMetadata(self.local_server_config)
+
+    def _init_aws_secret_manager(self):
+        self.metadata = OpenMetadata(self.aws_server_config)

--- a/ingestion/tests/unit/metadata/utils/test_secrets_manager.py
+++ b/ingestion/tests/unit/metadata/utils/test_secrets_manager.py
@@ -23,6 +23,8 @@ from metadata.generated.schema.entity.services.connections.database.mysqlConnect
     MysqlConnection,
 )
 from metadata.generated.schema.entity.services.connections.metadata.openMetadataConnection import (
+    AuthProvider,
+    OpenMetadataConnection,
     SecretsManagerProvider,
 )
 from metadata.generated.schema.entity.services.databaseService import (
@@ -30,8 +32,16 @@ from metadata.generated.schema.entity.services.databaseService import (
     DatabaseService,
     DatabaseServiceType,
 )
+from metadata.generated.schema.security.client.googleSSOClientConfig import (
+    GoogleSSOClientConfig,
+)
 from metadata.generated.schema.security.credentials.awsCredentials import AWSCredentials
-from metadata.utils.secrets_manager import Singleton, get_secrets_manager
+from metadata.utils.secrets_manager import (
+    AUTH_PROVIDER_MAPPING,
+    AuthProviderClientType,
+    Singleton,
+    get_secrets_manager,
+)
 
 DATABASE_CONNECTION = {"username": "test", "hostPort": "localhost:3306"}
 
@@ -42,15 +52,23 @@ DATABASE_SERVICE = {
     "connection": DatabaseConnection(),
 }
 
+AUTH_PROVIDER_CONFIG = {"secretKey": "/fake/path"}
+
 
 class TestSecretsManager(TestCase):
     service_type: str = "databaseService"
     service: DatabaseService
     database_connection = MysqlConnection(**DATABASE_CONNECTION)
+    auth_provider_config = GoogleSSOClientConfig(**AUTH_PROVIDER_CONFIG)
+    om_connection: OpenMetadataConnection
 
     @classmethod
     def setUpClass(cls) -> None:
         cls.service = DatabaseService(**DATABASE_SERVICE)
+        cls.om_connection = OpenMetadataConnection(
+            authProvider=AuthProvider.google,
+            hostPort="http://localhost:8585/api",
+        )
 
     @classmethod
     def setUp(cls) -> None:
@@ -66,22 +84,23 @@ class TestSecretsManager(TestCase):
         self.assertEqual(expected_service, self.service)
         assert id(self.database_connection) == id(self.service.connection.config)
 
+    def test_local_manager_add_auth_provider_security_config(self):
+        local_manager = get_secrets_manager(SecretsManagerProvider.local, None)
+        actual_om_connection = deepcopy(self.om_connection)
+        actual_om_connection.securityConfig = self.auth_provider_config
+
+        local_manager.add_auth_provider_security_config(actual_om_connection)
+
+        self.assertEqual(self.auth_provider_config, actual_om_connection.securityConfig)
+        assert id(self.auth_provider_config) == id(actual_om_connection.securityConfig)
+
     @patch("metadata.utils.secrets_manager.boto3")
     def test_aws_manager_add_service_config_connection(self, boto3_mock):
-        self._init_boto3_mock(
+        aws_manager = self._build_secret_manager(
             boto3_mock, {"SecretString": json.dumps(DATABASE_CONNECTION)}
-        )
-        aws_manager = get_secrets_manager(
-            SecretsManagerProvider.aws,
-            AWSCredentials(
-                awsAccessKeyId="fake_key",
-                awsSecretAccessKey="fake_access",
-                awsRegion="fake-region",
-            ),
         )
         expected_service = deepcopy(self.service)
         expected_service.connection.config = self.database_connection
-
         self.service.connection = None
 
         aws_manager.add_service_config_connection(self.service, self.service_type)
@@ -90,18 +109,33 @@ class TestSecretsManager(TestCase):
         assert id(self.database_connection) != id(self.service.connection.config)
 
     @patch("metadata.utils.secrets_manager.boto3")
+    def test_aws_manager_fails_add_auth_provider_security_config(self, mocked_boto3):
+        aws_manager = self._build_secret_manager(mocked_boto3, {})
+
+        with self.assertRaises(ValueError) as value_error:
+            aws_manager.add_service_config_connection(self.service, self.service_type)
+            self.assertEqual(
+                "[SecretString] not present in the response.", value_error.exception
+            )
+
+    @patch("metadata.utils.secrets_manager.boto3")
+    def test_aws_manager_add_auth_provider_security_config(self, boto3_mock):
+        aws_manager = self._build_secret_manager(
+            boto3_mock, {"SecretString": json.dumps(AUTH_PROVIDER_CONFIG)}
+        )
+        actual_om_connection = deepcopy(self.om_connection)
+        actual_om_connection.securityConfig = None
+
+        aws_manager.add_auth_provider_security_config(actual_om_connection)
+
+        self.assertEqual(self.auth_provider_config, actual_om_connection.securityConfig)
+        assert id(self.auth_provider_config) != id(actual_om_connection.securityConfig)
+
+    @patch("metadata.utils.secrets_manager.boto3")
     def test_aws_manager_fails_add_service_config_connection_when_not_stored(
         self, mocked_boto3
     ):
-        self._init_boto3_mock(mocked_boto3, {})
-        aws_manager = get_secrets_manager(
-            SecretsManagerProvider.aws,
-            AWSCredentials(
-                awsAccessKeyId="fake_key",
-                awsSecretAccessKey="fake_access",
-                awsRegion="fake-region",
-            ),
-        )
+        aws_manager = self._build_secret_manager(mocked_boto3, {})
 
         with self.assertRaises(ValueError) as value_error:
             aws_manager.add_service_config_connection(self.service, self.service_type)
@@ -115,6 +149,25 @@ class TestSecretsManager(TestCase):
             self.assertEqual(
                 "[any] is not implemented.", not_implemented_error.exception
             )
+
+    def test_all_auth_provider_has_auth_client(self):
+        auth_provider_with_client = [
+            e for e in AuthProvider if e is not AuthProvider.no_auth
+        ]
+        for auth_provider in auth_provider_with_client:
+            assert AUTH_PROVIDER_MAPPING.get(auth_provider, None) is not None
+
+    def _build_secret_manager(self, mocked_boto3: Mock, expected_json: Dict[str, Any]):
+        self._init_boto3_mock(mocked_boto3, expected_json)
+        aws_manager = get_secrets_manager(
+            SecretsManagerProvider.aws,
+            AWSCredentials(
+                awsAccessKeyId="fake_key",
+                awsSecretAccessKey="fake_access",
+                awsRegion="fake-region",
+            ),
+        )
+        return aws_manager
 
     @staticmethod
     def _init_boto3_mock(boto3_mock: Mock, client_return: Dict[str, Any]):

--- a/openmetadata-airflow-apis/src/openmetadata/workflows/ingestion/common.py
+++ b/openmetadata-airflow-apis/src/openmetadata/workflows/ingestion/common.py
@@ -99,9 +99,7 @@ def build_source(ingestion_pipeline: IngestionPipeline) -> WorkflowSource:
     if not service:
         raise ValueError(f"Could not get service from type {service_type}")
 
-    service = metadata.secrets_manager_client.add_service_config_connection(
-        service, service_type
-    )
+    metadata.secrets_manager_client.add_service_config_connection(service, service_type)
 
     return WorkflowSource(
         type=service.serviceType.value.lower(),


### PR DESCRIPTION
Fixes: https://github.com/open-metadata/OpenMetadata/issues/5921

### Describe your changes :
Implemented a new method for adding the auth provider configuration to the `OpenMetadataConnection` object when the secret manager is not `local`.

### Type of change :
- [x] New feature

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

### Reviewers
Ingestion: @open-metadata/ingestion
