### PR TITLE
Fix #7646 UI: Non-admin user should not be allowed to add a bot

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/BotListV1/BotListV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BotListV1/BotListV1.component.tsx
@@ -59,10 +59,15 @@ const BotListV1 = ({
   const [handleErrorPlaceholder, setHandleErrorPlaceholder] = useState(false);
   const [searchedData, setSearchedData] = useState<Bot[]>([]);
 
-  const createPermission = checkPermission(
-    Operation.Create,
-    ResourceEntity.BOT,
-    permissions
+  /**
+   * Bot creation is two step process so here we should check for
+   * Create User and Create Bot both permissions
+   */
+  const createPermission = useMemo(
+    () =>
+      checkPermission(Operation.Create, ResourceEntity.BOT, permissions) &&
+      checkPermission(Operation.Create, ResourceEntity.USER, permissions),
+    [permissions]
   );
 
   const deletePermission = useMemo(

--- a/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.test.tsx
@@ -105,6 +105,32 @@ const mockUserData = {
   ],
 };
 
+const mockUserRole = {
+  data: [
+    {
+      id: '3ed7b995-ce8b-4720-9beb-6f4a9c626920',
+      name: 'DataConsumer',
+      fullyQualifiedName: 'DataConsumer',
+      displayName: 'Data Consumer',
+      description:
+        'Users with Data Consumer role use different data assets for their day to day work.',
+      version: 0.1,
+      updatedAt: 1663825430544,
+      updatedBy: 'admin',
+      href: 'http://localhost:8585/api/v1/roles/3ed7b995-ce8b-4720-9beb-6f4a9c626920',
+      allowDelete: false,
+      deleted: false,
+    },
+  ],
+  paging: {
+    total: 1,
+  },
+};
+
+jest.mock('../../axiosAPIs/rolesAPIV1.ts', () => ({
+  getRoles: jest.fn().mockImplementation(() => Promise.resolve(mockUserRole)),
+}));
+
 jest.mock('../common/ProfilePicture/ProfilePicture', () => {
   return jest.fn().mockReturnValue(<p>ProfilePicture</p>);
 });

--- a/openmetadata-ui/src/main/resources/ui/src/jsons/en.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/jsons/en.ts
@@ -25,6 +25,7 @@ const jsonData = {
 
     'check-status-airflow': 'Error while connecting to Airflow instance!',
     'create-user-error': 'Error while creating user!',
+    'create-bot-error': 'Error while creating bot!',
     'create-conversation-error': 'Error while creating conversation!',
     'create-message-error': 'Error while creating message!',
     'create-role-error': 'Error While creating role!',

--- a/openmetadata-ui/src/main/resources/ui/src/pages/CreateUserPage/CreateUserPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/CreateUserPage/CreateUserPage.component.tsx
@@ -87,15 +87,22 @@ const CreateUserPage = () => {
               name: res.name,
               displayName: res.displayName,
               description: res.description,
-            } as Bot).then((res) => {
-              setStatus('success');
-              res && showSuccessToast(`Bot created successfully`);
-              setTimeout(() => {
-                setStatus('initial');
+            } as Bot)
+              .then((res) => {
+                setStatus('success');
+                res && showSuccessToast(`Bot created successfully`);
+                setTimeout(() => {
+                  setStatus('initial');
 
-                goToUserListPage();
-              }, 500);
-            });
+                  goToUserListPage();
+                }, 500);
+              })
+              .catch((err: AxiosError) => {
+                handleSaveFailure(
+                  err,
+                  jsonData['api-error-messages']['create-bot-error']
+                );
+              });
           } else {
             setStatus('success');
             setTimeout(() => {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/CreateUserPage/CreateUserPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/CreateUserPage/CreateUserPage.test.tsx
@@ -23,6 +23,32 @@ import { MemoryRouter } from 'react-router-dom';
 import { createUser } from '../../axiosAPIs/userAPI';
 import AddUserPageComponent from './CreateUserPage.component';
 
+const mockUserRole = {
+  data: [
+    {
+      id: '3ed7b995-ce8b-4720-9beb-6f4a9c626920',
+      name: 'DataConsumer',
+      fullyQualifiedName: 'DataConsumer',
+      displayName: 'Data Consumer',
+      description:
+        'Users with Data Consumer role use different data assets for their day to day work.',
+      version: 0.1,
+      updatedAt: 1663825430544,
+      updatedBy: 'admin',
+      href: 'http://localhost:8585/api/v1/roles/3ed7b995-ce8b-4720-9beb-6f4a9c626920',
+      allowDelete: false,
+      deleted: false,
+    },
+  ],
+  paging: {
+    total: 1,
+  },
+};
+
+jest.mock('../../axiosAPIs/rolesAPIV1', () => ({
+  getRoles: jest.fn().mockImplementation(() => Promise.resolve(mockUserRole)),
+}));
+
 jest.mock('../../components/containers/PageContainerV1', () => {
   return jest
     .fn()
@@ -53,7 +79,6 @@ jest.mock('../../axiosAPIs/userAPI', () => ({
 
 jest.mock('../../AppState', () =>
   jest.fn().mockReturnValue({
-    userRoles: [],
     userTeams: [],
   })
 );

--- a/openmetadata-ui/src/main/resources/ui/src/router/AuthenticatedAppRouter.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/router/AuthenticatedAppRouter.tsx
@@ -238,6 +238,13 @@ const AuthenticatedAppRouter: FunctionComponent = () => {
     [permissions]
   );
 
+  const createBotPermission = useMemo(
+    () =>
+      checkPermission(Operation.Create, ResourceEntity.USER, permissions) &&
+      checkPermission(Operation.Create, ResourceEntity.BOT, permissions),
+    [permissions]
+  );
+
   return (
     <Switch>
       <Route exact component={MyDataPage} path={ROUTES.MY_DATA} />
@@ -411,11 +418,7 @@ const AuthenticatedAppRouter: FunctionComponent = () => {
       <AdminProtectedRoute
         exact
         component={CreateUserPage}
-        hasPermission={checkPermission(
-          Operation.Create,
-          ResourceEntity.BOT,
-          permissions
-        )}
+        hasPermission={createBotPermission}
         path={ROUTES.CREATE_USER_WITH_BOT}
       />
       <Route exact component={BotDetailsPage} path={ROUTES.BOTS_PROFILE} />


### PR DESCRIPTION
Fixes #7646 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on issue #7646 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
