### PR TITLE
Revamp Policies CollapseTable in Card style

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/PoliciesDetailPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/PoliciesDetailPage.tsx
@@ -14,11 +14,13 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   Button,
-  Collapse,
+  Card,
+  Col,
   Dropdown,
   Empty,
   Menu,
   Modal,
+  Row,
   Space,
   Table,
   Tabs,
@@ -28,7 +30,7 @@ import {
 import { ColumnsType } from 'antd/lib/table';
 import { AxiosError } from 'axios';
 import { compare } from 'fast-json-patch';
-import { isEmpty, isUndefined, startCase, uniqueId } from 'lodash';
+import { isEmpty, isUndefined, startCase } from 'lodash';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, useHistory, useParams } from 'react-router-dom';
 import {
@@ -68,8 +70,6 @@ import {
 import SVGIcons, { Icons } from '../../../utils/SvgUtils';
 import { showErrorToast } from '../../../utils/ToastUtils';
 import './PoliciesDetail.less';
-
-const { Panel } = Collapse;
 
 const { TabPane } = Tabs;
 
@@ -474,89 +474,94 @@ const PoliciesDetailPage = () => {
                       Add Rule
                     </Button>
                   </Tooltip>
-                  <Space className="tw-w-full" direction="vertical" size={16}>
+
+                  <Space
+                    className="tw-w-full tw-pt-4"
+                    direction="vertical"
+                    size={20}>
                     {policy.rules.map((rule) => (
-                      <Collapse key={uniqueId()}>
-                        <Panel
-                          header={
-                            <Space
-                              className="tw-w-full"
-                              direction="vertical"
-                              size={4}>
-                              <Space
-                                align="baseline"
-                                className="tw-w-full tw-justify-between"
-                                size={4}>
-                                <Typography.Text
-                                  className="tw-font-medium tw-text-base tw-text-grey-body"
-                                  data-testid="rule-name">
-                                  {rule.name}
-                                </Typography.Text>
-                                {getRuleActionElement(rule)}
-                              </Space>
-                              <div
-                                className="tw--ml-5"
-                                data-testid="description">
+                      <Card key={rule.name || 'rule'}>
+                        <div className="tw-w-full tw-flex tw-justify-between tw-pb-7">
+                          <Typography.Text
+                            className="tw-font-medium tw-text-base tw-text-grey-body"
+                            data-testid="rule-name">
+                            {rule.name}
+                          </Typography.Text>
+                          {getRuleActionElement(rule)}
+                        </div>
+
+                        <Space
+                          className="tw-w-full"
+                          direction="vertical"
+                          size={12}>
+                          {rule.description && (
+                            <Row data-testid="description">
+                              <Col span={2}>
                                 <Typography.Text className="tw-text-grey-muted">
-                                  Description:
+                                  Description :
                                 </Typography.Text>
+                              </Col>
+                              <Col span={22}>
                                 <RichTextEditorPreviewer
                                   markdown={rule.description || ''}
                                 />
-                              </div>
-                            </Space>
-                          }
-                          key={rule.name || 'rule'}>
-                          <Space direction="vertical" size={16}>
-                            <Space
-                              data-testid="resources"
-                              direction="vertical"
-                              size={4}>
+                              </Col>
+                            </Row>
+                          )}
+
+                          <Row data-testid="resources">
+                            <Col span={2}>
                               <Typography.Text className="tw-text-grey-muted tw-mb-0">
-                                Resources:
+                                Resources :
                               </Typography.Text>
+                            </Col>
+                            <Col span={22}>
                               <Typography.Text className="tw-text-grey-body">
                                 {rule.resources
                                   ?.map((resource) => startCase(resource))
                                   ?.join(', ')}
                               </Typography.Text>
-                            </Space>
+                            </Col>
+                          </Row>
 
-                            <Space
-                              data-testid="operations"
-                              direction="vertical"
-                              size={4}>
+                          <Row data-testid="operations">
+                            <Col span={2}>
                               <Typography.Text className="tw-text-grey-muted">
-                                Operations:
+                                Operations :
                               </Typography.Text>
+                            </Col>
+                            <Col span={22}>
                               <Typography.Text className="tw-text-grey-body">
                                 {rule.operations?.join(', ')}
                               </Typography.Text>
-                            </Space>
-                            <Space
-                              data-testid="effect"
-                              direction="vertical"
-                              size={4}>
+                            </Col>
+                          </Row>
+                          <Row data-testid="effect">
+                            <Col span={2}>
                               <Typography.Text className="tw-text-grey-muted">
-                                Effect:
+                                Effect :
                               </Typography.Text>
+                            </Col>
+                            <Col span={22}>
                               <Typography.Text className="tw-text-grey-body">
                                 {startCase(rule.effect)}
                               </Typography.Text>
-                            </Space>
-                            {rule.condition && (
-                              <Space direction="vertical" size={4}>
+                            </Col>
+                          </Row>
+                          {rule.condition && (
+                            <Row data-testid="condition">
+                              <Col span={2}>
                                 <Typography.Text className="tw-text-grey-muted">
-                                  Condition:
+                                  Condition :
                                 </Typography.Text>
-                                <code data-testid="condition">
-                                  {rule.condition}
-                                </code>
-                              </Space>
-                            )}
-                          </Space>
-                        </Panel>
-                      </Collapse>
+                              </Col>
+                              <Col span={22}>
+                                <code>{rule.condition}</code>
+                              </Col>
+                            </Row>
+                          )}
+                        </Space>
+                      </Card>
                     ))}
                   </Space>
                 </Space>

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/PoliciesDetailPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/PoliciesDetailPage.tsx
@@ -481,14 +481,17 @@ const PoliciesDetailPage = () => {
                     size={20}>
                     {policy.rules.map((rule) => (
                       <Card key={rule.name || 'rule'}>
-                        <div className="tw-w-full tw-flex tw-justify-between tw-pb-7">
+                        <Space
+                          align="baseline"
+                          className="tw-w-full tw-justify-between tw-pb-5"
+                          direction="horizontal">
                           <Typography.Text
                             className="tw-font-medium tw-text-base tw-text-grey-body"
                             data-testid="rule-name">
                             {rule.name}
                           </Typography.Text>
                           {getRuleActionElement(rule)}
-                        </div>
+                        </Space>
 
                         <Space
                           className="tw-w-full"


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Convert Policies -> Organization collapse panel card into full card
https://github.com/open-metadata/OpenMetadata/issues/7071#issuecomment-1235765378
#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/66266464/188267436-58415f15-3c5d-40aa-a1ed-e73b0692f85f.png">

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 

