### PR TITLE
UI: Added a switch to show soft deleted teams on team details page

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/TeamDetails/TeamDetailsV1.utils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TeamDetails/TeamDetailsV1.utils.tsx
@@ -21,14 +21,14 @@ export const getTabs = (
   teamUserPagin: Paging,
   isGroupType: boolean,
   isOrganization: boolean,
-  teamsCount?: number
+  teamsCount: number
 ) => {
   const tabs = {
     teams: {
       name: 'Teams',
       isProtected: false,
       position: 1,
-      count: isUndefined(teamsCount) ? currentTeam.childrenCount : teamsCount,
+      count: teamsCount,
     },
     users: {
       name: 'Users',

--- a/openmetadata-ui/src/main/resources/ui/src/interface/teamsAndUsers.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/interface/teamsAndUsers.interface.ts
@@ -113,6 +113,8 @@ export interface TeamDetailsProp {
   handleJoinTeamClick: (id: string, data: Operation[]) => void;
   handleLeaveTeamClick: (id: string, data: Operation[]) => Promise<void>;
   childTeams: Team[];
+  showDeletedTeam: boolean;
+  onShowDeletedTeamChange: (checked: boolean) => void;
   onTeamExpand: (
     isPageLoading?: boolean,
     parentTeam?: string,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/teams/TeamsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/teams/TeamsPage.tsx
@@ -231,7 +231,6 @@ const TeamsPage = () => {
       const res = await createTeam(teamData);
       if (res) {
         const parent = fqn ? selectedTeam.fullyQualifiedName : undefined;
-        handleAddTeam(false);
         fetchAllTeams(true, parent);
         fetchTeamByFqn(selectedTeam.name);
       }
@@ -240,6 +239,8 @@ const TeamsPage = () => {
         error as AxiosError,
         jsonData['api-error-messages']['create-team-error']
       );
+    } finally {
+      handleAddTeam(false);
     }
   };
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/teams/TeamsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/teams/TeamsPage.tsx
@@ -162,33 +162,6 @@ const TeamsPage = () => {
   };
 
   /**
-   * Take Team data as input and create the team
-   * @param data - Team Data
-   */
-  const createNewTeam = async (data: Team) => {
-    try {
-      const teamData: CreateTeam = {
-        name: data.name,
-        displayName: data.displayName,
-        description: data.description,
-        teamType: data.teamType as TeamType,
-        parents: fqn ? [selectedTeam.id] : undefined,
-      };
-      const res = await createTeam(teamData);
-      if (res) {
-        const parent = fqn ? selectedTeam.fullyQualifiedName : undefined;
-        handleAddTeam(false);
-        fetchAllTeams(true, parent);
-      }
-    } catch (error) {
-      showErrorToast(
-        error as AxiosError,
-        jsonData['api-error-messages']['create-team-error']
-      );
-    }
-  };
-
-  /**
    * Make API call to fetch current team user data
    */
   const getCurrentTeamUsers = (
@@ -240,6 +213,34 @@ const TeamsPage = () => {
       );
     }
     setIsPageLoading(false);
+  };
+
+  /**
+   * Take Team data as input and create the team
+   * @param data - Team Data
+   */
+  const createNewTeam = async (data: Team) => {
+    try {
+      const teamData: CreateTeam = {
+        name: data.name,
+        displayName: data.displayName,
+        description: data.description,
+        teamType: data.teamType as TeamType,
+        parents: fqn ? [selectedTeam.id] : undefined,
+      };
+      const res = await createTeam(teamData);
+      if (res) {
+        const parent = fqn ? selectedTeam.fullyQualifiedName : undefined;
+        handleAddTeam(false);
+        fetchAllTeams(true, parent);
+        fetchTeamByFqn(selectedTeam.name);
+      }
+    } catch (error) {
+      showErrorToast(
+        error as AxiosError,
+        jsonData['api-error-messages']['create-team-error']
+      );
+    }
   };
 
   const searchUsers = (text: string, currentPage: number) => {
@@ -514,11 +515,13 @@ const TeamsPage = () => {
               isDescriptionEditable={isDescriptionEditable}
               isTeamMemberLoading={isDataLoading}
               removeUserFromTeam={removeUserFromTeam}
+              showDeletedTeam={showDeletedTeam}
               teamUserPagin={userPaging}
               teamUserPaginHandler={userPagingHandler}
               teamUsersSearchText={userSearchValue}
               updateTeamHandler={updateTeamHandler}
               onDescriptionUpdate={onDescriptionUpdate}
+              onShowDeletedTeamChange={handleShowDeletedTeam}
               onTeamExpand={fetchAllTeams}
             />
           )}

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TeamUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TeamUtils.ts
@@ -12,7 +12,7 @@
  */
 
 import { isNil } from 'lodash';
-import { EntityReference } from '../generated/entity/teams/team';
+import { EntityReference, Team } from '../generated/entity/teams/team';
 
 /**
  * To get filtered list of non-deleted(active) users
@@ -22,3 +22,8 @@ import { EntityReference } from '../generated/entity/teams/team';
 export const getActiveUsers = (users?: Array<EntityReference>) => {
   return !isNil(users) ? users.filter((item) => !item.deleted) : [];
 };
+
+export const filterChildTeams = (
+  teamsList: Team[],
+  showDeletedTeams: boolean
+) => teamsList.filter((d) => d.deleted === showDeletedTeams);


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on adding a switch to show soft deleted teams on team details page.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement

#
### Frontend Preview (Screenshots) :
<p align="center">

https://user-images.githubusercontent.com/51777795/191962885-aad3446d-c9bf-49de-99e4-a48d2ed27e98.mov

</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @open-metadata/ui
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
