### PR TITLE
Fix#6643: Secure in secrets manager the dbtConfigSource object

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/secrets/LocalSecretsManager.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/secrets/LocalSecretsManager.java
@@ -57,6 +57,11 @@ public class LocalSecretsManager extends SecretsManager {
   }
 
   @Override
+  public Object encryptOrDecryptDbtConfigSource(Object dbtConfigSource, String ingestionPipelineName, boolean encrypt) {
+    return dbtConfigSource;
+  }
+
+  @Override
   public AirflowConfiguration encryptAirflowConnection(AirflowConfiguration airflowConfiguration) {
     return airflowConfiguration;
   }

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/secrets/SecretsManager.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/secrets/SecretsManager.java
@@ -48,7 +48,7 @@ public abstract class SecretsManager {
   public abstract Object encryptOrDecryptServiceConnectionConfig(
       Object connectionConfig, String connectionType, String connectionName, ServiceType serviceType, boolean encrypt);
 
-  protected abstract Object encryptOrDecryptDbtConfigSource(
+  abstract Object encryptOrDecryptDbtConfigSource(
       Object dbtConfigSource, String ingestionPipelineName, boolean encrypt);
 
   public void encryptOrDecryptDbtConfigSource(IngestionPipeline ingestionPipeline, boolean encrypt) {

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/secrets/SecretsManager.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/secrets/SecretsManager.java
@@ -18,11 +18,16 @@ import static java.util.Objects.isNull;
 import com.google.common.base.CaseFormat;
 import java.util.List;
 import lombok.Getter;
+import org.openmetadata.catalog.Entity;
 import org.openmetadata.catalog.airflow.AirflowConfiguration;
 import org.openmetadata.catalog.airflow.AuthConfiguration;
 import org.openmetadata.catalog.entity.services.ServiceType;
+import org.openmetadata.catalog.entity.services.ingestionPipelines.IngestionPipeline;
+import org.openmetadata.catalog.entity.services.ingestionPipelines.PipelineType;
 import org.openmetadata.catalog.exception.SecretsManagerException;
+import org.openmetadata.catalog.metadataIngestion.DatabaseServiceMetadataPipeline;
 import org.openmetadata.catalog.services.connections.metadata.OpenMetadataServerConnection;
+import org.openmetadata.catalog.util.JsonUtils;
 
 public abstract class SecretsManager {
 
@@ -42,6 +47,28 @@ public abstract class SecretsManager {
 
   public abstract Object encryptOrDecryptServiceConnectionConfig(
       Object connectionConfig, String connectionType, String connectionName, ServiceType serviceType, boolean encrypt);
+
+  protected abstract Object encryptOrDecryptDbtConfigSource(
+      Object dbtConfigSource, String ingestionPipelineName, boolean encrypt);
+
+  public void encryptOrDecryptDbtConfigSource(IngestionPipeline ingestionPipeline, boolean encrypt) {
+    encryptOrDecryptDbtConfigSource(ingestionPipeline, ingestionPipeline.getService().getType(), encrypt);
+  }
+
+  public void encryptOrDecryptDbtConfigSource(
+      IngestionPipeline ingestionPipeline, String serviceType, boolean encrypt) {
+    // DatabaseServiceMetadataPipeline contains dbtConfigSource and must be encrypted
+    if (serviceType.equals(Entity.DATABASE_SERVICE)
+        && ingestionPipeline.getPipelineType().equals(PipelineType.METADATA)) {
+      DatabaseServiceMetadataPipeline databaseServiceMetadataPipeline =
+          JsonUtils.convertValue(
+              ingestionPipeline.getSourceConfig().getConfig(), DatabaseServiceMetadataPipeline.class);
+      databaseServiceMetadataPipeline.setDbtConfigSource(
+          encryptOrDecryptDbtConfigSource(
+              databaseServiceMetadataPipeline.getDbtConfigSource(), ingestionPipeline.getName(), encrypt));
+      ingestionPipeline.getSourceConfig().setConfig(databaseServiceMetadataPipeline);
+    }
+  }
 
   public OpenMetadataServerConnection decryptServerConnection(AirflowConfiguration airflowConfiguration) {
     OpenMetadataServerConnection.AuthProvider authProvider =

--- a/catalog-rest-service/src/main/resources/json/schema/metadataIngestion/databaseServiceMetadataPipeline.json
+++ b/catalog-rest-service/src/main/resources/json/schema/metadataIngestion/databaseServiceMetadataPipeline.json
@@ -154,6 +154,7 @@
       "$ref": "../type/filterPattern.json#/definitions/filterPattern"
     },
     "dbtConfigSource": {
+      "mask": true,
       "title": "DBT Configuration Source",
       "description": "Available sources to fetch DBT catalog and manifest files.",
       "oneOf": [

--- a/catalog-rest-service/src/main/resources/json/schema/metadataIngestion/workflow.json
+++ b/catalog-rest-service/src/main/resources/json/schema/metadataIngestion/workflow.json
@@ -11,7 +11,6 @@
       "type": "object",
       "properties": {
         "config": {
-          "mask": true,
           "oneOf": [
             {
               "$ref": "databaseServiceMetadataPipeline.json"

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/jdbi3/IngestionPipelineRepositoryTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/jdbi3/IngestionPipelineRepositoryTest.java
@@ -1,0 +1,109 @@
+/*
+ *  Copyright 2022 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.catalog.jdbi3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openmetadata.catalog.ServiceConnectionEntityInterface;
+import org.openmetadata.catalog.ServiceEntityInterface;
+import org.openmetadata.catalog.entity.services.ServiceType;
+import org.openmetadata.catalog.secrets.SecretsManager;
+
+@ExtendWith(MockitoExtension.class)
+public abstract class IngestionPipelineRepositoryTest<
+    T extends ServiceEntityRepository<R, S>,
+    R extends ServiceEntityInterface,
+    S extends ServiceConnectionEntityInterface> {
+
+  @Mock protected CollectionDAO collectionDAO;
+
+  @Mock protected SecretsManager secretsManager;
+
+  protected T serviceRepository;
+
+  protected R service;
+
+  protected S serviceConnection;
+
+  private final ServiceType expectedServiceType;
+
+  protected IngestionPipelineRepositoryTest(ServiceType serviceType) {
+    this.expectedServiceType = serviceType;
+  }
+
+  @BeforeEach
+  void beforeEach() {
+    mockServiceResourceSpecific();
+    serviceRepository = newServiceRepository(collectionDAO, secretsManager);
+  }
+
+  @AfterEach
+  void afterEach() {
+    reset(secretsManager, service);
+  }
+
+  protected abstract T newServiceRepository(CollectionDAO collectionDAO, SecretsManager secretsManager);
+
+  protected abstract void mockServiceResourceSpecific();
+
+  @Test
+  void testStoreEntityCallCorrectlyLocalSecretManager() throws IOException {
+    when(service.getName()).thenReturn("local");
+    when(secretsManager.isLocal()).thenReturn(true);
+    ArgumentCaptor<String> serviceNameCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<ServiceType> serviceTypeCaptor = ArgumentCaptor.forClass(ServiceType.class);
+
+    serviceRepository.storeEntity(service, true);
+
+    verify(serviceConnection, times(2)).getConfig();
+    verify(serviceConnection).setConfig(isNull());
+    verify(secretsManager)
+        .encryptOrDecryptServiceConnectionConfig(
+            any(), any(), serviceNameCaptor.capture(), serviceTypeCaptor.capture(), anyBoolean());
+    assertEquals("local", serviceNameCaptor.getValue());
+    assertEquals(expectedServiceType, serviceTypeCaptor.getValue());
+  }
+
+  @Test
+  void testStoreEntityCallCorrectlyNotLocalSecretManager() throws IOException {
+    when(service.getName()).thenReturn("not-local");
+    ArgumentCaptor<String> serviceNameCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<ServiceType> serviceTypeCaptor = ArgumentCaptor.forClass(ServiceType.class);
+
+    serviceRepository.storeEntity(service, true);
+
+    verify(serviceConnection, times(2)).getConfig();
+    verify(serviceConnection, times(2)).setConfig(isNull());
+    verify(secretsManager)
+        .encryptOrDecryptServiceConnectionConfig(
+            any(), any(), serviceNameCaptor.capture(), serviceTypeCaptor.capture(), anyBoolean());
+    assertEquals("not-local", serviceNameCaptor.getValue());
+    assertEquals(expectedServiceType, serviceTypeCaptor.getValue());
+  }
+}

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/jdbi3/IngestionPipelineRepositoryTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/jdbi3/IngestionPipelineRepositoryTest.java
@@ -15,14 +15,14 @@ package org.openmetadata.catalog.jdbi3;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.util.LinkedHashMap;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,80 +30,80 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.openmetadata.catalog.ServiceConnectionEntityInterface;
-import org.openmetadata.catalog.ServiceEntityInterface;
-import org.openmetadata.catalog.entity.services.ServiceType;
+import org.openmetadata.catalog.Entity;
+import org.openmetadata.catalog.entity.services.DatabaseService;
+import org.openmetadata.catalog.entity.services.ingestionPipelines.IngestionPipeline;
+import org.openmetadata.catalog.metadataIngestion.DatabaseServiceMetadataPipeline;
+import org.openmetadata.catalog.metadataIngestion.SourceConfig;
 import org.openmetadata.catalog.secrets.SecretsManager;
 
 @ExtendWith(MockitoExtension.class)
-public abstract class IngestionPipelineRepositoryTest<
-    T extends ServiceEntityRepository<R, S>,
-    R extends ServiceEntityInterface,
-    S extends ServiceConnectionEntityInterface> {
+public class IngestionPipelineRepositoryTest {
 
   @Mock protected CollectionDAO collectionDAO;
 
   @Mock protected SecretsManager secretsManager;
 
-  protected T serviceRepository;
+  @Mock protected CollectionDAO.IngestionPipelineDAO dao;
 
-  protected R service;
-
-  protected S serviceConnection;
-
-  private final ServiceType expectedServiceType;
-
-  protected IngestionPipelineRepositoryTest(ServiceType serviceType) {
-    this.expectedServiceType = serviceType;
-  }
+  protected IngestionPipelineRepository ingestionPipelineRepository;
 
   @BeforeEach
   void beforeEach() {
-    mockServiceResourceSpecific();
-    serviceRepository = newServiceRepository(collectionDAO, secretsManager);
+    when(collectionDAO.ingestionPipelineDAO()).thenReturn(dao);
+    ingestionPipelineRepository = new IngestionPipelineRepository(collectionDAO, secretsManager);
   }
 
   @AfterEach
   void afterEach() {
-    reset(secretsManager, service);
+    reset(secretsManager);
   }
-
-  protected abstract T newServiceRepository(CollectionDAO collectionDAO, SecretsManager secretsManager);
-
-  protected abstract void mockServiceResourceSpecific();
 
   @Test
   void testStoreEntityCallCorrectlyLocalSecretManager() throws IOException {
-    when(service.getName()).thenReturn("local");
-    when(secretsManager.isLocal()).thenReturn(true);
-    ArgumentCaptor<String> serviceNameCaptor = ArgumentCaptor.forClass(String.class);
-    ArgumentCaptor<ServiceType> serviceTypeCaptor = ArgumentCaptor.forClass(ServiceType.class);
+    IngestionPipeline ingestionPipeline = initStoreEntityTest(true);
 
-    serviceRepository.storeEntity(service, true);
+    ArgumentCaptor<String> serviceTypeCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> ingestionPipelineStringCaptor = ArgumentCaptor.forClass(String.class);
 
-    verify(serviceConnection, times(2)).getConfig();
-    verify(serviceConnection).setConfig(isNull());
+    ingestionPipelineRepository.storeEntity(ingestionPipeline, true);
+
     verify(secretsManager)
-        .encryptOrDecryptServiceConnectionConfig(
-            any(), any(), serviceNameCaptor.capture(), serviceTypeCaptor.capture(), anyBoolean());
-    assertEquals("local", serviceNameCaptor.getValue());
-    assertEquals(expectedServiceType, serviceTypeCaptor.getValue());
+        .encryptOrDecryptDbtConfigSource(any(IngestionPipeline.class), serviceTypeCaptor.capture(), eq(true));
+    verify(dao).update(isNull(), ingestionPipelineStringCaptor.capture());
+
+    assertEquals("databaseService", serviceTypeCaptor.getValue());
+    assertEquals(
+        "{\"name\":\"testPipeline\",\"sourceConfig\":{\"config\":{\"type\":\"DatabaseMetadata\",\"markDeletedTables\":true,\"includeTables\":true,\"includeViews\":true,\"includeTags\":true,\"dbtConfigSource\":{}}},\"loggerLevel\":\"INFO\",\"enabled\":true,\"version\":0.1,\"deleted\":false}",
+        ingestionPipelineStringCaptor.getValue());
   }
 
   @Test
-  void testStoreEntityCallCorrectlyNotLocalSecretManager() throws IOException {
-    when(service.getName()).thenReturn("not-local");
-    ArgumentCaptor<String> serviceNameCaptor = ArgumentCaptor.forClass(String.class);
-    ArgumentCaptor<ServiceType> serviceTypeCaptor = ArgumentCaptor.forClass(ServiceType.class);
+  void testStoreEntityCallCorrectlyAWSSecretManager() throws IOException {
+    IngestionPipeline ingestionPipeline = initStoreEntityTest(false);
 
-    serviceRepository.storeEntity(service, true);
+    ArgumentCaptor<String> serviceTypeCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> ingestionPipelineStringCaptor = ArgumentCaptor.forClass(String.class);
 
-    verify(serviceConnection, times(2)).getConfig();
-    verify(serviceConnection, times(2)).setConfig(isNull());
+    ingestionPipelineRepository.storeEntity(ingestionPipeline, true);
+
     verify(secretsManager)
-        .encryptOrDecryptServiceConnectionConfig(
-            any(), any(), serviceNameCaptor.capture(), serviceTypeCaptor.capture(), anyBoolean());
-    assertEquals("not-local", serviceNameCaptor.getValue());
-    assertEquals(expectedServiceType, serviceTypeCaptor.getValue());
+        .encryptOrDecryptDbtConfigSource(any(IngestionPipeline.class), serviceTypeCaptor.capture(), eq(true));
+    verify(dao).update(isNull(), ingestionPipelineStringCaptor.capture());
+
+    assertEquals("databaseService", serviceTypeCaptor.getValue());
+    assertEquals(
+        "{\"name\":\"testPipeline\",\"sourceConfig\":{\"config\":{\"type\":\"DatabaseMetadata\",\"markDeletedTables\":true,\"includeTables\":true,\"includeViews\":true,\"includeTags\":true}},\"loggerLevel\":\"INFO\",\"enabled\":true,\"version\":0.1,\"deleted\":false}",
+        ingestionPipelineStringCaptor.getValue());
+  }
+
+  private IngestionPipeline initStoreEntityTest(boolean isLocal) {
+    when(secretsManager.isLocal()).thenReturn(isLocal);
+    return new IngestionPipeline()
+        .withName("testPipeline")
+        .withService(new DatabaseService().getEntityReference().withType(Entity.DATABASE_SERVICE))
+        .withSourceConfig(
+            new SourceConfig()
+                .withConfig(new DatabaseServiceMetadataPipeline().withDbtConfigSource(new LinkedHashMap<>())));
   }
 }

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/ingestionpipelines/IngestionPipelineResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/ingestionpipelines/IngestionPipelineResourceTest.java
@@ -158,7 +158,11 @@ public class IngestionPipelineResourceTest extends EntityResourceTest<IngestionP
       IngestionPipeline expected, IngestionPipeline updated, Map<String, String> authHeaders) {
     assertEquals(expected.getDisplayName(), updated.getDisplayName());
     assertReference(expected.getService(), updated.getService());
-    assertNull(updated.getSourceConfig().getConfig());
+    if (Entity.DATABASE_SERVICE.equals(updated.getService().getType())) {
+      assertNull(
+          JsonUtils.convertValue(updated.getSourceConfig().getConfig(), DatabaseServiceMetadataPipeline.class)
+              .getDbtConfigSource());
+    }
   }
 
   @Override

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/ingestionpipelines/IngestionPipelineResourceUnitTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/ingestionpipelines/IngestionPipelineResourceUnitTest.java
@@ -14,10 +14,16 @@
 package org.openmetadata.catalog.resources.services.ingestionpipelines;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -29,14 +35,23 @@ import javax.ws.rs.core.SecurityContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedConstruction.Context;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.openmetadata.catalog.CatalogApplicationConfig;
+import org.openmetadata.catalog.Entity;
+import org.openmetadata.catalog.EntityInterface;
 import org.openmetadata.catalog.airflow.AirflowRESTClient;
 import org.openmetadata.catalog.entity.services.ingestionPipelines.IngestionPipeline;
+import org.openmetadata.catalog.entity.services.ingestionPipelines.PipelineType;
 import org.openmetadata.catalog.jdbi3.CollectionDAO;
+import org.openmetadata.catalog.jdbi3.EntityDAO;
+import org.openmetadata.catalog.jdbi3.EntityRepository;
+import org.openmetadata.catalog.metadataIngestion.DatabaseServiceMetadataPipeline;
+import org.openmetadata.catalog.metadataIngestion.SourceConfig;
 import org.openmetadata.catalog.secrets.SecretsManager;
 import org.openmetadata.catalog.security.Authorizer;
 import org.openmetadata.catalog.type.EntityReference;
@@ -46,6 +61,8 @@ import org.openmetadata.catalog.util.PipelineServiceClient;
 public class IngestionPipelineResourceUnitTest {
 
   private static final UUID DAG_ID = UUID.randomUUID();
+
+  private static final String PIPELINE_NAME = "service_test";
 
   private IngestionPipelineResource ingestionPipelineResource;
 
@@ -57,11 +74,13 @@ public class IngestionPipelineResourceUnitTest {
 
   @Mock CatalogApplicationConfig catalogApplicationConfig;
 
-  @Mock IngestionPipeline ingestionPipeline;
+  @Mock SecretsManager secretsManager;
+
+  @Mock CollectionDAO.IngestionPipelineDAO entityDAO;
 
   @BeforeEach
-  void setUp() throws IOException {
-    CollectionDAO.IngestionPipelineDAO entityDAO = mock(CollectionDAO.IngestionPipelineDAO.class);
+  void setUp() {
+    reset(entityDAO, collectionDAO, secretsManager, authorizer);
     CollectionDAO.EntityRelationshipDAO relationshipDAO = mock(CollectionDAO.EntityRelationshipDAO.class);
     CollectionDAO.EntityRelationshipRecord entityRelationshipRecord =
         mock(CollectionDAO.EntityRelationshipRecord.class);
@@ -70,14 +89,15 @@ public class IngestionPipelineResourceUnitTest {
     when(relationshipDAO.findFrom(any(), any(), anyInt())).thenReturn(List.of(entityRelationshipRecord));
     when(collectionDAO.ingestionPipelineDAO()).thenReturn(entityDAO);
     when(collectionDAO.relationshipDAO()).thenReturn(relationshipDAO);
-    when(entityDAO.findEntityById(any(), any())).thenReturn(ingestionPipeline);
-    when(entityDAO.findEntityReferenceById(any(), any())).thenReturn(mock(EntityReference.class));
-    when(ingestionPipeline.getId()).thenReturn(DAG_ID);
-    ingestionPipelineResource = new IngestionPipelineResource(collectionDAO, authorizer, mock(SecretsManager.class));
+    ingestionPipelineResource = new IngestionPipelineResource(collectionDAO, authorizer, secretsManager);
   }
 
   @Test
   public void testLastIngestionLogsAreRetrieved() throws IOException {
+    IngestionPipeline ingestionPipeline = mock(IngestionPipeline.class);
+    when(ingestionPipeline.getId()).thenReturn(DAG_ID);
+    when(entityDAO.findEntityById(any(), any())).thenReturn(ingestionPipeline);
+    when(entityDAO.findEntityReferenceById(any(), any())).thenReturn(mock(EntityReference.class));
     Map<String, String> expectedMap = Map.of("task", "log");
     try (MockedConstruction<AirflowRESTClient> mocked =
         mockConstruction(AirflowRESTClient.class, this::preparePipelineServiceClient)) {
@@ -89,7 +109,85 @@ public class IngestionPipelineResourceUnitTest {
     }
   }
 
+  @ParameterizedTest
+  @MethodSource(
+      "org.openmetadata.catalog.resources.services.ingestionpipelines.IngestionPipelineResourceUnitTestParams#params")
+  public void testGetIsEncryptedWhenSecretManagerIsConfigured(
+      Object config,
+      EntityReference service,
+      Class<? extends EntityInterface> serviceClass,
+      PipelineType pipelineType,
+      boolean mustBeEncrypted)
+      throws IOException {
+    UUID id = UUID.randomUUID();
+
+    IngestionPipeline ingestionPipeline = buildIngestionPipeline(config, pipelineType, id);
+
+    Entity.registerEntity(serviceClass, service.getType(), mock(EntityDAO.class), mock(EntityRepository.class));
+
+    when(entityDAO.findEntityById(eq(id), any())).thenReturn(ingestionPipeline);
+    when(entityDAO.findEntityReferenceById(any(), any())).thenReturn(service);
+
+    IngestionPipeline actualIngestionPipeline = ingestionPipelineResource.get(null, securityContext, id, null, null);
+
+    verifySecretManagerIsCalled(mustBeEncrypted, ingestionPipeline);
+    assertIngestionPipelineDbtConfigIsEncrypted(mustBeEncrypted, actualIngestionPipeline);
+  }
+
+  @ParameterizedTest
+  @MethodSource(
+      "org.openmetadata.catalog.resources.services.ingestionpipelines.IngestionPipelineResourceUnitTestParams#params")
+  public void testGetByNameIsEncryptedWhenSecretManagerIsConfigured(
+      Object config,
+      EntityReference service,
+      Class<? extends EntityInterface> serviceClass,
+      PipelineType pipelineType,
+      boolean mustBeEncrypted)
+      throws IOException {
+    UUID id = UUID.randomUUID();
+
+    IngestionPipeline ingestionPipeline = buildIngestionPipeline(config, pipelineType, id);
+
+    Entity.registerEntity(serviceClass, service.getType(), mock(EntityDAO.class), mock(EntityRepository.class));
+
+    when(entityDAO.findEntityByName(eq(PIPELINE_NAME), any())).thenReturn(ingestionPipeline);
+    when(entityDAO.findEntityReferenceById(any(), any())).thenReturn(service);
+
+    IngestionPipeline actualIngestionPipeline =
+        ingestionPipelineResource.getByName(null, PIPELINE_NAME, securityContext, null, null);
+
+    verifySecretManagerIsCalled(mustBeEncrypted, ingestionPipeline);
+    assertIngestionPipelineDbtConfigIsEncrypted(mustBeEncrypted, actualIngestionPipeline);
+  }
+
   private void preparePipelineServiceClient(AirflowRESTClient mockPipelineServiceClient, Context context) {
     when(mockPipelineServiceClient.getLastIngestionLogs(any())).thenReturn(Map.of("task", "log"));
+  }
+
+  private IngestionPipeline buildIngestionPipeline(Object config, PipelineType pipelineType, UUID id) {
+    return new IngestionPipeline()
+        .withId(id)
+        .withPipelineType(pipelineType)
+        .withSourceConfig(new SourceConfig().withConfig(config))
+        .withName(PIPELINE_NAME);
+  }
+
+  private void verifySecretManagerIsCalled(boolean mustBeEncrypted, IngestionPipeline ingestionPipeline) {
+    if (mustBeEncrypted) {
+      verify(secretsManager).encryptOrDecryptDbtConfigSource(eq(ingestionPipeline), eq(false));
+    } else {
+      verify(secretsManager, never()).encryptOrDecryptDbtConfigSource(any(), any(), anyBoolean());
+    }
+  }
+
+  private void assertIngestionPipelineDbtConfigIsEncrypted(
+      boolean mustBeEncrypted, IngestionPipeline actualIngestionPipeline) {
+    if (mustBeEncrypted) {
+      assertNull(
+          ((DatabaseServiceMetadataPipeline) actualIngestionPipeline.getSourceConfig().getConfig())
+              .getDbtConfigSource());
+    } else {
+      assertNotNull(actualIngestionPipeline.getSourceConfig().getConfig());
+    }
   }
 }

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/ingestionpipelines/IngestionPipelineResourceUnitTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/ingestionpipelines/IngestionPipelineResourceUnitTest.java
@@ -94,7 +94,7 @@ public class IngestionPipelineResourceUnitTest {
   }
 
   @Test
-  public void testLastIngestionLogsAreRetrieved() throws IOException {
+  void testLastIngestionLogsAreRetrieved() throws IOException {
     IngestionPipeline ingestionPipeline = mock(IngestionPipeline.class);
     when(ingestionPipeline.getId()).thenReturn(DAG_ID);
     when(entityDAO.findEntityById(any(), any())).thenReturn(ingestionPipeline);
@@ -113,7 +113,7 @@ public class IngestionPipelineResourceUnitTest {
   @ParameterizedTest
   @MethodSource(
       "org.openmetadata.catalog.resources.services.ingestionpipelines.IngestionPipelineResourceUnitTestParams#params")
-  public void testGetIsEncryptedWhenSecretManagerIsConfigured(
+  void testGetIsEncryptedWhenSecretManagerIsConfigured(
       Object config,
       EntityReference service,
       Class<? extends EntityInterface> serviceClass,
@@ -149,7 +149,7 @@ public class IngestionPipelineResourceUnitTest {
   @ParameterizedTest
   @MethodSource(
       "org.openmetadata.catalog.resources.services.ingestionpipelines.IngestionPipelineResourceUnitTestParams#params")
-  public void testGetByNameIsEncryptedWhenSecretManagerIsConfigured(
+  void testGetByNameIsEncryptedWhenSecretManagerIsConfigured(
       Object config,
       EntityReference service,
       Class<? extends EntityInterface> serviceClass,
@@ -197,7 +197,7 @@ public class IngestionPipelineResourceUnitTest {
 
   private void verifySecretManagerIsCalled(boolean mustBeEncrypted, IngestionPipeline ingestionPipeline) {
     if (mustBeEncrypted) {
-      verify(secretsManager).encryptOrDecryptDbtConfigSource(eq(ingestionPipeline), eq(false));
+      verify(secretsManager).encryptOrDecryptDbtConfigSource(ingestionPipeline, false);
     } else {
       verify(secretsManager, never()).encryptOrDecryptDbtConfigSource(any(), any(), anyBoolean());
     }

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/ingestionpipelines/IngestionPipelineResourceUnitTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/ingestionpipelines/IngestionPipelineResourceUnitTest.java
@@ -20,6 +20,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.never;
@@ -125,6 +126,17 @@ public class IngestionPipelineResourceUnitTest {
 
     Entity.registerEntity(serviceClass, service.getType(), mock(EntityDAO.class), mock(EntityRepository.class));
 
+    doAnswer(
+            invocation -> {
+              if (mustBeEncrypted) {
+                IngestionPipeline arg0 = invocation.getArgument(0);
+                ((DatabaseServiceMetadataPipeline) arg0.getSourceConfig().getConfig()).setDbtConfigSource(null);
+              }
+              return null;
+            })
+        .when(secretsManager)
+        .encryptOrDecryptDbtConfigSource(any(IngestionPipeline.class), anyBoolean());
+
     when(entityDAO.findEntityById(eq(id), any())).thenReturn(ingestionPipeline);
     when(entityDAO.findEntityReferenceById(any(), any())).thenReturn(service);
 
@@ -152,6 +164,17 @@ public class IngestionPipelineResourceUnitTest {
 
     when(entityDAO.findEntityByName(eq(PIPELINE_NAME), any())).thenReturn(ingestionPipeline);
     when(entityDAO.findEntityReferenceById(any(), any())).thenReturn(service);
+
+    doAnswer(
+            invocation -> {
+              if (mustBeEncrypted) {
+                IngestionPipeline arg0 = invocation.getArgument(0);
+                ((DatabaseServiceMetadataPipeline) arg0.getSourceConfig().getConfig()).setDbtConfigSource(null);
+              }
+              return null;
+            })
+        .when(secretsManager)
+        .encryptOrDecryptDbtConfigSource(any(IngestionPipeline.class), anyBoolean());
 
     IngestionPipeline actualIngestionPipeline =
         ingestionPipelineResource.getByName(null, PIPELINE_NAME, securityContext, null, null);

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/ingestionpipelines/IngestionPipelineResourceUnitTestParams.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/ingestionpipelines/IngestionPipelineResourceUnitTestParams.java
@@ -1,0 +1,123 @@
+/*
+ *  Copyright 2022 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.catalog.resources.services.ingestionpipelines;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+import org.openmetadata.catalog.Entity;
+import org.openmetadata.catalog.api.services.CreateDashboardService;
+import org.openmetadata.catalog.api.services.CreateDatabaseService;
+import org.openmetadata.catalog.api.services.CreateMessagingService;
+import org.openmetadata.catalog.api.services.CreateMlModelService;
+import org.openmetadata.catalog.api.services.CreatePipelineService;
+import org.openmetadata.catalog.entity.services.DashboardService;
+import org.openmetadata.catalog.entity.services.DatabaseService;
+import org.openmetadata.catalog.entity.services.MessagingService;
+import org.openmetadata.catalog.entity.services.MlModelService;
+import org.openmetadata.catalog.entity.services.PipelineService;
+import org.openmetadata.catalog.entity.services.ingestionPipelines.PipelineType;
+import org.openmetadata.catalog.metadataIngestion.DashboardServiceMetadataPipeline;
+import org.openmetadata.catalog.metadataIngestion.DatabaseServiceMetadataPipeline;
+import org.openmetadata.catalog.metadataIngestion.DatabaseServiceProfilerPipeline;
+import org.openmetadata.catalog.metadataIngestion.DatabaseServiceQueryLineagePipeline;
+import org.openmetadata.catalog.metadataIngestion.DatabaseServiceQueryUsagePipeline;
+import org.openmetadata.catalog.metadataIngestion.MessagingServiceMetadataPipeline;
+import org.openmetadata.catalog.metadataIngestion.MlmodelServiceMetadataPipeline;
+import org.openmetadata.catalog.metadataIngestion.PipelineServiceMetadataPipeline;
+import org.openmetadata.catalog.type.EntityReference;
+
+public class IngestionPipelineResourceUnitTestParams {
+
+  public static final EntityReference DATABASE_SERVICE_ENTITY =
+      new DatabaseService()
+          .withServiceType(CreateDatabaseService.DatabaseServiceType.Mysql)
+          .getEntityReference()
+          .withType(Entity.DATABASE_SERVICE);
+
+  public static final EntityReference PIPELINE_SERVICE_ENTITY =
+      new PipelineService()
+          .withServiceType(CreatePipelineService.PipelineServiceType.Airbyte)
+          .getEntityReference()
+          .withType(Entity.PIPELINE_SERVICE);
+
+  public static final EntityReference MESSAGING_SERVICE_ENTITY =
+      new MessagingService()
+          .withServiceType(CreateMessagingService.MessagingServiceType.Kafka)
+          .getEntityReference()
+          .withType(Entity.MESSAGING_SERVICE);
+
+  public static final EntityReference DASHBOARD_SERVICE_ENTITY =
+      new DashboardService()
+          .withServiceType(CreateDashboardService.DashboardServiceType.Looker)
+          .getEntityReference()
+          .withType(Entity.DASHBOARD_SERVICE);
+
+  public static final EntityReference MLMODEL_SERVICE_ENTITY =
+      new MlModelService()
+          .withServiceType(CreateMlModelService.MlModelServiceType.Mlflow)
+          .getEntityReference()
+          .withType(Entity.MLMODEL_SERVICE);
+
+  public static Stream<Arguments> params() {
+    return Stream.of(
+        Arguments.of(
+            new DatabaseServiceMetadataPipeline(),
+            DATABASE_SERVICE_ENTITY,
+            DatabaseService.class,
+            PipelineType.METADATA,
+            true),
+        Arguments.of(
+            new DatabaseServiceQueryUsagePipeline(),
+            DATABASE_SERVICE_ENTITY,
+            DatabaseService.class,
+            PipelineType.USAGE,
+            false),
+        Arguments.of(
+            new DatabaseServiceQueryLineagePipeline(),
+            DATABASE_SERVICE_ENTITY,
+            DatabaseService.class,
+            PipelineType.LINEAGE,
+            false),
+        Arguments.of(
+            new DashboardServiceMetadataPipeline(),
+            DASHBOARD_SERVICE_ENTITY,
+            DatabaseService.class,
+            PipelineType.METADATA,
+            false),
+        Arguments.of(
+            new MessagingServiceMetadataPipeline(),
+            MESSAGING_SERVICE_ENTITY,
+            DatabaseService.class,
+            PipelineType.METADATA,
+            false),
+        Arguments.of(
+            new DatabaseServiceProfilerPipeline(),
+            DATABASE_SERVICE_ENTITY,
+            DatabaseService.class,
+            PipelineType.PROFILER,
+            false),
+        Arguments.of(
+            new PipelineServiceMetadataPipeline(),
+            PIPELINE_SERVICE_ENTITY,
+            DatabaseService.class,
+            PipelineType.METADATA,
+            false),
+        Arguments.of(
+            new MlmodelServiceMetadataPipeline(),
+            MLMODEL_SERVICE_ENTITY,
+            DatabaseService.class,
+            PipelineType.METADATA,
+            false));
+  }
+}

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/ingestionpipelines/IngestionPipelineResourceUnitTestParams.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/ingestionpipelines/IngestionPipelineResourceUnitTestParams.java
@@ -13,6 +13,7 @@
 
 package org.openmetadata.catalog.resources.services.ingestionpipelines;
 
+import java.util.LinkedHashMap;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.provider.Arguments;
 import org.openmetadata.catalog.Entity;
@@ -72,7 +73,7 @@ public class IngestionPipelineResourceUnitTestParams {
   public static Stream<Arguments> params() {
     return Stream.of(
         Arguments.of(
-            new DatabaseServiceMetadataPipeline(),
+            new DatabaseServiceMetadataPipeline().withDbtConfigSource(new LinkedHashMap<>()),
             DATABASE_SERVICE_ENTITY,
             DatabaseService.class,
             PipelineType.METADATA,

--- a/ingestion/src/metadata/ingestion/api/workflow.py
+++ b/ingestion/src/metadata/ingestion/api/workflow.py
@@ -296,9 +296,9 @@ class Workflow:
                     f"{self.config.source.serviceName}_metadata",
                 )
             )
-            config = self.config.source.sourceConfig.config.dict()
-            config["dbtConfigSource"] = dbt_config_source
-            if dbt_config_source:
+            if dbt_config_source and self.config.source.sourceConfig.config:
+                config = self.config.source.sourceConfig.config.dict()
+                config["dbtConfigSource"] = dbt_config_source
                 self.config.source.sourceConfig.config = (
                     DatabaseServiceMetadataPipeline.parse_obj(config)
                 )

--- a/ingestion/src/metadata/ingestion/api/workflow.py
+++ b/ingestion/src/metadata/ingestion/api/workflow.py
@@ -10,6 +10,7 @@
 #  limitations under the License.
 
 import importlib
+import re
 from typing import Type, TypeVar
 
 import click
@@ -19,6 +20,9 @@ from metadata.generated.schema.entity.services.connections.metadata.openMetadata
     OpenMetadataConnection,
 )
 from metadata.generated.schema.entity.services.serviceType import ServiceType
+from metadata.generated.schema.metadataIngestion.databaseServiceMetadataPipeline import (
+    DatabaseServiceMetadataPipeline,
+)
 from metadata.generated.schema.metadataIngestion.workflow import (
     OpenMetadataWorkflowConfig,
 )
@@ -80,6 +84,8 @@ class Workflow:
         )
 
         self._retrieve_service_connection_if_needed(metadata_config, service_type)
+
+        self._retrieve_dbt_config_source_if_needed(metadata_config, service_type)
 
         self.source: Source = source_class.create(
             self.config.source.dict(), metadata_config
@@ -248,16 +254,13 @@ class Workflow:
     ) -> None:
         """
         We override the current `serviceConnection` source config object if source workflow service already exists
-        in OM. When it is configured, we retrieve the service connection from the secrets' manager. Otherwise, we get it
-        from the service object itself through the default `SecretsManager`.
+        in OM. When secrets' manager is configured, we retrieve the service connection from the secrets' manager.
+        Otherwise, we get the service connection from the service object itself through the default `SecretsManager`.
 
         :param metadata_config: OpenMetadata connection config
         :param service_type: source workflow service type
         :return:
         """
-        # We override the current serviceConnection source object if source workflow service already exists in OM.
-        # We retrieve the service connection from the secrets' manager when it is configured. Otherwise, we get it
-        # from the service object itself.
         if service_type is not ServiceType.Metadata and not self._is_sample_source(
             self.config.source.type
         ):
@@ -273,6 +276,40 @@ class Workflow:
                     )
                 )
 
+    def _retrieve_dbt_config_source_if_needed(
+        self, metadata_config: OpenMetadataConnection, service_type: ServiceType
+    ) -> None:
+        """
+        We override the current `config` source config object if it is a metadata ingestion type. When secrets' manager
+        is configured, we retrieve the config from the secrets' manager. Otherwise, we get the config from the source
+        config object itself through the default `SecretsManager`.
+
+        :return:
+        """
+        if service_type is ServiceType.Database and self.is_metadata_source_type(
+            self.config.source.type
+        ):
+            metadata = OpenMetadata(config=metadata_config)
+            dbt_config_source: object = (
+                metadata.secrets_manager_client.retrieve_dbt_source_config(
+                    self.config.source.sourceConfig,
+                    f"{self.config.source.serviceName}_metadata",
+                )
+            )
+            config = self.config.source.sourceConfig.config.dict()
+            config["dbtConfigSource"] = dbt_config_source
+            if dbt_config_source:
+                self.config.source.sourceConfig.config = (
+                    DatabaseServiceMetadataPipeline.parse_obj(config)
+                )
+
     @staticmethod
-    def _is_sample_source(service_type):
+    def _is_sample_source(service_type: str) -> bool:
         return service_type in SAMPLE_SOURCE
+
+    @staticmethod
+    def is_metadata_source_type(source_type: str) -> bool:
+        return (
+            re.match(r"_usage$", source_type) is None
+            or re.match(r"_lineage$", source_type) is None
+        )

--- a/ingestion/src/metadata/utils/secrets_manager.py
+++ b/ingestion/src/metadata/utils/secrets_manager.py
@@ -32,6 +32,7 @@ from metadata.generated.schema.entity.services.messagingService import Messaging
 from metadata.generated.schema.entity.services.metadataService import MetadataService
 from metadata.generated.schema.entity.services.mlmodelService import MlModelService
 from metadata.generated.schema.entity.services.pipelineService import PipelineService
+from metadata.generated.schema.metadataIngestion.workflow import SourceConfig
 from metadata.generated.schema.security.client import (
     auth0SSOClientConfig,
     azureSSOClientConfig,
@@ -96,7 +97,7 @@ class SecretsManager(metaclass=Singleton):
         service_type: str,
     ) -> ServiceConnection:
         """
-        Retrieve the service connection from the secret manager to a given service connection object.
+        Retrieve the service connection from the secret manager from a given service connection object.
         :param service: Service connection object e.g. DatabaseConnection
         :param service_type: Service type e.g. databaseService
         """
@@ -109,6 +110,17 @@ class SecretsManager(metaclass=Singleton):
         :param config: OpenMetadataConnection object
         """
         pass
+
+    @abstractmethod
+    def retrieve_dbt_source_config(
+        self, source_config: SourceConfig, pipeline_name: str
+    ) -> object:
+        """
+         Retrieve the DBT source config from the secret manager from a source config object.
+        :param source_config: SourceConfig object
+        :param pipeline_name: the pipeline's name
+        :return:
+        """
 
     @property
     def secret_id_separator(self) -> str:
@@ -179,6 +191,9 @@ class LocalSecretsManager(SecretsManager):
         """
         The LocalSecretsManager does not modify the OpenMetadataConnection object
         """
+        logger.debug(
+            f"Adding auth provider security config using {SecretsManagerProvider.local.name} secrets' manager"
+        )
         pass
 
     def retrieve_service_connection(
@@ -189,7 +204,18 @@ class LocalSecretsManager(SecretsManager):
         """
         The LocalSecretsManager does not modify the ServiceConnection object
         """
+        logger.debug(
+            f"Retrieving service connection from {SecretsManagerProvider.local.name} secrets' manager for {service_type} - {service.name}"
+        )
         return ServiceConnection(__root__=service.connection)
+
+    def retrieve_dbt_source_config(
+        self, source_config: SourceConfig, pipeline_name: str
+    ) -> object:
+        logger.debug(
+            f"Retrieving source_config from {SecretsManagerProvider.local.name} secrets' manager for {pipeline_name}"
+        )
+        return source_config.config.dbtConfigSource.dict()
 
 
 class AWSSecretsManager(SecretsManager):
@@ -212,6 +238,9 @@ class AWSSecretsManager(SecretsManager):
         service: ServiceWithConnectionType,
         service_type: str,
     ) -> ServiceConnection:
+        logger.debug(
+            f"Retrieving service connection from {SecretsManagerProvider.aws.name} secrets' manager for {service_type} - {service.name}"
+        )
         service_connection_type = service.serviceType.value
         service_name = service.name.__root__
         secret_id = self.build_secret_id(
@@ -229,6 +258,9 @@ class AWSSecretsManager(SecretsManager):
         return ServiceConnection(__root__=service_connection)
 
     def add_auth_provider_security_config(self, config: OpenMetadataConnection) -> None:
+        logger.debug(
+            f"Adding auth provider security config using {SecretsManagerProvider.aws.name} secrets' manager"
+        )
         if config.authProvider == AuthProvider.no_auth:
             return config
         secret_id = self.build_secret_id(
@@ -243,6 +275,16 @@ class AWSSecretsManager(SecretsManager):
             raise NotImplementedError(
                 f"No client implemented for auth provider: [{config.authProvider}]"
             )
+
+    def retrieve_dbt_source_config(
+        self, source_config: SourceConfig, pipeline_name: str
+    ) -> object:
+        logger.debug(
+            f"Retrieving source_config from {SecretsManagerProvider.local.name} secrets' manager for {pipeline_name}"
+        )
+        secret_id = self.build_secret_id("database-metadata-pipeline", pipeline_name)
+        source_config_json = self._get_string_value(secret_id)
+        return json.loads(source_config_json) if source_config_json else None
 
     def _get_string_value(self, name: str) -> str:
         """
@@ -263,7 +305,11 @@ class AWSSecretsManager(SecretsManager):
             raise
         else:
             if "SecretString" in response:
-                return response["SecretString"]
+                return (
+                    response["SecretString"]
+                    if response["SecretString"] != "null"
+                    else None
+                )
             else:
                 raise ValueError("[SecretString] not present in the response.")
 

--- a/ingestion/src/metadata/utils/secrets_manager.py
+++ b/ingestion/src/metadata/utils/secrets_manager.py
@@ -116,7 +116,7 @@ class SecretsManager(metaclass=Singleton):
         self, source_config: SourceConfig, pipeline_name: str
     ) -> object:
         """
-         Retrieve the DBT source config from the secret manager from a source config object.
+        Retrieve the DBT source config from the secret manager from a source config object.
         :param source_config: SourceConfig object
         :param pipeline_name: the pipeline's name
         :return:

--- a/ingestion/src/metadata/utils/secrets_manager.py
+++ b/ingestion/src/metadata/utils/secrets_manager.py
@@ -215,7 +215,13 @@ class LocalSecretsManager(SecretsManager):
         logger.debug(
             f"Retrieving source_config from {SecretsManagerProvider.local.name} secrets' manager for {pipeline_name}"
         )
-        return source_config.config.dbtConfigSource.dict()
+        return (
+            source_config.config.dbtConfigSource.dict()
+            if source_config
+            and source_config.config
+            and source_config.config.dbtConfigSource
+            else None
+        )
 
 
 class AWSSecretsManager(SecretsManager):

--- a/openmetadata-core/src/main/resources/json/schema/metadataIngestion/databaseServiceMetadataPipeline.json
+++ b/openmetadata-core/src/main/resources/json/schema/metadataIngestion/databaseServiceMetadataPipeline.json
@@ -154,6 +154,7 @@
       "$ref": "../type/filterPattern.json#/definitions/filterPattern"
     },
     "dbtConfigSource": {
+      "mask": true,
       "title": "DBT Configuration Source",
       "description": "Available sources to fetch DBT catalog and manifest files.",
       "oneOf": [

--- a/openmetadata-core/src/main/resources/json/schema/metadataIngestion/workflow.json
+++ b/openmetadata-core/src/main/resources/json/schema/metadataIngestion/workflow.json
@@ -11,7 +11,6 @@
       "type": "object",
       "properties": {
         "config": {
-          "mask": true,
           "oneOf": [
             {
               "$ref": "databaseServiceMetadataPipeline.json"


### PR DESCRIPTION
Fixes: #6643

### Describe your changes :
Added a new method in the secrets' manager interface for saving the DBT source config objects of the Services pipelines. 
In addition, we also migrate DBT source config objects of pipelines when a secret manager is activated.

### Type of change :
- [x] New feature

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

### Reviewers
Backend: @open-metadata/backend
Ingestion: @open-metadata/ingestion
