### PR TITLE
UI: Added cypress tests for soft deleted team checks.

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/cypress/common/common.js
+++ b/openmetadata-ui/src/main/resources/ui/cypress/common/common.js
@@ -19,7 +19,17 @@ export const uuid = () => Cypress._.random(0, 1e6);
 
 const AARON_JOHNSON = 'Aaron Johnson';
 
+const TEAM_TYPES = ['BusinessUnit', 'Department', 'Division', 'Group'];
+
 const isDatabaseService = (type) => type === 'database';
+
+const checkTeamTypeOptions = () => {
+  for (const teamType of TEAM_TYPES) {
+    cy.get(`.ant-select-dropdown [title="${teamType}"]`)
+      .should('exist')
+      .should('be.visible');
+  }
+};
 
 //intercepting URL with cy.intercept
 export const interceptURL = (method, url, alias) => {
@@ -816,10 +826,23 @@ export const addTeam = (TEAM_DETAILS) => {
     .should('be.visible')
     .type(TEAM_DETAILS.displayName);
 
+  cy.get('[data-testid="team-selector"]')
+    .should('exist')
+    .should('be.visible')
+    .click();
+
+  checkTeamTypeOptions();
+
+  cy.get(`.ant-select-dropdown [title="${TEAM_DETAILS.teamType}"]`)
+    .should('exist')
+    .should('be.visible')
+    .click();
+
   cy.get(descriptionBox)
     .should('exist')
     .should('be.visible')
     .type(TEAM_DETAILS.description);
+
   interceptURL('POST', '/api/v1/teams', 'saveTeam');
   interceptURL('GET', '/api/v1/team*', 'createTeam');
 

--- a/openmetadata-ui/src/main/resources/ui/cypress/common/common.js
+++ b/openmetadata-ui/src/main/resources/ui/cypress/common/common.js
@@ -753,11 +753,15 @@ export const updateOwner = () => {
     .invoke('text')
     .then((text) => {
       cy.get('[data-testid="hiden-layer"]').should('exist').click();
-      interceptURL('GET', '/api/v1/users/loggedInUser/groupTeams', 'getUser');
+      interceptURL(
+        'GET',
+        '/api/v1/search/query?q=*%20AND%20teamType:Group&from=0&size=10&index=team_search_index',
+        'getTeams'
+      );
       //Clicking on edit owner button
       cy.get('[data-testid="edit-Owner-icon"]').should('be.visible').click();
 
-      verifyResponseStatusCode('@getUser', 200);
+      verifyResponseStatusCode('@getTeams', 200);
 
       //Clicking on users tab
       cy.get('button[data-testid="dropdown-tab"]')
@@ -788,4 +792,43 @@ export const login = (username, password) => {
   cy.get('[id="email"]').should('be.visible').clear().type(username);
   cy.get('[id="password"]').should('be.visible').clear().type(password);
   cy.get('.ant-btn').contains('Login').should('be.visible').click();
+};
+
+export const addTeam = (TEAM_DETAILS) => {
+  interceptURL('GET', '/api/v1/teams*', 'addTeam');
+  //Fetching the add button and clicking on it
+  cy.get('button')
+    .find('span')
+    .contains('Add Team')
+    .should('be.visible')
+    .click();
+
+  verifyResponseStatusCode('@addTeam', 200);
+
+  //Entering team details
+  cy.get('[data-testid="name"]')
+    .should('exist')
+    .should('be.visible')
+    .type(TEAM_DETAILS.name);
+
+  cy.get('[data-testid="display-name"]')
+    .should('exist')
+    .should('be.visible')
+    .type(TEAM_DETAILS.displayName);
+
+  cy.get(descriptionBox)
+    .should('exist')
+    .should('be.visible')
+    .type(TEAM_DETAILS.description);
+  interceptURL('POST', '/api/v1/teams', 'saveTeam');
+  interceptURL('GET', '/api/v1/team*', 'createTeam');
+
+  //Saving the created team
+  cy.get('[form="add-team-form"]')
+    .scrollIntoView()
+    .should('be.visible')
+    .click();
+
+  verifyResponseStatusCode('@saveTeam', 201);
+  verifyResponseStatusCode('@createTeam', 200);
 };

--- a/openmetadata-ui/src/main/resources/ui/cypress/e2e/Pages/Teams.spec.js
+++ b/openmetadata-ui/src/main/resources/ui/cypress/e2e/Pages/Teams.spec.js
@@ -21,6 +21,7 @@ const TEAM_DETAILS = {
   name: teamName,
   displayName: teamName,
   updatedname: `${teamName}-updated`,
+  teamType: 'Department',
   description: `This is ${teamName} description`,
   ownername: 'Aaron Johnson',
   assetname: 'dim_address',
@@ -303,6 +304,27 @@ describe('Teams flow should work properly', () => {
       .should('be.visible')
       .click();
 
+    cy.get('[data-testid="confirm-button"]')
+      .should('exist')
+      .should('be.disabled');
+
+    cy.get('[data-testid="discard-button"]')
+      .should('exist')
+      .should('be.visible')
+      .click();
+
+    cy.get('[data-testid="manage-button"]')
+      .should('exist')
+      .should('be.visible')
+      .click();
+
+    cy.get('[data-menu-id*="delete-button"]').should('be.visible');
+
+    cy.get('[data-testid="delete-button-title"]')
+      .should('exist')
+      .should('be.visible')
+      .click();
+
     //Click on soft delete option
     cy.get('[data-testid="soft-delete-option"]')
       .should('contain', TEAM_DETAILS.name)
@@ -379,7 +401,7 @@ describe('Teams flow should work properly', () => {
     cy.get('table').should('not.contain', TEAM_DETAILS.name);
   });
 
-  it('Permanently delete team without soft delete should work properly', () => {
+  it('Permanently deleting a team without soft deleting should work properly', () => {
     //Add a new team
     addTeam(TEAM_DETAILS);
 
@@ -392,6 +414,27 @@ describe('Teams flow should work properly', () => {
     cy.get('table').find('.ant-table-row').contains(TEAM_DETAILS.name).click();
 
     verifyResponseStatusCode('@getSelectedTeam', 200);
+
+    cy.get('[data-testid="manage-button"]')
+      .should('exist')
+      .should('be.visible')
+      .click();
+
+    cy.get('[data-menu-id*="delete-button"]').should('be.visible');
+
+    cy.get('[data-testid="delete-button-title"]')
+      .should('exist')
+      .should('be.visible')
+      .click();
+
+    cy.get('[data-testid="confirm-button"]')
+      .should('exist')
+      .should('be.disabled');
+
+    cy.get('[data-testid="discard-button"]')
+      .should('exist')
+      .should('be.visible')
+      .click();
 
     cy.get('[data-testid="manage-button"]')
       .should('exist')

--- a/openmetadata-ui/src/main/resources/ui/cypress/e2e/Pages/Teams.spec.js
+++ b/openmetadata-ui/src/main/resources/ui/cypress/e2e/Pages/Teams.spec.js
@@ -11,9 +11,8 @@
  *  limitations under the License.
  */
 
-import { descriptionBox, interceptURL, login, toastNotification, updateOwner, uuid, verifyResponseStatusCode } from '../../common/common';
+import { addTeam, descriptionBox, interceptURL, login, toastNotification, updateOwner, uuid, verifyResponseStatusCode } from '../../common/common';
 import { LOGIN } from '../../constants/constants';
-
 
 const updateddescription = 'This is updated description';
 
@@ -44,42 +43,7 @@ describe('Teams flow should work properly', () => {
   });
 
   it('Add new team', () => {
-    interceptURL('GET', '/api/v1/teams*', 'addTeam');
-    //Fetching the add button and clicking on it
-    cy.get('button')
-      .find('span')
-      .contains('Add Team')
-      .should('be.visible')
-      .click();
-
-    verifyResponseStatusCode('@addTeam', 200);
-
-    //Entering team details
-    cy.get('[data-testid="name"]')
-      .should('exist')
-      .should('be.visible')
-      .type(TEAM_DETAILS.name);
-
-    cy.get('[data-testid="display-name"]')
-      .should('exist')
-      .should('be.visible')
-      .type(TEAM_DETAILS.displayName);
-
-    cy.get(descriptionBox)
-      .should('exist')
-      .should('be.visible')
-      .type(TEAM_DETAILS.description);
-    interceptURL('POST', '/api/v1/teams', 'saveTeam');
-    interceptURL('GET', '/api/v1/team*', 'createTeam');
-
-    //Saving the created team
-    cy.get('[form="add-team-form"]')
-      .scrollIntoView()
-      .should('be.visible')
-      .click();
-
-    verifyResponseStatusCode('@saveTeam', 201);
-    verifyResponseStatusCode('@createTeam', 200);
+    addTeam(TEAM_DETAILS);
 
     cy.reload();
 
@@ -315,7 +279,110 @@ describe('Teams flow should work properly', () => {
     cy.get('body').find('[data-testid="join-teams"]').should('exist');
   });
 
-  it('Delete created team', () => {
+  it('Permanently deleting soft deleted team should work properly', () => {
+    interceptURL(
+      'GET',
+      `/api/v1/teams/name/${TEAM_DETAILS.name}*`,
+      'getSelectedTeam'
+    );
+
+    //Click on created team
+    cy.get('table').find('.ant-table-row').contains(TEAM_DETAILS.name).click();
+
+    verifyResponseStatusCode('@getSelectedTeam', 200);
+
+    cy.get('[data-testid="manage-button"]')
+      .should('exist')
+      .should('be.visible')
+      .click();
+
+    cy.get('[data-menu-id*="delete-button"]').should('be.visible');
+
+    cy.get('[data-testid="delete-button-title"]')
+      .should('exist')
+      .should('be.visible')
+      .click();
+
+    //Click on soft delete option
+    cy.get('[data-testid="soft-delete-option"]')
+      .should('contain', TEAM_DETAILS.name)
+      .should('be.visible')
+      .click();
+
+    cy.get('[data-testid="confirmation-text-input"]').type('DELETE');
+
+    interceptURL('DELETE', '/api/v1/teams/*', 'softDeleteTeam');
+
+    cy.get('[data-testid="confirm-button"]')
+      .should('exist')
+      .should('be.visible')
+      .click();
+
+    verifyResponseStatusCode('@softDeleteTeam', 200);
+
+    //Verify the toast message
+    toastNotification('Team deleted successfully!');
+
+    //Check if soft deleted team is shown when 'Deleted Teams' switch is on
+    cy.get('table').should('not.contain', TEAM_DETAILS.name);
+
+    cy.get('[data-testid="show-deleted-switch"').should('exist').click();
+
+    interceptURL(
+      'GET',
+      `/api/v1/teams/name/${TEAM_DETAILS.name}*`,
+      'getSelectedTeam'
+    );
+
+    cy.get('table').should('contain', TEAM_DETAILS.name).click();
+
+    cy.get('table').find('.ant-table-row').contains(TEAM_DETAILS.name).click();
+
+    verifyResponseStatusCode('@getSelectedTeam', 200);
+
+    cy.get('[data-testid="manage-button"]')
+      .should('exist')
+      .should('be.visible')
+      .click();
+
+    cy.get('[data-menu-id*="delete-button"]').should('be.visible');
+
+    cy.get('[data-testid="delete-button-title"]')
+      .should('exist')
+      .should('be.visible')
+      .click();
+
+    //Check if soft delete option is not present
+    cy.get('[data-testid="soft-delete-option"]').should('not.exist');
+
+    //Click on permanent delete option
+    cy.get('[data-testid="hard-delete-option"]')
+      .should('contain', TEAM_DETAILS.name)
+      .should('be.visible')
+      .click();
+
+    cy.get('[data-testid="confirmation-text-input"]').type('DELETE');
+
+    interceptURL('DELETE', '/api/v1/teams/*', 'deleteTeam');
+    cy.get('[data-testid="confirm-button"]')
+      .should('exist')
+      .should('be.visible')
+      .click();
+
+    verifyResponseStatusCode('@deleteTeam', 200);
+
+    //Verify the toast message
+    toastNotification('Team deleted successfully!');
+
+    //Validating the deleted team
+
+    cy.get('table').should('not.contain', TEAM_DETAILS.name);
+  });
+
+  it('Permanently delete team without soft delete should work properly', () => {
+    //Add a new team
+    addTeam(TEAM_DETAILS);
+
     interceptURL(
       'GET',
       `/api/v1/teams/name/${TEAM_DETAILS.name}*`,
@@ -337,6 +404,11 @@ describe('Teams flow should work properly', () => {
       .should('exist')
       .should('be.visible')
       .click();
+
+    //Check if soft delete option is present
+    cy.get('[data-testid="soft-delete-option"]')
+      .should('contain', TEAM_DETAILS.name)
+      .should('be.visible');
 
     //Click on permanent delete option
     cy.get('[data-testid="hard-delete-option"]')

--- a/openmetadata-ui/src/main/resources/ui/src/components/TeamDetails/TeamDetailsV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TeamDetails/TeamDetailsV1.tsx
@@ -972,6 +972,7 @@ const TeamDetailsV1 = ({
                       <Space align="center">
                         <Switch
                           checked={showDeletedTeam}
+                          data-testid="show-deleted-switch"
                           onChange={onShowDeletedTeamChange}
                         />
                         <span>Deleted Teams</span>

--- a/openmetadata-ui/src/main/resources/ui/src/pages/teams/AddTeamForm.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/teams/AddTeamForm.tsx
@@ -142,6 +142,7 @@ const AddTeamForm: React.FC<AddTeamFormType> = ({
         </Form.Item>
         <Form.Item label="Team type" name="teamType">
           <Select
+            data-testid="team-selector"
             options={teamTypeOptions}
             placeholder="Please select a team type"
           />


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the adding cypress tests for checking the option for permanent delete is available for soft deleted teams
#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement

#
### Frontend Preview (Screenshots) :
<p align="center">

</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @open-metadata/ui
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
