### PR TITLE
Use JSON schema constraints to validate policies and other misc cleanup

### DIFF
--- a/catalog-rest-service/pom.xml
+++ b/catalog-rest-service/pom.xml
@@ -380,7 +380,7 @@
     <dependency>
       <groupId>io.jsonwebtoken</groupId>
       <artifactId>jjwt</artifactId>
-      <version>0.9.1</version>
+      <version>${jjwt.version}</version>
     </dependency>
 
 
@@ -388,14 +388,14 @@
     <dependency>
       <groupId>com.auth0</groupId>
       <artifactId>java-jwt</artifactId>
-      <version>3.19.1</version>
+      <version>${java-jwt.version}</version>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/com.auth0/jwks-rsa -->
     <dependency>
       <groupId>com.auth0</groupId>
       <artifactId>jwks-rsa</artifactId>
-      <version>0.21.1</version>
+      <version>${jwks-rsa.version}</version>
     </dependency>
 
 
@@ -408,7 +408,7 @@
     <dependency>
       <groupId>io.github.artsok</groupId>
       <artifactId>rerunner-jupiter</artifactId>
-      <version>2.1.6</version>
+      <version>${rerunner-jupiter.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -450,6 +450,11 @@
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-server</artifactId>
       <version>9.4.46.v20220331</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-expression</artifactId>
+      <version>${spring-expression.version}</version>
     </dependency>
   </dependencies>
 

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/lineage/LineageResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/lineage/LineageResource.java
@@ -246,5 +246,5 @@ public class LineageResource {
     public EntityInterface getEntity() throws IOException {
       return null;
     }
-  };
+  }
 }

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/security/NoopAuthorizer.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/security/NoopAuthorizer.java
@@ -57,7 +57,9 @@ public class NoopAuthorizer implements Authorizer {
       SecurityContext securityContext,
       OperationContext operationContext,
       ResourceContextInterface resourceContext,
-      boolean allowBots) {}
+      boolean allowBots) {
+    /* Always authorize */
+  }
 
   private void addAnonymousUser() {
     String username = "anonymous";
@@ -90,5 +92,7 @@ public class NoopAuthorizer implements Authorizer {
   }
 
   @Override
-  public void authorizeAdmin(SecurityContext securityContext, boolean allowBots) {}
+  public void authorizeAdmin(SecurityContext securityContext, boolean allowBots) {
+    /* Always authorize */
+  }
 }

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/security/policyevaluator/PolicyEvaluator.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/security/policyevaluator/PolicyEvaluator.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
-import org.jeasy.rules.api.Rule;
 import org.jeasy.rules.api.Rules;
 import org.jeasy.rules.api.RulesEngine;
 import org.jeasy.rules.api.RulesEngineParameters;

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/util/EntityUtil.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/util/EntityUtil.java
@@ -383,7 +383,8 @@ public final class EntityUtil {
     List<Rule> resolvedRules = new ArrayList<>();
     for (Object ruleObject : rules) {
       // Cast to access control policy Rule.
-      resolvedRules.add(JsonUtils.readValue(JsonUtils.getJsonStructure(ruleObject).toString(), Rule.class));
+      resolvedRules.add(
+          JsonUtils.readValueWithValidation(JsonUtils.getJsonStructure(ruleObject).toString(), Rule.class));
     }
     return resolvedRules;
   }

