### PR TITLE
6623:High Level Design documentation  starting paragraph has a typo

### DIFF
--- a/openmetadata-docs/content/main-concepts/high-level-design.md
+++ b/openmetadata-docs/content/main-concepts/high-level-design.md
@@ -5,7 +5,7 @@ slug: /main-concepts/high-level-design
 
 # High Level Design
 
-Thi Solution Design document will help us explore and understand the internals of OpenMetadata services, how are they built and
+This Solution Design document will help us explore and understand the internals of OpenMetadata services, how are they built and
 their interactions.
 
 We will start by describing the big picture of the software design of the application. Bit by bit we will get inside


### PR DESCRIPTION
Signed-off-by: Ramesh Mani <ramesh.mani@gmail.com>

### Describe your changes :
High Level Design documentation  starting paragraph has a typo


#
### Type of change :
- [x] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/open-source-community/developer) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
