### PR TITLE
Fix #7276 UI: Entity Page Activity Feed tab is empty   

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/cypress/integration/Pages/EntityDetails.spec.js
+++ b/openmetadata-ui/src/main/resources/ui/cypress/integration/Pages/EntityDetails.spec.js
@@ -179,6 +179,15 @@ describe('Entity Details Page', () => {
     cy.get('[data-testid="entity-tags"]').should('contain', 'Tier1');
     cy.wait(1000);
 
+    // Test out the activity feed and task tab
+    cy.get('[data-testid="Activity Feeds & Tasks"]').should('be.visible').click()
+    // Check for tab count
+    cy.get('[data-testid=filter-count').should('be.visible').contains("2")
+
+    // Check for activity feeds - count should be 2 
+    // 1 for tier change and 1 for owner change
+    cy.get('[data-testid="message-container"]').its('length').should("eq",2)
+
     cy.clickOnLogo();
 
     // checks newly generated feed for follow and setting owner

--- a/openmetadata-ui/src/main/resources/ui/src/axiosAPIs/feedsAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/axiosAPIs/feedsAPI.ts
@@ -13,6 +13,7 @@
 
 import { AxiosResponse } from 'axios';
 import { Operation } from 'fast-json-patch';
+import { isUndefined } from 'lodash';
 import { EntityFieldThreadCount } from 'Models';
 import { configOptions } from '../constants/constants';
 import { TaskOperation } from '../constants/feed.constants';
@@ -37,6 +38,8 @@ export const getAllFeeds = async (
   userId?: string
 ) => {
   const isFilterAll = filterType === FeedFilter.ALL;
+  const isFilterUndefined = isUndefined(filterType);
+
   const response = await APIClient.get<{ data: Thread[]; paging: Paging }>(
     `/feed`,
     {
@@ -44,9 +47,9 @@ export const getAllFeeds = async (
         entityLink: entityLink,
         after,
         type,
-        filterType: isFilterAll ? undefined : filterType,
+        filterType: isFilterAll || isFilterUndefined ? undefined : filterType,
         taskStatus,
-        userId: isFilterAll ? undefined : userId,
+        userId: isFilterAll || isFilterUndefined ? undefined : userId,
       },
     }
   );


### PR DESCRIPTION
Fixes #7276
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on issue #7276

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview

https://user-images.githubusercontent.com/59080942/188713013-d56936c4-67a9-4670-ae28-fb10874549ab.mov

 (Screenshots) :


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
