### PR TITLE
fix(ui): show actual count for index requests

### DIFF
--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/teams/UserResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/teams/UserResourceTest.java
@@ -790,26 +790,26 @@ public class UserResourceTest extends EntityResourceTest<User, CreateUser> {
         new RegistrationRequest()
             .withFirstName("Test")
             .withLastName("Test")
-            .withEmail("testBasicAuth@email.com")
+            .withEmail("testBasicAuth123@email.com")
             .withPassword("Test@1234");
 
     TestUtils.post(getResource("users/signup"), newRegistrationRequest, String.class, ADMIN_AUTH_HEADERS);
 
     // jwtAuth Response should be null always
-    User user = getEntityByName("testBasicAuth", "isEmailVerified,authenticationMechanism", ADMIN_AUTH_HEADERS);
+    User user = getEntityByName("testBasicAuth123", null, ADMIN_AUTH_HEADERS);
     assertNull(user.getAuthenticationMechanism());
 
     // Login With Correct Password
-    LoginRequest loginRequest = new LoginRequest().withEmail("testBasicAuth@email.com").withPassword("Test@1234");
+    LoginRequest loginRequest = new LoginRequest().withEmail("testBasicAuth123@email.com").withPassword("Test@1234");
     JwtResponse jwtResponse =
         TestUtils.post(
             getResource("users/login"), loginRequest, JwtResponse.class, OK.getStatusCode(), ADMIN_AUTH_HEADERS);
 
-    validateJwtBasicAuth(jwtResponse, "testBasicAuth");
+    validateJwtBasicAuth(jwtResponse, "testBasicAuth123");
 
     // Login With Wrong email
     LoginRequest failedLoginWithWrongEmail =
-        new LoginRequest().withEmail("testBasicAuth123@email.com").withPassword("Test@1234");
+        new LoginRequest().withEmail("testBasicAuth1234@email.com").withPassword("Test@1234");
     assertResponse(
         () ->
             TestUtils.post(
@@ -823,7 +823,7 @@ public class UserResourceTest extends EntityResourceTest<User, CreateUser> {
 
     // Login With Wrong Password
     LoginRequest failedLoginWithWrongPwd =
-        new LoginRequest().withEmail("testBasicAuth@email.com").withPassword("Test1@1234");
+        new LoginRequest().withEmail("testBasicAuth123@email.com").withPassword("Test1@1234");
     assertResponse(
         () ->
             TestUtils.post(

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ElasticSearchIndexPage/elastic-search-index.page.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ElasticSearchIndexPage/elastic-search-index.page.tsx
@@ -177,12 +177,14 @@ const ElasticSearchIndexPage = () => {
                                 <Badge
                                   className="request-badge running"
                                   count={batchJobData?.stats?.total}
+                                  overflowCount={99999999}
                                   title={`Total index sent: ${batchJobData?.stats?.total}`}
                                 />
 
                                 <Badge
                                   className="request-badge success"
                                   count={batchJobData?.stats?.success}
+                                  overflowCount={99999999}
                                   title={`Success index: ${batchJobData?.stats?.success}`}
                                 />
 
@@ -190,6 +192,7 @@ const ElasticSearchIndexPage = () => {
                                   showZero
                                   className="request-badge failed"
                                   count={batchJobData?.stats?.failed}
+                                  overflowCount={99999999}
                                   title={`Failed index: ${batchJobData?.stats?.failed}`}
                                 />
                               </Space>
@@ -262,7 +265,7 @@ const ElasticSearchIndexPage = () => {
                         Recreate indexes&nbsp;
                         <Tooltip
                           placement="bottomRight"
-                          title="This will delete exiting indexing and create new">
+                          title="This will delete existing indexes and re-create them.">
                           <QuestionCircleOutlined />
                         </Tooltip>
                       </Typography.Text>

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EventPublisherUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EventPublisherUtils.ts
@@ -36,7 +36,7 @@ export const getStatusResultBadgeIcon = (status: string) => {
 export const getEventPublisherStatusText = (status?: string) => {
   switch (status) {
     case Status.Idle:
-      return 'Ideal';
+      return 'Idle';
     case Status.Completed:
       return 'Completed';
     case Status.Active:


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the fixing below issues

1. Index request shows actual number instead truncated
2. Recreate index message update
3. Ideal --> Idel

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<img width="1221" alt="Screenshot 2022-10-03 at 12 41 50 PM" src="https://user-images.githubusercontent.com/12962843/193520187-587e3bfb-759a-46bb-9bd6-beeb0b47937d.png">


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
