### PR TITLE
Fix#5917: Implementation of temp secret for testing connection

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/ingestionpipelines/IngestionPipelineResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/ingestionpipelines/IngestionPipelineResource.java
@@ -492,6 +492,11 @@ public class IngestionPipelineResource extends EntityResource<IngestionPipeline,
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
       @Valid TestServiceConnection testServiceConnection) {
+    testServiceConnection =
+        testServiceConnection
+            .withConnection(secretsManager.storeTestConnectionObject(testServiceConnection))
+            .withSecretsManagerProvider(secretsManager.getSecretsManagerProvider())
+            .withClusterName(catalogApplicationConfig.getClusterName());
     HttpResponse<String> response = pipelineServiceClient.testConnection(testServiceConnection);
     return Response.status(200, response.body()).build();
   }

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/secrets/AWSSSMSecretsManager.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/secrets/AWSSSMSecretsManager.java
@@ -12,7 +12,7 @@
  */
 package org.openmetadata.catalog.secrets;
 
-import static org.openmetadata.catalog.services.connections.metadata.OpenMetadataServerConnection.SecretsManagerProvider.AWS_SSM;
+import static org.openmetadata.catalog.services.connections.metadata.SecretsManagerProvider.AWS_SSM;
 
 import com.google.common.annotations.VisibleForTesting;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/secrets/AWSSecretsManager.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/secrets/AWSSecretsManager.java
@@ -13,7 +13,7 @@
 
 package org.openmetadata.catalog.secrets;
 
-import static org.openmetadata.catalog.services.connections.metadata.OpenMetadataServerConnection.SecretsManagerProvider.AWS;
+import static org.openmetadata.catalog.services.connections.metadata.SecretsManagerProvider.AWS;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Objects;

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/secrets/LocalSecretsManager.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/secrets/LocalSecretsManager.java
@@ -13,13 +13,14 @@
 
 package org.openmetadata.catalog.secrets;
 
-import static org.openmetadata.catalog.services.connections.metadata.OpenMetadataServerConnection.SecretsManagerProvider.LOCAL;
+import static org.openmetadata.catalog.services.connections.metadata.SecretsManagerProvider.LOCAL;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import org.openmetadata.catalog.airflow.AirflowConfiguration;
 import org.openmetadata.catalog.airflow.AuthConfiguration;
+import org.openmetadata.catalog.api.services.ingestionPipelines.TestServiceConnection;
 import org.openmetadata.catalog.entity.services.ServiceType;
 import org.openmetadata.catalog.exception.InvalidServiceConnectionException;
 import org.openmetadata.catalog.fernet.Fernet;
@@ -87,6 +88,11 @@ public class LocalSecretsManager extends SecretsManager {
       default:
         throw new IllegalArgumentException("OpenMetadata doesn't support auth provider type " + authProvider.value());
     }
+  }
+
+  @Override
+  public Object storeTestConnectionObject(TestServiceConnection testServiceConnection) {
+    return testServiceConnection.getConnection();
   }
 
   private void encryptOrDecryptField(Object connConfig, String field, Class<?> clazz, boolean encrypt)

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/secrets/SecretsManager.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/secrets/SecretsManager.java
@@ -21,12 +21,14 @@ import lombok.Getter;
 import org.openmetadata.catalog.Entity;
 import org.openmetadata.catalog.airflow.AirflowConfiguration;
 import org.openmetadata.catalog.airflow.AuthConfiguration;
+import org.openmetadata.catalog.api.services.ingestionPipelines.TestServiceConnection;
 import org.openmetadata.catalog.entity.services.ServiceType;
 import org.openmetadata.catalog.entity.services.ingestionPipelines.IngestionPipeline;
 import org.openmetadata.catalog.entity.services.ingestionPipelines.PipelineType;
 import org.openmetadata.catalog.exception.SecretsManagerException;
 import org.openmetadata.catalog.metadataIngestion.DatabaseServiceMetadataPipeline;
 import org.openmetadata.catalog.services.connections.metadata.OpenMetadataServerConnection;
+import org.openmetadata.catalog.services.connections.metadata.SecretsManagerProvider;
 import org.openmetadata.catalog.type.EntityReference;
 import org.openmetadata.catalog.util.JsonUtils;
 
