### PR TITLE
Fix#6027: Improve logging in OpenMetadata Airflow APIs

### DIFF
--- a/openmetadata-airflow-apis/openmetadata_managed_apis/api/error_handlers.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/api/error_handlers.py
@@ -12,23 +12,24 @@
 Register error handlers
 """
 
-import logging
-
 from openmetadata_managed_apis.api.app import blueprint
 from openmetadata_managed_apis.api.response import ApiResponse
 from openmetadata_managed_apis.api.utils import MissingArgException
+from openmetadata_managed_apis.utils.logger import api_logger
 from werkzeug.exceptions import HTTPException
+
+logger = api_logger()
 
 
 @blueprint.app_errorhandler(Exception)
-def handle_any_error(e):
-    logging.exception("Wild exception")
-    if isinstance(e, HTTPException):
-        return ApiResponse.error(e.code, repr(e))
-    return ApiResponse.server_error(repr(e))
+def handle_any_error(exc):
+    logger.exception("Wild exception: {exc}")
+    if isinstance(exc, HTTPException):
+        return ApiResponse.error(exc.code, repr(exc))
+    return ApiResponse.server_error(repr(exc))
 
 
 @blueprint.app_errorhandler(MissingArgException)
-def handle_missing_arg(e):
-    logging.exception("Missing Argument Exception")
-    return ApiResponse.bad_request(repr(e))
+def handle_missing_arg(exc):
+    logger.exception(f"Missing Argument Exception: {exc}")
+    return ApiResponse.bad_request(repr(exc))

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/delete.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/delete.py
@@ -11,7 +11,6 @@
 """
 Delete the DAG in Airflow's db, as well as the python file
 """
-import logging
 import traceback
 
 from airflow.api_connexion import security
@@ -22,9 +21,10 @@ from openmetadata_managed_apis.api.app import blueprint
 from openmetadata_managed_apis.api.response import ApiResponse
 from openmetadata_managed_apis.api.utils import get_arg_dag_id
 from openmetadata_managed_apis.operations.delete import delete_dag_id
+from openmetadata_managed_apis.utils.logger import routes_logger
 from werkzeug.utils import secure_filename
 
-logger = logging.getLogger(__name__)
+logger = routes_logger()
 
 
 @blueprint.route("/delete", methods=["DELETE"])
@@ -53,5 +53,5 @@ def delete_dag() -> Response:
         )
         return ApiResponse.error(
             status=ApiResponse.STATUS_SERVER_ERROR,
-            error=f"Failed to delete [{dag_id}] [secured: {secure_dag_id}] due to [{exc}] - {traceback.format_exc()}",
+            error=f"Failed to delete [{dag_id}] [secured: {secure_dag_id}] due to [{exc}] ",
         )

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/delete.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/delete.py
@@ -24,6 +24,8 @@ from openmetadata_managed_apis.api.utils import get_arg_dag_id
 from openmetadata_managed_apis.operations.delete import delete_dag_id
 from werkzeug.utils import secure_filename
 
+logger = logging.getLogger(__name__)
+
 
 @blueprint.route("/delete", methods=["DELETE"])
 @csrf.exempt
@@ -45,8 +47,11 @@ def delete_dag() -> Response:
         return delete_dag_id(secure_dag_id)
 
     except Exception as exc:
-        logging.info(f"Failed to delete dag {dag_id} [secured: {secure_dag_id}]")
+        logger.debug(traceback.format_exc())
+        logger.error(
+            f"Failed to delete dag [{dag_id}] [secured: {secure_dag_id}]: {exc}"
+        )
         return ApiResponse.error(
             status=ApiResponse.STATUS_SERVER_ERROR,
-            error=f"Failed to delete {dag_id} [secured: {secure_dag_id}] due to {exc} - {traceback.format_exc()}",
+            error=f"Failed to delete [{dag_id}] [secured: {secure_dag_id}] due to [{exc}] - {traceback.format_exc()}",
         )

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/deploy.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/deploy.py
@@ -18,13 +18,14 @@ from airflow.api_connexion import security
 from airflow.security import permissions
 from airflow.www.app import csrf
 from flask import Response, request
-from metadata.generated.schema.entity.services.ingestionPipelines.ingestionPipeline import (
-    IngestionPipeline,
-)
 from openmetadata_managed_apis.api.app import blueprint
 from openmetadata_managed_apis.api.response import ApiResponse
 from openmetadata_managed_apis.operations.deploy import DagDeployer
 from pydantic import ValidationError
+
+from metadata.generated.schema.entity.services.ingestionPipelines.ingestionPipeline import (
+    IngestionPipeline,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/disable.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/disable.py
@@ -11,7 +11,6 @@
 """
 Disable/Pause a dag
 """
-import logging
 import traceback
 
 from airflow.api_connexion import security
@@ -22,8 +21,9 @@ from openmetadata_managed_apis.api.app import blueprint
 from openmetadata_managed_apis.api.response import ApiResponse
 from openmetadata_managed_apis.api.utils import get_request_dag_id
 from openmetadata_managed_apis.operations.state import disable_dag
+from openmetadata_managed_apis.utils.logger import routes_logger
 
-logger = logging.getLogger(__name__)
+logger = routes_logger()
 
 
 @blueprint.route("/disable", methods=["POST"])
@@ -43,5 +43,5 @@ def disable() -> Response:
         logger.error(f"Failed to get last run logs for [{dag_id}]: {exc}")
         return ApiResponse.error(
             status=ApiResponse.STATUS_SERVER_ERROR,
-            error=f"Failed to get last run logs for [{dag_id}] due to {exc} - {traceback.format_exc()}",
+            error=f"Failed to get last run logs for [{dag_id}] due to {exc} ",
         )

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/disable.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/disable.py
@@ -23,6 +23,8 @@ from openmetadata_managed_apis.api.response import ApiResponse
 from openmetadata_managed_apis.api.utils import get_request_dag_id
 from openmetadata_managed_apis.operations.state import disable_dag
 
+logger = logging.getLogger(__name__)
+
 
 @blueprint.route("/disable", methods=["POST"])
 @csrf.exempt
@@ -37,8 +39,9 @@ def disable() -> Response:
         return disable_dag(dag_id)
 
     except Exception as exc:
-        logging.info(f"Failed to get last run logs for '{dag_id}'")
+        logger.debug(traceback.format_exc())
+        logger.error(f"Failed to get last run logs for [{dag_id}]: {exc}")
         return ApiResponse.error(
             status=ApiResponse.STATUS_SERVER_ERROR,
-            error=f"Failed to get last run logs for '{dag_id}' due to {exc} - {traceback.format_exc()}",
+            error=f"Failed to get last run logs for [{dag_id}] due to {exc} - {traceback.format_exc()}",
         )

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/enable.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/enable.py
@@ -23,6 +23,8 @@ from openmetadata_managed_apis.api.response import ApiResponse
 from openmetadata_managed_apis.api.utils import get_request_dag_id
 from openmetadata_managed_apis.operations.state import enable_dag
 
+logger = logging.getLogger(__name__)
+
 
 @blueprint.route("/enable", methods=["POST"])
 @csrf.exempt
@@ -37,8 +39,9 @@ def enable() -> Response:
         return enable_dag(dag_id)
 
     except Exception as exc:
-        logging.info(f"Failed to get last run logs for '{dag_id}'")
+        logger.debug(traceback.format_exc())
+        logger.info(f"Failed to get last run logs for [{dag_id}]: {exc}")
         return ApiResponse.error(
             status=ApiResponse.STATUS_SERVER_ERROR,
-            error=f"Failed to get last run logs for '{dag_id}' due to {exc} - {traceback.format_exc()}",
+            error=f"Failed to get last run logs for [{dag_id}] due to {exc} - {traceback.format_exc()}",
         )

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/enable.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/enable.py
@@ -11,7 +11,6 @@
 """
 Enable/unpause a DAG
 """
-import logging
 import traceback
 
 from airflow.api_connexion import security
@@ -22,8 +21,9 @@ from openmetadata_managed_apis.api.app import blueprint
 from openmetadata_managed_apis.api.response import ApiResponse
 from openmetadata_managed_apis.api.utils import get_request_dag_id
 from openmetadata_managed_apis.operations.state import enable_dag
+from openmetadata_managed_apis.utils.logger import routes_logger
 
-logger = logging.getLogger(__name__)
+logger = routes_logger()
 
 
 @blueprint.route("/enable", methods=["POST"])
@@ -40,8 +40,8 @@ def enable() -> Response:
 
     except Exception as exc:
         logger.debug(traceback.format_exc())
-        logger.info(f"Failed to get last run logs for [{dag_id}]: {exc}")
+        logger.error(f"Failed to get last run logs for [{dag_id}]: {exc}")
         return ApiResponse.error(
             status=ApiResponse.STATUS_SERVER_ERROR,
-            error=f"Failed to get last run logs for [{dag_id}] due to {exc} - {traceback.format_exc()}",
+            error=f"Failed to get last run logs for [{dag_id}] due to {exc} ",
         )

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/health.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/health.py
@@ -11,8 +11,9 @@
 """
 Health endpoint. Globally accessible
 """
-import logging
 import traceback
+
+from openmetadata_managed_apis.utils.logger import routes_logger
 
 try:
     from importlib.metadata import version
@@ -23,7 +24,7 @@ from airflow.www.app import csrf
 from openmetadata_managed_apis.api.app import blueprint
 from openmetadata_managed_apis.api.response import ApiResponse
 
-logger = logging.getLogger(__name__)
+logger = routes_logger()
 
 
 @blueprint.route("/health", methods=["GET"])
@@ -38,9 +39,7 @@ def health():
             {"status": "healthy", "version": version("openmetadata-ingestion")}
         )
     except Exception as exc:
-        msg = (
-            f"Internal error obtaining REST status - [{exc}] - {traceback.format_exc()}"
-        )
+        msg = f"Internal error obtaining REST status due to [{exc}] "
         logger.debug(traceback.format_exc())
         logger.error(msg)
         return ApiResponse.error(

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/health.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/health.py
@@ -11,6 +11,7 @@
 """
 Health endpoint. Globally accessible
 """
+import logging
 import traceback
 
 try:
@@ -21,6 +22,8 @@ except ImportError:
 from airflow.www.app import csrf
 from openmetadata_managed_apis.api.app import blueprint
 from openmetadata_managed_apis.api.response import ApiResponse
+
+logger = logging.getLogger(__name__)
 
 
 @blueprint.route("/health", methods=["GET"])
@@ -34,8 +37,13 @@ def health():
         return ApiResponse.success(
             {"status": "healthy", "version": version("openmetadata-ingestion")}
         )
-    except Exception as err:
+    except Exception as exc:
+        msg = (
+            f"Internal error obtaining REST status - [{exc}] - {traceback.format_exc()}"
+        )
+        logger.debug(traceback.format_exc())
+        logger.error(msg)
         return ApiResponse.error(
             status=ApiResponse.STATUS_SERVER_ERROR,
-            error=f"Internal error obtaining REST status - {err} - {traceback.format_exc()}",
+            error=msg,
         )

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/ip.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/ip.py
@@ -11,6 +11,7 @@
 """
 IP endpoint
 """
+import logging
 import traceback
 
 import requests
@@ -26,6 +27,8 @@ from airflow.www.app import csrf
 from openmetadata_managed_apis.api.app import blueprint
 from openmetadata_managed_apis.api.response import ApiResponse
 
+logger = logging.getLogger(__name__)
+
 
 @blueprint.route("/ip", methods=["GET"])
 @csrf.exempt
@@ -38,8 +41,11 @@ def get_host_ip():
 
     try:
         return ApiResponse.success({"ip": requests.get("https://api.ipify.org").text})
-    except Exception as err:
+    except Exception as exc:
+        msg = f"Internal error obtaining host IP - [{exc}] - {traceback.format_exc()}"
+        logger.debug(traceback.format_exc())
+        logger.error(msg)
         return ApiResponse.error(
             status=ApiResponse.STATUS_SERVER_ERROR,
-            error=f"Internal error obtaining host IP - {err} - {traceback.format_exc()}",
+            error=msg,
         )

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/ip.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/ip.py
@@ -11,10 +11,10 @@
 """
 IP endpoint
 """
-import logging
 import traceback
 
 import requests
+from openmetadata_managed_apis.utils.logger import routes_logger
 
 try:
     from importlib.metadata import version
@@ -27,7 +27,7 @@ from airflow.www.app import csrf
 from openmetadata_managed_apis.api.app import blueprint
 from openmetadata_managed_apis.api.response import ApiResponse
 
-logger = logging.getLogger(__name__)
+logger = routes_logger()
 
 
 @blueprint.route("/ip", methods=["GET"])
@@ -42,7 +42,7 @@ def get_host_ip():
     try:
         return ApiResponse.success({"ip": requests.get("https://api.ipify.org").text})
     except Exception as exc:
-        msg = f"Internal error obtaining host IP - [{exc}] - {traceback.format_exc()}"
+        msg = f"Internal error obtaining host IP due to [{exc}] "
         logger.debug(traceback.format_exc())
         logger.error(msg)
         return ApiResponse.error(

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/kill.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/kill.py
@@ -23,6 +23,8 @@ from openmetadata_managed_apis.api.response import ApiResponse
 from openmetadata_managed_apis.api.utils import get_request_dag_id
 from openmetadata_managed_apis.operations.kill_all import kill_all
 
+logger = logging.getLogger(__name__)
+
 
 @blueprint.route("/kill", methods=["POST"])
 @csrf.exempt
@@ -38,8 +40,9 @@ def kill() -> Response:
         return kill_all(dag_id)
 
     except Exception as exc:
-        logging.info(f"Failed to get kill runs for '{dag_id}'")
+        logger.debug(traceback.format_exc())
+        logger.error(f"Failed to get kill runs for [{dag_id}]: {exc}")
         return ApiResponse.error(
             status=ApiResponse.STATUS_SERVER_ERROR,
-            error=f"Failed to kill runs for '{dag_id}' due to {exc} - {traceback.format_exc()}",
+            error=f"Failed to kill runs for [{dag_id}] - [{exc}] - {traceback.format_exc()}",
         )

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/kill.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/kill.py
@@ -11,7 +11,6 @@
 """
 Kill all not finished runs
 """
-import logging
 import traceback
 
 from airflow.api_connexion import security
@@ -22,8 +21,9 @@ from openmetadata_managed_apis.api.app import blueprint
 from openmetadata_managed_apis.api.response import ApiResponse
 from openmetadata_managed_apis.api.utils import get_request_dag_id
 from openmetadata_managed_apis.operations.kill_all import kill_all
+from openmetadata_managed_apis.utils.logger import routes_logger
 
-logger = logging.getLogger(__name__)
+logger = routes_logger()
 
 
 @blueprint.route("/kill", methods=["POST"])
@@ -44,5 +44,5 @@ def kill() -> Response:
         logger.error(f"Failed to get kill runs for [{dag_id}]: {exc}")
         return ApiResponse.error(
             status=ApiResponse.STATUS_SERVER_ERROR,
-            error=f"Failed to kill runs for [{dag_id}] - [{exc}] - {traceback.format_exc()}",
+            error=f"Failed to kill runs for [{dag_id}] due to [{exc}] ",
         )

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/last_dag_logs.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/last_dag_logs.py
@@ -11,7 +11,6 @@
 """
 Return the last DagRun logs for each task
 """
-import logging
 import traceback
 
 from airflow.api_connexion import security
@@ -22,8 +21,9 @@ from openmetadata_managed_apis.api.app import blueprint
 from openmetadata_managed_apis.api.response import ApiResponse
 from openmetadata_managed_apis.api.utils import get_arg_dag_id
 from openmetadata_managed_apis.operations.last_dag_logs import last_dag_logs
+from openmetadata_managed_apis.utils.logger import routes_logger
 
-logger = logging.getLogger(__name__)
+logger = routes_logger()
 
 
 @blueprint.route("/last_dag_logs", methods=["GET"])
@@ -44,5 +44,5 @@ def last_logs() -> Response:
         logger.error(f"Failed to get last run logs for [{dag_id}]: {exc}")
         return ApiResponse.error(
             status=ApiResponse.STATUS_SERVER_ERROR,
-            error=f"Failed to get last run logs for [{dag_id}] - [{exc}] - {traceback.format_exc()}",
+            error=f"Failed to get last run logs for [{dag_id}] due to [{exc}] ",
         )

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/last_dag_logs.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/last_dag_logs.py
@@ -23,6 +23,8 @@ from openmetadata_managed_apis.api.response import ApiResponse
 from openmetadata_managed_apis.api.utils import get_arg_dag_id
 from openmetadata_managed_apis.operations.last_dag_logs import last_dag_logs
 
+logger = logging.getLogger(__name__)
+
 
 @blueprint.route("/last_dag_logs", methods=["GET"])
 @csrf.exempt
@@ -38,8 +40,9 @@ def last_logs() -> Response:
         return last_dag_logs(dag_id)
 
     except Exception as exc:
-        logging.info(f"Failed to get last run logs for '{dag_id}'")
+        logger.debug(traceback.format_exc())
+        logger.error(f"Failed to get last run logs for [{dag_id}]: {exc}")
         return ApiResponse.error(
             status=ApiResponse.STATUS_SERVER_ERROR,
-            error=f"Failed to get last run logs for '{dag_id}' due to {exc} - {traceback.format_exc()}",
+            error=f"Failed to get last run logs for [{dag_id}] - [{exc}] - {traceback.format_exc()}",
         )

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/status.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/status.py
@@ -23,6 +23,8 @@ from openmetadata_managed_apis.api.response import ApiResponse
 from openmetadata_managed_apis.api.utils import get_arg_dag_id
 from openmetadata_managed_apis.operations.status import status
 
+logger = logging.getLogger(__name__)
+
 
 @blueprint.route("/status", methods=["GET"])
 @csrf.exempt
@@ -37,8 +39,9 @@ def dag_status() -> Response:
         return status(dag_id)
 
     except Exception as exc:
-        logging.info(f"Failed to get dag {dag_id} status")
+        logger.debug(traceback.format_exc())
+        logger.error(f"Failed to get dag [{dag_id}] status: {exc}")
         return ApiResponse.error(
             status=ApiResponse.STATUS_SERVER_ERROR,
-            error=f"Failed to get status for {dag_id} due to {exc} - {traceback.format_exc()}",
+            error=f"Failed to get status for [{dag_id}] - [{exc}] - {traceback.format_exc()}",
         )

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/status.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/status.py
@@ -11,7 +11,6 @@
 """
 Return a list of the 10 last status for the ingestion Pipeline
 """
-import logging
 import traceback
 
 from airflow.api_connexion import security
@@ -22,8 +21,9 @@ from openmetadata_managed_apis.api.app import blueprint
 from openmetadata_managed_apis.api.response import ApiResponse
 from openmetadata_managed_apis.api.utils import get_arg_dag_id
 from openmetadata_managed_apis.operations.status import status
+from openmetadata_managed_apis.utils.logger import routes_logger
 
-logger = logging.getLogger(__name__)
+logger = routes_logger()
 
 
 @blueprint.route("/status", methods=["GET"])
@@ -43,5 +43,5 @@ def dag_status() -> Response:
         logger.error(f"Failed to get dag [{dag_id}] status: {exc}")
         return ApiResponse.error(
             status=ApiResponse.STATUS_SERVER_ERROR,
-            error=f"Failed to get status for [{dag_id}] - [{exc}] - {traceback.format_exc()}",
+            error=f"Failed to get status for [{dag_id}] due to [{exc}] ",
         )

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/test_connection.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/test_connection.py
@@ -18,11 +18,12 @@ from airflow.api_connexion import security
 from airflow.security import permissions
 from airflow.www.app import csrf
 from flask import Response, request
-from metadata.ingestion.api.parser import parse_test_connection_request_gracefully
 from openmetadata_managed_apis.api.app import blueprint
 from openmetadata_managed_apis.api.response import ApiResponse
 from openmetadata_managed_apis.operations.test_connection import test_source_connection
 from pydantic import ValidationError
+
+from metadata.ingestion.api.parser import parse_test_connection_request_gracefully
 
 logger = logging.getLogger(__name__)
 

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/test_connection.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/test_connection.py
@@ -11,7 +11,6 @@
 """
 Test the connection against a source system
 """
-import logging
 import traceback
 
 from airflow.api_connexion import security
@@ -21,11 +20,12 @@ from flask import Response, request
 from openmetadata_managed_apis.api.app import blueprint
 from openmetadata_managed_apis.api.response import ApiResponse
 from openmetadata_managed_apis.operations.test_connection import test_source_connection
+from openmetadata_managed_apis.utils.logger import routes_logger
 from pydantic import ValidationError
 
 from metadata.ingestion.api.parser import parse_test_connection_request_gracefully
 
-logger = logging.getLogger(__name__)
+logger = routes_logger()
 
 
 @blueprint.route("/test_connection", methods=["POST"])
@@ -56,7 +56,7 @@ def test_connection() -> Response:
         )
 
     except Exception as exc:
-        msg = f"Internal error testing connection - [{exc}] - {traceback.format_exc()}"
+        msg = f"Internal error testing connection due to [{exc}] "
         logger.debug(traceback.format_exc())
         logger.error(msg)
         return ApiResponse.error(

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/test_connection.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/test_connection.py
@@ -11,18 +11,20 @@
 """
 Test the connection against a source system
 """
+import logging
 import traceback
 
 from airflow.api_connexion import security
 from airflow.security import permissions
 from airflow.www.app import csrf
 from flask import Response, request
+from metadata.ingestion.api.parser import parse_test_connection_request_gracefully
 from openmetadata_managed_apis.api.app import blueprint
 from openmetadata_managed_apis.api.response import ApiResponse
 from openmetadata_managed_apis.operations.test_connection import test_source_connection
 from pydantic import ValidationError
 
-from metadata.ingestion.api.parser import parse_test_connection_request_gracefully
+logger = logging.getLogger(__name__)
 
 
 @blueprint.route("/test_connection", methods=["POST"])
@@ -44,13 +46,19 @@ def test_connection() -> Response:
         return response
 
     except ValidationError as err:
+        msg = f"Request Validation Error parsing payload. (Workflow)Source expected: {err}"
+        logger.debug(traceback.format_exc())
+        logger.error(msg)
         return ApiResponse.error(
             status=ApiResponse.STATUS_BAD_REQUEST,
-            error=f"Request Validation Error parsing payload. (Workflow)Source expected - {err}",
+            error=msg,
         )
 
-    except Exception as err:
+    except Exception as exc:
+        msg = f"Internal error testing connection - [{exc}] - {traceback.format_exc()}"
+        logger.debug(traceback.format_exc())
+        logger.error(msg)
         return ApiResponse.error(
             status=ApiResponse.STATUS_SERVER_ERROR,
-            error=f"Internal error testing connection {err} - {traceback.format_exc()}",
+            error=msg,
         )

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/trigger.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/trigger.py
@@ -11,7 +11,6 @@
 """
 Trigger endpoint
 """
-import logging
 import traceback
 
 from airflow.api_connexion import security
@@ -22,8 +21,9 @@ from openmetadata_managed_apis.api.app import blueprint
 from openmetadata_managed_apis.api.response import ApiResponse
 from openmetadata_managed_apis.api.utils import get_request_arg, get_request_dag_id
 from openmetadata_managed_apis.operations.trigger import trigger
+from openmetadata_managed_apis.utils.logger import routes_logger
 
-logger = logging.getLogger(__name__)
+logger = routes_logger()
 
 
 @blueprint.route("/trigger", methods=["POST"])
@@ -46,5 +46,5 @@ def trigger_dag() -> Response:
         logger.error(f"Failed to trigger dag [{dag_id}]: {exc}")
         return ApiResponse.error(
             status=ApiResponse.STATUS_SERVER_ERROR,
-            error=f"Workflow [{dag_id}] has filed to trigger - [{exc}] - {traceback.format_exc()}",
+            error=f"Workflow [{dag_id}] has filed to trigger due to [{exc}] ",
         )

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/trigger.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/api/routes/trigger.py
@@ -23,6 +23,8 @@ from openmetadata_managed_apis.api.response import ApiResponse
 from openmetadata_managed_apis.api.utils import get_request_arg, get_request_dag_id
 from openmetadata_managed_apis.operations.trigger import trigger
 
+logger = logging.getLogger(__name__)
+
 
 @blueprint.route("/trigger", methods=["POST"])
 @csrf.exempt
@@ -40,8 +42,9 @@ def trigger_dag() -> Response:
         return response
 
     except Exception as exc:
-        logging.info(f"Failed to trigger dag {dag_id}")
+        logger.debug(traceback.format_exc())
+        logger.error(f"Failed to trigger dag [{dag_id}]: {exc}")
         return ApiResponse.error(
             status=ApiResponse.STATUS_SERVER_ERROR,
-            error=f"Workflow {dag_id} has filed to trigger due to {exc} - {traceback.format_exc()}",
+            error=f"Workflow [{dag_id}] has filed to trigger - [{exc}] - {traceback.format_exc()}",
         )

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/api/utils.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/api/utils.py
@@ -10,7 +10,6 @@
 #  limitations under the License.
 
 import importlib
-import logging
 import os
 import re
 import sys
@@ -22,8 +21,9 @@ from airflow import settings
 from airflow.jobs.scheduler_job import SchedulerJob
 from airflow.models import DagBag
 from flask import request
+from openmetadata_managed_apis.utils.logger import api_logger
 
-logger = logging.getLogger(__name__)
+logger = api_logger()
 
 
 class MissingArgException(Exception):

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/api/utils.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/api/utils.py
@@ -14,6 +14,7 @@ import logging
 import os
 import re
 import sys
+import traceback
 from multiprocessing import Process
 from typing import Optional
 
@@ -21,6 +22,8 @@ from airflow import settings
 from airflow.jobs.scheduler_job import SchedulerJob
 from airflow.models import DagBag
 from flask import request
+
+logger = logging.getLogger(__name__)
 
 
 class MissingArgException(Exception):
@@ -105,8 +108,9 @@ class ScanDagsTask(Process):
         scheduler_job.run()
         try:
             scheduler_job.kill()
-        except Exception:
-            logging.info("Rescan Complete: Killed Job")
+        except Exception as exc:
+            logger.debug(traceback.format_exc())
+            logger.info(f"Rescan Complete: Killed Job: {exc}")
 
 
 def scan_dags_job_background():

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/operations/deploy.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/operations/deploy.py
@@ -139,7 +139,7 @@ class DagDeployer:
                     {"message": f"Workflow [{self.dag_id}] has been created"}
                 )
             except Exception as exc:
-                msg = f"Workflow [{self.dag_id}] failed to refresh - [{exc}] - {traceback.format_exc()}"
+                msg = f"Workflow [{self.dag_id}] failed to refresh due to [{exc}]"
                 logger.debug(traceback.format_exc())
                 logger.error(msg)
                 return ApiResponse.server_error({f"message": msg})

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/operations/deploy.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/operations/deploy.py
@@ -18,10 +18,6 @@ from typing import Dict
 from airflow import DAG, settings
 from airflow.models import DagModel
 from jinja2 import Template
-from metadata.generated.schema.entity.services.ingestionPipelines.ingestionPipeline import (
-    IngestionPipeline,
-)
-from metadata.ingestion.models.encoders import show_secrets_encoder
 from openmetadata_managed_apis.api.config import (
     AIRFLOW_DAGS_FOLDER,
     DAG_GENERATED_CONFIGS,
@@ -34,6 +30,11 @@ from openmetadata_managed_apis.api.utils import (
     import_path,
     scan_dags_job_background,
 )
+
+from metadata.generated.schema.entity.services.ingestionPipelines.ingestionPipeline import (
+    IngestionPipeline,
+)
+from metadata.ingestion.models.encoders import show_secrets_encoder
 
 logger = logging.getLogger(__name__)
 

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/operations/deploy.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/operations/deploy.py
@@ -9,7 +9,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import logging
 import pkgutil
 import traceback
 from pathlib import Path
@@ -30,13 +29,14 @@ from openmetadata_managed_apis.api.utils import (
     import_path,
     scan_dags_job_background,
 )
+from openmetadata_managed_apis.utils.logger import operations_logger
 
 from metadata.generated.schema.entity.services.ingestionPipelines.ingestionPipeline import (
     IngestionPipeline,
 )
 from metadata.ingestion.models.encoders import show_secrets_encoder
 
-logger = logging.getLogger(__name__)
+logger = operations_logger()
 
 
 class DeployDagException(Exception):

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/operations/kill_all.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/operations/kill_all.py
@@ -17,7 +17,7 @@ from airflow import settings
 from airflow.models import DagModel, DagRun, TaskInstance
 from airflow.utils.state import DagRunState, TaskInstanceState
 from flask import Response
-from openmetadata_managed_apis.api.response import ApiResponse, ResponseFormat
+from openmetadata_managed_apis.api.response import ApiResponse
 
 
 def kill_all(dag_id: str) -> Response:

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/operations/test_connection.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/operations/test_connection.py
@@ -12,11 +12,11 @@
 Module containing the logic to test a connection
 from a WorkflowSource
 """
