### PR TITLE
(Feature) UI: Add ability to view and delete "soft-deleted" tests#7728

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/ProfilerDashboard/ProfilerDashboard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ProfilerDashboard/ProfilerDashboard.tsx
@@ -10,8 +10,19 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { Button, Col, Form, Radio, Row, Select, Space, Tooltip } from 'antd';
+import {
+  Button,
+  Col,
+  Form,
+  Radio,
+  Row,
+  Select,
+  Space,
+  Switch,
+  Tooltip,
+} from 'antd';
 import { RadioChangeEvent } from 'antd/lib/radio';
+import { SwitchChangeEventHandler } from 'antd/lib/switch';
 import { AxiosError } from 'axios';
 import { EntityTags, ExtraInfo } from 'Models';
 import React, { useEffect, useMemo, useState } from 'react';
@@ -79,6 +90,7 @@ const ProfilerDashboard: React.FC<ProfilerDashboardProps> = ({
   fetchProfilerData,
   fetchTestCases,
   onTestCaseUpdate,
+  isTestCaseLoading,
   profilerData,
   onTableChange,
 }) => {
@@ -93,6 +105,7 @@ const ProfilerDashboard: React.FC<ProfilerDashboardProps> = ({
   const isColumnView = dashboardType === ProfilerDashboardType.COLUMN;
   const [follower, setFollower] = useState<EntityReference[]>([]);
   const [isFollowing, setIsFollowing] = useState<boolean>(false);
+  const [showDeletedTest, setShowDeletedTest] = useState<boolean>(false);
   const [activeTab, setActiveTab] = useState<ProfilerDashboardTab>(
     tab ?? ProfilerDashboardTab.PROFILER
   );
@@ -350,6 +363,7 @@ const ProfilerDashboard: React.FC<ProfilerDashboardProps> = ({
     }
     setSelectedTestCaseStatus('');
     setActiveTab(value);
+    setShowDeletedTest(false);
     history.push(
       getProfilerDashboardWithFqnPath(dashboardType, entityTypeFQN, value)
     );
@@ -389,6 +403,15 @@ const ProfilerDashboard: React.FC<ProfilerDashboardProps> = ({
     );
 
     return dataByStatus;
+  };
+
+  const handleDeletedTestCaseClick: SwitchChangeEventHandler = (value) => {
+    setShowDeletedTest(value);
+    onTestCaseUpdate(value);
+  };
+
+  const handleTestUpdate = () => {
+    onTestCaseUpdate(showDeletedTest);
   };
 
   useEffect(() => {
@@ -455,13 +478,21 @@ const ProfilerDashboard: React.FC<ProfilerDashboardProps> = ({
 
             <Space size={16}>
               {activeTab === ProfilerDashboardTab.DATA_QUALITY && (
-                <Form.Item className="tw-mb-0 tw-w-40" label="Status">
-                  <Select
-                    options={testCaseStatusOption}
-                    value={selectedTestCaseStatus}
-                    onChange={handleTestCaseStatusChange}
-                  />
-                </Form.Item>
+                <>
+                  <Form.Item className="m-0 " label="Deleted Tests">
+                    <Switch
+                      checked={showDeletedTest}
+                      onClick={handleDeletedTestCaseClick}
+                    />
+                  </Form.Item>
+                  <Form.Item className="tw-mb-0 tw-w-40" label="Status">
+                    <Select
+                      options={testCaseStatusOption}
+                      value={selectedTestCaseStatus}
+                      onChange={handleTestCaseStatusChange}
+                    />
+                  </Form.Item>
+                </>
               )}
               {activeTab === ProfilerDashboardTab.PROFILER && (
                 <Select
@@ -502,9 +533,11 @@ const ProfilerDashboard: React.FC<ProfilerDashboardProps> = ({
         {activeTab === ProfilerDashboardTab.DATA_QUALITY && (
           <Col span={24}>
             <DataQualityTab
+              deletedTable={showDeletedTest}
               hasAccess={tablePermissions.EditAll}
+              isLoading={isTestCaseLoading}
               testCases={getFilterTestCase()}
-              onTestUpdate={onTestCaseUpdate}
+              onTestUpdate={handleTestUpdate}
             />
           </Col>
         )}

--- a/openmetadata-ui/src/main/resources/ui/src/components/ProfilerDashboard/component/DataQualityTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ProfilerDashboard/component/DataQualityTab.tsx
@@ -39,7 +39,7 @@ import { DataQualityTabProps } from '../profilerDashboard.interface';
 import TestSummary from './TestSummary';
 
 const DataQualityTab: React.FC<DataQualityTabProps> = ({
-  isLoading,
+  isLoading = false,
   testCases,
   deletedTable = false,
   onTestUpdate,

--- a/openmetadata-ui/src/main/resources/ui/src/components/ProfilerDashboard/component/DataQualityTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ProfilerDashboard/component/DataQualityTab.tsx
@@ -150,29 +150,31 @@ const DataQualityTab: React.FC<DataQualityTabProps> = ({
         render: (_, record) => {
           return (
             <Row align="middle">
-              <Tooltip
-                placement="bottomRight"
-                title={hasAccess ? 'Edit' : NO_PERMISSION_FOR_ACTION}>
-                <Button
-                  className="flex-center"
-                  data-testid={`edit-${record.name}`}
-                  disabled={!hasAccess}
-                  icon={
-                    <SVGIcons
-                      alt="edit"
-                      className="tw-h-4"
-                      icon={Icons.EDIT}
-                      title="Edit"
-                    />
-                  }
-                  type="text"
-                  onClick={(e) => {
-                    // preventing expand/collapse on click of edit button
-                    e.stopPropagation();
-                    setEditTestCase(record);
-                  }}
-                />
-              </Tooltip>
+              {!deletedTable && (
+                <Tooltip
+                  placement="bottomRight"
+                  title={hasAccess ? 'Edit' : NO_PERMISSION_FOR_ACTION}>
+                  <Button
+                    className="flex-center"
+                    data-testid={`edit-${record.name}`}
+                    disabled={!hasAccess}
+                    icon={
+                      <SVGIcons
+                        alt="edit"
+                        className="tw-h-4"
+                        icon={Icons.EDIT}
+                        title="Edit"
+                      />
+                    }
+                    type="text"
+                    onClick={(e) => {
+                      // preventing expand/collapse on click of edit button
+                      e.stopPropagation();
+                      setEditTestCase(record);
+                    }}
+                  />
+                </Tooltip>
+              )}
               <Tooltip
                 placement="bottomLeft"
                 title={hasAccess ? 'Delete' : NO_PERMISSION_FOR_ACTION}>
@@ -200,7 +202,7 @@ const DataQualityTab: React.FC<DataQualityTabProps> = ({
         },
       },
     ];
-  }, [hasAccess]);
+  }, [hasAccess, deletedTable]);
 
   return (
     <>

--- a/openmetadata-ui/src/main/resources/ui/src/components/ProfilerDashboard/component/DataQualityTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ProfilerDashboard/component/DataQualityTab.tsx
@@ -34,11 +34,14 @@ import {
 } from '../../../utils/TableUtils';
 import EditTestCaseModal from '../../AddDataQualityTest/EditTestCaseModal';
 import DeleteWidgetModal from '../../common/DeleteWidget/DeleteWidgetModal';
+import Loader from '../../Loader/Loader';
 import { DataQualityTabProps } from '../profilerDashboard.interface';
 import TestSummary from './TestSummary';
 
 const DataQualityTab: React.FC<DataQualityTabProps> = ({
+  isLoading,
   testCases,
+  deletedTable = false,
   onTestUpdate,
 }) => {
   const [selectedTestCase, setSelectedTestCase] = useState<TestCase>();
@@ -231,6 +234,10 @@ const DataQualityTab: React.FC<DataQualityTabProps> = ({
               />
             ),
         }}
+        loading={{
+          indicator: <Loader size="small" />,
+          spinning: isLoading,
+        }}
         pagination={false}
         size="small"
       />
@@ -243,6 +250,7 @@ const DataQualityTab: React.FC<DataQualityTabProps> = ({
 
       <DeleteWidgetModal
         afterDeleteAction={onTestUpdate}
+        allowSoftDelete={!deletedTable}
         entityId={selectedTestCase?.id || ''}
         entityName={selectedTestCase?.name || ''}
         entityType="testCase"

--- a/openmetadata-ui/src/main/resources/ui/src/components/ProfilerDashboard/profilerDashboard.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ProfilerDashboard/profilerDashboard.interface.ts
@@ -11,6 +11,7 @@
  *  limitations under the License.
  */
 
+import { ListTestCaseParams } from '../../axiosAPIs/testAPI';
 import {
   Column,
   ColumnProfile,
@@ -20,12 +21,13 @@ import { TestCase } from '../../generated/tests/testCase';
 
 export interface ProfilerDashboardProps {
   onTableChange: (table: Table) => void;
+  isTestCaseLoading?: boolean;
   table: Table;
   testCases: TestCase[];
   profilerData: ColumnProfile[];
   fetchProfilerData: (tableId: string, days?: number) => void;
-  fetchTestCases: (fqn: string) => void;
-  onTestCaseUpdate: () => void;
+  fetchTestCases: (fqn: string, params?: ListTestCaseParams) => void;
+  onTestCaseUpdate: (deleted?: boolean) => void;
 }
 
 export type MetricChartType = {

--- a/openmetadata-ui/src/main/resources/ui/src/components/ProfilerDashboard/profilerDashboard.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ProfilerDashboard/profilerDashboard.interface.ts
@@ -82,6 +82,8 @@ export interface DataQualityTabProps {
   testCases: TestCase[];
   onTestUpdate?: () => void;
   hasAccess: boolean;
+  isLoading?: boolean;
+  deletedTable?: boolean;
 }
 
 export interface TestSummaryProps {

--- a/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/TableProfilerV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/TableProfilerV1.tsx
@@ -20,8 +20,10 @@ import {
   Row,
   Select,
   Space,
+  Switch,
   Tooltip,
 } from 'antd';
+import { SwitchChangeEventHandler } from 'antd/lib/switch';
 import { AxiosError } from 'axios';
 import classNames from 'classnames';
 import { isEmpty, isUndefined } from 'lodash';
@@ -29,13 +31,14 @@ import { SelectableOption } from 'Models';
 import React, { FC, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { ReactComponent as NoDataIcon } from '../../assets/svg/no-data-icon.svg';
-import { getListTestCase } from '../../axiosAPIs/testAPI';
+import { getListTestCase, ListTestCaseParams } from '../../axiosAPIs/testAPI';
 import { API_RES_MAX_SIZE } from '../../constants/constants';
 import { NO_PERMISSION_FOR_ACTION } from '../../constants/HelperTextUtil';
 import { INITIAL_TEST_RESULT_SUMMARY } from '../../constants/profiler.constant';
 import { ProfilerDashboardType } from '../../enums/table.enum';
 import { TestCase, TestCaseStatus } from '../../generated/tests/testCase';
 import { EntityType as TestType } from '../../generated/tests/testDefinition';
+import { Include } from '../../generated/type/include';
 import {
   formatNumberWithComma,
   formTwoDigitNmber,
@@ -70,6 +73,8 @@ const TableProfilerV1: FC<TableProfilerProps> = ({ table, permissions }) => {
   const [selectedTestCaseStatus, setSelectedTestCaseStatus] =
     useState<string>('');
   const [selectedTestType, setSelectedTestType] = useState('');
+  const [deleted, setDeleted] = useState<boolean>(false);
+  const [isTestCaseLoading, setIsTestCaseLoading] = useState(false);
   const isSummary = activeTab === ProfilerDashboardTab.SUMMARY;
   const isDataQuality = activeTab === ProfilerDashboardTab.DATA_QUALITY;
 
@@ -162,13 +167,15 @@ const TableProfilerV1: FC<TableProfilerProps> = ({ table, permissions }) => {
     setActiveTab(value);
   };
 
-  const fetchAllTests = async () => {
+  const fetchAllTests = async (params?: ListTestCaseParams) => {
+    setIsTestCaseLoading(true);
     try {
       const { data } = await getListTestCase({
         fields: 'testCaseResult,entityLink,testDefinition,testSuite',
         entityLink: generateEntityLink(table.fullyQualifiedName || ''),
         includeAllTests: true,
         limit: API_RES_MAX_SIZE,
+        ...params,
       });
       const columnTestsCase: TestCase[] = [];
       const tableTests: TableTestsType = {
@@ -192,6 +199,8 @@ const TableProfilerV1: FC<TableProfilerProps> = ({ table, permissions }) => {
       setColumnTests(columnTestsCase);
     } catch (error) {
       showErrorToast(error as AxiosError);
+    } finally {
+      setIsTestCaseLoading(false);
     }
   };
 
@@ -224,6 +233,11 @@ const TableProfilerV1: FC<TableProfilerProps> = ({ table, permissions }) => {
     );
   };
 
+  const handleDeletedTestCaseClick: SwitchChangeEventHandler = (value) => {
+    setDeleted(value);
+    fetchAllTests({ include: value ? Include.Deleted : Include.NonDeleted });
+  };
+
   useEffect(() => {
     if (!isEmpty(table) && viewTest) {
       fetchAllTests();
@@ -249,6 +263,12 @@ const TableProfilerV1: FC<TableProfilerProps> = ({ table, permissions }) => {
         <Space>
           {isDataQuality && (
             <>
+              <Form.Item className="m-0 " label="Deleted Tests">
+                <Switch
+                  checked={deleted}
+                  onClick={handleDeletedTestCaseClick}
+                />
+              </Form.Item>
               <Form.Item className="m-0 w-40" label="Type">
                 <Select
                   options={testCaseTypeOption}
@@ -364,7 +384,9 @@ const TableProfilerV1: FC<TableProfilerProps> = ({ table, permissions }) => {
 
       {isDataQuality && (
         <DataQualityTab
+          deletedTable={deleted}
           hasAccess={permissions.EditAll}
+          isLoading={isTestCaseLoading}
           testCases={getFilterTestCase()}
           onTestUpdate={fetchAllTests}
         />

--- a/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/TableProfilerV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/TableProfilerV1.tsx
@@ -175,6 +175,7 @@ const TableProfilerV1: FC<TableProfilerProps> = ({ table, permissions }) => {
         entityLink: generateEntityLink(table.fullyQualifiedName || ''),
         includeAllTests: true,
         limit: API_RES_MAX_SIZE,
+        include: deleted ? Include.Deleted : Include.NonDeleted,
         ...params,
       });
       const columnTestsCase: TestCase[] = [];

--- a/openmetadata-ui/src/main/resources/ui/src/components/TestCasesTab/TestCasesTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TestCasesTab/TestCasesTab.component.tsx
@@ -11,9 +11,10 @@
  *  limitations under the License.
  */
 
-import { Col } from 'antd';
+import { Col, Switch } from 'antd';
+import { SwitchChangeEventHandler } from 'antd/lib/switch';
 import { orderBy } from 'lodash';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Operation } from '../../generated/entity/policies/policy';
 import { TestCase } from '../../generated/tests/testCase';
 import { Paging } from '../../generated/type/paging';
@@ -24,10 +25,11 @@ import DataQualityTab from '../ProfilerDashboard/component/DataQualityTab';
 import TestCaseCommonTabContainer from '../TestCaseCommonTabContainer/TestCaseCommonTabContainer.component';
 
 interface TestCasesTabProps {
+  isDataLoading: boolean;
   testCases: Array<TestCase>;
   testCasesPaging: Paging;
   currentPage: number;
-  onTestUpdate: () => void;
+  onTestUpdate: (deleted?: boolean) => void;
   testCasePageHandler: (
     cursorValue: string | number,
     activePage?: number | undefined
@@ -35,6 +37,7 @@ interface TestCasesTabProps {
 }
 
 const TestCasesTab = ({
+  isDataLoading,
   testCases,
   testCasesPaging,
   currentPage,
@@ -43,6 +46,7 @@ const TestCasesTab = ({
 }: TestCasesTabProps) => {
   const { permissions } = usePermissionProvider();
   const sortedTestCases = orderBy(testCases || [], ['name'], 'asc');
+  const [deleted, setDeleted] = useState<boolean>(false);
 
   const createPermission = useMemo(() => {
     return checkPermission(
@@ -51,6 +55,11 @@ const TestCasesTab = ({
       permissions
     );
   }, [permissions]);
+
+  const handleDeletedTestCaseClick: SwitchChangeEventHandler = (value) => {
+    setDeleted(value);
+    onTestUpdate(value);
+  };
 
   return (
     <TestCaseCommonTabContainer
@@ -61,13 +70,21 @@ const TestCasesTab = ({
       paging={testCasesPaging}
       showButton={false}
       testCasePageHandler={testCasePageHandler}>
-      <Col span={24}>
-        <DataQualityTab
-          hasAccess
-          testCases={sortedTestCases}
-          onTestUpdate={onTestUpdate}
-        />
-      </Col>
+      <>
+        <Col className="flex justify-end items-center" span={24}>
+          <Switch checked={deleted} onClick={handleDeletedTestCaseClick} />
+          <span className="m-l-xs">Deleted Tests</span>
+        </Col>
+        <Col span={24}>
+          <DataQualityTab
+            hasAccess
+            deletedTable={deleted}
+            isLoading={isDataLoading}
+            testCases={sortedTestCases}
+            onTestUpdate={onTestUpdate}
+          />
+        </Col>
+      </>
     </TestCaseCommonTabContainer>
   );
 };

--- a/openmetadata-ui/src/main/resources/ui/src/components/TestCasesTab/TestCasesTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TestCasesTab/TestCasesTab.component.tsx
@@ -81,7 +81,7 @@ const TestCasesTab = ({
             deletedTable={deleted}
             isLoading={isDataLoading}
             testCases={sortedTestCases}
-            onTestUpdate={onTestUpdate}
+            onTestUpdate={() => onTestUpdate(deleted)}
           />
         </Col>
       </>

--- a/openmetadata-ui/src/main/resources/ui/src/components/TestCasesTab/TestCasesTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TestCasesTab/TestCasesTab.component.tsx
@@ -72,8 +72,8 @@ const TestCasesTab = ({
       testCasePageHandler={testCasePageHandler}>
       <>
         <Col className="flex justify-end items-center" span={24}>
+          <span className="m-r-xs">Deleted Tests</span>
           <Switch checked={deleted} onClick={handleDeletedTestCaseClick} />
-          <span className="m-l-xs">Deleted Tests</span>
         </Col>
         <Col span={24}>
           <DataQualityTab

--- a/openmetadata-ui/src/main/resources/ui/src/styles/app.less
+++ b/openmetadata-ui/src/main/resources/ui/src/styles/app.less
@@ -20,33 +20,37 @@
 .flex {
   display: flex;
 }
+.items-center {
+  align-items: center;
+}
+.justify-end {
+  justify-content: flex-end;
+}
+.justify-between {
+  justify-content: space-between;
+}
+.justify-center {
+  justify-content: center;
+}
+.flex-col {
+  flex-direction: column;
+}
 .flex-center {
   display: flex;
   align-items: center;
   justify-content: center;
 }
-.flex {
-  display: flex;
-}
+
 .text-center {
   text-align: center;
-}
-.justify-between {
-  justify-content: space-between;
 }
 .break-word {
   word-break: break-all;
 }
-.justify-center {
-  justify-content: center;
-}
+
 .mx-auto {
   margin-right: auto;
   margin-left: auto;
-}
-
-.flex-col {
-  flex-direction: column;
 }
 .text-center {
   text-align: center;


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the [Add ability to view and delete "soft-deleted" tests#7728](https://github.com/open-metadata/OpenMetadata/issues/7728)
Closes #7728
#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement
- [x] New feature


#
### Frontend Preview (Screenshots) :


https://user-images.githubusercontent.com/71748675/192517117-503f8b23-4068-4ff4-bdb5-cb290232bd7a.mov


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
