### PR TITLE
FIX(UI): #8261: Handle Loading States In a Better Way

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/TeamDetails/TeamDetailsV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TeamDetails/TeamDetailsV1.tsx
@@ -162,7 +162,7 @@ const TeamDetailsV1 = ({
     TitleBreadcrumbProps['titleLinks']
   >([]);
   const [addAttribute, setAddAttribute] = useState<AddAttribute>();
-  const [loading, setLoading] = useState<boolean>(false);
+  const [loading, setLoading] = useState<boolean>(true);
   const [selectedEntity, setEntity] = useState<{
     attribute: 'defaultRoles' | 'policies';
     record: EntityReference;
@@ -618,7 +618,7 @@ const TeamDetailsV1 = ({
       <div>
         {isEmpty(currentTeamUsers) &&
         !teamUsersSearchText &&
-        !isTeamMemberLoading ? (
+        isTeamMemberLoading <= 0 ? (
           fetchErrorPlaceHolder({
             description: (
               <div className="tw-mb-2">
@@ -676,7 +676,7 @@ const TeamDetailsV1 = ({
               )}
             </div>
 
-            {isTeamMemberLoading ? (
+            {isTeamMemberLoading > 0 ? (
               <Loader />
             ) : (
               <div>
@@ -862,7 +862,7 @@ const TeamDetailsV1 = ({
   const viewPermission =
     entityPermissions.ViewAll || entityPermissions.ViewBasic;
 
-  if (loading) {
+  if (loading || isTeamMemberLoading > 0) {
     return <Loader />;
   }
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/TeamDetails/TeamHierarchy.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TeamDetails/TeamHierarchy.tsx
@@ -23,7 +23,7 @@ import { getTeamsWithFqnPath } from '../../utils/RouterUtils';
 interface TeamHierarchyProps {
   data: Team[];
   onTeamExpand: (
-    isPageLoading?: boolean,
+    loading?: boolean,
     parentTeam?: string,
     updateChildNode?: boolean
   ) => void;

--- a/openmetadata-ui/src/main/resources/ui/src/components/TeamDetails/Teams.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TeamDetails/Teams.tsx
@@ -37,7 +37,7 @@ interface TeamsProps {
   data: Team[];
   onAddTeamClick: (value: boolean) => void;
   onTeamExpand: (
-    isPageLoading?: boolean,
+    loading?: boolean,
     parentTeam?: string,
     updateChildNode?: boolean
   ) => void;

--- a/openmetadata-ui/src/main/resources/ui/src/interface/teamsAndUsers.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/interface/teamsAndUsers.interface.ts
@@ -95,7 +95,7 @@ export interface TeamDetailsProp {
   currentTeamUserPage: number;
   teamUsersSearchText: string;
   isDescriptionEditable: boolean;
-  isTeamMemberLoading: boolean;
+  isTeamMemberLoading: number;
   hasAccess: boolean;
   handleAddTeam: (value: boolean) => void;
   descriptionHandler: (value: boolean) => void;
@@ -116,7 +116,7 @@ export interface TeamDetailsProp {
   showDeletedTeam: boolean;
   onShowDeletedTeamChange: (checked: boolean) => void;
   onTeamExpand: (
-    isPageLoading?: boolean,
+    loading?: boolean,
     parentTeam?: string,
     updateChildNode?: boolean
   ) => void;

--- a/openmetadata-ui/src/main/resources/ui/src/pages/teams/TeamsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/teams/TeamsPage.tsx
@@ -69,7 +69,7 @@ const TeamsPage = () => {
   const [selectedTeam, setSelectedTeam] = useState<Team>({} as Team);
   const [users, setUsers] = useState<User[]>([]);
   const [userPaging, setUserPaging] = useState<Paging>(pagingObject);
-  const [isDataLoading, setIsDataLoading] = useState(false);
+  const [isDataLoading, setIsDataLoading] = useState(0);
   const [currentUserPage, setCurrentUserPage] = useState(INITIAL_PAGING_VALUE);
   const [showDeletedTeam, setShowDeletedTeam] = useState<boolean>(false);
   const [isPageLoading, setIsPageLoading] = useState<boolean>(true);
@@ -126,11 +126,12 @@ const TeamsPage = () => {
   };
 
   const fetchAllTeams = async (
-    isPageLoading = true,
+    loading = true,
     parentTeam?: string,
     updateChildNode = false
   ) => {
-    isPageLoading && setIsPageLoading(true);
+    loading && setIsDataLoading((isDataLoading) => ++isDataLoading);
+
     try {
       const { data } = await getTeams(
         ['defaultRoles', 'userCount', 'childrenCount'],
@@ -159,7 +160,7 @@ const TeamsPage = () => {
         jsonData['api-error-messages']['unexpected-server-response']
       );
     }
-    setIsPageLoading(false);
+    loading && setIsDataLoading((isDataLoading) => --isDataLoading);
   };
 
   /**
@@ -169,7 +170,7 @@ const TeamsPage = () => {
     team: string,
     paging = {} as { [key: string]: string }
   ) => {
-    setIsDataLoading(true);
+    setIsDataLoading((isDataLoading) => ++isDataLoading);
     getUsers('teams,roles', PAGE_SIZE_MEDIUM, { team, ...paging })
       .then((res) => {
         if (res.data) {
@@ -181,7 +182,7 @@ const TeamsPage = () => {
         setUsers([]);
         setUserPaging({ total: 0 });
       })
-      .finally(() => setIsDataLoading(false));
+      .finally(() => setIsDataLoading((isDataLoading) => --isDataLoading));
   };
 
   const fetchTeamByFqn = async (name: string) => {
@@ -246,7 +247,7 @@ const TeamsPage = () => {
   };
 
   const searchUsers = (text: string, currentPage: number) => {
-    setIsDataLoading(true);
+    setIsDataLoading((isDataLoading) => ++isDataLoading);
     searchData(
       text,
       currentPage,
@@ -266,7 +267,7 @@ const TeamsPage = () => {
       .catch(() => {
         setUsers([]);
       })
-      .finally(() => setIsDataLoading(false));
+      .finally(() => setIsDataLoading((isDataLoading) => --isDataLoading));
   };
 
   const updateTeamHandler = (updatedData: Team, fetchTeam = true) => {
@@ -478,7 +479,7 @@ const TeamsPage = () => {
       if (fqn) {
         fetchTeamByFqn(fqn);
       }
-      fetchAllTeams(false, fqn);
+      fetchAllTeams(true, fqn);
       setCurrentFqn(fqn);
     }
   }, [entityPermissions, fqn]);


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Issue: #8261 

Includes:
- changes from boolean to number for loader state to account for multiple functions loading data asynchronously
- the teams page will now only load once isdataloading is < 0 otherwise the loader is displayed

Changes made to stop incorrect placeholder appearing when there is a delay in API


#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>


https://user-images.githubusercontent.com/110955804/197248518-2a9acb38-28ec-459b-ae5a-a511720bacde.mov



#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
