### PR TITLE
Fix: RedshiftSource’ object has no attribute ‘dbt_manifest’

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/database_service.py
+++ b/ingestion/src/metadata/ingestion/source/database/database_service.py
@@ -235,13 +235,16 @@ class DatabaseServiceSource(DBTMixin, TopologyRunnerMixin, Source, ABC):
     dbt_tests = {}
 
     def __init__(self):
-        if hasattr(self.source_config.dbtConfigSource, "dbtSecurityConfig"):
-            if self.source_config.dbtConfigSource.dbtSecurityConfig is None:
-                logger.info("dbtConfigSource is not configured")
-                self.dbt_catalog = None
-                self.dbt_manifest = None
-                self.dbt_run_results = None
-                self.data_models = {}
+
+        if (
+            hasattr(self.source_config.dbtConfigSource, "dbtSecurityConfig")
+            and self.source_config.dbtConfigSource.dbtSecurityConfig is None
+        ):
+            logger.info("dbtConfigSource is not configured")
+            self.dbt_catalog = None
+            self.dbt_manifest = None
+            self.dbt_run_results = None
+            self.data_models = {}
         else:
             dbt_details = get_dbt_details(self.source_config.dbtConfigSource)
             if dbt_details:


### PR DESCRIPTION


### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the fixing Error initializing ingest: ‘RedshiftSource’ object has no attribute ‘dbt_manifest’.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement


### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
