### PR TITLE
Fix#5917: Stop saving connection service configuration parameters when secret manager is configured

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/DashboardServiceRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/DashboardServiceRepository.java
@@ -15,6 +15,7 @@ package org.openmetadata.catalog.jdbi3;
 
 import org.openmetadata.catalog.Entity;
 import org.openmetadata.catalog.entity.services.DashboardService;
+import org.openmetadata.catalog.entity.services.ServiceType;
 import org.openmetadata.catalog.resources.services.dashboard.DashboardServiceResource;
 import org.openmetadata.catalog.secrets.SecretsManager;
 import org.openmetadata.catalog.type.DashboardConnection;
@@ -28,7 +29,8 @@ public class DashboardServiceRepository extends ServiceRepository<DashboardServi
         dao,
         dao.dashboardServiceDAO(),
         secretsManager,
-        DashboardConnection.class);
+        DashboardConnection.class,
+        ServiceType.DASHBOARD);
   }
 
   @Override

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/DatabaseServiceRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/DatabaseServiceRepository.java
@@ -16,6 +16,7 @@ package org.openmetadata.catalog.jdbi3;
 import org.openmetadata.catalog.Entity;
 import org.openmetadata.catalog.api.services.DatabaseConnection;
 import org.openmetadata.catalog.entity.services.DatabaseService;
+import org.openmetadata.catalog.entity.services.ServiceType;
 import org.openmetadata.catalog.resources.services.database.DatabaseServiceResource;
 import org.openmetadata.catalog.secrets.SecretsManager;
 
@@ -27,7 +28,8 @@ public class DatabaseServiceRepository extends ServiceRepository<DatabaseService
         dao,
         dao.dbServiceDAO(),
         secretsManager,
-        DatabaseConnection.class);
+        DatabaseConnection.class,
+        ServiceType.DATABASE);
   }
 
   @Override

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/MessagingServiceRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/MessagingServiceRepository.java
@@ -15,6 +15,7 @@ package org.openmetadata.catalog.jdbi3;
 
 import org.openmetadata.catalog.Entity;
 import org.openmetadata.catalog.entity.services.MessagingService;
+import org.openmetadata.catalog.entity.services.ServiceType;
 import org.openmetadata.catalog.resources.services.messaging.MessagingServiceResource;
 import org.openmetadata.catalog.secrets.SecretsManager;
 import org.openmetadata.catalog.type.MessagingConnection;
@@ -30,7 +31,8 @@ public class MessagingServiceRepository extends ServiceRepository<MessagingServi
         dao.messagingServiceDAO(),
         secretsManager,
         MessagingConnection.class,
-        UPDATE_FIELDS);
+        UPDATE_FIELDS,
+        ServiceType.MESSAGING);
   }
 
   @Override

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/MlModelServiceRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/MlModelServiceRepository.java
@@ -15,6 +15,7 @@ package org.openmetadata.catalog.jdbi3;
 
 import org.openmetadata.catalog.Entity;
 import org.openmetadata.catalog.entity.services.MlModelService;
+import org.openmetadata.catalog.entity.services.ServiceType;
 import org.openmetadata.catalog.resources.services.mlmodel.MlModelServiceResource;
 import org.openmetadata.catalog.secrets.SecretsManager;
 import org.openmetadata.catalog.type.MlModelConnection;
@@ -30,7 +31,8 @@ public class MlModelServiceRepository extends ServiceRepository<MlModelService, 
         dao.mlModelServiceDAO(),
         secretsManager,
         MlModelConnection.class,
-        UPDATE_FIELDS);
+        UPDATE_FIELDS,
+        ServiceType.ML_MODEL);
   }
 
   @Override

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/PipelineServiceRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/PipelineServiceRepository.java
@@ -15,6 +15,7 @@ package org.openmetadata.catalog.jdbi3;
 
 import org.openmetadata.catalog.Entity;
 import org.openmetadata.catalog.entity.services.PipelineService;
+import org.openmetadata.catalog.entity.services.ServiceType;
 import org.openmetadata.catalog.resources.services.pipeline.PipelineServiceResource;
 import org.openmetadata.catalog.secrets.SecretsManager;
 import org.openmetadata.catalog.type.PipelineConnection;
@@ -28,7 +29,8 @@ public class PipelineServiceRepository extends ServiceRepository<PipelineService
         dao,
         dao.pipelineServiceDAO(),
         secretsManager,
-        PipelineConnection.class);
+        PipelineConnection.class,
+        ServiceType.PIPELINE);
   }
 
   @Override

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/ServiceEntityResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/ServiceEntityResource.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import javax.ws.rs.core.SecurityContext;
 import org.openmetadata.catalog.ServiceConnectionEntityInterface;
 import org.openmetadata.catalog.ServiceEntityInterface;
+import org.openmetadata.catalog.entity.services.ServiceType;
 import org.openmetadata.catalog.jdbi3.ServiceRepository;
 import org.openmetadata.catalog.resources.EntityResource;
 import org.openmetadata.catalog.secrets.SecretsManager;
@@ -18,10 +19,17 @@ public abstract class ServiceEntityResource<
 
   private final SecretsManager secretsManager;
 
+  private final ServiceType serviceType;
+
   protected ServiceEntityResource(
-      Class<T> entityClass, R serviceRepository, Authorizer authorizer, SecretsManager secretsManager) {
+      Class<T> entityClass,
+      R serviceRepository,
+      Authorizer authorizer,
+      SecretsManager secretsManager,
+      ServiceType serviceType) {
     super(entityClass, serviceRepository, authorizer);
     this.secretsManager = secretsManager;
+    this.serviceType = serviceType;
   }
 
   protected T decryptOrNullify(SecurityContext securityContext, T service) {
@@ -30,8 +38,11 @@ public abstract class ServiceEntityResource<
     } catch (AuthorizationException e) {
       return nullifyConnection(service);
     }
-    secretsManager.encryptOrDecryptServiceConnection(
-        service.getConnection(), extractServiceType(service), service.getName(), false);
+    service
+        .getConnection()
+        .setConfig(
+            secretsManager.encryptOrDecryptServiceConnectionConfig(
+                service.getConnection(), extractServiceType(service), service.getName(), serviceType, false));
     return service;
   }
 

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/ServiceEntityResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/ServiceEntityResource.java
@@ -42,7 +42,11 @@ public abstract class ServiceEntityResource<
         .getConnection()
         .setConfig(
             secretsManager.encryptOrDecryptServiceConnectionConfig(
-                service.getConnection(), extractServiceType(service), service.getName(), serviceType, false));
+                service.getConnection().getConfig(),
+                extractServiceType(service),
+                service.getName(),
+                serviceType,
+                false));
     return service;
   }
 

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/dashboard/DashboardServiceResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/dashboard/DashboardServiceResource.java
@@ -45,6 +45,7 @@ import javax.ws.rs.core.UriInfo;
 import org.openmetadata.catalog.Entity;
 import org.openmetadata.catalog.api.services.CreateDashboardService;
 import org.openmetadata.catalog.entity.services.DashboardService;
