### PR TITLE
Fix: Snyk vulnerability found in org.postgresql:postgresql@42.3.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <redshift-jdbc.version>2.1.0.7</redshift-jdbc.version>
     <gson.version>2.9.0</gson.version>
     <mysql.connector.version>8.0.29</mysql.connector.version>
-    <postgres.connector.version>42.3.6</postgres.connector.version>
+    <postgres.connector.version>42.4.1</postgres.connector.version>
     <jsonschema2pojo.version>1.1.1</jsonschema2pojo.version>
     <commons-lang.version>2.6</commons-lang.version>
     <lombok.version>1.18.24</lombok.version>


### PR DESCRIPTION
### Describe your changes :
Fix for vulnerability found in org.postgresql:postgresql@42.3.6 by Snyk.

```
Issues with no direct upgrade or patch:
  ✗ SQL Injection [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGPOSTGRESQL-2970521] in org.postgresql:postgresql@42.3.6
    introduced by org.open-metadata:catalog-rest-service@0.12.0-SNAPSHOT > org.postgresql:postgresql@42.3.6
  This issue was fixed in versions: 42.2.26, 42.4.1
```

### Type of change :
- [x] Improvement

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
Backend: @open-metadata/backend 
