### PR TITLE
Fix#7493: Airflow container can not be restarted

### DIFF
--- a/ingestion/ingestion_dependency.sh
+++ b/ingestion/ingestion_dependency.sh
@@ -39,5 +39,7 @@ airflow users create \
 
 (sleep 5; airflow db upgrade)
 (sleep 5; airflow db upgrade)
+# we need to this in case the container is restarted and the scheduler exited without tidying up its lock file
+rm -f /opt/airflow/airflow-webserver-monitor.pid
 airflow webserver --port 8080 -D &
 airflow scheduler


### PR DESCRIPTION
Fixes: #7493 

### Describe your changes :
We can not restart `ingestion` container due to the following error:
```
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.9/site-packages/lockfile/pidlockfile.py", line 77, in acquire
    write_pid_to_pidfile(self.path)
  File "/home/airflow/.local/lib/python3.9/site-packages/lockfile/pidlockfile.py", line 161, in write_pid_to_pidfile
    pidfile_fd = os.open(pidfile_path, open_flags, open_mode)
FileExistsError: [Errno 17] File exists: '/opt/airflow/airflow-webserver-monitor.pid'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/airflow/.local/bin/airflow", line 8, in <module>
    sys.exit(main())
  File "/home/airflow/.local/lib/python3.9/site-packages/airflow/__main__.py", line 38, in main
    args.func(args)
  File "/home/airflow/.local/lib/python3.9/site-packages/airflow/cli/cli_parser.py", line 51, in command
    return func(*args, **kwargs)
  File "/home/airflow/.local/lib/python3.9/site-packages/airflow/utils/cli.py", line 99, in wrapper
    return f(*args, **kwargs)
  File "/home/airflow/.local/lib/python3.9/site-packages/airflow/cli/commands/webserver_command.py", line 459, in webserver
    with ctx:
  File "/home/airflow/.local/lib/python3.9/site-packages/daemon/daemon.py", line 389, in __enter__
    self.open()
  File "/home/airflow/.local/lib/python3.9/site-packages/daemon/daemon.py", line 381, in open
    self.pidfile.__enter__()
  File "/home/airflow/.local/lib/python3.9/site-packages/lockfile/__init__.py", line 197, in __enter__
    self.acquire()
  File "/home/airflow/.local/lib/python3.9/site-packages/daemon/pidfile.py", line 57, in acquire
    super().acquire(timeout, *args, **kwargs)
  File "/home/airflow/.local/lib/python3.9/site-packages/lockfile/pidlockfile.py", line 87, in acquire
    raise AlreadyLocked("%s is already locked" %
lockfile.AlreadyLocked: /opt/airflow/airflow-webserver-monitor.pid is already locked
```

This happens when the container is restarted and the scheduler exited without tidying up its lock file.

### Type of change :
- [x] Bug fix

### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

### Reviewers
@akash-jain-10 