@@ -34,10 +36,9 @@ public abstract class SecretsManager {
 
   @Getter private final String clusterPrefix;
 
-  @Getter private final OpenMetadataServerConnection.SecretsManagerProvider secretsManagerProvider;
+  @Getter private final SecretsManagerProvider secretsManagerProvider;
 
-  protected SecretsManager(
-      OpenMetadataServerConnection.SecretsManagerProvider secretsManagerProvider, String clusterPrefix) {
+  protected SecretsManager(SecretsManagerProvider secretsManagerProvider, String clusterPrefix) {
     this.secretsManagerProvider = secretsManagerProvider;
     this.clusterPrefix = clusterPrefix;
   }
@@ -117,4 +118,6 @@ public abstract class SecretsManager {
   protected String extractConnectionPackageName(ServiceType serviceType) {
     return CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, serviceType.value());
   }
+
+  public abstract Object storeTestConnectionObject(TestServiceConnection testServiceConnection);
 }

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/secrets/SecretsManagerConfiguration.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/secrets/SecretsManagerConfiguration.java
@@ -14,10 +14,9 @@
 package org.openmetadata.catalog.secrets;
 
 import java.util.Map;
-import javax.validation.constraints.NotEmpty;
 import lombok.Getter;
 import lombok.Setter;
-import org.openmetadata.catalog.services.connections.metadata.OpenMetadataServerConnection.SecretsManagerProvider;
+import org.openmetadata.catalog.services.connections.metadata.SecretsManagerProvider;
 
 @Getter
 @Setter
@@ -25,7 +24,7 @@ public class SecretsManagerConfiguration {
 
   public static final SecretsManagerProvider DEFAULT_SECRET_MANAGER = SecretsManagerProvider.LOCAL;
 
-  @NotEmpty private SecretsManagerProvider secretsManager;
+  private SecretsManagerProvider secretsManager;
 
   private Map<String, String> parameters;
 }

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/secrets/SecretsManagerFactory.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/secrets/SecretsManagerFactory.java
@@ -13,7 +13,7 @@
 
 package org.openmetadata.catalog.secrets;
 
-import org.openmetadata.catalog.services.connections.metadata.OpenMetadataServerConnection.SecretsManagerProvider;
+import org.openmetadata.catalog.services.connections.metadata.SecretsManagerProvider;
 
 public class SecretsManagerFactory {
 

--- a/catalog-rest-service/src/main/resources/json/schema/api/services/ingestionPipelines/testServiceConnection.json
+++ b/catalog-rest-service/src/main/resources/json/schema/api/services/ingestionPipelines/testServiceConnection.json
@@ -26,7 +26,7 @@
       ]
     },
     "connectionType": {
-      "description": "Type of database service such as MySQL, BigQuery, Snowflake, Redshift, Postgres...",
+      "description": "Type of service such as Database, Dashboard, Messaging, etc.",
       "type": "string",
       "enum": ["Database", "Dashboard", "Messaging", "Pipeline", "MlModel"],
       "javaEnums": [
@@ -46,6 +46,14 @@
           "name": "MlModel"
         }
       ]
+    },
+    "secretsManagerProvider": {
+      "$ref": "../../../entity/services/connections/metadata/secretsManagerProvider.json"
+    },
+    "clusterName": {
+      "description": "Cluster name to differentiate OpenMetadata Server instance",
+      "type": "string",
+      "default": "openmetadata"
     }
   },
   "additionalProperties": false

