### PR TITLE
Fix #6932 UI | Full Table name is not displayed on the Table Home Page

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/title-breadcrumb/title-breadcrumb.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/title-breadcrumb/title-breadcrumb.component.tsx
@@ -13,6 +13,7 @@
 
 import { faAngleRight } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Tooltip } from 'antd';
 import classNames from 'classnames';
 import React, {
   FunctionComponent,
@@ -106,17 +107,19 @@ const TitleBreadcrumb: FunctionComponent<TitleBreadcrumbProps> = ({
                 </Link>
               ) : (
                 <>
-                  <span
-                    className={classNames(
-                      classes,
-                      'tw-cursor-text hover:tw-text-primary hover:tw-no-underline'
-                    )}
-                    data-testid="inactive-link"
-                    style={{
-                      maxWidth,
-                    }}>
-                    {link.name}
-                  </span>
+                  <Tooltip align={{ offset: [0, 10] }} title={link.name}>
+                    <span
+                      className={classNames(
+                        classes,
+                        'tw-cursor-text hover:tw-text-primary hover:tw-no-underline'
+                      )}
+                      data-testid="inactive-link"
+                      style={{
+                        maxWidth,
+                      }}>
+                      {link.name}
+                    </span>
+                  </Tooltip>
                   {noLink && index < titleLinks.length - 1 && (
                     <span className="tw-px-2">
                       <FontAwesomeIcon


### PR DESCRIPTION
Fixes #6932 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on issue #6932 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement


#
### Frontend Preview (Screenshots) :
![image](https://user-images.githubusercontent.com/59080942/186735663-d875a310-9c7d-49ce-8de4-21d688c445a0.png)


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effectiv@open-metadata/ui r that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
