### PR TITLE
#7994 Updating password error message to mention numbers.

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/constants/error-message.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/error-message.ts
@@ -12,4 +12,5 @@
  */
 
 export const passwordErrorMessage =
-  'Password must be a minimum of 8 and a maximum of 16 characters long and contain at least one uppercase and one lowercase letter (A, z), and one special character (such as !, %, @, or #)';
+  'Password must be a minimum of 8 and a maximum of 16 characters long and contain at least one uppercase character ' +
+  '(A-Z), one lowercase character (a-z), one number, and one special character (such as !, %, @, or #)';


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->

**Updating the password error string to match the regex**
The error string now mentions that numbers are required in password

Closes: #7994 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :

<p align="center"> 
New error string
<br>
<img width="393" alt="Screen Shot 2022-10-12 at 1 06 05 AM" src="https://user-images.githubusercontent.com/6575568/195286950-36484f60-219e-43d3-bcb1-b656528f2244.png">
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
 Frontend: @open-metadata/ui
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
