### PR TITLE
revert(ui): react-slick added back as it's breaking login page

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/package.json
+++ b/openmetadata-ui/src/main/resources/ui/package.json
@@ -43,6 +43,8 @@
     "fs-extra": "^10.1.0",
     "html-react-parser": "^1.2.6",
     "https-browserify": "^1.0.0",
+    "ieee754": "^1.2.1",
+    "immutable": "^4.0.0-rc.14",
     "jwt-decode": "^3.1.2",
     "less": "^4.1.3",
     "less-loader": "^11.0.0",

--- a/openmetadata-ui/src/main/resources/ui/package.json
+++ b/openmetadata-ui/src/main/resources/ui/package.json
@@ -80,6 +80,7 @@
     "reactjs-localstorage": "^1.0.1",
     "recharts": "^1.8.5",
     "rehype-raw": "^6.1.1",
+    "slick-carousel": "^1.8.1",
     "remark-gfm": "^3.0.1",
     "socket.io-client": "^4.5.1",
     "stream-http": "^3.2.0",

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/DescriptionTabs.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/DescriptionTabs.test.tsx
@@ -59,12 +59,12 @@ describe('Test Description Tabs Component', () => {
 
     expect(tabs).toHaveLength(tabList.length);
 
-    tabs.forEach(async (_tab, index) => {
-      expect(await screen.findByText(tabList[index])).toBeInTheDocument();
-    });
+    expect(await screen.findByText('Current')).toBeInTheDocument();
+    expect(await screen.findByText('Diff')).toBeInTheDocument();
+    expect(await screen.findByText('New')).toBeInTheDocument();
   });
 
-  it('Should render the component relavant tab component', async () => {
+  it('Should render the component relevant tab component', async () => {
     render(<DescriptionTabs {...mockProps} />);
 
     const tabs = await screen.findAllByRole('tab');

--- a/openmetadata-ui/src/main/resources/ui/src/styles/index.js
+++ b/openmetadata-ui/src/main/resources/ui/src/styles/index.js
@@ -16,6 +16,7 @@ import '../fonts/Inter/Inter-VariableFont_slnt,wght.ttf';
 import './antd-master.less';
 import './fonts.css';
 import './myDataDetailsTemp.css';
+import './slick-carousel.scss';
 import './tailwind.css';
 import './temp.css';
 import './x-custom/code-mirror.css';

--- a/openmetadata-ui/src/main/resources/ui/src/styles/slick-carousel.scss
+++ b/openmetadata-ui/src/main/resources/ui/src/styles/slick-carousel.scss
@@ -1,0 +1,17 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+$slick-font-path: '~slick-carousel/slick/fonts/';
+$slick-loader-path: '~slick-carousel/slick/';
+
+@import '~slick-carousel/slick/slick', '~slick-carousel/slick/slick-theme';

--- a/openmetadata-ui/src/main/resources/ui/webpack.config.dev.js
+++ b/openmetadata-ui/src/main/resources/ui/webpack.config.dev.js
@@ -144,6 +144,7 @@ module.exports = {
         ],
         include: [
           path.resolve(__dirname, 'src'),
+          path.resolve(__dirname, 'node_modules/slick-carousel'),
           path.resolve(__dirname, 'node_modules/quill-emoji'),
         ], // Just the source code
       },
@@ -159,7 +160,10 @@ module.exports = {
             },
           },
         ],
-        include: [path.resolve(__dirname, 'src')], // Just the source code
+        include: [
+          path.resolve(__dirname, 'src'),
+          path.resolve(__dirname, 'node_modules/slick-carousel'),
+        ], // Just the source code
       },
     ],
   },

--- a/openmetadata-ui/src/main/resources/ui/webpack.config.prod.js
+++ b/openmetadata-ui/src/main/resources/ui/webpack.config.prod.js
@@ -138,6 +138,7 @@ module.exports = {
         ],
         include: [
           path.resolve(__dirname, 'src'),
+          path.resolve(__dirname, 'node_modules/slick-carousel'),
           path.resolve(__dirname, 'node_modules/quill-emoji'),
         ], // Just the source code
       },
@@ -153,7 +154,10 @@ module.exports = {
             },
           },
         ],
-        include: [path.resolve(__dirname, 'src')], // Just the source code
+        include: [
+          path.resolve(__dirname, 'src'),
+          path.resolve(__dirname, 'node_modules/slick-carousel'),
+        ], // Just the source code
       },
     ],
   },

--- a/openmetadata-ui/src/main/resources/ui/yarn.lock
+++ b/openmetadata-ui/src/main/resources/ui/yarn.lock
@@ -13588,6 +13588,11 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
+slick-carousel@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/slick-carousel/-/slick-carousel-1.8.1.tgz#a4bfb29014887bb66ce528b90bd0cda262cc8f8d"
+  integrity sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA==
+
 slugify@^1.3.6:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/slugify/-/slugify-1.6.3.tgz#325aec50871acfb17976f2d3cb09ee1e7ab563be"

--- a/openmetadata-ui/src/main/resources/ui/yarn.lock
+++ b/openmetadata-ui/src/main/resources/ui/yarn.lock
@@ -7957,7 +7957,7 @@ icss-utils@^4.0.0, icss-utils@^4.1.1:
   dependencies:
     postcss "^7.0.14"
 
-ieee754@^1.1.13:
+ieee754@^1.1.13, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -7976,6 +7976,11 @@ image-size@~0.5.0:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.5.5.tgz#09dfd4ab9d20e29eb1c3e80b8990378df9e3cb9c"
   integrity sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==
+
+immutable@^4.0.0-rc.14:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.1.0.tgz#f795787f0db780183307b9eb2091fcac1f6fafef"
+  integrity sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==
 
 import-cwd@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Revert react-slick package as it's breaking login page

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [x] New feature
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @open-metadata/ui
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