--- a/catalog-rest-service/src/main/resources/json/schema/entity/services/connections/metadata/openMetadataConnection.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/services/connections/metadata/openMetadataConnection.json
@@ -68,10 +68,7 @@
       ]
     },
     "secretsManagerProvider": {
-      "description": "OpenMetadata Secrets Manager Provider. Make sure to configure the same secrets manager providers as the ones configured on the OpenMetadata server.",
-      "type": "string",
-      "enum": ["local", "aws", "aws-ssm"],
-      "default": "local"
+      "$ref": "./secretsManagerProvider.json"
     },
     "secretsManagerCredentials": {
       "description": "OpenMetadata Secrets Manager Client credentials",

--- a/catalog-rest-service/src/main/resources/json/schema/entity/services/connections/metadata/secretsManagerProvider.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/services/connections/metadata/secretsManagerProvider.json
@@ -1,0 +1,10 @@
+{
+  "$id": "https://open-metadata.org/schema/entity/services/connections/metadata/secretsManagersProvider.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Secrets Manager Provider",
+  "description": "OpenMetadata Secrets Manager Provider. Make sure to configure the same secrets manager providers as the ones configured on the OpenMetadata server.",
+  "type": "string",
+  "javaType": "org.openmetadata.catalog.services.connections.metadata.SecretsManagerProvider",
+  "enum": ["local", "aws", "aws-ssm"],
+  "additionalProperties": false
+}

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/ingestionpipelines/IngestionPipelineResourceUnitTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/ingestionpipelines/IngestionPipelineResourceUnitTest.java
@@ -21,6 +21,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.never;
@@ -29,6 +30,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.net.http.HttpResponse;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -46,6 +48,7 @@ import org.openmetadata.catalog.CatalogApplicationConfig;
 import org.openmetadata.catalog.Entity;
 import org.openmetadata.catalog.EntityInterface;
 import org.openmetadata.catalog.airflow.AirflowRESTClient;
+import org.openmetadata.catalog.api.services.ingestionPipelines.TestServiceConnection;
 import org.openmetadata.catalog.entity.services.ingestionPipelines.IngestionPipeline;
 import org.openmetadata.catalog.entity.services.ingestionPipelines.PipelineType;
 import org.openmetadata.catalog.jdbi3.CollectionDAO;
@@ -85,11 +88,11 @@ public class IngestionPipelineResourceUnitTest {
     CollectionDAO.EntityRelationshipDAO relationshipDAO = mock(CollectionDAO.EntityRelationshipDAO.class);
     CollectionDAO.EntityRelationshipRecord entityRelationshipRecord =
         mock(CollectionDAO.EntityRelationshipRecord.class);
-    when(entityRelationshipRecord.getId()).thenReturn(UUID.randomUUID());
-    when(entityRelationshipRecord.getType()).thenReturn("ingestionPipeline");
-    when(relationshipDAO.findFrom(any(), any(), anyInt())).thenReturn(List.of(entityRelationshipRecord));
+    lenient().when(entityRelationshipRecord.getId()).thenReturn(UUID.randomUUID());
+    lenient().when(entityRelationshipRecord.getType()).thenReturn("ingestionPipeline");
+    lenient().when(relationshipDAO.findFrom(any(), any(), anyInt())).thenReturn(List.of(entityRelationshipRecord));
     when(collectionDAO.ingestionPipelineDAO()).thenReturn(entityDAO);
-    when(collectionDAO.relationshipDAO()).thenReturn(relationshipDAO);
+    lenient().when(collectionDAO.relationshipDAO()).thenReturn(relationshipDAO);
     ingestionPipelineResource = new IngestionPipelineResource(collectionDAO, authorizer, secretsManager);
   }
 
@@ -107,6 +110,21 @@ public class IngestionPipelineResourceUnitTest {
           expectedMap, ingestionPipelineResource.getLastIngestionLogs(null, securityContext, DAG_ID).getEntity());
       PipelineServiceClient client = mocked.constructed().get(0);
       verify(client).getLastIngestionLogs(ingestionPipeline);
+    }
+  }
+
+  @Test
+  void testTestConnectionCallSecretsManager() {
+    TestServiceConnection testServiceConnection = mock(TestServiceConnection.class);
+    try (MockedConstruction<AirflowRESTClient> mocked =
+        mockConstruction(AirflowRESTClient.class, this::preparePipelineServiceClient)) {
+      ingestionPipelineResource.initialize(catalogApplicationConfig);
+      PipelineServiceClient client = mocked.constructed().get(0);
+      HttpResponse<String> httpResponse = mock(HttpResponse.class);
+      when(client.testConnection(any())).thenReturn(httpResponse);
+      ingestionPipelineResource.testIngestion(null, null, testServiceConnection);
+      verify(client).testConnection(testServiceConnection);
+      verify(secretsManager).storeTestConnectionObject(testServiceConnection);
     }
   }
 

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/ingestionpipelines/IngestionPipelineResourceUnitTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/ingestionpipelines/IngestionPipelineResourceUnitTest.java
@@ -115,7 +115,7 @@ public class IngestionPipelineResourceUnitTest {
 
   @Test
   void testTestConnectionCallSecretsManager() {
-    TestServiceConnection testServiceConnection = mock(TestServiceConnection.class);
+    TestServiceConnection testServiceConnection = new TestServiceConnection();
     try (MockedConstruction<AirflowRESTClient> mocked =
         mockConstruction(AirflowRESTClient.class, this::preparePipelineServiceClient)) {
       ingestionPipelineResource.initialize(catalogApplicationConfig);

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/secrets/ExternalSecretsManagerTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/secrets/ExternalSecretsManagerTest.java
@@ -55,13 +55,15 @@ import org.openmetadata.catalog.metadataIngestion.DatabaseServiceMetadataPipelin
 import org.openmetadata.catalog.metadataIngestion.SourceConfig;
 import org.openmetadata.catalog.services.connections.database.MysqlConnection;
 import org.openmetadata.catalog.services.connections.metadata.OpenMetadataServerConnection;
+import org.openmetadata.catalog.services.connections.metadata.SecretsManagerProvider;
 import org.openmetadata.catalog.type.EntityReference;
 
 @ExtendWith(MockitoExtension.class)
 public abstract class ExternalSecretsManagerTest {
 
   static final boolean ENCRYPT = true;
-  static final String AUTH_PROVIDER_SECRET_ID_SUFFIX = "auth-provider";
+  static final String AUTH_PROVIDER_SECRET_ID_PREFIX = "auth-provider";
+  static final String TEST_CONNECTION_SECRET_ID_PREFIX = "test-connection-temp";
   static final boolean DECRYPT = false;
   static final String EXPECTED_CONNECTION_JSON =
       "{\"type\":\"Mysql\",\"scheme\":\"mysql+pymysql\",\"password\":\"openmetadata-test\",\"supportsMetadataExtraction\":true,\"supportsProfiler\":true}";
@@ -112,7 +114,7 @@ public abstract class ExternalSecretsManagerTest {
       OpenMetadataServerConnection.AuthProvider authProvider,
       AuthConfiguration authConfig)
       throws JsonProcessingException {
-    String expectedSecretId = String.format("/openmetadata/%s/%s", AUTH_PROVIDER_SECRET_ID_SUFFIX, authProvider);
+    String expectedSecretId = String.format("/openmetadata/%s/%s", AUTH_PROVIDER_SECRET_ID_PREFIX, authProvider);
     AirflowConfiguration airflowConfiguration = ConfigurationFixtures.buildAirflowConfig(authProvider);
     airflowConfiguration.setAuthConfig(authConfig);
     AirflowConfiguration expectedAirflowConfiguration = ConfigurationFixtures.buildAirflowConfig(authProvider);
@@ -223,5 +225,5 @@ public abstract class ExternalSecretsManagerTest {
             ConfigurationFixtures.buildAzureClientConfig(), AZURE, ConfigurationFixtures.buildAzureAuthConfig()));
   }
 
-  abstract OpenMetadataServerConnection.SecretsManagerProvider expectedSecretManagerProvider();
+  abstract SecretsManagerProvider expectedSecretManagerProvider();
 }

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/secrets/LocalSecretsManagerTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/secrets/LocalSecretsManagerTest.java
@@ -48,6 +48,7 @@ import org.openmetadata.catalog.airflow.AirflowConfiguration;
 import org.openmetadata.catalog.airflow.AuthConfiguration;
 import org.openmetadata.catalog.api.services.CreateDatabaseService;
 import org.openmetadata.catalog.api.services.CreateMlModelService;
+import org.openmetadata.catalog.api.services.ingestionPipelines.TestServiceConnection;
 import org.openmetadata.catalog.entity.services.ServiceType;
 import org.openmetadata.catalog.entity.services.ingestionPipelines.IngestionPipeline;
 import org.openmetadata.catalog.entity.services.ingestionPipelines.PipelineType;
@@ -56,6 +57,7 @@ import org.openmetadata.catalog.fixtures.ConfigurationFixtures;
 import org.openmetadata.catalog.metadataIngestion.SourceConfig;
 import org.openmetadata.catalog.services.connections.database.MysqlConnection;
 import org.openmetadata.catalog.services.connections.metadata.OpenMetadataServerConnection;
+import org.openmetadata.catalog.services.connections.metadata.SecretsManagerProvider;
 import org.openmetadata.catalog.services.connections.mlModel.SklearnConnection;
 import org.openmetadata.catalog.type.EntityReference;
 
@@ -99,6 +101,17 @@ public class LocalSecretsManagerTest {
   }
 
   @Test
+  void testEncryptTestServiceConnection() {
+    TestServiceConnection testServiceConnection =
+        new TestServiceConnection()
+            .withConnection(new MysqlConnection())
+            .withConnectionType(TestServiceConnection.ConnectionType.Database)
+            .withSecretsManagerProvider(secretsManager.getSecretsManagerProvider());
+    Object actualServiceConnection = secretsManager.storeTestConnectionObject(testServiceConnection);
+    assertEquals(testServiceConnection.getConnection(), actualServiceConnection);
+  }
+
+  @Test
   void testEncryptServiceConnectionWithoutPassword() {
     testEncryptDecryptServiceConnectionWithoutPassword(ENCRYPT);
   }
@@ -133,7 +146,7 @@ public class LocalSecretsManagerTest {
 
   @Test
   void testReturnsExpectedSecretManagerProvider() {
-    assertEquals(OpenMetadataServerConnection.SecretsManagerProvider.LOCAL, secretsManager.getSecretsManagerProvider());
+    assertEquals(SecretsManagerProvider.LOCAL, secretsManager.getSecretsManagerProvider());
   }
 
   @ParameterizedTest

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/secrets/SecretsManagerFactoryTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/secrets/SecretsManagerFactoryTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.HashMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.openmetadata.catalog.services.connections.metadata.OpenMetadataServerConnection.SecretsManagerProvider;
+import org.openmetadata.catalog.services.connections.metadata.SecretsManagerProvider;
 
 public class SecretsManagerFactoryTest {
 

--- a/ingestion/src/metadata/ingestion/ometa/ometa_api.py
+++ b/ingestion/src/metadata/ingestion/ometa/ometa_api.py
@@ -19,7 +19,9 @@ from typing import Dict, Generic, Iterable, List, Optional, Type, TypeVar, Union
 
 from metadata.ingestion.ometa.mixins.dashboard_mixin import OMetaDashboardMixin
 from metadata.ingestion.ometa.mixins.patch_mixin import OMetaPatchMixin
-from metadata.utils.secrets.secrets_manager_factory import get_secrets_manager
+from metadata.utils.secrets.secrets_manager_factory import (
+    get_secrets_manager_from_om_connection,
+)
 
 try:
     from typing import get_args
@@ -167,7 +169,7 @@ class OpenMetadata(
         self.config = config
 
         # Load the secrets' manager client
-        self.secrets_manager_client = get_secrets_manager(
+        self.secrets_manager_client = get_secrets_manager_from_om_connection(
             config, config.secretsManagerCredentials
         )
 

--- a/ingestion/src/metadata/utils/secrets/aws_secrets_manager.py
+++ b/ingestion/src/metadata/utils/secrets/aws_secrets_manager.py
@@ -16,7 +16,7 @@ from typing import Optional
 
 from botocore.exceptions import ClientError
 
-from metadata.generated.schema.entity.services.connections.metadata.openMetadataConnection import (
+from metadata.generated.schema.entity.services.connections.metadata.secretsManagerProvider import (
     SecretsManagerProvider,
 )
 from metadata.generated.schema.security.credentials.awsCredentials import AWSCredentials

--- a/ingestion/src/metadata/utils/secrets/aws_ssm_secrets_manager.py
+++ b/ingestion/src/metadata/utils/secrets/aws_ssm_secrets_manager.py
@@ -16,7 +16,7 @@ from typing import Optional
 
 from botocore.exceptions import ClientError
 
-from metadata.generated.schema.entity.services.connections.metadata.openMetadataConnection import (
+from metadata.generated.schema.entity.services.connections.metadata.secretsManagerProvider import (
     SecretsManagerProvider,
 )
 from metadata.generated.schema.security.credentials.awsCredentials import AWSCredentials

--- a/ingestion/src/metadata/utils/secrets/local_secrets_manager.py
+++ b/ingestion/src/metadata/utils/secrets/local_secrets_manager.py
@@ -14,6 +14,8 @@ Secrets manager implementation for local secrets manager
 """
 from metadata.generated.schema.entity.services.connections.metadata.openMetadataConnection import (
     OpenMetadataConnection,
+)
+from metadata.generated.schema.entity.services.connections.metadata.secretsManagerProvider import (
     SecretsManagerProvider,
 )
 from metadata.generated.schema.entity.services.connections.serviceConnection import (
@@ -22,6 +24,7 @@ from metadata.generated.schema.entity.services.connections.serviceConnection imp
 from metadata.generated.schema.metadataIngestion.workflow import SourceConfig
 from metadata.utils.secrets.secrets_manager import (
     SecretsManager,
+    ServiceConnectionType,
     ServiceWithConnectionType,
     logger,
 )
@@ -51,7 +54,7 @@ class LocalSecretsManager(SecretsManager):
         service_type: str,
     ) -> ServiceConnection:
         """
-        The LocalSecretsManager does not modify the ServiceConnection object
+        Returns the ServiceConnection object with the service connection
         """
         logger.debug(
             f"Retrieving service connection from {self.provider} secrets' manager for {service_type} - {service.name}"
@@ -62,7 +65,7 @@ class LocalSecretsManager(SecretsManager):
         self, source_config: SourceConfig, pipeline_name: str
     ) -> object:
         """
-        Retrieve the DBT source config from the secret manager from a source config object.
+        Retrieve the DBT source config if it is present in the source config object
         :param source_config: SourceConfig object
         :param pipeline_name: the pipeline's name
         :return:
@@ -77,3 +80,15 @@ class LocalSecretsManager(SecretsManager):
             and source_config.config.dbtConfigSource
             else None
         )
+
+    def retrieve_temp_service_test_connection(
+        self,
+        connection: ServiceConnectionType,
+        service_type: str,
+    ) -> ServiceConnectionType:
+        """
+        Returns the connection
+        :param connection: Connection of the service
+        :param service_type: Service type e.g. Database
+        """
+        return connection

--- a/ingestion/tests/integration/ometa/test_ometa_secrets_manager.py
+++ b/ingestion/tests/integration/ometa/test_ometa_secrets_manager.py
@@ -16,6 +16,8 @@ from unittest.mock import Mock, patch
 from metadata.generated.schema.entity.services.connections.metadata.openMetadataConnection import (
     AuthProvider,
     OpenMetadataConnection,
+)
+from metadata.generated.schema.entity.services.connections.metadata.secretsManagerProvider import (
     SecretsManagerProvider,
 )
 from metadata.generated.schema.security.client.googleSSOClientConfig import (
@@ -70,7 +72,7 @@ class OMetaSecretManagerTest(TestCase):
         assert type(self.metadata.secrets_manager_client) is AWSSecretsManager
         assert type(self.metadata._auth_provider) is NoOpAuthenticationProvider
 
-    @patch("metadata.ingestion.ometa.ometa_api.get_secrets_manager")
+    @patch("metadata.ingestion.ometa.ometa_api.get_secrets_manager_from_om_connection")
     def test_ometa_with_aws_secret_manager_with_google_auth(self, secrets_manager_mock):
         security_config = copy(self.aws_server_config)
         security_config.securityConfig = GoogleSSOClientConfig(secretKey="/fake/path")

--- a/ingestion/tests/unit/metadata/utils/secrets/test_aws_ssm_secrets_manager.py
+++ b/ingestion/tests/unit/metadata/utils/secrets/test_aws_ssm_secrets_manager.py
@@ -27,7 +27,7 @@ from .test_aws_based_secrets_manager import AWSBasedSecretsManager
 class TestAWSSecretsManager(AWSBasedSecretsManager.TestCase, ABC):
     def build_secret_manager(
         self, mocked_get_client: Mock, expected_json: Dict[str, Any]
-    ) -> AWSSecretsManager:
+    ) -> AWSSSMSecretsManager:
         self.init_mocked_get_client(mocked_get_client, expected_json)
         return AWSSSMSecretsManager(
             AWSCredentials(

--- a/ingestion/tests/unit/metadata/utils/secrets/test_secrets_manager.py
+++ b/ingestion/tests/unit/metadata/utils/secrets/test_secrets_manager.py
@@ -21,6 +21,8 @@ from metadata.generated.schema.entity.services.connections.database.mysqlConnect
 from metadata.generated.schema.entity.services.connections.metadata.openMetadataConnection import (
     AuthProvider,
     OpenMetadataConnection,
+)
+from metadata.generated.schema.entity.services.connections.metadata.secretsManagerProvider import (
     SecretsManagerProvider,
 )
 from metadata.generated.schema.entity.services.connections.serviceConnection import (
@@ -39,7 +41,13 @@ from metadata.generated.schema.security.client.googleSSOClientConfig import (
 )
 from metadata.utils.secrets.secrets_manager import AUTH_PROVIDER_MAPPING
 
-DATABASE_CONNECTION = {"username": "test", "hostPort": "localhost:3306"}
+DATABASE_CONNECTION_CONFIG = {
+    "type": "Mysql",
+    "username": "test",
+    "hostPort": "localhost:3306",
+}
+
+DATABASE_CONNECTION = {"config": DATABASE_CONNECTION_CONFIG}
 
 DATABASE_SERVICE = {
     "id": uuid.uuid4(),
@@ -68,7 +76,7 @@ class TestSecretsManager(TestCase):
         service_type: str = "database"
         service: DatabaseService
         service_connection: ServiceConnection
-        database_connection = MysqlConnection(**DATABASE_CONNECTION)
+        database_connection = MysqlConnection(**DATABASE_CONNECTION_CONFIG)
         auth_provider_config = GoogleSSOClientConfig(**AUTH_PROVIDER_CONFIG)
         om_connection: OpenMetadataConnection
         dbt_source_config: DbtHttpConfig

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/ingestion/credentials_builder.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/ingestion/credentials_builder.py
@@ -1,7 +1,7 @@
 from airflow.configuration import conf
 from pydantic import SecretStr
 
-from metadata.generated.schema.entity.services.connections.metadata.openMetadataConnection import (
+from metadata.generated.schema.entity.services.connections.metadata.secretsManagerProvider import (
     SecretsManagerProvider,
 )
 from metadata.generated.schema.security.credentials.awsCredentials import AWSCredentials

--- a/openmetadata-core/src/main/resources/json/schema/api/services/ingestionPipelines/testServiceConnection.json
+++ b/openmetadata-core/src/main/resources/json/schema/api/services/ingestionPipelines/testServiceConnection.json
@@ -23,7 +23,7 @@
       ]
     },
     "connectionType": {
-      "description": "Type of database service such as MySQL, BigQuery, Snowflake, Redshift, Postgres...",
+      "description": "Type of service such as Database, Dashboard, Messaging, etc.",
       "type": "string",
       "enum": ["Database", "Dashboard", "Messaging", "Pipeline"],
       "javaEnums": [
@@ -40,6 +40,14 @@
           "name": "Pipeline"
         }
       ]
+    },
+    "secretsManagerProvider": {
+      "$ref": "../../../entity/services/connections/metadata/secretsManagerProvider.json"
+    },
+    "clusterName": {
+      "description": "Cluster name to differentiate OpenMetadata Server instance",
+      "type": "string",
+      "default": "openmetadata"
     }
   },
   "additionalProperties": false

--- a/openmetadata-core/src/main/resources/json/schema/entity/services/connections/metadata/openMetadataConnection.json
+++ b/openmetadata-core/src/main/resources/json/schema/entity/services/connections/metadata/openMetadataConnection.json
@@ -68,10 +68,7 @@
       ]
     },
     "secretsManagerProvider": {
-      "description": "OpenMetadata Secrets Manager Provider. Make sure to configure the same secrets manager providers as the ones configured on the OpenMetadata server.",
-      "type": "string",
-      "enum": ["local", "aws", "aws-ssm"],
-      "default": "local"
+      "$ref": "./secretsManagerProvider.json"
     },
     "secretsManagerCredentials": {
       "description": "OpenMetadata Secrets Manager Client credentials",

--- a/openmetadata-core/src/main/resources/json/schema/entity/services/connections/metadata/secretsManagerProvider.json
+++ b/openmetadata-core/src/main/resources/json/schema/entity/services/connections/metadata/secretsManagerProvider.json
@@ -1,0 +1,10 @@
+{
+  "$id": "https://open-metadata.org/schema/entity/services/connections/metadata/secretsManagersProvider.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Secrets Manager Provider",
+  "description": "OpenMetadata Secrets Manager Provider. Make sure to configure the same secrets manager providers as the ones configured on the OpenMetadata server.",
+  "type": "string",
+  "javaType": "org.openmetadata.catalog.services.connections.metadata.SecretsManagerProvider",
+  "enum": ["local", "aws", "aws-ssm"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
Fixes: #5917 

### Describe your changes :
Use of temporary secret id when testing connection. Updated `testServiceConnection` JSON schema definition with necessary parameters needed to use secrets manager from `testConnection` method invoked in Airflow REST plugin.

### Type of change :
- [x] Improvement
- [x] New feature

### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

### Reviewers
Backend: @open-metadata/backend 
Ingestion: @open-metadata/ingestion
