### PR TITLE
Fix: Sonar coverage test run only for Python 3.9

### DIFF
--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -72,7 +72,14 @@ jobs:
       run: ./docker/run_local_docker.sh -m no-ui
       timeout-minutes: 30
 
+    - name: Run Python Tests
+      if: ${{ matrix.py-version != '3.9' }}
+      run: |
+        source env/bin/activate
+        make run_python_tests
+
     - name: Run Python Tests & record coverage
+      if: ${{ matrix.py-version == '3.9' }}
       run: |
         source env/bin/activate
         make coverage


### PR DESCRIPTION
### Describe your changes :
Sonar coverage tests must run only for Python 3.9 tests.

### Type of change :
- [x] Bug fix

### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

### Reviewers
Ingestion: @open-metadata/ingestion