-import logging
 import traceback
 
 from flask import Response
 from openmetadata_managed_apis.api.response import ApiResponse
+from openmetadata_managed_apis.utils.logger import operations_logger
 from openmetadata_managed_apis.workflows.ingestion.credentials_builder import (
     build_secrets_manager_credentials,
 )
@@ -31,7 +31,7 @@ from metadata.utils.connections import (
 )
 from metadata.utils.secrets.secrets_manager_factory import get_secrets_manager
 
-logger = logging.getLogger(__name__)
+logger = operations_logger()
 
 
 def test_source_connection(

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/operations/test_connection.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/operations/test_connection.py
@@ -16,6 +16,11 @@ import logging
 import traceback
 
 from flask import Response
+from openmetadata_managed_apis.api.response import ApiResponse
+from openmetadata_managed_apis.workflows.ingestion.credentials_builder import (
+    build_secrets_manager_credentials,
+)
+
 from metadata.generated.schema.api.services.ingestionPipelines.testServiceConnection import (
     TestServiceConnectionRequest,
 )
@@ -25,10 +30,6 @@ from metadata.utils.connections import (
     test_connection,
 )
 from metadata.utils.secrets.secrets_manager_factory import get_secrets_manager
-from openmetadata_managed_apis.api.response import ApiResponse
-from openmetadata_managed_apis.workflows.ingestion.credentials_builder import (
-    build_secrets_manager_credentials,
-)
 
 logger = logging.getLogger(__name__)
 

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/operations/test_connection.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/operations/test_connection.py
@@ -12,12 +12,10 @@
 Module containing the logic to test a connection
 from a WorkflowSource
 """
-from flask import Response
-from openmetadata_managed_apis.api.response import ApiResponse
-from openmetadata_managed_apis.workflows.ingestion.credentials_builder import (
-    build_secrets_manager_credentials,
-)
+import logging
+import traceback
 
+from flask import Response
 from metadata.generated.schema.api.services.ingestionPipelines.testServiceConnection import (
     TestServiceConnectionRequest,
 )
@@ -27,6 +25,12 @@ from metadata.utils.connections import (
     test_connection,
 )
 from metadata.utils.secrets.secrets_manager_factory import get_secrets_manager
+from openmetadata_managed_apis.api.response import ApiResponse
+from openmetadata_managed_apis.workflows.ingestion.credentials_builder import (
+    build_secrets_manager_credentials,
+)
+
+logger = logging.getLogger(__name__)
 
 
 def test_source_connection(
@@ -55,10 +59,13 @@ def test_source_connection(
     try:
         test_connection(connection)
 
-    except SourceConnectionException as err:
+    except SourceConnectionException as exc:
+        msg = f"Connection error from [{connection}]: {exc}"
+        logger.debug(traceback.format_exc())
+        logger.error(msg)
         return ApiResponse.error(
             status=ApiResponse.STATUS_SERVER_ERROR,
-            error=f"Connection error from {connection} - {err}",
+            error=msg,
         )
 
     return ApiResponse.success({"message": f"Connection with {connection} successful!"})

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/utils/logger.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/utils/logger.py
@@ -8,18 +8,6 @@ BASE_LOGGING_FORMAT = (
     "[%(asctime)s] %(levelname)-8s {%(name)s:%(module)s:%(lineno)d} - %(message)s"
 )
 
-logging.basicConfig(
-    handlers=[
-        RotatingFileHandler(
-            f"{conf.get('logging', 'base_log_folder', fallback='.')}/openmetadata_airflow_api.log",
-            maxBytes=1000000,
-            backupCount=10,
-        )
-    ],
-    format=BASE_LOGGING_FORMAT,
-    level=logging.DEBUG,
-)
-
 
 class Loggers(Enum):
     API_ROUTES = "AirflowAPIRoutes"
@@ -28,17 +16,31 @@ class Loggers(Enum):
     WORKFLOW = "AirflowWorkflow"
 
 
-def routes_logger():
-    return logging.getLogger(Loggers.API_ROUTES.value)
+def build_logger(logger_name: str) -> logging.Logger:
+    logger = logging.getLogger(logger_name)
+    log_format = logging.Formatter(BASE_LOGGING_FORMAT)
+    rotating_log_handler = RotatingFileHandler(
+        f"{conf.get('logging', 'base_log_folder', fallback='')}/openmetadata_airflow_api.log",
+        maxBytes=1000000,
+        backupCount=10,
+    )
+    rotating_log_handler.setFormatter(log_format)
+    logger.addHandler(rotating_log_handler)
+    logger.setLevel(logging.DEBUG)
+    return logger
+
+
+def routes_logger() -> logging.Logger:
+    return build_logger(Loggers.API_ROUTES.value)
 
 
 def api_logger():
-    return logging.getLogger(Loggers.API.value)
+    return build_logger(Loggers.API.value)
 
 
 def operations_logger():
-    return logging.getLogger(Loggers.OPERATIONS.value)
+    return build_logger(Loggers.OPERATIONS.value)
 
 
 def workflow_logger():
-    return logging.getLogger(Loggers.WORKFLOW.value)
+    return build_logger(Loggers.WORKFLOW.value)

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/utils/logger.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/utils/logger.py
@@ -1,12 +1,23 @@
 import logging
 from enum import Enum
+from logging.handlers import RotatingFileHandler
+
+from airflow.configuration import conf
 
 BASE_LOGGING_FORMAT = (
     "[%(asctime)s] %(levelname)-8s {%(name)s:%(module)s:%(lineno)d} - %(message)s"
 )
 
 logging.basicConfig(
-    filename="std.out", filemode="a", format=BASE_LOGGING_FORMAT, level=logging.DEBUG
+    handlers=[
+        RotatingFileHandler(
+            f"{conf.get('logging', 'base_log_folder', fallback='.')}/openmetadata_airflow_api.log",
+            maxBytes=1000000,
+            backupCount=10,
+        )
+    ],
+    format=BASE_LOGGING_FORMAT,
+    level=logging.DEBUG,
 )
 
 

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/utils/logger.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/utils/logger.py
@@ -1,0 +1,33 @@
+import logging
+from enum import Enum
+
+BASE_LOGGING_FORMAT = (
+    "[%(asctime)s] %(levelname)-8s {%(name)s:%(module)s:%(lineno)d} - %(message)s"
+)
+
+logging.basicConfig(
+    filename="std.out", filemode="a", format=BASE_LOGGING_FORMAT, level=logging.DEBUG
+)
+
+
+class Loggers(Enum):
+    API_ROUTES = "AirflowAPIRoutes"
+    API = "AirflowAPI"
+    OPERATIONS = "AirflowOperations"
+    WORKFLOW = "AirflowWorkflow"
+
+
+def routes_logger():
+    return logging.getLogger(Loggers.API_ROUTES.value)
+
+
+def api_logger():
+    return logging.getLogger(Loggers.API.value)
+
+
+def operations_logger():
+    return logging.getLogger(Loggers.OPERATIONS.value)
+
+
+def workflow_logger():
+    return logging.getLogger(Loggers.WORKFLOW.value)

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/ingestion/common.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/ingestion/common.py
@@ -17,6 +17,7 @@ from typing import Callable, Optional, Union
 
 import airflow
 from airflow import DAG
+from openmetadata_managed_apis.api.utils import clean_dag_id
 
 from metadata.generated.schema.entity.services.dashboardService import DashboardService
 from metadata.generated.schema.entity.services.databaseService import DatabaseService
@@ -28,7 +29,6 @@ from metadata.ingestion.models.encoders import show_secrets_encoder
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.orm_profiler.api.workflow import ProfilerWorkflow
 from metadata.utils.logger import set_loggers_level
-from openmetadata_managed_apis.api.utils import clean_dag_id
 
 try:
     from airflow.operators.python import PythonOperator

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/ingestion/common.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/ingestion/common.py
@@ -17,6 +17,9 @@ from typing import Callable, Optional, Union
 
 import airflow
 from airflow import DAG
+from openmetadata_managed_apis.api.utils import clean_dag_id
+from openmetadata_managed_apis.workflows import workflow_factory
+
 from metadata.generated.schema.entity.services.dashboardService import DashboardService
 from metadata.generated.schema.entity.services.databaseService import DatabaseService
 from metadata.generated.schema.entity.services.messagingService import MessagingService
@@ -27,13 +30,15 @@ from metadata.ingestion.models.encoders import show_secrets_encoder
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.orm_profiler.api.workflow import ProfilerWorkflow
 from metadata.utils.logger import set_loggers_level
-from openmetadata_managed_apis.api.utils import clean_dag_id
-from openmetadata_managed_apis.workflows import workflow_factory
 
 try:
     from airflow.operators.python import PythonOperator
 except ModuleNotFoundError:
     from airflow.operators.python_operator import PythonOperator
+
+from openmetadata_managed_apis.workflows.ingestion.credentials_builder import (
+    build_secrets_manager_credentials,
+)
 
 from metadata.generated.schema.entity.services.ingestionPipelines.ingestionPipeline import (
     IngestionPipeline,
@@ -47,9 +52,6 @@ from metadata.generated.schema.metadataIngestion.workflow import (
 )
 from metadata.generated.schema.metadataIngestion.workflow import WorkflowConfig
 from metadata.ingestion.api.workflow import Workflow
-from openmetadata_managed_apis.workflows.ingestion.credentials_builder import (
-    build_secrets_manager_credentials,
-)
 
 
 def build_source(ingestion_pipeline: IngestionPipeline) -> WorkflowSource:

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/ingestion/common.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/ingestion/common.py
@@ -240,8 +240,3 @@ def build_dag(
         )
 
         return dag
-
-
-workflow = workflow_factory.WorkflowFactory.create(
-    "/Users/nahuelverdugo/dev/git/OpenMetadata/ingestion/examples/workflows/mysql.yaml"
-)

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/ingestion/common.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/ingestion/common.py
@@ -17,8 +17,6 @@ from typing import Callable, Optional, Union
 
 import airflow
 from airflow import DAG
-from openmetadata_managed_apis.api.utils import clean_dag_id
-
 from metadata.generated.schema.entity.services.dashboardService import DashboardService
 from metadata.generated.schema.entity.services.databaseService import DatabaseService
 from metadata.generated.schema.entity.services.messagingService import MessagingService
@@ -29,15 +27,13 @@ from metadata.ingestion.models.encoders import show_secrets_encoder
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.orm_profiler.api.workflow import ProfilerWorkflow
 from metadata.utils.logger import set_loggers_level
+from openmetadata_managed_apis.api.utils import clean_dag_id
+from openmetadata_managed_apis.workflows import workflow_factory
 
 try:
     from airflow.operators.python import PythonOperator
 except ModuleNotFoundError:
     from airflow.operators.python_operator import PythonOperator
-
-from openmetadata_managed_apis.workflows.ingestion.credentials_builder import (
-    build_secrets_manager_credentials,
-)
 
 from metadata.generated.schema.entity.services.ingestionPipelines.ingestionPipeline import (
     IngestionPipeline,
@@ -51,6 +47,9 @@ from metadata.generated.schema.metadataIngestion.workflow import (
 )
 from metadata.generated.schema.metadataIngestion.workflow import WorkflowConfig
 from metadata.ingestion.api.workflow import Workflow
+from openmetadata_managed_apis.workflows.ingestion.credentials_builder import (
+    build_secrets_manager_credentials,
+)
 
 
 def build_source(ingestion_pipeline: IngestionPipeline) -> WorkflowSource:
@@ -224,3 +223,8 @@ def build_dag(
         )
 
         return dag
+
+
+workflow = workflow_factory.WorkflowFactory.create(
+    "/Users/nahuelverdugo/dev/git/OpenMetadata/ingestion/examples/workflows/mysql.yaml"
+)

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/ingestion/common.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/ingestion/common.py
@@ -17,8 +17,6 @@ from typing import Callable, Optional, Union
 
 import airflow
 from airflow import DAG
-from openmetadata_managed_apis.api.utils import clean_dag_id
-from openmetadata_managed_apis.workflows import workflow_factory
 
 from metadata.generated.schema.entity.services.dashboardService import DashboardService
 from metadata.generated.schema.entity.services.databaseService import DatabaseService
@@ -30,6 +28,7 @@ from metadata.ingestion.models.encoders import show_secrets_encoder
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.orm_profiler.api.workflow import ProfilerWorkflow
 from metadata.utils.logger import set_loggers_level
+from openmetadata_managed_apis.api.utils import clean_dag_id
 
 try:
     from airflow.operators.python import PythonOperator

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/ingestion/common.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/ingestion/common.py
@@ -54,6 +54,18 @@ from metadata.generated.schema.metadataIngestion.workflow import WorkflowConfig
 from metadata.ingestion.api.workflow import Workflow
 
 
+class InvalidServiceException(Exception):
+    """
+    Exception to be thrown when couldn't fetch the service from server
+    """
+
+
+class ClientInitializationError(Exception):
+    """
+    Exception to be thrown when couldn't initialize the Openmetadata Client
+    """
+
+
 def build_source(ingestion_pipeline: IngestionPipeline) -> WorkflowSource:
     """
     Use the service EntityReference to build the Source.
@@ -69,7 +81,10 @@ def build_source(ingestion_pipeline: IngestionPipeline) -> WorkflowSource:
         build_secrets_manager_credentials(secrets_manager)
     )
 
