### PR TITLE
UI: Removed group type option for teams with child teams.

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/TeamDetails/TeamDetailsV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TeamDetails/TeamDetailsV1.tsx
@@ -829,6 +829,7 @@ const TeamDetailsV1 = ({
                 <EntitySummaryDetails
                   data={info}
                   isGroupType={isGroupType}
+                  showGroupOption={!childTeams.length}
                   teamType={currentTeam.teamType}
                   updateOwner={
                     entityPermissions.EditAll || entityPermissions.EditOwner

--- a/openmetadata-ui/src/main/resources/ui/src/components/TeamDetails/TeamDetailsV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TeamDetails/TeamDetailsV1.tsx
@@ -161,7 +161,7 @@ const TeamDetailsV1 = ({
         isOrganization,
         searchTerm ? table.length : undefined
       ),
-    [currentTeam, teamUserPagin, searchTerm]
+    [currentTeam, teamUserPagin, searchTerm, table]
   );
 
   const createTeamPermission = useMemo(

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/EntitySummaryDetails/EntitySummaryDetails.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/EntitySummaryDetails/EntitySummaryDetails.tsx
@@ -36,6 +36,7 @@ export interface GetInfoElementsProps {
   tier?: TagLabel;
   currentTier?: string;
   teamType?: TeamType;
+  showGroupOption?: boolean;
   isGroupType?: boolean;
   updateTier?: (value: string) => void;
   updateTeamType?: (type: TeamType) => void;
@@ -47,7 +48,7 @@ const EditIcon = ({ iconClasses }: { iconClasses?: string }): JSX.Element => (
     className={classNames('tw-cursor-pointer tw-align-text-top', iconClasses)}
     icon={Icons.EDIT}
     title="Edit"
-    width="15px"
+    width="16px"
   />
 );
 
@@ -66,6 +67,7 @@ const EntitySummaryDetails = ({
   isGroupType,
   tier,
   teamType,
+  showGroupOption,
   updateOwner,
   updateTier,
   updateTeamType,
@@ -307,6 +309,7 @@ const EntitySummaryDetails = ({
             showTypeSelector ? (
               <TeamTypeSelect
                 handleShowTypeSelector={handleShowTypeSelector}
+                showGroupOption={showGroupOption ?? false}
                 teamType={teamType ?? TeamType.Department}
                 updateTeamType={updateTeamType}
               />

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/TeamTypeSelect/TeamTypeSelect.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/TeamTypeSelect/TeamTypeSelect.component.tsx
@@ -21,6 +21,7 @@ import { getTeamTypeOptions } from './TeamTypeSelect.utils';
 
 function TeamTypeSelect({
   handleShowTypeSelector,
+  showGroupOption,
   teamType,
   updateTeamType,
 }: TeamTypeSelectProps) {
@@ -38,7 +39,7 @@ function TeamTypeSelect({
     updateTeamType && updateTeamType(value);
   };
 
-  const options = useMemo(() => getTeamTypeOptions(), []);
+  const options = useMemo(() => getTeamTypeOptions(showGroupOption), []);
 
   return (
     <Space align="center" className="team-type-select" size={4}>

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/TeamTypeSelect/TeamTypeSelect.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/TeamTypeSelect/TeamTypeSelect.interface.ts
@@ -16,5 +16,6 @@ import { TeamType } from '../../../generated/entity/teams/team';
 export interface TeamTypeSelectProps {
   handleShowTypeSelector: (value: boolean) => void;
   teamType: TeamType;
+  showGroupOption: boolean;
   updateTeamType?: (type: TeamType) => void;
 }

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/TeamTypeSelect/TeamTypeSelect.utils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/TeamTypeSelect/TeamTypeSelect.utils.ts
@@ -13,9 +13,9 @@
 
 import { TeamType } from '../../../generated/entity/teams/team';
 
-export const getTeamTypeOptions = () => {
-  const teamTypesArray = Object.values(TeamType).filter(
-    (key) => key !== TeamType.Organization
+export const getTeamTypeOptions = (showGroupOption: boolean) => {
+  const teamTypesArray = Object.values(TeamType).filter((key) =>
+    key === TeamType.Group ? showGroupOption : key !== TeamType.Organization
   );
 
   return teamTypesArray.map((teamType) => ({


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on removing the group type option for teams with child teams while editing team type.
Fixed a bug with team count for child teams not in sync with search results

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Frontend Preview (Screenshots) :
<p align="center">

<img width="402" alt="Screenshot 2022-09-06 at 11 24 19 AM" src="https://user-images.githubusercontent.com/51777795/188557282-e80ec9e4-346b-42b7-958e-3a39f73b9a6f.png">
<img width="399" alt="Screenshot 2022-09-06 at 11 24 32 AM" src="https://user-images.githubusercontent.com/51777795/188557305-aafe6c5f-e7f6-47a9-bf42-b4ff83ac3e2b.png">

</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
