### PR TITLE
UI : Make AuthMechanism Fields to readOnly from NonEditable

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/BotDetails/AuthMechanism.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BotDetails/AuthMechanism.tsx
@@ -86,7 +86,7 @@ const AuthMechanism: FC<Props> = ({
           <>
             <Space className="w-full tw-justify-between ant-space-authMechanism">
               <Input.Password
-                contentEditable={false}
+                readOnly
                 data-testid="token"
                 placeholder="Generate new token..."
                 value={JWTToken}
@@ -146,7 +146,7 @@ const AuthMechanism: FC<Props> = ({
             <Typography.Text>Account Email</Typography.Text>
             <Space className="w-full tw-justify-between ant-space-authMechanism">
               <Input
-                contentEditable={false}
+                readOnly
                 data-testid="botUser-email"
                 value={botUser.email}
               />
@@ -159,7 +159,7 @@ const AuthMechanism: FC<Props> = ({
               <Typography.Text>SecretKey</Typography.Text>
               <Space className="w-full tw-justify-between ant-space-authMechanism">
                 <Input.Password
-                  contentEditable={false}
+                  readOnly
                   data-testid="secretKey"
                   value={authConfig?.secretKey}
                 />
@@ -172,7 +172,7 @@ const AuthMechanism: FC<Props> = ({
               <Typography.Text>PrivateKey</Typography.Text>
               <Space className="w-full tw-justify-between ant-space-authMechanism">
                 <Input.Password
-                  contentEditable={false}
+                  readOnly
                   data-testid="privateKey"
                   value={authConfig?.privateKey}
                 />
@@ -185,7 +185,7 @@ const AuthMechanism: FC<Props> = ({
               <Typography.Text>ClientSecret</Typography.Text>
               <Space className="w-full tw-justify-between ant-space-authMechanism">
                 <Input.Password
-                  contentEditable={false}
+                  readOnly
                   data-testid="clientSecret"
                   value={authConfig?.clientSecret}
                 />
@@ -198,7 +198,7 @@ const AuthMechanism: FC<Props> = ({
               <Typography.Text>Audience</Typography.Text>
               <Space className="w-full tw-justify-between ant-space-authMechanism">
                 <Input
-                  contentEditable={false}
+                  readOnly
                   data-testid="audience"
                   value={authConfig?.audience}
                 />
@@ -211,7 +211,7 @@ const AuthMechanism: FC<Props> = ({
               <Typography.Text>ClientId</Typography.Text>
               <Space className="w-full tw-justify-between ant-space-authMechanism">
                 <Input
-                  contentEditable={false}
+                  readOnly
                   data-testid="clientId"
                   value={authConfig?.clientId}
                 />
@@ -223,11 +223,7 @@ const AuthMechanism: FC<Props> = ({
             <>
               <Typography.Text>Email</Typography.Text>
               <Space className="w-full tw-justify-between ant-space-authMechanism">
-                <Input
-                  contentEditable={false}
-                  data-testid="email"
-                  value={authConfig?.email}
-                />
+                <Input readOnly data-testid="email" value={authConfig?.email} />
                 <CopyToClipboardButton copyText={authConfig?.email} />
               </Space>
             </>
@@ -237,7 +233,7 @@ const AuthMechanism: FC<Props> = ({
               <Typography.Text>OrgURL</Typography.Text>
               <Space className="w-full tw-justify-between ant-space-authMechanism">
                 <Input
-                  contentEditable={false}
+                  readOnly
                   data-testid="orgURL"
                   value={authConfig?.orgURL}
                 />
@@ -250,7 +246,7 @@ const AuthMechanism: FC<Props> = ({
               <Typography.Text>Scopes</Typography.Text>
               <Space className="w-full tw-justify-between ant-space-authMechanism">
                 <Input
-                  contentEditable={false}
+                  readOnly
                   data-testid="scopes"
                   value={authConfig?.scopes.join(',')}
                 />
@@ -265,7 +261,7 @@ const AuthMechanism: FC<Props> = ({
               <Typography.Text>Domain</Typography.Text>
               <Space className="w-full tw-justify-between ant-space-authMechanism">
                 <Input
-                  contentEditable={false}
+                  readOnly
                   data-testid="domain"
                   value={authConfig?.domain}
                 />
@@ -278,7 +274,7 @@ const AuthMechanism: FC<Props> = ({
               <Typography.Text>Authority</Typography.Text>
               <Space className="w-full tw-justify-between ant-space-authMechanism">
                 <Input
-                  contentEditable={false}
+                  readOnly
                   data-testid="authority"
                   value={authConfig?.authority}
                 />
@@ -291,7 +287,7 @@ const AuthMechanism: FC<Props> = ({
               <Typography.Text>TokenEndpoint</Typography.Text>
               <Space className="w-full tw-justify-between ant-space-authMechanism">
                 <Input
-                  contentEditable={false}
+                  readOnly
                   data-testid="tokenEndpoint"
                   value={authConfig?.tokenEndpoint}
                 />


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on making AuthMechanism Fields to readOnly from NonEditable.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] Improvement


#
### Frontend Preview (Screenshots) :


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
