### PR TITLE
FIX: connection failed because of having '@' character in uname and pass

### DIFF
--- a/ingestion/src/metadata/utils/source_connections.py
+++ b/ingestion/src/metadata/utils/source_connections.py
@@ -100,7 +100,7 @@ def get_connection_url_common(connection):
     url = f"{connection.scheme.value}://"
 
     if connection.username:
-        url += f"{connection.username}"
+        url += f"{quote_plus(connection.username)}"
         if not connection.password:
             connection.password = SecretStr("")
         url += f":{quote_plus(connection.password.get_secret_value())}"
@@ -175,7 +175,7 @@ def _(connection: OracleConnection):
 
     url = f"{connection.scheme.value}://"
     if connection.username:
-        url += f"{connection.username}"
+        url += f"{quote_plus(connection.username)}"
         if not connection.password:
             connection.password = SecretStr("")
         url += f":{quote_plus(connection.password.get_secret_value())}"
@@ -289,7 +289,7 @@ def _(connection: SnowflakeConnection):
     url = f"{connection.scheme.value}://"
 
     if connection.username:
-        url += f"{connection.username}"
+        url += f"{quote_plus(connection.username)}"
         if not connection.password:
             connection.password = SecretStr("")
         url += (
@@ -334,7 +334,7 @@ def _(connection: HiveConnection):
         and hasattr(connection.connectionArguments, "auth")
         and connection.connectionArguments.auth in ("LDAP", "CUSTOM")
     ):
-        url += f"{connection.username}"
+        url += f"{quote_plus(connection.username)}"
         if not connection.password:
             connection.password = SecretStr("")
         url += f":{quote_plus(connection.password.get_secret_value())}"
@@ -384,8 +384,12 @@ def _(connection: AzureSQLConnection):
     url = f"{connection.scheme.value}://"
 
     if connection.username:
-        url += f"{connection.username}"
-        url += f":{connection.password.get_secret_value()}" if connection else ""
+        url += f"{quote_plus(connection.username)}"
+        url += (
+            f":{quote_plus(connection.password.get_secret_value())}"
+            if connection
+            else ""
+        )
         url += "@"
 
     url += f"{connection.hostPort}"

--- a/ingestion/tests/unit/test_source_connection.py
+++ b/ingestion/tests/unit/test_source_connection.py
@@ -143,6 +143,18 @@ class SouceConnectionTest(TestCase):
         )
         assert expected_result == get_connection_url(hive_conn_obj)
 
+        # Passing @ in username and password
+        expected_result = "hive://username%40444:password%40333@localhost:10000"
+        hive_conn_obj = HiveConnection(
+            scheme=HiveScheme.hive.value,
+            username="username@444",
+            password="password@333",
+            hostPort="localhost:10000",
+            connectionArguments={"auth": "CUSTOM"},
+        )
+        print("get_connection_url(hive_conn_obj)...", get_connection_url(hive_conn_obj))
+        assert expected_result == get_connection_url(hive_conn_obj)
+
     def test_hive_url_conn_options_with_db(self):
         expected_result = "hive://localhost:10000/test_db?Key=Value"
         hive_conn_obj = HiveConnection(
@@ -204,6 +216,18 @@ class SouceConnectionTest(TestCase):
             password="pass",
             catalog="catalog",
         )
+        assert expected_url == get_connection_url(trino_conn_obj)
+
+        # Passing @ in username and password
+        expected_url = "trino://username%40444:pass%40111@localhost:443/catalog"
+        trino_conn_obj = TrinoConnection(
+            scheme=TrinoScheme.trino,
+            hostPort="localhost:443",
+            username="username@444",
+            password="pass@111",
+            catalog="catalog",
+        )
+
         assert expected_url == get_connection_url(trino_conn_obj)
 
     def test_trino_conn_arguments(self):
@@ -301,6 +325,18 @@ class SouceConnectionTest(TestCase):
             password="password",
             database="database",
         )
+        assert expected_url == get_connection_url(vertica_conn_obj)
+
+        # Passing @ in username and password
+        expected_url = "vertica+vertica_python://username%40444:password%40123@localhost:5443/database"
+        vertica_conn_obj = VerticaConnection(
+            scheme=VerticaScheme.vertica_vertica_python,
+            hostPort="localhost:5443",
+            username="username@444",
+            password="password@123",
+            database="database",
+        )
+
         assert expected_url == get_connection_url(vertica_conn_obj)
 
     def test_druid_url(self):
@@ -472,6 +508,22 @@ class SouceConnectionTest(TestCase):
             password="Abhi",
             warehouse="COMPUTE_WH",
             account="ue18849.us-east-2.aws",
+        )
+        assert expected_url == get_connection_url(snowflake_conn_obj)
+
+    def test_snowflake_url(self):
+        # Passing @ in username and password
+        expected_url = "snowflake://coding%40444:Abhi%40123@ue18849.us-east-2.aws?account=ue18849.us-east-2.aws&warehouse=COMPUTE_WH"
+        snowflake_conn_obj = SnowflakeConnection(
+            scheme=SnowflakeScheme.snowflake,
+            username="coding@444",
+            password="Abhi@123",
+            warehouse="COMPUTE_WH",
+            account="ue18849.us-east-2.aws",
+        )
+        print(
+            "get_connection_url(snowflake_conn_obj),,,,,",
+            get_connection_url(snowflake_conn_obj),
         )
         assert expected_url == get_connection_url(snowflake_conn_obj)
 
@@ -718,6 +770,19 @@ class SouceConnectionTest(TestCase):
 
         assert expected_url == get_connection_url(mssql_conn_obj)
 
+    def test_mssql_url(self):
+        # Passing @ in username and password
+        expected_url = "mssql+pytds://sa%40123:password%40444@localhost:1433"
+        mssql_conn_obj = MssqlConnection(
+            username="sa@123",
+            password="password@444",
+            hostPort="localhost:1433",
+            scheme=MssqlScheme.mssql_pytds,
+            database=None,
+        )
+
+        assert expected_url == get_connection_url(mssql_conn_obj)
+
         # connection arguments witho db
         expected_url = "mssql+pytds://sa:password@localhost:1433/catalog_test"
         mssql_conn_obj = MssqlConnection(
@@ -739,6 +804,19 @@ class SouceConnectionTest(TestCase):
             scheme=PrestoScheme.presto,
             catalog="test_catalog",
         )
+        assert expected_url == get_connection_url(presto_conn_obj)
+
+        # Passing @ in username and password
+        expected_url = "presto://admin%40333:pass%40111@localhost:8080/test_catalog"
+
+        presto_conn_obj = PrestoConnection(
+            username="admin@333",
+            password="pass@111",
+            hostPort="localhost:8080",
+            scheme=PrestoScheme.presto,
+            catalog="test_catalog",
+        )
+
         assert expected_url == get_connection_url(presto_conn_obj)
 
     def test_oracle_url(self):


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the fixing connection failed because of having '@' character in uname and pass
Fix: #7182

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement

### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
