### PR TITLE
UI : Add Permission Check on Entity Page

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/axiosAPIs/permissionAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/axiosAPIs/permissionAPI.ts
@@ -38,6 +38,16 @@ export const getEntityPermissionById = async (
 
   return response.data;
 };
+export const getEntityPermissionByFqn = async (
+  resource: ResourceEntity,
+  entityFqn: string
+) => {
+  const response = await APIClient.get<ResourcePermission>(
+    `/permissions/${resource}/name/${entityFqn}`
+  );
+
+  return response.data;
+};
 
 export const getResourcePermission = async (resource: ResourceEntity) => {
   const response = await APIClient.get<ResourcePermission>(

--- a/openmetadata-ui/src/main/resources/ui/src/components/DashboardDetails/DashboardDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DashboardDetails/DashboardDetails.component.tsx
@@ -161,7 +161,7 @@ const DashboardDetails = ({
     if (dashboardDetails.id) {
       fetchResourcePermission();
     }
-  }, [dashboardDetails.id]);
+  }, [dashboardDetails]);
 
   const onEntityFieldSelect = (value: string) => {
     setSelectedField(value);

--- a/openmetadata-ui/src/main/resources/ui/src/components/DashboardDetails/DashboardDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DashboardDetails/DashboardDetails.component.tsx
@@ -161,7 +161,7 @@ const DashboardDetails = ({
     if (dashboardDetails.id) {
       fetchResourcePermission();
     }
-  }, [dashboardDetails]);
+  }, [dashboardDetails.id]);
 
   const onEntityFieldSelect = (value: string) => {
     setSelectedField(value);

--- a/openmetadata-ui/src/main/resources/ui/src/components/DatasetDetails/DatasetDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DatasetDetails/DatasetDetails.component.tsx
@@ -175,7 +175,7 @@ const DatasetDetails: React.FC<DatasetDetailsProps> = ({
     if (tableDetails.id) {
       fetchResourcePermission();
     }
-  }, [tableDetails]);
+  }, [tableDetails.id]);
 
   const onEntityFieldSelect = (value: string) => {
     setSelectedField(value);

--- a/openmetadata-ui/src/main/resources/ui/src/components/DatasetDetails/DatasetDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DatasetDetails/DatasetDetails.component.tsx
@@ -172,8 +172,10 @@ const DatasetDetails: React.FC<DatasetDetailsProps> = ({
   }, [tableDetails.id, getEntityPermission, setTablePermissions]);
 
   useEffect(() => {
-    fetchResourcePermission();
-  }, [tableDetails.id]);
+    if (tableDetails.id) {
+      fetchResourcePermission();
+    }
+  }, [tableDetails]);
 
   const onEntityFieldSelect = (value: string) => {
     setSelectedField(value);

--- a/openmetadata-ui/src/main/resources/ui/src/components/DatasetDetails/DatasetDetails.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DatasetDetails/DatasetDetails.test.tsx
@@ -269,6 +269,31 @@ jest.mock('../PermissionProvider/PermissionProvider', () => ({
   })),
 }));
 
