### PR TITLE
Remove unique computation for unsupported fields

### DIFF
--- a/ingestion/src/metadata/orm_profiler/metrics/static/unique_count.py
+++ b/ingestion/src/metadata/orm_profiler/metrics/static/unique_count.py
@@ -18,6 +18,7 @@ from sqlalchemy import column, func
 from sqlalchemy.orm import DeclarativeMeta, Session
 
 from metadata.orm_profiler.metrics.core import QueryMetric
+from metadata.orm_profiler.orm.registry import NOT_COMPUTE
 
 
 class UniqueCount(QueryMetric):
@@ -45,6 +46,9 @@ class UniqueCount(QueryMetric):
             raise AttributeError(
                 "We are missing the session attribute to compute the UniqueCount."
             )
+
+        if self.col.type.__class__ in NOT_COMPUTE:
+            return None
 
         # Run all queries on top of the sampled data
         col = column(self.col.name)

--- a/ingestion/src/metadata/orm_profiler/profiler/core.py
+++ b/ingestion/src/metadata/orm_profiler/profiler/core.py
@@ -290,11 +290,6 @@ class Profiler(Generic[TMetric]):
 
     def _prepare_column_metrics_for_thread_pool(self):
         """prepare column metrics for thread pool"""
-        window_metrics = [
-            metric
-            for metric in self.get_col_metrics(self.static_metrics)
-            if metric.is_window_metric()
-        ]
         columns = [
             column
             for column in self.columns


### PR DESCRIPTION
### Describe your changes :
Some data type do not support unique count due to the impossibility to group by this field type (i.e. arrays, structs, etc.)

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
Ingestion: @open-metadata/ingestion
