### PR TITLE
Fix Glossary trailing name space issue

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/cypress/integration/Pages/Roles.spec.js
+++ b/openmetadata-ui/src/main/resources/ui/cypress/integration/Pages/Roles.spec.js
@@ -84,7 +84,7 @@ describe('Roles page should work properly', () => {
   });
 
   it('Add new role', () => {
-    cy.get('button').contains('Add Role').should('be.visible').click();
+    cy.get('[data-testid="add-role"]').contains('Add Role').should('be.visible').click();
 
     //Asserting navigation
     cy.get('[data-testid="inactive-link"]')

--- a/openmetadata-ui/src/main/resources/ui/src/components/AddGlossary/AddGlossary.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AddGlossary/AddGlossary.component.tsx
@@ -116,8 +116,8 @@ const AddGlossary = ({
   const handleSave = () => {
     if (validateForm()) {
       const data: CreateGlossary = {
-        name,
-        displayName: name,
+        name: name.trim(),
+        displayName: name.trim(),
         description: getDescription(),
         reviewers: reviewer.map((d) => ({ id: d.id, type: d.type })),
         owner: {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryV1.component.tsx
@@ -200,19 +200,21 @@ const GlossaryV1 = ({
    * @param fqn fqn of glossary or glossary term
    */
   const handleBreadcrumb = (fqn: string) => {
-    const arr = fqn.split(FQN_SEPARATOR_CHAR);
-    const dataFQN: Array<string> = [];
-    const newData = arr.map((d, i) => {
-      dataFQN.push(d);
-      const isLink = i < arr.length - 1;
+    if (fqn) {
+      const arr = fqn.split(FQN_SEPARATOR_CHAR);
+      const dataFQN: Array<string> = [];
+      const newData = arr.map((d, i) => {
+        dataFQN.push(d);
+        const isLink = i < arr.length - 1;
 
-      return {
-        name: d,
-        url: isLink ? getGlossaryPath(dataFQN.join(FQN_SEPARATOR_CHAR)) : '',
-        activeTitle: isLink,
-      };
-    });
-    setBreadcrumb(newData);
+        return {
+          name: d,
+          url: isLink ? getGlossaryPath(dataFQN.join(FQN_SEPARATOR_CHAR)) : '',
+          activeTitle: isLink,
+        };
+      });
+      setBreadcrumb(newData);
+    }
   };
 
   const handleDelete = () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/PropertyValue.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/PropertyValue.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { toNumber } from 'lodash';
+import { isUndefined, toNumber } from 'lodash';
 import React, { FC, Fragment, useState } from 'react';
 import { Table } from '../../../generated/entity/data/table';
 import { EntityReference } from '../../../generated/type/entityReference';
@@ -111,7 +111,13 @@ export const PropertyValue: FC<Props> = ({
     const propertyValue = getPropertyValue();
     const isInteger = propertyType.name === 'integer';
     if (isInteger) {
-      return propertyValue;
+      return !isUndefined(value) ? (
+        propertyValue
+      ) : (
+        <span className="tw-text-grey-muted" data-testid="no-data">
+          No data
+        </span>
+      );
     } else {
       return value ? (
         propertyValue

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/PropertyValue.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/PropertyValue.tsx
@@ -107,14 +107,21 @@ export const PropertyValue: FC<Props> = ({
     }
   };
 
-  const getValueElement = () =>
-    value ? (
-      getPropertyValue()
-    ) : (
-      <span className="tw-text-grey-muted" data-testid="no-data">
-        No data
-      </span>
-    );
+  const getValueElement = () => {
+    const propertyValue = getPropertyValue();
+    const isInteger = propertyType.name === 'integer';
+    if (isInteger) {
+      return propertyValue;
+    } else {
+      return value ? (
+        propertyValue
+      ) : (
+        <span className="tw-text-grey-muted" data-testid="no-data">
+          No data
+        </span>
+      );
+    }
+  };
 
   return (
     <div>

--- a/openmetadata-ui/src/main/resources/ui/src/utils/GlossaryUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/GlossaryUtils.ts
@@ -189,9 +189,11 @@ export const getSearchedGlossaryTermTree = (
 ): GlossaryTermTreeNode[] => {
   const termTree: GlossaryTermTreeNode[] = [];
   for (const term of searchedTerms) {
-    const arrFQN = term.fullyQualifiedName.split(FQN_SEPARATOR_CHAR);
-    const rootName = arrFQN[0];
-    termTree.push(createGlossaryTermNode(term.fullyQualifiedName, rootName));
+    if (term.fullyQualifiedName) {
+      const arrFQN = term.fullyQualifiedName.split(FQN_SEPARATOR_CHAR);
+      const rootName = arrFQN[0];
+      termTree.push(createGlossaryTermNode(term.fullyQualifiedName, rootName));
+    }
   }
   optimiseGlossaryTermTree(termTree);
 
@@ -242,15 +244,19 @@ export const getActionsList = () => {
  * @returns list of fqns
  */
 export const getHierarchicalKeysByFQN = (fqn: string) => {
-  const keys = fqn.split(FQN_SEPARATOR_CHAR).reduce((prev, curr) => {
-    const currFqn = prev.length
-      ? `${prev[prev.length - 1]}${FQN_SEPARATOR_CHAR}${curr}`
-      : curr;
+  if (fqn) {
+    const keys = fqn.split(FQN_SEPARATOR_CHAR).reduce((prev, curr) => {
+      const currFqn = prev.length
+        ? `${prev[prev.length - 1]}${FQN_SEPARATOR_CHAR}${curr}`
+        : curr;
 
-    return [...prev, currFqn];
-  }, [] as string[]);
+      return [...prev, currFqn];
+    }, [] as string[]);
 
-  return keys;
+    return keys;
+  } else {
+    return [];
+  }
 };
 
 /**


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on fixing the glossary trailing name space issue. 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
