### PR TITLE
Fix #7575 UI : Fetch bots with limit=100 and filter it on the UI side.

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/cypress/e2e/Pages/Bots.spec.js
+++ b/openmetadata-ui/src/main/resources/ui/cypress/e2e/Pages/Bots.spec.js
@@ -40,7 +40,7 @@ describe('Bots Page should work properly', () => {
       .click();
     interceptURL(
       'GET',
-      'api/v1/bots?limit=*&include=non-deleted',
+      'api/v1/bots?limit=100&include=non-deleted',
       'getBotsPage'
     );
     cy.get('.ant-menu-title-content')

--- a/openmetadata-ui/src/main/resources/ui/cypress/e2e/Pages/Bots.spec.js
+++ b/openmetadata-ui/src/main/resources/ui/cypress/e2e/Pages/Bots.spec.js
@@ -40,7 +40,7 @@ describe('Bots Page should work properly', () => {
       .click();
     interceptURL(
       'GET',
-      'api/v1/bots?limit=15&include=non-deleted',
+      'api/v1/bots?limit=*&include=non-deleted',
       'getBotsPage'
     );
     cy.get('.ant-menu-title-content')

--- a/openmetadata-ui/src/main/resources/ui/src/components/BotListV1/BotListV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BotListV1/BotListV1.component.tsx
@@ -14,7 +14,7 @@
 import { Button, Col, Row, Space, Switch, Table, Tooltip } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
 import { AxiosError } from 'axios';
-import { isEmpty } from 'lodash';
+import { isEmpty, lowerCase } from 'lodash';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { getBots } from '../../axiosAPIs/botsAPI';
@@ -178,11 +178,12 @@ const BotListV1 = ({
 
   const handleSearch = (text: string) => {
     if (text) {
+      const normalizeText = lowerCase(text);
       const matchedData = botUsers.filter(
         (bot) =>
-          bot.name.includes(text) ||
-          bot.displayName?.includes(text) ||
-          bot.description?.includes(text)
+          bot.name.includes(normalizeText) ||
+          bot.displayName?.includes(normalizeText) ||
+          bot.description?.includes(normalizeText)
       );
       setSearchedData(matchedData);
     } else {

--- a/openmetadata-ui/src/main/resources/ui/src/components/BotListV1/BotListV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BotListV1/BotListV1.component.tsx
@@ -38,6 +38,7 @@ import DeleteWidgetModal from '../common/DeleteWidget/DeleteWidgetModal';
 import ErrorPlaceHolder from '../common/error-with-placeholder/ErrorPlaceHolder';
 import NextPrevious from '../common/next-previous/NextPrevious';
 import RichTextEditorPreviewer from '../common/rich-text-editor/RichTextEditorPreviewer';
+import Searchbar from '../common/searchbar/Searchbar';
 import Loader from '../Loader/Loader';
 import { usePermissionProvider } from '../PermissionProvider/PermissionProvider';
 import { ResourceEntity } from '../PermissionProvider/PermissionProvider.interface';
@@ -56,6 +57,7 @@ const BotListV1 = ({
   const [currentPage, setCurrentPage] = useState<number>(INITIAL_PAGING_VALUE);
 
   const [handleErrorPlaceholder, setHandleErrorPlaceholder] = useState(false);
+  const [searchedData, setSearchedData] = useState<Bot[]>([]);
 
   const createPermission = checkPermission(
     Operation.Create,
@@ -77,11 +79,12 @@ const BotListV1 = ({
       setLoading(true);
       const { data, paging } = await getBots({
         after,
-        limit: PAGE_SIZE_MEDIUM,
+        limit: 100,
         include: showDeleted ? Include.Deleted : Include.NonDeleted,
       });
       setPaging(paging);
       setBotUsers(data);
+      setSearchedData(data);
       if (!showDeleted && isEmpty(data)) {
         setHandleErrorPlaceholder(true);
       } else {
@@ -173,9 +176,24 @@ const BotListV1 = ({
     fetchBots();
   }, [selectedUser]);
 
+  const handleSearch = (text: string) => {
+    if (text) {
+      const matchedData = botUsers.filter(
+        (bot) =>
+          bot.name.includes(text) ||
+          bot.displayName?.includes(text) ||
+          bot.description?.includes(text)
+      );
+      setSearchedData(matchedData);
+    } else {
+      setSearchedData(botUsers);
+    }
+  };
+
   // Fetch initial bot
   useEffect(() => {
     setBotUsers([]);
+    setSearchedData([]);
     fetchBots(showDeleted);
   }, [showDeleted]);
 
@@ -218,9 +236,16 @@ const BotListV1 = ({
     </Row>
   ) : (
     <Row gutter={[16, 16]}>
-      <Col flex={1} />
-      <Col>
-        <Space size={16}>
+      <Col span={8}>
+        <Searchbar
+          removeMargin
+          placeholder="Search for bots..."
+          typingInterval={500}
+          onSearch={handleSearch}
+        />
+      </Col>
+      <Col span={16}>
+        <Space align="center" className="tw-w-full tw-justify-end" size={16}>
           <Space align="end" size={5}>
             <Switch
               checked={showDeleted}
@@ -247,7 +272,7 @@ const BotListV1 = ({
           <Col span={24}>
             <Table
               columns={columns}
-              dataSource={botUsers}
+              dataSource={searchedData}
               loading={{
                 spinning: loading,
                 indicator: <Loader size="small" />,

--- a/openmetadata-ui/src/main/resources/ui/src/components/BotListV1/BotListV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BotListV1/BotListV1.component.tsx
@@ -21,7 +21,7 @@ import { getBots } from '../../axiosAPIs/botsAPI';
 import {
   getBotsPath,
   INITIAL_PAGING_VALUE,
-  PAGE_SIZE_MEDIUM,
+  PAGE_SIZE_LARGE,
 } from '../../constants/constants';
 import { BOTS_DOCS } from '../../constants/docs.constants';
 import { NO_PERMISSION_FOR_ACTION } from '../../constants/HelperTextUtil';
@@ -79,7 +79,7 @@ const BotListV1 = ({
       setLoading(true);
       const { data, paging } = await getBots({
         after,
-        limit: 100,
+        limit: PAGE_SIZE_LARGE,
         include: showDeleted ? Include.Deleted : Include.NonDeleted,
       });
       setPaging(paging);
@@ -282,10 +282,10 @@ const BotListV1 = ({
             />
           </Col>
           <Col span={24}>
-            {paging.total > PAGE_SIZE_MEDIUM && (
+            {paging.total > PAGE_SIZE_LARGE && (
               <NextPrevious
                 currentPage={currentPage}
-                pageSize={PAGE_SIZE_MEDIUM}
+                pageSize={PAGE_SIZE_LARGE}
                 paging={paging}
                 pagingHandler={handlePageChange}
                 totalCount={paging.total}

--- a/openmetadata-ui/src/main/resources/ui/src/constants/constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/constants.ts
@@ -34,6 +34,7 @@ export const JSON_TAB_SIZE = 2;
 export const PAGE_SIZE = 10;
 export const PAGE_SIZE_BASE = 12;
 export const PAGE_SIZE_MEDIUM = 15;
+export const PAGE_SIZE_LARGE = 100;
 export const API_RES_MAX_SIZE = 100000;
 export const LIST_SIZE = 5;
 export const SIDEBAR_WIDTH_COLLAPSED = 290;


### PR DESCRIPTION
Fixes #7575 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on issue #7575 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Frontend Preview (Screenshots) :

https://user-images.githubusercontent.com/59080942/191232062-b4097a09-0ea6-40dc-9bab-5d15c20e4ac1.mov




#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
