### PR TITLE
Fixed issue: for non-admin user global setting left panel should visible properly  #6710

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/CreateUserPage/CreateUserPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/CreateUserPage/CreateUserPage.component.tsx
@@ -54,12 +54,7 @@ const CreateUserPage = () => {
         )
       );
     } else {
-      history.push(
-        getSettingPath(
-          GlobalSettingsMenuCategory.ACCESS,
-          GlobalSettingOptions.USERS
-        )
-      );
+      history.goBack();
     }
   };
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/CustomPropertiesPage/CustomPropertiesPageV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/CustomPropertiesPage/CustomPropertiesPageV1.tsx
@@ -39,6 +39,9 @@ const CustomEntityDetailV1 = () => {
   const [selectedEntityTypeDetail, setSelectedEntityTypeDetail] =
     useState<Type>({} as Type);
 
+  const tabAttributePath =
+    customAttributesPath[tab as keyof typeof customAttributesPath];
+
   const fetchTypeDetail = async (typeFQN: string) => {
     setIsLoading(true);
     try {
@@ -56,7 +59,7 @@ const CustomEntityDetailV1 = () => {
   };
 
   const handleAddProperty = () => {
-    const path = getAddCustomPropertyPath(tab);
+    const path = getAddCustomPropertyPath(tabAttributePath);
     history.push(path);
   };
 
@@ -99,9 +102,7 @@ const CustomEntityDetailV1 = () => {
     if (!isUndefined(tab)) {
       setActiveTab(1);
       setIsError(false);
-      fetchTypeDetail(
-        customAttributesPath[tab as keyof typeof customAttributesPath]
-      );
+      fetchTypeDetail(tabAttributePath);
     }
   }, [tab]);
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/AddRolePage/AddRolePage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/AddRolePage/AddRolePage.tsx
@@ -18,21 +18,15 @@ import { useHistory } from 'react-router-dom';
 import { addRole, getPolicies } from '../../../axiosAPIs/rolesAPIV1';
 import RichTextEditor from '../../../components/common/rich-text-editor/RichTextEditor';
 import TitleBreadcrumb from '../../../components/common/title-breadcrumb/title-breadcrumb.component';
-import {
-  GlobalSettingOptions,
-  GlobalSettingsMenuCategory,
-} from '../../../constants/globalSettings.constants';
+import { GlobalSettingOptions } from '../../../constants/globalSettings.constants';
 import { Policy } from '../../../generated/entity/policies/policy';
-import { getRoleWithFqnPath, getSettingPath } from '../../../utils/RouterUtils';
+import { getPath, getRoleWithFqnPath } from '../../../utils/RouterUtils';
 import { showErrorToast } from '../../../utils/ToastUtils';
 const { Option } = Select;
 const breadcrumb = [
   {
     name: 'Roles',
-    url: getSettingPath(
-      GlobalSettingsMenuCategory.ACCESS,
-      GlobalSettingOptions.ROLES
-    ),
+    url: getPath(GlobalSettingOptions.ROLES),
   },
   {
     name: 'Add New Role',
@@ -58,12 +52,7 @@ const AddRolePage = () => {
   };
 
   const handleCancel = () => {
-    history.push(
-      getSettingPath(
-        GlobalSettingsMenuCategory.ACCESS,
-        GlobalSettingOptions.ROLES
-      )
-    );
+    history.push(getPath(GlobalSettingOptions.ROLES));
   };
 
   const handleSumbit = async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/AddRolePage/AddRolePage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/AddRolePage/AddRolePage.tsx
@@ -23,10 +23,12 @@ import { Policy } from '../../../generated/entity/policies/policy';
 import { getPath, getRoleWithFqnPath } from '../../../utils/RouterUtils';
 import { showErrorToast } from '../../../utils/ToastUtils';
 const { Option } = Select;
+const rolesPath = getPath(GlobalSettingOptions.ROLES);
+
 const breadcrumb = [
   {
     name: 'Roles',
-    url: getPath(GlobalSettingOptions.ROLES),
+    url: rolesPath,
   },
   {
     name: 'Add New Role',
@@ -52,7 +54,7 @@ const AddRolePage = () => {
   };
 
   const handleCancel = () => {
-    history.push(getPath(GlobalSettingOptions.ROLES));
+    history.push(rolesPath);
   };
 
   const handleSumbit = async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/router/GlobalSettingRouter.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/router/GlobalSettingRouter.tsx
@@ -20,6 +20,7 @@ import {
 } from '../constants/globalSettings.constants';
 import TeamsPage from '../pages/teams/TeamsPage';
 import { getSettingCategoryPath, getSettingPath } from '../utils/RouterUtils';
+import AdminProtectedRoute from './AdminProtectedRoute';
 import withSuspenseFallback from './withSuspenseFallback';
 
 const WebhooksPageV1 = withSuspenseFallback(
@@ -98,7 +99,7 @@ const GlobalSettingRouter = () => {
       {/* Roles route start
        * Do not change the order of these route
        */}
-      <Route
+      <AdminProtectedRoute
         exact
         component={RolesListPage}
         path={getSettingPath(
@@ -106,8 +107,12 @@ const GlobalSettingRouter = () => {
           GlobalSettingOptions.ROLES
         )}
       />
-      <Route exact component={AddRolePage} path={ROUTES.ADD_ROLE} />
-      <Route
+      <AdminProtectedRoute
+        exact
+        component={AddRolePage}
+        path={ROUTES.ADD_ROLE}
+      />
+      <AdminProtectedRoute
         exact
         component={RolesDetailPage}
         path={getSettingPath(
@@ -120,7 +125,7 @@ const GlobalSettingRouter = () => {
        * Do not change the order of these route
        */}
 
-      <Route
+      <AdminProtectedRoute
         exact
         component={PoliciesListPage}
         path={getSettingPath(
@@ -128,7 +133,7 @@ const GlobalSettingRouter = () => {
           GlobalSettingOptions.POLICIES
         )}
       />
-      <Route
+      <AdminProtectedRoute
         exact
         component={PoliciesDetailPage}
         path={getSettingPath(
@@ -137,13 +142,13 @@ const GlobalSettingRouter = () => {
           true
         )}
       />
-      <Route
+      <AdminProtectedRoute
         exact
         component={UserListPageV1}
         path={getSettingCategoryPath(GlobalSettingsMenuCategory.ACCESS)}
       />
 
-      <Route
+      <AdminProtectedRoute
         exact
         component={WebhooksPageV1}
         path={getSettingPath(
@@ -151,7 +156,7 @@ const GlobalSettingRouter = () => {
           GlobalSettingOptions.WEBHOOK
         )}
       />
-      <Route
+      <AdminProtectedRoute
         exact
         component={BotsPageV1}
         path={getSettingPath(
@@ -160,7 +165,7 @@ const GlobalSettingRouter = () => {
         )}
       />
 
-      <Route
+      <AdminProtectedRoute
         exact
         component={SlackSettingsPage}
         path={getSettingPath(
@@ -175,7 +180,7 @@ const GlobalSettingRouter = () => {
         path={getSettingCategoryPath(GlobalSettingsMenuCategory.SERVICES)}
       />
 
-      <Route
+      <AdminProtectedRoute
         exact
         component={CustomPropertiesPageV1}
         path={getSettingCategoryPath(

--- a/openmetadata-ui/src/main/resources/ui/src/utils/GlobalSettingsUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/GlobalSettingsUtils.tsx
@@ -40,17 +40,15 @@ export const getGlobalSettingMenus = (
     icon,
     children: children
       ? children
-          .filter(({ isProtected }) => {
-            return hasAccess ?? !isProtected;
-          })
-          .map(({ label, icon }) =>
-            getGlobalSettingMenus(
+          .filter((menu) => (hasAccess ? menu : !menu.isProtected))
+          .map(({ label, icon }) => {
+            return getGlobalSettingMenus(
               label,
               camelCase(label),
               key,
               <SVGIcons alt={label} className="tw-w-4" icon={icon} />
-            )
-          )
+            );
+          })
       : undefined,
     label,
     type,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/RouterUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/RouterUtils.ts
@@ -261,3 +261,34 @@ export const getPolicyWithFqnPath = (fqn: string) => {
 
   return path;
 };
+
+export const getPath = (pathName: string) => {
+  switch (pathName) {
+    case GlobalSettingOptions.TEAMS:
+      return getSettingPath(
+        GlobalSettingsMenuCategory.ACCESS,
+        GlobalSettingOptions.TEAMS
+      );
+
+    case GlobalSettingOptions.USERS:
+      return getSettingPath(
+        GlobalSettingsMenuCategory.ACCESS,
+        GlobalSettingOptions.USERS
+      );
+
+    case GlobalSettingOptions.ROLES:
+      return getSettingPath(
+        GlobalSettingsMenuCategory.ACCESS,
+        GlobalSettingOptions.ROLES
+      );
+
+    case GlobalSettingOptions.POLICIES:
+      return getSettingPath(
+        GlobalSettingsMenuCategory.ACCESS,
+        GlobalSettingOptions.POLICIES
+      );
+
+    default:
+      return getSettingPath();
+  }
+};


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the non-admin user global setting left panel should be visible properly 
Fixes #6710

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement


#
### Frontend Preview (Screenshots) :
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/71748675/184857434-5b3a6ae2-1a2f-4b9e-a69c-5b143bc12f77.png">


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
