### PR TITLE
Fix #6780 : fixed the error occurring  when dataTypeDisplay value is not present

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/EntityTable/EntityTable.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/EntityTable/EntityTable.component.tsx
@@ -597,38 +597,46 @@ const EntityTable = ({
 
                       {cell.column.id === 'dataTypeDisplay' && (
                         <>
-                          {isReadOnly ? (
-                            <div className="tw-flex tw-flex-wrap tw-w-60 tw-overflow-x-auto">
-                              <RichTextEditorPreviewer
-                                markdown={cell.value.toLowerCase()}
-                              />
-                            </div>
-                          ) : (
+                          {cell.value ? (
                             <>
-                              {cell.value.length > 25 ? (
-                                <span>
-                                  <PopOver
-                                    html={
-                                      <div className="tw-break-words">
-                                        <span>{cell.value.toLowerCase()}</span>
-                                      </div>
-                                    }
-                                    position="bottom"
-                                    theme="light"
-                                    trigger="click">
-                                    <div className="tw-cursor-pointer tw-underline tw-inline-block">
-                                      <RichTextEditorPreviewer
-                                        markdown={`${cell.value
-                                          .slice(0, 20)
-                                          .toLowerCase()}...`}
-                                      />
-                                    </div>
-                                  </PopOver>
-                                </span>
+                              {isReadOnly ? (
+                                <div className="tw-flex tw-flex-wrap tw-w-60 tw-overflow-x-auto">
+                                  <RichTextEditorPreviewer
+                                    markdown={cell.value.toLowerCase()}
+                                  />
+                                </div>
                               ) : (
-                                cell.value.toLowerCase()
+                                <>
+                                  {cell.value.length > 25 ? (
+                                    <span>
+                                      <PopOver
+                                        html={
+                                          <div className="tw-break-words">
+                                            <span>
+                                              {cell.value.toLowerCase()}
+                                            </span>
+                                          </div>
+                                        }
+                                        position="bottom"
+                                        theme="light"
+                                        trigger="click">
+                                        <div className="tw-cursor-pointer tw-underline tw-inline-block">
+                                          <RichTextEditorPreviewer
+                                            markdown={`${cell.value
+                                              .slice(0, 20)
+                                              .toLowerCase()}...`}
+                                          />
+                                        </div>
+                                      </PopOver>
+                                    </span>
+                                  ) : (
+                                    cell.value.toLowerCase()
+                                  )}
+                                </>
                               )}
                             </>
+                          ) : (
+                            '--'
                           )}
                         </>
                       )}


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the entityTable component to eliminate the error occurred when no dataTypeDisplay value present.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<p align="center">
<img width="729" alt="Screenshot 2022-08-22 at 3 46 05 PM" src="https://user-images.githubusercontent.com/51777795/185898065-ef63c50c-8b5f-456a-8f02-4b12e50f69b2.png">

</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @open-metadata/ui
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
