### PR TITLE
Fixes #5830 Added timestamp with timezone data type

### DIFF
--- a/catalog-rest-service/src/main/resources/json/schema/entity/data/table.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/data/table.json
@@ -62,6 +62,7 @@
         "DECIMAL",
         "NUMERIC",
         "TIMESTAMP",
+        "TIMESTAMPZ",
         "TIME",
         "DATE",
         "DATETIME",


### PR DESCRIPTION
### Describe your changes :
Fixes #5830 by implementing `timestampz` to distinguish timestamp with timezone.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
<img width="1147" alt="Screenshot 2022-08-17 at 12 05 53 PM" src="https://user-images.githubusercontent.com/13626425/185093883-2a0dec04-f6a4-4b13-9fd3-14ad8edc5400.png">

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
Ingestion: @open-metadata/ingestion
