### PR TITLE
fix two hardcoded references to old version number

### DIFF
--- a/openmetadata-docs/content/deployment/upgrade/docker.md
+++ b/openmetadata-docs/content/deployment/upgrade/docker.md
@@ -26,7 +26,7 @@ wget https://github.com/open-metadata/OpenMetadata/releases/download/{version}-r
 ```
 or if you wish to use postgres as the database
 ```
-wget https://github.com/open-metadata/OpenMetadata/releases/download/0.12.0-release/docker-compose-postgres.yml
+wget https://github.com/open-metadata/OpenMetadata/releases/download/{version}-release/docker-compose-postgres.yml
 ```
 
 ### 2. Backup your Data [IMPORTANT]

--- a/openmetadata-docs/content/quick-start/local-deployment.md
+++ b/openmetadata-docs/content/quick-start/local-deployment.md
@@ -305,7 +305,7 @@ you can always run `docker compose` manually after picking up the latest `docker
 
 ```commandline
 mkdir openmetadata && cd "$_"
-wget https://github.com/open-metadata/OpenMetadata/releases/download/0.11.3-release/docker-compose.yml
+wget https://github.com/open-metadata/OpenMetadata/releases/download/{version}-release/docker-compose.yml
 docker compose up -d
 ```
 


### PR DESCRIPTION
### Describe your changes :
There were two references in the docs to `0.12.0` and `0.11.3`, I replaced them with `{version}` which I saw used elsewhere in one of the same files.

#
### Type of change :
- [x] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