+import org.openmetadata.catalog.entity.services.ServiceType;
 import org.openmetadata.catalog.jdbi3.CollectionDAO;
 import org.openmetadata.catalog.jdbi3.DashboardServiceRepository;
 import org.openmetadata.catalog.jdbi3.ListFilter;
@@ -77,7 +78,12 @@ public class DashboardServiceResource
   }
 
   public DashboardServiceResource(CollectionDAO dao, Authorizer authorizer, SecretsManager secretsManager) {
-    super(DashboardService.class, new DashboardServiceRepository(dao, secretsManager), authorizer, secretsManager);
+    super(
+        DashboardService.class,
+        new DashboardServiceRepository(dao, secretsManager),
+        authorizer,
+        secretsManager,
+        ServiceType.DASHBOARD);
   }
 
   public static class DashboardServiceList extends ResultList<DashboardService> {

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/database/DatabaseServiceResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/database/DatabaseServiceResource.java
@@ -45,6 +45,7 @@ import org.openmetadata.catalog.Entity;
 import org.openmetadata.catalog.api.services.CreateDatabaseService;
 import org.openmetadata.catalog.api.services.DatabaseConnection;
 import org.openmetadata.catalog.entity.services.DatabaseService;
+import org.openmetadata.catalog.entity.services.ServiceType;
 import org.openmetadata.catalog.jdbi3.CollectionDAO;
 import org.openmetadata.catalog.jdbi3.DatabaseServiceRepository;
 import org.openmetadata.catalog.jdbi3.ListFilter;
@@ -79,7 +80,12 @@ public class DatabaseServiceResource
   }
 
   public DatabaseServiceResource(CollectionDAO dao, Authorizer authorizer, SecretsManager secretsManager) {
-    super(DatabaseService.class, new DatabaseServiceRepository(dao, secretsManager), authorizer, secretsManager);
+    super(
+        DatabaseService.class,
+        new DatabaseServiceRepository(dao, secretsManager),
+        authorizer,
+        secretsManager,
+        ServiceType.DATABASE);
   }
 
   public static class DatabaseServiceList extends ResultList<DatabaseService> {

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/messaging/MessagingServiceResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/messaging/MessagingServiceResource.java
@@ -45,6 +45,7 @@ import javax.ws.rs.core.UriInfo;
 import org.openmetadata.catalog.Entity;
 import org.openmetadata.catalog.api.services.CreateMessagingService;
 import org.openmetadata.catalog.entity.services.MessagingService;
+import org.openmetadata.catalog.entity.services.ServiceType;
 import org.openmetadata.catalog.jdbi3.CollectionDAO;
 import org.openmetadata.catalog.jdbi3.ListFilter;
 import org.openmetadata.catalog.jdbi3.MessagingServiceRepository;
@@ -78,7 +79,12 @@ public class MessagingServiceResource
   }
 
   public MessagingServiceResource(CollectionDAO dao, Authorizer authorizer, SecretsManager secretsManager) {
-    super(MessagingService.class, new MessagingServiceRepository(dao, secretsManager), authorizer, secretsManager);
+    super(
+        MessagingService.class,
+        new MessagingServiceRepository(dao, secretsManager),
+        authorizer,
+        secretsManager,
+        ServiceType.MESSAGING);
   }
 
   public static class MessagingServiceList extends ResultList<MessagingService> {

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/mlmodel/MlModelServiceResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/mlmodel/MlModelServiceResource.java
@@ -43,6 +43,7 @@ import javax.ws.rs.core.UriInfo;
 import org.openmetadata.catalog.Entity;
 import org.openmetadata.catalog.api.services.CreateMlModelService;
 import org.openmetadata.catalog.entity.services.MlModelService;
+import org.openmetadata.catalog.entity.services.ServiceType;
 import org.openmetadata.catalog.jdbi3.CollectionDAO;
 import org.openmetadata.catalog.jdbi3.ListFilter;
 import org.openmetadata.catalog.jdbi3.MlModelServiceRepository;
@@ -77,7 +78,12 @@ public class MlModelServiceResource
   }
 
   public MlModelServiceResource(CollectionDAO dao, Authorizer authorizer, SecretsManager secretsManager) {
-    super(MlModelService.class, new MlModelServiceRepository(dao, secretsManager), authorizer, secretsManager);
+    super(
+        MlModelService.class,
+        new MlModelServiceRepository(dao, secretsManager),
+        authorizer,
+        secretsManager,
+        ServiceType.ML_MODEL);
   }
 
   public static class MlModelServiceList extends ResultList<MlModelService> {

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/pipeline/PipelineServiceResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/pipeline/PipelineServiceResource.java
@@ -43,6 +43,7 @@ import javax.ws.rs.core.UriInfo;
 import org.openmetadata.catalog.Entity;
 import org.openmetadata.catalog.api.services.CreatePipelineService;
 import org.openmetadata.catalog.entity.services.PipelineService;
+import org.openmetadata.catalog.entity.services.ServiceType;
 import org.openmetadata.catalog.jdbi3.CollectionDAO;
 import org.openmetadata.catalog.jdbi3.ListFilter;
 import org.openmetadata.catalog.jdbi3.PipelineServiceRepository;
@@ -76,7 +77,12 @@ public class PipelineServiceResource
   }
 
   public PipelineServiceResource(CollectionDAO dao, Authorizer authorizer, SecretsManager secretsManager) {
-    super(PipelineService.class, new PipelineServiceRepository(dao, secretsManager), authorizer, secretsManager);
+    super(
+        PipelineService.class,
+        new PipelineServiceRepository(dao, secretsManager),
+        authorizer,
+        secretsManager,
+        ServiceType.PIPELINE);
   }
 
   public static class PipelineServiceList extends ResultList<PipelineService> {

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/secrets/LocalSecretsManager.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/secrets/LocalSecretsManager.java
@@ -7,6 +7,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import org.openmetadata.catalog.airflow.AirflowConfiguration;
 import org.openmetadata.catalog.airflow.AuthConfiguration;
+import org.openmetadata.catalog.entity.services.ServiceType;
 import org.openmetadata.catalog.exception.InvalidServiceConnectionException;
 import org.openmetadata.catalog.fernet.Fernet;
 import org.openmetadata.catalog.services.connections.metadata.OpenMetadataServerConnection;
@@ -30,13 +31,9 @@ public class LocalSecretsManager extends SecretsManager {
 
   @Override
   public Object encryptOrDecryptServiceConnectionConfig(
-      Object connectionConfig,
-      String connectionType,
-      String connectionName,
-      String connectionPackage,
-      boolean encrypt) {
+      Object connectionConfig, String connectionType, String connectionName, ServiceType serviceType, boolean encrypt) {
     try {
-      Class<?> clazz = createConnectionConfigClass(connectionType, connectionPackage);
+      Class<?> clazz = createConnectionConfigClass(connectionType, extractConnectionPackageName(serviceType));
       Object newConnectionConfig = JsonUtils.convertValue(connectionConfig, clazz);
       encryptOrDecryptField(newConnectionConfig, "Password", clazz, encrypt);
       return newConnectionConfig;

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/secrets/SecretsManager.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/secrets/SecretsManager.java
@@ -5,9 +5,9 @@ import static java.util.Objects.isNull;
 import com.google.common.base.CaseFormat;
 import java.util.List;
 import lombok.Getter;
-import org.openmetadata.catalog.ServiceConnectionEntityInterface;
 import org.openmetadata.catalog.airflow.AirflowConfiguration;
 import org.openmetadata.catalog.airflow.AuthConfiguration;
+import org.openmetadata.catalog.entity.services.ServiceType;
 import org.openmetadata.catalog.exception.SecretsManagerException;
 import org.openmetadata.catalog.services.connections.metadata.OpenMetadataServerConnection;
 
@@ -24,18 +24,7 @@ public abstract class SecretsManager {
   public abstract boolean isLocal();
 
   public abstract Object encryptOrDecryptServiceConnectionConfig(
-      Object connectionConfig, String connectionType, String connectionName, String connectionPackage, boolean encrypt);
-
-  public void encryptOrDecryptServiceConnection(
-      ServiceConnectionEntityInterface serviceConnection, String serviceType, String connectionName, boolean encrypt) {
-    serviceConnection.setConfig(
-        encryptOrDecryptServiceConnectionConfig(
-            serviceConnection.getConfig(),
-            serviceType,
-            connectionName,
-            extractConnectionPackageName(serviceConnection),
-            encrypt));
-  }
+      Object connectionConfig, String connectionType, String connectionName, ServiceType serviceType, boolean encrypt);
 
   public OpenMetadataServerConnection decryptServerConnection(AirflowConfiguration airflowConfiguration) {
     OpenMetadataServerConnection.AuthProvider authProvider =
@@ -71,8 +60,7 @@ public abstract class SecretsManager {
     return Class.forName(clazzName);
   }
 
-  private String extractConnectionPackageName(ServiceConnectionEntityInterface serviceConnection) {
-    String upperCamelClassName = serviceConnection.getClass().getSimpleName().replace("Connection", "");
-    return CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, upperCamelClassName);
+  protected String extractConnectionPackageName(ServiceType serviceType) {
+    return CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, serviceType.value());
   }
 }

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/jdbi3/DashboardServiceRepositoryUnitTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/jdbi3/DashboardServiceRepositoryUnitTest.java
@@ -1,0 +1,35 @@
+package org.openmetadata.catalog.jdbi3;
+
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.openmetadata.catalog.api.services.CreateDashboardService.DashboardServiceType.Looker;
+
+import org.openmetadata.catalog.entity.services.DashboardService;
+import org.openmetadata.catalog.secrets.SecretsManager;
+import org.openmetadata.catalog.services.connections.database.MysqlConnection;
+import org.openmetadata.catalog.type.DashboardConnection;
+
+public class DashboardServiceRepositoryUnitTest
+    extends ServiceRepositoryTest<DashboardServiceRepository, DashboardService, DashboardConnection> {
+
+  @Override
+  protected DashboardServiceRepository newServiceRepository(
+      CollectionDAO collectionDAO, SecretsManager secretsManager) {
+    return new DashboardServiceRepository(collectionDAO, secretsManager);
+  }
+
+  @Override
+  protected void mockServiceResourceSpecific() {
+    service = mock(DashboardService.class);
+    serviceConnection = mock(DashboardConnection.class);
+    when(serviceConnection.getConfig()).thenReturn(mock(MysqlConnection.class));
+    CollectionDAO.DashboardServiceDAO entityDAO = mock(CollectionDAO.DashboardServiceDAO.class);
+    when(collectionDAO.dashboardServiceDAO()).thenReturn(entityDAO);
+    when(entityDAO.getEntityClass()).thenReturn(DashboardService.class);
+    when(service.withHref(isNull())).thenReturn(service);
+    when(service.withOwner(isNull())).thenReturn(service);
+    when(service.getConnection()).thenReturn(serviceConnection);
+    when(service.getServiceType()).thenReturn(Looker);
+  }
+}

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/jdbi3/DashboardServiceRepositoryUnitTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/jdbi3/DashboardServiceRepositoryUnitTest.java
@@ -6,12 +6,17 @@ import static org.mockito.Mockito.when;
 import static org.openmetadata.catalog.api.services.CreateDashboardService.DashboardServiceType.Looker;
 
 import org.openmetadata.catalog.entity.services.DashboardService;
+import org.openmetadata.catalog.entity.services.ServiceType;
 import org.openmetadata.catalog.secrets.SecretsManager;
 import org.openmetadata.catalog.services.connections.database.MysqlConnection;
 import org.openmetadata.catalog.type.DashboardConnection;
 
 public class DashboardServiceRepositoryUnitTest
     extends ServiceRepositoryTest<DashboardServiceRepository, DashboardService, DashboardConnection> {
+
+  protected DashboardServiceRepositoryUnitTest() {
+    super(ServiceType.DASHBOARD);
+  }
 
   @Override
   protected DashboardServiceRepository newServiceRepository(

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/jdbi3/DatabaseServiceRepositoryUnitTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/jdbi3/DatabaseServiceRepositoryUnitTest.java
@@ -1,0 +1,34 @@
+package org.openmetadata.catalog.jdbi3;
+
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.openmetadata.catalog.api.services.CreateDatabaseService.DatabaseServiceType.Mysql;
+
+import org.openmetadata.catalog.api.services.DatabaseConnection;
+import org.openmetadata.catalog.entity.services.DatabaseService;
+import org.openmetadata.catalog.secrets.SecretsManager;
+import org.openmetadata.catalog.services.connections.database.MysqlConnection;
+
+public class DatabaseServiceRepositoryUnitTest
+    extends ServiceRepositoryTest<DatabaseServiceRepository, DatabaseService, DatabaseConnection> {
+
+  @Override
+  protected DatabaseServiceRepository newServiceRepository(CollectionDAO collectionDAO, SecretsManager secretsManager) {
+    return new DatabaseServiceRepository(collectionDAO, secretsManager);
+  }
+
+  @Override
+  protected void mockServiceResourceSpecific() {
+    service = mock(DatabaseService.class);
+    serviceConnection = mock(DatabaseConnection.class);
+    when(serviceConnection.getConfig()).thenReturn(mock(MysqlConnection.class));
+    CollectionDAO.DatabaseServiceDAO entityDAO = mock(CollectionDAO.DatabaseServiceDAO.class);
+    when(collectionDAO.dbServiceDAO()).thenReturn(entityDAO);
+    when(entityDAO.getEntityClass()).thenReturn(DatabaseService.class);
+    when(service.withHref(isNull())).thenReturn(service);
+    when(service.withOwner(isNull())).thenReturn(service);
+    when(service.getConnection()).thenReturn(serviceConnection);
+    when(service.getServiceType()).thenReturn(Mysql);
+  }
+}

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/jdbi3/DatabaseServiceRepositoryUnitTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/jdbi3/DatabaseServiceRepositoryUnitTest.java
@@ -7,11 +7,16 @@ import static org.openmetadata.catalog.api.services.CreateDatabaseService.Databa
 
 import org.openmetadata.catalog.api.services.DatabaseConnection;
 import org.openmetadata.catalog.entity.services.DatabaseService;
+import org.openmetadata.catalog.entity.services.ServiceType;
 import org.openmetadata.catalog.secrets.SecretsManager;
 import org.openmetadata.catalog.services.connections.database.MysqlConnection;
 
 public class DatabaseServiceRepositoryUnitTest
     extends ServiceRepositoryTest<DatabaseServiceRepository, DatabaseService, DatabaseConnection> {
+
+  protected DatabaseServiceRepositoryUnitTest() {
+    super(ServiceType.DATABASE);
+  }
 
   @Override
   protected DatabaseServiceRepository newServiceRepository(CollectionDAO collectionDAO, SecretsManager secretsManager) {

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/jdbi3/MessagingServiceRepositoryUnitTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/jdbi3/MessagingServiceRepositoryUnitTest.java
@@ -6,12 +6,17 @@ import static org.mockito.Mockito.when;
 import static org.openmetadata.catalog.api.services.CreateMessagingService.MessagingServiceType.Kafka;
 
 import org.openmetadata.catalog.entity.services.MessagingService;
+import org.openmetadata.catalog.entity.services.ServiceType;
 import org.openmetadata.catalog.secrets.SecretsManager;
 import org.openmetadata.catalog.services.connections.database.MysqlConnection;
 import org.openmetadata.catalog.type.MessagingConnection;
 
 public class MessagingServiceRepositoryUnitTest
     extends ServiceRepositoryTest<MessagingServiceRepository, MessagingService, MessagingConnection> {
+
+  protected MessagingServiceRepositoryUnitTest() {
+    super(ServiceType.MESSAGING);
+  }
 
   @Override
   protected MessagingServiceRepository newServiceRepository(

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/jdbi3/MessagingServiceRepositoryUnitTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/jdbi3/MessagingServiceRepositoryUnitTest.java
@@ -1,0 +1,35 @@
+package org.openmetadata.catalog.jdbi3;
+
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.openmetadata.catalog.api.services.CreateMessagingService.MessagingServiceType.Kafka;
+
+import org.openmetadata.catalog.entity.services.MessagingService;
+import org.openmetadata.catalog.secrets.SecretsManager;
+import org.openmetadata.catalog.services.connections.database.MysqlConnection;
+import org.openmetadata.catalog.type.MessagingConnection;
+
+public class MessagingServiceRepositoryUnitTest
+    extends ServiceRepositoryTest<MessagingServiceRepository, MessagingService, MessagingConnection> {
+
+  @Override
+  protected MessagingServiceRepository newServiceRepository(
+      CollectionDAO collectionDAO, SecretsManager secretsManager) {
+    return new MessagingServiceRepository(collectionDAO, secretsManager);
+  }
+
+  @Override
+  protected void mockServiceResourceSpecific() {
+    service = mock(MessagingService.class);
+    serviceConnection = mock(MessagingConnection.class);
+    when(serviceConnection.getConfig()).thenReturn(mock(MysqlConnection.class));
+    CollectionDAO.MessagingServiceDAO entityDAO = mock(CollectionDAO.MessagingServiceDAO.class);
+    when(collectionDAO.messagingServiceDAO()).thenReturn(entityDAO);
+    when(entityDAO.getEntityClass()).thenReturn(MessagingService.class);
+    when(service.withHref(isNull())).thenReturn(service);
+    when(service.withOwner(isNull())).thenReturn(service);
+    when(service.getConnection()).thenReturn(serviceConnection);
+    when(service.getServiceType()).thenReturn(Kafka);
+  }
+}

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/jdbi3/MlModelServiceRepositoryUnitTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/jdbi3/MlModelServiceRepositoryUnitTest.java
@@ -1,0 +1,34 @@
+package org.openmetadata.catalog.jdbi3;
+
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.openmetadata.catalog.api.services.CreateMlModelService.MlModelServiceType.Mlflow;
+
+import org.openmetadata.catalog.entity.services.MlModelService;
+import org.openmetadata.catalog.secrets.SecretsManager;
+import org.openmetadata.catalog.services.connections.database.MysqlConnection;
+import org.openmetadata.catalog.type.MlModelConnection;
+
+public class MlModelServiceRepositoryUnitTest
+    extends ServiceRepositoryTest<MlModelServiceRepository, MlModelService, MlModelConnection> {
+
+  @Override
+  protected MlModelServiceRepository newServiceRepository(CollectionDAO collectionDAO, SecretsManager secretsManager) {
+    return new MlModelServiceRepository(collectionDAO, secretsManager);
+  }
+
+  @Override
+  protected void mockServiceResourceSpecific() {
+    service = mock(MlModelService.class);
+    serviceConnection = mock(MlModelConnection.class);
+    when(serviceConnection.getConfig()).thenReturn(mock(MysqlConnection.class));
+    CollectionDAO.MlModelServiceDAO entityDAO = mock(CollectionDAO.MlModelServiceDAO.class);
+    when(collectionDAO.mlModelServiceDAO()).thenReturn(entityDAO);
+    when(entityDAO.getEntityClass()).thenReturn(MlModelService.class);
+    when(service.withHref(isNull())).thenReturn(service);
+    when(service.withOwner(isNull())).thenReturn(service);
+    when(service.getConnection()).thenReturn(serviceConnection);
+    when(service.getServiceType()).thenReturn(Mlflow);
+  }
+}

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/jdbi3/MlModelServiceRepositoryUnitTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/jdbi3/MlModelServiceRepositoryUnitTest.java
@@ -6,12 +6,17 @@ import static org.mockito.Mockito.when;
 import static org.openmetadata.catalog.api.services.CreateMlModelService.MlModelServiceType.Mlflow;
 
 import org.openmetadata.catalog.entity.services.MlModelService;
+import org.openmetadata.catalog.entity.services.ServiceType;
 import org.openmetadata.catalog.secrets.SecretsManager;
 import org.openmetadata.catalog.services.connections.database.MysqlConnection;
 import org.openmetadata.catalog.type.MlModelConnection;
 
 public class MlModelServiceRepositoryUnitTest
     extends ServiceRepositoryTest<MlModelServiceRepository, MlModelService, MlModelConnection> {
+
+  protected MlModelServiceRepositoryUnitTest() {
+    super(ServiceType.ML_MODEL);
+  }
 
   @Override
   protected MlModelServiceRepository newServiceRepository(CollectionDAO collectionDAO, SecretsManager secretsManager) {

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/jdbi3/PipelineServiceRepositoryUnitTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/jdbi3/PipelineServiceRepositoryUnitTest.java
@@ -6,12 +6,17 @@ import static org.mockito.Mockito.when;
 import static org.openmetadata.catalog.api.services.CreatePipelineService.PipelineServiceType.Airflow;
 
 import org.openmetadata.catalog.entity.services.PipelineService;
+import org.openmetadata.catalog.entity.services.ServiceType;
 import org.openmetadata.catalog.secrets.SecretsManager;
 import org.openmetadata.catalog.services.connections.database.MysqlConnection;
 import org.openmetadata.catalog.type.PipelineConnection;
 
 public class PipelineServiceRepositoryUnitTest
     extends ServiceRepositoryTest<PipelineServiceRepository, PipelineService, PipelineConnection> {
+
+  protected PipelineServiceRepositoryUnitTest() {
+    super(ServiceType.PIPELINE);
+  }
 
   @Override
   protected PipelineServiceRepository newServiceRepository(CollectionDAO collectionDAO, SecretsManager secretsManager) {

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/jdbi3/PipelineServiceRepositoryUnitTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/jdbi3/PipelineServiceRepositoryUnitTest.java
@@ -1,0 +1,34 @@
+package org.openmetadata.catalog.jdbi3;
+
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.openmetadata.catalog.api.services.CreatePipelineService.PipelineServiceType.Airflow;
+
+import org.openmetadata.catalog.entity.services.PipelineService;
+import org.openmetadata.catalog.secrets.SecretsManager;
+import org.openmetadata.catalog.services.connections.database.MysqlConnection;
+import org.openmetadata.catalog.type.PipelineConnection;
+
+public class PipelineServiceRepositoryUnitTest
+    extends ServiceRepositoryTest<PipelineServiceRepository, PipelineService, PipelineConnection> {
+
+  @Override
+  protected PipelineServiceRepository newServiceRepository(CollectionDAO collectionDAO, SecretsManager secretsManager) {
+    return new PipelineServiceRepository(collectionDAO, secretsManager);
+  }
+
+  @Override
+  protected void mockServiceResourceSpecific() {
+    service = mock(PipelineService.class);
+    serviceConnection = mock(PipelineConnection.class);
+    when(serviceConnection.getConfig()).thenReturn(mock(MysqlConnection.class));
+    CollectionDAO.PipelineServiceDAO entityDAO = mock(CollectionDAO.PipelineServiceDAO.class);
+    when(collectionDAO.pipelineServiceDAO()).thenReturn(entityDAO);
+    when(entityDAO.getEntityClass()).thenReturn(PipelineService.class);
+    when(service.withHref(isNull())).thenReturn(service);
+    when(service.withOwner(isNull())).thenReturn(service);
+    when(service.getConnection()).thenReturn(serviceConnection);
+    when(service.getServiceType()).thenReturn(Airflow);
+  }
+}

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/jdbi3/ServiceRepositoryTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/jdbi3/ServiceRepositoryTest.java
@@ -1,0 +1,84 @@
+package org.openmetadata.catalog.jdbi3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openmetadata.catalog.ServiceConnectionEntityInterface;
+import org.openmetadata.catalog.ServiceEntityInterface;
+import org.openmetadata.catalog.secrets.SecretsManager;
+
+@ExtendWith(MockitoExtension.class)
+public abstract class ServiceRepositoryTest<
+    T extends ServiceRepository<R, S>, R extends ServiceEntityInterface, S extends ServiceConnectionEntityInterface> {
+
+  @Mock protected CollectionDAO collectionDAO;
+
+  @Mock protected SecretsManager secretsManager;
+
+  protected T serviceRepository;
+
+  protected R service;
+
+  protected S serviceConnection;
+
+  @BeforeEach
+  void beforeEach() {
+    mockServiceResourceSpecific();
+    serviceRepository = newServiceRepository(collectionDAO, secretsManager);
+  }
+
+  @AfterEach
+  void afterEach() {
+    reset(secretsManager, service);
+  }
+
+  protected abstract T newServiceRepository(CollectionDAO collectionDAO, SecretsManager secretsManager);
+
+  protected abstract void mockServiceResourceSpecific();
+
+  @Test
+  void testStoreEntityCallCorrectlyLocalSecretManager() throws IOException {
+    when(service.getName()).thenReturn("local");
+    when(secretsManager.isLocal()).thenReturn(true);
+    ArgumentCaptor<String> serviceNameCaptor = ArgumentCaptor.forClass(String.class);
+
+    serviceRepository.storeEntity(service, true);
+
+    verify(serviceConnection, times(2)).getConfig();
+    verify(serviceConnection, never()).setConfig(any());
+    verify(secretsManager).encryptOrDecryptServiceConnection(any(), any(), serviceNameCaptor.capture(), anyBoolean());
+    assertEquals("local", serviceNameCaptor.getValue());
+  }
+
+  @Test
+  void testStoreEntityCallCorrectlyNotLocalSecretManager() throws IOException {
+    when(service.getName()).thenReturn("not-local");
+    ArgumentCaptor<Object> configCaptor = ArgumentCaptor.forClass(Object.class);
+    ArgumentCaptor<String> serviceNameCaptor = ArgumentCaptor.forClass(String.class);
+
+    serviceRepository.storeEntity(service, true);
+
+    verify(serviceConnection, times(2)).getConfig();
+    verify(serviceConnection, times(2)).setConfig(configCaptor.capture());
+    verify(secretsManager).encryptOrDecryptServiceConnection(any(), any(), serviceNameCaptor.capture(), anyBoolean());
+    assertNull(configCaptor.getAllValues().get(0));
+    assertNotNull(configCaptor.getAllValues().get(1));
+    assertEquals("not-local", serviceNameCaptor.getValue());
+  }
+}

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/DashboardServiceResourceUnitTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/DashboardServiceResourceUnitTest.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 import javax.ws.rs.core.UriInfo;
 import org.openmetadata.catalog.api.services.CreateDashboardService;
 import org.openmetadata.catalog.entity.services.DashboardService;
+import org.openmetadata.catalog.entity.services.ServiceType;
 import org.openmetadata.catalog.jdbi3.CollectionDAO;
 import org.openmetadata.catalog.jdbi3.DashboardServiceRepository;
 import org.openmetadata.catalog.resources.services.dashboard.DashboardServiceResource;
@@ -58,8 +59,13 @@ public class DashboardServiceResourceUnitTest
   }
 
   @Override
-  protected String serviceType() {
+  protected String serviceConnectionType() {
     return CreateDashboardService.DashboardServiceType.Tableau.value();
+  }
+
+  @Override
+  protected ServiceType serviceType() {
+    return ServiceType.DASHBOARD;
   }
 
   @Override

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/DashboardServiceResourceUnitTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/DashboardServiceResourceUnitTest.java
@@ -33,6 +33,7 @@ import org.openmetadata.catalog.jdbi3.DashboardServiceRepository;
 import org.openmetadata.catalog.resources.services.dashboard.DashboardServiceResource;
 import org.openmetadata.catalog.secrets.SecretsManager;
 import org.openmetadata.catalog.security.Authorizer;
+import org.openmetadata.catalog.services.connections.dashboard.TableauConnection;
 import org.openmetadata.catalog.type.DashboardConnection;
 import org.openmetadata.catalog.type.Include;
 
@@ -49,10 +50,12 @@ public class DashboardServiceResourceUnitTest
   @Override
   protected void mockServiceResourceSpecific() throws IOException {
     service = mock(DashboardService.class);
+    DashboardConnection serviceConnection = mock(DashboardConnection.class);
+    lenient().when(serviceConnection.getConfig()).thenReturn(mock(TableauConnection.class));
     CollectionDAO.DashboardServiceDAO entityDAO = mock(CollectionDAO.DashboardServiceDAO.class);
     when(collectionDAO.dashboardServiceDAO()).thenReturn(entityDAO);
     lenient().when(service.getServiceType()).thenReturn(CreateDashboardService.DashboardServiceType.Tableau);
-    lenient().when(service.getConnection()).thenReturn(mock(DashboardConnection.class));
+    lenient().when(service.getConnection()).thenReturn(serviceConnection);
     lenient().when(service.withConnection(isNull())).thenReturn(service);
     when(entityDAO.findEntityById(any(), any())).thenReturn(service);
     when(entityDAO.getEntityClass()).thenReturn(DashboardService.class);

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/DatabaseServiceResourceUnitTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/DatabaseServiceResourceUnitTest.java
@@ -28,6 +28,7 @@ import javax.ws.rs.core.UriInfo;
 import org.openmetadata.catalog.api.services.CreateDatabaseService;
 import org.openmetadata.catalog.api.services.DatabaseConnection;
 import org.openmetadata.catalog.entity.services.DatabaseService;
+import org.openmetadata.catalog.entity.services.ServiceType;
 import org.openmetadata.catalog.jdbi3.CollectionDAO;
 import org.openmetadata.catalog.jdbi3.DatabaseServiceRepository;
 import org.openmetadata.catalog.resources.services.database.DatabaseServiceResource;
@@ -58,8 +59,13 @@ public class DatabaseServiceResourceUnitTest
   }
 
   @Override
-  protected String serviceType() {
+  protected String serviceConnectionType() {
     return CreateDatabaseService.DatabaseServiceType.Mysql.value();
+  }
+
+  @Override
+  protected ServiceType serviceType() {
+    return ServiceType.DATABASE;
   }
 
   @Override

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/DatabaseServiceResourceUnitTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/DatabaseServiceResourceUnitTest.java
@@ -34,6 +34,7 @@ import org.openmetadata.catalog.jdbi3.DatabaseServiceRepository;
 import org.openmetadata.catalog.resources.services.database.DatabaseServiceResource;
 import org.openmetadata.catalog.secrets.SecretsManager;
 import org.openmetadata.catalog.security.Authorizer;
+import org.openmetadata.catalog.services.connections.database.MysqlConnection;
 import org.openmetadata.catalog.type.Include;
 
 public class DatabaseServiceResourceUnitTest
@@ -49,10 +50,12 @@ public class DatabaseServiceResourceUnitTest
   @Override
   protected void mockServiceResourceSpecific() throws IOException {
     service = mock(DatabaseService.class);
+    DatabaseConnection serviceConnection = mock(DatabaseConnection.class);
+    lenient().when(serviceConnection.getConfig()).thenReturn(mock(MysqlConnection.class));
     CollectionDAO.DatabaseServiceDAO entityDAO = mock(CollectionDAO.DatabaseServiceDAO.class);
     when(collectionDAO.dbServiceDAO()).thenReturn(entityDAO);
     lenient().when(service.getServiceType()).thenReturn(CreateDatabaseService.DatabaseServiceType.Mysql);
-    lenient().when(service.getConnection()).thenReturn(mock(DatabaseConnection.class));
+    lenient().when(service.getConnection()).thenReturn(serviceConnection);
     lenient().when(service.withConnection(isNull())).thenReturn(service);
     when(entityDAO.findEntityById(any(), any())).thenReturn(service);
     when(entityDAO.getEntityClass()).thenReturn(DatabaseService.class);

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/MessagingServiceResourceUnitTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/MessagingServiceResourceUnitTest.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 import javax.ws.rs.core.UriInfo;
 import org.openmetadata.catalog.api.services.CreateMessagingService;
 import org.openmetadata.catalog.entity.services.MessagingService;
+import org.openmetadata.catalog.entity.services.ServiceType;
 import org.openmetadata.catalog.jdbi3.CollectionDAO;
 import org.openmetadata.catalog.jdbi3.MessagingServiceRepository;
 import org.openmetadata.catalog.resources.services.messaging.MessagingServiceResource;
@@ -58,8 +59,13 @@ public class MessagingServiceResourceUnitTest
   }
 
   @Override
-  protected String serviceType() {
+  protected String serviceConnectionType() {
     return CreateMessagingService.MessagingServiceType.Kafka.value();
+  }
+
+  @Override
+  protected ServiceType serviceType() {
+    return ServiceType.MESSAGING;
   }
 
   @Override

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/MessagingServiceResourceUnitTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/MessagingServiceResourceUnitTest.java
@@ -33,6 +33,7 @@ import org.openmetadata.catalog.jdbi3.MessagingServiceRepository;
 import org.openmetadata.catalog.resources.services.messaging.MessagingServiceResource;
 import org.openmetadata.catalog.secrets.SecretsManager;
 import org.openmetadata.catalog.security.Authorizer;
+import org.openmetadata.catalog.services.connections.messaging.KafkaConnection;
 import org.openmetadata.catalog.type.Include;
 import org.openmetadata.catalog.type.MessagingConnection;
 
@@ -49,10 +50,12 @@ public class MessagingServiceResourceUnitTest
   @Override
   protected void mockServiceResourceSpecific() throws IOException {
     service = mock(MessagingService.class);
+    MessagingConnection serviceConnection = mock(MessagingConnection.class);
+    lenient().when(serviceConnection.getConfig()).thenReturn(mock(KafkaConnection.class));
     CollectionDAO.MessagingServiceDAO entityDAO = mock(CollectionDAO.MessagingServiceDAO.class);
     when(collectionDAO.messagingServiceDAO()).thenReturn(entityDAO);
     lenient().when(service.getServiceType()).thenReturn(CreateMessagingService.MessagingServiceType.Kafka);
-    lenient().when(service.getConnection()).thenReturn(mock(MessagingConnection.class));
+    lenient().when(service.getConnection()).thenReturn(serviceConnection);
     lenient().when(service.withConnection(isNull())).thenReturn(service);
     when(entityDAO.findEntityById(any(), any())).thenReturn(service);
     when(entityDAO.getEntityClass()).thenReturn(MessagingService.class);

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/MlModelServiceResourceUnitTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/MlModelServiceResourceUnitTest.java
@@ -35,6 +35,7 @@ import org.openmetadata.catalog.jdbi3.MlModelServiceRepository;
 import org.openmetadata.catalog.resources.services.mlmodel.MlModelServiceResource;
 import org.openmetadata.catalog.secrets.SecretsManager;
 import org.openmetadata.catalog.security.Authorizer;
+import org.openmetadata.catalog.services.connections.mlModel.MlflowConnection;
 import org.openmetadata.catalog.type.Include;
 import org.openmetadata.catalog.type.MlModelConnection;
 
@@ -51,10 +52,12 @@ public class MlModelServiceResourceUnitTest
   @Override
   protected void mockServiceResourceSpecific() throws IOException {
     service = mock(MlModelService.class);
+    MlModelConnection serviceConnection = mock(MlModelConnection.class);
+    lenient().when(serviceConnection.getConfig()).thenReturn(mock(MlflowConnection.class));
     CollectionDAO.MlModelServiceDAO entityDAO = mock(CollectionDAO.MlModelServiceDAO.class);
     when(collectionDAO.mlModelServiceDAO()).thenReturn(entityDAO);
     lenient().when(service.getServiceType()).thenReturn(CreateMlModelService.MlModelServiceType.Mlflow);
-    lenient().when(service.getConnection()).thenReturn(mock(MlModelConnection.class));
+    lenient().when(service.getConnection()).thenReturn(serviceConnection);
     lenient().when(service.withConnection(isNull())).thenReturn(service);
     when(entityDAO.findEntityById(any(), any())).thenReturn(service);
     when(entityDAO.getEntityClass()).thenReturn(MlModelService.class);

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/MlModelServiceResourceUnitTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/MlModelServiceResourceUnitTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.openmetadata.catalog.api.services.CreateMlModelService;
 import org.openmetadata.catalog.entity.services.MlModelService;
+import org.openmetadata.catalog.entity.services.ServiceType;
 import org.openmetadata.catalog.jdbi3.CollectionDAO;
 import org.openmetadata.catalog.jdbi3.MlModelServiceRepository;
 import org.openmetadata.catalog.resources.services.mlmodel.MlModelServiceResource;
@@ -60,8 +61,13 @@ public class MlModelServiceResourceUnitTest
   }
 
   @Override
-  protected String serviceType() {
+  protected String serviceConnectionType() {
     return CreateMlModelService.MlModelServiceType.Mlflow.value();
+  }
+
+  @Override
+  protected ServiceType serviceType() {
+    return ServiceType.ML_MODEL;
   }
 
   @Override

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/PipelineServiceResourceUnitTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/PipelineServiceResourceUnitTest.java
@@ -35,6 +35,7 @@ import org.openmetadata.catalog.jdbi3.PipelineServiceRepository;
 import org.openmetadata.catalog.resources.services.pipeline.PipelineServiceResource;
 import org.openmetadata.catalog.secrets.SecretsManager;
 import org.openmetadata.catalog.security.Authorizer;
+import org.openmetadata.catalog.services.connections.pipeline.AirflowConnection;
 import org.openmetadata.catalog.type.Include;
 import org.openmetadata.catalog.type.PipelineConnection;
 
@@ -52,10 +53,12 @@ public class PipelineServiceResourceUnitTest
   @Override
   protected void mockServiceResourceSpecific() throws IOException {
     service = mock(PipelineService.class);
+    PipelineConnection serviceConnection = mock(PipelineConnection.class);
+    lenient().when(serviceConnection.getConfig()).thenReturn(mock(AirflowConnection.class));
     CollectionDAO.PipelineServiceDAO entityDAO = mock(CollectionDAO.PipelineServiceDAO.class);
     when(collectionDAO.pipelineServiceDAO()).thenReturn(entityDAO);
     lenient().when(service.getServiceType()).thenReturn(CreatePipelineService.PipelineServiceType.Airflow);
-    lenient().when(service.getConnection()).thenReturn(mock(PipelineConnection.class));
+    lenient().when(service.getConnection()).thenReturn(serviceConnection);
     lenient().when(service.withConnection(isNull())).thenReturn(service);
     when(entityDAO.findEntityById(any(), any())).thenReturn(service);
     when(entityDAO.getEntityClass()).thenReturn(PipelineService.class);

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/PipelineServiceResourceUnitTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/PipelineServiceResourceUnitTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.openmetadata.catalog.api.services.CreatePipelineService;
 import org.openmetadata.catalog.entity.services.PipelineService;
+import org.openmetadata.catalog.entity.services.ServiceType;
 import org.openmetadata.catalog.jdbi3.CollectionDAO;
 import org.openmetadata.catalog.jdbi3.PipelineServiceRepository;
 import org.openmetadata.catalog.resources.services.pipeline.PipelineServiceResource;
@@ -61,8 +62,13 @@ public class PipelineServiceResourceUnitTest
   }
 
   @Override
-  protected String serviceType() {
+  protected String serviceConnectionType() {
     return CreatePipelineService.PipelineServiceType.Airflow.value();
+  }
+
+  @Override
+  protected ServiceType serviceType() {
+    return ServiceType.PIPELINE;
   }
 
   @Override

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/ServiceResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/ServiceResourceTest.java
@@ -23,6 +23,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.openmetadata.catalog.ServiceConnectionEntityInterface;
 import org.openmetadata.catalog.ServiceEntityInterface;
+import org.openmetadata.catalog.entity.services.ServiceType;
 import org.openmetadata.catalog.jdbi3.CollectionDAO;
 import org.openmetadata.catalog.jdbi3.ServiceRepository;
 import org.openmetadata.catalog.secrets.SecretsManager;
@@ -57,7 +58,7 @@ public abstract class ServiceResourceTest<
     lenient()
         .when(
             secretsManager.encryptOrDecryptServiceConnectionConfig(
-                any(), anyString(), anyString(), anyString(), anyBoolean()))
+                any(), anyString(), anyString(), any(ServiceType.class), anyBoolean()))
         .thenReturn(service);
     serviceResource = newServiceResource(collectionDAO, authorizer, secretsManager);
   }
@@ -98,14 +99,17 @@ public abstract class ServiceResourceTest<
 
     verify(secretsManager, times(1)).isLocal();
     verify(secretsManager, times(shouldBeNull ? 0 : 1))
-        .encryptOrDecryptServiceConnection(notNull(), eq(serviceType()), any(), eq(false));
+        .encryptOrDecryptServiceConnectionConfig(
+            notNull(), eq(serviceConnectionType()), any(), eq(serviceType()), eq(false));
 
     verifyServiceWithConnectionCall(shouldBeNull, service);
 
     assertEquals(service, actual);
   }
 
-  protected abstract String serviceType();
+  protected abstract String serviceConnectionType();
+
+  protected abstract ServiceType serviceType();
 
   protected abstract void verifyServiceWithConnectionCall(boolean shouldBeNull, R service);
 

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/secrets/AWSSecretsManagerTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/secrets/AWSSecretsManagerTest.java
@@ -36,7 +36,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.openmetadata.catalog.airflow.AirflowConfiguration;
 import org.openmetadata.catalog.airflow.AuthConfiguration;
 import org.openmetadata.catalog.api.services.CreateDatabaseService;
-import org.openmetadata.catalog.api.services.DatabaseConnection;
+import org.openmetadata.catalog.entity.services.ServiceType;
 import org.openmetadata.catalog.fixtures.ConfigurationFixtures;
 import org.openmetadata.catalog.services.connections.database.MysqlConnection;
 import org.openmetadata.catalog.services.connections.metadata.OpenMetadataServerConnection;
@@ -168,22 +168,20 @@ public class AWSSecretsManagerTest {
   }
 
   private void testEncryptDecryptServiceConnection(boolean decrypt) {
-    DatabaseConnection databaseConnection = new DatabaseConnection();
     MysqlConnection mysqlConnection = new MysqlConnection();
     mysqlConnection.setPassword("openmetadata-test");
-    databaseConnection.setConfig(mysqlConnection);
     CreateDatabaseService.DatabaseServiceType databaseServiceType = CreateDatabaseService.DatabaseServiceType.Mysql;
     String connectionName = "test";
 
-    secretsManager.encryptOrDecryptServiceConnection(
-        databaseConnection, databaseServiceType.value(), connectionName, decrypt);
+    Object actualConfig =
+        secretsManager.encryptOrDecryptServiceConnectionConfig(
+            mysqlConnection, databaseServiceType.value(), connectionName, ServiceType.DATABASE, decrypt);
 
     if (decrypt) {
-      assertNull(databaseConnection.getConfig());
-      assertNotSame(mysqlConnection, databaseConnection.getConfig());
+      assertNull(actualConfig);
     } else {
-      assertEquals(mysqlConnection, databaseConnection.getConfig());
-      assertNotSame(mysqlConnection, databaseConnection.getConfig());
+      assertEquals(mysqlConnection, actualConfig);
+      assertNotSame(mysqlConnection, actualConfig);
     }
   }
 

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/secrets/LocalSecretsManagerTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/secrets/LocalSecretsManagerTest.java
@@ -28,13 +28,12 @@ import org.openmetadata.catalog.airflow.AirflowConfiguration;
 import org.openmetadata.catalog.airflow.AuthConfiguration;
 import org.openmetadata.catalog.api.services.CreateDatabaseService;
 import org.openmetadata.catalog.api.services.CreateMlModelService;
-import org.openmetadata.catalog.api.services.DatabaseConnection;
+import org.openmetadata.catalog.entity.services.ServiceType;
 import org.openmetadata.catalog.fernet.Fernet;
 import org.openmetadata.catalog.fixtures.ConfigurationFixtures;
 import org.openmetadata.catalog.services.connections.database.MysqlConnection;
 import org.openmetadata.catalog.services.connections.metadata.OpenMetadataServerConnection;
 import org.openmetadata.catalog.services.connections.mlModel.SklearnConnection;
-import org.openmetadata.catalog.type.MlModelConnection;
 
 @ExtendWith(MockitoExtension.class)
 public class LocalSecretsManagerTest {
@@ -119,31 +118,29 @@ public class LocalSecretsManagerTest {
   }
 
   private void testEncryptDecryptServiceConnectionWithoutPassword(boolean decrypt) {
-    MlModelConnection mlModelConnection = new MlModelConnection();
     SklearnConnection sklearnConnection = new SklearnConnection();
-    mlModelConnection.setConfig(sklearnConnection);
     CreateMlModelService.MlModelServiceType databaseServiceType = CreateMlModelService.MlModelServiceType.Sklearn;
     String connectionName = "test";
 
-    secretsManager.encryptOrDecryptServiceConnection(
-        mlModelConnection, databaseServiceType.value(), connectionName, decrypt);
+    Object actualConfig =
+        secretsManager.encryptOrDecryptServiceConnectionConfig(
+            sklearnConnection, databaseServiceType.value(), connectionName, ServiceType.ML_MODEL, decrypt);
 
-    assertNotSame(sklearnConnection, mlModelConnection.getConfig());
+    assertNotSame(sklearnConnection, actualConfig);
   }
 
   private void testEncryptDecryptServiceConnection(String encryptedValue, String decryptedValue, boolean decrypt) {
-    DatabaseConnection databaseConnection = new DatabaseConnection();
     MysqlConnection mysqlConnection = new MysqlConnection();
     mysqlConnection.setPassword(encryptedValue);
-    databaseConnection.setConfig(mysqlConnection);
     CreateDatabaseService.DatabaseServiceType databaseServiceType = CreateDatabaseService.DatabaseServiceType.Mysql;
     String connectionName = "test";
 
-    secretsManager.encryptOrDecryptServiceConnection(
-        databaseConnection, databaseServiceType.value(), connectionName, decrypt);
+    Object actualConfig =
+        secretsManager.encryptOrDecryptServiceConnectionConfig(
+            mysqlConnection, databaseServiceType.value(), connectionName, ServiceType.DATABASE, decrypt);
 
-    assertEquals(decryptedValue, ((MysqlConnection) databaseConnection.getConfig()).getPassword());
-    assertNotSame(mysqlConnection, databaseConnection.getConfig());
+    assertEquals(decryptedValue, ((MysqlConnection) actualConfig).getPassword());
+    assertNotSame(mysqlConnection, actualConfig);
   }
 
   private static Stream<Arguments> testDecryptAuthProviderConfigParams() {


### PR DESCRIPTION
Fixes: https://github.com/open-metadata/OpenMetadata/issues/6487

### Describe your changes :

Change how service repositories stores and update services and interact with the secrets manager.

### Type of change :
- [x] Improvement
- [x] New feature

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

### Reviewers
Backend: @open-metadata/backend
Ingestion: @open-metadata/ingestion
