### PR TITLE
Added logic to allow profile data to be ingested when sample data fetch fails

### DIFF
--- a/ingestion/src/metadata/orm_profiler/profiler/core.py
+++ b/ingestion/src/metadata/orm_profiler/profiler/core.py
@@ -375,10 +375,16 @@ class Profiler(Generic[TMetric]):
         self.compute_metrics()
 
         if generate_sample_data:
-            logger.info(
-                f"Fetching sample data for {self.profiler_interface.table_entity.fullyQualifiedName.__root__}..."
-            )
-            sample_data = self.profiler_interface.fetch_sample_data()
+            try:
+                logger.info(
+                    f"Fetching sample data for {self.profiler_interface.table_entity.fullyQualifiedName.__root__}..."
+                )
+                sample_data = self.profiler_interface.fetch_sample_data()
+            except Exception as err:
+                logger.debug(traceback.format_exc())
+                logger.error(f"Error fetching sample data: {err}")
+                sample_data = None
+
         else:
             sample_data = None
 

--- a/ingestion/src/metadata/orm_profiler/profiler/core.py
+++ b/ingestion/src/metadata/orm_profiler/profiler/core.py
@@ -382,7 +382,7 @@ class Profiler(Generic[TMetric]):
                 sample_data = self.profiler_interface.fetch_sample_data()
             except Exception as err:
                 logger.debug(traceback.format_exc())
-                logger.error(f"Error fetching sample data: {err}")
+                logger.warning(f"Error fetching sample data: {err}")
                 sample_data = None
 
         else:


### PR DESCRIPTION

### Describe your changes :
Fixes #7086 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
Ingestion: @open-metadata/ingestion
