### PR TITLE
Allow settings path for all the domains

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/constants/constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/constants.ts
@@ -22,11 +22,6 @@ export const TEXT_BODY_COLOR = '#37352F';
 export const SUCCESS_COLOR = '#008376';
 
 export const SUPPORTED_FIELD_TYPES = ['string', 'markdown', 'integer'];
-export const SUPPORTED_DOMAIN_TYPES = [
-  'localhost:3000',
-  'localhost:8585',
-  'sandbox-beta.open-metadata.org',
-];
 
 export const FOLLOWERS_VIEW_CAP = 20;
 export const INITIAL_PAGING_VALUE = 1;

--- a/openmetadata-ui/src/main/resources/ui/src/router/AuthenticatedAppRouter.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/router/AuthenticatedAppRouter.tsx
@@ -17,7 +17,6 @@ import { Redirect, Route, Switch } from 'react-router-dom';
 import AppState from '../AppState';
 import AddCustomProperty from '../components/CustomEntityDetail/AddCustomProperty/AddCustomProperty';
 import { ROUTES } from '../constants/constants';
-import { isAllowedHost } from '../utils/CommonUtils';
 import withSuspenseFallback from './withSuspenseFallback';
 
 const GlobalSettingPage = withSuspenseFallback(
@@ -355,21 +354,17 @@ const AuthenticatedAppRouter: FunctionComponent = () => {
       <Route exact component={RequestTagsPage} path={ROUTES.REQUEST_TAGS} />
       <Route exact component={UpdateTagsPage} path={ROUTES.UPDATE_TAGS} />
 
-      <Route exact component={GlobalSettingPage} path={ROUTES.SETTINGS}>
-        {!isAllowedHost() && <Redirect to={ROUTES.NOT_FOUND} />}
-      </Route>
+      <Route exact component={GlobalSettingPage} path={ROUTES.SETTINGS} />
       <Route
         exact
         component={GlobalSettingPage}
-        path={ROUTES.SETTINGS_WITH_TAB}>
-        {!isAllowedHost() && <Redirect to={ROUTES.NOT_FOUND} />}
-      </Route>
+        path={ROUTES.SETTINGS_WITH_TAB}
+      />
       <Route
         exact
         component={GlobalSettingPage}
-        path={ROUTES.SETTINGS_WITH_TAB_FQN}>
-        {!isAllowedHost() && <Redirect to={ROUTES.NOT_FOUND} />}
-      </Route>
+        path={ROUTES.SETTINGS_WITH_TAB_FQN}
+      />
 
       <Redirect to={ROUTES.NOT_FOUND} />
     </Switch>

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CommonUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CommonUtils.tsx
@@ -32,7 +32,6 @@ import {
   imageTypes,
   LOCALSTORAGE_RECENTLY_SEARCHED,
   LOCALSTORAGE_RECENTLY_VIEWED,
-  SUPPORTED_DOMAIN_TYPES,
   TITLE_FOR_NON_OWNER_ACTION,
 } from '../constants/constants';
 import {
@@ -738,10 +737,6 @@ export const getFeedCounts = (
  */
 export const isTaskSupported = (entityType: EntityType) =>
   TASK_ENTITIES.includes(entityType);
-
-export const isAllowedHost = () => {
-  return SUPPORTED_DOMAIN_TYPES.includes(window.location.host);
-};
 
 /**
  * Utility function to show pagination


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the Removed restriction for settings path

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/71748675/185100776-3c0df17d-8a20-4f62-b57c-9f75acf8cf38.png">


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
