### PR TITLE
fix(ui): for use signin we should try fallback popup login

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/login/index.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/login/index.tsx
@@ -12,11 +12,9 @@
  */
 
 import jwtDecode, { JwtPayload } from 'jwt-decode';
-import { isEmpty } from 'lodash';
 import { observer } from 'mobx-react';
 import React, { useEffect, useMemo } from 'react';
 import { useHistory } from 'react-router-dom';
-import appState from '../../AppState';
 import loginBG from '../../assets/img/login-bg.png';
 import { useAuthContext } from '../../authentication/auth-provider/AuthProvider';
 import Loader from '../../components/Loader/Loader';
@@ -28,11 +26,16 @@ import LoginCarousel from './LoginCarousel';
 
 const SigninPage = () => {
   const history = useHistory();
-  const { isAuthDisabled, authConfig, onLoginHandler, onLogoutHandler } =
-    useAuthContext();
+  const {
+    isAuthDisabled,
+    authConfig,
+    onLoginHandler,
+    onLogoutHandler,
+    isAuthenticated,
+  } = useAuthContext();
   const isAlreadyLoggedIn = useMemo(() => {
-    return isAuthDisabled || !isEmpty(appState.userDetails);
-  }, [isAuthDisabled, appState.userDetails]);
+    return isAuthDisabled || isAuthenticated;
+  }, [isAuthDisabled, isAuthenticated]);
 
   const isTokenExpired = () => {
     const token = localStorage.getItem(oidcTokenKey);

--- a/openmetadata-ui/src/main/resources/ui/src/pages/signup/index.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/signup/index.tsx
@@ -17,6 +17,7 @@ import { UserProfile } from 'Models';
 import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import appState from '../../AppState';
+import { useAuthContext } from '../../authentication/auth-provider/AuthProvider';
 import { getLoggedInUserPermissions } from '../../axiosAPIs/miscAPI';
 import { createUser } from '../../axiosAPIs/userAPI';
 import { Button } from '../../components/buttons/Button/Button';
@@ -42,6 +43,7 @@ const Signup = () => {
     name: getNameFromEmail(appState.newUser.email),
     email: appState.newUser.email || '',
   });
+  const { setIsSigningIn } = useAuthContext();
 
   const history = useHistory();
 
@@ -73,6 +75,7 @@ const Signup = () => {
           fetchAllUsers();
           getUserPermissions();
           cookieStorage.removeItem(REDIRECT_PATHNAME);
+          setIsSigningIn(false);
           history.push(ROUTES.HOME);
         } else {
           setLoading(false);


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the infinite loop issue for azure sso.
Also fixed redirection based on isAuthenticated instead of userDetails


**Issue**

If user try login after a while app goes to infinite loading.

**Fix**

For azure auth we only leveraged on `ssoSilent`.  Where as per [doc](https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-js-sso#using-an-account-object) we need to have fallback to `loginPopup` as well

@harshach Unable to replicate exact case yet, Trying to have reproducible steps to get exact details but this is potential fix that needed to Azure auth.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @open-metadata/ui
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
