### PR TITLE
fix(ui): invalidate token on logout via API call

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/cypress/constants/constants.js
+++ b/openmetadata-ui/src/main/resources/ui/cypress/constants/constants.js
@@ -14,6 +14,10 @@
 export const uuid = () => Cypress._.random(0, 1e6);
 const id = uuid();
 
+export const BASE_URL = location.origin;
+
+export const LOGIN_ERROR_MESSAGE = 'You have entered an invalid username or password.';
+
 export const MYDATA_SUMMARY_OPTIONS = {
   tables: 'tables',
   topics: 'topics',

--- a/openmetadata-ui/src/main/resources/ui/cypress/e2e/Flow/LogoutUser.spec.js
+++ b/openmetadata-ui/src/main/resources/ui/cypress/e2e/Flow/LogoutUser.spec.js
@@ -1,0 +1,36 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { interceptURL, login, verifyResponseStatusCode } from "../../common/common";
+import { BASE_URL, LOGIN } from "../../constants/constants";
+
+describe("Logout User", () => {
+  beforeEach(() => {
+    login(LOGIN.username, LOGIN.password);
+    cy.goToHomePage();
+  });
+
+  it("After login logout the user and invalidate the token", () => {
+    
+    cy.get('[data-testid="avatar"]').should("be.visible").click()
+
+    interceptURL('POST', '/api/v1/users/logout', 'logoutUser');
+    
+    cy.get('[data-testid="menu-item-Logout"]').should("be.visible").click()
+
+    // verify the logout request
+    verifyResponseStatusCode('@logoutUser', 200);
+
+    cy.url().should('eq', `${BASE_URL}/signin`);
+  })
+})

--- a/openmetadata-ui/src/main/resources/ui/cypress/e2e/Pages/Login.spec.js
+++ b/openmetadata-ui/src/main/resources/ui/cypress/e2e/Pages/Login.spec.js
@@ -12,6 +12,7 @@
  */
 
 import { interceptURL, login, verifyResponseStatusCode } from '../../common/common';
+import { BASE_URL, LOGIN_ERROR_MESSAGE } from '../../constants/constants';
 
 const CREDENTIALS = {
   firstName: 'Test',
@@ -21,10 +22,6 @@ const CREDENTIALS = {
 };
 const invalidEmail = 'userTest@openmetadata.org';
 const invalidPassword = 'testUsers@123';
-
-const baseURL = location.origin;
-
-const ERROR_MESSAGE = 'You have entered an invalid username or password.';
 
 describe('Login flow should work properly', () => {
   it('Signup and Login with signed up credentials', () => {
@@ -57,13 +54,13 @@ describe('Login flow should work properly', () => {
       .type(CREDENTIALS.password);
     //Click on create account button
     cy.get('.ant-btn').contains('Create Account').should('be.visible').click();
-    cy.url().should('eq', `${baseURL}/signin`).and('contain', 'signin');
+    cy.url().should('eq', `${BASE_URL}/signin`).and('contain', 'signin');
 
     //Login with the created user
 
     login(CREDENTIALS.email, CREDENTIALS.password);
     cy.goToHomePage();
-    cy.url().should('eq', `${baseURL}/my-data`);
+    cy.url().should('eq', `${BASE_URL}/my-data`);
 
     //Verify user profile
     cy.get('[data-testid="avatar"]').should('be.visible').click();
@@ -89,14 +86,14 @@ describe('Login flow should work properly', () => {
     cy.get('[data-testid="login-error-container"]')
       .should('be.visible')
       .invoke('text')
-      .should('eq', ERROR_MESSAGE);
+      .should('eq', LOGIN_ERROR_MESSAGE);
 
     //Login with invalid password
     login(CREDENTIALS.email, invalidPassword);
     cy.get('[data-testid="login-error-container"]')
       .should('be.visible')
       .invoke('text')
-      .should('eq', ERROR_MESSAGE);
+      .should('eq', LOGIN_ERROR_MESSAGE);
   });
 
   it('Forgot password and login with new password', () => {
@@ -110,7 +107,7 @@ describe('Login flow should work properly', () => {
       .click();
 
     cy.url()
-      .should('eq', `${baseURL}/forgot-password`)
+      .should('eq', `${BASE_URL}/forgot-password`)
       .and('contain', 'forgot-password');
     //Enter email
     cy.get('[id="email"]').should('be.visible').clear().type(CREDENTIALS.email);

--- a/openmetadata-ui/src/main/resources/ui/src/authentication/auth-provider/basic-auth.provider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/authentication/auth-provider/basic-auth.provider.tsx
@@ -20,6 +20,7 @@ import {
   basicAuthSignIn,
   checkEmailInUse,
   generatePasswordResetLink,
+  logoutUser,
   resetPassword,
 } from '../../axiosAPIs/auth-API';
 import {
@@ -192,8 +193,16 @@ const BasicAuthProvider = ({
   };
 
   const handleLogout = async () => {
-    localState.removeOidcToken();
-    history.push(ROUTES.SIGNIN);
+    const token = localState.getOidcToken();
+    if (token) {
+      try {
+        await logoutUser(token);
+        localState.removeOidcToken();
+        history.push(ROUTES.SIGNIN);
+      } catch (error) {
+        showErrorToast(error as AxiosError);
+      }
+    }
   };
 
   const contextValue = {

--- a/openmetadata-ui/src/main/resources/ui/src/axiosAPIs/auth-API.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/axiosAPIs/auth-API.ts
@@ -101,3 +101,12 @@ export const generateRandomPwd = async () => {
 
   return response.data;
 };
+
+/**
+ * Logout a User(Only called for saml and basic Auth)
+ */
+export const logoutUser = async (token: string) => {
+  const response = await axiosClient.post(`${apiPath}/logout`, { token });
+
+  return response.data;
+};


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the closing: #7372

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :

https://user-images.githubusercontent.com/12962843/196609962-5e3edce0-0294-41ac-8257-ce522cae324c.mov



#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
