### PR TITLE
FIX(UI) #7834: unable to type and search in the Teams dropdown

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
@@ -450,9 +450,9 @@ const Users = ({
                 <Select
                   isClearable
                   isMulti
+                  isSearchable
                   aria-label="Select teams"
                   className="tw-w-full"
-                  isSearchable={false}
                   options={teams?.map((team) => ({
                     label: getEntityName(team as unknown as EntityReference),
                     value: team.id,
@@ -587,10 +587,10 @@ const Users = ({
                 <Select
                   isClearable
                   isMulti
+                  isSearchable
                   aria-label="Select roles"
                   className="tw-w-full"
                   id="select-role"
-                  isSearchable={false}
                   options={userRolesOption}
                   placeholder="Roles..."
                   styles={reactSingleSelectCustomStyle}


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Issue: #7834 

Includes
- adds searchable property to teams and roles on profile

Changes made to make it more intuitive for users to locate specific roles or teams

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

![Screenshot from 2022-10-19 17-41-59](https://user-images.githubusercontent.com/110955804/196620115-a4df6333-88a0-4d5f-b1ce-d15c20f48597.png)
Can now search for teams and roles.

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
