### PR TITLE
Fix(UI): Updated labels for add and edit announcement modals

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/AnnouncementModal/AddAnnouncementModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/AnnouncementModal/AddAnnouncementModal.test.tsx
@@ -56,6 +56,7 @@ jest.mock('../../../utils/EntityUtils', () => ({
 
 jest.mock('../../../utils/TimeUtils', () => ({
   getUTCDateTime: jest.fn(),
+  getTimeZone: jest.fn(),
 }));
 
 jest.mock('../../../utils/ToastUtils', () => ({

--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/AnnouncementModal/AddAnnouncementModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/AnnouncementModal/AddAnnouncementModal.tsx
@@ -26,7 +26,7 @@ import {
   validateMessages,
 } from '../../../utils/AnnouncementsUtils';
 import { getEntityFeedLink } from '../../../utils/EntityUtils';
-import { getUTCDateTime } from '../../../utils/TimeUtils';
+import { getTimeZone, getUTCDateTime } from '../../../utils/TimeUtils';
 import { showErrorToast, showSuccessToast } from '../../../utils/ToastUtils';
 import RichTextEditor from '../../common/rich-text-editor/RichTextEditor';
 import './AnnouncementModal.less';
@@ -130,7 +130,7 @@ const AddAnnouncementModal: FC<Props> = ({
         </Form.Item>
         <Space className="announcement-date-space" size={16}>
           <Form.Item
-            label="Start Date:"
+            label={`Start Date: (${getTimeZone()})`}
             name="startDate"
             rules={[
               {
@@ -144,7 +144,7 @@ const AddAnnouncementModal: FC<Props> = ({
             />
           </Form.Item>
           <Form.Item
-            label="End Date:"
+            label={`End Date: (${getTimeZone()})`}
             name="endtDate"
             rules={[
               {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/AnnouncementModal/AddAnnouncementModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/AnnouncementModal/AddAnnouncementModal.tsx
@@ -130,7 +130,7 @@ const AddAnnouncementModal: FC<Props> = ({
         </Form.Item>
         <Space className="announcement-date-space" size={16}>
           <Form.Item
-            label="Start Date (UTC):"
+            label="Start Date:"
             name="startDate"
             rules={[
               {
@@ -144,7 +144,7 @@ const AddAnnouncementModal: FC<Props> = ({
             />
           </Form.Item>
           <Form.Item
-            label="End Date (UTC):"
+            label="End Date:"
             name="endtDate"
             rules={[
               {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/AnnouncementModal/EditAnnouncementModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/AnnouncementModal/EditAnnouncementModal.test.tsx
@@ -42,6 +42,7 @@ jest.mock('../../../utils/EntityUtils', () => ({
 jest.mock('../../../utils/TimeUtils', () => ({
   getUTCDateTime: jest.fn(),
   getLocaleDate: jest.fn(),
+  getTimeZone: jest.fn(),
 }));
 
 jest.mock('../../common/rich-text-editor/RichTextEditor', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/AnnouncementModal/EditAnnouncementModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/AnnouncementModal/EditAnnouncementModal.tsx
@@ -108,7 +108,7 @@ const EditAnnouncementModal: FC<Props> = ({
         </Form.Item>
         <Space className="announcement-date-space" size={16}>
           <Form.Item
-            label="Start Date (UTC):"
+            label="Start Date:"
             name="startDate"
             rules={[
               {
@@ -122,7 +122,7 @@ const EditAnnouncementModal: FC<Props> = ({
             />
           </Form.Item>
           <Form.Item
-            label="End Date (UTC):"
+            label="End Date:"
             name="endDate"
             rules={[
               {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/AnnouncementModal/EditAnnouncementModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/AnnouncementModal/EditAnnouncementModal.tsx
@@ -19,7 +19,11 @@ import {
   announcementInvalidStartTime,
   validateMessages,
 } from '../../../utils/AnnouncementsUtils';
-import { getLocaleDate, getUTCDateTime } from '../../../utils/TimeUtils';
+import {
+  getLocaleDate,
+  getTimeZone,
+  getUTCDateTime,
+} from '../../../utils/TimeUtils';
 import { showErrorToast } from '../../../utils/ToastUtils';
 import RichTextEditor from '../../common/rich-text-editor/RichTextEditor';
 import './AnnouncementModal.less';
@@ -108,7 +112,7 @@ const EditAnnouncementModal: FC<Props> = ({
         </Form.Item>
         <Space className="announcement-date-space" size={16}>
           <Form.Item
-            label="Start Date:"
+            label={`Start Date: (${getTimeZone()})`}
             name="startDate"
             rules={[
               {
@@ -122,7 +126,7 @@ const EditAnnouncementModal: FC<Props> = ({
             />
           </Form.Item>
           <Form.Item
-            label="End Date:"
+            label={`End Date: (${getTimeZone()})`}
             name="endDate"
             rules={[
               {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TimeUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TimeUtils.ts
@@ -130,10 +130,17 @@ export const getLocaleDate = (timeStamp: number): string => {
 };
 
 export const getTimeZone = (): string => {
-  const date = new Date();
-  const timeZone = date.toString().match(/\(([^)]+)\)$/);
-  const timeZoneString = timeZone ? timeZone[1] : '';
-  const abbreviation = timeZoneString.match(/\b[A-Z]+/g)?.join('') || '';
+  // Getting local time zone
+  const timeZoneToString = new Date()
+    .toLocaleDateString('en-US', {
+      day: '2-digit',
+      timeZoneName: 'long',
+    })
+    .slice(4);
+
+  // Line below finds out the abbrevation for time zone
+  // e.g. India Standard Time --> IST
+  const abbreviation = timeZoneToString.match(/\b[A-Z]+/g)?.join('') || '';
 
   return abbreviation;
 };

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TimeUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TimeUtils.ts
@@ -128,3 +128,12 @@ export const getDateTimeByTimeStamp = (timeStamp: number): string => {
 export const getLocaleDate = (timeStamp: number): string => {
   return moment(timeStamp, 'x').format('yyyy-MM-DDThh:mm');
 };
+
+export const getTimeZone = (): string => {
+  const date = new Date();
+  const timeZone = date.toString().match(/\(([^)]+)\)$/);
+  const timeZoneString = timeZone ? timeZone[1] : '';
+  const abbreviation = timeZoneString.match(/\b[A-Z]+/g)?.join('') || '';
+
+  return abbreviation;
+};


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the changing labels for add and edit announcement modals.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<p align="center">

Before:
<img width="611" alt="Screenshot 2022-08-27 at 3 23 15 PM" src="https://user-images.githubusercontent.com/51777795/187025084-044cdac5-3ea8-4a8e-8685-cad3420bf779.png">

Now:
<img width="611" alt="Screenshot 2022-08-29 at 4 55 48 PM" src="https://user-images.githubusercontent.com/51777795/187192117-4e891191-788b-40f0-95ce-2b5c2beabfa8.png">


</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @open-metadata/ui
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
