### PR TITLE
Fix #7319: For non admin users with ViewAll or ViewTests permissions testCaseResource listing with testSuiteID is returning null

### DIFF
--- a/catalog-rest-service/src/main/java/org/openmetadata/catalog/security/policyevaluator/TestCaseResourceContext.java
+++ b/catalog-rest-service/src/main/java/org/openmetadata/catalog/security/policyevaluator/TestCaseResourceContext.java
@@ -97,6 +97,7 @@ public class TestCaseResourceContext implements ResourceContextInterface {
   }
 
   private static EntityInterface resolveEntityByName(String fqn) throws IOException {
+    if (fqn == null) return null;
     EntityRepository<TestCase> dao = Entity.getEntityRepository(Entity.TEST_CASE);
     TestCase testCase = dao.getByName(null, fqn, dao.getFields("entityLink"), Include.ALL);
     return resolveEntityByEntityLink(EntityLink.parse(testCase.getEntityLink()));


### PR DESCRIPTION
#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
