### PR TITLE
Fix lineage to support 'merge into' queries starting with comments

### DIFF
--- a/ingestion/src/metadata/ingestion/lineage/sql_lineage.py
+++ b/ingestion/src/metadata/ingestion/lineage/sql_lineage.py
@@ -60,7 +60,7 @@ def clean_raw_query(raw_query: str) -> str:
         replace_by=" ",
     )
 
-    if insensitive_match(clean_query, "merge into .*when matched.*"):
+    if insensitive_match(clean_query, ".*merge into .*when matched.*"):
         clean_query = insensitive_replace(
             raw_str=clean_query,
             to_replace="when matched.*",  # merge into queries specific

--- a/ingestion/tests/unit/test_query_parser.py
+++ b/ingestion/tests/unit/test_query_parser.py
@@ -166,10 +166,10 @@ class QueryParserTests(TestCase):
         Validate query cleaning logic
         """
         query = """
-            merge into table_1 using (select a, b from table_2) when matched update set t.a = 'value' 
+            /* comment */ merge into table_1 using (select a, b from table_2) when matched update set t.a = 'value' 
             when not matched then insert (table_1.a, table_2.b) values ('value1', 'value2')
         """
         self.assertEqual(
             clean_raw_query(query),
-            "merge into table_1 using (select a, b from table_2)",
+            "/* comment */ merge into table_1 using (select a, b from table_2)",
         )


### PR DESCRIPTION
### Describe your changes :
Fix `merge into` queries which could start with a comment like:
```sql
/* comment */ 
merge into table_1 using (select a, b from table_2) 
when matched update set t.a = 'value' 
when not matched then insert (table_1.a, table_2.b) values ('value1', 'value2')
```

### Type of change :
- [x] Bug fix

### Reviewers
Ingestion: @open-metadata/ingestion