+jest.mock('../../utils/PermissionsUtils', () => ({
+  DEFAULT_ENTITY_PERMISSION: {
+    Create: true,
+    Delete: true,
+    EditAll: true,
+    EditCustomFields: true,
+    EditDataProfile: true,
+    EditDescription: true,
+    EditDisplayName: true,
+    EditLineage: true,
+    EditOwner: true,
+    EditQueries: true,
+    EditSampleData: true,
+    EditTags: true,
+    EditTests: true,
+    EditTier: true,
+    ViewAll: true,
+    ViewDataProfile: true,
+    ViewQueries: true,
+    ViewSampleData: true,
+    ViewTests: true,
+    ViewUsage: true,
+  },
+}));
+
 describe('Test MyDataDetailsPage page', () => {
   it('Checks if the page has all the proper components rendered', async () => {
     const { container } = render(<DatasetDetails {...DatasetDetailsProps} />, {

--- a/openmetadata-ui/src/main/resources/ui/src/components/MlModelDetail/MlModelDetail.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MlModelDetail/MlModelDetail.component.tsx
@@ -131,7 +131,7 @@ const MlModelDetail: FC<MlModelDetailProp> = ({
     if (mlModelDetail.id) {
       fetchResourcePermission();
     }
-  }, [mlModelDetail]);
+  }, [mlModelDetail.id]);
 
   const currentUser = useMemo(
     () => AppState.getCurrentUserDetails(),

--- a/openmetadata-ui/src/main/resources/ui/src/components/MlModelDetail/MlModelDetail.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MlModelDetail/MlModelDetail.component.tsx
@@ -128,8 +128,10 @@ const MlModelDetail: FC<MlModelDetailProp> = ({
   }, [mlModelDetail.id, getEntityPermission, setPipelinePermissions]);
 
   useEffect(() => {
-    fetchResourcePermission();
-  }, [mlModelDetail.id]);
+    if (mlModelDetail.id) {
+      fetchResourcePermission();
+    }
+  }, [mlModelDetail]);
 
   const currentUser = useMemo(
     () => AppState.getCurrentUserDetails(),

--- a/openmetadata-ui/src/main/resources/ui/src/components/PermissionProvider/PermissionProvider.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/PermissionProvider/PermissionProvider.interface.ts
@@ -65,6 +65,10 @@ export interface PermissionContextType {
     resource: ResourceEntity,
     entityId: string
   ) => Promise<OperationPermission>;
+  getEntityPermissionByFqn: (
+    resource: ResourceEntity,
+    entityFqn: string
+  ) => Promise<OperationPermission>;
   getResourcePermission: (
     resource: ResourceEntity
   ) => Promise<OperationPermission>;

--- a/openmetadata-ui/src/main/resources/ui/src/components/PermissionProvider/PermissionProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/PermissionProvider/PermissionProvider.tsx
@@ -23,6 +23,7 @@ import React, {
 } from 'react';
 import AppState from '../../AppState';
 import {
+  getEntityPermissionByFqn,
   getEntityPermissionById,
   getLoggedInUserPermissions,
   getResourcePermission,
@@ -105,6 +106,25 @@ const PermissionProvider: FC<PermissionProviderProps> = ({ children }) => {
     }
   };
 
+  const fetchEntityPermissionByFqn = async (
+    resource: ResourceEntity,
+    entityFqn: string
+  ) => {
+    const entityPermission = entitiesPermission[entityFqn];
+    if (entityPermission) {
+      return entityPermission;
+    } else {
+      const response = await getEntityPermissionByFqn(resource, entityFqn);
+      const operationPermission = getOperationPermissions(response);
+      setEntitiesPermission((prev) => ({
+        ...prev,
+        [entityFqn]: operationPermission,
+      }));
+
+      return operationPermission;
+    }
+  };
+
   const fetchResourcePermission = async (resource: ResourceEntity) => {
     const resourcePermission = resourcesPermission[resource];
     if (resourcePermission) {
@@ -134,6 +154,7 @@ const PermissionProvider: FC<PermissionProviderProps> = ({ children }) => {
         permissions,
         getEntityPermission: fetchEntityPermission,
         getResourcePermission: fetchResourcePermission,
+        getEntityPermissionByFqn: fetchEntityPermissionByFqn,
       }}>
       {children}
     </PermissionContext.Provider>

--- a/openmetadata-ui/src/main/resources/ui/src/components/PipelineDetails/PipelineDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/PipelineDetails/PipelineDetails.component.tsx
@@ -157,7 +157,7 @@ const PipelineDetails = ({
     if (pipelineDetails.id) {
       fetchResourcePermission();
     }
-  }, [pipelineDetails]);
+  }, [pipelineDetails.id]);
 
   const onEntityFieldSelect = (value: string) => {
     setSelectedField(value);

--- a/openmetadata-ui/src/main/resources/ui/src/components/PipelineDetails/PipelineDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/PipelineDetails/PipelineDetails.component.tsx
@@ -154,8 +154,10 @@ const PipelineDetails = ({
   }, [pipelineDetails.id, getEntityPermission, setPipelinePermissions]);
 
   useEffect(() => {
-    fetchResourcePermission();
-  }, [pipelineDetails.id]);
+    if (pipelineDetails.id) {
+      fetchResourcePermission();
+    }
+  }, [pipelineDetails]);
 
   const onEntityFieldSelect = (value: string) => {
     setSelectedField(value);

--- a/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/TableProfilerV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/TableProfilerV1.tsx
@@ -272,12 +272,14 @@ const TableProfilerV1: FC<TableProfilerProps> = ({
         onAddTestClick={onAddTestClick}
       />
 
-      <ProfilerSettingsModal
-        columns={columns}
-        tableId={table.id}
-        visible={settingModalVisible}
-        onVisibilityChange={handleSettingModal}
-      />
+      {settingModalVisible && (
+        <ProfilerSettingsModal
+          columns={columns}
+          tableId={table.id}
+          visible={settingModalVisible}
+          onVisibilityChange={handleSettingModal}
+        />
+      )}
     </div>
   );
 };

--- a/openmetadata-ui/src/main/resources/ui/src/components/TopicDetails/TopicDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TopicDetails/TopicDetails.component.tsx
@@ -142,7 +142,7 @@ const TopicDetails: React.FC<TopicDetailsProps> = ({
     if (topicDetails.id) {
       fetchResourcePermission();
     }
-  }, [topicDetails]);
+  }, [topicDetails.id]);
 
   const onEntityFieldSelect = (value: string) => {
     setSelectedField(value);

--- a/openmetadata-ui/src/main/resources/ui/src/components/TopicDetails/TopicDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TopicDetails/TopicDetails.component.tsx
@@ -139,8 +139,10 @@ const TopicDetails: React.FC<TopicDetailsProps> = ({
   }, [topicDetails.id, getEntityPermission, setTopicPermissions]);
 
   useEffect(() => {
-    fetchResourcePermission();
-  }, [topicDetails.id]);
+    if (topicDetails.id) {
+      fetchResourcePermission();
+    }
+  }, [topicDetails]);
 
   const onEntityFieldSelect = (value: string) => {
     setSelectedField(value);

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatasetDetailsPage/DatasetDetailsPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatasetDetailsPage/DatasetDetailsPage.test.tsx
@@ -70,6 +70,59 @@ jest.mock('../../AppState', () => ({
   ],
 }));
 
