### PR TITLE
Fix minor issues with dbt test results ingestion

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/dbt_source.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt_source.py
@@ -413,11 +413,11 @@ class DBTMixin:
                 try:
                     # Process the Test Status
                     test_case_status = TestCaseStatus.Aborted
-                    test_result_value = -1
-                    if dbt_test_result.get("status") == "success":
+                    test_result_value = 0
+                    if dbt_test_result.get("status") in {"success", "pass"}:
                         test_case_status = TestCaseStatus.Success
                         test_result_value = 1
-                    elif dbt_test_result.get("status") == "failure":
+                    elif dbt_test_result.get("status") in {"failure", "fail"}:
                         test_case_status = TestCaseStatus.Failed
                         test_result_value = 0
 
@@ -431,8 +431,8 @@ class DBTMixin:
                     if dbt_test_completed_at:
                         dbt_timestamp = datetime.strptime(
                             dbt_test_completed_at, "%Y-%m-%dT%H:%M:%S.%fZ"
-                        )
-                        dbt_timestamp = self.unix_time_millis(dbt_timestamp)
+                        ).replace(microsecond=0)
+                        dbt_timestamp = dbt_timestamp.timestamp()
 
                     test_case_result = TestCaseResult(
                         timestamp=dbt_timestamp,

--- a/ingestion/src/metadata/ingestion/source/database/dbt_source.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt_source.py
@@ -511,11 +511,3 @@ class DBTMixin:
                 entity_link = f"<#E::table::" f"{table_fqn}>"
             entity_link_list.append(entity_link)
         return entity_link_list
-
-    def unix_time(self, dt):
-        epoch = datetime.utcfromtimestamp(0)
-        delta = dt - epoch
-        return delta.total_seconds()
-
-    def unix_time_millis(self, dt):
-        return int(self.unix_time(dt) * 1000)


### PR DESCRIPTION
- Added support for test ingestion without `dbt docs generate` run
- removed millisecond from timestamp
- changed test result failure to 0

### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the ..... because ...

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
