### PR TITLE
Fix(UI): Increase size param for teams search by query api

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/TeamsSelectable/TeamsSelectable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TeamsSelectable/TeamsSelectable.tsx
@@ -15,7 +15,6 @@ import { SelectableOption } from 'Models';
 import React, { useState } from 'react';
 import AsyncSelect from 'react-select/async';
 import { getSuggestedTeams, getTeamsByQuery } from '../../axiosAPIs/miscAPI';
-import { PAGE_SIZE } from '../../constants/constants';
 import { Team } from '../../generated/entity/teams/team';
 import { EntityReference } from '../../generated/type/entityReference';
 import { formatTeamsResponse } from '../../utils/APIUtils';
@@ -33,6 +32,8 @@ interface Props {
   filterJoinable?: boolean;
   placeholder?: string;
 }
+
+const TEAM_OPTION_PAGE_LIMIT = 100;
 
 const TeamsSelectable = ({
   showTeamsAlert,
@@ -71,7 +72,7 @@ const TeamsSelectable = ({
         getTeamsByQuery({
           q: '*',
           from: 0,
-          size: PAGE_SIZE,
+          size: TEAM_OPTION_PAGE_LIMIT,
           isJoinable: filterJoinable,
         }).then((res) => {
           const teams: Team[] =


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the TeamsSelectable component to increase the size parameter for search/query api call

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<p align="center">
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @open-metadata/ui
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
