### PR TITLE
fix(ui): notify auth provider for login failed event

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/authentication/auth-provider/AuthProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/authentication/auth-provider/AuthProvider.tsx
@@ -557,6 +557,7 @@ export const AuthProvider = ({
           <MsalProvider instance={msalInstance}>
             <MsalAuthenticator
               ref={authenticatorRef}
+              onLoginFailure={handleFailedLogin}
               onLoginSuccess={handleSuccessfulLogin}
               onLogoutSuccess={handleSuccessfulLogout}>
               {children}

--- a/openmetadata-ui/src/main/resources/ui/src/authentication/authenticators/MsalAuthenticator.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/authentication/authenticators/MsalAuthenticator.test.tsx
@@ -30,10 +30,12 @@ describe('Test MsalAuthenticator component', () => {
   it('Checks if the MsalAuthenticator renders', async () => {
     const onLogoutMock = jest.fn();
     const onLoginMock = jest.fn();
+    const onFailedLoginMock = jest.fn();
     const authenticatorRef = null;
     render(
       <MsalAuthenticator
         ref={authenticatorRef}
+        onLoginFailure={onFailedLoginMock}
         onLoginSuccess={onLoginMock}
         onLogoutSuccess={onLogoutMock}>
         <p data-testid="children" />

--- a/openmetadata-ui/src/main/resources/ui/src/authentication/authenticators/MsalAuthenticator.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/authentication/authenticators/MsalAuthenticator.tsx
@@ -13,6 +13,7 @@
 
 import { InteractionStatus } from '@azure/msal-browser';
 import { useAccount, useIsAuthenticated, useMsal } from '@azure/msal-react';
+import { AxiosError } from 'axios';
 import React, {
   forwardRef,
   Fragment,
@@ -32,11 +33,15 @@ import {
 interface Props {
   children: ReactNode;
   onLoginSuccess: (user: OidcUser) => void;
+  onLoginFailure: (error: AxiosError) => void;
   onLogoutSuccess: () => void;
 }
 
 const MsalAuthenticator = forwardRef<AuthenticatorRef, Props>(
-  ({ children, onLoginSuccess, onLogoutSuccess }: Props, ref) => {
+  (
+    { children, onLoginSuccess, onLogoutSuccess, onLoginFailure }: Props,
+    ref
+  ) => {
     const { setIsAuthenticated, loading, setLoadingIndicator } =
       useAuthContext();
     const { instance, accounts, inProgress } = useMsal();
@@ -115,6 +120,7 @@ const MsalAuthenticator = forwardRef<AuthenticatorRef, Props>(
                 onLoginSuccess(user as OidcUser);
               }
             })
+            .catch(onLoginFailure)
             .finally(() => {
               if (loading) {
                 setLoadingIndicator(false);


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the ..... because ...

Closes: #6483 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @open-metadata/ui
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
