### PR TITLE
Fix: Flaky cypress for teams spec

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/cypress/e2e/Pages/Teams.spec.js
+++ b/openmetadata-ui/src/main/resources/ui/cypress/e2e/Pages/Teams.spec.js
@@ -178,11 +178,10 @@ describe('Teams flow should work properly', () => {
       .clear()
       .type(TEAM_DETAILS.updatedname);
 
-    interceptURL('PATCH', 'api/v1/teams/*', 'saveTeamName');
     interceptURL(
       'GET',
       `api/v1/users?fields=teams,roles&team=${TEAM_DETAILS.name}&limit=15`,
-      'getTeam'
+      'getTeamDetails'
     );
     //Save the updated display name
     cy.get('[data-testid="saveAssociatedTag"]')
@@ -190,15 +189,22 @@ describe('Teams flow should work properly', () => {
       .should('be.visible')
       .click();
 
+    verifyResponseStatusCode('@getTeamDetails', 200);
     //Validate the updated display name
     cy.get('[data-testid="team-heading"]').then(($el) => {
       cy.wrap($el).should('have.text', TEAM_DETAILS.updatedname);
     });
-    verifyResponseStatusCode('@saveTeamName', 200);
-    verifyResponseStatusCode('@getTeam', 200);
+
+    cy.get('[data-testid="inactive-link"]')
+      .should('be.visible')
+      .should('contain', TEAM_DETAILS.updatedname);
 
     //Click on edit description button
-    cy.get('[data-testid="edit-description"]').should('be.visible').click();
+    cy.get('[data-testid="edit-description"]')
+      .should('exist')
+      .then(($editDescription) => {
+        cy.wrap($editDescription).should('be.visible').click();
+      });
 
     //Entering updated description
     cy.get(descriptionBox).clear().type(updateddescription);


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the fixing flaky cypress for teams page
#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement


#
### Frontend Preview (Screenshots) :


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
