### PR TITLE
Fix #6397 UI : Override markdown parser default stylings 

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/rich-text-editor/RichTextEditorPreviewer.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/rich-text-editor/RichTextEditorPreviewer.less
@@ -1,20 +1,57 @@
+@body-text-color: #37352f;
+@badge-color: #d5d8dc;
+@while-color: #ffffff;
+
 .markdown-parser {
   .toastui-editor-contents {
+    font-size: 14px;
+    h1,
+    h2 {
+      border-bottom: 1px solid @badge-color;
+    }
+
+    blockquote {
+      padding: 0px 16px;
+    }
+
+    code {
+      color: @body-text-color;
+      background-color: @badge-color;
+    }
+
+    pre {
+      background-color: @badge-color;
+      code {
+        background-color: transparent;
+      }
+    }
+
+    table {
+      width: 100%;
+      overflow: auto;
+      th {
+        background-color: @badge-color;
+        color: @body-text-color;
+        font-weight: bold;
+      }
+    }
+
     p {
       margin-top: 0px;
       margin-bottom: 10px;
-      color: #37352f;
+      color: @body-text-color;
       word-break: break-word;
     }
   }
 }
+
 .markdown-parser.white {
   .toastui-editor-contents {
     p {
-      color: white;
+      color: @while-color;
     }
     ul li::before {
-      background-color: white;
+      background-color: @while-color;
     }
   }
 }

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/rich-text-editor/RichTextEditorPreviewer.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/rich-text-editor/RichTextEditorPreviewer.less
@@ -1,6 +1,7 @@
 @body-text-color: #37352f;
 @badge-color: #d5d8dc;
 @while-color: #ffffff;
+@border-radius: 6px;
 
 .markdown-parser {
   .toastui-editor-contents {
@@ -21,6 +22,7 @@
 
     pre {
       background-color: @badge-color;
+      border-radius: @border-radius;
       code {
         background-color: transparent;
       }
@@ -41,6 +43,10 @@
       margin-bottom: 10px;
       color: @body-text-color;
       word-break: break-word;
+    }
+
+    img {
+      border-radius: @border-radius;
     }
   }
 }


### PR DESCRIPTION
Fixes #6397 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on overriding markdown parser default stylings.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] Improvement


#
### Frontend Preview (Screenshots) :
![image](https://user-images.githubusercontent.com/59080942/181482847-e3dcfeed-0cf8-4992-996b-5c0d303e9d50.png)

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
