### PR TITLE
Fixed#6054: Propagate Schema ownership to all tables

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -737,7 +737,8 @@ public abstract class EntityRepository<T extends EntityInterface> {
         List<EntityRelationshipRecord> records =
             daoCollection
                 .relationshipDAO()
-                .findTo(entity.getId().toString(), entity.getEntityReference().getType(), Relationship.CONTAINS.ordinal());
+                .findTo(
+                    entity.getId().toString(), entity.getEntityReference().getType(), Relationship.CONTAINS.ordinal());
         entityReferences = getEntityReferences(records);
         if (childrenList.contains(entity.getEntityReference().getType())) {
           EntityRepository<EntityInterface> entityRepository =
@@ -745,7 +746,8 @@ public abstract class EntityRepository<T extends EntityInterface> {
           PatchResponse<EntityInterface> patchResponse =
               entityRepository.patch(null, entity.getId(), securityContext.getUserPrincipal().getName(), patch);
           EventPubSub.publish(
-              getChangeEvent(EventType.ENTITY_UPDATED, entity.getEntityReference().getType(), patchResponse.getEntity()));
+              getChangeEvent(
+                  EventType.ENTITY_UPDATED, entity.getEntityReference().getType(), patchResponse.getEntity()));
         }
         for (EntityReference entityReference : entityReferences) {
           entity = getEntity(entityReference, new Fields(allowedFields), ALL);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/DatabaseResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/DatabaseResource.java
@@ -291,6 +291,11 @@ public class DatabaseResource extends EntityResource<Database, DatabaseRepositor
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
       @PathParam("id") UUID id,
+      @Parameter(
+              description = "Filter to apply patch to child entities",
+              schema = @Schema(type = "list", example = "false"))
+          @QueryParam("applyPatch")
+          List<String> applyPatch,
       @RequestBody(
               description = "JsonPatch with array of operations",
               content =
@@ -301,7 +306,12 @@ public class DatabaseResource extends EntityResource<Database, DatabaseRepositor
                       }))
           JsonPatch patch)
       throws IOException {
-    return patchInternal(uriInfo, securityContext, id, patch);
+    Response response = patchInternal(uriInfo, securityContext, id, patch);
+    if (!applyPatch.isEmpty()) {
+      Database database = getInternal(uriInfo, securityContext, id, FIELDS, Include.ALL);
+      dao.applyPatchToChildren(applyPatch, patch, database, securityContext);
+    }
+    return response;
   }
 
   @PUT

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/DatabaseSchemaResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/DatabaseSchemaResource.java
@@ -295,6 +295,11 @@ public class DatabaseSchemaResource extends EntityResource<DatabaseSchema, Datab
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
       @PathParam("id") UUID id,
+      @Parameter(
+              description = "Filter to apply patch to child entities",
+              schema = @Schema(type = "list", example = "false"))
+          @QueryParam("applyPatch")
+          List<String> applyPatch,
       @RequestBody(
               description = "JsonPatch with array of operations",
               content =
@@ -305,7 +310,12 @@ public class DatabaseSchemaResource extends EntityResource<DatabaseSchema, Datab
                       }))
           JsonPatch patch)
       throws IOException {
-    return patchInternal(uriInfo, securityContext, id, patch);
+    Response response = patchInternal(uriInfo, securityContext, id, patch);
+    if (!applyPatch.isEmpty()) {
+      DatabaseSchema databaseSchema = getInternal(uriInfo, securityContext, id, FIELDS, Include.ALL);
+      dao.applyPatchToChildren(applyPatch, patch, databaseSchema, securityContext);
+    }
+    return response;
   }
 
   @PUT


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Fixes #6054 
The method can patch the owner to the bottom-most child of an entity.
E.g.:```DatabaseService > Database > DatabaseSchema > Tables```
#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement
- [x] New feature

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@mohitdeuex @harshach 
