### PR TITLE
[ISSUE-5522] Fix profiler timeout

### DIFF
--- a/ingestion/src/metadata/utils/timeout.py
+++ b/ingestion/src/metadata/utils/timeout.py
@@ -65,7 +65,7 @@ def cls_timeout(seconds: int = TEN_MIN):
     """
 
     def inner(cls):
-        for attr_name, attr in inspect.getmembers(cls, inspect.isfunction):
+        for attr_name, attr in inspect.getmembers(cls, inspect.ismethod):
             setattr(cls, attr_name, timeout(seconds)(getattr(cls, attr_name)))
 
         return cls

--- a/ingestion/tests/unit/profiler/test_runner.py
+++ b/ingestion/tests/unit/profiler/test_runner.py
@@ -63,7 +63,6 @@ class RunnerTest(TestCase):
     sample = sampler.random_sample()
 
     raw_runner = QueryRunner(session=session, table=User, sample=sample)
-    
     timeout_runner: Timer = cls_timeout(1)(Timer())
 
     @classmethod

--- a/ingestion/tests/unit/profiler/test_runner.py
+++ b/ingestion/tests/unit/profiler/test_runner.py
@@ -43,13 +43,11 @@ class Timer:
     Helper to test timeouts
     """
 
-    @staticmethod
-    def slow():
+    def slow(self):
         time.sleep(10)
         return 1
 
-    @staticmethod
-    def fast():
+    def fast(self):
         return 1
 
 
@@ -65,7 +63,7 @@ class RunnerTest(TestCase):
     sample = sampler.random_sample()
 
     raw_runner = QueryRunner(session=session, table=User, sample=sample)
-
+    
     timeout_runner: Timer = cls_timeout(1)(Timer())
 
     @classmethod


### PR DESCRIPTION
#5522 

### Describe your changes :
Fixing the profiler timeout not working. When listing the objects we passed as a predicate [isfunction](https://docs.python.org/3/library/inspect.html#inspect.isfunction), which evaluates as true is an object is a function or a lambda. When setting the [QueryRunner](https://github.com/open-metadata/OpenMetadata/blob/aae4410c93a03263c5a6ee755630a7982d4457c5/ingestion/src/metadata/orm_profiler/interfaces/sqa_profiler_interface.py#L137-L145) we are not passing the class itself but rather an instance of the class (we're calling the constructor) so all methods inside the instance will be member(bound) methods. Member methods in python are not considered as functions but rather as [bound methods](https://www.geeksforgeeks.org/bound-methods-python/#:~:text=A%20bound%20method%20is%20the,are%20by%20default%20bound%20methods.) so we were filter everything out. In order to filter them out we need to use [ismethod](https://docs.python.org/3/library/inspect.html#inspect.ismethod) instead.

**EDIT**: After having to fix a test that was relying on static methods (which are not bound to any instance) I have questions on the intention behind the `cls_timeout` decorator: The goal is to modify the class itself or the instances created from the class?

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
N/A

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
Ingestion: @open-metadata/ingestion
