### PR TITLE
Fix: connector for hive has double dash

### DIFF
--- a/ingestion/src/metadata/utils/source_connections.py
+++ b/ingestion/src/metadata/utils/source_connections.py
@@ -340,9 +340,6 @@ def _(connection: HiveConnection):
     )
 
     if options:
-        if not connection.databaseSchema:
-            url += "/"
-        url += "/"
         params = "&".join(
             f"{key}={quote_plus(value)}" for (key, value) in options.items() if value
         )

--- a/ingestion/tests/unit/test_source_connection.py
+++ b/ingestion/tests/unit/test_source_connection.py
@@ -143,6 +143,23 @@ class SouceConnectionTest(TestCase):
         )
         assert expected_result == get_connection_url(hive_conn_obj)
 
+    def test_hive_url_conn_options_with_db(self):
+        expected_result = "hive://localhost:10000/test_db?Key=Value"
+        hive_conn_obj = HiveConnection(
+            hostPort="localhost:10000",
+            databaseSchema="test_db",
+            connectionOptions={"Key": "Value"},
+        )
+        assert expected_result == get_connection_url(hive_conn_obj)
+
+    def test_hive_url_conn_options_without_db(self):
+        expected_result = "hive://localhost:10000?Key=Value"
+        hive_conn_obj = HiveConnection(
+            hostPort="localhost:10000",
+            connectionOptions={"Key": "Value"},
+        )
+        assert expected_result == get_connection_url(hive_conn_obj)
+
     def test_hive_url_with_kerberos_auth(self):
         expected_result = "hive://localhost:10000"
         hive_conn_obj = HiveConnection(


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the fixing connector for hive has double dash.
Fix: #7715 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement


### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
