### PR TITLE
fix(ui): allow username or email login

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/authentication/authenticators/basic-auth.authenticator.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/authentication/authenticators/basic-auth.authenticator.tsx
@@ -1,3 +1,16 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 import React, {
   forwardRef,
   Fragment,

--- a/openmetadata-ui/src/main/resources/ui/src/axiosAPIs/auth-API.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/axiosAPIs/auth-API.ts
@@ -1,3 +1,16 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 import { AxiosResponse } from 'axios';
 import axiosClient from '.';
 import { LoginRequest } from '../generated/auth/loginRequest';

--- a/openmetadata-ui/src/main/resources/ui/src/jsons/en.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/jsons/en.ts
@@ -181,6 +181,7 @@ const jsonData = {
     'update-webhook-success': 'Webhook updated successfully!',
     'create-user-account': 'User account created successfully!',
     'reset-password-success': 'Password reset successfully!',
+    'account-verify-success': 'Email verified successfully!',
   },
   'form-error-messages': {
     'empty-email': 'Email is required.',

--- a/openmetadata-ui/src/main/resources/ui/src/pages/forgot-password/forgot-password.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/forgot-password/forgot-password.component.tsx
@@ -1,3 +1,16 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 import { Button, Card, Col, Form, Input, Row, Typography } from 'antd';
 import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/forgot-password/forgot-password.styles.less
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/forgot-password/forgot-password.styles.less
@@ -1,3 +1,16 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 input.forgot-email-input {
   border-color: #ff4c3b;
   &:focus {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/login/index.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/login/index.tsx
@@ -41,6 +41,11 @@ const SigninPage = () => {
     isAuthenticated,
   } = useAuthContext();
 
+  const enableSelfSignUp = useMemo(
+    () => authConfig?.enableSelfSignup,
+    [authConfig]
+  );
+
   const { isAuthProviderBasic } = useMemo(() => {
     return {
       isAuthProviderBasic: authConfig?.provider === AuthTypes.BASIC,
@@ -218,22 +223,26 @@ const SigninPage = () => {
                   </Typography.Link>
                 </div>
 
-                <Divider className="w-min-0 mt-8 mb-12 justify-center">
-                  <Typography.Text type="secondary">or</Typography.Text>
-                </Divider>
+                {enableSelfSignUp && (
+                  <>
+                    <Divider className="w-min-0 mt-8 mb-12 justify-center">
+                      <Typography.Text type="secondary">or</Typography.Text>
+                    </Divider>
 
-                <div className="mt-4 flex flex-center">
-                  <Typography.Text className="mr-4">
-                    New on the platform?
-                  </Typography.Text>
-                  <Button
-                    ghost
-                    data-testid="signup"
-                    type="link"
-                    onClick={onClickSignUp}>
-                    Create Account
-                  </Button>
-                </div>
+                    <div className="mt-4 flex flex-center">
+                      <Typography.Text className="mr-4">
+                        New on the platform?
+                      </Typography.Text>
+                      <Button
+                        ghost
+                        data-testid="signup"
+                        type="link"
+                        onClick={onClickSignUp}>
+                        Create Account
+                      </Button>
+                    </div>
+                  </>
+                )}
               </div>
             ) : (
               <div className="">{getSignInButton()}</div>

--- a/openmetadata-ui/src/main/resources/ui/src/pages/login/login.style.less
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/login/login.style.less
@@ -1,3 +1,16 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 .ant-form-item-explain-error {
   text-align: left;
 }

--- a/openmetadata-ui/src/main/resources/ui/src/pages/reset-password/reset-password.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/reset-password/reset-password.component.tsx
@@ -1,4 +1,18 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 import { Alert, Button, Card, Col, Form, Input, Row, Typography } from 'antd';
+import { AxiosError } from 'axios';
 import React, { useEffect, useMemo } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import { useBasicAuth } from '../../authentication/auth-provider/basic-auth.provider';
@@ -6,7 +20,9 @@ import { VALIDATION_MESSAGES } from '../../constants/auth.constants';
 import { ROUTES } from '../../constants/constants';
 import { passwordRegex } from '../../constants/regex.constants';
 import { PasswordResetRequest } from '../../generated/auth/passwordResetRequest';
+import jsonData from '../../jsons/en';
 import SVGIcons, { Icons } from '../../utils/SvgUtils';
+import { showErrorToast } from '../../utils/ToastUtils';
 import './reset-password.style.less';
 import { getUserNameAndToken } from './reset-password.utils';
 
@@ -34,7 +50,7 @@ const ResetPassword = () => {
 
   const password = Form.useWatch('password', form);
 
-  const handleSubmit = (data: ResetFormData) => {
+  const handleSubmit = async (data: ResetFormData) => {
     const ResetRequest = {
       token: params?.token,
       username: params?.userName,
@@ -42,7 +58,15 @@ const ResetPassword = () => {
       confirmPassword: data.confirmPassword,
     } as PasswordResetRequest;
 
-    handleResetPassword(ResetRequest);
+    try {
+      await handleResetPassword(ResetRequest);
+      history.push(ROUTES.SIGNIN);
+    } catch (err) {
+      showErrorToast(
+        err as AxiosError,
+        jsonData['api-error-messages']['unexpected-server-response']
+      );
+    }
   };
 
   const handleReVerify = () => history.push(ROUTES.FORGOT_PASSWORD);

--- a/openmetadata-ui/src/main/resources/ui/src/pages/reset-password/reset-password.style.less
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/reset-password/reset-password.style.less
@@ -1,3 +1,16 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 .reset-logo {
   display: flex;
   justify-content: center;

--- a/openmetadata-ui/src/main/resources/ui/src/pages/reset-password/reset-password.utils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/reset-password/reset-password.utils.ts
@@ -1,3 +1,16 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 export const getUserNameAndToken = (searchParam: string) => {
   const searchParams = new URLSearchParams(searchParam);
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/signup/account-activation-confirmation.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/signup/account-activation-confirmation.component.tsx
@@ -1,3 +1,16 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 import { Alert, Card, Space, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import { isEmpty } from 'lodash';
@@ -6,7 +19,7 @@ import { useHistory, useLocation } from 'react-router-dom';
 import { confirmRegistration } from '../../axiosAPIs/auth-API';
 import { ROUTES } from '../../constants/constants';
 import jsonData from '../../jsons/en';
-import { showErrorToast } from '../../utils/ToastUtils';
+import { showErrorToast, showSuccessToast } from '../../utils/ToastUtils';
 
 const AccountActivationConfirmation = () => {
   const [isAccountVerified, setIsAccountVerified] = useState(false);
@@ -20,6 +33,10 @@ const AccountActivationConfirmation = () => {
       const res = await confirmRegistration(searchParam.get('token') as string);
       if (!isEmpty(res)) {
         setIsAccountVerified(true);
+        showSuccessToast(
+          jsonData['api-success-messages']['account-verify-success']
+        );
+        history.push(ROUTES.SIGNIN);
       }
     } catch (err) {
       showErrorToast(
@@ -37,33 +54,31 @@ const AccountActivationConfirmation = () => {
 
   return (
     <Card>
-      <>
-        {isAccountVerified ? (
-          <div className="mt-12 w-16">
-            <Space align="center" direction="vertical">
-              <Alert
-                showIcon
-                message="User Verified Successfully"
-                type="success"
-              />
-              <div className="mt-12" onClick={handleBackToLogin}>
-                <Typography.Link underline>back to login</Typography.Link>
-              </div>
-            </Space>
-          </div>
-        ) : (
-          <div className="mt-12 w-16">
-            <Space align="center" direction="vertical">
-              <Alert showIcon message="Token Expired" type="error" />
-              <div className="mt-12">
-                <Typography.Link underline>
-                  Regenerate registration token
-                </Typography.Link>
-              </div>
-            </Space>
-          </div>
-        )}
-      </>
+      {isAccountVerified ? (
+        <div className="mt-12 w-16">
+          <Space align="center" direction="vertical">
+            <Alert
+              showIcon
+              message="User Verified Successfully"
+              type="success"
+            />
+            <div className="mt-12" onClick={handleBackToLogin}>
+              <Typography.Link underline>back to login</Typography.Link>
+            </div>
+          </Space>
+        </div>
+      ) : (
+        <div className="mt-12 w-16">
+          <Space align="center" direction="vertical">
+            <Alert showIcon message="Token Expired" type="error" />
+            <div className="mt-12">
+              <Typography.Link underline>
+                Regenerate registration token
+              </Typography.Link>
+            </div>
+          </Space>
+        </div>
+      )}
     </Card>
   );
 };

--- a/openmetadata-ui/src/main/resources/ui/src/pages/signup/basic-signup.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/signup/basic-signup.component.tsx
@@ -1,3 +1,16 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 import { Button, Col, Divider, Form, Input, Row, Typography } from 'antd';
 import { isEmpty } from 'lodash';
 import React, { useMemo } from 'react';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/signup/basic-signup.style.less
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/signup/basic-signup.style.less
@@ -1,3 +1,16 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 .basic-auth-card .children-container {
   margin: 1rem 3rem;
 }

--- a/openmetadata-ui/src/main/resources/ui/src/router/AppRouter.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/router/AppRouter.tsx
@@ -13,7 +13,7 @@
 
 import { AxiosError } from 'axios';
 import { SlackChatConfig } from 'Models';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import { useAuthContext } from '../authentication/auth-provider/AuthProvider';
 import { fetchSlackConfig } from '../axiosAPIs/miscAPI';
@@ -55,6 +55,12 @@ const AppRouter = () => {
     isSigningIn,
     getCallBackComponent,
   } = useAuthContext();
+
+  const enableSelfSignUp = useMemo(
+    () => authConfig?.enableSelfSignup,
+    [authConfig]
+  );
+
   const [slackConfig, setSlackConfig] = useState<SlackChatConfig | undefined>();
   const callbackComponent = getCallBackComponent();
   const oidcProviders = [
@@ -107,7 +113,9 @@ const AppRouter = () => {
         <>
           {slackChat}
           <Switch>
-            <Route exact component={BasicSignupPage} path={ROUTES.REGISTER} />
+            {enableSelfSignUp && (
+              <Route exact component={BasicSignupPage} path={ROUTES.REGISTER} />
+            )}
 
             <Route exact path={ROUTES.HOME}>
               {!isAuthDisabled && !isAuthenticated && !isSigningIn ? (

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AuthProvider.util.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AuthProvider.util.ts
@@ -211,6 +211,7 @@ export const isProtectedRoute = (pathname: string) => {
       ROUTES.SILENT_CALLBACK,
       ROUTES.REGISTER,
       ROUTES.RESET_PASSWORD,
+      ROUTES.ACCOUNT_ACTIVATION,
     ].indexOf(pathname) === -1
   );
 };

--- a/openmetadata-ui/src/main/resources/ui/src/utils/LocalStorageUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/LocalStorageUtils.ts
@@ -1,3 +1,16 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 import { oidcTokenKey, refreshTokenKey } from '../constants/constants';
 
 /* A util that sets and gets the data in/from local storage. 

--- a/openmetadata-ui/src/main/resources/ui/src/utils/UserDataUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/UserDataUtils.ts
@@ -53,7 +53,10 @@ export const getUserDataFromOidc = (
     ? getImages(oidcUser.profile.picture)
     : undefined;
   const profileEmail = oidcUser.profile.email;
-  const email = profileEmail ? profileEmail : userData.email;
+  const email =
+    profileEmail && profileEmail.indexOf('@') !== -1
+      ? profileEmail
+      : userData.email;
 
   return {
     ...userData,


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the:

1. Added licence file to each newly files
2. Fix error/success messages
3. Tested with username sign-in only
4. Once the email confirm user should get toast and redirect to the Sign in page
5. Integrate self signup feature so that admin can control over who can sign-in or not

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] Improvement

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
