### PR TITLE
Fix #6248: Use PUT API instead of POST for tag & tagCategory

### DIFF
--- a/ingestion/src/metadata/ingestion/ometa/mixins/tag_mixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/tag_mixin.py
@@ -75,7 +75,7 @@ class OMetaTagMixin:
         path = f"{category_name}"
         return self._get(entity=entity, path=path, fields=fields)
 
-    def update_tag_category(
+    def create_or_update_tag_category(
         self, category_name: str, tag_category_body: CreateTagCategoryRequest
     ) -> None:
         """Method to update a tag category
@@ -117,7 +117,7 @@ class OMetaTagMixin:
         path = f"{category_name}/{primary_tag_fqn}"
         return self._get(entity=entity, path=path, fields=fields)
 
-    def update_primary_tag(
+    def create_or_update_primary_tag(
         self,
         category_name: str,
         primary_tag_fqn: str,

--- a/ingestion/src/metadata/ingestion/sink/metadata_rest.py
+++ b/ingestion/src/metadata/ingestion/sink/metadata_rest.py
@@ -463,7 +463,7 @@ class MetadataRestSink(Sink[Entity]):
 
     def write_tag_category(self, record: OMetaTagAndCategory):
         try:
-            self.metadata.update_tag_category(
+            self.metadata.create_or_update_tag_category(
                 tag_category_body=record.category_name,
                 category_name=record.category_name.name.__root__,
             )
@@ -471,7 +471,7 @@ class MetadataRestSink(Sink[Entity]):
             logger.debug(traceback.format_exc())
             logger.error(err)
         try:
-            self.metadata.update_primary_tag(
+            self.metadata.create_or_update_primary_tag(
                 category_name=record.category_name.name.__root__,
                 primary_tag_body=record.category_details,
                 primary_tag_fqn=fqn.build(

--- a/ingestion/src/metadata/ingestion/source/database/bigquery.py
+++ b/ingestion/src/metadata/ingestion/source/database/bigquery.py
@@ -123,8 +123,6 @@ class BigquerySource(CommonDbSourceService):
         :param _:
         :return:
         """
-        if not self.source_config.includeTags:
-            return
         taxonomies = PolicyTagManagerClient().list_taxonomies(
             parent=f"projects/{self.project_id}/locations/{self.service_connection.taxonomyLocation}"
         )

--- a/ingestion/src/metadata/ingestion/source/database/database_service.py
+++ b/ingestion/src/metadata/ingestion/source/database/database_service.py
@@ -125,7 +125,7 @@ class DatabaseServiceTopology(ServiceTopology):
             NodeStage(
                 type_=OMetaTagAndCategory,
                 context="tags",
-                processor="yield_tag",
+                processor="yield_tag_details",
                 ack_sink=False,
                 nullable=True,
                 cache_all=True,
@@ -264,6 +264,13 @@ class DatabaseServiceSource(DBTMixin, TopologyRunnerMixin, Source, ABC):
         """
         From topology. To be run for each schema
         """
+
+    def yield_tag_details(self, schema_name: str) -> Iterable[OMetaTagAndCategory]:
+        """
+        From topology. To be run for each schema
+        """
+        if self.source_config.includeTags:
+            yield from self.yield_tag(schema_name) or []
 
     @abstractmethod
     def yield_view_lineage(

--- a/ingestion/tests/integration/ometa/test_ometa_tags_mixin.py
+++ b/ingestion/tests/integration/ometa/test_ometa_tags_mixin.py
@@ -126,7 +126,7 @@ class OMetaTagMixinPut(TestCase):
             categoryType="Descriptive", description="test tag", name=f"{rand_name}"
         )
 
-        self.metadata.update_tag_category(CATEGORY_NAME, updated_tag_category)
+        self.metadata.create_or_update_tag_category(CATEGORY_NAME, updated_tag_category)
 
         assert True
 
@@ -138,7 +138,7 @@ class OMetaTagMixinPut(TestCase):
             description="test tag", name=f"{rand_name}"
         )
 
-        self.metadata.update_primary_tag(
+        self.metadata.create_or_update_primary_tag(
             CATEGORY_NAME, PRIMARY_TAG_NAME, updated_primary_tag
         )
 


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Fix #6248: Use PUT API instead of POST for tag & tagCategory

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
@open-metadata/ingestion 