--- a/catalog-rest-service/src/main/resources/json/data/ResourceDescriptors.json
+++ b/catalog-rest-service/src/main/resources/json/data/ResourceDescriptors.json
@@ -1,5 +1,32 @@
 [
   {
+    "name" : "all",
+    "operations" : [
+      "All",
+      "Create",
+      "Delete",
+      "ViewAll",
+      "ViewUsage",
+      "ViewTests",
+      "ViewQueries",
+      "ViewDataProfile",
+      "ViewSampleData",
+      "EditAll",
+      "EditDescription",
+      "EditTags",
+      "EditOwner",
+      "EditTier",
+      "EditCustomFields",
+      "EditLineage",
+      "EditReviewers",
+      "EditTests",
+      "EditQueries",
+      "EditDataProfile",
+      "EditSampleData",
+      "EditUsers"
+    ]
+  },
+  {
     "name" : "bot",
     "operations" : [
       "Create",

--- a/catalog-rest-service/src/main/resources/json/schema/entity/policies/accessControl/resourceDescriptor.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/policies/accessControl/resourceDescriptor.json
@@ -11,6 +11,7 @@
       "description": "This schema defines all possible operations on metadata of entities in OpenMetadata.",
       "type": "string",
       "enum": [
+        "All",
         "Create",
         "Delete",
         "ViewAll",

--- a/catalog-rest-service/src/main/resources/json/schema/entity/policies/accessControl/rule.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/policies/accessControl/rule.json
@@ -7,7 +7,7 @@
   "javaType": "org.openmetadata.catalog.entity.policies.accessControl.Rule",
   "properties": {
     "name": {
-      "description": "Name for this Rule.",
+      "description": "Name of this Rule.",
       "type": "string"
     },
     "fullyQualifiedName": {
@@ -40,8 +40,6 @@
       "default": false
     }
   },
-  "required": [
-    "name"
-  ],
+  "required": ["name", "operation"],
   "additionalProperties": false
 }

--- a/catalog-rest-service/src/main/resources/json/schema/entity/policies/policy.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/policies/policy.json
@@ -105,6 +105,6 @@
       "default": false
     }
   },
-  "required": ["id", "name", "policyType"],
+  "required": ["id", "name", "policyType", "rules"],
   "additionalProperties": false
 }

--- a/catalog-rest-service/src/main/resources/json/schema/type/basic.json
+++ b/catalog-rest-service/src/main/resources/json/schema/type/basic.json
@@ -85,7 +85,7 @@
       "pattern": "^<#E::\\S+::\\S+>$"
     },
     "entityName": {
-      "description": "Name that identifies this dashboard service.",
+      "description": "Name that identifies a entity.",
       "type": "string",
       "minLength": 1,
       "maxLength": 128
@@ -107,7 +107,11 @@
     },
     "markdown": {
       "$comment" : "@om-field-type",
-      "description": "Text in Markdown format",
+      "description": "Text in Markdown format.",
+      "type": "string"
+    },
+    "expression": {
+      "description": "Expression in SpEL.",
       "type": "string"
     },
     "jsonSchema": {

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/policies/PolicyResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/policies/PolicyResourceTest.java
@@ -21,7 +21,6 @@ import static org.openmetadata.catalog.util.TestUtils.UpdateType.MINOR_UPDATE;
 import static org.openmetadata.catalog.util.TestUtils.assertListNotNull;
 import static org.openmetadata.catalog.util.TestUtils.assertListNull;
 import static org.openmetadata.catalog.util.TestUtils.assertResponse;
-import static org.openmetadata.catalog.util.TestUtils.assertResponseContains;
 
 import java.io.IOException;
 import java.net.URI;
@@ -43,7 +42,6 @@ import org.openmetadata.catalog.api.policies.CreatePolicy;
 import org.openmetadata.catalog.entity.data.Location;
 import org.openmetadata.catalog.entity.policies.Policy;
 import org.openmetadata.catalog.entity.policies.accessControl.Rule;
-import org.openmetadata.catalog.exception.CatalogExceptionMessage;
 import org.openmetadata.catalog.resources.EntityResourceTest;
 import org.openmetadata.catalog.resources.locations.LocationResourceTest;
 import org.openmetadata.catalog.resources.policies.PolicyResource.PolicyList;
@@ -136,7 +134,7 @@ public class PolicyResourceTest extends EntityResourceTest<Policy, CreatePolicy>
   void post_AccessControlPolicyWithValidRules_200_ok(TestInfo test) throws IOException {
     List<Rule> rules = new ArrayList<>();
     rules.add(PolicyUtils.accessControlRule(null, null, MetadataOperation.EDIT_DESCRIPTION, true));
-    rules.add(PolicyUtils.accessControlRule(null, null, "DataConsumer", MetadataOperation.EDIT_TAGS, true));
+    rules.add(PolicyUtils.accessControlRule(null, "DataConsumer", MetadataOperation.EDIT_TAGS, true));
     CreatePolicy create = createAccessControlPolicyWithRules(getEntityName(test), rules);
     createAndCheckEntity(create, ADMIN_AUTH_HEADERS);
   }
@@ -149,27 +147,7 @@ public class PolicyResourceTest extends EntityResourceTest<Policy, CreatePolicy>
     List<Rule> rules = new ArrayList<>();
     rules.add(PolicyUtils.accessControlRule(ruleName, null, null, null, true));
     CreatePolicy create = createAccessControlPolicyWithRules(policyName, rules);
-    assertResponse(
-        () -> createEntity(create, ADMIN_AUTH_HEADERS),
-        BAD_REQUEST,
-        CatalogExceptionMessage.invalidPolicyOperationNull(ruleName, policyName));
-  }
-
-  @Test
-  void post_AccessControlPolicyWithDuplicateRules_400_error(TestInfo test) {
-    List<Rule> rules = new ArrayList<>();
-    rules.add(PolicyUtils.accessControlRule("rule1", null, null, MetadataOperation.EDIT_DESCRIPTION, true));
-    rules.add(PolicyUtils.accessControlRule("rule2", null, null, MetadataOperation.EDIT_TAGS, true));
-    rules.add(PolicyUtils.accessControlRule("rule3", null, null, MetadataOperation.EDIT_TAGS, true));
-    String policyName = getEntityName(test);
-    CreatePolicy create = createAccessControlPolicyWithRules(policyName, rules);
-    assertResponseContains(
-        () -> createEntity(create, ADMIN_AUTH_HEADERS),
-        BAD_REQUEST,
-        String.format(
-            "Found multiple rules with operation EditTags within policy %s. "
-                + "Please ensure that operation across all rules within the policy are distinct",
-            policyName));
+    assertResponse(() -> createEntity(create, ADMIN_AUTH_HEADERS), BAD_REQUEST, "[operation must not be null]");
   }
 
   @Test

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -91,7 +91,7 @@
     <dependency>
       <groupId>io.jsonwebtoken</groupId>
       <artifactId>jjwt</artifactId>
