### PR TITLE
Fixes #5313 by adding logic to skip non OM on testSuite workflow

### DIFF
--- a/ingestion/src/metadata/interfaces/sqa_interface.py
+++ b/ingestion/src/metadata/interfaces/sqa_interface.py
@@ -352,13 +352,19 @@ class SQAInterface(InterfaceProtocol):
             profile_sample: sample for the profile
         """
 
-        return validation_enum_registry.registry[
-            test_case.testDefinition.fullyQualifiedName
-        ](
-            test_case,
-            execution_date=datetime.now(tz=timezone.utc).timestamp(),
-            runner=self.runner,
-        )
+        try:
+            return validation_enum_registry.registry[
+                test_case.testDefinition.fullyQualifiedName
+            ](
+                test_case,
+                execution_date=datetime.now(tz=timezone.utc).timestamp(),
+                runner=self.runner,
+            )
+        except KeyError as err:
+            logger.warning(
+                f"Test definition {test_case.testDefinition.fullyQualifiedName} not registered in OpenMetadata TestDefintion registry. Skipping test case {test_case.name.__root__}"
+            )
+            return None
 
     def close(self):
         """close session"""

--- a/ingestion/src/metadata/test_suite/api/workflow.py
+++ b/ingestion/src/metadata/test_suite/api/workflow.py
@@ -347,6 +347,8 @@ class TestSuiteWorkflow:
                 try:
                     data_test_runner = self._create_data_tests_runner(sqa_interface)
                     test_result = data_test_runner.run_and_handle(test_case)
+                    if not test_result:
+                        continue
                     if hasattr(self, "sink"):
                         self.sink.write_record(test_result)
                     logger.info(f"Successfuly ran test case {test_case.name.__root__}")

--- a/ingestion/src/metadata/test_suite/runner/core.py
+++ b/ingestion/src/metadata/test_suite/runner/core.py
@@ -37,4 +37,6 @@ class DataTestsRunner:
             test_case,
         )
 
-        return TestCaseResultResponse(testCaseResult=test_result, testCase=test_case)
+        if test_result:
+            return TestCaseResultResponse(testCaseResult=test_result, testCase=test_case)
+        return None

--- a/ingestion/src/metadata/test_suite/runner/core.py
+++ b/ingestion/src/metadata/test_suite/runner/core.py
@@ -38,5 +38,7 @@ class DataTestsRunner:
         )
 
         if test_result:
-            return TestCaseResultResponse(testCaseResult=test_result, testCase=test_case)
+            return TestCaseResultResponse(
+                testCaseResult=test_result, testCase=test_case
+            )
         return None


### PR DESCRIPTION
### Describe your changes :
Fixes #5313  If non-OM test definitions are found we will skip them from workflow execution. 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
Ingestion: @open-metadata/ingestion
