### PR TITLE
Fix(Ui): Fixed the teams search irrelevant  suggestions issue

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/axiosAPIs/miscAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/axiosAPIs/miscAPI.ts
@@ -151,7 +151,14 @@ export const getTeamsByQuery = async (params: {
   isJoinable?: boolean;
 }) => {
   const response = await APIClient.get(`/search/query`, {
-    params: { index: SearchIndex.TEAM, ...params },
+    params: {
+      index: SearchIndex.TEAM,
+      ...params,
+      // eslint-disable-next-line @typescript-eslint/camelcase
+      sort_field: 'name.keyword',
+      // eslint-disable-next-line @typescript-eslint/camelcase
+      sort_order: 'asc',
+    },
   });
 
   return response.data;

--- a/openmetadata-ui/src/main/resources/ui/src/components/TeamsSelectable/TeamsSelectable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TeamsSelectable/TeamsSelectable.tsx
@@ -14,10 +14,9 @@
 import { SelectableOption } from 'Models';
 import React, { useState } from 'react';
 import AsyncSelect from 'react-select/async';
-import { getSuggestedTeams, getTeamsByQuery } from '../../axiosAPIs/miscAPI';
+import { getTeamsByQuery } from '../../axiosAPIs/miscAPI';
 import { Team } from '../../generated/entity/teams/team';
 import { EntityReference } from '../../generated/type/entityReference';
-import { formatTeamsResponse } from '../../utils/APIUtils';
 import { getEntityName } from '../../utils/CommonUtils';
 import SVGIcons from '../../utils/SvgUtils';
 import { reactSingleSelectCustomStyle } from '../common/react-select-component/reactSelectCustomStyle';
@@ -61,26 +60,18 @@ const TeamsSelectable = ({
 
   const loadOptions = (text: string) => {
     return new Promise<SelectableOption[]>((resolve) => {
-      if (text) {
-        getSuggestedTeams(text).then((res) => {
-          const teams: Team[] = formatTeamsResponse(
-            res.data.suggest['metadata-suggest'][0].options
-          );
-          resolve(getOptions(teams));
-        });
-      } else {
-        getTeamsByQuery({
-          q: '*',
-          from: 0,
-          size: TEAM_OPTION_PAGE_LIMIT,
-          isJoinable: filterJoinable,
-        }).then((res) => {
-          const teams: Team[] =
-            res.hits.hits.map((t: { _source: Team }) => t._source) || [];
-          showTeamsAlert && setNoTeam(teams.length === 0);
-          resolve(getOptions(teams));
-        });
-      }
+      const trimmedText = text.trim();
+      getTeamsByQuery({
+        q: trimmedText ? `*${trimmedText}*` : '*',
+        from: 0,
+        size: TEAM_OPTION_PAGE_LIMIT,
+        isJoinable: filterJoinable,
+      }).then((res) => {
+        const teams: Team[] =
+          res.hits.hits.map((t: { _source: Team }) => t._source) || [];
+        showTeamsAlert && setNoTeam(teams.length === 0);
+        resolve(getOptions(teams));
+      });
     });
   };
 


### PR DESCRIPTION

### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the issue where the suggestions shown in the dropdown while creating a user when searched with some input were not showing proper teams.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [] Improvement
- [] New feature
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">
<img width="979" alt="Screenshot 2022-08-02 at 7 59 00 PM" src="https://user-images.githubusercontent.com/51777795/182399549-7d72e5fc-42fc-48bb-8987-19902062fc09.png">

</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @open-metadata/ui
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
