### PR TITLE
Issue-8315: Parameter 'input' on the metadata restore CLI not working

### DIFF
--- a/ingestion/src/metadata/cmd.py
+++ b/ingestion/src/metadata/cmd.py
@@ -396,10 +396,10 @@ def openmetadata_imports_migration(
     required=False,
 )
 @click.option(
-    "--input",
-    help="Local backup file path for restore",
-    type=click.Path(exists=False, dir_okay=True),
-    default=None,
+    "-b",
+    "--backup-file",
+    type=click.Path(exists=True, dir_okay=False),
+    help="Backup file",
     required=True,
 )
 @click.option(
@@ -426,7 +426,7 @@ def restore(
     password: str,
     database: str,
     port: str,
-    sql_file: str,
+    backup_file: str,
     options: List[str],
     arguments: List[str],
     schema: str,
@@ -447,7 +447,7 @@ def restore(
         password,
         database,
         port,
-        sql_file,
+        backup_file,
         options,
         arguments,
         schema,


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the ..... because ...

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
