### PR TITLE
Fix #7000: Delete with recursive=true is not working for testSuite API

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/dqtests/TestSuiteResource.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/resources/dqtests/TestSuiteResource.java
@@ -325,13 +325,17 @@ public class TestSuiteResource extends EntityResource<TestSuite, TestSuiteReposi
   public Response delete(
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
+      @Parameter(description = "Recursively delete this entity and it's children. (Default `false`)")
+          @DefaultValue("false")
+          @QueryParam("recursive")
+          boolean recursive,
       @Parameter(description = "Hard delete the entity. (Default = `false`)")
           @QueryParam("hardDelete")
           @DefaultValue("false")
           boolean hardDelete,
-      @Parameter(description = "Topic Id", schema = @Schema(type = "UUID")) @PathParam("id") UUID id)
+      @Parameter(description = "TestSuite Id", schema = @Schema(type = "UUID")) @PathParam("id") UUID id)
       throws IOException {
-    return delete(uriInfo, securityContext, id, false, hardDelete, true);
+    return delete(uriInfo, securityContext, id, recursive, hardDelete, true);
   }
 
   private TestSuite getTestSuite(CreateTestSuite create, String user) throws IOException {

--- a/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/dqtests/TestSuiteResourceTest.java
+++ b/catalog-rest-service/src/test/java/org/openmetadata/catalog/resources/dqtests/TestSuiteResourceTest.java
@@ -1,6 +1,7 @@
 package org.openmetadata.catalog.resources.dqtests;
 
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.openmetadata.catalog.util.TestUtils.ADMIN_AUTH_HEADERS;
 import static org.openmetadata.catalog.util.TestUtils.assertResponse;
@@ -92,6 +93,16 @@ public class TestSuiteResourceTest extends EntityResourceTest<TestSuite, CreateT
         verifyTestCases(testSuite.getTests(), testCases1);
       }
     }
+    deleteEntity(testSuite1.getId(), true, false, ADMIN_AUTH_HEADERS);
+    assertResponse(
+        () -> getEntity(testSuite1.getId(), ADMIN_AUTH_HEADERS),
+        NOT_FOUND,
+        "testSuite instance for " + testSuite1.getId() + " not found");
+    Map<String, String> queryParams = new HashMap<>();
+    queryParams.put("include", "all");
+    TestSuite deletedTestSuite = getEntity(testSuite1.getId(), queryParams, null, ADMIN_AUTH_HEADERS);
+    assertEquals(testSuite1.getId(), deletedTestSuite.getId());
+    assertEquals(deletedTestSuite.getDeleted(), true);
   }
 
   public static ResultList<TestSuite> getTestSuites(Integer limit, String fields, Map<String, String> authHeaders)


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the ..... because ...

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
