### PR TITLE
Fix#7112: Issue ingesting Kafka when the basic auth is enabled in the Schea Registry

### DIFF
--- a/ingestion/src/metadata/utils/connections.py
+++ b/ingestion/src/metadata/utils/connections.py
@@ -362,13 +362,10 @@ def _(connection, verbose: bool = False) -> KafkaClient:
             consumer_config["group.id"] = "openmetadata-consumer"
         if "auto.offset.reset" not in consumer_config:
             consumer_config["auto.offset.reset"] = "earliest"
-
-        for key in connection.schemaRegistryConfig:
-            consumer_config["schema.registry." + key] = connection.schemaRegistryConfig[
-                key
-            ]
         logger.debug(f"Using Kafka consumer config: {consumer_config}")
-        consumer_client = AvroConsumer(consumer_config)
+        consumer_client = AvroConsumer(
+            consumer_config, schema_registry=schema_registry_client
+        )
 
     return KafkaClient(
         admin_client=admin_client,


### PR DESCRIPTION
Fixes: #7112 

### Describe your changes :
Pass the `SchemaRegistryClient` to the `AvroConsumer` to avoid using `CachedSchemaRegistryClient`.

### Type of change :
- [x] Bug fix

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

### Reviewers
Ingestion: @open-metadata/ingestion
