### PR TITLE
fix: Split cypress integrations tests to mysql and psql CI

### DIFF
--- a/.github/workflows/cypress-integration-tests-mysql.yml
+++ b/.github/workflows/cypress-integration-tests-mysql.yml
@@ -1,0 +1,107 @@
+#  Copyright 2021 Collate
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
+# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
+
+name: MySQL Cypress Integration Tests
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'openmetadata-docs/**'
+  pull_request_target:
+    types: [labeled, opened, synchronize, reopened]
+    paths-ignore:
+      - 'openmetadata-docs/**'
+
+concurrency:
+  group: cypress-integration-tests-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  install:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        job: [0, 1]
+    environment: cypress
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+
+      - name: Generating Data Models
+        run: |
+          sudo make install_antlr_cli
+          make install_dev generate
+
+      - name: Start Server and Ingest Sample Data
+        env:
+          INGESTION_DEPENDENCY: "all"
+        run: ./docker/run_local_docker.sh -d mysql
+        timeout-minutes: 30
+
+      - name: Run Cypress Tests
+        uses: cypress-io/github-action@v4
+        with:
+          install: false
+          record: true
+          parallel: true
+          working-directory: openmetadata-ui/src/main/resources/ui/
+          wait-on: 'http://localhost:8585'
+          browser: chrome
+        env:
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          CYPRESS_SNOWFLAKE_USERNAME: ${{ secrets.CYPRESS_SNOWFLAKE_USERNAME }}
+          CYPRESS_SNOWFLAKE_PASSWORD: ${{ secrets.CYPRESS_SNOWFLAKE_PASSWORD }}
+          CYPRESS_SNOWFLAKE_ACCOUNT: ${{ secrets.CYPRESS_SNOWFLAKE_ACCOUNT }}
+          CYPRESS_SNOWFLAKE_DATABASE: ${{ secrets.CYPRESS_SNOWFLAKE_DATABASE }}
+          CYPRESS_SNOWFLAKE_WAREHOUSE: ${{ secrets.CYPRESS_SNOWFLAKE_WAREHOUSE }}
+          CYPRESS_BQ_PRIVATE_KEY: ${{ secrets.CYPRESS_BQ_PRIVATE_KEY }}
+          CYPRESS_BQ_PROJECT_ID: ${{ secrets.CYPRESS_BQ_PROJECT_ID }}
+          CYPRESS_BQ_PRIVATE_KEY_ID: ${{ secrets.CYPRESS_BQ_PRIVATE_KEY_ID }}
+          CYPRESS_BQ_CLIENT_EMAIL: ${{ secrets.CYPRESS_BQ_CLIENT_EMAIL }}
+          CYPRESS_BQ_CLIENT_ID: ${{ secrets.CYPRESS_BQ_CLIENT_ID }}
+          CYPRESS_REDSHIFT_HOST: ${{ secrets.CYPRESS_REDSHIFT_HOST }}
+          CYPRESS_REDSHIFT_USERNAME: ${{ secrets.CYPRESS_REDSHIFT_USERNAME }}
+          CYPRESS_REDSHIFT_PASSWORD: ${{ secrets.CYPRESS_REDSHIFT_PASSWORD }}
+          CYPRESS_REDSHIFT_DATABASE: ${{ secrets.CYPRESS_REDSHIFT_DATABASE }}
+          CYPRESS_METABASE_USERNAME: ${{ secrets.CYPRESS_METABASE_USERNAME }}
+          CYPRESS_METABASE_PASSWORD: ${{ secrets.CYPRESS_METABASE_PASSWORD }}
+          CYPRESS_METABASE_DB_SERVICE_NAME: ${{ secrets.CYPRESS_METABASE_DB_SERVICE_NAME }}
+          CYPRESS_METABASE_HOST_PORT: ${{ secrets.CYPRESS_METABASE_HOST_PORT }}
+          CYPRESS_SUPERSET_USERNAME: ${{ secrets.CYPRESS_SUPERSET_USERNAME }}
+          CYPRESS_SUPERSET_PASSWORD: ${{ secrets.CYPRESS_SUPERSET_PASSWORD }}
+          CYPRESS_SUPERSET_HOST_PORT: ${{ secrets.CYPRESS_SUPERSET_HOST_PORT }}
+          CYPRESS_KAFKA_BOOTSTRAP_SERVERS: ${{ secrets.CYPRESS_KAFKA_BOOTSTRAP_SERVERS }}
+          CYPRESS_KAFKA_SCHEMA_REGISTRY_URL: ${{ secrets.CYPRESS_KAFKA_SCHEMA_REGISTRY_URL }}
+          CYPRESS_GLUE_ACCESS_KEY: ${{ secrets.CYPRESS_GLUE_ACCESS_KEY }}
+          CYPRESS_GLUE_SECRET_KEY: ${{ secrets.CYPRESS_GLUE_SECRET_KEY }}
+          CYPRESS_GLUE_AWS_REGION: ${{ secrets.CYPRESS_GLUE_AWS_REGION }}
+          CYPRESS_GLUE_ENDPOINT: ${{ secrets.CYPRESS_GLUE_ENDPOINT }}
+          CYPRESS_GLUE_STORAGE_SERVICE: ${{ secrets.CYPRESS_GLUE_STORAGE_SERVICE }}
+          CYPRESS_MYSQL_USERNAME: ${{ secrets.CYPRESS_MYSQL_USERNAME }}
+          CYPRESS_MYSQL_PASSWORD: ${{ secrets.CYPRESS_MYSQL_PASSWORD }}
+          CYPRESS_MYSQL_HOST_PORT: ${{ secrets.CYPRESS_MYSQL_HOST_PORT }}
+          CYPRESS_MYSQL_DATABASE_SCHEMA: ${{ secrets.CYPRESS_MYSQL_DATABASE_SCHEMA }}
+
+          # Recommended: pass the GitHub token lets this action correctly
+          # determine the unique run id necessary to re-run the checks
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cypress-integration-tests-postgresql.yml
+++ b/.github/workflows/cypress-integration-tests-postgresql.yml
@@ -12,7 +12,7 @@
 # This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
 # For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
 
-name: Cypress Integration Tests
+name: PostgreSQL Cypress Integration Tests
 
 on:
   push:
@@ -33,7 +33,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        database: [mysql, postgresql]
         job: [0, 1]
     environment: cypress
     steps:
@@ -56,7 +55,7 @@ jobs:
       - name: Start Server and Ingest Sample Data
         env:
           INGESTION_DEPENDENCY: "all"
-        run: ./docker/run_local_docker.sh -d ${{ matrix.database }}
+        run: ./docker/run_local_docker.sh -d postgresql
         timeout-minutes: 30
 
       - name: Run Cypress Tests
@@ -67,7 +66,6 @@ jobs:
           parallel: true
           working-directory: openmetadata-ui/src/main/resources/ui/
           wait-on: 'http://localhost:8585'
-          group: Tests with database ${{ matrix.database }}
           browser: chrome
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Split cypress integrations tests to mysql and psql CI.

Looks like the operation of CI gets cancelled when running with multi dimension matrix strategy. Fallback to splitting cypress in its own separate ci for postgres.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
