### PR TITLE
Fix #7466 UI throws fetch entity count error when there is no data in ElasticSearch

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/explore/ExplorePage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/explore/ExplorePage.component.tsx
@@ -35,10 +35,8 @@ import {
   tabsInfo,
 } from '../../constants/explore.constants';
 import { SearchIndex } from '../../enums/search.enum';
-import jsonData from '../../jsons/en';
 import { getTotalEntityCountByType } from '../../utils/EntityUtils';
 import { getFilterString, prepareQueryParams } from '../../utils/FilterUtils';
-import { showErrorToast } from '../../utils/ToastUtils';
 
 const ExplorePage: FunctionComponent = () => {
   const location = useLocation();
@@ -108,9 +106,8 @@ const ExplorePage: FunctionComponent = () => {
 
       setTabCounts((prev) => ({ ...prev, [entityType]: count }));
     } catch (_error) {
-      showErrorToast(
-        jsonData['api-error-messages']['fetch-entity-count-error']
-      );
+      // eslint-disable-next-line no-console
+      console.error(_error);
     }
   };
 


### PR DESCRIPTION
Fixes #7466 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on issue #7466 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] Improvement


#
### Frontend Preview (Screenshots) :

https://user-images.githubusercontent.com/59080942/191233694-8f464d8b-1590-4c01-8f75-5f03c44b6456.mov



#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
