### PR TITLE
Replaced wget with nc in entrypoint to support PostgreSQL

### DIFF
--- a/docker/metadata/openmetadata-start.sh
+++ b/docker/metadata/openmetadata-start.sh
@@ -11,7 +11,7 @@
 #  limitations under the License.
 
 MYSQL="${MYSQL_HOST:-mysql}":"${MYSQL_PORT:-3306}"
-while ! wget -O /dev/null -o /dev/null "${MYSQL}";
+while ! nc -z -w 5 "${MYSQL}";
   do echo "Trying to connect to ${MYSQL}"; sleep 5;
 done
 cd /openmetadata-*/


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Replaced `wget` with `nc` in openmetadata entrypoint as `wget` fails in case PostgreSQL is used even when the DB server is available.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