+jest.mock('../../components/PermissionProvider/PermissionProvider', () => ({
+  usePermissionProvider: jest.fn().mockImplementation(() => ({
+    permissions: {},
+    getEntityPermission: jest.fn().mockResolvedValue({
+      Create: true,
+      Delete: true,
+      EditAll: true,
+      EditCustomFields: true,
+      EditDataProfile: true,
+      EditDescription: true,
+      EditDisplayName: true,
+      EditLineage: true,
+      EditOwner: true,
+      EditQueries: true,
+      EditSampleData: true,
+      EditTags: true,
+      EditTests: true,
+      EditTier: true,
+      ViewAll: true,
+      ViewDataProfile: true,
+      ViewQueries: true,
+      ViewSampleData: true,
+      ViewTests: true,
+      ViewUsage: true,
+    }),
+  })),
+}));
+
+jest.mock('../../utils/PermissionsUtils', () => ({
+  DEFAULT_ENTITY_PERMISSION: {
+    Create: true,
+    Delete: true,
+    EditAll: true,
+    EditCustomFields: true,
+    EditDataProfile: true,
+    EditDescription: true,
+    EditDisplayName: true,
+    EditLineage: true,
+    EditOwner: true,
+    EditQueries: true,
+    EditSampleData: true,
+    EditTags: true,
+    EditTests: true,
+    EditTier: true,
+    ViewAll: true,
+    ViewDataProfile: true,
+    ViewQueries: true,
+    ViewSampleData: true,
+    ViewTests: true,
+    ViewUsage: true,
+  },
+}));
+
 jest.mock('../../components/DatasetDetails/DatasetDetails.component', () => {
   return jest
     .fn()

--- a/openmetadata-ui/src/main/resources/ui/src/pages/MlModelPage/MlModelPage.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/MlModelPage/MlModelPage.component.test.tsx
@@ -153,6 +153,59 @@ jest.mock('../../components/MlModelDetail/MlModelDetail.component', () => {
     .mockReturnValue(<div data-testid="mlmodel-details">MlModelDetails</div>);
 });
 
+jest.mock('../../components/PermissionProvider/PermissionProvider', () => ({
+  usePermissionProvider: jest.fn().mockImplementation(() => ({
+    permissions: {},
+    getEntityPermission: jest.fn().mockResolvedValue({
+      Create: true,
+      Delete: true,
+      EditAll: true,
+      EditCustomFields: true,
+      EditDataProfile: true,
+      EditDescription: true,
+      EditDisplayName: true,
+      EditLineage: true,
+      EditOwner: true,
+      EditQueries: true,
+      EditSampleData: true,
+      EditTags: true,
+      EditTests: true,
+      EditTier: true,
+      ViewAll: true,
+      ViewDataProfile: true,
+      ViewQueries: true,
+      ViewSampleData: true,
+      ViewTests: true,
+      ViewUsage: true,
+    }),
+  })),
+}));
+
+jest.mock('../../utils/PermissionsUtils', () => ({
+  DEFAULT_ENTITY_PERMISSION: {
+    Create: true,
+    Delete: true,
+    EditAll: true,
+    EditCustomFields: true,
+    EditDataProfile: true,
+    EditDescription: true,
+    EditDisplayName: true,
+    EditLineage: true,
+    EditOwner: true,
+    EditQueries: true,
+    EditSampleData: true,
+    EditTags: true,
+    EditTests: true,
+    EditTier: true,
+    ViewAll: true,
+    ViewDataProfile: true,
+    ViewQueries: true,
+    ViewSampleData: true,
+    ViewTests: true,
+    ViewUsage: true,
+  },
+}));
+
 describe('Test MlModel Entity Page', () => {
   it('Should render component', async () => {
     const { container } = render(<MlModelPageComponent />, {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PipelineDetails/PipelineDetailsPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PipelineDetails/PipelineDetailsPage.test.tsx
@@ -38,6 +38,59 @@ jest.mock(
   }
 );
 
+jest.mock('../../components/PermissionProvider/PermissionProvider', () => ({
+  usePermissionProvider: jest.fn().mockImplementation(() => ({
+    permissions: {},
+    getEntityPermission: jest.fn().mockResolvedValue({
+      Create: true,
+      Delete: true,
+      EditAll: true,
+      EditCustomFields: true,
+      EditDataProfile: true,
+      EditDescription: true,
+      EditDisplayName: true,
+      EditLineage: true,
+      EditOwner: true,
+      EditQueries: true,
+      EditSampleData: true,
+      EditTags: true,
+      EditTests: true,
+      EditTier: true,
+      ViewAll: true,
+      ViewDataProfile: true,
+      ViewQueries: true,
+      ViewSampleData: true,
+      ViewTests: true,
+      ViewUsage: true,
+    }),
+  })),
+}));
+
+jest.mock('../../utils/PermissionsUtils', () => ({
+  DEFAULT_ENTITY_PERMISSION: {
+    Create: true,
+    Delete: true,
+    EditAll: true,
+    EditCustomFields: true,
+    EditDataProfile: true,
+    EditDescription: true,
+    EditDisplayName: true,
+    EditLineage: true,
+    EditOwner: true,
+    EditQueries: true,
+    EditSampleData: true,
+    EditTags: true,
+    EditTests: true,
+    EditTier: true,
+    ViewAll: true,
+    ViewDataProfile: true,
+    ViewQueries: true,
+    ViewSampleData: true,
+    ViewTests: true,
+    ViewUsage: true,
+  },
+}));
+
 describe('Test PipelineDetailsPage component', () => {
   it('PipelineDetailsPage component should render properly', async () => {
     const { container } = render(<PipelineDetailsPage />, {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TopicDetails/TopicDetailsPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TopicDetails/TopicDetailsPage.test.tsx
@@ -21,6 +21,59 @@ jest.mock('react-router-dom', () => ({
   useHistory: jest.fn(),
 }));
 
+jest.mock('../../components/PermissionProvider/PermissionProvider', () => ({
+  usePermissionProvider: jest.fn().mockImplementation(() => ({
+    permissions: {},
+    getEntityPermission: jest.fn().mockResolvedValue({
+      Create: true,
+      Delete: true,
+      EditAll: true,
+      EditCustomFields: true,
+      EditDataProfile: true,
+      EditDescription: true,
+      EditDisplayName: true,
+      EditLineage: true,
+      EditOwner: true,
+      EditQueries: true,
+      EditSampleData: true,
+      EditTags: true,
+      EditTests: true,
+      EditTier: true,
+      ViewAll: true,
+      ViewDataProfile: true,
+      ViewQueries: true,
+      ViewSampleData: true,
+      ViewTests: true,
+      ViewUsage: true,
+    }),
+  })),
+}));
+
+jest.mock('../../utils/PermissionsUtils', () => ({
+  DEFAULT_ENTITY_PERMISSION: {
+    Create: true,
+    Delete: true,
+    EditAll: true,
+    EditCustomFields: true,
+    EditDataProfile: true,
+    EditDescription: true,
+    EditDisplayName: true,
+    EditLineage: true,
+    EditOwner: true,
+    EditQueries: true,
+    EditSampleData: true,
+    EditTags: true,
+    EditTests: true,
+    EditTier: true,
+    ViewAll: true,
+    ViewDataProfile: true,
+    ViewQueries: true,
+    ViewSampleData: true,
+    ViewTests: true,
+    ViewUsage: true,
+  },
+}));
+
 describe('Test TopicDetailsPage component', () => {
   it('TopicDetailsPage component should render properly', async () => {
     const { container } = render(<TopicDetailsPageComponent />, {


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on adding Permission Check on Entity Page.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement


#
### Frontend Preview (Screenshots) :


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
