### PR TITLE
Fix 'Use the primitive boolean expression' - warning

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TeamRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TeamRepository.java
@@ -247,7 +247,7 @@ public class TeamRepository extends EntityRepository<Team> {
     List<Team> allTeams = resultList.getData();
     List<Team> joinableTeams =
         allTeams.stream()
-            .filter(isJoinable ? Team::getIsJoinable : t -> true)
+            .filter(Boolean.TRUE.equals(isJoinable) ? Team::getIsJoinable : t -> true)
             .filter(t -> !t.getName().equals(ORGANIZATION_NAME))
             .collect(Collectors.toList());
     // build hierarchy of joinable teams

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
@@ -85,7 +85,7 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
       values.put(testCaseParameterValue.getName(), testCaseParameterValue.getValue());
     }
     for (TestCaseParameter parameter : parameterDefinition) {
-      if (parameter.getRequired()
+      if (Boolean.TRUE.equals(parameter.getRequired())
           && (!values.containsKey(parameter.getName()) || values.get(parameter.getName()) == null)) {
         throw new IllegalArgumentException(
             "Required parameter " + parameter.getName() + " is not passed in parameterValues");

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/elasticSearch/BuildSearchIndexResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/elasticSearch/BuildSearchIndexResource.java
@@ -266,7 +266,7 @@ public class BuildSearchIndexResource {
     ElasticSearchIndexDefinition.ElasticSearchIndexType indexType =
         elasticSearchIndexDefinition.getIndexMappingByEntityType(entityType);
 
-    if (createRequest.getRecreateIndex()) {
+    if (Boolean.TRUE.equals(createRequest.getRecreateIndex())) {
       // Delete index
       elasticSearchIndexDefinition.deleteIndex(indexType);
       // Create index
@@ -307,7 +307,7 @@ public class BuildSearchIndexResource {
     ElasticSearchIndexDefinition.ElasticSearchIndexType indexType =
         elasticSearchIndexDefinition.getIndexMappingByEntityType(entityType);
 
-    if (createRequest.getRecreateIndex()) {
+    if (Boolean.TRUE.equals(createRequest.getRecreateIndex())) {
       // Delete index
       elasticSearchIndexDefinition.deleteIndex(indexType);
       // Create index

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java
@@ -788,9 +788,10 @@ public class UserResource extends EntityResource<User, UserRepository> {
         @ApiResponse(responseCode = "400", description = "Bad request")
       })
   public Response registerNewUser(@Context UriInfo uriInfo, @Valid RegistrationRequest create) throws IOException {
-    if (Boolean.TRUE.equals(ConfigurationHolder.getInstance()
-        .getConfig(ConfigurationHolder.ConfigurationType.AUTHENTICATION_CONFIG, AuthenticationConfiguration.class)
-        .getEnableSelfSignup())) {
+    if (Boolean.TRUE.equals(
+        ConfigurationHolder.getInstance()
+            .getConfig(ConfigurationHolder.ConfigurationType.AUTHENTICATION_CONFIG, AuthenticationConfiguration.class)
+            .getEnableSelfSignup())) {
       User registeredUser = registerUser(uriInfo, create);
       if (isEmailServiceEnabled) {
         try {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java
@@ -788,9 +788,9 @@ public class UserResource extends EntityResource<User, UserRepository> {
         @ApiResponse(responseCode = "400", description = "Bad request")
       })
   public Response registerNewUser(@Context UriInfo uriInfo, @Valid RegistrationRequest create) throws IOException {
-    if (ConfigurationHolder.getInstance()
+    if (Boolean.TRUE.equals(ConfigurationHolder.getInstance()
         .getConfig(ConfigurationHolder.ConfigurationType.AUTHENTICATION_CONFIG, AuthenticationConfiguration.class)
-        .getEnableSelfSignup()) {
+        .getEnableSelfSignup())) {
       User registeredUser = registerUser(uriInfo, create);
       if (isEmailServiceEnabled) {
         try {
@@ -847,7 +847,7 @@ public class UserResource extends EntityResource<User, UserRepository> {
           String user)
       throws IOException {
     User registeredUser = dao.getByName(uriInfo, user, getFields("isEmailVerified"));
-    if (registeredUser.getIsEmailVerified()) {
+    if (Boolean.TRUE.equals(registeredUser.getIsEmailVerified())) {
       // no need to do anything
       return Response.status(Response.Status.OK).entity("Email Already Verified For User.").build();
     }
@@ -1100,7 +1100,7 @@ public class UserResource extends EntityResource<User, UserRepository> {
             .build();
       }
 
-      if (storedUser != null && storedUser.getIsBot() != null && storedUser.getIsBot()) {
+      if (storedUser != null && Boolean.TRUE.equals(storedUser.getIsBot())) {
         return Response.status(BAD_REQUEST)
             .entity(new ErrorMessage(BAD_REQUEST.getStatusCode(), INVALID_USERNAME_PASSWORD))
             .build();
@@ -1235,7 +1235,7 @@ public class UserResource extends EntityResource<User, UserRepository> {
     }
     User registeredUser =
         dao.get(uriInfo, emailVerificationToken.getUserId(), userRepository.getFieldsWithUserAuth("*"));
-    if (registeredUser.getIsEmailVerified()) {
+    if (Boolean.TRUE.equals(registeredUser.getIsEmailVerified())) {
       LOG.info("User [{}] already registered.", emailToken);
       return;
     }
@@ -1259,7 +1259,7 @@ public class UserResource extends EntityResource<User, UserRepository> {
   public User extendRegistrationToken(UriInfo uriInfo, String existingToken) throws IOException {
     EmailVerificationToken emailVerificationToken = (EmailVerificationToken) tokenRepository.findByToken(existingToken);
     User registeredUser = dao.get(uriInfo, emailVerificationToken.getUserId(), getFields("isEmailVerified"));
-    if (registeredUser.getIsEmailVerified()) {
+    if (Boolean.TRUE.equals(registeredUser.getIsEmailVerified())) {
       // no need to do anything
       return registeredUser;
     }
@@ -1400,7 +1400,7 @@ public class UserResource extends EntityResource<User, UserRepository> {
       throw new RuntimeException(
           "Password Reset Token" + token.getToken() + "Expired token. Please issue a new request");
     }
-    if (!token.getIsActive()) {
+    if (Boolean.FALSE.equals(token.getIsActive())) {
       throw new RuntimeException("Password Reset Token" + token.getToken() + "Token was marked inactive");
     }
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/JwtFilter.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/JwtFilter.java
@@ -135,7 +135,7 @@ public class JwtFilter implements ContainerRequestFilter {
     String userName = validateAndReturnUsername(claims);
 
     // validate bot token
-    if (claims.containsKey(BOT_CLAIM) && claims.get(BOT_CLAIM).asBoolean()) {
+    if (claims.containsKey(BOT_CLAIM) && Boolean.TRUE.equals(claims.get(BOT_CLAIM).asBoolean())) {
       validateBotToken(tokenFromHeader, userName);
     }
 


### PR DESCRIPTION
### Describe your changes :
Related issue: #7863 
I fixed the use of boolean wrapper class return values in order to prevent NPE's. Conditional clauses checking these return values now  use a NPE safe alternative.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
