### PR TITLE
Reduce the CI times for py-tests

### DIFF
--- a/.github/workflows/py-tests-3_10.yml
+++ b/.github/workflows/py-tests-3_10.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Start Server and Ingest Sample Data
       env:
         INGESTION_DEPENDENCY: "airflow-container,sample-data,elasticsearch"
-      run: ./docker/run_local_docker.sh
+      run: ./docker/run_local_docker.sh no-ui
       timeout-minutes: 30
 
     - name: Run Python Tests & record coverage

--- a/.github/workflows/py-tests-3_7.yml
+++ b/.github/workflows/py-tests-3_7.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Start Server and Ingest Sample Data
       env:
         INGESTION_DEPENDENCY: "airflow-container,sample-data,elasticsearch"
-      run: ./docker/run_local_docker.sh
+      run: ./docker/run_local_docker.sh no-ui
       timeout-minutes: 30
 
     - name: Run Python Tests

--- a/.github/workflows/py-tests-3_8.yml
+++ b/.github/workflows/py-tests-3_8.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Start Server and Ingest Sample Data
       env:
         INGESTION_DEPENDENCY: "airflow-container,sample-data,elasticsearch"
-      run: ./docker/run_local_docker.sh
+      run: ./docker/run_local_docker.sh no-ui
       timeout-minutes: 30
 
     - name: Run Python Tests

--- a/.github/workflows/py-tests-3_9.yml
+++ b/.github/workflows/py-tests-3_9.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Start Server and Ingest Sample Data
       env:
         INGESTION_DEPENDENCY: "airflow-container,sample-data,elasticsearch"
-      run: ./docker/run_local_docker.sh
+      run: ./docker/run_local_docker.sh no-ui
       timeout-minutes: 30
 
     - name: Run Python Tests & Record Coverage

--- a/docker/local-metadata/.ci_env
+++ b/docker/local-metadata/.ci_env
@@ -1,0 +1,1 @@
+INGESTION_DEPENDENCY=airflow-container,elasticsearch,mysql

--- a/docker/local-metadata/.ci_env
+++ b/docker/local-metadata/.ci_env
@@ -1,1 +1,0 @@
-INGESTION_DEPENDENCY=airflow-container,elasticsearch,mysql

--- a/docker/run_local_docker.sh
+++ b/docker/run_local_docker.sh
@@ -11,13 +11,20 @@
 #  limitations under the License.
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
-echo "Maven Build - Skipping Tests"
-cd ../ && mvn -DskipTests -DonlyBackend -DskipDefault clean package -pl !openmetadata-ui
-echo "Prepare Docker volume for the operators"
+
+if [[ $1 == "no-ui" ]]; then
+    echo "Maven Build - Skipping Tests and UI"
+    cd ../ && mvn -DskipTests -DonlyBackend clean package -pl !openmetadata-ui
+else
+    echo "Maven Build - Skipping Tests"
+    cd ../ && mvn -DskipTests clean package
+fi
+
+echo "Prepare Docker volume for the operators"@
 cd docker/local-metadata
 echo "Starting Local Docker Containers"
 
-docker compose down && docker compose --env-file .ci_env up --build -d
+docker compose down && docker compose up --build -d
 
 until curl -s -f "http://localhost:9200/_cat/indices/team_search_index"; do
   printf 'Checking if Elastic Search instance is up...\n'

--- a/docker/run_local_docker.sh
+++ b/docker/run_local_docker.sh
@@ -12,12 +12,12 @@
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 echo "Maven Build - Skipping Tests"
-cd ../ && mvn -DskipTests clean package
+cd ../ && mvn -DskipTests -DonlyBackend -DskipDefault clean package -pl !openmetadata-ui
 echo "Prepare Docker volume for the operators"
 cd docker/local-metadata
 echo "Starting Local Docker Containers"
 
-docker compose down && docker compose up --build -d
+docker compose down && docker compose --env-file .ci_env up --build -d
 
 until curl -s -f "http://localhost:9200/_cat/indices/team_search_index"; do
   printf 'Checking if Elastic Search instance is up...\n'

--- a/openmetadata-dist/pom.xml
+++ b/openmetadata-dist/pom.xml
@@ -47,58 +47,9 @@
 
   <profiles>
     <profile>
