### PR TITLE
Fix: Profiler DAG takes loggerLevel from ingestion pipeline into account

### DIFF
--- a/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/ingestion/profiler.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/ingestion/profiler.py
@@ -28,6 +28,7 @@ from metadata.generated.schema.entity.services.ingestionPipelines.ingestionPipel
     IngestionPipeline,
 )
 from metadata.generated.schema.metadataIngestion.workflow import (
+    LogLevels,
     OpenMetadataWorkflowConfig,
     Processor,
     Sink,
@@ -52,7 +53,8 @@ def build_profiler_workflow_config(
             config={},
         ),
         workflowConfig=WorkflowConfig(
-            openMetadataServerConfig=ingestion_pipeline.openMetadataServerConnection
+            loggerLevel=ingestion_pipeline.loggerLevel or LogLevels.INFO,
+            openMetadataServerConfig=ingestion_pipeline.openMetadataServerConnection,
         ),
     )
 


### PR DESCRIPTION
### Describe your changes :
When creating a Profiler DAG, it did not consider `loggerLevel` from the ingestion pipeline.

### Type of change :
- [x] Improvement

### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

### Reviewers
Ingestion: @open-metadata/ingestion
