### PR TITLE
Fix #4391 UI : Use user API to get owns and following data on home page.

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/EntityList/EntityList.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/EntityList/EntityList.tsx
@@ -12,7 +12,6 @@
  */
 
 import { Button, Card, Typography } from 'antd';
-import { FormattedTableData } from 'Models';
 import React, { Fragment, FunctionComponent } from 'react';
 import { Link } from 'react-router-dom';
 import { EntityReference } from '../../generated/type/entityReference';
@@ -21,14 +20,14 @@ import { getEntityIcon, getEntityLink } from '../../utils/TableUtils';
 import Ellipses from '../common/Ellipses/Ellipses';
 import { leftPanelAntCardStyle } from '../containers/PageLayout';
 interface Prop {
-  entityList: Array<FormattedTableData>;
+  entityList: Array<EntityReference>;
   headerText: string | JSX.Element;
   noDataPlaceholder: JSX.Element;
   testIDText: string;
 }
 
 interface AntdEntityListProp {
-  entityList: Array<FormattedTableData>;
+  entityList: Array<EntityReference>;
   headerText?: string | JSX.Element;
   headerTextLabel: string;
   noDataPlaceholder: JSX.Element;
@@ -58,12 +57,12 @@ const EntityList: FunctionComponent<Prop> = ({
                 )}`}
                 key={index}>
                 <div className="tw-flex">
-                  {getEntityIcon(item.index || item.type || '')}
+                  {getEntityIcon(item.type || '')}
                   <Link
                     className="tw-font-medium"
                     to={getEntityLink(
-                      item.index || item.type || '',
-                      item.fullyQualifiedName
+                      item.type || '',
+                      item.fullyQualifiedName as string
                     )}>
                     <Button
                       className="tw-text-grey-body hover:tw-text-primary-hover hover:tw-underline"
@@ -103,12 +102,12 @@ export const EntityListWithAntd: FunctionComponent<AntdEntityListProp> = ({
                 )}`}
                 key={index}>
                 <div className="tw-flex">
-                  {getEntityIcon(item.index || item.type || '')}
+                  {getEntityIcon(item.type || '')}
                   <Link
                     className="tw-font-medium"
                     to={getEntityLink(
-                      item.index || item.type || '',
-                      item.fullyQualifiedName
+                      item.type || '',
+                      item.fullyQualifiedName as string
                     )}>
                     <Button
                       className="tw-text-grey-body hover:tw-text-primary-hover hover:tw-underline"

--- a/openmetadata-ui/src/main/resources/ui/src/components/MyData/MyData.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MyData/MyData.interface.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { FormattedTableData, SearchDataFunctionType } from 'Models';
+import { EntityReference, SearchDataFunctionType } from 'Models';
 import { FeedFilter } from '../../enums/mydata.enum';
 import { Thread, ThreadType } from '../../generated/entity/feed/thread';
 import { User } from '../../generated/entity/teams/user';
