### PR TITLE
Fix Superset REST client requests

### DIFF
--- a/ingestion/src/metadata/ingestion/ometa/superset_rest.py
+++ b/ingestion/src/metadata/ingestion/ometa/superset_rest.py
@@ -94,7 +94,7 @@ class SupersetAPIClient:
         Returns:
             int
         """
-        response = self.client.get("/dashboard?q=(page:0,page_size:1)")
+        response = self.client.get("/dashboard/?q=(page:0,page_size:1)")
         return response.get("count") or 0
 
     def fetch_dashboards(self, current_page: int, page_size: int):
@@ -109,7 +109,7 @@ class SupersetAPIClient:
             requests.Response
         """
         response = self.client.get(
-            f"/dashboard?q=(page:{current_page},page_size:{page_size})"
+            f"/dashboard/?q=(page:{current_page},page_size:{page_size})"
         )
         return response
 
@@ -120,7 +120,7 @@ class SupersetAPIClient:
         Returns:
              int
         """
-        response = self.client.get("/chart?q=(page:0,page_size:1)")
+        response = self.client.get("/chart/?q=(page:0,page_size:1)")
         return response.get("count") or 0
 
     def fetch_charts(self, current_page: int, page_size: int):
@@ -135,7 +135,7 @@ class SupersetAPIClient:
             requests.Response
         """
         response = self.client.get(
-            f"/chart?q=(page:{current_page},page_size:{page_size})"
+            f"/chart/?q=(page:{current_page},page_size:{page_size})"
         )
         return response
 


### PR DESCRIPTION
### Describe your changes :
A user reported that the connector for Superset (version 2.0.0) was failing to a missing slash in the queries done to the API. 
From the [documentation](https://superset.apache.org/docs/api/), it seems we need to add a slash at the end to the requests to `/chart` and `/dashboard`. 

In our dev instance, both queries work.

### Type of change :
- [x] Bug fix

### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

### Reviewers
Ingestion: @open-metadata/ingestion 