### PR TITLE
Add port mapping for postgres container

### DIFF
--- a/docker/metadata/docker-compose-postgres.yml
+++ b/docker/metadata/docker-compose-postgres.yml
@@ -25,6 +25,8 @@ services:
       POSTGRES_PASSWORD: password
     expose:
       - 5432
+    ports:
+      - "5432:5432"
     networks:
       app_net:
         ipv4_address: 172.16.240.10

--- a/docker/metadata/docker-compose-postgres.yml
+++ b/docker/metadata/docker-compose-postgres.yml
@@ -145,6 +145,7 @@ services:
       AIRFLOW_DB_SCHEME: ${AIRFLOW_DB_SCHEME:-postgresql+psycopg2}
       DB_USER: ${DB_USER:-airflow_user}
       DB_PASSWORD: ${DB_PASSWORD:-airflow_pass}
+      DB_SCHEME: ${DB_SCHEME:-postgresql+psycopg2}
     expose:
       - 8080
     ports:


### PR DESCRIPTION
### Describe your changes :
Postgres container misses port mapping required to connect to the database

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
