### PR TITLE
Make WebhookType part of webhook.json and not the create request

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/WebhookRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/WebhookRepository.java
@@ -35,6 +35,7 @@ import org.openmetadata.catalog.slack.SlackWebhookEventPublisher;
 import org.openmetadata.catalog.type.EventFilter;
 import org.openmetadata.catalog.type.Webhook;
 import org.openmetadata.catalog.type.Webhook.Status;
+import org.openmetadata.catalog.type.WebhookType;
 import org.openmetadata.catalog.util.EntityUtil.Fields;
 
 @Slf4j
@@ -87,9 +88,9 @@ public class WebhookRepository extends EntityRepository<Webhook> {
     }
 
     WebhookPublisher publisher;
-    if (webhook.getWebhookType() == Webhook.WebhookType.slack) {
+    if (webhook.getWebhookType() == WebhookType.slack) {
       publisher = new SlackWebhookEventPublisher(webhook, daoCollection);
-    } else if (webhook.getWebhookType() == Webhook.WebhookType.kafka) {
+    } else if (webhook.getWebhookType() == WebhookType.kafka) {
       publisher = new KafkaWebhookEventPublisher(webhook, daoCollection);
     } else {
       publisher = new WebhookPublisher(webhook, daoCollection);

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/events/WebhookResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/events/WebhookResource.java
@@ -58,6 +58,7 @@ import org.openmetadata.catalog.type.EntityHistory;
 import org.openmetadata.catalog.type.Include;
 import org.openmetadata.catalog.type.Webhook;
 import org.openmetadata.catalog.type.Webhook.Status;
+import org.openmetadata.catalog.type.WebhookType;
 import org.openmetadata.catalog.util.EntityUtil;
 import org.openmetadata.catalog.util.JsonUtils;
 import org.openmetadata.catalog.util.ResultList;
@@ -69,7 +70,7 @@ import org.openmetadata.catalog.util.ResultList;
 @Collection(name = "webhook")
 public class WebhookResource extends EntityResource<Webhook, WebhookRepository> {
   public static final String COLLECTION_PATH = "v1/webhook/";
-  private WebhookDAO webhookDAO;
+  private final WebhookDAO webhookDAO;
 
   @Override
   public Webhook addHref(UriInfo uriInfo, Webhook entity) {
@@ -357,6 +358,6 @@ public class WebhookResource extends EntityResource<Webhook, WebhookRepository> 
         .withSecretKey(create.getSecretKey())
         .withKafkaProperties(create.getKafkaProperties())
         .withStatus(Boolean.TRUE.equals(create.getEnabled()) ? Status.ACTIVE : Status.DISABLED)
-        .withWebhookType(Webhook.WebhookType.fromValue(create.getWebhookType().value()));
+        .withWebhookType(WebhookType.fromValue(create.getWebhookType().value()));
   }
 }

--- a/catalog-rest-service/src/main/resources/json/schema/api/events/createWebhook.json
+++ b/catalog-rest-service/src/main/resources/json/schema/api/events/createWebhook.json
@@ -57,20 +57,7 @@
     },
     "webhookType": {
       "description": "Type of webhook slack,generic,kafka etc",
-      "type": "string",
-      "default": "generic",
-      "enum": ["slack", "generic", "kafka"],
-      "javaEnums": [
-        {
-          "name": "slack"
-        },
-        {
-          "name": "generic"
-        },
-        {
-          "name": "kafka"
-        }
-      ]
+      "$ref": "../../entity/events/webhook.json#/definitions/webhookType"
     }
   },
   "required": ["name", "endpoint", "eventFilters"],

--- a/catalog-rest-service/src/main/resources/json/schema/entity/events/webhook.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/events/webhook.json
@@ -6,6 +6,26 @@
   "type": "object",
   "javaType": "org.openmetadata.catalog.type.Webhook",
   "javaInterfaces": ["org.openmetadata.catalog.EntityInterface"],
+  "definitions": {
+    "webhookType": {
+      "description": "Type of webhook slack, generic, kafka, etc.",
+      "type": "string",
+      "javaType": "org.openmetadata.catalog.type.WebhookType",
+      "default": "generic",
+      "enum": ["slack", "generic", "kafka"],
+      "javaEnums": [
+        {
+          "name": "slack"
+        },
+        {
+          "name": "generic"
+        },
+        {
+          "name": "kafka"
+        }
+      ]
+    }
+  },
   "properties": {
     "id": {
       "description": "Unique ID associated with a webhook subscription.",
@@ -24,8 +44,8 @@
       "type": "string"
     },
     "webhookType": {
-      "description": "Type of webhook slack,generic,kafka etc",
-      "$ref": "../../api/events/createWebhook.json#/properties/webhookType"
+      "description": "Type of webhook slack, generic, kafka, etc.",
+      "$ref": "#/definitions/webhookType"
     },
     "description": {
       "description": "Description of the application.",


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
All types must be defined in entities and used by createRequest types and not the other way around. cc @mohitdeuex 
#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.
