### PR TITLE
Fixes #7623 -- Added logic to encode and decode entityLink

### DIFF
--- a/ingestion/src/metadata/test_suite/validations/column/column_value_max_to_be_between.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_value_max_to_be_between.py
@@ -17,6 +17,7 @@ ColumnValuesToBeBetween validation implementation
 import traceback
 from datetime import datetime
 
+from requests.compat import unquote_plus
 from sqlalchemy import inspect
 
 from metadata.generated.schema.tests.basic import (
@@ -46,7 +47,9 @@ def column_value_max_to_be_between(
     """
 
     try:
-        column_name = test_case.entityLink.__root__.split("::")[-1].replace(">", "")
+        column_name = unquote_plus(
+            test_case.entityLink.__root__.split("::")[-1].replace(">", "")
+        )
         col = next(
             (col for col in inspect(runner.table).c if col.name == column_name),
             None,

--- a/ingestion/src/metadata/test_suite/validations/column/column_value_max_to_be_between.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_value_max_to_be_between.py
@@ -17,7 +17,6 @@ ColumnValuesToBeBetween validation implementation
 import traceback
 from datetime import datetime
 
-from requests.compat import unquote_plus
 from sqlalchemy import inspect
 
 from metadata.generated.schema.tests.basic import (
@@ -28,6 +27,7 @@ from metadata.generated.schema.tests.basic import (
 from metadata.generated.schema.tests.testCase import TestCase
 from metadata.orm_profiler.metrics.registry import Metrics
 from metadata.orm_profiler.profiler.runner import QueryRunner
+from metadata.utils.entity_link import get_decoded_column
 from metadata.utils.logger import test_suite_logger
 
 logger = test_suite_logger()
@@ -47,9 +47,7 @@ def column_value_max_to_be_between(
     """
 
     try:
-        column_name = unquote_plus(
-            test_case.entityLink.__root__.split("::")[-1].replace(">", "")
-        )
+        column_name = get_decoded_column(test_case.entityLink.__root__)
         col = next(
             (col for col in inspect(runner.table).c if col.name == column_name),
             None,

--- a/ingestion/src/metadata/test_suite/validations/column/column_value_mean_to_be_between.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_value_mean_to_be_between.py
@@ -17,7 +17,6 @@ ColumnValuesToBeBetween validation implementation
 import traceback
 from datetime import datetime
 
-from requests.compat import unquote_plus
 from sqlalchemy import inspect
 
 from metadata.generated.schema.tests.basic import (
@@ -28,6 +27,7 @@ from metadata.generated.schema.tests.basic import (
 from metadata.generated.schema.tests.testCase import TestCase
 from metadata.orm_profiler.metrics.registry import Metrics
 from metadata.orm_profiler.profiler.runner import QueryRunner
+from metadata.utils.entity_link import get_decoded_column
 from metadata.utils.logger import test_suite_logger
 
 logger = test_suite_logger()
@@ -47,9 +47,7 @@ def column_value_mean_to_be_between(
     """
 
     try:
-        column_name = unquote_plus(
-            test_case.entityLink.__root__.split("::")[-1].replace(">", "")
-        )
+        column_name = get_decoded_column(test_case.entityLink.__root__)
         col = next(
             (col for col in inspect(runner.table).c if col.name == column_name),
             None,

--- a/ingestion/src/metadata/test_suite/validations/column/column_value_mean_to_be_between.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_value_mean_to_be_between.py
@@ -17,6 +17,7 @@ ColumnValuesToBeBetween validation implementation
 import traceback
 from datetime import datetime
 
+from requests.compat import unquote_plus
 from sqlalchemy import inspect
 
 from metadata.generated.schema.tests.basic import (
@@ -46,7 +47,9 @@ def column_value_mean_to_be_between(
     """
 
     try:
-        column_name = test_case.entityLink.__root__.split("::")[-1].replace(">", "")
+        column_name = unquote_plus(
+            test_case.entityLink.__root__.split("::")[-1].replace(">", "")
+        )
         col = next(
             (col for col in inspect(runner.table).c if col.name == column_name),
             None,

--- a/ingestion/src/metadata/test_suite/validations/column/column_value_median_to_be_between.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_value_median_to_be_between.py
@@ -17,6 +17,7 @@ ColumnValuesToBeBetween validation implementation
 import traceback
 from datetime import datetime
 
+from requests.compat import unquote_plus
 from sqlalchemy import inspect
 
 from metadata.generated.schema.tests.basic import (
@@ -46,7 +47,9 @@ def column_value_median_to_be_between(
     """
 
     try:
-        column_name = test_case.entityLink.__root__.split("::")[-1].replace(">", "")
+        column_name = unquote_plus(
+            test_case.entityLink.__root__.split("::")[-1].replace(">", "")
+        )
         col = next(
             (col for col in inspect(runner.table).c if col.name == column_name),
             None,

--- a/ingestion/src/metadata/test_suite/validations/column/column_value_median_to_be_between.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_value_median_to_be_between.py
@@ -17,7 +17,6 @@ ColumnValuesToBeBetween validation implementation
 import traceback
 from datetime import datetime
 
-from requests.compat import unquote_plus
 from sqlalchemy import inspect
 
 from metadata.generated.schema.tests.basic import (
@@ -28,6 +27,7 @@ from metadata.generated.schema.tests.basic import (
 from metadata.generated.schema.tests.testCase import TestCase
 from metadata.orm_profiler.metrics.registry import Metrics
 from metadata.orm_profiler.profiler.runner import QueryRunner
+from metadata.utils.entity_link import get_decoded_column
 from metadata.utils.logger import test_suite_logger
 
 logger = test_suite_logger()
@@ -47,9 +47,7 @@ def column_value_median_to_be_between(
     """
 
     try:
-        column_name = unquote_plus(
-            test_case.entityLink.__root__.split("::")[-1].replace(">", "")
-        )
+        column_name = get_decoded_column(test_case.entityLink.__root__)
         col = next(
             (col for col in inspect(runner.table).c if col.name == column_name),
             None,

--- a/ingestion/src/metadata/test_suite/validations/column/column_value_min_to_be_between.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_value_min_to_be_between.py
@@ -17,7 +17,6 @@ ColumnValuesToBeBetween validation implementation
 import traceback
 from datetime import datetime
 
-from requests.compat import unquote_plus
 from sqlalchemy import inspect
 
 from metadata.generated.schema.tests.basic import (
@@ -28,6 +27,7 @@ from metadata.generated.schema.tests.basic import (
 from metadata.generated.schema.tests.testCase import TestCase
 from metadata.orm_profiler.metrics.registry import Metrics
 from metadata.orm_profiler.profiler.runner import QueryRunner
+from metadata.utils.entity_link import get_decoded_column
 from metadata.utils.logger import test_suite_logger
 
 logger = test_suite_logger()
@@ -47,9 +47,7 @@ def column_value_min_to_be_between(
     """
 
     try:
-        column_name = unquote_plus(
-            test_case.entityLink.__root__.split("::")[-1].replace(">", "")
-        )
+        column_name = get_decoded_column(test_case.entityLink.__root__)
         col = next(
             (col for col in inspect(runner.table).c if col.name == column_name),
             None,

--- a/ingestion/src/metadata/test_suite/validations/column/column_value_min_to_be_between.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_value_min_to_be_between.py
@@ -17,6 +17,7 @@ ColumnValuesToBeBetween validation implementation
 import traceback
 from datetime import datetime
 
+from requests.compat import unquote_plus
 from sqlalchemy import inspect
 
 from metadata.generated.schema.tests.basic import (
@@ -46,7 +47,9 @@ def column_value_min_to_be_between(
     """
 
     try:
-        column_name = test_case.entityLink.__root__.split("::")[-1].replace(">", "")
+        column_name = unquote_plus(
+            test_case.entityLink.__root__.split("::")[-1].replace(">", "")
+        )
         col = next(
             (col for col in inspect(runner.table).c if col.name == column_name),
             None,

--- a/ingestion/src/metadata/test_suite/validations/column/column_value_stddev_to_be_between.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_value_stddev_to_be_between.py
@@ -17,7 +17,6 @@ ColumnValuesToBeBetween validation implementation
 import traceback
 from datetime import datetime
 
-from requests.compat import unquote_plus
 from sqlalchemy import inspect
 
 from metadata.generated.schema.tests.basic import (
@@ -28,6 +27,7 @@ from metadata.generated.schema.tests.basic import (
 from metadata.generated.schema.tests.testCase import TestCase
 from metadata.orm_profiler.metrics.registry import Metrics
 from metadata.orm_profiler.profiler.runner import QueryRunner
+from metadata.utils.entity_link import get_decoded_column
 from metadata.utils.logger import test_suite_logger
 
 logger = test_suite_logger()
@@ -47,9 +47,7 @@ def column_value_stddev_to_be_between(
     """
 
     try:
-        column_name = unquote_plus(
-            test_case.entityLink.__root__.split("::")[-1].replace(">", "")
-        )
+        column_name = get_decoded_column(test_case.entityLink.__root__)
         col = next(
             (col for col in inspect(runner.table).c if col.name == column_name),
             None,

--- a/ingestion/src/metadata/test_suite/validations/column/column_value_stddev_to_be_between.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_value_stddev_to_be_between.py
@@ -17,6 +17,7 @@ ColumnValuesToBeBetween validation implementation
 import traceback
 from datetime import datetime
 
+from requests.compat import unquote_plus
 from sqlalchemy import inspect
 
 from metadata.generated.schema.tests.basic import (
@@ -46,7 +47,9 @@ def column_value_stddev_to_be_between(
     """
 
     try:
-        column_name = test_case.entityLink.__root__.split("::")[-1].replace(">", "")
+        column_name = unquote_plus(
+            test_case.entityLink.__root__.split("::")[-1].replace(">", "")
+        )
         col = next(
             (col for col in inspect(runner.table).c if col.name == column_name),
             None,

--- a/ingestion/src/metadata/test_suite/validations/column/column_values_in_set.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_values_in_set.py
@@ -17,6 +17,7 @@ import traceback
 from ast import literal_eval
 from datetime import datetime
 
+from requests.compat import unquote_plus
 from sqlalchemy import inspect
 
 from metadata.generated.schema.tests.basic import (
@@ -59,7 +60,9 @@ def column_values_in_set(
     set_count = add_props(values=allowed_value)(Metrics.COUNT_IN_SET.value)
 
     try:
-        column_name = test_case.entityLink.__root__.split("::")[-1].replace(">", "")
+        column_name = unquote_plus(
+            test_case.entityLink.__root__.split("::")[-1].replace(">", "")
+        )
         col = next(
             (col for col in inspect(runner.table).c if col.name == column_name),
             None,

--- a/ingestion/src/metadata/test_suite/validations/column/column_values_in_set.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_values_in_set.py
@@ -17,7 +17,6 @@ import traceback
 from ast import literal_eval
 from datetime import datetime
 
-from requests.compat import unquote_plus
 from sqlalchemy import inspect
 
 from metadata.generated.schema.tests.basic import (
@@ -29,6 +28,7 @@ from metadata.generated.schema.tests.testCase import TestCase
 from metadata.orm_profiler.metrics.core import add_props
 from metadata.orm_profiler.metrics.registry import Metrics
 from metadata.orm_profiler.profiler.runner import QueryRunner
+from metadata.utils.entity_link import get_decoded_column
 from metadata.utils.logger import test_suite_logger
 
 logger = test_suite_logger()
@@ -60,9 +60,7 @@ def column_values_in_set(
     set_count = add_props(values=allowed_value)(Metrics.COUNT_IN_SET.value)
 
     try:
-        column_name = unquote_plus(
-            test_case.entityLink.__root__.split("::")[-1].replace(">", "")
-        )
+        column_name = get_decoded_column(test_case.entityLink.__root__)
         col = next(
             (col for col in inspect(runner.table).c if col.name == column_name),
             None,

--- a/ingestion/src/metadata/test_suite/validations/column/column_values_length_to_be_between.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_values_length_to_be_between.py
@@ -17,6 +17,7 @@ ColumnValueLengthsToBeBetween validation implementation
 import traceback
 from datetime import datetime
 
+from requests.compat import unquote_plus
 from sqlalchemy import inspect
 
 from metadata.generated.schema.tests.basic import (
@@ -46,7 +47,9 @@ def column_value_length_to_be_between(
     """
 
     try:
-        column_name = test_case.entityLink.__root__.split("::")[-1].replace(">", "")
+        column_name = unquote_plus(
+            test_case.entityLink.__root__.split("::")[-1].replace(">", "")
+        )
         col = next(
             (col for col in inspect(runner.table).c if col.name == column_name),
             None,

--- a/ingestion/src/metadata/test_suite/validations/column/column_values_length_to_be_between.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_values_length_to_be_between.py
@@ -17,7 +17,6 @@ ColumnValueLengthsToBeBetween validation implementation
 import traceback
 from datetime import datetime
 
-from requests.compat import unquote_plus
 from sqlalchemy import inspect
 
 from metadata.generated.schema.tests.basic import (
@@ -28,6 +27,7 @@ from metadata.generated.schema.tests.basic import (
 from metadata.generated.schema.tests.testCase import TestCase
 from metadata.orm_profiler.metrics.registry import Metrics
 from metadata.orm_profiler.profiler.runner import QueryRunner
+from metadata.utils.entity_link import get_decoded_column
 from metadata.utils.logger import test_suite_logger
 
 logger = test_suite_logger()
@@ -47,9 +47,7 @@ def column_value_length_to_be_between(
     """
 
     try:
-        column_name = unquote_plus(
-            test_case.entityLink.__root__.split("::")[-1].replace(">", "")
-        )
+        column_name = get_decoded_column(test_case.entityLink.__root__)
         col = next(
             (col for col in inspect(runner.table).c if col.name == column_name),
             None,

--- a/ingestion/src/metadata/test_suite/validations/column/column_values_missing_count_to_be_equal.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_values_missing_count_to_be_equal.py
@@ -17,6 +17,7 @@ import traceback
 from ast import literal_eval
 from datetime import datetime
 
+from requests.compat import unquote_plus
 from sqlalchemy import inspect
 
 from metadata.generated.schema.tests.basic import (
@@ -49,7 +50,9 @@ def column_values_missing_count_to_be_equal(
     :return: TestCaseResult with status and results
     """
     try:
-        column_name = test_case.entityLink.__root__.split("::")[-1].replace(">", "")
+        column_name = unquote_plus(
+            test_case.entityLink.__root__.split("::")[-1].replace(">", "")
+        )
         col = next(
             (col for col in inspect(runner.table).c if col.name == column_name),
             None,

--- a/ingestion/src/metadata/test_suite/validations/column/column_values_missing_count_to_be_equal.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_values_missing_count_to_be_equal.py
@@ -17,7 +17,6 @@ import traceback
 from ast import literal_eval
 from datetime import datetime
 
-from requests.compat import unquote_plus
 from sqlalchemy import inspect
 
 from metadata.generated.schema.tests.basic import (
@@ -29,6 +28,7 @@ from metadata.generated.schema.tests.testCase import TestCase
 from metadata.orm_profiler.metrics.core import add_props
 from metadata.orm_profiler.metrics.registry import Metrics
 from metadata.orm_profiler.profiler.runner import QueryRunner
+from metadata.utils.entity_link import get_decoded_column
 from metadata.utils.logger import profiler_logger
 
 logger = profiler_logger()
@@ -50,9 +50,7 @@ def column_values_missing_count_to_be_equal(
     :return: TestCaseResult with status and results
     """
     try:
-        column_name = unquote_plus(
-            test_case.entityLink.__root__.split("::")[-1].replace(">", "")
-        )
+        column_name = get_decoded_column(test_case.entityLink.__root__)
         col = next(
             (col for col in inspect(runner.table).c if col.name == column_name),
             None,

--- a/ingestion/src/metadata/test_suite/validations/column/column_values_not_in_set.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_values_not_in_set.py
@@ -17,7 +17,6 @@ import traceback
 from ast import literal_eval
 from datetime import datetime
 
-from requests.compat import unquote_plus
 from sqlalchemy import inspect
 
 from metadata.generated.schema.tests.basic import (
@@ -29,6 +28,7 @@ from metadata.generated.schema.tests.testCase import TestCase
 from metadata.orm_profiler.metrics.core import add_props
 from metadata.orm_profiler.metrics.registry import Metrics
 from metadata.orm_profiler.profiler.runner import QueryRunner
+from metadata.utils.entity_link import get_decoded_column
 from metadata.utils.logger import test_suite_logger
 
 logger = test_suite_logger()
@@ -60,9 +60,7 @@ def column_values_not_in_set(
     set_count = add_props(values=forbidden_value)(Metrics.COUNT_IN_SET.value)
 
     try:
-        column_name = unquote_plus(
-            test_case.entityLink.__root__.split("::")[-1].replace(">", "")
-        )
+        column_name = get_decoded_column(test_case.entityLink.__root__)
         col = next(
             (col for col in inspect(runner.table).c if col.name == column_name),
             None,

--- a/ingestion/src/metadata/test_suite/validations/column/column_values_not_in_set.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_values_not_in_set.py
@@ -17,6 +17,7 @@ import traceback
 from ast import literal_eval
 from datetime import datetime
 
+from requests.compat import unquote_plus
 from sqlalchemy import inspect
 
 from metadata.generated.schema.tests.basic import (
@@ -59,7 +60,9 @@ def column_values_not_in_set(
     set_count = add_props(values=forbidden_value)(Metrics.COUNT_IN_SET.value)
 
     try:
-        column_name = test_case.entityLink.__root__.split("::")[-1].replace(">", "")
+        column_name = unquote_plus(
+            test_case.entityLink.__root__.split("::")[-1].replace(">", "")
+        )
         col = next(
             (col for col in inspect(runner.table).c if col.name == column_name),
             None,

--- a/ingestion/src/metadata/test_suite/validations/column/column_values_sum_to_be_between.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_values_sum_to_be_between.py
@@ -17,7 +17,6 @@ ColumnValuesToBeBetween validation implementation
 import traceback
 from datetime import datetime
 
-from requests.compat import unquote_plus
 from sqlalchemy import inspect
 
 from metadata.generated.schema.tests.basic import (
@@ -28,6 +27,7 @@ from metadata.generated.schema.tests.basic import (
 from metadata.generated.schema.tests.testCase import TestCase
 from metadata.orm_profiler.metrics.registry import Metrics
 from metadata.orm_profiler.profiler.runner import QueryRunner
+from metadata.utils.entity_link import get_decoded_column
 from metadata.utils.logger import test_suite_logger
 
 logger = test_suite_logger()
@@ -47,9 +47,7 @@ def column_values_sum_to_be_between(
     """
 
     try:
-        column_name = unquote_plus(
-            test_case.entityLink.__root__.split("::")[-1].replace(">", "")
-        )
+        column_name = get_decoded_column(test_case.entityLink.__root__)
         col = next(
             (col for col in inspect(runner.table).c if col.name == column_name),
             None,

--- a/ingestion/src/metadata/test_suite/validations/column/column_values_sum_to_be_between.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_values_sum_to_be_between.py
@@ -17,6 +17,7 @@ ColumnValuesToBeBetween validation implementation
 import traceback
 from datetime import datetime
 
+from requests.compat import unquote_plus
 from sqlalchemy import inspect
 
 from metadata.generated.schema.tests.basic import (
@@ -46,7 +47,9 @@ def column_values_sum_to_be_between(
     """
 
     try:
-        column_name = test_case.entityLink.__root__.split("::")[-1].replace(">", "")
+        column_name = unquote_plus(
+            test_case.entityLink.__root__.split("::")[-1].replace(">", "")
+        )
         col = next(
             (col for col in inspect(runner.table).c if col.name == column_name),
             None,

--- a/ingestion/src/metadata/test_suite/validations/column/column_values_to_be_between.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_values_to_be_between.py
@@ -17,6 +17,7 @@ ColumnValuesToBeBetween validation implementation
 import traceback
 from datetime import datetime
 
+from requests.compat import unquote_plus
 from sqlalchemy import inspect
 
 from metadata.generated.schema.tests.basic import (
@@ -46,7 +47,9 @@ def column_values_to_be_between(
     """
 
     try:
-        column_name = test_case.entityLink.__root__.split("::")[-1].replace(">", "")
+        column_name = unquote_plus(
+            test_case.entityLink.__root__.split("::")[-1].replace(">", "")
+        )
         col = next(
             (col for col in inspect(runner.table).c if col.name == column_name),
             None,

--- a/ingestion/src/metadata/test_suite/validations/column/column_values_to_be_between.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_values_to_be_between.py
@@ -17,7 +17,6 @@ ColumnValuesToBeBetween validation implementation
 import traceback
 from datetime import datetime
 
-from requests.compat import unquote_plus
 from sqlalchemy import inspect
 
 from metadata.generated.schema.tests.basic import (
@@ -28,6 +27,7 @@ from metadata.generated.schema.tests.basic import (
 from metadata.generated.schema.tests.testCase import TestCase
 from metadata.orm_profiler.metrics.registry import Metrics
 from metadata.orm_profiler.profiler.runner import QueryRunner
+from metadata.utils.entity_link import get_decoded_column
 from metadata.utils.logger import test_suite_logger
 
 logger = test_suite_logger()
@@ -47,9 +47,7 @@ def column_values_to_be_between(
     """
 
     try:
-        column_name = unquote_plus(
-            test_case.entityLink.__root__.split("::")[-1].replace(">", "")
-        )
+        column_name = get_decoded_column(test_case.entityLink.__root__)
         col = next(
             (col for col in inspect(runner.table).c if col.name == column_name),
             None,

--- a/ingestion/src/metadata/test_suite/validations/column/column_values_to_be_not_null.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_values_to_be_not_null.py
@@ -17,7 +17,6 @@ ColumnValuesToBeNotNull validation implementation
 import traceback
 from datetime import datetime
 
-from requests.compat import unquote_plus
 from sqlalchemy import inspect
 
 from metadata.generated.schema.tests.basic import (
@@ -28,6 +27,7 @@ from metadata.generated.schema.tests.basic import (
 from metadata.generated.schema.tests.testCase import TestCase
 from metadata.orm_profiler.metrics.registry import Metrics
 from metadata.orm_profiler.profiler.runner import QueryRunner
+from metadata.utils.entity_link import get_decoded_column
 from metadata.utils.logger import test_suite_logger
 
 logger = test_suite_logger()
@@ -47,9 +47,7 @@ def column_values_to_be_not_null(
     """
 
     try:
-        column_name = unquote_plus(
-            test_case.entityLink.__root__.split("::")[-1].replace(">", "")
-        )
+        column_name = get_decoded_column(test_case.entityLink.__root__)
         col = next(
             (col for col in inspect(runner.table).c if col.name == column_name),
             None,

--- a/ingestion/src/metadata/test_suite/validations/column/column_values_to_be_not_null.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_values_to_be_not_null.py
@@ -17,6 +17,7 @@ ColumnValuesToBeNotNull validation implementation
 import traceback
 from datetime import datetime
 
+from requests.compat import unquote_plus
 from sqlalchemy import inspect
 
 from metadata.generated.schema.tests.basic import (
@@ -46,7 +47,9 @@ def column_values_to_be_not_null(
     """
 
     try:
-        column_name = test_case.entityLink.__root__.split("::")[-1].replace(">", "")
+        column_name = unquote_plus(
+            test_case.entityLink.__root__.split("::")[-1].replace(">", "")
+        )
         col = next(
             (col for col in inspect(runner.table).c if col.name == column_name),
             None,

--- a/ingestion/src/metadata/test_suite/validations/column/column_values_to_be_unique.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_values_to_be_unique.py
@@ -17,7 +17,6 @@ ColumnValuesToBeUnique validation implementation
 import traceback
 from datetime import datetime
 
-from requests.compat import unquote_plus
 from sqlalchemy import inspect
 from sqlalchemy.orm.util import AliasedClass
 
@@ -29,6 +28,7 @@ from metadata.generated.schema.tests.basic import (
 from metadata.generated.schema.tests.testCase import TestCase
 from metadata.orm_profiler.metrics.registry import Metrics
 from metadata.orm_profiler.profiler.runner import QueryRunner
+from metadata.utils.entity_link import get_decoded_column
 from metadata.utils.logger import test_suite_logger
 
 logger = test_suite_logger()
@@ -48,9 +48,7 @@ def column_values_to_be_unique(
     """
 
     try:
-        column_name = unquote_plus(
-            test_case.entityLink.__root__.split("::")[-1].replace(">", "")
-        )
+        column_name = get_decoded_column(test_case.entityLink.__root__)
         col = next(
             (col for col in inspect(runner.table).c if col.name == column_name),
             None,

--- a/ingestion/src/metadata/test_suite/validations/column/column_values_to_be_unique.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_values_to_be_unique.py
@@ -17,6 +17,7 @@ ColumnValuesToBeUnique validation implementation
 import traceback
 from datetime import datetime
 
+from requests.compat import unquote_plus
 from sqlalchemy import inspect
 from sqlalchemy.orm.util import AliasedClass
 
@@ -47,7 +48,9 @@ def column_values_to_be_unique(
     """
 
     try:
-        column_name = test_case.entityLink.__root__.split("::")[-1].replace(">", "")
+        column_name = unquote_plus(
+            test_case.entityLink.__root__.split("::")[-1].replace(">", "")
+        )
         col = next(
             (col for col in inspect(runner.table).c if col.name == column_name),
             None,

--- a/ingestion/src/metadata/test_suite/validations/column/column_values_to_match_regex.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_values_to_match_regex.py
@@ -16,7 +16,6 @@ ColumnValuesToBeNotNull validation implementation
 import traceback
 from datetime import datetime
 
-from requests.compat import unquote_plus
 from sqlalchemy import inspect
 
 from metadata.generated.schema.tests.basic import (
@@ -28,6 +27,7 @@ from metadata.generated.schema.tests.testCase import TestCase
 from metadata.orm_profiler.metrics.core import add_props
 from metadata.orm_profiler.metrics.registry import Metrics
 from metadata.orm_profiler.profiler.runner import QueryRunner
+from metadata.utils.entity_link import get_decoded_column
 from metadata.utils.logger import test_suite_logger
 
 logger = test_suite_logger()
@@ -55,9 +55,7 @@ def column_values_to_match_regex(
     like_count = add_props(expression=regex)(Metrics.LIKE_COUNT.value)
 
     try:
-        column_name = unquote_plus(
-            test_case.entityLink.__root__.split("::")[-1].replace(">", "")
-        )
+        column_name = get_decoded_column(test_case.entityLink.__root__)
         col = next(
             (col for col in inspect(runner.table).c if col.name == column_name),
             None,

--- a/ingestion/src/metadata/test_suite/validations/column/column_values_to_match_regex.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_values_to_match_regex.py
@@ -16,6 +16,7 @@ ColumnValuesToBeNotNull validation implementation
 import traceback
 from datetime import datetime
 
+from requests.compat import unquote_plus
 from sqlalchemy import inspect
 
 from metadata.generated.schema.tests.basic import (
@@ -54,7 +55,9 @@ def column_values_to_match_regex(
     like_count = add_props(expression=regex)(Metrics.LIKE_COUNT.value)
 
     try:
-        column_name = test_case.entityLink.__root__.split("::")[-1].replace(">", "")
+        column_name = unquote_plus(
+            test_case.entityLink.__root__.split("::")[-1].replace(">", "")
+        )
         col = next(
             (col for col in inspect(runner.table).c if col.name == column_name),
             None,

--- a/ingestion/src/metadata/test_suite/validations/column/column_values_to_not_match_regex.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_values_to_not_match_regex.py
@@ -16,6 +16,7 @@ ColumnValuesToBeNotNull validation implementation
 import traceback
 from datetime import datetime
 
+from requests.compat import unquote_plus
 from sqlalchemy import inspect
 
 from metadata.generated.schema.tests.basic import (
@@ -58,7 +59,9 @@ def column_values_to_not_match_regex(
     not_like_count = add_props(expression=forbidden_regex)(Metrics.NOT_LIKE_COUNT.value)
 
     try:
-        column_name = test_case.entityLink.__root__.split("::")[-1].replace(">", "")
+        column_name = unquote_plus(
+            test_case.entityLink.__root__.split("::")[-1].replace(">", "")
+        )
         col = next(
             (col for col in inspect(runner.table).c if col.name == column_name),
             None,

--- a/ingestion/src/metadata/test_suite/validations/column/column_values_to_not_match_regex.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_values_to_not_match_regex.py
@@ -16,7 +16,6 @@ ColumnValuesToBeNotNull validation implementation
 import traceback
 from datetime import datetime
 
-from requests.compat import unquote_plus
 from sqlalchemy import inspect
 
 from metadata.generated.schema.tests.basic import (
@@ -28,6 +27,7 @@ from metadata.generated.schema.tests.testCase import TestCase
 from metadata.orm_profiler.metrics.core import add_props
 from metadata.orm_profiler.metrics.registry import Metrics
 from metadata.orm_profiler.profiler.runner import QueryRunner
+from metadata.utils.entity_link import get_decoded_column
 from metadata.utils.logger import test_suite_logger
 
 logger = test_suite_logger()
@@ -59,9 +59,7 @@ def column_values_to_not_match_regex(
     not_like_count = add_props(expression=forbidden_regex)(Metrics.NOT_LIKE_COUNT.value)
 
     try:
-        column_name = unquote_plus(
-            test_case.entityLink.__root__.split("::")[-1].replace(">", "")
-        )
+        column_name = get_decoded_column(test_case.entityLink.__root__)
         col = next(
             (col for col in inspect(runner.table).c if col.name == column_name),
             None,

--- a/ingestion/src/metadata/utils/entity_link.py
+++ b/ingestion/src/metadata/utils/entity_link.py
@@ -19,6 +19,7 @@ from antlr4.CommonTokenStream import CommonTokenStream
 from antlr4.error.ErrorStrategy import BailErrorStrategy
 from antlr4.InputStream import InputStream
 from antlr4.tree.Tree import ParseTreeWalker
+from requests.compat import unquote_plus
 
 from metadata.antlr.split_listener import EntityLinkSplitListener
 from metadata.generated.antlr.EntityLinkLexer import EntityLinkLexer
@@ -41,3 +42,13 @@ def split(s: str) -> List[str]:
     splitter = EntityLinkSplitListener()
     walker.walk(splitter, tree)
     return splitter.split()
+
+
+def get_decoded_column(entity_link: str) -> str:
+    """From an URL encoded entity link get the decoded column name
+
+    Args:
+        entity_link: entity link
+    """
+
+    return unquote_plus(entity_link.split("::")[-1].replace(">", ""))

--- a/ingestion/tests/unit/metadata/utils/test_entity_link.py
+++ b/ingestion/tests/unit/metadata/utils/test_entity_link.py
@@ -1,0 +1,36 @@
+#  Copyright 2021 Collate
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+test entity link utils
+"""
+
+import pytest
+
+from metadata.utils.entity_link import get_decoded_column
+
+
+@pytest.mark.parametrize(
+    "entity_link,expected",
+    [
+        (
+            "<#E::table::rds.dev.dbt_jaffle.column_w_space::columns::first+name>",
+            "first name",
+        ),
+        (
+            "<#E::table::rds.dev.dbt_jaffle.column_w_space::columns::last_name>",
+            "last_name",
+        ),
+    ],
+)
+def test_get_decoded_column(entity_link, expected):
+    """test get_decoded_column return expected values"""
+    assert get_decoded_column(entity_link) == expected

--- a/ingestion/tests/unit/test_suite/test_validations.py
+++ b/ingestion/tests/unit/test_suite/test_validations.py
@@ -46,6 +46,7 @@ TABLE = Table(
     columns=[
         Column(name="id", dataType=DataType.INT),
         Column(name="name", dataType=DataType.STRING),
+        Column(name="first name", dataType=DataType.STRING),
         Column(name="fullname", dataType=DataType.STRING),
         Column(name="nickname", dataType=DataType.STRING),
         Column(name="age", dataType=DataType.INT),
@@ -60,6 +61,7 @@ class User(Base):
     __tablename__ = "users"
     id = sqa.Column(sqa.Integer, primary_key=True)
     name = sqa.Column(sqa.String(256))
+    first_name = sqa.Column("first name", sqa.String(256))
     fullname = sqa.Column(sqa.String(256))
     nickname = sqa.Column(sqa.String(256))
     age = sqa.Column(sqa.Integer)
@@ -96,18 +98,21 @@ class testSuiteValidation(unittest.TestCase):
             data = [
                 User(
                     name="John",
+                    first_name="Jo",
                     fullname="John Doe",
                     nickname="johnny b goode",
                     age=30,
                 ),
                 User(
                     name="Jane",
+                    first_name="Ja",
                     fullname="Jone Doe",
                     nickname="Johnny d",
                     age=31,
                 ),
                 User(
                     name="John",
+                    first_name="Joh",
                     fullname="John Doe",
                     nickname=None,
                     age=None,
@@ -142,6 +147,28 @@ class testSuiteValidation(unittest.TestCase):
         assert res.testCaseStatus == TestCaseStatus.Failed
         assert res.testResultValue[0].value == "8"
         assert res.testResultValue[1].value == "14"
+
+        test_case = TestCase(
+            name="my_test_case",
+            entityLink="<#E::table::service.db.users::columns::first+name>",
+            testSuite=EntityReference(id=uuid4(), type="TestSuite"),
+            testDefinition=EntityReference(id=uuid4(), type="TestDefinition"),
+            parameterValues=[
+                TestCaseParameterValue(name="minLength", value="1"),
+                TestCaseParameterValue(name="maxLength", value="10"),
+            ],
+        )
+
+        res = validation_enum_registry.registry["columnValueLengthsToBeBetween"](
+            test_case=test_case,
+            execution_date=EXECUTION_DATE.timestamp(),
+            runner=self.runner,
+        )
+
+        assert isinstance(res, TestCaseResult)
+        assert res.testCaseStatus == TestCaseStatus.Success
+        assert res.testResultValue[0].value == "2"
+        assert res.testResultValue[1].value == "3"
 
     def test_column_value_max_to_be_between(self):
         """test column value max to be between"""
@@ -492,7 +519,7 @@ class testSuiteValidation(unittest.TestCase):
 
         assert isinstance(res, TestCaseResult)
         assert res.testCaseStatus == TestCaseStatus.Success
-        assert res.testResultValue[0].value == "5"
+        assert res.testResultValue[0].value == "6"
 
     def test_table_column_count_to_equal(self):
         """test column value to be equal"""
@@ -501,7 +528,7 @@ class testSuiteValidation(unittest.TestCase):
             entityLink="<#E::table::service.db.users>",
             testSuite=EntityReference(id=uuid4(), type="TestSuite"),
             testDefinition=EntityReference(id=uuid4(), type="TestDefinition"),
-            parameterValues=[TestCaseParameterValue(name="columnCount", value="6")],
+            parameterValues=[TestCaseParameterValue(name="columnCount", value="7")],
         )
 
         res = validation_enum_registry.registry["tableColumnCountToEqual"](
@@ -512,7 +539,7 @@ class testSuiteValidation(unittest.TestCase):
 
         assert isinstance(res, TestCaseResult)
         assert res.testCaseStatus == TestCaseStatus.Failed
-        assert res.testResultValue[0].value == "5"
+        assert res.testResultValue[0].value == "6"
 
     def test_table_column_name_to_exist(self):
         """test column name to exist"""
@@ -556,7 +583,7 @@ class testSuiteValidation(unittest.TestCase):
         assert res.testCaseStatus == TestCaseStatus.Failed
         assert (
             res.testResultValue[0].value
-            == "['id', 'name', 'fullname', 'nickname', 'age']"
+            == "['first name', 'id', 'name', 'fullname', 'nickname', 'age']"
         )
 
         test_case = TestCase(
@@ -577,7 +604,7 @@ class testSuiteValidation(unittest.TestCase):
             runner=self.runner,
         )
 
-        assert res.testCaseStatus == TestCaseStatus.Success
+        assert res.testCaseStatus == TestCaseStatus.Failed
 
         test_case = TestCase(
             name="my_test_case",

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResource.java
@@ -13,6 +13,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import javax.json.JsonPatch;
 import javax.validation.Valid;
 import javax.validation.constraints.Max;
@@ -170,7 +172,7 @@ public class TestCaseResource extends EntityResource<TestCase, TestCaseRepositor
     ResourceContextInterface resourceContext;
     if (entityLink != null) {
       EntityLink entityLinkParsed = EntityLink.parse(entityLink);
-      filter.addQueryParam("entityFQN", entityLinkParsed.getFullyQualifiedFieldValue());
+      filter.addQueryParam("entityFQN", URLEncoder.encode(entityLinkParsed.getFullyQualifiedFieldValue(), StandardCharsets.UTF_8));
       resourceContext = TestCaseResourceContext.builder().entityLink(entityLinkParsed).build();
     } else {
       resourceContext = TestCaseResourceContext.builder().build();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResource.java
@@ -11,10 +11,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
-import java.util.List;
-import java.util.UUID;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
 import javax.json.JsonPatch;
 import javax.validation.Valid;
 import javax.validation.constraints.Max;
@@ -172,7 +172,8 @@ public class TestCaseResource extends EntityResource<TestCase, TestCaseRepositor
     ResourceContextInterface resourceContext;
     if (entityLink != null) {
       EntityLink entityLinkParsed = EntityLink.parse(entityLink);
-      filter.addQueryParam("entityFQN", URLEncoder.encode(entityLinkParsed.getFullyQualifiedFieldValue(), StandardCharsets.UTF_8));
+      filter.addQueryParam(
+          "entityFQN", URLEncoder.encode(entityLinkParsed.getFullyQualifiedFieldValue(), StandardCharsets.UTF_8));
       resourceContext = TestCaseResourceContext.builder().entityLink(entityLinkParsed).build();
     } else {
       resourceContext = TestCaseResourceContext.builder().build();


### PR DESCRIPTION
### Describe your changes :

Issue #7623 

- Backend -> entityLink will be encoded (i.e. `first name` will become `first+name`)
- ingestion -> we will be expecting an encoded entityLink from the `testCase` (`+` to encode spaces). We will be decoding the column name to perform the check and run the tests

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
