### PR TITLE
Fixed issue : Trailing space in display name and FQN of glossary term is not handled correctly

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/AddGlossaryTerm/AddGlossaryTerm.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AddGlossaryTerm/AddGlossaryTerm.component.tsx
@@ -219,9 +219,10 @@ const AddGlossaryTerm = ({
     }));
 
     if (validateForm(updatedReference)) {
+      const updatedName = name.trim();
       const data: CreateGlossaryTerm = {
-        name,
-        displayName: name,
+        name: updatedName,
+        displayName: updatedName,
         description: getDescription(),
         reviewers: reviewer.map((r) => ({
           id: r.id,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryV1.component.tsx
@@ -251,7 +251,7 @@ const GlossaryV1 = ({
 
     updatedDetails = {
       ...selectedData,
-      displayName: displayName,
+      displayName: displayName?.trim(),
     };
 
     if (


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the issue where Trailing space in display name and FQN of glossary term is not handled correctly
https://github.com/open-metadata/OpenMetadata/issues/7074#issuecomment-1245849177
Closes #7704

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement


#
### Frontend Preview (Screenshots) :


https://user-images.githubusercontent.com/71748675/192083464-8a9367b8-8448-45fe-abdc-59adba7b03da.mov


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
