### PR TITLE
[Backend][Notifications] Fix taskConversation sent as taskNotification

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/events/ChangeEventHandler.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/events/ChangeEventHandler.java
@@ -137,22 +137,24 @@ public class ChangeEventHandler implements EventHandler {
         String jsonThread = mapper.writeValueAsString(thread);
         switch (thread.getType()) {
           case Task:
-            List<EntityReference> assignees = thread.getTask().getAssignees();
-            assignees.forEach(
-                (e) -> {
-                  if (Entity.USER.equals(e.getType())) {
-                    WebSocketManager.getInstance()
-                        .sendToOne(e.getId(), WebSocketManager.taskBroadcastChannel, jsonThread);
-                  } else if (Entity.TEAM.equals(e.getType())) {
-                    // fetch all that are there in the team
-                    List<EntityRelationshipRecord> records =
-                        dao.relationshipDAO()
-                            .findTo(e.getId().toString(), TEAM, Relationship.HAS.ordinal(), Entity.USER);
-                    WebSocketManager.getInstance()
-                        .sendToManyWithString(records, WebSocketManager.taskBroadcastChannel, jsonThread);
-                  }
-                });
-            return;
+            if (thread.getPostsCount() == 0) {
+              List<EntityReference> assignees = thread.getTask().getAssignees();
+              assignees.forEach(
+                  (e) -> {
+                    if (Entity.USER.equals(e.getType())) {
+                      WebSocketManager.getInstance()
+                          .sendToOne(e.getId(), WebSocketManager.taskBroadcastChannel, jsonThread);
+                    } else if (Entity.TEAM.equals(e.getType())) {
+                      // fetch all that are there in the team
+                      List<EntityRelationshipRecord> records =
+                          dao.relationshipDAO()
+                              .findTo(e.getId().toString(), TEAM, Relationship.HAS.ordinal(), Entity.USER);
+                      WebSocketManager.getInstance()
+                          .sendToManyWithString(records, WebSocketManager.taskBroadcastChannel, jsonThread);
+                    }
+                  });
+              return;
+            }
           case Conversation:
             WebSocketManager.getInstance().broadCastMessageToAll(WebSocketManager.feedBroadcastChannel, jsonThread);
             List<EntityLink> mentions;


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Task Conversation had thread type as "Task" , because of which task notification were getting created, This fixes that issue

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!--- Backend: @open-metadata/backend -->
