### PR TITLE
Fix #6587 Backend: Announcement start and end time should not clash w…

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/exception/CatalogExceptionMessage.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/exception/CatalogExceptionMessage.java
@@ -146,4 +146,12 @@ public final class CatalogExceptionMessage {
   public static String invalidTeamOwner(TeamType teamType) {
     return String.format("Team of type %s can't own entities. Only Team of type Group can own entities.", teamType);
   }
+
+  public static String announcementOverlap() {
+    return "There is already an announcement scheduled that overlaps with the given start time and end time";
+  }
+
+  public static String announcementInvalidStartTime() {
+    return "Announcement start time must be earlier than the end time";
+  }
 }

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/CollectionDAO.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/CollectionDAO.java
@@ -618,6 +618,23 @@ public interface CollectionDAO {
       return listBefore(limit, before, status, resolved, type);
     }
 
+    default List<String> listAnnouncementBetween(String entityId, long startTs, long endTs) {
+      return listAnnouncementBetween(null, entityId, startTs, endTs);
+    }
+
+    @SqlQuery(
+        "SELECT json FROM thread_entity "
+            + "WHERE type='Announcement' AND (:threadId IS NULL OR id != :threadId) "
+            + "AND entityId = :entityId "
+            + "AND (( :startTs >= announcementStart AND :startTs < announcementEnd) "
+            + "OR (:endTs > announcementStart AND :endTs < announcementEnd) "
+            + "OR (:startTs <= announcementStart AND :endTs >= announcementEnd))")
+    List<String> listAnnouncementBetween(
+        @Bind("threadId") String threadId,
+        @Bind("entityId") String entityId,
+        @Bind("startTs") long startTs,
+        @Bind("endTs") long endTs);
+
     @ConnectionAwareSqlQuery(
         value =
             "SELECT json FROM thread_entity "

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/FeedRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/FeedRepository.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -68,6 +69,7 @@ import org.openmetadata.catalog.resources.feeds.FeedResource;
 import org.openmetadata.catalog.resources.feeds.FeedUtil;
 import org.openmetadata.catalog.resources.feeds.MessageParser;
 import org.openmetadata.catalog.resources.feeds.MessageParser.EntityLink;
+import org.openmetadata.catalog.type.AnnouncementDetails;
 import org.openmetadata.catalog.type.Column;
 import org.openmetadata.catalog.type.EntityReference;
 import org.openmetadata.catalog.type.Include;
@@ -125,6 +127,18 @@ public class FeedRepository {
     // if thread is of type "task", assign a taskId
     if (thread.getType().equals(ThreadType.Task)) {
       thread.withTask(thread.getTask().withId(getNextTaskId()));
+    }
+
+    // if thread is of type "announcement", validate start and end time
+    if (thread.getType().equals(ThreadType.Announcement)) {
+      validateAnnouncement(thread.getAnnouncement());
+      long startTime = thread.getAnnouncement().getStartTime();
+      long endTime = thread.getAnnouncement().getEndTime();
+      List<String> announcements = dao.feedDAO().listAnnouncementBetween(entityId.toString(), startTime, endTime);
+      if (announcements.size() > 0) {
+        // There is already an announcement that overlaps the new one
+        throw new IllegalArgumentException(CatalogExceptionMessage.announcementOverlap());
+      }
     }
 
     // Insert a new thread
@@ -749,6 +763,21 @@ public class FeedRepository {
       updated.getTask().getAssignees().sort(compareEntityReference);
     }
 
+    if (updated.getAnnouncement() != null) {
+      validateAnnouncement(updated.getAnnouncement());
+      // check if the announcement start and end time clashes with other existing announcements
+      List<String> announcements =
+          dao.feedDAO()
+              .listAnnouncementBetween(
+                  id.toString(),
+                  updated.getEntityId().toString(),
+                  updated.getAnnouncement().getStartTime(),
+                  updated.getAnnouncement().getEndTime());
+      if (announcements.size() > 0) {
+        throw new IllegalArgumentException(CatalogExceptionMessage.announcementOverlap());
+      }
+    }
+
     // Update the attributes
     String change = patchUpdate(original, updated) ? RestUtil.ENTITY_UPDATED : RestUtil.ENTITY_NO_CHANGE;
     sortPosts(updated);
@@ -756,9 +785,15 @@ public class FeedRepository {
     return new PatchResponse<>(Status.OK, updatedHref, change);
   }
 
+  private void validateAnnouncement(AnnouncementDetails announcementDetails) {
+    if (announcementDetails.getStartTime() >= announcementDetails.getEndTime()) {
+      throw new IllegalArgumentException(CatalogExceptionMessage.announcementInvalidStartTime());
+    }
+  }
+
   private void restorePatchAttributes(Thread original, Thread updated) {
     // Patch can't make changes to following fields. Ignore the changes
-    updated.withId(original.getId()).withAbout(original.getAbout());
+    updated.withId(original.getId()).withAbout(original.getAbout()).withType(original.getType());
   }
 
   private void restorePatchAttributes(Post original, Post updated) {
@@ -810,13 +845,17 @@ public class FeedRepository {
   }
 
   private boolean fieldsChanged(Thread original, Thread updated) {
-    // Patch supports isResolved, message, task assignees, and reactions for now
+    // Patch supports isResolved, message, task assignees, reactions, and announcements for now
     return !original.getResolved().equals(updated.getResolved())
         || !original.getMessage().equals(updated.getMessage())
         || (Collections.isEmpty(original.getReactions()) && !Collections.isEmpty(updated.getReactions()))
         || (!Collections.isEmpty(original.getReactions()) && Collections.isEmpty(updated.getReactions()))
         || original.getReactions().size() != updated.getReactions().size()
         || !original.getReactions().containsAll(updated.getReactions())
+        || (original.getAnnouncement() != null
+            && (!original.getAnnouncement().getDescription().equals(updated.getAnnouncement().getDescription())
+                || !Objects.equals(original.getAnnouncement().getStartTime(), updated.getAnnouncement().getStartTime())
+                || !Objects.equals(original.getAnnouncement().getEndTime(), updated.getAnnouncement().getEndTime())))
         || (original.getTask() != null
             && (original.getTask().getAssignees().size() != updated.getTask().getAssignees().size()
                 || !original.getTask().getAssignees().containsAll(updated.getTask().getAssignees())));

--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/AnnouncementModal/AddAnnouncementModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/AnnouncementModal/AddAnnouncementModal.tsx
@@ -91,7 +91,7 @@ const AddAnnouncementModal: FC<Props> = ({
         type: 'primary',
         htmlType: 'submit',
       }}
-      okText="Sumbit"
+      okText="Submit"
       title="Make an announcement"
       visible={open}
       width={620}


### PR DESCRIPTION
…ith another announcement

### Describe your changes :
 - Throw an exception when Announcement start and end time clashes with an existing announcement
 - Add support for patch API for announcements

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Frontend Preview (Screenshots) :

https://user-images.githubusercontent.com/1051198/183240192-48e272eb-98b0-4400-8fc1-103f00c77458.mov



#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
