### PR TITLE
Fix: Add missing dependency to rpm profile in openmetadata-dist pom

### DIFF
--- a/openmetadata-dist/pom.xml
+++ b/openmetadata-dist/pom.xml
@@ -171,6 +171,13 @@
         </plugin>
       </plugins>
     </build>
+    <dependencies>
+      <dependency>
+        <groupId>org.open-metadata</groupId>
+        <artifactId>openmetadata-ui</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+    </dependencies>
   </profile>
   <profile>
     <id>only-backend</id>


### PR DESCRIPTION
### Describe your changes :
Add missing dependency to rpm profile in `openmetadata-dist` project pom.

### Type of change :
- [x] Bug fix

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@pmbrull 
