### PR TITLE
Fix(UI): Fixed styling of edit icon, switch and filter for user page

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
@@ -272,6 +272,7 @@ const Users = ({
                 onClick={() => setIsDisplayNameEdit(true)}>
                 <SVGIcons
                   alt="edit"
+                  className="tw-mb-2"
                   icon="icon-edit"
                   title="Edit"
                   width="16px"
@@ -374,6 +375,7 @@ const Users = ({
                   onClick={() => setIsTeamsEdit(true)}>
                   <SVGIcons
                     alt="edit"
+                    className=" tw-mb-1"
                     icon="icon-edit"
                     title="Edit"
                     width="16px"
@@ -508,6 +510,7 @@ const Users = ({
                   onClick={() => setIsRolesEdit(true)}>
                   <SVGIcons
                     alt="edit"
+                    className="tw-mb-1"
                     icon="icon-edit"
                     title="Edit"
                     width="16px"
@@ -698,14 +701,9 @@ const Users = ({
             )}
           </div>
           {isTaskType ? (
-            <Space
-              align="center"
-              className="tw-w-full tw-justify-end"
-              size={16}>
-              <Space align="end" size={5}>
-                <Switch onChange={onSwitchChange} />
-                <span className="tw-ml-1">Closed Tasks</span>
-              </Space>
+            <Space align="end" size={5}>
+              <Switch size="small" onChange={onSwitchChange} />
+              <span className="tw-ml-1">Closed Tasks</span>
             </Space>
           ) : null}
         </div>


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the fixing the styling of edit icon, switch and filter for user page

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<p>

- [x] Aligned the edit icons properly
Before : 
<img width="255" alt="Screenshot 2022-08-19 at 12 22 39 AM" src="https://user-images.githubusercontent.com/51777795/185472532-1e237322-32b5-4fd0-aa06-a11f86817ae4.png">

After : 
<img width="272" alt="Screenshot 2022-08-19 at 12 22 23 AM" src="https://user-images.githubusercontent.com/51777795/185472586-c9b62809-7b59-4bc1-adc9-48e691398b2b.png">

- [ ] Fixed styling of switch and filter 
Before : 
<img width="1155" alt="Screenshot 2022-08-19 at 12 22 45 AM" src="https://user-images.githubusercontent.com/51777795/185472702-6b22b599-1cd2-4fa1-b4fb-707af3198c73.png">

After : 
<img width="1149" alt="Screenshot 2022-08-19 at 12 22 30 AM" src="https://user-images.githubusercontent.com/51777795/185472748-921657a2-e904-4665-a808-d4e3d4d0095c.png">


</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @open-metadata/ui
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
