### PR TITLE
Fix UI Issue: Allow decimal point in profile sample

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/AddIngestion/Steps/ConfigureIngestion.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AddIngestion/Steps/ConfigureIngestion.tsx
@@ -145,9 +145,7 @@ const ConfigureIngestion = ({
           placeholder="75"
           type="number"
           value={profileSample}
-          onChange={(e) =>
-            handleProfileSampleValidation(parseInt(e.target.value))
-          }
+          onChange={(e) => handleProfileSampleValidation(+e.target.value)}
         />
         {profileSampleError && errorMsg('Value must be between 0 and 99.')}
       </div>

--- a/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/Component/ProfilerSettingsModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/Component/ProfilerSettingsModal.tsx
@@ -12,7 +12,7 @@
  */
 
 import { PlusOutlined } from '@ant-design/icons';
-import { Button, Modal, Select, Slider, TreeSelect } from 'antd';
+import { Button, InputNumber, Modal, Select, Slider, TreeSelect } from 'antd';
 import Form from 'antd/lib/form';
 import { List } from 'antd/lib/form/Form';
 import { Col, Row } from 'antd/lib/grid';
@@ -193,22 +193,41 @@ const ProfilerSettingsModal: React.FC<ProfilerSettingsModalProps> = ({
         <Col data-testid="profile-sample-container" span={24}>
           <p>Profile Sample %</p>
           <div className="tw-px-2 tw-mb-1.5">
-            <Slider
-              className="profiler-slider"
-              marks={{
-                0: '0%',
-                100: '100%',
-                [profileSample as number]: `${profileSample}%`,
-              }}
-              max={100}
-              min={0}
-              tooltipPlacement="bottom"
-              tooltipVisible={false}
-              value={profileSample}
-              onChange={(value) => {
-                setProfileSample(value);
-              }}
-            />
+            <Row>
+              <Col span={20}>
+                <Slider
+                  className="profiler-slider"
+                  marks={{
+                    0: '0%',
+                    100: '100%',
+                    [profileSample as number]: `${profileSample}%`,
+                  }}
+                  max={100}
+                  min={0}
+                  tooltipPlacement="bottom"
+                  tooltipVisible={false}
+                  value={profileSample}
+                  onChange={(value) => {
+                    setProfileSample(value);
+                  }}
+                />
+              </Col>
+              <Col span={4}>
+                <InputNumber
+                  formatter={(value) => `${value}%`}
+                  max={100}
+                  min={0}
+                  step={1}
+                  style={{
+                    margin: '0 16px',
+                  }}
+                  value={profileSample}
+                  onChange={(value) => {
+                    setProfileSample(value);
+                  }}
+                />
+              </Col>
+            </Row>
           </div>
         </Col>
         <Col data-testid="sql-editor-container" span={24}>

--- a/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/Component/ProfilerSettingsModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/Component/ProfilerSettingsModal.tsx
@@ -193,7 +193,7 @@ const ProfilerSettingsModal: React.FC<ProfilerSettingsModalProps> = ({
         <Col data-testid="profile-sample-container" span={24}>
           <p>Profile Sample %</p>
           <div className="tw-px-2 tw-mb-1.5">
-            <Row>
+            <Row gutter={20}>
               <Col span={20}>
                 <Slider
                   className="profiler-slider"
@@ -218,9 +218,6 @@ const ProfilerSettingsModal: React.FC<ProfilerSettingsModalProps> = ({
                   max={100}
                   min={0}
                   step={1}
-                  style={{
-                    margin: '0 16px',
-                  }}
                   value={profileSample}
                   onChange={(value) => {
                     setProfileSample(value);


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
- Issue : #7392
- allowed to use decimal point in Profile sample progress bar
- allowed to use decimal point in Add Profile ingestion sample

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Frontend Preview (Screenshots) :
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/66266464/190393671-dd18d506-e2c6-4d55-abde-39616bd4b5c0.png">

<img width="1439" alt="image" src="https://user-images.githubusercontent.com/66266464/190394025-b009dafb-d62f-4e6b-aede-4e512d8a3bc3.png">


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
