### PR TITLE
fix(ui) :  Remove icon visible in Dropdown other than owner

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/dropdown/DropDownList.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/dropdown/DropDownList.tsx
@@ -110,7 +110,7 @@ const DropDownList: FunctionComponent<DropDownListProp> = ({
   };
 
   const removeOwnerButton = (item: DropDownListItem) => {
-    return !isNil(value) && item.value === value ? (
+    return !isNil(value) && item.value === value && removeOwner ? (
       <Tooltip title="Remove owner">
         <button
           className="cursor-pointer"


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
- Issue : Closes  #8290
- Remove icon visible in Dropdown other than owner

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<img width="631" alt="image" src="https://user-images.githubusercontent.com/66266464/196950831-d8a4aad3-1ae7-4843-b65a-da8048a40382.png">

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
 @open-metadata/ui 
