### PR TITLE
Fix#6517: Add clusterName property to the application config yaml

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/CatalogApplication.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/CatalogApplication.java
@@ -96,7 +96,8 @@ public class CatalogApplication extends Application<CatalogApplicationConfig> {
     jdbi.setTimingCollector(new MicrometerJdbiTimingCollector());
 
     final SecretsManager secretsManager =
-        SecretsManagerFactory.createSecretsManager(catalogConfig.getSecretsManagerConfiguration());
+        SecretsManagerFactory.createSecretsManager(
+            catalogConfig.getSecretsManagerConfiguration(), catalogConfig.getClusterName());
 
     secretsManager.encryptAirflowConnection(catalogConfig.getAirflowConfiguration());
 

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/CatalogApplicationConfig.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/CatalogApplicationConfig.java
@@ -92,6 +92,9 @@ public class CatalogApplicationConfig extends Configuration {
   @JsonProperty("secretsManagerConfiguration")
   private SecretsManagerConfiguration secretsManagerConfiguration;
 
+  @JsonProperty("clusterName")
+  private String clusterName;
+
   @Override
   public String toString() {
     return "catalogConfig{"

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/ingestionpipelines/IngestionPipelineResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/ingestionpipelines/IngestionPipelineResource.java
@@ -53,7 +53,6 @@ import javax.ws.rs.core.UriInfo;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.catalog.CatalogApplicationConfig;
 import org.openmetadata.catalog.Entity;
-import org.openmetadata.catalog.airflow.AirflowConfiguration;
 import org.openmetadata.catalog.airflow.AirflowRESTClient;
 import org.openmetadata.catalog.api.services.ingestionPipelines.CreateIngestionPipeline;
 import org.openmetadata.catalog.api.services.ingestionPipelines.TestServiceConnection;
@@ -81,7 +80,7 @@ import org.openmetadata.catalog.util.ResultList;
 public class IngestionPipelineResource extends EntityResource<IngestionPipeline, IngestionPipelineRepository> {
   public static final String COLLECTION_PATH = "v1/services/ingestionPipelines/";
   private PipelineServiceClient pipelineServiceClient;
-  private AirflowConfiguration airflowConfiguration;
+  private CatalogApplicationConfig catalogApplicationConfig;
   private final SecretsManager secretsManager;
 
   @Override
@@ -97,8 +96,8 @@ public class IngestionPipelineResource extends EntityResource<IngestionPipeline,
   }
 
   public void initialize(CatalogApplicationConfig config) {
-    this.airflowConfiguration = config.getAirflowConfiguration();
-    this.pipelineServiceClient = new AirflowRESTClient(config.getAirflowConfiguration());
+    this.catalogApplicationConfig = config;
+    this.pipelineServiceClient = new AirflowRESTClient(catalogApplicationConfig.getAirflowConfiguration());
     dao.setPipelineServiceClient(pipelineServiceClient);
   }
 
@@ -550,7 +549,8 @@ public class IngestionPipelineResource extends EntityResource<IngestionPipeline,
 
   private IngestionPipeline getIngestionPipeline(CreateIngestionPipeline create, String user) {
     OpenMetadataServerConnection openMetadataServerConnection =
-        secretsManager.decryptServerConnection(airflowConfiguration);
+        secretsManager.decryptServerConnection(catalogApplicationConfig.getAirflowConfiguration());
+    openMetadataServerConnection.setClusterName(catalogApplicationConfig.getClusterName());
     openMetadataServerConnection.setSecretsManagerProvider(this.secretsManager.getSecretsManagerProvider());
     return copy(new IngestionPipeline(), create, user)
         .withPipelineType(create.getPipelineType())

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/secrets/AWSSecretsManager.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/secrets/AWSSecretsManager.java
@@ -28,8 +28,10 @@ public class AWSSecretsManager extends SecretsManager {
   private SecretsManagerClient secretsClient;
 
   private AWSSecretsManager(
-      OpenMetadataServerConnection.SecretsManagerProvider secretsManagerProvider, SecretsManagerConfiguration config) {
-    super(secretsManagerProvider);
+      OpenMetadataServerConnection.SecretsManagerProvider secretsManagerProvider,
+      SecretsManagerConfiguration config,
+      String clusterPrefix) {
+    super(secretsManagerProvider, clusterPrefix);
     if (config == null) {
       throw new SecretsManagerException("Secrets manager configuration is empty.");
     }
@@ -52,7 +54,8 @@ public class AWSSecretsManager extends SecretsManager {
   @Override
   public Object encryptOrDecryptServiceConnectionConfig(
       Object connectionConfig, String connectionType, String connectionName, ServiceType serviceType, boolean encrypt) {
-    String secretName = buildSecretId(serviceType.value().toLowerCase(Locale.ROOT), connectionType, connectionName);
+    String secretName =
+        buildSecretId("service", serviceType.value().toLowerCase(Locale.ROOT), connectionType, connectionName);
     try {
       if (encrypt) {
         String connectionConfigJson = JsonUtils.pojoToJson(connectionConfig);
@@ -160,8 +163,8 @@ public class AWSSecretsManager extends SecretsManager {
     return this.secretsClient.getSecretValue(getSecretValueRequest).secretString();
   }
 
-  public static AWSSecretsManager getInstance(SecretsManagerConfiguration config) {
-    if (INSTANCE == null) INSTANCE = new AWSSecretsManager(AWS, config);
+  public static AWSSecretsManager getInstance(SecretsManagerConfiguration config, String clusterPrefix) {
+    if (INSTANCE == null) INSTANCE = new AWSSecretsManager(AWS, config, clusterPrefix);
     return INSTANCE;
   }
 

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/secrets/LocalSecretsManager.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/secrets/LocalSecretsManager.java
@@ -19,8 +19,9 @@ public class LocalSecretsManager extends SecretsManager {
 
   private Fernet fernet;
 
-  private LocalSecretsManager(OpenMetadataServerConnection.SecretsManagerProvider secretsManagerProvider) {
-    super(secretsManagerProvider);
+  private LocalSecretsManager(
+      OpenMetadataServerConnection.SecretsManagerProvider secretsManagerProvider, String clusterPrefix) {
+    super(secretsManagerProvider, clusterPrefix);
     this.fernet = Fernet.getInstance();
   }
 
@@ -89,8 +90,8 @@ public class LocalSecretsManager extends SecretsManager {
     }
   }
 
-  public static LocalSecretsManager getInstance() {
-    if (INSTANCE == null) INSTANCE = new LocalSecretsManager(LOCAL);
+  public static LocalSecretsManager getInstance(String clusterPrefix) {
+    if (INSTANCE == null) INSTANCE = new LocalSecretsManager(LOCAL, clusterPrefix);
     return INSTANCE;
   }
 

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/secrets/SecretsManagerFactory.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/secrets/SecretsManagerFactory.java
@@ -4,16 +4,16 @@ import org.openmetadata.catalog.services.connections.metadata.OpenMetadataServer
 
 public class SecretsManagerFactory {
 
-  public static SecretsManager createSecretsManager(SecretsManagerConfiguration config) {
+  public static SecretsManager createSecretsManager(SecretsManagerConfiguration config, String clusterName) {
     SecretsManagerProvider secretManager =
         config != null && config.getSecretsManager() != null
             ? config.getSecretsManager()
             : SecretsManagerConfiguration.DEFAULT_SECRET_MANAGER;
     switch (secretManager) {
       case LOCAL:
-        return LocalSecretsManager.getInstance();
+        return LocalSecretsManager.getInstance(clusterName);
       case AWS:
-        return AWSSecretsManager.getInstance(config);
+        return AWSSecretsManager.getInstance(config, clusterName);
       default:
         throw new IllegalArgumentException("Not implemented secret manager store: " + secretManager);
     }

--- a/catalog-rest-service/src/main/resources/json/schema/entity/services/connections/metadata/openMetadataConnection.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/services/connections/metadata/openMetadataConnection.json
@@ -14,6 +14,11 @@
     }
   },
   "properties": {
+    "clusterName": {
+      "description": "Cluster name to differentiate OpenMetadata Server instance",
+      "type": "string",
+      "default": "openmetadata"
+    },
     "type": {
       "description": "Service Type",
       "$ref": "#/definitions/openmetadataType",

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/secrets/AWSSecretsManagerTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/secrets/AWSSecretsManagerTest.java
@@ -51,12 +51,11 @@ import software.amazon.awssdk.services.secretsmanager.model.UpdateSecretRequest;
 public class AWSSecretsManagerTest {
 
   private static final String AUTH_PROVIDER_SECRET_ID_SUFFIX = "auth-provider";
-
   private static final boolean ENCRYPT = true;
   private static final boolean DECRYPT = false;
   private static final String EXPECTED_CONNECTION_JSON =
       "{\"type\":\"Mysql\",\"scheme\":\"mysql+pymysql\",\"password\":\"openmetadata-test\",\"supportsMetadataExtraction\":true,\"supportsProfiler\":true}";
-  private static final String EXPECTED_SECRET_ID = "openmetadata-database-mysql-test";
+  private static final String EXPECTED_SECRET_ID = "/openmetadata/service/database/mysql/test";
 
   @Mock private SecretsManagerClient secretsManagerClient;
 
@@ -70,7 +69,7 @@ public class AWSSecretsManagerTest {
     parameters.put("secretAccessKey", "654321");
     SecretsManagerConfiguration config = new SecretsManagerConfiguration();
     config.setParameters(parameters);
-    secretsManager = AWSSecretsManager.getInstance(config);
+    secretsManager = AWSSecretsManager.getInstance(config, "openmetadata");
     secretsManager.setSecretsClient(secretsManagerClient);
     reset(secretsManagerClient);
   }
@@ -136,7 +135,7 @@ public class AWSSecretsManagerTest {
       OpenMetadataServerConnection.AuthProvider authProvider,
       AuthConfiguration authConfig)
       throws JsonProcessingException {
-    String expectedSecretId = String.format("openmetadata-%s-%s", AUTH_PROVIDER_SECRET_ID_SUFFIX, authProvider);
+    String expectedSecretId = String.format("/openmetadata/%s/%s", AUTH_PROVIDER_SECRET_ID_SUFFIX, authProvider);
     AirflowConfiguration airflowConfiguration = ConfigurationFixtures.buildAirflowConfig(authProvider);
     airflowConfiguration.setAuthConfig(authConfig);
     AirflowConfiguration expectedAirflowConfiguration = ConfigurationFixtures.buildAirflowConfig(authProvider);

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/secrets/LocalSecretsManagerTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/secrets/LocalSecretsManagerTest.java
@@ -47,7 +47,7 @@ public class LocalSecretsManagerTest {
 
   @BeforeAll
   static void setUp() {
-    secretsManager = LocalSecretsManager.getInstance();
+    secretsManager = LocalSecretsManager.getInstance("openmetadata");
     Fernet fernet = Mockito.mock(Fernet.class);
     lenient().when(fernet.decrypt(anyString())).thenReturn(DECRYPTED_VALUE);
     lenient().when(fernet.encrypt(anyString())).thenReturn(ENCRYPTED_VALUE);

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/secrets/SecretsManagerFactoryTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/secrets/SecretsManagerFactoryTest.java
@@ -11,6 +11,8 @@ public class SecretsManagerFactoryTest {
 
   private SecretsManagerConfiguration config;
 
+  private static final String CLUSTER_NAME = "openmetadata";
+
   @BeforeEach
   void setUp() {
     config = new SecretsManagerConfiguration();
@@ -19,18 +21,18 @@ public class SecretsManagerFactoryTest {
 
   @Test
   void testDefaultIsCreatedIfNullConfig() {
-    assertTrue(SecretsManagerFactory.createSecretsManager(config) instanceof LocalSecretsManager);
+    assertTrue(SecretsManagerFactory.createSecretsManager(config, CLUSTER_NAME) instanceof LocalSecretsManager);
   }
 
   @Test
   void testDefaultIsCreatedIfMissingSecretManager() {
-    assertTrue(SecretsManagerFactory.createSecretsManager(config) instanceof LocalSecretsManager);
+    assertTrue(SecretsManagerFactory.createSecretsManager(config, CLUSTER_NAME) instanceof LocalSecretsManager);
   }
 
   @Test
   void testIsCreatedIfLocalSecretsManager() {
     config.setSecretsManager(SecretsManagerProvider.LOCAL);
-    assertTrue(SecretsManagerFactory.createSecretsManager(config) instanceof LocalSecretsManager);
+    assertTrue(SecretsManagerFactory.createSecretsManager(config, CLUSTER_NAME) instanceof LocalSecretsManager);
   }
 
   @Test
@@ -39,6 +41,6 @@ public class SecretsManagerFactoryTest {
     config.getParameters().put("region", "eu-west-1");
     config.getParameters().put("accessKeyId", "123456");
     config.getParameters().put("secretAccessKey", "654321");
-    assertTrue(SecretsManagerFactory.createSecretsManager(config) instanceof AWSSecretsManager);
+    assertTrue(SecretsManagerFactory.createSecretsManager(config, CLUSTER_NAME) instanceof AWSSecretsManager);
   }
 }

--- a/catalog-rest-service/src/test/resources/openmetadata-secure-test.yaml
+++ b/catalog-rest-service/src/test/resources/openmetadata-secure-test.yaml
@@ -9,6 +9,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+clusterName: openmetadata
+
 swagger:
   resourcePackage: org.openmetadata.catalog.webservice.resources
 

--- a/conf/openmetadata.yaml
+++ b/conf/openmetadata.yaml
@@ -9,6 +9,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+clusterName: ${OPENMETADATA_CLUSTER_NAME:-openmetadata}
+
 swagger:
   resourcePackage: org.openmetadata.catalog.resources
 

--- a/ingestion/airflow.cfg
+++ b/ingestion/airflow.cfg
@@ -426,7 +426,8 @@ access_control_allow_origin =
 [openmetadata_airflow_apis]
 dag_generated_configs = /airflow/dag_generated_configs
 
-[openmetadata_secrets_manager]
+# this section is optional, the default auth provider for the secrets' manager service will be used if it is not set
+# [openmetadata_secrets_manager]
 # aws_access_key_id =
 # aws_secret_access_key =
 # aws_region =

--- a/ingestion/examples/airflow/airflow.cfg
+++ b/ingestion/examples/airflow/airflow.cfg
@@ -423,7 +423,8 @@ auth_provider_type = no-auth
 dag_runner_template = /airflow/dag_templates/dag_runner.j2
 dag_generated_configs = /airflow/dag_generated_configs
 
-[openmetadata_secrets_manager]
+# this section is optional, the default auth provider for the secrets' manager service will be used if it is not set
+# [openmetadata_secrets_manager]
 # aws_access_key_id =
 # aws_secret_access_key =
 # aws_region =

--- a/ingestion/src/metadata/ingestion/ometa/ometa_api.py
+++ b/ingestion/src/metadata/ingestion/ometa/ometa_api.py
@@ -168,7 +168,7 @@ class OpenMetadata(
 
         # Load the secrets' manager client
         self.secrets_manager_client = get_secrets_manager(
-            config.secretsManagerProvider, config.secretsManagerCredentials
+            config, config.secretsManagerCredentials
         )
 
         # Load auth provider config from Secret Manager if necessary

--- a/ingestion/src/metadata/utils/secrets_manager.py
+++ b/ingestion/src/metadata/utils/secrets_manager.py
@@ -195,12 +195,17 @@ class LocalSecretsManager(SecretsManager):
 class AWSSecretsManager(SecretsManager):
     def __init__(self, credentials: AWSCredentials, cluster_prefix: str):
         super().__init__(cluster_prefix)
-        session = boto3.Session(
-            aws_access_key_id=credentials.awsAccessKeyId,
-            aws_secret_access_key=credentials.awsSecretAccessKey.get_secret_value(),
-            region_name=credentials.awsRegion,
-        )
-        self.secretsmanager_client = session.client("secretsmanager")
+        # initialize the secret client depending on the SecretsManagerConfiguration passed
+        if credentials:
+            session = boto3.Session(
+                aws_access_key_id=credentials.awsAccessKeyId,
+                aws_secret_access_key=credentials.awsSecretAccessKey.get_secret_value(),
+                region_name=credentials.awsRegion,
+            )
+            self.secretsmanager_client = session.client("secretsmanager")
+        else:
+            # initialized with the credentials loaded from running machine
+            self.secretsmanager_client = boto3.client("secretsmanager")
 
     def retrieve_service_connection(
         self,

--- a/ingestion/src/metadata/utils/secrets_manager.py
+++ b/ingestion/src/metadata/utils/secrets_manager.py
@@ -84,6 +84,11 @@ class SecretsManager(metaclass=Singleton):
     providers.
     """
 
+    cluster_prefix: str
+
+    def __init__(self, cluster_prefix: str):
+        self.cluster_prefix = cluster_prefix
+
     @abstractmethod
     def retrieve_service_connection(
         self,
@@ -105,8 +110,15 @@ class SecretsManager(metaclass=Singleton):
         """
         pass
 
-    @staticmethod
-    def build_secret_id(*args: str) -> str:
+    @property
+    def secret_id_separator(self) -> str:
+        return "/"
+
+    @property
+    def starts_with_separator(self) -> bool:
+        return True
+
+    def build_secret_id(self, *args: str) -> str:
         """
         Returns a secret_id used by the secrets' manager providers for retrieving a secret.
         For example:
@@ -114,8 +126,8 @@ class SecretsManager(metaclass=Singleton):
         :param args: sorted parameters for building the secret_id
         :return: the secret_id
         """
-        secret_suffix = "-".join([arg.lower() for arg in args])
-        return f"openmetadata-{secret_suffix}"
+        secret_id = self.secret_id_separator.join([arg.lower() for arg in args])
+        return f"{self.secret_id_separator if self.starts_with_separator else ''}{self.cluster_prefix}{self.secret_id_separator}{secret_id}"
 
     @staticmethod
     def get_service_connection_class(service_type: str) -> object:
@@ -181,7 +193,8 @@ class LocalSecretsManager(SecretsManager):
 
 
 class AWSSecretsManager(SecretsManager):
-    def __init__(self, credentials: AWSCredentials):
+    def __init__(self, credentials: AWSCredentials, cluster_prefix: str):
+        super().__init__(cluster_prefix)
         session = boto3.Session(
             aws_access_key_id=credentials.awsAccessKeyId,
             aws_secret_access_key=credentials.awsSecretAccessKey.get_secret_value(),
@@ -197,7 +210,7 @@ class AWSSecretsManager(SecretsManager):
         service_connection_type = service.serviceType.value
         service_name = service.name.__root__
         secret_id = self.build_secret_id(
-            service_type, service_connection_type, service_name
+            "service", service_type, service_connection_type, service_name
         )
         connection_class = self.get_connection_class(
             service_type, service_connection_type
@@ -251,12 +264,14 @@ class AWSSecretsManager(SecretsManager):
 
 
 def get_secrets_manager(
-    secret_manager: SecretsManagerProvider,
+    open_metadata_config: OpenMetadataConnection,
     credentials: Optional[Union[AWSCredentials]] = None,
 ) -> SecretsManager:
-    if secret_manager == SecretsManagerProvider.local:
-        return LocalSecretsManager()
-    elif secret_manager == SecretsManagerProvider.aws:
-        return AWSSecretsManager(credentials)
+    if open_metadata_config.secretsManagerProvider == SecretsManagerProvider.local:
+        return LocalSecretsManager(open_metadata_config.clusterName)
+    elif open_metadata_config.secretsManagerProvider == SecretsManagerProvider.aws:
+        return AWSSecretsManager(credentials, open_metadata_config.clusterName)
     else:
-        raise NotImplementedError(f"[{secret_manager}] is not implemented.")
+        raise NotImplementedError(
+            f"[{open_metadata_config.secretsManagerProvider}] is not implemented."
+        )

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/ingestion/credentials_builder.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/ingestion/credentials_builder.py
@@ -9,16 +9,18 @@ from metadata.utils.secrets_manager import SECRET_MANAGER_AIRFLOW_CONF
 
 
 def build_aws_credentials():
-    credentials = AWSCredentials(
-        awsRegion=conf.get(SECRET_MANAGER_AIRFLOW_CONF, "aws_region", fallback="")
-    )
-    credentials.awsAccessKeyId = conf.get(
-        SECRET_MANAGER_AIRFLOW_CONF, "aws_access_key_id", fallback=""
-    )
-    credentials.awsSecretAccessKey = SecretStr(
-        conf.get(SECRET_MANAGER_AIRFLOW_CONF, "aws_secret_access_key", fallback="")
-    )
-    return credentials
+    if conf.has_section(SECRET_MANAGER_AIRFLOW_CONF):
+        credentials = AWSCredentials(
+            awsRegion=conf.get(SECRET_MANAGER_AIRFLOW_CONF, "aws_region", fallback="")
+        )
+        credentials.awsAccessKeyId = conf.get(
+            SECRET_MANAGER_AIRFLOW_CONF, "aws_access_key_id", fallback=""
+        )
+        credentials.awsSecretAccessKey = SecretStr(
+            conf.get(SECRET_MANAGER_AIRFLOW_CONF, "aws_secret_access_key", fallback="")
+        )
+        return credentials
+    return None
 
 
 def build_secrets_manager_credentials(secrets_manager: SecretsManagerProvider):

--- a/openmetadata-core/src/main/resources/json/schema/entity/services/connections/metadata/openMetadataConnection.json
+++ b/openmetadata-core/src/main/resources/json/schema/entity/services/connections/metadata/openMetadataConnection.json
@@ -14,6 +14,11 @@
     }
   },
   "properties": {
+    "clusterName": {
+      "description": "Cluster name to differentiate OpenMetadata Server instance",
+      "type": "string",
+      "default": "openmetadata"
+    },
     "type": {
       "description": "Service Type",
       "$ref": "#/definitions/openmetadataType",


### PR DESCRIPTION
Fixes: #6517 

### Describe your changes :
Added `clusterName` property to the application config YAML to differentiate OpenMetadata Server instance.
Started using the `clusterName` in the new name convention for storing secrets:
- `/{clusterName}/service/{serviceType}/{connectionType}/{serviceName}`
- `/{clusterName}/auth-provider/{authProvider}`

### Type of change :
- [x] New feature

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

### Reviewers
Backend: @open-metadata/backend 
Ingestion: @open-metadata/ingestion 
