### PR TITLE
Fixes #6476 -- Multiple db connections opened

### DIFF
--- a/ingestion/src/metadata/orm_profiler/interfaces/sqa_profiler_interface.py
+++ b/ingestion/src/metadata/orm_profiler/interfaces/sqa_profiler_interface.py
@@ -60,7 +60,8 @@ class SQAProfilerInterface(InterfaceProtocol):
         self._runner = None
         self._thread_count = thread_count
         self.service_connection_config = service_connection_config
-        self.session: Session = self._session_factory()
+        self.session_factory = self._session_factory()
+        self.session: Session = self.session_factory()
 
     @property
     def sample(self):
@@ -85,7 +86,7 @@ class SQAProfilerInterface(InterfaceProtocol):
     def _session_factory(self):
         """Create thread safe session"""
         engine = get_connection(self.service_connection_config)
-        return create_and_bind_thread_safe_session(engine)()
+        return create_and_bind_thread_safe_session(engine)
 
     def _create_thread_safe_sampler(
         self, session, table, profile_sample, partition_details, profile_sample_query
@@ -132,7 +133,8 @@ class SQAProfilerInterface(InterfaceProtocol):
         logger.debug(
             f"Running profiler for {table.__tablename__} on thread {threading.current_thread()}"
         )
-        session = self._session_factory()
+        Session = self.session_factory
+        session = Session()
         sampler = self._create_thread_safe_sampler(
             session, table, profile_sample, partition_details, profile_sample_query
         )

--- a/ingestion/src/metadata/orm_profiler/interfaces/sqa_profiler_interface.py
+++ b/ingestion/src/metadata/orm_profiler/interfaces/sqa_profiler_interface.py
@@ -84,7 +84,9 @@ class SQAProfilerInterface(InterfaceProtocol):
         return self._sampler
 
     def _session_factory(self):
-        """Create thread safe session"""
+        """Create thread safe session that will be automatically
+        garbage collected once the application thread ends
+        """
         engine = get_connection(self.service_connection_config)
         return create_and_bind_thread_safe_session(engine)
 

--- a/ingestion/src/metadata/utils/connections.py
+++ b/ingestion/src/metadata/utils/connections.py
@@ -157,6 +157,7 @@ def create_generic_connection(connection, verbose: bool = False) -> Engine:
         connect_args=get_connection_args(connection),
         pool_reset_on_return=None,  # https://docs.sqlalchemy.org/en/14/core/pooling.html#reset-on-return
         echo=verbose,
+        max_overflow=-1
     )
     listen(engine, "before_cursor_execute", inject_query_header, retval=True)
 

--- a/ingestion/src/metadata/utils/connections.py
+++ b/ingestion/src/metadata/utils/connections.py
@@ -157,7 +157,7 @@ def create_generic_connection(connection, verbose: bool = False) -> Engine:
         connect_args=get_connection_args(connection),
         pool_reset_on_return=None,  # https://docs.sqlalchemy.org/en/14/core/pooling.html#reset-on-return
         echo=verbose,
-        max_overflow=-1
+        max_overflow=-1,
     )
     listen(engine, "before_cursor_execute", inject_query_header, retval=True)
 

--- a/ingestion/src/metadata/utils/connections.py
+++ b/ingestion/src/metadata/utils/connections.py
@@ -28,6 +28,7 @@ from sqlalchemy.event import listen
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.orm.session import Session
+from sqlalchemy.pool import QueuePool
 
 from metadata.generated.schema.entity.services.connections.connectionBasicType import (
     ConnectionArguments,
@@ -155,6 +156,7 @@ def create_generic_connection(connection, verbose: bool = False) -> Engine:
     engine = create_engine(
         get_connection_url(connection),
         connect_args=get_connection_args(connection),
+        poolclass=QueuePool,
         pool_reset_on_return=None,  # https://docs.sqlalchemy.org/en/14/core/pooling.html#reset-on-return
         echo=verbose,
         max_overflow=-1,


### PR DESCRIPTION
### Describe your changes :
Fixes #6476 by changing how scoped_session factory is created. `max_overflow=-1` is set to allow infinite connection creation (though the pool has a set limit of 5). This should allow room for slight lag between connections release and connection creation (between python and the db).

When testing against redshift and mysql opened connections remained stable.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
Ingestion: @open-metadata/ingestion
