### PR TITLE
Redshift constrain error

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/sql_column_handler.py
+++ b/ingestion/src/metadata/ingestion/source/database/sql_column_handler.py
@@ -25,6 +25,7 @@ from metadata.generated.schema.entity.data.table import (
     TableConstraint,
 )
 from metadata.ingestion.source.database.column_type_parser import ColumnTypeParser
+from metadata.utils.helpers import clean_up_starting_ending_double_quotes_in_string
 from metadata.utils.logger import ingestion_logger
 
 logger = ingestion_logger()
@@ -128,6 +129,18 @@ class SqlColumnHandlerMixin:
         for constraint in unique_constraints:
             if constraint.get("column_names"):
                 unique_columns.extend(constraint.get("column_names"))
+        pk_columns = [
+            clean_up_starting_ending_double_quotes_in_string(pk_column)
+            for pk_column in pk_columns
+        ]
+        unique_columns = [
+            clean_up_starting_ending_double_quotes_in_string(unique_column)
+            for unique_column in unique_columns
+        ]
+        foreign_columns = [
+            clean_up_starting_ending_double_quotes_in_string(foreign_column)
+            for foreign_column in foreign_columns
+        ]
         return pk_columns, unique_columns, foreign_columns
 
     def _process_complex_col_type(self, parsed_string: dict, column: dict) -> Column:

--- a/ingestion/src/metadata/utils/helpers.py
+++ b/ingestion/src/metadata/utils/helpers.py
@@ -334,3 +334,21 @@ def list_to_dict(original: Optional[List[str]], sep: str = "=") -> Dict[str, str
         (elem.split(sep)[0], elem.split(sep)[1]) for elem in original if sep in elem
     ]
     return dict(split_original)
+
+
+def clean_up_starting_ending_double_quotes_in_string(string: str) -> str:
+    """Remove start and ending double quotes in a string
+
+    Args:
+        string (str): a string
+
+    Raises:
+        TypeError: An error occure checking the type of `string`
+
+    Returns:
+        str: a string with no double quotes
+    """
+    if not isinstance(string, str):
+        raise TypeError(f"{string}, must be of type str, instead got `{type(string)}`")
+
+    return string.strip('"')

--- a/ingestion/tests/unit/test_helpers.py
+++ b/ingestion/tests/unit/test_helpers.py
@@ -13,7 +13,10 @@ Test helpers module
 """
 from unittest import TestCase
 
-from metadata.utils.helpers import list_to_dict
+from metadata.utils.helpers import (
+    clean_up_starting_ending_double_quotes_in_string,
+    list_to_dict,
+)
 
 
 class TestHelpers(TestCase):
@@ -27,3 +30,9 @@ class TestHelpers(TestCase):
         self.assertEqual(list_to_dict(original=original), {"key": "value", "a": "b"})
         self.assertEqual(list_to_dict([]), {})
         self.assertEqual(list_to_dict(None), {})
+
+    def test_clean_up_starting_ending_double_quotes_in_string(self):
+        input_ = '"password"'
+        output_ = "password"
+
+        assert clean_up_starting_ending_double_quotes_in_string(input_) == output_


### PR DESCRIPTION
### Describe your changes :
Contraint column names are returned by SQA with double quotes when the table DDL include this character. This causes an error to be raised `Invalid column name found in table constraint` as the column name is not found in the table entity columns https://github.com/open-metadata/OpenMetadata/blob/cd43f1fdcf4103f205864a721e8747f38502051d/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/DatabaseUtil.java#L62.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
