### PR TITLE
fix(ui): bot is not part of re-index entity

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/constants/elasticsearch.constant.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/elasticsearch.constant.ts
@@ -57,7 +57,6 @@ export const ELASTIC_SEARCH_INITIAL_VALUES = {
     'dashboard',
     'pipeline',
     'mlmodel',
-    'bot',
     'user',
     'team',
     'glossaryTerm',


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the removing unwanted "bot" entity from re-indexing API

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :

<img width="1800" alt="Screenshot 2022-10-12 at 12 33 10 PM" src="https://user-images.githubusercontent.com/12962843/195272844-f2041c6c-d2c5-4fd5-8273-50666d53de6f.png">


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
