### PR TITLE
Fix(UI): Clicking on browser notification for chrome will now open new window

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/nav-bar/NavBar.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/nav-bar/NavBar.tsx
@@ -154,7 +154,14 @@ const NavBar = ({
       icon: Logo,
     });
     notification.onclick = () => {
-      history.push(path);
+      const isChrome = window.navigator.userAgent.indexOf('Chrome');
+      // Applying logic to open a new window onclick of browser notification from chrome
+      // As it does not open the concerned tab by default.
+      if (isChrome > -1) {
+        window.open(path);
+      } else {
+        history.push(path);
+      }
     };
   };
 


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the browser notification bug.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<p align="center">
clicking on browser notification of chrome will now open the concerned link in new tab.

https://user-images.githubusercontent.com/51777795/187506788-9658149e-a5f8-4ce9-b7fa-4c39b589dd66.mov


</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @open-metadata/ui
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
