### PR TITLE
Fix: DBT root config error handled

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/database_service.py
+++ b/ingestion/src/metadata/ingestion/source/database/database_service.py
@@ -233,7 +233,7 @@ class DatabaseServiceSource(DBTMixin, TopologyRunnerMixin, Source, ABC):
     def __init__(self):
         if hasattr(self.source_config.dbtConfigSource, "dbtSecurityConfig"):
             if self.source_config.dbtConfigSource.dbtSecurityConfig is None:
-                logger.warning("dbtConfigSource is not configured")
+                logger.info("dbtConfigSource is not configured")
                 self.dbt_catalog = None
                 self.dbt_manifest = None
                 self.dbt_run_results = None

--- a/ingestion/src/metadata/ingestion/source/database/database_service.py
+++ b/ingestion/src/metadata/ingestion/source/database/database_service.py
@@ -240,10 +240,10 @@ class DatabaseServiceSource(DBTMixin, TopologyRunnerMixin, Source, ABC):
                 self.data_models = {}
         else:
             dbt_details = get_dbt_details(self.source_config.dbtConfigSource)
-            if len(dbt_details) == 3:
-                self.dbt_catalog = dbt_details[0]
-                self.dbt_manifest = dbt_details[1]
-                self.dbt_run_results = dbt_details[2]
+            if dbt_details:
+                self.dbt_catalog = dbt_details[0] if len(dbt_details) == 3 else None
+                self.dbt_manifest = dbt_details[1] if len(dbt_details) == 3 else None
+                self.dbt_run_results = dbt_details[2] if len(dbt_details) == 3 else None
                 self.data_models = {}
 
     def prepare(self):

--- a/ingestion/src/metadata/ingestion/source/database/database_service.py
+++ b/ingestion/src/metadata/ingestion/source/database/database_service.py
@@ -231,11 +231,20 @@ class DatabaseServiceSource(DBTMixin, TopologyRunnerMixin, Source, ABC):
     context = create_source_context(topology)
 
     def __init__(self):
-        dbt_details = get_dbt_details(self.source_config.dbtConfigSource)
-        self.dbt_catalog = dbt_details[0] if dbt_details else None
-        self.dbt_manifest = dbt_details[1] if dbt_details else None
-        self.dbt_run_results = dbt_details[2] if dbt_details else None
-        self.data_models = {}
+        if hasattr(self.source_config.dbtConfigSource, "dbtSecurityConfig"):
+            if self.source_config.dbtConfigSource.dbtSecurityConfig is None:
+                logger.warning("dbtConfigSource is not configured")
+                self.dbt_catalog = None
+                self.dbt_manifest = None
+                self.dbt_run_results =  None
+                self.data_models = {}
+        else:
+            dbt_details = get_dbt_details(self.source_config.dbtConfigSource)
+            if len(dbt_details)==3:
+                self.dbt_catalog = dbt_details[0] 
+                self.dbt_manifest = dbt_details[1] 
+                self.dbt_run_results = dbt_details[2] 
+                self.data_models = {}
 
     def prepare(self):
         self._parse_data_model()

--- a/ingestion/src/metadata/ingestion/source/database/database_service.py
+++ b/ingestion/src/metadata/ingestion/source/database/database_service.py
@@ -236,14 +236,14 @@ class DatabaseServiceSource(DBTMixin, TopologyRunnerMixin, Source, ABC):
                 logger.warning("dbtConfigSource is not configured")
                 self.dbt_catalog = None
                 self.dbt_manifest = None
-                self.dbt_run_results =  None
+                self.dbt_run_results = None
                 self.data_models = {}
         else:
             dbt_details = get_dbt_details(self.source_config.dbtConfigSource)
-            if len(dbt_details)==3:
-                self.dbt_catalog = dbt_details[0] 
-                self.dbt_manifest = dbt_details[1] 
-                self.dbt_run_results = dbt_details[2] 
+            if len(dbt_details) == 3:
+                self.dbt_catalog = dbt_details[0]
+                self.dbt_manifest = dbt_details[1]
+                self.dbt_run_results = dbt_details[2]
                 self.data_models = {}
 
     def prepare(self):


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the Fixing DBT root config error handling.
When `"dbtConfigSource":{}` that time it was giving tuple index of range error, and `get_dbt_details()` also execute that block even `"dbtConfigSource":{}` so that is handled . 
Fix: #7341

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement


### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
