### PR TITLE
Fix #6497 UI : Replace arrow with `Read more` text

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/rich-text-editor/BlurLayout.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/rich-text-editor/BlurLayout.test.tsx
@@ -102,4 +102,26 @@ describe('Test BlurLayout Component', () => {
 
     expect(displayMoreHandler).toBeCalled();
   });
+
+  it('Should toggle between `Read more` and `Read less` when button click', async () => {
+    const { container } = render(<BlurLayout {...mockProp} />, {
+      wrapper: MemoryRouter,
+    });
+
+    const blurLayout = await findByTestId(container, 'blur-layout');
+
+    const displayButton = await findByTestId(container, 'display-button');
+
+    expect(blurLayout).toBeInTheDocument();
+
+    expect(displayButton).toBeInTheDocument();
+
+    // default will be `Read more`
+    expect(displayButton).toHaveTextContent('Read more');
+
+    fireEvent.click(displayButton);
+
+    // after click text should be `Read less`
+    expect(displayButton).toHaveTextContent('Read less');
+  });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/rich-text-editor/BlurLayout.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/rich-text-editor/BlurLayout.test.tsx
@@ -104,9 +104,12 @@ describe('Test BlurLayout Component', () => {
   });
 
   it('Should toggle between `Read more` and `Read less` when button click', async () => {
-    const { container } = render(<BlurLayout {...mockProp} />, {
-      wrapper: MemoryRouter,
-    });
+    const { container } = render(
+      <BlurLayout {...mockProp} displayMoreText={false} />,
+      {
+        wrapper: MemoryRouter,
+      }
+    );
 
     const blurLayout = await findByTestId(container, 'blur-layout');
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/rich-text-editor/BlurLayout.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/rich-text-editor/BlurLayout.test.tsx
@@ -98,33 +98,10 @@ describe('Test BlurLayout Component', () => {
 
     expect(displayButton).toBeInTheDocument();
 
+    expect(displayButton).toHaveTextContent('Read less');
+
     fireEvent.click(displayButton);
 
     expect(displayMoreHandler).toBeCalled();
-  });
-
-  it('Should toggle between `Read more` and `Read less` when button click', async () => {
-    const { container } = render(
-      <BlurLayout {...mockProp} displayMoreText={false} />,
-      {
-        wrapper: MemoryRouter,
-      }
-    );
-
-    const blurLayout = await findByTestId(container, 'blur-layout');
-
-    const displayButton = await findByTestId(container, 'display-button');
-
-    expect(blurLayout).toBeInTheDocument();
-
-    expect(displayButton).toBeInTheDocument();
-
-    // default will be `Read more`
-    expect(displayButton).toHaveTextContent('Read more');
-
-    fireEvent.click(displayButton);
-
-    // after click text should be `Read less`
-    expect(displayButton).toHaveTextContent('Read less');
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/rich-text-editor/BlurLayout.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/rich-text-editor/BlurLayout.tsx
@@ -13,7 +13,6 @@
 
 import classNames from 'classnames';
 import React, { FC } from 'react';
-import SVGIcons, { Icons } from '../../../utils/SvgUtils';
 import { MAX_LENGTH } from './RichTextEditorPreviewer';
 
 interface BlurLayoutProp {
@@ -51,12 +50,7 @@ export const BlurLayout: FC<BlurLayoutProp> = ({
         data-testid="display-button"
         onClick={displayMoreHandler}>
         <span className="tw-flex tw-items-center tw-gap-2">
-          <SVGIcons
-            alt="expand-collapse"
-            className={classNames({ 'rotate-inverse': displayMoreText })}
-            icon={Icons.CHEVRON_DOWN}
-            width="32"
-          />
+          {displayMoreText ? 'Read less' : 'Read more'}
         </span>
       </p>
     </div>


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on issue #6497

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] Improvement


#
### Frontend Preview (Screenshots) :

https://user-images.githubusercontent.com/59080942/182307696-9dd7a9b5-9e31-4578-890c-a724319e1aa0.mov



#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
