### PR TITLE
Do 'mvn clean install' when running security-scan GH workflow

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -54,7 +54,7 @@ jobs:
           make install_all install_apis
 
       - name: Maven build
-        run: mvn -DskipTests clean package
+        run: mvn -DskipTests clean install
 
       - name: Run Scan
         run: |


### PR DESCRIPTION
### Describe your changes :
Security scan GH workflow fails with the following error:

![image](https://user-images.githubusercontent.com/11074908/182222923-42e059c2-3611-435e-84b2-4aff05008634.png)

We are doing `mvn -DskipTests clean install` before running the security scan which does not put the package in the local repository.

### Type of change :
- [x] Bug fix

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

### Reviewers
Ingestion: @open-metadata/ingestion
