### PR TITLE
Fix #7753 Empty bot view when the bot user auth mechanism is not set

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/BotDetails/AuthMechanismForm.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BotDetails/AuthMechanismForm.tsx
@@ -12,6 +12,7 @@
  */
 
 import { Button, Form, Input, Select, Space } from 'antd';
+import { isEmpty } from 'lodash';
 import React, { FC, useEffect, useState } from 'react';
 import { useAuthContext } from '../../authentication/auth-provider/AuthProvider';
 import { SsoServiceType } from '../../generated/entity/teams/authN/ssoAuth';
@@ -524,9 +525,11 @@ const AuthMechanismForm: FC<Props> = ({
       )}
       {authMechanism === AuthType.Sso && <>{getSSOConfig()}</>}
       <Space className="w-full tw-justify-end" size={4}>
-        <Button data-testid="cancel-edit" type="link" onClick={onCancel}>
-          Cancel
-        </Button>
+        {!isEmpty(authenticationMechanism) && (
+          <Button data-testid="cancel-edit" type="link" onClick={onCancel}>
+            Cancel
+          </Button>
+        )}
         <Button
           data-testid="save-edit"
           form="update-auth-mechanism-form"

--- a/openmetadata-ui/src/main/resources/ui/src/components/BotDetails/BotDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BotDetails/BotDetails.component.tsx
@@ -327,30 +327,39 @@ const BotDetails: FC<BotsDetailProp> = ({
       }
       leftPanel={fetchLeftPanel()}
       rightPanel={rightPanel}>
-      {authenticationMechanism && (
-        <Card
-          data-testid="center-panel"
-          style={{
-            ...leftPanelAntCardStyle,
-            marginTop: '16px',
-          }}>
-          {isAuthMechanismEdit ? (
-            <AuthMechanismForm
-              authenticationMechanism={authenticationMechanism}
-              isUpdating={isUpdating}
-              onCancel={() => setIsAuthMechanismEdit(false)}
-              onSave={handleAuthMechanismUpdate}
-            />
-          ) : (
-            <AuthMechanism
-              authenticationMechanism={authenticationMechanism}
-              hasPermission={editAllPermission}
-              onEdit={handleAuthMechanismEdit}
-              onTokenRevoke={() => setIsRevokingToken(true)}
-            />
-          )}
-        </Card>
-      )}
+      <Card
+        data-testid="center-panel"
+        style={{
+          ...leftPanelAntCardStyle,
+          marginTop: '16px',
+        }}>
+        {authenticationMechanism ? (
+          <>
+            {isAuthMechanismEdit ? (
+              <AuthMechanismForm
+                authenticationMechanism={authenticationMechanism}
+                isUpdating={isUpdating}
+                onCancel={() => setIsAuthMechanismEdit(false)}
+                onSave={handleAuthMechanismUpdate}
+              />
+            ) : (
+              <AuthMechanism
+                authenticationMechanism={authenticationMechanism}
+                hasPermission={editAllPermission}
+                onEdit={handleAuthMechanismEdit}
+                onTokenRevoke={() => setIsRevokingToken(true)}
+              />
+            )}
+          </>
+        ) : (
+          <AuthMechanismForm
+            authenticationMechanism={{} as AuthenticationMechanism}
+            isUpdating={isUpdating}
+            onCancel={() => setIsAuthMechanismEdit(false)}
+            onSave={handleAuthMechanismUpdate}
+          />
+        )}
+      </Card>
 
       {isRevokingToken ? (
         <ConfirmationModal

--- a/openmetadata-ui/src/main/resources/ui/src/components/BotDetails/BotDetails.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BotDetails/BotDetails.test.tsx
@@ -14,6 +14,7 @@
 import { findByTestId, fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
+import { getAuthMechanismForBotUser } from '../../axiosAPIs/userAPI';
 import { OperationPermission } from '../PermissionProvider/PermissionProvider.interface';
 import BotDetails from './BotDetails.component';
 
@@ -78,6 +79,14 @@ jest.mock('../common/description/Description', () => {
   return jest.fn().mockReturnValue(<p>Description Component</p>);
 });
 
+jest.mock('./AuthMechanismForm', () =>
+  jest
+    .fn()
+    .mockReturnValue(
+      <div data-testid="AuthMechanismForm">AuthMechanismForm</div>
+    )
+);
+
 describe('Test BotsDetail Component', () => {
   it('Should render all child elements', async () => {
     const { container } = render(<BotDetails {...mockProp} />, {
@@ -135,5 +144,22 @@ describe('Test BotsDetail Component', () => {
 
     // revoke token handler should get called
     expect(revokeTokenHandler).toBeCalled();
+  });
+
+  it('Should render the edit form if the authmechanism is empty', async () => {
+    (getAuthMechanismForBotUser as jest.Mock).mockImplementationOnce(() => {
+      return Promise.resolve(undefined);
+    });
+
+    const { container } = render(<BotDetails {...mockProp} />, {
+      wrapper: MemoryRouter,
+    });
+
+    const authMechanismForm = await findByTestId(
+      container,
+      'AuthMechanismForm'
+    );
+
+    expect(authMechanismForm).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Fixes #7753
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on issue #7753 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/59080942/192540525-a876a664-2de4-4f8b-b5a2-e13a0a065a27.png">


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