-    metadata = OpenMetadata(config=ingestion_pipeline.openMetadataServerConnection)
+    try:
+        metadata = OpenMetadata(config=ingestion_pipeline.openMetadataServerConnection)
+    except Exception as exc:
+        raise ClientInitializationError(f"Failed to initialize the client: {exc}")
 
     service_type = ingestion_pipeline.service.type
     service: Optional[
@@ -98,7 +113,7 @@ def build_source(ingestion_pipeline: IngestionPipeline) -> WorkflowSource:
         )
 
     if not service:
-        raise ValueError(f"Could not get service from type {service_type}")
+        raise InvalidServiceException(f"Could not get service from type {service_type}")
 
     return WorkflowSource(
         type=service.serviceType.value.lower(),

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/workflow_builder.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/workflow_builder.py
@@ -12,12 +12,13 @@
 import logging
 
 from airflow import DAG
-from metadata.generated.schema.entity.services.ingestionPipelines.ingestionPipeline import (
-    IngestionPipeline,
-)
 
 # these are params only used in the DAG factory, not in the tasks
 from openmetadata_managed_apis.workflows.ingestion.registry import build_registry
+
+from metadata.generated.schema.entity.services.ingestionPipelines.ingestionPipeline import (
+    IngestionPipeline,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/workflow_builder.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/workflow_builder.py
@@ -12,13 +12,12 @@
 import logging
 
 from airflow import DAG
-
-# these are params only used in the DAG factory, not in the tasks
-from openmetadata_managed_apis.workflows.ingestion.registry import build_registry
-
 from metadata.generated.schema.entity.services.ingestionPipelines.ingestionPipeline import (
     IngestionPipeline,
 )
+
+# these are params only used in the DAG factory, not in the tasks
+from openmetadata_managed_apis.workflows.ingestion.registry import build_registry
 
 logger = logging.getLogger(__name__)
 
@@ -44,14 +43,14 @@ class WorkflowBuilder:
 
         build_fn = build_registry.registry.get(dag_type)
         if not build_fn:
-            raise ValueError(
-                f"Cannot find build function for {dag_type} in {build_registry.registry}"
-            )
+            msg = f"Cannot find build function for {dag_type} in {build_registry.registry}"
+            logger.error(msg)
+            raise ValueError(msg)
 
         dag = build_fn(self.airflow_pipeline)
         if not isinstance(dag, DAG):
-            raise ValueError(
-                f"Invalid return type from {build_fn.__name__} when building {dag_type}."
-            )
+            msg = f"Invalid return type from {build_fn.__name__} when building {dag_type}."
+            logger.error(msg)
+            raise ValueError(msg)
 
         return dag

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/workflow_builder.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/workflow_builder.py
@@ -9,18 +9,17 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import logging
-
 from airflow import DAG
 
 # these are params only used in the DAG factory, not in the tasks
+from openmetadata_managed_apis.utils.logger import workflow_logger
 from openmetadata_managed_apis.workflows.ingestion.registry import build_registry
 
 from metadata.generated.schema.entity.services.ingestionPipelines.ingestionPipeline import (
     IngestionPipeline,
 )
 
-logger = logging.getLogger(__name__)
+logger = workflow_logger()
 
 
 class WorkflowBuilder:

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/workflow_factory.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/workflow_factory.py
@@ -62,7 +62,7 @@ class WorkflowFactory:
         try:
             workflow = workflow_builder.build()
         except Exception as exc:
-            msg = f"Failed to generate workflow [{self.airflow_pipeline.name.__root__}] verify config is correct"
+            msg = f"Failed to generate workflow [{self.airflow_pipeline.name.__root__}] verify config is correct: {exc}"
             logger.debug(traceback.format_exc())
             logger.error(msg)
             raise WorkflowCreationError(msg) from exc

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/workflow_factory.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/workflow_factory.py
@@ -20,13 +20,14 @@ import traceback
 from typing import Any, Dict
 
 from airflow.models import DAG
-from metadata.generated.schema.entity.services.ingestionPipelines.ingestionPipeline import (
-    IngestionPipeline,
-)
 
 # these are params that cannot be a dag name
 from openmetadata_managed_apis.workflows.config import load_config_file
 from openmetadata_managed_apis.workflows.workflow_builder import WorkflowBuilder
+
+from metadata.generated.schema.entity.services.ingestionPipelines.ingestionPipeline import (
+    IngestionPipeline,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/workflow_factory.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/workflow_factory.py
@@ -14,7 +14,6 @@ based on incoming configs.
 
 Called in dag_runner.j2
 """
-import logging
 import pathlib
 import traceback
 from typing import Any, Dict
@@ -22,6 +21,7 @@ from typing import Any, Dict
 from airflow.models import DAG
 
 # these are params that cannot be a dag name
+from openmetadata_managed_apis.utils.logger import workflow_logger
 from openmetadata_managed_apis.workflows.config import load_config_file
 from openmetadata_managed_apis.workflows.workflow_builder import WorkflowBuilder
 
@@ -29,7 +29,7 @@ from metadata.generated.schema.entity.services.ingestionPipelines.ingestionPipel
     IngestionPipeline,
 )
 
-logger = logging.getLogger(__name__)
+logger = workflow_logger()
 
 
 class WorkflowCreationError(Exception):


### PR DESCRIPTION
Part of: #6027 and #5835

### Describe your changes :

We are trying to improve and align logging by following these rules:

- Use `logger.debug(traceback.format_exc())` after catching an exception
- Log the exception/error as part of the logger message. Tried to follow the convention `{message}: {err/exc}`
- Use `warning` instead of `warn` and log it when the application encounters a problem that interrupts normal operation flow, but it has a fallback or can fix the problem itself or can continue
- Log an error if the `except` is at the end of the method or if we are rolling back

### Type of change :
- [x] Improvement

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

### Reviewers
Ingestion: @open-metadata/ingestion
