### PR TITLE
Fix#6360: Airflow 2.3.3 None schedule validation

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/CronEditor/CronEditor.jsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/CronEditor/CronEditor.jsx
@@ -590,7 +590,7 @@ const CronEditor = (props) => {
           {getMonthComponent(cronPeriodString)}
           {getYearComponent(cronPeriodString)}
           {isEmpty(value) && (
-            <p className="tw-col-span-2">
+            <p className="tw-col-span-2" data-testid="manual-segment-container">
               Pipeline will only be triggered manually.
             </p>
           )}

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/CronEditor/CronEditor.jsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/CronEditor/CronEditor.jsx
@@ -59,7 +59,7 @@ const getCron = (state) => {
     case 'year':
       return getYearCron(selectedYearOption);
     default:
-      return '';
+      return null;
   }
 };
 
@@ -105,7 +105,7 @@ const CronEditor = (props) => {
     };
     let t = getCronType(valueStr);
 
-    let d = valueStr.split(' ');
+    let d = valueStr ? valueStr.split(' ') : [];
     let v = {
       min: d[0],
       hour: d[1],

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/CronEditor/CronEditor.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/CronEditor/CronEditor.test.tsx
@@ -27,7 +27,7 @@ describe('Test CronEditor component', () => {
     expect(await screen.findByTestId('ingestion-type')).toBeInTheDocument();
   });
 
-  it('Hour option should render corrosponding component', async () => {
+  it('Hour option should render corresponding component', async () => {
     render(<CronEditor disabled={false} onChange={jest.fn} />);
 
     const ingestionType = await screen.findByTestId('ingestion-type');
@@ -65,7 +65,7 @@ describe('Test CronEditor component', () => {
     expect(await screen.findByText('10')).toBeInTheDocument();
   });
 
-  it('Day option should render corrosponding component', async () => {
+  it('Day option should render corresponding component', async () => {
     render(<CronEditor disabled={false} onChange={jest.fn} />);
 
     const ingestionType = await screen.findByTestId('ingestion-type');
@@ -91,7 +91,7 @@ describe('Test CronEditor component', () => {
     expect((await screen.findAllByText('02')).length).toBe(2);
   });
 
-  it('week option should render corrosponding component', async () => {
+  it('week option should render corresponding component', async () => {
     render(<CronEditor disabled={false} onChange={jest.fn} />);
 
     const ingestionType = await screen.findByTestId('ingestion-type');
@@ -118,5 +118,16 @@ describe('Test CronEditor component', () => {
 
     expect((await screen.findAllByText('10')).length).toBe(2);
     expect((await screen.findAllByText('02')).length).toBe(2);
+  });
+
+  it('None option should render corresponding component', async () => {
+    render(<CronEditor disabled={false} onChange={jest.fn} />);
+
+    const ingestionType = await screen.findByTestId('ingestion-type');
+    userEvent.selectOptions(ingestionType, '');
+
+    expect(
+      await screen.findByTestId('manual-segment-container')
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Fixes: #6360

### Describe your changes :
Changed the empty string we were sending for `none` time schedule by `null`.

### Type of change :
- [x] Bug fix

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

### Reviewers
Frontend: @open-metadata/ui