-      <id>testing</id>
-      <activation>
-        <property>
-          <name>onlyBackend</name>
-        </property>
-      </activation>
-      <build>
-        <finalName>${final.Name}-${project.version}</finalName>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-assembly-plugin</artifactId>
-            <executions>
-              <execution>
-                <phase>package</phase>
-                <goals>
-                  <goal>single</goal>
-                </goals>
-              </execution>
-            </executions>
-            <configuration>
-              <attach>true</attach>
-              <runOnlyAtExecutionRoot>false</runOnlyAtExecutionRoot>
-              <descriptors>
-                <descriptor>${project.basedir}/src/main/assembly/binary.xml</descriptor>
-              </descriptors>
-              <appendAssemblyId>false</appendAssemblyId>
-            </configuration>
-          </plugin>
-          <plugin>
-            <artifactId>maven-dependency-plugin</artifactId>
-            <executions>
-              <execution>
-                <phase>install</phase>
-                <goals>
-                  <goal>copy-dependencies</goal>
-                </goals>
-                <configuration>
-                  <outputDirectory>${project.build.directory}/libs</outputDirectory>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>default</id>
       <activation>
-        <property>
-          <name>!skipDefault</name>
-        </property>
+        <activeByDefault>true</activeByDefault>
       </activation>
       <build>
         <finalName>${final.Name}-${project.version}</finalName>
@@ -220,12 +171,15 @@
         </plugin>
       </plugins>
     </build>
+  </profile>
+  <profile>
+    <id>only-backend</id>
+    <activation>
+      <property>
+        <name>onlyBackend</name>
+      </property>
+    </activation>
     <dependencies>
-      <dependency>
-        <groupId>org.open-metadata</groupId>
-        <artifactId>openmetadata-ui</artifactId>
-        <version>${project.version}</version>
-      </dependency>
     </dependencies>
   </profile>
  </profiles>

--- a/openmetadata-dist/pom.xml
+++ b/openmetadata-dist/pom.xml
@@ -39,11 +39,6 @@
       <artifactId>common</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.open-metadata</groupId>
-      <artifactId>openmetadata-ui</artifactId>
-      <version>${project.version}</version>
-    </dependency>
   </dependencies>
 
   <properties>
@@ -52,9 +47,11 @@
 
   <profiles>
     <profile>
-      <id>default</id>
+      <id>testing</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>onlyBackend</name>
+        </property>
       </activation>
       <build>
         <finalName>${final.Name}-${project.version}</finalName>
@@ -95,6 +92,60 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>default</id>
+      <activation>
+        <property>
+          <name>!skipDefault</name>
+        </property>
+      </activation>
+      <build>
+        <finalName>${final.Name}-${project.version}</finalName>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>single</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <attach>true</attach>
+              <runOnlyAtExecutionRoot>false</runOnlyAtExecutionRoot>
+              <descriptors>
+                <descriptor>${project.basedir}/src/main/assembly/binary.xml</descriptor>
+              </descriptors>
+              <appendAssemblyId>false</appendAssemblyId>
+            </configuration>
+          </plugin>
+          <plugin>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>install</phase>
+                <goals>
+                  <goal>copy-dependencies</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>${project.build.directory}/libs</outputDirectory>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+      <dependencies>
+        <dependency>
+          <groupId>org.open-metadata</groupId>
+          <artifactId>openmetadata-ui</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
     </profile>
     <profile>
       <id>rpm</id>
@@ -169,6 +220,13 @@
         </plugin>
       </plugins>
     </build>
+    <dependencies>
+      <dependency>
+        <groupId>org.open-metadata</groupId>
+        <artifactId>openmetadata-ui</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+    </dependencies>
   </profile>
  </profiles>
 


### PR DESCRIPTION
### Describe your changes :
Added `no-ui` option for start server from `run_local_docker.sh` script without the web interface. This can be used when starting the server for running the py-test integration tests so the CI time will be reduced.

An [example](https://github.com/open-metadata/OpenMetadata/runs/7520340330?check_suite_focus=true) of this approach running in CI.

### Type of change :
- [x] Improvement

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

### Reviewers
Ingestion: @open-metadata/ingestion