### PR TITLE
Fix(UI): Fixed issue with confirm button falling out of container.

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
@@ -12,7 +12,7 @@
  */
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Card, Switch } from 'antd';
+import { Card, Space, Switch } from 'antd';
 import { AxiosError } from 'axios';
 import { capitalize, isEmpty, isEqual, isNil, toLower } from 'lodash';
 import { observer } from 'mobx-react';
@@ -229,7 +229,7 @@ const Users = ({
       return (
         <div className="tw-mt-4 tw-w-full tw-px-3">
           {isDisplayNameEdit ? (
-            <div className="tw-flex tw-flex-col tw-justify-between tw-gap-2">
+            <Space className="tw-w-full" direction="vertical">
               <input
                 className="tw-form-inputs tw-form-inputs-padding tw-py-0.5 tw-w-full"
                 data-testid="displayName"
@@ -260,7 +260,7 @@ const Users = ({
                   <FontAwesomeIcon className="tw-w-3.5 tw-h-3.5" icon="check" />
                 </Button>
               </div>
-            </div>
+            </Space>
           ) : (
             <Fragment>
               <span className="tw-text-base tw-font-medium tw-mr-2 tw-overflow-auto">
@@ -384,7 +384,7 @@ const Users = ({
           }>
           <div className="tw-mb-4">
             {isTeamsEdit ? (
-              <div className="tw-flex tw-flex-col tw-justify-between tw-gap-2">
+              <Space className="tw-w-full" direction="vertical">
                 <Select
                   isClearable
                   isMulti
@@ -426,7 +426,7 @@ const Users = ({
                     />
                   </Button>
                 </div>
-              </div>
+              </Space>
             ) : (
               teamsElement
             )}
@@ -518,7 +518,7 @@ const Users = ({
           }>
           <div className="tw-mb-4">
             {isRolesEdit ? (
-              <div className="tw-flex tw-flex-col tw-justify-between tw-gap-2">
+              <Space className="tw-w-full" direction="vertical">
                 <Select
                   isClearable
                   isMulti
@@ -558,7 +558,7 @@ const Users = ({
                     />
                   </Button>
                 </div>
-              </div>
+              </Space>
             ) : (
               rolesElement
             )}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
@@ -384,7 +384,7 @@ const Users = ({
           }>
           <div className="tw-mb-4">
             {isTeamsEdit ? (
-              <div className="tw-flex tw-justify-between tw-items-center tw-gap-2">
+              <div className="tw-flex tw-flex-col tw-justify-between tw-gap-2">
                 <Select
                   isClearable
                   isMulti
@@ -518,7 +518,7 @@ const Users = ({
           }>
           <div className="tw-mb-4">
             {isRolesEdit ? (
-              <div className="tw-flex tw-items-center tw-justify-between tw-gap-2">
+              <div className="tw-flex tw-flex-col tw-justify-between tw-gap-2">
                 <Select
                   isClearable
                   isMulti

--- a/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
@@ -229,7 +229,7 @@ const Users = ({
       return (
         <div className="tw-mt-4 tw-w-full tw-px-3">
           {isDisplayNameEdit ? (
-            <div className="tw-flex tw-justify-between tw-items-center tw-gap-2">
+            <div className="tw-flex tw-flex-col tw-justify-between tw-gap-2">
               <input
                 className="tw-form-inputs tw-form-inputs-padding tw-py-0.5 tw-w-full"
                 data-testid="displayName"

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/react-select-component/reactSelectCustomStyle.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/react-select-component/reactSelectCustomStyle.ts
@@ -68,4 +68,10 @@ export const reactSingleSelectCustomStyle: StylesConfig = {
     background: isSelected ? `#DBD1F9` : '#ffffff',
     color: `${bodyTextColor}`,
   }),
+  multiValue: (styles) => {
+    return {
+      ...styles,
+      width: '70px',
+    };
+  },
 };

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/react-select-component/reactSelectCustomStyle.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/react-select-component/reactSelectCustomStyle.ts
@@ -68,10 +68,4 @@ export const reactSingleSelectCustomStyle: StylesConfig = {
     background: isSelected ? `#DBD1F9` : '#ffffff',
     color: `${bodyTextColor}`,
   }),
-  multiValue: (styles) => {
-    return {
-      ...styles,
-      width: '70px',
-    };
-  },
 };


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the issue with user page confirm button while editing teams falling out of the container.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<p align="center">
Before : 
<img width="266" alt="Screenshot 2022-08-16 at 11 34 42 AM" src="https://user-images.githubusercontent.com/51777795/184809157-3abdfdee-268c-483d-b970-fee733f63e00.png">
Now : 
<img width="261" alt="Screenshot 2022-08-16 at 11 34 53 AM" src="https://user-images.githubusercontent.com/51777795/184809211-be529e46-3932-41b4-9f6f-e8bc8d23ced9.png">
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @open-metadata/ui
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
