### PR TITLE
Fix UI :  Empty data issue while changing owner in Profiler and DataQuality

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/Component/ColumnProfileTable.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/Component/ColumnProfileTable.test.tsx
@@ -28,6 +28,9 @@ import { ColumnProfileTableProps } from '../TableProfiler.interface';
 import ColumnProfileTable from './ColumnProfileTable';
 
 jest.mock('antd', () => ({
+  Typography: {
+    Text: jest.fn().mockImplementation(({ children }) => <div>{children}</div>),
+  },
   Button: jest
     .fn()
     .mockImplementation(({ children, ...props }) => (

--- a/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/Component/ColumnProfileTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/Component/ColumnProfileTable.tsx
@@ -157,16 +157,16 @@ const ColumnProfileTable: FC<ColumnProfileTableProps> = ({
               }))
             : DEFAULT_TEST_VALUE;
 
-          const hasStatus = currentResult.every(({ value }) => !value);
+          const hasStatus = currentResult.some(({ value }) => value !== 0);
 
           return hasStatus ? (
-            <Typography.Text> --- </Typography.Text>
-          ) : (
             <Space size={16}>
               {currentResult.map((test, i) => (
                 <TestIndicator key={i} type={test.type} value={test.value} />
               ))}
             </Space>
+          ) : (
+            <Typography.Text> --- </Typography.Text>
           );
         },
       },

--- a/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/Component/ColumnProfileTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/Component/ColumnProfileTable.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { Button, Space, Table, Tooltip } from 'antd';
+import { Button, Space, Table, Tooltip, Typography } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
 import { isUndefined } from 'lodash';
 import React, { FC, useEffect, useMemo, useState } from 'react';
@@ -157,7 +157,11 @@ const ColumnProfileTable: FC<ColumnProfileTableProps> = ({
               }))
             : DEFAULT_TEST_VALUE;
 
-          return (
+          const hasStatus = currentResult.every(({ value }) => !value);
+
+          return hasStatus ? (
+            <Typography.Text> --- </Typography.Text>
+          ) : (
             <Space size={16}>
               {currentResult.map((test, i) => (
                 <TestIndicator key={i} type={test.type} value={test.value} />

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatasetDetailsPage/DatasetDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatasetDetailsPage/DatasetDetailsPage.component.tsx
@@ -501,7 +501,8 @@ const DatasetDetailsPage: FunctionComponent = () => {
       if (response) {
         const { description, version } = response;
         setCurrentVersion(version + '');
-        setTableDetails(response);
+        setTableDetails((previous) => ({ ...response, ...previous }));
+
         setDescription(description ?? '');
         getEntityFeedCount();
       } else {
@@ -518,7 +519,7 @@ const DatasetDetailsPage: FunctionComponent = () => {
       if (response) {
         const { columns, version } = response;
         setCurrentVersion(version + '');
-        setTableDetails(response);
+        setTableDetails((previous) => ({ ...response, ...previous }));
         setColumns(columns);
         getEntityFeedCount();
       } else {
@@ -533,7 +534,7 @@ const DatasetDetailsPage: FunctionComponent = () => {
     saveUpdatedTableData(updatedTable)
       .then((res) => {
         if (res) {
-          setTableDetails(res);
+          setTableDetails((previous) => ({ ...res, ...previous }));
           setTier(getTierTags(res.tags ?? []));
           setCurrentVersion(res.version + '');
           setTableTags(getTagsWithoutTier(res.tags ?? []));
@@ -557,7 +558,7 @@ const DatasetDetailsPage: FunctionComponent = () => {
           if (res) {
             const { version, owner, tags = [] } = res;
             setCurrentVersion(version + '');
-            setTableDetails(res);
+            setTableDetails((previous) => ({ ...res, ...previous }));
             setOwner(owner);
             setTier(getTierTags(tags));
             getEntityFeedCount();
@@ -773,7 +774,7 @@ const DatasetDetailsPage: FunctionComponent = () => {
       if (response) {
         const { version, owner: ownerValue, tags } = response;
         setCurrentVersion(version?.toString());
-        setTableDetails(response);
+        setTableDetails((previous) => ({ ...response, ...previous }));
         setOwner(ownerValue);
         setTier(getTierTags(tags ?? []));
       } else {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatasetDetailsPage/DatasetDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatasetDetailsPage/DatasetDetailsPage.component.tsx
@@ -501,7 +501,7 @@ const DatasetDetailsPage: FunctionComponent = () => {
       if (response) {
         const { description, version } = response;
         setCurrentVersion(version + '');
-        setTableDetails((previous) => ({ ...response, ...previous }));
+        setTableDetails((previous) => ({ ...previous, description, version }));
 
         setDescription(description ?? '');
         getEntityFeedCount();
@@ -519,7 +519,7 @@ const DatasetDetailsPage: FunctionComponent = () => {
       if (response) {
         const { columns, version } = response;
         setCurrentVersion(version + '');
-        setTableDetails((previous) => ({ ...response, ...previous }));
+        setTableDetails(response);
         setColumns(columns);
         getEntityFeedCount();
       } else {
@@ -534,7 +534,7 @@ const DatasetDetailsPage: FunctionComponent = () => {
     saveUpdatedTableData(updatedTable)
       .then((res) => {
         if (res) {
-          setTableDetails((previous) => ({ ...res, ...previous }));
+          setTableDetails((previous) => ({ ...previous, tags: res.tags }));
           setTier(getTierTags(res.tags ?? []));
           setCurrentVersion(res.version + '');
           setTableTags(getTagsWithoutTier(res.tags ?? []));
@@ -558,7 +558,12 @@ const DatasetDetailsPage: FunctionComponent = () => {
           if (res) {
             const { version, owner, tags = [] } = res;
             setCurrentVersion(version + '');
-            setTableDetails((previous) => ({ ...res, ...previous }));
+            setTableDetails((previous) => ({
+              ...previous,
+              owner,
+              version,
+              tags,
+            }));
             setOwner(owner);
             setTier(getTierTags(tags));
             getEntityFeedCount();
@@ -772,9 +777,15 @@ const DatasetDetailsPage: FunctionComponent = () => {
     try {
       const response = await saveUpdatedTableData(updatedTable);
       if (response) {
-        const { version, owner: ownerValue, tags } = response;
+        const { version, owner: ownerValue, tags, extension } = response;
         setCurrentVersion(version?.toString());
-        setTableDetails((previous) => ({ ...response, ...previous }));
+        setTableDetails((previous) => ({
+          ...previous,
+          version,
+          owner,
+          tags,
+          extension,
+        }));
         setOwner(ownerValue);
         setTier(getTierTags(tags ?? []));
       } else {


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
- https://github.com/open-metadata/OpenMetadata/issues/7496
- https://github.com/open-metadata/OpenMetadata/issues/7334#issuecomment-1241309097
- fix empty data issue while changing owner in Profiler and DataQuality

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :

https://user-images.githubusercontent.com/66266464/191016032-eeddc276-7a7c-4aa6-b825-f69d1e836d8a.mov

<img width="1439" alt="image" src="https://user-images.githubusercontent.com/66266464/191191504-fa36dd98-8e0f-4e16-af03-6e62f43e3515.png">


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
