### PR TITLE
Fixes #7399 Removed typing_extension dependency

### DIFF
--- a/ingestion/setup.py
+++ b/ingestion/setup.py
@@ -26,7 +26,6 @@ base_requirements = {
     "commonregex",
     "idna<3,>=2.5",
     "click>=7.1.1",
-    "typing_extensions>=3.7.4",
     "mypy_extensions>=0.4.3",
     "typing-inspect",
     "pydantic[email]==1.8.2",

--- a/ingestion/src/metadata/orm_profiler/profiler/core.py
+++ b/ingestion/src/metadata/orm_profiler/profiler/core.py
@@ -12,6 +12,8 @@
 """
 Main Profile definition and queries to execute
 """
+from __future__ import annotations
+
 import traceback
 import warnings
 from datetime import datetime, timezone
@@ -21,7 +23,6 @@ from pydantic import ValidationError
 from sqlalchemy import Column
 from sqlalchemy.orm import DeclarativeMeta
 from sqlalchemy.orm.session import Session
-from typing_extensions import Self
 
 from metadata.generated.schema.api.data.createTableProfile import (
     CreateTableProfileRequest,
@@ -359,7 +360,7 @@ class Profiler(Generic[TMetric]):
         self._table_results = profile_results["table"]
         self._column_results = profile_results["columns"]
 
-    def compute_metrics(self) -> Self:
+    def compute_metrics(self) -> Profiler:
         """Run the whole profiling using multithreading"""
         self.profile_entity()
         for column in self.columns:


### PR DESCRIPTION
### Describe your changes :
Fixes #7399 -- Use `__future__ annotation` to use class object type hint instead of `Self`

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
Ingestion: @open-metadata/ingestion
