### PR TITLE
Fixes 6453 -- Changed ometa_service_name to database_service_name

### DIFF
--- a/ingestion/tests/unit/great_expectations/test_ometa_validation_action.py
+++ b/ingestion/tests/unit/great_expectations/test_ometa_validation_action.py
@@ -15,6 +15,7 @@ Test suite for the action module implementation
 import os
 from unittest import mock
 
+import pytest
 from jinja2 import Environment
 from pytest import mark
 
@@ -35,6 +36,27 @@ def test_get_table_entity(input, expected, mocked_ometa, mocked_ge_data_context)
         data_context=mocked_ge_data_context,
         config_file_path="my/config/path",
         ometa_service_name=input,
+    )
+
+    res = ometa_validation._get_table_entity("database", "schema", "table")
+    assert res._type == expected
+
+
+@mark.parametrize(
+    "input,expected",
+    [
+        (None, "list_entities"),
+        ("service_name", "get_by_name"),
+    ],
+)
+def test_get_table_entity_database_service_name(
+    input, expected, mocked_ometa, mocked_ge_data_context
+):
+    """Test get table entity"""
+    ometa_validation = OpenMetadataValidationAction(
+        data_context=mocked_ge_data_context,
+        config_file_path="my/config/path",
+        database_service_name=input,
     )
 
     res = ometa_validation._get_table_entity("database", "schema", "table")


### PR DESCRIPTION
### Describe your changes :
Fixes #6453 by changing ometa_service_name to database_service_name. This is a backward compatible change. Using `ometa_service_name` will throw a deprecation warning.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
Ingestion: @open-metadata/ingestion
