### PR TITLE
Fix #7881 Tag page throws 404 for tierTag when upgrading from 0.11.5 to 0.12.1

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/constants/constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/constants.ts
@@ -496,3 +496,4 @@ export const configOptions = {
 };
 
 export const NOTIFICATION_READ_TIMER = 2500;
+export const TIER_CATEGORY = 'Tier';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/tags/index.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/tags/index.tsx
@@ -43,6 +43,7 @@ import {
   OperationPermission,
   ResourceEntity,
 } from '../../components/PermissionProvider/PermissionProvider.interface';
+import { TIER_CATEGORY } from '../../constants/constants';
 import { NO_PERMISSION_FOR_ACTION } from '../../constants/HelperTextUtil';
 import { delimiterRegex } from '../../constants/regex.constants';
 import {
@@ -427,21 +428,23 @@ const TagsPage = () => {
   };
 
   useEffect(() => {
-    fetchCategories(true);
-  }, []);
-
-  useEffect(() => {
     if (currentCategory) {
       fetchCurrentCategoryPermission();
     }
   }, [currentCategory]);
 
   useEffect(() => {
+    /**
+     * If tagCategoryName is present then fetch that category
+     */
     if (tagCategoryName) {
-      fetchCurrentCategory(tagCategoryName);
-    } else {
-      setCurrentCategory(categories[0]);
+      const isTier = tagCategoryName.startsWith(TIER_CATEGORY);
+      fetchCurrentCategory(isTier ? TIER_CATEGORY : tagCategoryName);
     }
+    /**
+     * Fetch all categories and set current category only if there is no categoryName
+     */
+    fetchCategories(!tagCategoryName);
   }, [tagCategoryName]);
 
   const fetchLeftPanel = () => {


### PR DESCRIPTION
Fixes #7881
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on issue #7881 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :


https://user-images.githubusercontent.com/59080942/193564293-95c00393-fd89-4b50-a29f-141188bded39.mov


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
