### PR TITLE
Fix UI :-  Glossary default item after clicking from list to navigation

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/GlossaryPage/GlossaryPageV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/GlossaryPage/GlossaryPageV1.component.tsx
@@ -289,7 +289,7 @@ const GlossaryPageV1 = () => {
     const hierarchy = getTermPosFromGlossaries(arrGlossary, dataFQN);
     if (hierarchy.length < 2) {
       setSelectedData(dataFQN ? arrGlossary[hierarchy[0]] : arrGlossary[0]);
-      handleSelectedKey(dataFQN ? dataFQN : arrGlossary[0].name);
+      handleSelectedKey(dataFQN ? dataFQN : arrGlossary[0]?.name);
       if (!expandedKey.length) {
         handleExpandedKey([dataFQN], true);
       }

--- a/openmetadata-ui/src/main/resources/ui/src/pages/GlossaryPage/GlossaryPageV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/GlossaryPage/GlossaryPageV1.component.tsx
@@ -287,9 +287,10 @@ const GlossaryPageV1 = () => {
   ) => {
     handleChildLoading(true);
     const hierarchy = getTermPosFromGlossaries(arrGlossary, dataFQN);
+    const isFQN = dataFQN;
     if (hierarchy.length < 2) {
-      setSelectedData(arrGlossary[hierarchy[0]]);
-      handleSelectedKey(dataFQN);
+      setSelectedData(isFQN ? arrGlossary[hierarchy[0]] : arrGlossary[0]);
+      handleSelectedKey(isFQN ? dataFQN : arrGlossary[0].name);
       if (!expandedKey.length) {
         handleExpandedKey([dataFQN], true);
       }

--- a/openmetadata-ui/src/main/resources/ui/src/pages/GlossaryPage/GlossaryPageV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/GlossaryPage/GlossaryPageV1.component.tsx
@@ -287,10 +287,9 @@ const GlossaryPageV1 = () => {
   ) => {
     handleChildLoading(true);
     const hierarchy = getTermPosFromGlossaries(arrGlossary, dataFQN);
-    const isFQN = dataFQN;
     if (hierarchy.length < 2) {
-      setSelectedData(isFQN ? arrGlossary[hierarchy[0]] : arrGlossary[0]);
-      handleSelectedKey(isFQN ? dataFQN : arrGlossary[0].name);
+      setSelectedData(dataFQN ? arrGlossary[hierarchy[0]] : arrGlossary[0]);
+      handleSelectedKey(dataFQN ? dataFQN : arrGlossary[0].name);
       if (!expandedKey.length) {
         handleExpandedKey([dataFQN], true);
       }

--- a/openmetadata-ui/src/main/resources/ui/src/styles/app.less
+++ b/openmetadata-ui/src/main/resources/ui/src/styles/app.less
@@ -148,6 +148,7 @@
 .activeCategory {
   border-left: 2px solid @primary;
   background: @primary-light;
+  font-weight: 600;
 }
 
 .mt-0 {


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
- Issue : Closes #7878
- Fix glossary default item after clicking from list to navigation
- Increase font weight of tags list as per glossary

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement

#
### Frontend Preview (Screenshots) :
Issue : 

https://user-images.githubusercontent.com/66266464/193534805-7510d20e-53a4-4a67-a1c2-3f5aa1f25500.mov

Resolved : 
 

https://user-images.githubusercontent.com/66266464/193534839-4361e749-66c2-4205-965c-176edd786dc6.mov


<img width="300" alt="image" src="https://user-images.githubusercontent.com/66266464/193534535-3523da57-09a8-403c-bc7f-14a1dde39851.png">
<img width="300" alt="image" src="https://user-images.githubusercontent.com/66266464/193534562-3edcb6c7-d717-4189-bfda-00022178e522.png">


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
 @open-metadata/ui 
