### PR TITLE
Fix#6027: Fix logging in metadata package modules except ingestion and orm_profiler

### DIFF
--- a/ingestion/connectors/docker-cli.py
+++ b/ingestion/connectors/docker-cli.py
@@ -5,6 +5,7 @@ all the connectors
 import io
 import logging
 import sys
+import traceback
 from distutils.core import run_setup
 
 import click
@@ -65,7 +66,8 @@ def build():
                 fileobj=io.BytesIO(file.encode()), tag=f"{target}:latest"
             )
         except Exception as exc:
-            logger.error(f"Error trying to build {conn}", exc)
+            logger.debug(traceback.format_exc())
+            logger.warning(f"Error trying to build {conn}: {exc}")
 
 
 @click.command()
@@ -89,7 +91,8 @@ def push():
                 decode=True,
             )
         except Exception as exc:
-            logger.error(f"Error trying to push {conn}", exc)
+            logger.debug(traceback.format_exc())
+            logger.warning(f"Error trying to push {conn}: {exc}")
 
 
 cli.add_command(build)

--- a/ingestion/src/metadata/cli/backup.py
+++ b/ingestion/src/metadata/cli/backup.py
@@ -12,6 +12,7 @@
 """
 Backup utility for the metadata CLI
 """
+import traceback
 from datetime import datetime
 from pathlib import Path
 from typing import List, Optional, Tuple
@@ -72,6 +73,7 @@ def upload_backup(endpoint: str, bucket: str, key: str, file: Path) -> None:
         import boto3
         from boto3.exceptions import S3UploadFailedError
     except ModuleNotFoundError as err:
+        logger.debug(traceback.format_exc())
         logger.error(
             "Trying to import boto3 to run the backup upload."
             + " Please install openmetadata-ingestion[backup]."
@@ -89,9 +91,11 @@ def upload_backup(endpoint: str, bucket: str, key: str, file: Path) -> None:
         resource.Object(bucket, str(s3_key)).upload_file(str(file.absolute()))
 
     except ValueError as err:
+        logger.debug(traceback.format_exc())
         logger.error("Revisit the values of --upload")
         raise err
     except S3UploadFailedError as err:
+        logger.debug(traceback.format_exc())
         logger.error(
             "Error when uploading the backup to S3. Revisit the config and permissions."
             + " You should have set the environment values for AWS_ACCESS_KEY_ID"

--- a/ingestion/src/metadata/cli/docker.py
+++ b/ingestion/src/metadata/cli/docker.py
@@ -191,14 +191,15 @@ def run_docker(
                 docker_compose_file_path.unlink()
 
     except MemoryError:
+        logger.debug(traceback.format_exc())
         click.secho(
             f"Please Allocate More memory to Docker.\nRecommended: 6GB\nCurrent: "
             f"{round(float(dict(docker_info).get('mem_total')) / calc_gb)}",
             fg="red",
         )
-    except Exception as err:
+    except Exception as exc:
         logger.debug(traceback.format_exc())
-        click.secho(str(err), fg="red")
+        click.secho(str(exc), fg="red")
 
 
 def reset_db_om(docker):
@@ -264,7 +265,8 @@ def run_sample_data() -> None:
             elif time.time() > timeout:
                 raise TimeoutError("Ingestion container timed out")
         except TimeoutError as err:
-            print(err)
+            logger.debug(traceback.format_exc())
+            sys.stdout.write(str(err))
             sys.exit(1)
         except Exception:
             sys.stdout.write(".")

--- a/ingestion/src/metadata/cli/ingest.py
+++ b/ingestion/src/metadata/cli/ingest.py
@@ -39,9 +39,9 @@ def run_ingest(config_path: str) -> None:
     try:
         workflow = Workflow.create(config_dict)
         logger.debug(f"Using config: {workflow.config}")
-    except ValidationError as e:
-        click.echo(e, err=True)
+    except ValidationError as err:
         logger.debug(traceback.format_exc())
+        click.echo(err, err=True)
         sys.exit(1)
 
     workflow.execute()

--- a/ingestion/src/metadata/clients/mode_client.py
+++ b/ingestion/src/metadata/clients/mode_client.py
@@ -81,9 +81,9 @@ class ModeApiClient:
                 reports = response_reports[EMBEDDED][REPORTS]
                 all_reports.extend(reports)
             return all_reports
-        except Exception as err:  # pylint: disable=broad-except
-            logger.error(err)
+        except Exception as exc:  # pylint: disable=broad-except
             logger.debug(traceback.format_exc())
+            logger.warning(f"Error fetching all reports: {exc}")
 
     def get_all_reports_for_collection(
         self, workspace_name: str, collection_token: str
@@ -100,9 +100,9 @@ class ModeApiClient:
                 f"/{workspace_name}/{COLLECTIONS}/{collection_token}/{REPORTS}"
             )
             return response
-        except Exception as err:  # pylint: disable=broad-except
-            logger.error(err)
+        except Exception as exc:  # pylint: disable=broad-except
             logger.debug(traceback.format_exc())
+            logger.warning(f"Error fetching charts: {exc}")
 
     def get_all_queries(self, workspace_name: str, report_token: str) -> dict:
         """Method to fetch all queries
@@ -117,9 +117,9 @@ class ModeApiClient:
                 f"/{workspace_name}/{REPORTS}/{report_token}/{QUERIES}"
             )
             return response
-        except Exception as err:  # pylint: disable=broad-except
-            logger.error(err)
+        except Exception as exc:  # pylint: disable=broad-except
             logger.debug(traceback.format_exc())
+            logger.warning(f"Error fetching all queries: {exc}")
 
     def get_all_charts(
         self, workspace_name: str, report_token: str, query_token: str
@@ -137,9 +137,9 @@ class ModeApiClient:
                 f"/{workspace_name}/{REPORTS}/{report_token}/{QUERIES}/{query_token}/{CHARTS}"
             )
             return response
-        except Exception as err:  # pylint: disable=broad-except
-            logger.error(err)
+        except Exception as exc:  # pylint: disable=broad-except
             logger.debug(traceback.format_exc())
+            logger.warning(f"Error fetching all charts: {exc}")
 
     def get_all_data_sources(self, workspace_name: str) -> dict:
         """Method to get all data sources
@@ -162,9 +162,9 @@ class ModeApiClient:
                     all_data_sources[data_source.get("id")] = data_source_dict
 
             return all_data_sources
-        except Exception as err:  # pylint: disable=broad-except
-            logger.error(err)
+        except Exception as exc:  # pylint: disable=broad-except
             logger.debug(traceback.format_exc())
+            logger.warning(f"Error fetching all data sources: {exc}")
 
     def get_user_account(self) -> dict:
         """Method to fetch account details

--- a/ingestion/src/metadata/clients/neo4j_client.py
+++ b/ingestion/src/metadata/clients/neo4j_client.py
@@ -10,6 +10,7 @@
 #  limitations under the License.
 
 import importlib
+import traceback
 from typing import Any, Iterable, Iterator, Optional, Union
 
 import neo4j
@@ -99,5 +100,8 @@ class Neo4jHelper:
         """
         try:
             self.driver.close()
-        except Exception as e:
-            logger.error("Exception encountered while closing the graph driver", e)
+        except Exception as exc:
+            logger.debug(traceback.format_exc())
+            logger.warning(
+                f"Exception encountered while closing the graph driver: {exc}"
+            )

--- a/ingestion/src/metadata/clients/powerbi_client.py
+++ b/ingestion/src/metadata/clients/powerbi_client.py
@@ -60,9 +60,6 @@ class PowerBiApiClient:
             )
 
         if not auth_response.get("access_token"):
-            logger.error(
-                "Failed to generate the PowerBi access token. Please check provided config"
-            )
             raise InvalidSourceException(
                 "Failed to generate the PowerBi access token. Please check provided config"
             )
@@ -84,9 +81,9 @@ class PowerBiApiClient:
         try:
             response = self.client.get(f"/myorg/admin/dashboards/{dashboard_id}/tiles")
             return response
-        except Exception as err:  # pylint: disable=broad-except
-            logger.error(err)
+        except Exception as exc:  # pylint: disable=broad-except
             logger.debug(traceback.format_exc())
+            logger.warning(f"Error fetching charts: {exc}")
 
     def fetch_dashboards(self) -> dict:
         """Get dashboards method
@@ -97,9 +94,9 @@ class PowerBiApiClient:
         try:
             response = self.client.get(f"/myorg/admin/dashboards")
             return response
-        except Exception as err:  # pylint: disable=broad-except
-            logger.error(err)
+        except Exception as exc:  # pylint: disable=broad-except
             logger.debug(traceback.format_exc())
+            logger.warning(f"Error fetching dashboards: {exc}")
 
     def fetch_datasets(self) -> dict:
         """Get datasets method
@@ -110,9 +107,9 @@ class PowerBiApiClient:
         try:
             response = self.client.get(f"/myorg/admin/datasets")
             return response
-        except Exception as err:  # pylint: disable=broad-except
-            logger.error(err)
+        except Exception as exc:  # pylint: disable=broad-except
             logger.debug(traceback.format_exc())
+            logger.warning(f"Error fetching datasets: {exc}")
 
     def fetch_data_sources(self, dataset_id: str) -> dict:
         """Get dataset by id method
@@ -126,6 +123,6 @@ class PowerBiApiClient:
                 f"/myorg/admin/datasets/{dataset_id}/datasources"
             )
             return response
-        except Exception as err:  # pylint: disable=broad-except
-            logger.error(err)
+        except Exception as exc:  # pylint: disable=broad-except
             logger.debug(traceback.format_exc())
+            logger.warning(f"Error fetching data sources: {exc}")

--- a/ingestion/src/metadata/cmd.py
+++ b/ingestion/src/metadata/cmd.py
@@ -13,6 +13,7 @@ import logging
 import os
 import pathlib
 import sys
+import traceback
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import List, Optional, Tuple
 
@@ -114,8 +115,10 @@ def profile(config: str) -> None:
     try:
         logger.debug(f"Using config: {workflow_config}")
         workflow = ProfilerWorkflow.create(workflow_config)
-    except ValidationError as e:
-        click.echo(e, err=True)
+    except ValidationError as err:
+        logger.debug(traceback.format_exc())
+        logger.warning(f"Error creating Profiler Workflow: {err}")
+        click.echo(err, err=True)
         sys.exit(1)
 
     workflow.execute()

--- a/ingestion/src/metadata/config/common.py
+++ b/ingestion/src/metadata/config/common.py
@@ -56,7 +56,7 @@ class YamlConfigurationMechanism(ConfigurationMechanism):
             config = yaml.safe_load(config_fp)
             return config
         except yaml.error.YAMLError:
-            msg = "YAML Configuration file is not a valid YAML"
+            msg = f"YAML Configuration file [{config_fp}] is not a valid YAML"
             logger.error(msg)
             raise ConfigurationError(msg)
 
@@ -69,7 +69,7 @@ class JsonConfigurationMechanism(ConfigurationMechanism):
             config = json.load(config_fp)
             return config
         except json.decoder.JSONDecodeError:
-            msg = "JSON Configuration file is not a valid JSON"
+            msg = f"JSON Configuration file [{config_fp}] is not a valid JSON"
             logger.error(msg)
             raise ConfigurationError(msg)
 

--- a/ingestion/src/metadata/great_expectations/action.py
+++ b/ingestion/src/metadata/great_expectations/action.py
@@ -15,7 +15,7 @@ Open Metadata table quality.
 This subpackage needs to be used in Great Expectations
 checkpoints actions.
 """
-
+import traceback
 import warnings
 from typing import Dict, Optional, Union
 
@@ -245,6 +245,7 @@ class OpenMetadataValidationAction(ValidationAction):
                 test_case_builder=test_builder
             ).build_test_from_builder()
         except KeyError:
+            logger.debug(traceback.format_exc())
             logger.warning(
                 "GE Test %s not yet support. Skipping test ingestion",
                 result["expectation_config"]["expectation_type"],

--- a/ingestion/src/metadata/great_expectations/utils/ometa_config_handler.py
+++ b/ingestion/src/metadata/great_expectations/utils/ometa_config_handler.py
@@ -13,6 +13,7 @@ Utility functions to create open metadata connections from yaml file
 """
 
 import os
+import traceback
 from typing import Any, Optional
 
 import yaml
@@ -21,6 +22,9 @@ from jinja2 import Environment, FileSystemLoader, TemplateNotFound, select_autoe
 from metadata.generated.schema.entity.services.connections.metadata.openMetadataConnection import (
     OpenMetadataConnection,
 )
+from metadata.utils.logger import great_expectations_logger
+
+logger = great_expectations_logger()
 
 
 def env(key: str) -> Optional[Any]:
@@ -69,6 +73,8 @@ def render_template(environment: Environment, template_file: str = "config.yml")
         tmplt = environment.get_template(template_file)
         return tmplt.render()
     except TemplateNotFound as err:
+        logger.debug(traceback.format_exc())
+        logger.warning(f"Template file at {template_file} not found: {err}")
         try:
             tmplt = environment.get_template("config.yaml")
             return tmplt.render()

--- a/ingestion/src/metadata/ingestion/ometa/mixins/table_mixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/table_mixin.py
@@ -17,7 +17,6 @@ import json
 import traceback
 from typing import List, Optional, Union
 
-from metadata.generated.schema.api.data.createTable import CreateTableRequest
 from metadata.generated.schema.api.data.createTableProfile import (
     CreateTableProfileRequest,
 )

--- a/ingestion/src/metadata/ingestion/sink/metadata_rest.py
+++ b/ingestion/src/metadata/ingestion/sink/metadata_rest.py
@@ -33,7 +33,6 @@ from metadata.generated.schema.api.teams.createRole import CreateRoleRequest
 from metadata.generated.schema.api.teams.createTeam import CreateTeamRequest
 from metadata.generated.schema.api.teams.createUser import CreateUserRequest
 from metadata.generated.schema.entity.data.location import Location
-from metadata.generated.schema.entity.data.pipeline import Pipeline
 from metadata.generated.schema.entity.data.table import Table
 from metadata.generated.schema.entity.services.connections.metadata.openMetadataConnection import (
     OpenMetadataConnection,

--- a/ingestion/src/metadata/ingestion/source/database/sql_column_handler.py
+++ b/ingestion/src/metadata/ingestion/source/database/sql_column_handler.py
@@ -100,12 +100,16 @@ class SqlColumnHandlerMixin:
                 table_name, schema_name
             )
         except NotImplementedError:
-            logger.warning("Cannot obtain unique constraints - NotImplementedError")
+            logger.debug(
+                f"Cannot obtain unique constraints for table [{schema_name}.{table_name}]: NotImplementedError"
+            )
             unique_constraints = []
         try:
             foreign_constraints = inspector.get_foreign_keys(table_name, schema_name)
         except NotImplementedError:
-            logger.warning("Cannot obtain foreign constraints - NotImplementedError")
+            logger.debug(
+                "Cannot obtain foreign constraints for table [{schema_name}.{table_name}]: NotImplementedError"
+            )
             foreign_constraints = []
 
         pk_columns = (

--- a/ingestion/src/metadata/test_suite/api/workflow.py
+++ b/ingestion/src/metadata/test_suite/api/workflow.py
@@ -105,7 +105,9 @@ class TestSuiteWorkflow:
             config = parse_workflow_config_gracefully(config_dict)
             return cls(config)
         except ValidationError as err:
-            logger.error("Error trying to parse the Profiler Workflow configuration")
+            logger.error(
+                f"Error trying to parse the Profiler Workflow configuration: {err}"
+            )
             raise err
 
     def _get_unique_table_entities(self, test_cases: List[TestCase]) -> Set:
@@ -316,11 +318,11 @@ class TestSuiteWorkflow:
                         )
                     )
                 )
-            except Exception as err:
+            except Exception as exc:
                 logger.warning(
-                    f"Couldn't create test case name {test_case_name_to_create}: {err}"
+                    f"Couldn't create test case name {test_case_name_to_create}: {exc}"
                 )
-                logger.debug(traceback.format_exc(err))
+                logger.debug(traceback.format_exc(exc))
 
         return created_test_case
 
@@ -351,9 +353,9 @@ class TestSuiteWorkflow:
                         self.sink.write_record(test_result)
                     logger.info(f"Successfuly ran test case {test_case.name.__root__}")
                     self.status.processed(test_case.fullyQualifiedName.__root__)
-                except Exception as err:
-                    logger.debug(traceback.format_exc(err))
-                    logger.warning(f"Could not run test case {test_case.name}: {err}")
+                except Exception as exc:
+                    logger.debug(traceback.format_exc(exc))
+                    logger.warning(f"Could not run test case {test_case.name}: {exc}")
                     self.status.failure(test_case.fullyQualifiedName.__root__)
 
     def print_status(self) -> int:

--- a/ingestion/src/metadata/test_suite/validations/column/column_value_max_to_be_between.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_value_max_to_be_between.py
@@ -61,9 +61,9 @@ def column_value_max_to_be_between(
         )
         max_value_res = max_value_dict.get(Metrics.MAX.name)
 
-    except Exception as err:  # pylint: disable=broad-except
+    except Exception as exc:  # pylint: disable=broad-except
         msg = (
-            f"Error computing {test_case.name} for {runner.table.__tablename__}: {err}"
+            f"Error computing {test_case.name} for {runner.table.__tablename__}: {exc}"
         )
         logger.debug(traceback.format_exc())
         logger.warning(msg)

--- a/ingestion/src/metadata/test_suite/validations/column/column_value_mean_to_be_between.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_value_mean_to_be_between.py
@@ -61,9 +61,9 @@ def column_value_mean_to_be_between(
         )
         mean_value_res = mean_value_dict.get(Metrics.MEAN.name)
 
-    except Exception as err:
+    except Exception as exc:
         msg = (
-            f"Error computing {test_case.name} for {runner.table.__tablename__}: {err}"
+            f"Error computing {test_case.name} for {runner.table.__tablename__}: {exc}"
         )
         logger.debug(traceback.format_exc())
         logger.warning(msg)

--- a/ingestion/src/metadata/test_suite/validations/column/column_value_median_to_be_between.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_value_median_to_be_between.py
@@ -61,9 +61,9 @@ def column_value_median_to_be_between(
         )
         median_value_res = median_value_dict.get(Metrics.MEDIAN.name)
 
-    except Exception as err:
+    except Exception as exc:
         msg = (
-            f"Error computing {test_case.name} for {runner.table.__tablename__}: {err}"
+            f"Error computing {test_case.name} for {runner.table.__tablename__}: {exc}"
         )
         logger.debug(traceback.format_exc())
         logger.warning(msg)

--- a/ingestion/src/metadata/test_suite/validations/column/column_value_min_to_be_between.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_value_min_to_be_between.py
@@ -61,9 +61,9 @@ def column_value_min_to_be_between(
         )
         min_value_res = min_value_dict.get(Metrics.MIN.name)
 
-    except Exception as err:
+    except Exception as exc:
         msg = (
-            f"Error computing {test_case.name} for {runner.table.__tablename__}: {err}"
+            f"Error computing {test_case.name} for {runner.table.__tablename__}: {exc}"
         )
         logger.debug(traceback.format_exc())
         logger.warning(msg)

--- a/ingestion/src/metadata/test_suite/validations/column/column_value_stddev_to_be_between.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_value_stddev_to_be_between.py
@@ -61,9 +61,9 @@ def column_value_stddev_to_be_between(
         )
         stddev_value_res = stddev_value_dict.get(Metrics.STDDEV.name)
 
-    except Exception as err:
+    except Exception as exc:
         msg = (
-            f"Error computing {test_case.name} for {runner.table.__tablename__}: {err}"
+            f"Error computing {test_case.name} for {runner.table.__tablename__}: {exc}"
         )
         logger.debug(traceback.format_exc())
         logger.warning(msg)

--- a/ingestion/src/metadata/test_suite/validations/column/column_values_in_set.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_values_in_set.py
@@ -72,9 +72,9 @@ def column_values_in_set(
         set_count_dict = dict(runner.dispatch_query_select_first(set_count(col).fn()))
         set_count_res = set_count_dict.get(Metrics.COUNT_IN_SET.name)
 
-    except Exception as err:  # pylint: disable=broad-except
+    except Exception as exc:  # pylint: disable=broad-except
         msg = (
-            f"Error computing {test_case.name} for {runner.table.__tablename__}: {err}"
+            f"Error computing {test_case.name} for {runner.table.__tablename__}: {exc}"
         )
         logger.debug(traceback.format_exc())
         logger.warning(msg)

--- a/ingestion/src/metadata/test_suite/validations/column/column_values_length_to_be_between.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_values_length_to_be_between.py
@@ -69,9 +69,9 @@ def column_value_length_to_be_between(
             Metrics.MIN_LENGTH.name
         )
 
-    except Exception as err:
+    except Exception as exc:
         msg = (
-            f"Error computing {test_case.name} for {runner.table.__tablename__}: {err}"
+            f"Error computing {test_case.name} for {runner.table.__tablename__}: {exc}"
         )
         logger.debug(traceback.format_exc())
         logger.warning(msg)

--- a/ingestion/src/metadata/test_suite/validations/column/column_values_missing_count_to_be_equal.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_values_missing_count_to_be_equal.py
@@ -64,9 +64,9 @@ def column_values_missing_count_to_be_equal(
         )
         null_count_value_res = null_count_value_dict.get(Metrics.NULL_COUNT.name)
 
-    except Exception as err:
+    except Exception as exc:
         msg = (
-            f"Error computing {test_case.name} for {runner.table.__tablename__}: {err}"
+            f"Error computing {test_case.name} for {runner.table.__tablename__}: {exc}"
         )
         logger.debug(traceback.format_exc())
         logger.warning(msg)
@@ -105,8 +105,8 @@ def column_values_missing_count_to_be_equal(
             # Add set count for special values into the missing count
             null_count_value_res += set_count_res
 
-        except Exception as err:  # pylint: disable=broad-except
-            msg = f"Error computing {test_case.__class__.__name__} for {runner.table.__tablename__}: {err}"
+        except Exception as exc:  # pylint: disable=broad-except
+            msg = f"Error computing {test_case.__class__.__name__} for {runner.table.__tablename__}: {exc}"
             logger.debug(traceback.format_exc())
             logger.warning(msg)
             return TestCaseResult(

--- a/ingestion/src/metadata/test_suite/validations/column/column_values_not_in_set.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_values_not_in_set.py
@@ -71,9 +71,9 @@ def column_values_not_in_set(
         set_count_dict = dict(runner.dispatch_query_select_first(set_count(col).fn()))
         set_count_res = set_count_dict.get(Metrics.COUNT_IN_SET.name)
 
-    except Exception as err:
+    except Exception as exc:
         msg = (
-            f"Error computing {test_case.name} for {runner.table.__tablename__}: {err}"
+            f"Error computing {test_case.name} for {runner.table.__tablename__}: {exc}"
         )
         logger.debug(traceback.format_exc())
         logger.warning(msg)

--- a/ingestion/src/metadata/test_suite/validations/column/column_values_sum_to_be_between.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_values_sum_to_be_between.py
@@ -61,9 +61,9 @@ def column_values_sum_to_be_between(
         )
         sum_value_res = sum_value_dict.get(Metrics.SUM.name)
 
-    except Exception as err:
+    except Exception as exc:
         msg = (
-            f"Error computing {test_case.name} for {runner.table.__tablename__}: {err}"
+            f"Error computing {test_case.name} for {runner.table.__tablename__}: {exc}"
         )
         logger.debug(traceback.format_exc())
         logger.warning(msg)

--- a/ingestion/src/metadata/test_suite/validations/column/column_values_to_be_between.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_values_to_be_between.py
@@ -65,9 +65,9 @@ def column_values_to_be_between(
         )
         max_value_res = max_value_dict.get(Metrics.MAX.name)
 
-    except Exception as err:
+    except Exception as exc:
         msg = (
-            f"Error computing {test_case.name} for {runner.table.__tablename__}: {err}"
+            f"Error computing {test_case.name} for {runner.table.__tablename__}: {exc}"
         )
         logger.debug(traceback.format_exc())
         logger.warning(msg)

--- a/ingestion/src/metadata/test_suite/validations/column/column_values_to_be_not_null.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_values_to_be_not_null.py
@@ -61,9 +61,9 @@ def column_values_to_be_not_null(
         )
         null_count_value_res = null_count_value_dict.get(Metrics.NULL_COUNT.name)
 
-    except Exception as err:
+    except Exception as exc:
         msg = (
-            f"Error computing {test_case.name} for {runner.table.__tablename__}: {err}"
+            f"Error computing {test_case.name} for {runner.table.__tablename__}: {exc}"
         )
         logger.debug(traceback.format_exc())
         logger.warning(msg)

--- a/ingestion/src/metadata/test_suite/validations/column/column_values_to_be_unique.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_values_to_be_unique.py
@@ -73,8 +73,8 @@ def column_values_to_be_unique(
         )
         unique_count_value_res = unique_count_value_dict.get(Metrics.UNIQUE_COUNT.name)
 
-    except Exception as err:
-        msg = f"Error computing {test_case.name.__root__} for {runner.table.__tablename__}: {err}"
+    except Exception as exc:
+        msg = f"Error computing {test_case.name.__root__} for {runner.table.__tablename__}: {exc}"
         logger.debug(traceback.format_exc())
         logger.warning(msg)
         return TestCaseResult(

--- a/ingestion/src/metadata/test_suite/validations/column/column_values_to_match_regex.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_values_to_match_regex.py
@@ -73,9 +73,9 @@ def column_values_to_match_regex(
         )
         like_count_value_res = like_count_value_dict.get(Metrics.LIKE_COUNT.name)
 
-    except Exception as err:
+    except Exception as exc:
         msg = (
-            f"Error computing {test_case.name} for {runner.table.__tablename__}: {err}"
+            f"Error computing {test_case.name} for {runner.table.__tablename__}: {exc}"
         )
         logger.debug(traceback.format_exc())
         logger.warning(msg)

--- a/ingestion/src/metadata/test_suite/validations/column/column_values_to_not_match_regex.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_values_to_not_match_regex.py
@@ -73,9 +73,9 @@ def column_values_to_not_match_regex(
         )
         not_like_count_res = not_like_count_dict.get(Metrics.NOT_LIKE_COUNT.name)
 
-    except Exception as err:
+    except Exception as exc:
         msg = (
-            f"Error computing {test_case.name} for {runner.table.__tablename__}: {err}"
+            f"Error computing {test_case.name} for {runner.table.__tablename__}: {exc}"
         )
         logger.debug(traceback.format_exc())
         logger.warning(msg)

--- a/ingestion/src/metadata/test_suite/validations/table/table_column_count_to_be_between.py
+++ b/ingestion/src/metadata/test_suite/validations/table/table_column_count_to_be_between.py
@@ -50,9 +50,9 @@ def table_column_count_to_be_between(
     try:
         column_count = len(inspect(runner.table).c)
 
-    except Exception as err:
+    except Exception as exc:
         msg = (
-            f"Error computing {test_case.name} for {runner.table.__tablename__}: {err}"
+            f"Error computing {test_case.name} for {runner.table.__tablename__}: {exc}"
         )
         logger.debug(traceback.format_exc())
         logger.warning(msg)

--- a/ingestion/src/metadata/test_suite/validations/table/table_column_count_to_equal.py
+++ b/ingestion/src/metadata/test_suite/validations/table/table_column_count_to_equal.py
@@ -47,9 +47,9 @@ def table_column_count_to_equal(
     try:
         column_count = len(inspect(runner.table).c)
 
-    except Exception as err:
+    except Exception as exc:
         msg = (
-            f"Error computing {test_case.name} for {runner.table.__tablename__}: {err}"
+            f"Error computing {test_case.name} for {runner.table.__tablename__}: {exc}"
         )
         logger.debug(traceback.format_exc())
         logger.warning(msg)

--- a/ingestion/src/metadata/test_suite/validations/table/table_column_name_to_exist.py
+++ b/ingestion/src/metadata/test_suite/validations/table/table_column_name_to_exist.py
@@ -64,9 +64,9 @@ def table_column_name_to_exist(
     try:
         column_names = inspect(runner.table).c
 
-    except Exception as err:
+    except Exception as exc:
         msg = (
-            f"Error computing {test_case.name} for {runner.table.__tablename__}: {err}"
+            f"Error computing {test_case.name} for {runner.table.__tablename__}: {exc}"
         )
         logger.debug(traceback.format_exc())
         logger.warning(msg)

--- a/ingestion/src/metadata/test_suite/validations/table/table_column_to_match_set.py
+++ b/ingestion/src/metadata/test_suite/validations/table/table_column_to_match_set.py
@@ -65,9 +65,9 @@ def table_column_to_match_set(
     try:
         column_names = inspect(runner.table).c
 
-    except Exception as err:
+    except Exception as exc:
         msg = (
-            f"Error computing {test_case.name} for {runner.table.__tablename__}: {err}"
+            f"Error computing {test_case.name} for {runner.table.__tablename__}: {exc}"
         )
         logger.debug(traceback.format_exc())
         logger.warning(msg)

--- a/ingestion/src/metadata/test_suite/validations/table/table_custom_sql_query.py
+++ b/ingestion/src/metadata/test_suite/validations/table/table_custom_sql_query.py
@@ -59,9 +59,9 @@ def table_custom_sql_query(
     try:
         rows = runner._session.execute(text(sql_expression)).all()
 
-    except Exception as err:
+    except Exception as exc:
         msg = (
-            f"Error computing {test_case.name} for {runner.table.__tablename__}: {err}"
+            f"Error computing {test_case.name} for {runner.table.__tablename__}: {exc}"
         )
         logger.debug(traceback.format_exc())
         logger.warning(msg)

--- a/ingestion/src/metadata/test_suite/validations/table/table_row_count_to_be_between.py
+++ b/ingestion/src/metadata/test_suite/validations/table/table_row_count_to_be_between.py
@@ -49,9 +49,9 @@ def table_row_count_to_be_between(
         )
         row_count_value = row_count_dict.get(Metrics.ROW_COUNT.name)
 
-    except Exception as err:
+    except Exception as exc:
         msg = (
-            f"Error computing {test_case.name} for {runner.table.__tablename__}: {err}"
+            f"Error computing {test_case.name} for {runner.table.__tablename__}: {exc}"
         )
         logger.debug(traceback.format_exc())
         logger.warning(msg)

--- a/ingestion/src/metadata/test_suite/validations/table/table_row_count_to_equal.py
+++ b/ingestion/src/metadata/test_suite/validations/table/table_row_count_to_equal.py
@@ -49,9 +49,9 @@ def table_row_count_to_equal(
         )
         row_count_value = row_count_dict.get(Metrics.ROW_COUNT.name)
 
-    except Exception as err:
+    except Exception as exc:
         msg = (
-            f"Error computing {test_case.name} for {runner.table.__tablename__}: {err}"
+            f"Error computing {test_case.name} for {runner.table.__tablename__}: {exc}"
         )
         logger.debug(traceback.format_exc())
         logger.warning(msg)

--- a/ingestion/src/metadata/utils/connections.py
+++ b/ingestion/src/metadata/utils/connections.py
@@ -356,7 +356,7 @@ def _(connection: KafkaConnection, verbose: bool = False) -> KafkaClient:
             consumer_config["schema.registry." + key] = connection.schemaRegistryConfig[
                 key
             ]
-        logger.debug(consumer_config)
+        logger.debug(f"Using Kafka consumer config: {consumer_config}")
         consumer_client = AvroConsumer(consumer_config)
 
     return KafkaClient(
@@ -400,13 +400,11 @@ def test_connection(connection) -> None:
         with connection.connect() as conn:
             conn.execute(ConnTestFn())
     except OperationalError as err:
-        raise SourceConnectionException(
-            f"Connection error for {connection} - {err}. Check the connection details."
-        )
-    except Exception as err:
-        raise SourceConnectionException(
-            f"Unknown error connecting with {connection} - {err}."
-        )
+        msg = f"Connection error for {connection}: {err}. Check the connection details."
+        raise SourceConnectionException(msg)
+    except Exception as exc:
+        msg = f"Unknown error connecting with {connection}: {exc}."
+        raise SourceConnectionException(msg)
 
 
 @test_connection.register
@@ -421,13 +419,11 @@ def _(connection: DynamoClient) -> None:
     try:
         connection.client.tables.all()
     except ClientError as err:
-        raise SourceConnectionException(
-            f"Connection error for {connection} - {err}. Check the connection details."
-        )
-    except Exception as err:
-        raise SourceConnectionException(
-            f"Unknown error connecting with {connection} - {err}."
-        )
+        msg = f"Connection error for {connection}: {err}. Check the connection details."
+        raise SourceConnectionException(msg)
+    except Exception as exc:
+        msg = f"Unknown error connecting with {connection}: {exc}."
+        raise SourceConnectionException(msg)
 
 
 @test_connection.register
@@ -442,13 +438,11 @@ def _(connection: GlueDBClient) -> None:
     try:
         connection.client.list_workflows()
     except ClientError as err:
-        raise SourceConnectionException(
-            f"Connection error for {connection} - {err}. Check the connection details."
-        )
-    except Exception as err:
-        raise SourceConnectionException(
-            f"Unknown error connecting with {connection} - {err}."
-        )
+        msg = f"Connection error for {connection}: {err}. Check the connection details."
+        raise SourceConnectionException(msg)
+    except Exception as exc:
+        msg = f"Unknown error connecting with {connection}: {exc}."
+        raise SourceConnectionException(msg)
 
 
 @test_connection.register
@@ -463,13 +457,11 @@ def _(connection: GluePipelineClient) -> None:
     try:
         connection.client.get_paginator("get_databases")
     except ClientError as err:
-        raise SourceConnectionException(
-            f"Connection error for {connection} - {err}. Check the connection details."
-        )
-    except Exception as err:
-        raise SourceConnectionException(
-            f"Unknown error connecting with {connection} - {err}."
-        )
+        msg = f"Connection error for {connection}: {err}. Check the connection details."
+        raise SourceConnectionException(msg)
+    except Exception as exc:
+        msg = f"Unknown error connecting with {connection}: {exc}."
+        raise SourceConnectionException(msg)
 
 
 @test_connection.register
@@ -479,13 +471,11 @@ def _(connection: SalesforceClient) -> None:
     try:
         connection.client.describe()
     except SalesforceAuthenticationFailed as err:
-        raise SourceConnectionException(
-            f"Connection error for {connection} - {err}. Check the connection details."
-        )
-    except Exception as err:
-        raise SourceConnectionException(
-            f"Unknown error connecting with {connection} - {err}."
-        )
+        msg = f"Connection error for {connection}: {err}. Check the connection details."
+        raise SourceConnectionException(msg)
+    except Exception as exc:
+        msg = f"Unknown error connecting with {connection}: {exc}."
+        raise SourceConnectionException(msg)
 
 
 @test_connection.register
@@ -499,20 +489,18 @@ def _(connection: KafkaClient) -> None:
         _ = connection.admin_client.list_topics().topics
         if connection.schema_registry_client:
             _ = connection.schema_registry_client.get_subjects()
-    except Exception as err:
-        raise SourceConnectionException(
-            f"Unknown error connecting with {connection} - {err}."
-        )
+    except Exception as exc:
+        msg = f"Unknown error connecting with {connection}: {exc}."
+        raise SourceConnectionException(msg)
 
 
 @test_connection.register
 def _(connection: DeltaLakeClient) -> None:
     try:
         connection.client.catalog.listDatabases()
-    except Exception as err:
-        raise SourceConnectionException(
-            f"Unknown error connecting with {connection} - {err}."
-        )
+    except Exception as exc:
+        msg = f"Unknown error connecting with {connection}: {exc}."
+        raise SourceConnectionException(msg)
 
 
 @get_connection.register
@@ -535,9 +523,9 @@ def _(connection: MetabaseConnection, verbose: bool = False):
         conn = {"connection": connection, "metabase_session": metabase_session}
         return MetabaseClient(conn)
 
-    except Exception as err:
-        logger.error(f"Failed to connect with error :  {err}")
-        logger.debug(traceback.format_exc())
+    except Exception as exc:
+        msg = f"Unknown error connecting with {connection}: {exc}."
+        raise SourceConnectionException(msg)
 
 
 @test_connection.register
@@ -547,30 +535,27 @@ def _(connection: MetabaseClient) -> None:
             connection.client["connection"].hostPort + "/api/dashboard",
             headers=connection.client["metabase_session"],
         )
-    except Exception as err:
-        raise SourceConnectionException(
-            f"Unknown error connecting with {connection} - {err}."
-        )
+    except Exception as exc:
+        msg = f"Unknown error connecting with {connection}: {exc}."
+        raise SourceConnectionException(msg)
 
 
 @test_connection.register
 def _(connection: AirflowConnection) -> None:
     try:
         test_connection(connection.connection)
-    except Exception as err:
-        raise SourceConnectionException(
-            f"Unknown error connecting with {connection} - {err}."
-        )
+    except Exception as exc:
+        msg = f"Unknown error connecting with {connection}: {exc}."
+        raise SourceConnectionException(msg)
 
 
 @get_connection.register
 def _(connection: AirflowConnection) -> None:
     try:
         return get_connection(connection.connection)
-    except Exception as err:
-        raise SourceConnectionException(
-            f"Unknown error connecting with {connection} - {err}."
-        )
+    except Exception as exc:
+        msg = f"Unknown error connecting with {connection}: {exc}."
+        raise SourceConnectionException(msg)
 
 
 @get_connection.register
@@ -584,10 +569,9 @@ def _(connection: AirbyteConnection, verbose: bool = False):
 def _(connection: AirByteClient) -> None:
     try:
         connection.client.list_workspaces()
-    except Exception as err:
-        raise SourceConnectionException(
-            f"Unknown error connecting with {connection} - {err}."
-        )
+    except Exception as exc:
+        msg = f"Unknown error connecting with {connection}: {exc}."
+        raise SourceConnectionException(msg)
 
 
 @get_connection.register
@@ -601,10 +585,9 @@ def _(connection: FivetranConnection, verbose: bool = False):
 def _(connection: FivetranClient) -> None:
     try:
         connection.client.list_groups()
-    except Exception as err:
-        raise SourceConnectionException(
-            f"Unknown error connecting with {connection} - {err}."
-        )
+    except Exception as exc:
+        msg = f"Unknown error connecting with {connection}: {exc}."
+        raise SourceConnectionException(msg)
 
 
 @get_connection.register
@@ -617,19 +600,18 @@ def _(connection: RedashConnection, verbose: bool = False):
         redash_client = RedashClient(redash)
         return redash_client
 
-    except Exception as err:
-        logger.error(f"Failed to connect with error :  {err}")
-        logger.error(err)
+    except Exception as exc:
+        msg = f"Unknown error connecting with {connection}: {exc}."
+        raise SourceConnectionException(msg)
 
 
 @test_connection.register
 def _(connection: RedashClient) -> None:
     try:
         connection.client.dashboards()
-    except Exception as err:
-        raise SourceConnectionException(
-            f"Unknown error connecting with {connection} - {err}."
-        )
+    except Exception as exc:
+        msg = f"Unknown error connecting with {connection}: {exc}."
+        raise SourceConnectionException(msg)
 
 
 @get_connection.register
@@ -645,10 +627,9 @@ def _(connection: SupersetConnection, verbose: bool = False):
 def _(connection: SupersetClient) -> None:
     try:
         connection.client.fetch_menu()
-    except Exception as err:
-        raise SourceConnectionException(
-            f"Unknown error connecting with {connection} - {err}."
-        )
+    except Exception as exc:
+        msg = f"Unknown error connecting with {connection}: {exc}."
+        raise SourceConnectionException(msg)
 
 
 @get_connection.register
@@ -686,8 +667,9 @@ def _(connection: TableauConnection, verbose: bool = False):
         )
         conn.sign_in().json()
         return TableauClient(conn)
-    except Exception as err:  # pylint: disable=broad-except
-        logger.error("%s: %s", repr(err), err)
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.debug(traceback.format_exc())
+        logger.warning(f"Unknown error connecting with {connection}: {exc}.")
 
 
 @test_connection.register
@@ -695,10 +677,9 @@ def _(connection: TableauClient) -> None:
     try:
         connection.client.server_info()
 
-    except Exception as err:
-        raise SourceConnectionException(
-            f"Unknown error connecting with {connection} - {err}."
-        )
+    except Exception as exc:
+        msg = f"Unknown error connecting with {connection}: {exc}."
+        raise SourceConnectionException(msg)
 
 
 @get_connection.register
@@ -712,10 +693,9 @@ def _(connection: PowerBIConnection, verbose: bool = False):
 def _(connection: PowerBiClient) -> None:
     try:
         connection.client.fetch_dashboards()
-    except Exception as err:
-        raise SourceConnectionException(
-            f"Unknown error connecting with {connection} - {err}."
-        )
+    except Exception as exc:
+        msg = f"Unknown error connecting with {connection}: {exc}."
+        raise SourceConnectionException(msg)
 
 
 @get_connection.register
@@ -738,10 +718,9 @@ def _(connection: LookerConnection, verbose: bool = False):
 def _(connection: LookerClient) -> None:
     try:
         connection.client.me()
-    except Exception as err:
-        raise SourceConnectionException(
-            f"Unknown error connecting with {connection} - {err}."
-        )
+    except Exception as exc:
+        msg = f"Unknown error connecting with {connection}: {exc}."
+        raise SourceConnectionException(msg)
 
 
 @test_connection.register
@@ -768,17 +747,15 @@ def _(connection: DatalakeClient) -> None:
                 connection.client.list_buckets()
 
     except ClientError as err:
-        raise SourceConnectionException(
-            f"Connection error for {connection} - {err}. Check the connection details."
-        )
+        msg = f"Connection error for {connection}: {err}. Check the connection details."
+        raise SourceConnectionException(msg)
 
 
 @singledispatch
 def get_datalake_client(config):
     if config:
-        raise NotImplementedError(
-            f"Config not implemented for type {type(config)}: {config}"
-        )
+        msg = f"Config not implemented for type {type(config)}: {config}"
+        raise NotImplementedError(msg)
 
 
 @get_connection.register
@@ -815,10 +792,9 @@ def _(connection: ModeConnection, verbose: bool = False):
 def _(connection: ModeClient) -> None:
     try:
         connection.client.get_user_account()
-    except Exception as err:
-        raise SourceConnectionException(
-            f"Unknown error connecting with {connection} - {err}."
-        )
+    except Exception as exc:
+        msg = f"Unknown error connecting with {connection}: {exc}."
+        raise SourceConnectionException(msg)
 
 
 @get_connection.register
@@ -837,10 +813,9 @@ def _(connection: MlflowConnection, verbose: bool = False):
 def _(connection: MlflowClientWrapper) -> None:
     try:
         connection.client.list_registered_models()
-    except Exception as err:
-        raise SourceConnectionException(
-            f"Unknown error connecting with {connection} - {err}."
-        )
+    except Exception as exc:
+        msg = f"Unknown error connecting with {connection}: {exc}."
+        raise SourceConnectionException(msg)
 
 
 @get_connection.register
@@ -858,17 +833,15 @@ def _(_: BackendConnection, verbose: bool = False):
 def _(connection: DagsterConnection) -> None:
     try:
         test_connection(connection.dbConnection)
-    except Exception as err:
-        raise SourceConnectionException(
-            f"Unknown error connecting with {connection} - {err}."
-        )
+    except Exception as exc:
+        msg = f"Unknown error connecting with {connection}: {exc}."
+        raise SourceConnectionException(msg)
 
 
 @get_connection.register
 def _(connection: DagsterConnection) -> None:
     try:
         return get_connection(connection.dbConnection)
-    except Exception as err:
-        raise SourceConnectionException(
-            f"Unknown error connecting with {connection} - {err}."
-        )
+    except Exception as exc:
+        msg = f"Unknown error connecting with {connection}: {exc}."
+        raise SourceConnectionException(msg)

--- a/ingestion/src/metadata/utils/credentials.py
+++ b/ingestion/src/metadata/utils/credentials.py
@@ -51,7 +51,8 @@ def validate_private_key(private_key: str) -> None:
     try:
         serialization.load_pem_private_key(private_key.encode(), password=None)
     except ValueError as err:
-        raise InvalidPrivateKeyException(f"Cannot serialise key - {err}")
+        msg = f"Cannot serialise key: {err}"
+        raise InvalidPrivateKeyException(msg)
 
 
 def create_credential_tmp_file(credentials: dict) -> str:

--- a/ingestion/src/metadata/utils/filters.py
+++ b/ingestion/src/metadata/utils/filters.py
@@ -35,8 +35,9 @@ def validate_regex(regex_list: List[str]) -> None:
     for regex in regex_list:
         try:
             re.compile(regex)
-        except re.error:
-            raise InvalidPatternException(f"Invalid regex {regex}.")
+        except re.error as err:
+            msg = f"Invalid regex [{regex}]: {err}"
+            raise InvalidPatternException(msg)
 
 
 def _filter(filter_pattern: Optional[FilterPattern], name: str) -> bool:

--- a/ingestion/src/metadata/utils/gcs_utils.py
+++ b/ingestion/src/metadata/utils/gcs_utils.py
@@ -24,13 +24,19 @@ logger = utils_logger()
 
 
 def read_csv_from_gcs(key: str, bucket_name: str) -> DataFrame:
-    df = dd.read_csv(f"gs://{bucket_name}/{key}")
-    return df
+    try:
+        return dd.read_csv(f"gs://{bucket_name}/{key}")
+    except Exception as exc:
+        logger.debug(traceback.format_exc())
+        logger.warning(f"Error reading CSV from GCS - {exc}")
 
 
 def read_tsv_from_gcs(key: str, bucket_name: str) -> DataFrame:
-    df = dd.read_csv(f"gs://{bucket_name}/{key}", sep="\t")
-    return df
+    try:
+        return dd.read_csv(f"gs://{bucket_name}/{key}", sep="\t")
+    except Exception as exc:
+        logger.debug(traceback.format_exc())
+        logger.warning(f"Error reading TSV from GCS - {exc}")
 
 
 def read_json_from_gcs(client, key: str, bucket_name: str) -> DataFrame:
@@ -40,7 +46,7 @@ def read_json_from_gcs(client, key: str, bucket_name: str) -> DataFrame:
         data = blob.download_as_string().decode()
         data = json.loads(data)
         if isinstance(data, list):
-            df = pd.DataFrame.from_dict(data)
+            df = pd.DataFrame.from_records(data)
         else:
             df = pd.DataFrame.from_dict(
                 dict([(k, pd.Series(v)) for k, v in data.items()])
@@ -49,7 +55,7 @@ def read_json_from_gcs(client, key: str, bucket_name: str) -> DataFrame:
 
     except ValueError as verr:
         logger.debug(traceback.format_exc())
-        logger.error(verr)
+        logger.warning(f"Error reading JSON from GCS - {verr}")
 
 
 def read_parquet_from_gcs(key: str, bucket_name: str) -> DataFrame:

--- a/ingestion/src/metadata/utils/secrets/aws_based_secrets_manager.py
+++ b/ingestion/src/metadata/utils/secrets/aws_based_secrets_manager.py
@@ -29,6 +29,7 @@ from metadata.generated.schema.entity.services.connections.serviceConnection imp
 )
 from metadata.generated.schema.metadataIngestion.workflow import SourceConfig
 from metadata.generated.schema.security.credentials.awsCredentials import AWSCredentials
+from metadata.utils.logger import utils_logger
 from metadata.utils.secrets.secrets_manager import (
     AUTH_PROVIDER_MAPPING,
     AUTH_PROVIDER_SECRET_PREFIX,
@@ -37,8 +38,9 @@ from metadata.utils.secrets.secrets_manager import (
     SecretsManager,
     ServiceConnectionType,
     ServiceWithConnectionType,
-    logger,
 )
+
+logger = utils_logger()
 
 NULL_VALUE = "null"
 
@@ -101,10 +103,9 @@ class AWSBasedSecretsManager(SecretsManager, ABC):
                 config.securityConfig = AUTH_PROVIDER_MAPPING.get(
                     config.authProvider
                 ).parse_obj(json.loads(auth_config_json))
-            except KeyError:
-                raise NotImplementedError(
-                    f"No client implemented for auth provider: [{config.authProvider}]"
-                )
+            except KeyError as err:
+                msg = f"No client implemented for auth provider [{config.authProvider}]: {err}"
+                raise NotImplementedError(msg)
 
     def retrieve_dbt_source_config(
         self, source_config: SourceConfig, pipeline_name: str

--- a/ingestion/src/metadata/utils/secrets/aws_secrets_manager.py
+++ b/ingestion/src/metadata/utils/secrets/aws_secrets_manager.py
@@ -12,6 +12,7 @@
 """
 Secrets manager implementation using AWS Secrets Manager
 """
+import traceback
 from typing import Optional
 
 from botocore.exceptions import ClientError
@@ -41,15 +42,16 @@ class AWSSecretsManager(AWSBasedSecretsManager):
                  it throws a `ValueError` exception.
         """
         if name is None:
-            raise ValueError
+            raise ValueError("[name] argument is None")
 
         try:
             kwargs = {"SecretId": name}
             response = self.client.get_secret_value(**kwargs)
             logger.debug("Got value for secret %s.", name)
-        except ClientError:
-            logger.exception("Couldn't get value for secret %s.", name)
-            raise
+        except ClientError as err:
+            logger.debug(traceback.format_exc())
+            logger.error(f"Couldn't get value for secret [{name}]: {err}")
+            raise err
         else:
             if "SecretString" in response:
                 return (

--- a/ingestion/tests/unit/test_column_type_parser.py
+++ b/ingestion/tests/unit/test_column_type_parser.py
@@ -31,8 +31,8 @@ import json
 try:
     with open(os.path.join(root, "resources/expected_output_column_parser.json")) as f:
         EXPECTED_OUTPUT = json.loads(f.read())["data"]
-except Exception as err:
-    print(err)
+except Exception as exc:
+    print(exc)
 
 
 class ColumnTypeParseTest(TestCase):


### PR DESCRIPTION
Fixes: #6027

### Describe your changes :

We are trying to improve and align logging by following these rules:

- Use `logger.debug(traceback.format_exc())` after catching an exception
- Log the exception/error as part of the logger message. Tried to follow the convention `{message}: {err/exc}`
- Use `warning` instead of `warn` and log it when the application encounters a problem that interrupts normal operation flow, but it has a fallback or can fix the problem itself or can continue
- Log an error if the `except` is at the end of the method or if we are rolling back

### Type of change :
- [x] Improvement

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

### Reviewers
Ingestion: @open-metadata/ingestion