-      <version>0.9.1</version>
+      <version>${jjwt.version}</version>
     </dependency>
 
 
@@ -99,14 +99,14 @@
     <dependency>
       <groupId>com.auth0</groupId>
       <artifactId>java-jwt</artifactId>
-      <version>3.19.2</version>
+      <version>${java-jwt.version}</version>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/com.auth0/jwks-rsa -->
     <dependency>
       <groupId>com.auth0</groupId>
       <artifactId>jwks-rsa</artifactId>
-      <version>0.21.1</version>
+      <version>${jwks-rsa.version}</version>
     </dependency>
 
     <!--test dependencies-->

--- a/ingestion-core/src/metadata/_version.py
+++ b/ingestion-core/src/metadata/_version.py
@@ -7,5 +7,5 @@ Provides metadata version information.
 
 from incremental import Version
 
-__version__ = Version("metadata", 0, 12, 0, dev=5)
+__version__ = Version("metadata", 0, 12, 0, dev=6)
 __all__ = ["__version__"]

--- a/openmetadata-core/pom.xml
+++ b/openmetadata-core/pom.xml
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt</artifactId>
-            <version>0.9.1</version>
+            <version>${jjwt.version}</version>
         </dependency>
 
 
@@ -110,14 +110,14 @@
         <dependency>
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
-            <version>3.19.1</version>
+            <version>${java-jwt.version}</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.auth0/jwks-rsa -->
         <dependency>
             <groupId>com.auth0</groupId>
             <artifactId>jwks-rsa</artifactId>
-            <version>0.21.1</version>
+            <version>${jwks-rsa.version}</version>
         </dependency>
 
         <!--test dependencies-->

--- a/openmetadata-ui/pom.xml
+++ b/openmetadata-ui/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>io.github.artsok</groupId>
       <artifactId>rerunner-jupiter</artifactId>
-      <version>2.1.6</version>
+      <version>${rerunner-jupiter.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,11 @@
     <testng.version>7.6.0</testng.version>
     <dropwizard-micrometer.version>2.0.5</dropwizard-micrometer.version>
     <json-schema-validator.version>1.0.70</json-schema-validator.version>
+    <spring-expression.version>5.3.21</spring-expression.version>
+    <java-jwt.version>3.19.2</java-jwt.version>
+    <jwks-rsa.version>0.21.1</jwks-rsa.version>
+    <jjwt.version>0.9.1</jjwt.version>
+    <rerunner-jupiter.version>2.1.6</rerunner-jupiter.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Currently, Policy validation is handcoded because of `anyOf` field in the Policy.json. Making change to use JsonSchema based constraint validation. Also making a few changes in POM.xml to avoid defining the same version numbers, adding SpEL as a dependency, and other changes...

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.
