### PR TITLE
UI: Fixed issue with suggestion overlay staying after redirection to the result

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/cypress/e2e/Pages/myData.spec.js
+++ b/openmetadata-ui/src/main/resources/ui/cypress/e2e/Pages/myData.spec.js
@@ -55,7 +55,7 @@ describe('MyData page should work', () => {
   };
 
   const checkRecentlySearchElement = (term) => {
-    searchEntity(term);
+    searchEntity(term, false);
     cy.clickOnLogo();
     cy.get(`[data-testid="search-term-${term}"]`)
       .scrollIntoView()

--- a/openmetadata-ui/src/main/resources/ui/src/components/app-bar/Appbar.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/app-bar/Appbar.tsx
@@ -75,6 +75,7 @@ const Appbar: React.FC = (): JSX.Element => {
 
   const handleSearchChange = (value: string) => {
     setSearchValue(value);
+    value ? setIsOpen(true) : setIsOpen(false);
   };
 
   const supportLinks = [

--- a/openmetadata-ui/src/main/resources/ui/src/components/app-bar/Suggestions.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/app-bar/Suggestions.tsx
@@ -298,7 +298,6 @@ const Suggestions = ({ searchText, isOpen, setIsOpen }: SuggestionProp) => {
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
               (res.data as any).suggest['metadata-suggest'][0].options
             );
-            setIsOpen(true);
           } else {
             throw jsonData['api-error-messages']['unexpected-server-response'];
           }


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on fixing the issue with suggestion overlay staying after redirection to the search result page. This behaviour was seen when user clicks on the result immediately after typing in search box where search result is present already, or clicks on previous suggestions before the suggestion results for newly typed text are populated (due to delay in API response)

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<p align="center">

**Before :**

https://user-images.githubusercontent.com/51777795/193206233-366d2ad0-ec0e-46f3-af66-8f9881493e9f.mov


**After :**

https://user-images.githubusercontent.com/51777795/193206290-2c31916c-f9fb-4f6e-8aa3-0443e70c656d.mov


</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @open-metadata/ui
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
