### PR TITLE
Fix Sonar Cloud issue - Static initialization of JWTTokenGenerator

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/security/jwt/JWTTokenGenerator.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/security/jwt/JWTTokenGenerator.java
@@ -23,29 +23,19 @@ import org.openmetadata.catalog.teams.authn.JWTTokenExpiry;
 
 @Slf4j
 public class JWTTokenGenerator {
-  private static volatile JWTTokenGenerator instance;
+  private static JWTTokenGenerator instance = new JWTTokenGenerator();
   private RSAPrivateKey privateKey;
   @Getter private RSAPublicKey publicKey;
   private String issuer;
   private String kid;
 
-  private JWTTokenGenerator() {
-    if (instance != null) {
-      throw new RuntimeException("Use getInstance() method to get the single instance of this class");
-    }
-  }
+  private JWTTokenGenerator() {}
 
   public static JWTTokenGenerator getInstance() {
-    if (instance == null) {
-      synchronized (JWTTokenGenerator.class) {
-        if (instance == null) {
-          instance = new JWTTokenGenerator();
-        }
-      }
-    }
     return instance;
   }
 
+  /** Expected to be initialized only once during application start */
   public void init(JWTTokenConfiguration jwtTokenConfiguration) {
     try {
       if (jwtTokenConfiguration.getRsaprivateKeyFilePath() != null


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Initialize JWTTokenGenerator instance in a static block instead of volatile variable based, synchronized initialization that is marked as a bug in Sonar cloud.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

