### PR TITLE
Fix a few typo in the doc (airflow instead of airbite)

### DIFF
--- a/openmetadata-docs/content/openmetadata/connectors/pipeline/airflow/cli.md
+++ b/openmetadata-docs/content/openmetadata/connectors/pipeline/airflow/cli.md
@@ -22,10 +22,10 @@ custom Airflow plugins to handle the workflow deployment.
 
 ### Python Requirements
 
-To run the Airbyte ingestion, you will need to install:
+To run the Airflow ingestion, you will need to install:
 
 ```bash
-pip3 install "openmetadata-ingestion[airbyte]"
+pip3 install "openmetadata-ingestion[airflow]"
 ```
 
 Note that this installs the same Airflow version that we ship in the Ingestion Container, which is


### PR DESCRIPTION
The documentation for Airflow include reference to Airbite ingestion.

### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the documentation fix because it refer to the wrong package

#
### Type of change :

- [x] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
 - @harshach (I see you are the one that work on that file in the past, if you're not the right one feel free to ignore it)