@@ -34,8 +34,8 @@ export interface MyDataProps {
   ownedDataCount: number;
   countPipelines: number;
   userDetails?: User;
-  ownedData: Array<FormattedTableData>;
-  followedData: Array<FormattedTableData>;
+  ownedData: Array<EntityReference>;
+  followedData: Array<EntityReference>;
   feedData: Thread[];
   paging: Paging;
   isFeedLoading: boolean;

--- a/openmetadata-ui/src/main/resources/ui/src/components/MyData/MyData.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MyData/MyData.test.tsx
@@ -19,6 +19,7 @@ import {
   findByText,
   render,
 } from '@testing-library/react';
+import { EntityReference } from 'Models';
 import React, { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { User } from '../../generated/entity/teams/user';
@@ -233,6 +234,16 @@ const mockUserDetails = {
   },
 };
 
+const currentUserMockData = {
+  id: '7b26a534-25e8-4112-ae08-ee059f8918c4',
+  type: 'table',
+  name: 'test_dim_staff',
+  fullyQualifiedName: 'test_sample.test_db.test_dim_staff',
+  description: 'test test_dim_staff',
+  deleted: false,
+  href: 'http://localhost:8585/api/v1/tables/7b26a534-25e8-4112-ae08-ee059f8918c4',
+} as EntityReference;
+
 jest.mock('../../axiosAPIs/miscAPI', () => ({
   searchData: jest
     .fn()
@@ -333,14 +344,14 @@ const mockProp: MyDataProps = {
   feedData: formatDataResponse(mockData.data.hits.hits),
   fetchData: fetchData,
   fetchFeedHandler: mockFetchFeedHandler,
-  followedData: formatDataResponse(mockData.data.hits.hits),
+  followedData: currentUserMockData,
   isFeedLoading: false,
-  ownedData: formatDataResponse(mockData.data.hits.hits),
+  ownedData: currentUserMockData,
   paging: mockPaging,
   postFeedHandler: postFeed,
   userDetails: mockUserDetails as unknown as User,
   updateThreadHandler: jest.fn(),
-};
+} as unknown as MyDataProps;
 
 const mockObserve = jest.fn();
 const mockunObserve = jest.fn();

--- a/openmetadata-ui/src/main/resources/ui/src/components/recently-viewed/RecentlyViewed.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/recently-viewed/RecentlyViewed.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { FormattedTableData } from 'Models';
+import { EntityReference } from 'Models';
 import React, { Fragment, FunctionComponent, useEffect, useState } from 'react';
 import { getRecentlyViewedData, prepareLabel } from '../../utils/CommonUtils';
 import { EntityListWithAntd } from '../EntityList/EntityList';
@@ -19,7 +19,7 @@ import Loader from '../Loader/Loader';
 
 const RecentlyViewed: FunctionComponent = () => {
   const recentlyViewedData = getRecentlyViewedData();
-  const [data, setData] = useState<Array<FormattedTableData>>([]);
+  const [data, setData] = useState<Array<EntityReference>>([]);
   const [isLoading, setIsloading] = useState<boolean>(false);
 
   const prepareData = () => {
@@ -31,11 +31,11 @@ const RecentlyViewed: FunctionComponent = () => {
             serviceType: item.serviceType,
             name: item.displayName || prepareLabel(item.entityType, item.fqn),
             fullyQualifiedName: item.fqn,
-            index: item.entityType,
+            type: item.entityType,
           };
         })
         .filter((item) => item.name);
-      setData(formattedData as unknown as FormattedTableData[]);
+      setData(formattedData as unknown as EntityReference[]);
       setIsloading(false);
     }
   };

--- a/openmetadata-ui/src/main/resources/ui/src/interface/types.d.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/interface/types.d.ts
@@ -491,6 +491,7 @@ declare module 'Models' {
     fqn: string;
     serviceType?: string;
     timestamp: number;
+    id: number;
   }
 
   interface RecentlySearchedData {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DashboardDetailsPage/DashboardDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DashboardDetailsPage/DashboardDetailsPage.component.tsx
@@ -376,6 +376,7 @@ const DashboardDetailsPage = () => {
             fqn: fullyQualifiedName,
             serviceType: serviceType,
             timestamp: 0,
+            id: id,
           });
 
           fetchServiceDetails(service.type, service.name)

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatasetDetailsPage/DatasetDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatasetDetailsPage/DatasetDetailsPage.component.tsx
@@ -369,6 +369,7 @@ const DatasetDetailsPage: FunctionComponent = () => {
             fqn: fullyQualifiedName,
             serviceType: serviceType,
             timestamp: 0,
+            id: id,
           });
           setName(name);
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PipelineDetails/PipelineDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PipelineDetails/PipelineDetailsPage.component.tsx
@@ -317,6 +317,7 @@ const PipelineDetailsPage = () => {
             fqn: fullyQualifiedName,
             serviceType: serviceType,
             timestamp: 0,
+            id: id,
           });
 
           setPipelineUrl(pipelineUrl);

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TopicDetails/TopicDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TopicDetails/TopicDetailsPage.component.tsx
@@ -428,6 +428,7 @@ const TopicDetailsPage: FunctionComponent = () => {
             fqn: fullyQualifiedName,
             serviceType: serviceType,
             timestamp: 0,
+            id: id,
           });
         } else {
           showErrorToast(


### PR DESCRIPTION
Closes #4391 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on issue #4391 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] Improvement


#
### Frontend Preview (Screenshots) :
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/59080942/181737251-9582888f-ef3c-4863-a1f3-8bf36a360bab.png">


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
