### PR TITLE
Fixes #6860 Add policy support for policies based on resource ownership hierachy

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/Entity.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/Entity.java
@@ -130,6 +130,7 @@ public final class Entity {
   // Reserved names in OpenMetadata
   //
   public static final String ORGANIZATION_NAME = "Organization";
+  public static final String DATACONSUMER_ROLE = "DataConsumer";
 
   //
   // List of entities whose changes should not be published to the Activity Feed

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/Function.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/Function.java
@@ -15,4 +15,10 @@ public @interface Function {
   String description();
 
   String[] examples();
+
+  /**
+   * Some functions are used for capturing resource based rules where policies are applied based on resource being
+   * accessed and team hierarchy the resource belongs to instead of the subject.
+   */
+  boolean resourceBased() default false;
 }

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/UserRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/UserRepository.java
@@ -77,7 +77,7 @@ public class UserRepository extends EntityRepository<User> {
     updated
         .withId(original.getId())
         .withName(original.getName())
-        .withInheritedRoles(original.getInheritedRoles() != null ? original.getInheritedRoles() : null)
+        .withInheritedRoles(original.getInheritedRoles())
         .withAuthenticationMechanism(original.getAuthenticationMechanism());
   }
 

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/UserRepository.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/jdbi3/UserRepository.java
@@ -77,7 +77,7 @@ public class UserRepository extends EntityRepository<User> {
     updated
         .withId(original.getId())
         .withName(original.getName())
-        .withInheritedRoles(original.getInheritedRoles())
+        .withInheritedRoles(original.getInheritedRoles() != null ? original.getInheritedRoles() : null)
         .withAuthenticationMechanism(original.getAuthenticationMechanism());
   }
 

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/EntityResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/EntityResource.java
@@ -40,10 +40,6 @@ public abstract class EntityResource<T extends EntityInterface, K extends Entity
   protected final K dao;
   protected final Authorizer authorizer;
   private final boolean supportsOwner;
-  protected final OperationContext createOperationContext;
-  protected final OperationContext deleteOperationContext;
-  protected final OperationContext getOperationContext;
-  protected final OperationContext listOperationContext;
 
   protected EntityResource(Class<T> entityClass, K repository, Authorizer authorizer) {
     this.entityClass = entityClass;
@@ -52,12 +48,6 @@ public abstract class EntityResource<T extends EntityInterface, K extends Entity
     supportsOwner = allowedFields.contains(FIELD_OWNER);
     this.dao = repository;
     this.authorizer = authorizer;
-
-    createOperationContext = new OperationContext(entityType, MetadataOperation.CREATE);
-    deleteOperationContext = new OperationContext(entityType, MetadataOperation.DELETE);
-
-    listOperationContext = new OperationContext(entityType, MetadataOperation.VIEW_ALL);
-    getOperationContext = new OperationContext(entityType, MetadataOperation.VIEW_ALL);
   }
 
   public final Fields getFields(String fields) {
@@ -84,6 +74,7 @@ public abstract class EntityResource<T extends EntityInterface, K extends Entity
       String after)
       throws IOException {
     RestUtil.validateCursors(before, after);
+    OperationContext listOperationContext = new OperationContext(entityType, MetadataOperation.VIEW_ALL);
     authorizer.authorize(securityContext, listOperationContext, getResourceContext(), true);
     Fields fields = getFields(fieldsParam);
 
@@ -98,6 +89,7 @@ public abstract class EntityResource<T extends EntityInterface, K extends Entity
 
   public T getInternal(UriInfo uriInfo, SecurityContext securityContext, UUID id, String fieldsParam, Include include)
       throws IOException {
+    OperationContext getOperationContext = new OperationContext(entityType, MetadataOperation.VIEW_ALL);
     authorizer.authorize(securityContext, getOperationContext, getResourceContextById(id), true);
     Fields fields = getFields(fieldsParam);
     return addHref(uriInfo, dao.get(uriInfo, id, fields, include));
@@ -106,6 +98,7 @@ public abstract class EntityResource<T extends EntityInterface, K extends Entity
   public T getByNameInternal(
       UriInfo uriInfo, SecurityContext securityContext, String name, String fieldsParam, Include include)
       throws IOException {
+    OperationContext getOperationContext = new OperationContext(entityType, MetadataOperation.VIEW_ALL);
     authorizer.authorize(securityContext, getOperationContext, getResourceContextByName(name), true);
     Fields fields = getFields(fieldsParam);
     return addHref(uriInfo, dao.getByName(uriInfo, name, fields, include));
@@ -121,6 +114,7 @@ public abstract class EntityResource<T extends EntityInterface, K extends Entity
 
   public Response createOrUpdate(UriInfo uriInfo, SecurityContext securityContext, T entity, boolean allowBots)
       throws IOException {
+    OperationContext createOperationContext = new OperationContext(entityType, MetadataOperation.CREATE);
     dao.prepare(entity);
     authorizer.authorize(
         securityContext, createOperationContext, getResourceContextByName(entity.getFullyQualifiedName()), allowBots);

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/permissions/PermissionsResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/permissions/PermissionsResource.java
@@ -140,46 +140,6 @@ public class PermissionsResource {
     return authorizer.getPermission(securityContext, user, resourceContext);
   }
 
-  @GET
-  @Path("/{resource}")
-  @Operation(
-          operationId = "getResourcePermission",
-          summary = "Get permissions for logged in user",
-          tags = "permission",
-          responses = {
-                  @ApiResponse(
-                          responseCode = "200",
-                          description = "Permissions for logged in user",
-                          content =
-                          @Content(
-                                  mediaType = "application/json",
-                                  schema = @Schema(implementation = ResourcePermissionList.class)))
-          })
-  public ResourcePermission getPermission(@Context SecurityContext securityContext,
-      @Parameter(description = "Resource type", schema = @Schema(type = "String")) @PathParam("resource") String resource
-  ) {
-    return authorizer.getPermission(securityContext, resource));
-  }
-
-  @GET
-  @Path("/{resource}/{id}")
-  @Operation(
-          operationId = "getResourcePermission",
-          summary = "Get permissions for logged in user",
-          tags = "permission",
-          responses = {
-                  @ApiResponse(
-                          responseCode = "200",
-                          description = "Permissions for logged in user",
-                          content =
-                          @Content(
-                                  mediaType = "application/json",
-                                  schema = @Schema(implementation = ResourcePermissionList.class)))
-          })
-  public ResourcePermission getPermission(@Context SecurityContext securityContext) {
-    return new ResourcePermissionList(authorizer.listPermissions(securityContext));
-  }
-
   static class ResourcePermissionList extends ResultList<ResourcePermission> {
     @SuppressWarnings("unused")
     public ResourcePermissionList() {}

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/permissions/PermissionsResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/permissions/PermissionsResource.java
@@ -140,6 +140,46 @@ public class PermissionsResource {
     return authorizer.getPermission(securityContext, user, resourceContext);
   }
 
+  @GET
+  @Path("/{resource}")
+  @Operation(
+          operationId = "getResourcePermission",
+          summary = "Get permissions for logged in user",
+          tags = "permission",
+          responses = {
+                  @ApiResponse(
+                          responseCode = "200",
+                          description = "Permissions for logged in user",
+                          content =
+                          @Content(
+                                  mediaType = "application/json",
+                                  schema = @Schema(implementation = ResourcePermissionList.class)))
+          })
+  public ResourcePermission getPermission(@Context SecurityContext securityContext,
+      @Parameter(description = "Resource type", schema = @Schema(type = "String")) @PathParam("resource") String resource
+  ) {
+    return authorizer.getPermission(securityContext, resource));
+  }
+
+  @GET
+  @Path("/{resource}/{id}")
+  @Operation(
+          operationId = "getResourcePermission",
+          summary = "Get permissions for logged in user",
+          tags = "permission",
+          responses = {
+                  @ApiResponse(
+                          responseCode = "200",
+                          description = "Permissions for logged in user",
+                          content =
+                          @Content(
+                                  mediaType = "application/json",
+                                  schema = @Schema(implementation = ResourcePermissionList.class)))
+          })
+  public ResourcePermission getPermission(@Context SecurityContext securityContext) {
+    return new ResourcePermissionList(authorizer.listPermissions(securityContext));
+  }
+
   static class ResourcePermissionList extends ResultList<ResourcePermission> {
     @SuppressWarnings("unused")
     public ResourcePermissionList() {}

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/ingestionpipelines/IngestionPipelineResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/services/ingestionpipelines/IngestionPipelineResource.java
@@ -67,9 +67,11 @@ import org.openmetadata.catalog.resources.EntityResource;
 import org.openmetadata.catalog.secrets.SecretsManager;
 import org.openmetadata.catalog.security.AuthorizationException;
 import org.openmetadata.catalog.security.Authorizer;
+import org.openmetadata.catalog.security.policyevaluator.OperationContext;
 import org.openmetadata.catalog.services.connections.metadata.OpenMetadataServerConnection;
 import org.openmetadata.catalog.type.EntityHistory;
 import org.openmetadata.catalog.type.Include;
+import org.openmetadata.catalog.type.MetadataOperation;
 import org.openmetadata.catalog.util.EntityUtil.Fields;
 import org.openmetadata.catalog.util.PipelineServiceClient;
 import org.openmetadata.catalog.util.ResultList;
@@ -595,7 +597,7 @@ public class IngestionPipelineResource extends EntityResource<IngestionPipeline,
     try {
       authorizer.authorize(
           securityContext,
-          getOperationContext,
+          new OperationContext(entityType, MetadataOperation.VIEW_ALL),
           getResourceContextById(ingestionPipeline.getId()),
           secretsManager.isLocal());
     } catch (AuthorizationException | IOException e) {

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/teams/UserResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/teams/UserResource.java
@@ -60,11 +60,13 @@ import org.openmetadata.catalog.resources.Collection;
 import org.openmetadata.catalog.resources.EntityResource;
 import org.openmetadata.catalog.security.Authorizer;
 import org.openmetadata.catalog.security.jwt.JWTTokenGenerator;
+import org.openmetadata.catalog.security.policyevaluator.OperationContext;
 import org.openmetadata.catalog.teams.authn.GenerateTokenRequest;
 import org.openmetadata.catalog.teams.authn.JWTAuthMechanism;
 import org.openmetadata.catalog.teams.authn.JWTTokenExpiry;
 import org.openmetadata.catalog.type.EntityHistory;
 import org.openmetadata.catalog.type.Include;
+import org.openmetadata.catalog.type.MetadataOperation;
 import org.openmetadata.catalog.util.EntityUtil;
 import org.openmetadata.catalog.util.EntityUtil.Fields;
 import org.openmetadata.catalog.util.JsonUtils;
@@ -362,6 +364,7 @@ public class UserResource extends EntityResource<User, UserRepository> {
     if (Boolean.TRUE.equals(create.getIsAdmin()) || Boolean.TRUE.equals(create.getIsBot())) {
       authorizer.authorizeAdmin(securityContext, true);
     } else {
+      OperationContext createOperationContext = new OperationContext(entityType, MetadataOperation.CREATE);
       authorizer.authorize(securityContext, createOperationContext, getResourceContextByName(user.getName()), true);
     }
     RestUtil.PutResponse<User> response = dao.createOrUpdate(uriInfo, user);

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/security/Authorizer.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/security/Authorizer.java
@@ -15,6 +15,7 @@ package org.openmetadata.catalog.security;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.UUID;
 import javax.ws.rs.core.SecurityContext;
 import org.jdbi.v3.core.Jdbi;
 import org.openmetadata.catalog.security.policyevaluator.OperationContext;
@@ -36,6 +37,16 @@ public interface Authorizer {
   /** Returns a list of operations that the authenticated user (subject) can perform on a given resource */
   ResourcePermission getPermission(
       SecurityContext securityContext, String user, ResourceContextInterface resourceContext);
+
+  /**
+   * Returns a list of operations that the authenticated user (subject) can perform on a given resource
+   */
+  ResourcePermission getPermission(SecurityContext securityContext, String resource);
+
+  /**
+   * Returns a list of operations that the authenticated user (subject) can perform on a given resource
+   */
+  ResourcePermission getPermission(SecurityContext securityContext, String resource, UUID id);
 
   boolean isOwner(SecurityContext ctx, EntityReference entityReference);
 

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/security/Authorizer.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/security/Authorizer.java
@@ -15,7 +15,6 @@ package org.openmetadata.catalog.security;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.UUID;
 import javax.ws.rs.core.SecurityContext;
 import org.jdbi.v3.core.Jdbi;
 import org.openmetadata.catalog.security.policyevaluator.OperationContext;
@@ -37,16 +36,6 @@ public interface Authorizer {
   /** Returns a list of operations that the authenticated user (subject) can perform on a given resource */
   ResourcePermission getPermission(
       SecurityContext securityContext, String user, ResourceContextInterface resourceContext);
-
-  /**
-   * Returns a list of operations that the authenticated user (subject) can perform on a given resource
-   */
-  ResourcePermission getPermission(SecurityContext securityContext, String resource);
-
-  /**
-   * Returns a list of operations that the authenticated user (subject) can perform on a given resource
-   */
-  ResourcePermission getPermission(SecurityContext securityContext, String resource, UUID id);
 
   boolean isOwner(SecurityContext ctx, EntityReference entityReference);
 

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/security/DefaultAuthorizer.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/security/DefaultAuthorizer.java
@@ -37,7 +37,6 @@ import org.openmetadata.catalog.security.policyevaluator.RoleCache;
 import org.openmetadata.catalog.security.policyevaluator.SubjectCache;
 import org.openmetadata.catalog.security.policyevaluator.SubjectContext;
 import org.openmetadata.catalog.type.EntityReference;
-import org.openmetadata.catalog.type.MetadataOperation;
 import org.openmetadata.catalog.type.Permission.Access;
 import org.openmetadata.catalog.type.ResourcePermission;
 import org.openmetadata.catalog.util.RestUtil;
@@ -51,7 +50,7 @@ public class DefaultAuthorizer implements Authorizer {
 
   @Override
   public void init(AuthorizerConfiguration config, Jdbi dbi) {
-    LOG.debug("Initializing DefaultAuthorizer with config {}", config);
+    LOG.info("Initializing DefaultAuthorizer with config {}", config);
     this.adminUsers = new HashSet<>(config.getAdminPrincipals());
     this.botUsers = new HashSet<>(config.getBotPrincipals());
     this.testUsers = new HashSet<>(config.getTestPrincipals());
@@ -154,12 +153,6 @@ public class DefaultAuthorizer implements Authorizer {
       throws IOException {
     SubjectContext subjectContext = getSubjectContext(securityContext);
     if (subjectContext.isAdmin() || (allowBots && subjectContext.isBot())) {
-      return;
-    }
-
-    // TODO view is currently allowed for everyone
-    if (operationContext.getOperations().size() == 1
-        && operationContext.getOperations().get(0) == MetadataOperation.VIEW_ALL) {
       return;
     }
     PolicyEvaluator.hasPermission(subjectContext, resourceContext, operationContext);

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/security/DefaultAuthorizer.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/security/DefaultAuthorizer.java
@@ -133,16 +133,6 @@ public class DefaultAuthorizer implements Authorizer {
   }
 
   @Override
-  public ResourcePermission getPermission(SecurityContext securityContext, String resource) {
-    return null;
-  }
-
-  @Override
-  public ResourcePermission getPermission(SecurityContext securityContext, String resource, UUID id) {
-    return null;
-  }
-
-  @Override
   public boolean isOwner(SecurityContext securityContext, EntityReference owner) {
     if (owner == null) {
       return false;

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/security/DefaultAuthorizer.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/security/DefaultAuthorizer.java
@@ -133,6 +133,16 @@ public class DefaultAuthorizer implements Authorizer {
   }
 
   @Override
+  public ResourcePermission getPermission(SecurityContext securityContext, String resource) {
+    return null;
+  }
+
+  @Override
+  public ResourcePermission getPermission(SecurityContext securityContext, String resource, UUID id) {
+    return null;
+  }
+
+  @Override
   public boolean isOwner(SecurityContext securityContext, EntityReference owner) {
     if (owner == null) {
       return false;

--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/security/NoopAuthorizer.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/security/NoopAuthorizer.java
@@ -27,6 +27,7 @@ import org.openmetadata.catalog.jdbi3.EntityRepository;
 import org.openmetadata.catalog.security.policyevaluator.OperationContext;
 import org.openmetadata.catalog.security.policyevaluator.PolicyEvaluator;
 import org.openmetadata.catalog.security.policyevaluator.ResourceContextInterface;
+import org.openmetadata.catalog.security.policyevaluator.SubjectCache;
 import org.openmetadata.catalog.type.EntityReference;
 import org.openmetadata.catalog.type.Permission.Access;
 import org.openmetadata.catalog.type.ResourcePermission;
@@ -37,6 +38,7 @@ import org.openmetadata.catalog.util.RestUtil;
 public class NoopAuthorizer implements Authorizer {
   @Override
   public void init(AuthorizerConfiguration config, Jdbi jdbi) {
+    SubjectCache.initialize();
     addAnonymousUser();
   }
 

--- a/catalog-rest-service/src/main/resources/json/data/policy/TeamOnlyPolicy.json
+++ b/catalog-rest-service/src/main/resources/json/data/policy/TeamOnlyPolicy.json
@@ -1,0 +1,18 @@
+{
+  "name": "TeamOnlyPolicy",
+  "displayName": "Team only access Policy",
+  "fullyQualifiedName": "TeamOnlyPolicy",
+  "description": "Policy when attached to a team allows only users with in the team hierarchy to access the resources.",
+  "policyType": "AccessControl",
+  "enabled": true,
+  "rules": [
+    {
+      "name": "TeamOnlyPolicy-Rule",
+      "description" : "Deny all the operations on all the resources for all outside the team hierarchy..",
+      "resources" : ["all"],
+      "operations": ["All"],
+      "effect": "deny",
+      "condition": "!matchTeam()"
+    }
+  ]
+}

--- a/catalog-rest-service/src/main/resources/json/data/role/DataConsumer.json
+++ b/catalog-rest-service/src/main/resources/json/data/role/DataConsumer.json
@@ -2,8 +2,6 @@
   "name": "DataConsumer",
   "displayName": "Data Consumer",
   "description": "Users with Data Consumer role use different data assets for their day to day work.",
-  "deleted": false,
-  "defaultRole": true,
   "policies" : [
     {
       "type" : "policy",

--- a/catalog-rest-service/src/main/resources/json/schema/entity/teams/role.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/teams/role.json
@@ -60,11 +60,6 @@
       "description": "Policies that is attached to this role.",
       "$ref": "../../type/entityReference.json#/definitions/entityReferenceList"
     },
-    "defaultRole": {
-      "description": "If `true`, this role is set as default system role and will be inherited by all the users.",
-      "type": "boolean",
-      "default": false
-    },
     "users": {
       "description": "Users that have this role assigned to them.",
       "$ref": "../../type/entityReference.json#/definitions/entityReferenceList"

--- a/catalog-rest-service/src/main/resources/json/schema/entity/teams/team.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/teams/team.json
@@ -112,6 +112,10 @@
       "description": "Default roles of a team. These roles will be inherited by all the users that are part of this team.",
       "$ref": "../../type/entityReference.json#/definitions/entityReferenceList"
     },
+    "inheritedRoles": {
+      "description": "Roles that a team is inheriting through membership in teams that have set team default roles.",
+      "$ref": "../../type/entityReference.json#/definitions/entityReferenceList"
+    },
     "policies": {
       "description": "Policies that is attached to this team.",
       "$ref": "../../type/entityReference.json#/definitions/entityReferenceList"

--- a/catalog-rest-service/src/main/resources/json/schema/entity/teams/user.json
+++ b/catalog-rest-service/src/main/resources/json/schema/entity/teams/user.json
@@ -117,7 +117,7 @@
       "$ref": "../../type/entityReference.json#/definitions/entityReferenceList"
     },
     "inheritedRoles": {
-      "description": "Roles that a user is inheriting either as part of system default role or through membership in teams that have set team default roles.",
+      "description": "Roles that a user is inheriting through membership in teams that have set team default roles.",
       "$ref": "../../type/entityReference.json#/definitions/entityReferenceList"
     }
   },

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/databases/TableResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/databases/TableResourceTest.java
@@ -530,9 +530,9 @@ public class TableResourceTest extends EntityResourceTest<Table, CreateTable> {
   void put_tableTableConstraintUpdate_200(TestInfo test) throws IOException {
     // Create table without table constraints
     CreateTable request =
-        createRequest(test).withOwner(USER_OWNER1).withDescription("description").withTableConstraints(null);
+        createRequest(test).withOwner(USER1_REF).withDescription("description").withTableConstraints(null);
     Table table = createAndCheckEntity(request, ADMIN_AUTH_HEADERS);
-    checkOwnerOwns(USER_OWNER1, table.getId(), true);
+    checkOwnerOwns(USER1_REF, table.getId(), true);
 
     // Update the table with constraints and ensure minor version change
     ChangeDescription change = getChangeDescription(table.getVersion());
@@ -1560,7 +1560,7 @@ public class TableResourceTest extends EntityResourceTest<Table, CreateTable> {
 
   @Test
   void get_deletedTableWithDeleteLocation(TestInfo test) throws IOException {
-    CreateTable create = createRequest(getEntityName(test), "description", "displayName", USER_OWNER1);
+    CreateTable create = createRequest(getEntityName(test), "description", "displayName", USER1_REF);
     // Create first time using POST
     Table table = beforeDeletion(test, createEntity(create, ADMIN_AUTH_HEADERS));
     Table tableBeforeDeletion = getEntity(table.getId(), TableResource.FIELDS, ADMIN_AUTH_HEADERS);
@@ -1579,7 +1579,7 @@ public class TableResourceTest extends EntityResourceTest<Table, CreateTable> {
     // Create a table test1 with 1 table tag and 3 column tags
     CreateTable create =
         createRequest(test, 1)
-            .withOwner(USER_OWNER1)
+            .withOwner(USER1_REF)
             .withTags(List.of(USER_ADDRESS_TAG_LABEL, GLOSSARY2_TERM1_LABEL)) // 2 table tags - USER_ADDRESS, g2t1
             .withColumns(COLUMNS); // 3 column tags - 2 USER_ADDRESS and 1 g1t1
     createAndCheckEntity(create, ADMIN_AUTH_HEADERS);
@@ -1604,7 +1604,7 @@ public class TableResourceTest extends EntityResourceTest<Table, CreateTable> {
     CreateTable create1 =
         createRequest(test, 2)
             .withDescription("description")
-            .withOwner(USER_OWNER1)
+            .withOwner(USER1_REF)
             .withColumns(COLUMNS); // 3 column tags - 2 USER_ADDRESS and 1 USER_BANK_ACCOUNT
     createAndCheckEntity(create1, ADMIN_AUTH_HEADERS);
 
@@ -1650,7 +1650,7 @@ public class TableResourceTest extends EntityResourceTest<Table, CreateTable> {
     assertEquals(4, tableList.getData().size());
     assertFields(tableList.getData(), fields1);
     for (Table table : tableList.getData()) {
-      assertEquals(USER_OWNER1, table.getOwner());
+      assertEquals(USER1_REF, table.getOwner());
       assertReference(DATABASE_REFERENCE, table.getDatabase());
     }
 

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/dqtests/TestCaseResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/dqtests/TestCaseResourceTest.java
@@ -77,7 +77,7 @@ public class TestCaseResourceTest extends EntityResourceTest<TestCase, CreateTes
                         .withDisplayName("c1")
                         .withDataType(ColumnDataType.VARCHAR)
                         .withDataLength(10)))
-            .withOwner(USER_OWNER1);
+            .withOwner(USER1_REF);
     TEST_TABLE1 = tableResourceTest.createAndCheckEntity(tableReq, ADMIN_AUTH_HEADERS);
     tableReq =
         tableResourceTest
@@ -91,7 +91,7 @@ public class TestCaseResourceTest extends EntityResourceTest<TestCase, CreateTes
                         .withDisplayName("c1")
                         .withDataType(ColumnDataType.VARCHAR)
                         .withDataLength(10)))
-            .withOwner(USER_OWNER1);
+            .withOwner(USER1_REF);
     TEST_TABLE2 = tableResourceTest.createAndCheckEntity(tableReq, ADMIN_AUTH_HEADERS);
     TABLE_LINK = String.format("<#E::table::%s>", TEST_TABLE1.getFullyQualifiedName());
     TABLE_LINK_2 = String.format("<#E::table::%s>", TEST_TABLE2.getFullyQualifiedName());

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/feeds/FeedResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/feeds/FeedResourceTest.java
@@ -142,16 +142,16 @@ public class FeedResourceTest extends CatalogApplicationTest {
     TABLE_RESOURCE_TEST.setup(test); // Initialize TableResourceTest for using helper methods
 
     UserResourceTest userResourceTest = new UserResourceTest();
-    USER2 = userResourceTest.createEntity(userResourceTest.createRequest(test, 2), TEST_AUTH_HEADERS);
+    USER2 = userResourceTest.createEntity(userResourceTest.createRequest(test, 4), TEST_AUTH_HEADERS);
 
     CreateTable createTable = TABLE_RESOURCE_TEST.createRequest(test);
-    createTable.withOwner(TableResourceTest.USER_OWNER1);
+    createTable.withOwner(TableResourceTest.USER1_REF);
     TABLE = TABLE_RESOURCE_TEST.createAndCheckEntity(createTable, ADMIN_AUTH_HEADERS);
 
     TeamResourceTest teamResourceTest = new TeamResourceTest();
     CreateTeam createTeam =
         teamResourceTest
-            .createRequest(test, 2)
+            .createRequest(test, 4)
             .withDisplayName("Team2")
             .withDescription("Team2 description")
             .withUsers(List.of(USER2.getId()));

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/glossary/GlossaryResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/glossary/GlossaryResourceTest.java
@@ -95,23 +95,23 @@ public class GlossaryResourceTest extends EntityResourceTest<Glossary, CreateGlo
 
     // Add reviewer USER1 in PATCH request
     String origJson = JsonUtils.pojoToJson(glossary);
-    glossary.withReviewers(List.of(USER_OWNER1));
+    glossary.withReviewers(List.of(USER1_REF));
     ChangeDescription change = getChangeDescription(glossary.getVersion());
-    change.getFieldsAdded().add(new FieldChange().withName("reviewers").withNewValue(List.of(USER_OWNER1)));
+    change.getFieldsAdded().add(new FieldChange().withName("reviewers").withNewValue(List.of(USER1_REF)));
     glossary = patchEntityAndCheck(glossary, origJson, ADMIN_AUTH_HEADERS, UpdateType.MINOR_UPDATE, change);
 
     // Add another reviewer USER2 in PATCH request
     origJson = JsonUtils.pojoToJson(glossary);
-    glossary.withReviewers(List.of(USER_OWNER1, USER_OWNER2));
+    glossary.withReviewers(List.of(USER1_REF, USER2_REF));
     change = getChangeDescription(glossary.getVersion());
-    change.getFieldsAdded().add(new FieldChange().withName("reviewers").withNewValue(List.of(USER_OWNER2)));
+    change.getFieldsAdded().add(new FieldChange().withName("reviewers").withNewValue(List.of(USER2_REF)));
     glossary = patchEntityAndCheck(glossary, origJson, ADMIN_AUTH_HEADERS, UpdateType.MINOR_UPDATE, change);
 
     // Remove a reviewer USER1 in PATCH request
     origJson = JsonUtils.pojoToJson(glossary);
-    glossary.withReviewers(List.of(USER_OWNER2));
+    glossary.withReviewers(List.of(USER2_REF));
     change = getChangeDescription(glossary.getVersion());
-    change.getFieldsDeleted().add(new FieldChange().withName("reviewers").withOldValue(List.of(USER_OWNER1)));
+    change.getFieldsDeleted().add(new FieldChange().withName("reviewers").withOldValue(List.of(USER1_REF)));
     patchEntityAndCheck(glossary, origJson, ADMIN_AUTH_HEADERS, UpdateType.MINOR_UPDATE, change);
   }
 

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/glossary/GlossaryTermResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/glossary/GlossaryTermResourceTest.java
@@ -30,7 +30,6 @@ import static org.openmetadata.catalog.resources.databases.TableResourceTest.get
 import static org.openmetadata.catalog.type.ColumnDataType.BIGINT;
 import static org.openmetadata.catalog.util.TestUtils.ADMIN_AUTH_HEADERS;
 import static org.openmetadata.catalog.util.TestUtils.UpdateType.MINOR_UPDATE;
-import static org.openmetadata.catalog.util.TestUtils.assertEntityReferences;
 import static org.openmetadata.catalog.util.TestUtils.assertListNotEmpty;
 import static org.openmetadata.catalog.util.TestUtils.assertListNotNull;
 import static org.openmetadata.catalog.util.TestUtils.assertListNull;
@@ -163,9 +162,9 @@ public class GlossaryTermResourceTest extends EntityResourceTest<GlossaryTerm, C
     // Add reviewer USER1, synonym1, reference1 in PATCH request
     String origJson = JsonUtils.pojoToJson(term);
     TermReference reference1 = new TermReference().withName("reference1").withEndpoint(URI.create("http://reference1"));
-    term.withReviewers(List.of(USER_OWNER1)).withSynonyms(List.of("synonym1")).withReferences(List.of(reference1));
+    term.withReviewers(List.of(USER1_REF)).withSynonyms(List.of("synonym1")).withReferences(List.of(reference1));
     ChangeDescription change = getChangeDescription(term.getVersion());
-    change.getFieldsAdded().add(new FieldChange().withName("reviewers").withNewValue(List.of(USER_OWNER1)));
+    change.getFieldsAdded().add(new FieldChange().withName("reviewers").withNewValue(List.of(USER1_REF)));
     change.getFieldsAdded().add(new FieldChange().withName("synonyms").withNewValue(List.of("synonym1")));
     change.getFieldsAdded().add(new FieldChange().withName("references").withNewValue(List.of(reference1)));
     term = patchEntityAndCheck(term, origJson, ADMIN_AUTH_HEADERS, MINOR_UPDATE, change);
@@ -173,20 +172,20 @@ public class GlossaryTermResourceTest extends EntityResourceTest<GlossaryTerm, C
     // Add reviewer USER2, synonym2, reference2 in PATCH request
     origJson = JsonUtils.pojoToJson(term);
     TermReference reference2 = new TermReference().withName("reference2").withEndpoint(URI.create("http://reference2"));
-    term.withReviewers(List.of(USER_OWNER1, USER_OWNER2))
+    term.withReviewers(List.of(USER1_REF, USER2_REF))
         .withSynonyms(List.of("synonym1", "synonym2"))
         .withReferences(List.of(reference1, reference2));
     change = getChangeDescription(term.getVersion());
-    change.getFieldsAdded().add(new FieldChange().withName("reviewers").withNewValue(List.of(USER_OWNER2)));
+    change.getFieldsAdded().add(new FieldChange().withName("reviewers").withNewValue(List.of(USER2_REF)));
     change.getFieldsAdded().add(new FieldChange().withName("synonyms").withNewValue(List.of("synonym2")));
     change.getFieldsAdded().add(new FieldChange().withName("references").withNewValue(List.of(reference2)));
     term = patchEntityAndCheck(term, origJson, ADMIN_AUTH_HEADERS, MINOR_UPDATE, change);
 
     // Remove a reviewer USER1, synonym1, reference1 in PATCH request
     origJson = JsonUtils.pojoToJson(term);
-    term.withReviewers(List.of(USER_OWNER2)).withSynonyms(List.of("synonym2")).withReferences(List.of(reference2));
+    term.withReviewers(List.of(USER2_REF)).withSynonyms(List.of("synonym2")).withReferences(List.of(reference2));
     change = getChangeDescription(term.getVersion());
-    change.getFieldsDeleted().add(new FieldChange().withName("reviewers").withOldValue(List.of(USER_OWNER1)));
+    change.getFieldsDeleted().add(new FieldChange().withName("reviewers").withOldValue(List.of(USER1_REF)));
     change.getFieldsDeleted().add(new FieldChange().withName("synonyms").withOldValue(List.of("synonym1")));
     change.getFieldsDeleted().add(new FieldChange().withName("references").withOldValue(List.of(reference1)));
     term = patchEntityAndCheck(term, origJson, ADMIN_AUTH_HEADERS, MINOR_UPDATE, change);
@@ -340,7 +339,7 @@ public class GlossaryTermResourceTest extends EntityResourceTest<GlossaryTerm, C
         .withSynonyms(List.of("syn1", "syn2", "syn3"))
         .withGlossary(GLOSSARY1_REF)
         .withRelatedTerms(Arrays.asList(GLOSSARY1_TERM1_REF, GLOSSARY2_TERM1_REF))
-        .withReviewers(List.of(USER_OWNER1));
+        .withReviewers(List.of(USER1_REF));
   }
 
   @Override

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/mlmodels/MlModelResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/mlmodels/MlModelResourceTest.java
@@ -157,7 +157,7 @@ public class MlModelResourceTest extends EntityResourceTest<MlModel, CreateMlMod
   @Test
   void put_MlModelUpdateWithNoChange_200(TestInfo test) throws IOException {
     // Create a Model with POST
-    CreateMlModel request = createRequest(test).withOwner(USER_OWNER1);
+    CreateMlModel request = createRequest(test).withOwner(USER1_REF);
     MlModel model = createAndCheckEntity(request, ADMIN_AUTH_HEADERS);
     ChangeDescription change = getChangeDescription(model.getVersion());
 

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/policies/PolicyResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/policies/PolicyResourceTest.java
@@ -88,9 +88,11 @@ public class PolicyResourceTest extends EntityResourceTest<Policy, CreatePolicy>
     location = createLocation();
   }
 
-  public void setupPolicies() throws HttpResponseException {
+  public void setupPolicies() throws IOException {
     POLICY1 = createEntity(createRequest("policy1").withOwner(null), ADMIN_AUTH_HEADERS);
     POLICY2 = createEntity(createRequest("policy2").withOwner(null), ADMIN_AUTH_HEADERS);
+    TEAM_ONLY_POLICY = getEntityByName("TeamOnlyPolicy", "", ADMIN_AUTH_HEADERS);
+    TEAM_ONLY_POLICY_RULES = EntityUtil.resolveRules(TEAM_ONLY_POLICY.getRules());
   }
 
   @Override
@@ -375,7 +377,7 @@ public class PolicyResourceTest extends EntityResourceTest<Policy, CreatePolicy>
         .withDescription("description")
         .withPolicyType(PolicyType.AccessControl)
         .withRules(rules.stream().map(rule -> (Object) rule).collect(Collectors.toList()))
-        .withOwner(USER_OWNER1);
+        .withOwner(USER1_REF);
   }
 
   private void validateCondition(String expression) throws HttpResponseException {

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/ingestionpipelines/IngestionPipelineResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/services/ingestionpipelines/IngestionPipelineResourceTest.java
@@ -455,7 +455,7 @@ public class IngestionPipelineResourceTest extends EntityResourceTest<IngestionP
             .withService(new EntityReference().withId(BIGQUERY_REFERENCE.getId()).withType("databaseService"))
             .withDescription("description")
             .withAirflowConfig(new AirflowConfig().withScheduleInterval("5 * * * *").withStartDate(START_DATE))
-            .withOwner(USER_OWNER1);
+            .withOwner(USER1_REF);
     IngestionPipeline ingestionPipeline = createAndCheckEntity(request, ADMIN_AUTH_HEADERS);
 
     // Update pipeline attributes
@@ -590,9 +590,9 @@ public class IngestionPipelineResourceTest extends EntityResourceTest<IngestionP
     // Add description and tasks
     ChangeDescription change = getChangeDescription(ingestion.getVersion());
     change.getFieldsAdded().add(new FieldChange().withName("description").withNewValue("newDescription"));
-    change.getFieldsAdded().add(new FieldChange().withName(FIELD_OWNER).withNewValue(USER_OWNER1));
+    change.getFieldsAdded().add(new FieldChange().withName(FIELD_OWNER).withNewValue(USER1_REF));
     updateAndCheckEntity(
-        request.withDescription("newDescription").withOwner(USER_OWNER1), OK, ADMIN_AUTH_HEADERS, MINOR_UPDATE, change);
+        request.withDescription("newDescription").withOwner(USER1_REF), OK, ADMIN_AUTH_HEADERS, MINOR_UPDATE, change);
   }
 
   private IngestionPipeline updateIngestionPipeline(

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/topics/TopicResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/topics/TopicResourceTest.java
@@ -102,7 +102,7 @@ public class TopicResourceTest extends EntityResourceTest<Topic, CreateTopic> {
   void put_topicAttributes_200_ok(TestInfo test) throws IOException {
     CreateTopic createTopic =
         createRequest(test)
-            .withOwner(USER_OWNER1)
+            .withOwner(USER1_REF)
             .withMaximumMessageSize(1)
             .withMinimumInSyncReplicas(1)
             .withPartitions(1)
@@ -116,7 +116,7 @@ public class TopicResourceTest extends EntityResourceTest<Topic, CreateTopic> {
     // Patch and update the topic
     Topic topic = createEntity(createTopic, ADMIN_AUTH_HEADERS);
     createTopic
-        .withOwner(TEAM_OWNER1)
+        .withOwner(TEAM11_REF)
         .withMinimumInSyncReplicas(2)
         .withMaximumMessageSize(2)
         .withPartitions(2)
@@ -130,7 +130,7 @@ public class TopicResourceTest extends EntityResourceTest<Topic, CreateTopic> {
     ChangeDescription change = getChangeDescription(topic.getVersion());
     change
         .getFieldsUpdated()
-        .add(new FieldChange().withName(FIELD_OWNER).withOldValue(USER_OWNER1).withNewValue(TEAM_OWNER1));
+        .add(new FieldChange().withName(FIELD_OWNER).withOldValue(USER1_REF).withNewValue(TEAM11_REF));
     change.getFieldsUpdated().add(new FieldChange().withName("maximumMessageSize").withOldValue(1).withNewValue(2));
     change.getFieldsUpdated().add(new FieldChange().withName("minimumInSyncReplicas").withOldValue(1).withNewValue(2));
     change.getFieldsUpdated().add(new FieldChange().withName("partitions").withOldValue(1).withNewValue(2));
@@ -155,7 +155,7 @@ public class TopicResourceTest extends EntityResourceTest<Topic, CreateTopic> {
   void patch_topicAttributes_200_ok(TestInfo test) throws IOException {
     CreateTopic createTopic =
         createRequest(test)
-            .withOwner(USER_OWNER1)
+            .withOwner(USER1_REF)
             .withMaximumMessageSize(1)
             .withMinimumInSyncReplicas(1)
             .withPartitions(1)
@@ -171,7 +171,7 @@ public class TopicResourceTest extends EntityResourceTest<Topic, CreateTopic> {
     String origJson = JsonUtils.pojoToJson(topic);
 
     topic
-        .withOwner(TEAM_OWNER1)
+        .withOwner(TEAM11_REF)
         .withMinimumInSyncReplicas(2)
         .withMaximumMessageSize(2)
         .withPartitions(2)
@@ -185,7 +185,7 @@ public class TopicResourceTest extends EntityResourceTest<Topic, CreateTopic> {
     ChangeDescription change = getChangeDescription(topic.getVersion());
     change
         .getFieldsUpdated()
-        .add(new FieldChange().withName(FIELD_OWNER).withOldValue(USER_OWNER1).withNewValue(TEAM_OWNER1));
+        .add(new FieldChange().withName(FIELD_OWNER).withOldValue(USER1_REF).withNewValue(TEAM11_REF));
     change.getFieldsUpdated().add(new FieldChange().withName("maximumMessageSize").withOldValue(1).withNewValue(2));
     change.getFieldsUpdated().add(new FieldChange().withName("minimumInSyncReplicas").withOldValue(1).withNewValue(2));
     change.getFieldsUpdated().add(new FieldChange().withName("partitions").withOldValue(1).withNewValue(2));

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/security/policyevaluator/SubjectContextTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/security/policyevaluator/SubjectContextTest.java
@@ -13,11 +13,14 @@
 package org.openmetadata.catalog.security.policyevaluator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -40,6 +43,24 @@ import org.openmetadata.catalog.security.policyevaluator.SubjectContext.PolicyCo
 import org.openmetadata.catalog.type.EntityReference;
 
 public class SubjectContextTest {
+  private static List<Role> team1Roles;
+  private static List<Policy> team1Policies;
+  private static Team team1;
+
+  private static List<Role> team11Roles;
+  private static List<Policy> team11Policies;
+  private static Team team11;
+
+  private static List<Role> team12Roles;
+  private static List<Policy> team12Policies;
+
+  private static List<Role> team111Roles;
+  private static List<Policy> team111Policies;
+  private static Team team111;
+
+  private static List<Role> userRoles;
+  private static User user;
+
   @BeforeAll
   public static void setup() throws NoSuchMethodException {
     Entity.registerEntity(User.class, Entity.USER, Mockito.mock(UserDAO.class), Mockito.mock(UserRepository.class));
@@ -47,59 +68,131 @@ public class SubjectContextTest {
     Entity.registerEntity(
         Policy.class, Entity.POLICY, Mockito.mock(PolicyDAO.class), Mockito.mock(PolicyRepository.class));
     Entity.registerEntity(Role.class, Entity.ROLE, Mockito.mock(RoleDAO.class), Mockito.mock(RoleRepository.class));
+    PolicyCache.initialize();
+    RoleCache.initialize();
+    SubjectCache.initialize();
+
+    // Create team hierarchy:
+    // team1, has  team11, team12, team13 as children
+    // team11 has team111 as children
+    // team111 has user as children
+    // Each with 3 roles and 3 policies
+    team1Roles = getRoles("team1", 3);
+    team1Policies = getPolicies("team1", 3);
+    team1 = createTeam("team1", team1Roles, team1Policies, null);
+
+    team11Roles = getRoles("team11", 3);
+    team11Policies = getPolicies("team11", 3);
+    team11 = createTeam("team11", team11Roles, team11Policies, List.of(team1));
+
+    team12Roles = getRoles("team12", 3);
+    team12Policies = getPolicies("team12", 3);
+    Team team12 = createTeam("team12", team12Roles, team12Policies, List.of(team1));
+
+    List<Role> team13Roles = getRoles("team13", 3);
+    List<Policy> team13Policies = getPolicies("team13", 3);
+    createTeam("team13", team13Roles, team13Policies, List.of(team1));
+
+    team111Roles = getRoles("team111", 3);
+    team111Policies = getPolicies("team111", 3);
+    team111 = createTeam("team111", team111Roles, team111Policies, List.of(team11, team12));
+
+    // Add user to team111
+    userRoles = getRoles("user", 3);
+    List<EntityReference> userRolesRef = toEntityReferences(userRoles);
+    user = new User().withName("user").withRoles(userRolesRef).withTeams(List.of(team111.getEntityReference()));
+    SubjectCache.USER_CACHE.put("user", new SubjectContext(user));
+  }
+
+  @AfterAll
+  public static void tearDown() {
+    SubjectCache.cleanUp();
+    PolicyCache.cleanUp();
+    RoleCache.cleanUp();
   }
 
   @Test
   void testPolicyIterator() {
-    // Create team hierarchy team1, team11, team111 each with 3 roles and 3 policies
-    List<Role> team1Roles = getRoles("team1", 3);
-    List<Policy> team1Policies = getPolicies("team1", 3);
-    Team team1 = createTeam("team1", team1Roles, team1Policies, null);
-
-    List<Role> team11Roles = getRoles("team11", 3);
-    List<Policy> team11Policies = getPolicies("team11", 3);
-    Team team11 = createTeam("team11", team11Roles, team11Policies, List.of(team1));
-
-    List<Role> team12Roles = getRoles("team12", 3);
-    List<Policy> team12Policies = getPolicies("team12", 3);
-    Team team12 = createTeam("team12", team12Roles, team12Policies, List.of(team1));
-
-    List<Role> team111Roles = getRoles("team111", 3);
-    List<Policy> team111Policies = getPolicies("team111", 3);
-    Team team111 = createTeam("team111", team111Roles, team111Policies, List.of(team11, team12));
-
-    // Add user to team111
-    List<Role> userRoles = getRoles("user", 3);
-    List<EntityReference> userRolesRef = toEntityReferences(userRoles);
-    User user = new User().withName("user").withRoles(userRolesRef).withTeams(List.of(team111.getEntityReference()));
-    SubjectCache.USER_CACHE.put("user", new SubjectContext(user));
-
     //
     // Check iteration order of the policies
     //
-    List<String> expectedPolicyOrder = new ArrayList<>();
-    expectedPolicyOrder.addAll(getPolicyListFromRoles(userRoles)); // First polices associated with user roles
-    expectedPolicyOrder.addAll(getPolicyListFromRoles(team111Roles)); // Next parent team111 roles
-    expectedPolicyOrder.addAll(getPolicyList(team111Policies)); // Next parent team111 policies
-    expectedPolicyOrder.addAll(getPolicyListFromRoles(team11Roles)); // Next parent of team111 team11 roles first
-    expectedPolicyOrder.addAll(getPolicyList(team11Policies)); // Next parent of team111 team11 policies first
-    expectedPolicyOrder.addAll(getPolicyListFromRoles(team1Roles)); // Next parent of team11 team1 roles
-    expectedPolicyOrder.addAll(getPolicyList(team1Policies)); // Next parent of team11 team1 policies
-    expectedPolicyOrder.addAll(getPolicyListFromRoles(team12Roles)); // Next parent of team111 team12 roles next
-    expectedPolicyOrder.addAll(getPolicyList(team12Policies)); // Next parent of team111 team12 policies next
-
     SubjectContext subjectContext = SubjectCache.getInstance().getSubjectContext(user.getName());
     Iterator<PolicyContext> policyContextIterator = subjectContext.getPolicies();
-    int count = 0;
-    while (policyContextIterator.hasNext()) {
-      PolicyContext policyContext = policyContextIterator.next();
-      assertEquals(expectedPolicyOrder.get(count), policyContext.getPolicyName());
-      count++;
-    }
-    assertEquals(expectedPolicyOrder.size(), count);
+    assertUserPolicyIterator(policyContextIterator);
   }
 
-  private List<Role> getRoles(String prefix, int count) {
+  @Test
+  void testUserInHierarchy() {
+    SubjectContext subjectContext = SubjectCache.getInstance().getSubjectContext(user.getName());
+    //
+    // Now test given user is part of team hierarchy
+    //
+    // user is in team111, team11, team12, team1 and not in team13
+    assertTrue(subjectContext.isUserUnderTeam("team111"));
+    assertTrue(subjectContext.isUserUnderTeam("team11"));
+    assertTrue(subjectContext.isUserUnderTeam("team12"));
+    assertTrue(subjectContext.isUserUnderTeam("team1"));
+    assertFalse(subjectContext.isUserUnderTeam("team13"));
+  }
+
+  @Test
+  void testResourceIsTeamAsset() {
+    SubjectContext subjectContext = SubjectCache.getInstance().getSubjectContext(user.getName());
+
+    //
+    // Given entity owner "user", ensure isTeamAsset is true for teams 111, 11, 12, 1 and not for 13
+    //
+    EntityReference userOwner = new EntityReference().withName("user").withType(Entity.USER);
+    assertTrue(subjectContext.isTeamAsset("team111", userOwner));
+    assertTrue(subjectContext.isTeamAsset("team11", userOwner));
+    assertTrue(subjectContext.isTeamAsset("team12", userOwner));
+    assertTrue(subjectContext.isTeamAsset("team1", userOwner));
+    assertFalse(subjectContext.isTeamAsset("team13", userOwner));
+
+    //
+    // Given entity owner "team111", ensure isTeamAsset is true for 11, 12, 1 and not for 13
+    //
+    EntityReference teamOwner = new EntityReference().withId(team111.getId()).withType(Entity.TEAM);
+    assertTrue(subjectContext.isTeamAsset("team11", teamOwner));
+    assertTrue(subjectContext.isTeamAsset("team12", teamOwner));
+    assertTrue(subjectContext.isTeamAsset("team1", teamOwner));
+    assertFalse(subjectContext.isTeamAsset("team13", teamOwner));
+  }
+
+  @Test
+  void testResourcePolicyIterator() {
+    // A resource with user as owner and make sure all policies from user's hierarchy is in the iterator
+    EntityReference userOwner = user.getEntityReference();
+    SubjectContext subjectContext = SubjectCache.getInstance().getSubjectContext(user.getName());
+    Iterator<PolicyContext> actualPolicyIterator = subjectContext.getResourcePolicies(userOwner);
+    assertUserPolicyIterator(actualPolicyIterator);
+
+    // A resource with team1 as owner and make sure all policies from user's hierarchy is in the iterator
+    EntityReference team1Owner = team1.getEntityReference();
+    actualPolicyIterator = subjectContext.getResourcePolicies(team1Owner);
+    // add policies from team1
+    List<String> expectedPolicyOrder = new ArrayList<>(getAllTeamPolicies(team1Roles, team1Policies));
+    assertPolicyIterator(expectedPolicyOrder, actualPolicyIterator);
+
+    // A resource with team11 as owner and make sure all policies from user's hierarchy is in the iterator
+    EntityReference team11Owner = team11.getEntityReference();
+    actualPolicyIterator = subjectContext.getResourcePolicies(team11Owner);
+    List<String> list = new ArrayList<>(getAllTeamPolicies(team11Roles, team11Policies)); // add policies from team11
+    list.addAll(expectedPolicyOrder); // Add all policies from parent team1 previously setup
+    expectedPolicyOrder = list;
+    assertPolicyIterator(expectedPolicyOrder, actualPolicyIterator);
+
+    // A resource with team11 as owner and make sure all policies from user's hierarchy is in the iterator
+    EntityReference team111Owner = team111.getEntityReference();
+    actualPolicyIterator = subjectContext.getResourcePolicies(team111Owner);
+    list = new ArrayList<>(getAllTeamPolicies(team111Roles, team111Policies)); // add policies from team111
+    list.addAll(expectedPolicyOrder); // Add all policies form team11 and team1 previously setup
+    list.addAll(getPolicyListFromRoles(team12Roles)); // add policies from team12 roles
+    list.addAll(getPolicyList(team12Policies)); // add team12 policies
+    assertPolicyIterator(list, actualPolicyIterator);
+  }
+
+  private static List<Role> getRoles(String prefix, int count) {
     // Create roles with 3 policies each and each policy with 3 rules
     List<Role> roles = new ArrayList<>(count);
     for (int i = 1; i <= count; i++) {
@@ -112,7 +205,7 @@ public class SubjectContextTest {
     return roles;
   }
 
-  private List<Policy> getPolicies(String prefix, int count) {
+  private static List<Policy> getPolicies(String prefix, int count) {
     List<Policy> policies = new ArrayList<>(count);
     for (int i = 1; i <= count; i++) {
       String name = prefix + "_policy_" + i;
@@ -123,7 +216,7 @@ public class SubjectContextTest {
     return policies;
   }
 
-  private List<Object> getRules(String prefix, int count) {
+  private static List<Object> getRules(String prefix, int count) {
     List<Object> rules = new ArrayList<>(count);
     for (int i = 1; i <= count; i++) {
       rules.add(new Rule().withName(prefix + "rule" + count));
@@ -131,7 +224,7 @@ public class SubjectContextTest {
     return rules;
   }
 
-  private <T extends EntityInterface> List<EntityReference> toEntityReferences(List<T> entities) {
+  private static <T extends EntityInterface> List<EntityReference> toEntityReferences(List<T> entities) {
     List<EntityReference> references = new ArrayList<>();
     for (T entity : entities) {
       references.add(entity.getEntityReference());
@@ -139,25 +232,32 @@ public class SubjectContextTest {
     return references;
   }
 
-  private List<String> getPolicyListFromRoles(List<Role> roles) {
+  private static List<String> getAllTeamPolicies(List<Role> roles, List<Policy> policies) {
+    List<String> list = new ArrayList<>();
+    list.addAll(getPolicyListFromRoles(roles));
+    list.addAll(getPolicyList(policies));
+    return list;
+  }
+
+  private static List<String> getPolicyListFromRoles(List<Role> roles) {
     List<String> list = new ArrayList<>();
     roles.forEach(r -> list.addAll(getPolicyRefList(r.getPolicies())));
     return list;
   }
 
-  private List<String> getPolicyRefList(List<EntityReference> policies) {
+  private static List<String> getPolicyRefList(List<EntityReference> policies) {
     List<String> list = new ArrayList<>();
     policies.forEach(p -> list.add(p.getName()));
     return list;
   }
 
-  private List<String> getPolicyList(List<Policy> policies) {
+  private static List<String> getPolicyList(List<Policy> policies) {
     List<String> list = new ArrayList<>();
     policies.forEach(p -> list.add(p.getName()));
     return list;
   }
 
-  private Team createTeam(String name, List<Role> roles, List<Policy> policies, List<Team> parents) {
+  private static Team createTeam(String name, List<Role> roles, List<Policy> policies, List<Team> parents) {
     List<EntityReference> parentList = parents == null ? null : toEntityReferences(parents);
     Team team =
         new Team()
@@ -168,5 +268,28 @@ public class SubjectContextTest {
             .withParents(parentList);
     SubjectCache.TEAM_CACHE.put(team.getId(), team);
     return team;
+  }
+
+  void assertUserPolicyIterator(Iterator<PolicyContext> actualPolicyIterator) {
+    //
+    // Check iteration order of the policies
+    //
+    List<String> expectedPolicyOrder = new ArrayList<>();
+    expectedPolicyOrder.addAll(getPolicyListFromRoles(userRoles)); // First polices associated with user roles
+    expectedPolicyOrder.addAll(getAllTeamPolicies(team111Roles, team111Policies)); // Next parent team111 policies
+    expectedPolicyOrder.addAll(getAllTeamPolicies(team11Roles, team11Policies)); // Next team111 parent team11 policies
+    expectedPolicyOrder.addAll(getAllTeamPolicies(team1Roles, team1Policies)); // Next team11 parent team1 policies
+    expectedPolicyOrder.addAll(getAllTeamPolicies(team12Roles, team12Policies)); // Next team111 parent team12 policies
+    assertPolicyIterator(expectedPolicyOrder, actualPolicyIterator);
+  }
+
+  void assertPolicyIterator(List<String> expectedPolicyOrder, Iterator<PolicyContext> actualPolicyIterator) {
+    int count = 0;
+    while (actualPolicyIterator.hasNext()) {
+      PolicyContext policyContext = actualPolicyIterator.next();
+      assertEquals(expectedPolicyOrder.get(count), policyContext.getPolicyName());
+      count++;
+    }
+    assertEquals(expectedPolicyOrder.size(), count);
   }
 }

--- a/ingestion-core/src/metadata/_version.py
+++ b/ingestion-core/src/metadata/_version.py
@@ -7,5 +7,5 @@ Provides metadata version information.
 
 from incremental import Version
 
-__version__ = Version("metadata", 0, 12, 0, dev=15)
+__version__ = Version("metadata", 0, 12, 0, dev=16)
 __all__ = ["__version__"]


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
See #6860 for more details

This PR makes the following backward incompatible changes: (@Sachin-chaurasiya and @pmbrull please see):
1. **No Default Role**. Earlier a Role (DataConsumer) could be marked as the default role.  This default role was assigned to every user. With this change, there is no longer flag to mark a role as the default role. A team can be assigned a default role and it is inherited by all the teams and users below it in that team hierarchy. This gives maximum flexibility in defining a default role at multiple levels in the team hierarchy.
2. **Inherited roles for users** includes all the default roles from all the teams in the hierarchy it belongs to.
3. **Inherited roles for teams**. Given a team can inherit a role from its parent team, parent's parent, etc. the team now has a field that includes all the roles inherited by it from the team hierarchy.

**Example:**
Organization has default role X
Team1 under Organization has a default role Y
Team11 under Team1 has a default role Z
UserX is under Team11 and has a role U

So UserX has roles U and inherited roles X, Y, Z
Team11 has roles Z and inherited roles X, Y
Team1 has roles Y and inherited roles X
Organization has roles X and no inherited roles



#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] New feature
- [x] Backward incompatible

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.
