### PR TITLE
tier description dropdown

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/rich-text-editor/RichTextEditor.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/rich-text-editor/RichTextEditor.interface.ts
@@ -14,6 +14,8 @@
 import { HTMLAttributes, ReactNode } from 'react';
 
 export type editorRef = ReactNode | HTMLElement | string;
+export type TextVariant = 'white' | 'black';
+
 export enum Format {
   JSON = 'json',
   MARKDOWN = 'markdown',
@@ -34,6 +36,7 @@ export interface PreviewerProp {
   maxHtClass?: string;
   maxLen?: number;
   enableSeeMoreVariant?: boolean;
+  textVariant?: TextVariant;
 }
 
 export type PreviewStyle = 'tab' | 'vertical';

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/rich-text-editor/RichTextEditorPreviewer.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/rich-text-editor/RichTextEditorPreviewer.less
@@ -11,10 +11,7 @@
 .markdown-parser.white {
   .toastui-editor-contents {
     p {
-      margin-top: 0px;
-      margin-bottom: 10px;
       color: white;
-      word-break: break-word;
     }
     ul li::before {
       background-color: white;

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/rich-text-editor/RichTextEditorPreviewer.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/rich-text-editor/RichTextEditorPreviewer.less
@@ -1,9 +1,23 @@
-body {
+.markdown-parser {
   .toastui-editor-contents {
     p {
       margin-top: 0px;
       margin-bottom: 10px;
       color: #37352f;
+      word-break: break-word;
+    }
+  }
+}
+.markdown-parser.white {
+  .toastui-editor-contents {
+    p {
+      margin-top: 0px;
+      margin-bottom: 10px;
+      color: white;
+      word-break: break-word;
+    }
+    ul li::before {
+      background-color: white;
     }
   }
 }

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/rich-text-editor/RichTextEditorPreviewer.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/rich-text-editor/RichTextEditorPreviewer.tsx
@@ -28,7 +28,7 @@ const RichTextEditorPreviewer = ({
   maxHtClass = 'tw-h-24',
   maxLen = MAX_LENGTH,
   enableSeeMoreVariant = true,
-  textVariant,
+  textVariant = 'black',
 }: PreviewerProp) => {
   const [content, setContent] = useState<string>('');
   const [displayMoreText, setDisplayMoreText] = useState<boolean>(false);

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/rich-text-editor/RichTextEditorPreviewer.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/rich-text-editor/RichTextEditorPreviewer.tsx
@@ -28,6 +28,7 @@ const RichTextEditorPreviewer = ({
   maxHtClass = 'tw-h-24',
   maxLen = MAX_LENGTH,
   enableSeeMoreVariant = true,
+  textVariant,
 }: PreviewerProp) => {
   const [content, setContent] = useState<string>('');
   const [displayMoreText, setDisplayMoreText] = useState<boolean>(false);
@@ -53,7 +54,9 @@ const RichTextEditorPreviewer = ({
         }
       )}
       data-testid="viewer-container">
-      <div data-testid="markdown-parser">
+      <div
+        className={classNames('markdown-parser', textVariant)}
+        data-testid="markdown-parser">
         <Viewer extendedAutolinks initialValue={content} key={uniqueId()} />
       </div>
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/tags/tags.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/tags/tags.tsx
@@ -12,12 +12,12 @@
  */
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Tooltip } from 'antd';
 import classNames from 'classnames';
 import { isString } from 'lodash';
 import React, { FunctionComponent } from 'react';
 import { FQN_SEPARATOR_CHAR } from '../../constants/char.constants';
 import SVGIcons, { Icons } from '../../utils/SvgUtils';
-import PopOver from '../common/popover/PopOver';
 import RichTextEditorPreviewer from '../common/rich-text-editor/RichTextEditorPreviewer';
 import { TagProps } from './tags.interface';
 import { tagStyles } from './tags.styles';
@@ -95,25 +95,24 @@ const Tags: FunctionComponent<TagProps> = ({
       ) : (
         <>
           {!editable && tag.description ? (
-            <PopOver
-              html={
+            <Tooltip
+              placement="bottomLeft"
+              title={
                 <div className="tw-text-left tw-p-1">
                   {tag.description && (
-                    <div className="tw-mb-3">
+                    <div className="tw-mb-2">
                       <RichTextEditorPreviewer
                         enableSeeMoreVariant={false}
                         markdown={tag.description}
+                        textVariant="white"
                       />
                     </div>
                   )}
                 </div>
               }
-              position="top"
-              size="small"
-              title=""
-              trigger="mouseenter">
+              trigger="hover">
               {getTag(tag.tagFQN, startWith)}
-            </PopOver>
+            </Tooltip>
           ) : (
             getTag(tag.tagFQN, startWith)
           )}

--- a/openmetadata-ui/src/main/resources/ui/src/styles/tailwind.css
+++ b/openmetadata-ui/src/main/resources/ui/src/styles/tailwind.css
@@ -301,20 +301,6 @@
     @apply tw-bg-primary tw-translate-x-4;
   }
 
-  body .content-container h1,
-  body .content-container h2 {
-    @apply tw-text-h3;
-  }
-  body .editor-wrapper ul,
-  body #description ul,
-  body .content-container ul {
-    @apply tw-list-disc;
-  }
-
-  body .content-container p {
-    word-break: break-word;
-  }
-
   .signin-box {
     @apply tw-m-auto tw-h-100 tw-w-120 tw-bg-white tw-shadow-modal;
   }


### PR DESCRIPTION

### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the Tier Description Dropdown which did not show any tier description on hover.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<img width="347" alt="Screenshot 2022-07-26 at 6 38 19 PM" src="https://user-images.githubusercontent.com/58542468/181013524-650e737d-9a0d-4280-9998-07f7ba81dedd.png">

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
