### PR TITLE
Update POM profile build configuration when using the only-backend profile

### DIFF
--- a/openmetadata-dist/pom.xml
+++ b/openmetadata-dist/pom.xml
@@ -179,8 +179,45 @@
         <name>onlyBackend</name>
       </property>
     </activation>
-    <dependencies>
-    </dependencies>
+    <build>
+      <finalName>${final.Name}-${project.version}</finalName>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <executions>
+            <execution>
+              <phase>package</phase>
+              <goals>
+                <goal>single</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <attach>true</attach>
+            <runOnlyAtExecutionRoot>false</runOnlyAtExecutionRoot>
+            <descriptors>
+              <descriptor>${project.basedir}/src/main/assembly/binary.xml</descriptor>
+            </descriptors>
+            <appendAssemblyId>false</appendAssemblyId>
+          </configuration>
+        </plugin>
+        <plugin>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <executions>
+            <execution>
+              <phase>install</phase>
+              <goals>
+                <goal>copy-dependencies</goal>
+              </goals>
+              <configuration>
+                <outputDirectory>${project.build.directory}/libs</outputDirectory>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </build>
   </profile>
  </profiles>
 


### PR DESCRIPTION
### Describe your changes :
Add missing build definition to profile `only-backend` in `openmetadata-ui`.

### Type of change :
- [x] Bug fix

### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

### Reviewers
Ingestion: @open-metadata/ingestion
