### PR TITLE
Added checks to see if DAG can reach OM

### DIFF
--- a/ingestion/src/metadata/test_suite/api/workflow.py
+++ b/ingestion/src/metadata/test_suite/api/workflow.py
@@ -14,8 +14,8 @@ Workflow definition for the test suite
 """
 
 from __future__ import annotations
-import sys
 
+import sys
 import traceback
 from copy import deepcopy
 from logging import Logger

--- a/ingestion/src/metadata/test_suite/api/workflow.py
+++ b/ingestion/src/metadata/test_suite/api/workflow.py
@@ -14,6 +14,7 @@ Workflow definition for the test suite
 """
 
 from __future__ import annotations
+import sys
 
 import traceback
 from copy import deepcopy
@@ -277,8 +278,9 @@ class TestSuiteWorkflow:
         processor.config.testSuites
         """
         test_suite_entities = []
+        test_suites = self.processor_config.testSuites or []
 
-        for test_suite in self.processor_config.testSuites:
+        for test_suite in test_suites:
             test_suite_entity = self.metadata.get_by_name(
                 entity=TestSuite,
                 fqn=test_suite.name,
@@ -388,6 +390,10 @@ class TestSuiteWorkflow:
             self.get_test_suite_entity_for_ui_workflow()
             or self.get_or_create_test_suite_entity_for_cli_workflow()
         )
+        if not test_suites:
+            logger.warning("No testSuite found in configuration file. Exiting.")
+            sys.exit(1)
+
         test_cases = self.get_test_cases_from_test_suite(test_suites)
         if self.processor_config.testSuites:
             cli_config_test_cases_def = self.get_test_case_from_cli_config()

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/ingestion/common.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/ingestion/common.py
@@ -24,6 +24,7 @@ from metadata.generated.schema.entity.services.databaseService import DatabaseSe
 from metadata.generated.schema.entity.services.messagingService import MessagingService
 from metadata.generated.schema.entity.services.mlmodelService import MlModelService
 from metadata.generated.schema.entity.services.pipelineService import PipelineService
+from metadata.generated.schema.tests.testSuite import TestSuite
 from metadata.generated.schema.type import basic
 from metadata.ingestion.models.encoders import show_secrets_encoder
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
@@ -92,13 +93,18 @@ def build_source(ingestion_pipeline: IngestionPipeline) -> WorkflowSource:
     ] = None
 
     if service_type == "testSuite":
+        service = metadata.get_by_name(
+            entity=TestSuite, fqn=ingestion_pipeline.service.name
+        )  # check we are able to access OM server
+        if not service:
+            raise InvalidServiceException(f"Could not get service from type {service_type}")
         return WorkflowSource(
             type=service_type,
             serviceName=ingestion_pipeline.service.name,
             sourceConfig=ingestion_pipeline.sourceConfig,
         )
 
-    elif service_type == "databaseService":
+    if service_type == "databaseService":
         service: DatabaseService = metadata.get_by_name(
             entity=DatabaseService, fqn=ingestion_pipeline.service.name
         )

--- a/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/ingestion/common.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/ingestion/common.py
@@ -97,7 +97,9 @@ def build_source(ingestion_pipeline: IngestionPipeline) -> WorkflowSource:
             entity=TestSuite, fqn=ingestion_pipeline.service.name
         )  # check we are able to access OM server
         if not service:
-            raise InvalidServiceException(f"Could not get service from type {service_type}")
+            raise InvalidServiceException(
+                f"Could not get service from type {service_type}"
+            )
         return WorkflowSource(
             type=service_type,
             serviceName=ingestion_pipeline.service.name,


### PR DESCRIPTION
### Describe your changes :
- In airflow workflow first try to get the testSuite entity to check if we can reach the OM server, otherwise raise same errors than other service
- In testSuite workflow exit the whole workflow if we cannot find any testSuite in the config file and throw an error message

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
Ingestion: @open-metadata/ingestion
