### PR TITLE
Clean col-level lineage internal logic

### DIFF
--- a/ingestion/src/metadata/ingestion/lineage/sql_lineage.py
+++ b/ingestion/src/metadata/ingestion/lineage/sql_lineage.py
@@ -364,6 +364,8 @@ def get_lineage_via_table_entity(
 
     # Reverting changes after import is done
     DictConfigurator.configure = configure
+    column_lineage = {}
+
     try:
         parser = LineageRunner(query)
         to_table_name = table_entity.name.__root__
@@ -377,6 +379,7 @@ def get_lineage_via_table_entity(
                 database_name=database_name,
                 schema_name=schema_name,
                 query=query,
+                column_lineage_map=column_lineage,
             ) or []
     except Exception:  # pylint: disable=broad-except
         logger.warn("Failed to create view lineage")

--- a/ingestion/src/metadata/ingestion/lineage/sql_lineage.py
+++ b/ingestion/src/metadata/ingestion/lineage/sql_lineage.py
@@ -176,6 +176,7 @@ def _build_table_lineage(
     from_table_raw_name: str,
     to_table_raw_name: str,
     query: str,
+    column_lineage_map: dict,
 ) -> Optional[Iterator[AddLineageRequest]]:
     """
     Prepare the lineage request generator
@@ -185,6 +186,7 @@ def _build_table_lineage(
         to_table_raw_name=str(to_table_raw_name),
         from_entity=from_entity,
         from_table_raw_name=str(from_table_raw_name),
+        column_lineage_map=column_lineage_map,
     )
     lineage_details = None
     if col_lineage:

--- a/ingestion/src/metadata/ingestion/lineage/sql_lineage.py
+++ b/ingestion/src/metadata/ingestion/lineage/sql_lineage.py
@@ -152,7 +152,7 @@ def get_column_lineage(
     from_entity: Table,
     to_table_raw_name: str,
     from_table_raw_name: str,
-    column_lineage_map: dict
+    column_lineage_map: dict,
 ) -> List[ColumnLineage]:
     column_lineage = []
     if column_lineage_map.get(to_table_raw_name) and column_lineage_map.get(
@@ -215,7 +215,7 @@ def _create_lineage_by_table_name(
     database_name: Optional[str],
     schema_name: Optional[str],
     query: str,
-    column_lineage_map: dict
+    column_lineage_map: dict,
 ) -> Optional[Iterable[AddLineageRequest]]:
     """
     This method is to create a lineage between two tables
@@ -247,7 +247,7 @@ def _create_lineage_by_table_name(
                     from_table_raw_name=from_table,
                     query=query,
                     from_table_raw_name=str(from_table),
-                    column_lineage_map=column_lineage_map
+                    column_lineage_map=column_lineage_map,
                 )
 
     except Exception as err:
@@ -316,7 +316,7 @@ def get_lineage_by_query(
                     database_name=database_name,
                     schema_name=schema_name,
                     query=query,
-                    column_lineage_map=column_lineage
+                    column_lineage_map=column_lineage,
                 )
             for target_table in result.target_tables:
                 yield from _create_lineage_by_table_name(
@@ -327,7 +327,7 @@ def get_lineage_by_query(
                     database_name=database_name,
                     schema_name=schema_name,
                     query=query,
-                    column_lineage_map=column_lineage
+                    column_lineage_map=column_lineage,
                 )
         if not result.intermediate_tables:
             for target_table in result.target_tables:
@@ -340,7 +340,7 @@ def get_lineage_by_query(
                         database_name=database_name,
                         schema_name=schema_name,
                         query=query,
-                        column_lineage_map=column_lineage
+                        column_lineage_map=column_lineage,
                     )
     except Exception as err:
         logger.debug(str(err))

--- a/ingestion/src/metadata/ingestion/lineage/sql_lineage.py
+++ b/ingestion/src/metadata/ingestion/lineage/sql_lineage.py
@@ -13,7 +13,7 @@ Helper functions to handle SQL lineage operations
 """
 import traceback
 from logging.config import DictConfigurator
-from typing import Any, Iterator, List, Optional, Iterable
+from typing import Any, Iterable, Iterator, List, Optional
 
 from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
 from metadata.generated.schema.entity.data.table import Table
@@ -246,7 +246,6 @@ def _create_lineage_by_table_name(
                     to_table_raw_name=to_table,
                     from_table_raw_name=from_table,
                     query=query,
-                    from_table_raw_name=str(from_table),
                     column_lineage_map=column_lineage_map,
                 )
 

--- a/ingestion/tests/unit/test_sql_lineage.py
+++ b/ingestion/tests/unit/test_sql_lineage.py
@@ -12,12 +12,18 @@
 """
 sql lineage utils tests
 """
-
-from unittest import TestCase
-
-from sqllineage.runner import LineageRunner
-
 from metadata.utils.sql_lineage import populate_column_lineage_map
+from unittest import TestCase
+from sqllineage.runner import LineageRunner
+from logging.config import DictConfigurator
+# Prevent sqllineage from modifying the logger config
+# Disable the DictConfigurator.configure method while importing LineageRunner
+configure = DictConfigurator.configure
+DictConfigurator.configure = lambda _: None
+
+# Reverting changes after import is done
+DictConfigurator.configure = configure
+
 
 QUERY = [
     "CREATE TABLE MYTABLE2 AS SELECT * FROM MYTABLE1;",

--- a/ingestion/tests/unit/test_sql_lineage.py
+++ b/ingestion/tests/unit/test_sql_lineage.py
@@ -1,0 +1,36 @@
+#  Copyright 2021 Collate
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+sql lineage utils tests
+"""
+
+from unittest import TestCase
+
+from sqllineage.runner import LineageRunner
+
+from metadata.utils.sql_lineage import populate_column_lineage_map
+
+QUERY = """create view test2 as
+SELECT brand_id
+FROM production.brands;"""
+
+EXPECTED_LINEAGE_MAP = {
+    "<default>.test2": {"production.brands": [("brand_id", "brand_id")]}
+}
+
+
+class SqlLineageTest(TestCase):
+    def test_populate_column_lineage_map(self):
+        result = LineageRunner(QUERY)
+        raw_column_lineage = result.get_column_lineage()
+        lineage_map = populate_column_lineage_map(raw_column_lineage)
+        self.assertEqual(lineage_map, EXPECTED_LINEAGE_MAP)

--- a/ingestion/tests/unit/test_sql_lineage.py
+++ b/ingestion/tests/unit/test_sql_lineage.py
@@ -17,7 +17,7 @@ from unittest import TestCase
 
 from sqllineage.runner import LineageRunner
 
-from metadata.utils.sql_lineage import populate_column_lineage_map
+from metadata.ingestion.lineage.sql_lineage import populate_column_lineage_map
 
 # Prevent sqllineage from modifying the logger config
 # Disable the DictConfigurator.configure method while importing LineageRunner

--- a/ingestion/tests/unit/test_sql_lineage.py
+++ b/ingestion/tests/unit/test_sql_lineage.py
@@ -12,10 +12,13 @@
 """
 sql lineage utils tests
 """
-from metadata.utils.sql_lineage import populate_column_lineage_map
-from unittest import TestCase
-from sqllineage.runner import LineageRunner
 from logging.config import DictConfigurator
+from unittest import TestCase
+
+from sqllineage.runner import LineageRunner
+
+from metadata.utils.sql_lineage import populate_column_lineage_map
+
 # Prevent sqllineage from modifying the logger config
 # Disable the DictConfigurator.configure method while importing LineageRunner
 configure = DictConfigurator.configure


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
`get_lineage_by_query` function uses a global dict to handle the columns, which is not great.
I worked on improving this logic.
Fix: #5789 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement

### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
