### PR TITLE
Remove unused methods in ResultList implementations

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/exception/CatalogExceptionMessage.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/exception/CatalogExceptionMessage.java
@@ -111,10 +111,6 @@ public final class CatalogExceptionMessage {
     return String.format("Principal: CatalogPrincipal{name='%s'} is not admin", name);
   }
 
-  public static String notAdminOrBot(String name) {
-    return String.format("Principal: CatalogPrincipal{name='%s'} is not admin or bot", name);
-  }
-
   public static String permissionDenied(
       String user, MetadataOperation operation, String roleName, String policyName, String ruleName) {
     if (roleName != null) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/exception/CatalogExceptionMessage.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/exception/CatalogExceptionMessage.java
@@ -111,6 +111,10 @@ public final class CatalogExceptionMessage {
     return String.format("Principal: CatalogPrincipal{name='%s'} is not admin", name);
   }
 
+  public static String notAdminOrBot(String name) {
+    return String.format("Principal: CatalogPrincipal{name='%s'} is not admin or bot", name);
+  }
+
   public static String permissionDenied(
       String user, MetadataOperation operation, String roleName, String policyName, String ruleName) {
     if (roleName != null) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/analytics/ReportDataResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/analytics/ReportDataResource.java
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
-import java.util.List;
 import javax.validation.Valid;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -53,10 +52,6 @@ public class ReportDataResource {
     @SuppressWarnings("unused")
     public ReportDataResultList() {
       /* Required for serde */
-    }
-
-    public ReportDataResultList(List<ReportData> data, String beforeCursor, String afterCursor, int total) {
-      super(data, beforeCursor, afterCursor, total);
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/analytics/ReportDataResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/analytics/ReportDataResource.java
@@ -115,7 +115,7 @@ public class ReportDataResource {
   public Response addReportData(
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid ReportData reportData)
       throws IOException {
-    authorizer.authorizeAdmin(securityContext, true);
+    authorizer.authorizeAdmin(securityContext);
     return dao.addReportData(reportData);
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/analytics/WebAnalyticEventResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/analytics/WebAnalyticEventResource.java
@@ -389,7 +389,7 @@ public class WebAnalyticEventResource extends EntityResource<WebAnalyticEvent, W
       @Context SecurityContext securityContext,
       @Valid WebAnalyticEventData webAnalyticEventData)
       throws IOException {
-    authorizer.authorizeAdmin(securityContext, true);
+    authorizer.authorizeAdmin(securityContext);
     return dao.addWebAnalyticEventData(uriInfo, webAnalyticEventData);
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/analytics/WebAnalyticEventResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/analytics/WebAnalyticEventResource.java
@@ -89,11 +89,6 @@ public class WebAnalyticEventResource extends EntityResource<WebAnalyticEvent, W
     public WebAnalyticEventDataList() {
       // Empty constructor needed for deserialization
     }
-
-    public WebAnalyticEventDataList(
-        List<WebAnalyticEventData> data, String beforeCursor, String afterCursor, int total) {
-      super(data, beforeCursor, afterCursor, total);
-    }
   }
 
   @SuppressWarnings("unused") // Method used for reflection of webAnalyticEventTypes

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/bots/BotResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/bots/BotResource.java
@@ -130,10 +130,6 @@ public class BotResource extends EntityResource<Bot, BotRepository> {
     public BotList() {
       /* Required for serde */
     }
-
-    public BotList(List<Bot> data) {
-      super(data);
-    }
   }
 
   @GET

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/charts/ChartResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/charts/ChartResource.java
@@ -23,7 +23,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
-import java.util.List;
 import java.util.UUID;
 import javax.json.JsonPatch;
 import javax.validation.Valid;
@@ -84,10 +83,6 @@ public class ChartResource extends EntityResource<Chart, ChartRepository> {
     @SuppressWarnings("unused")
     ChartList() {
       // Empty constructor needed for deserialization
-    }
-
-    public ChartList(List<Chart> data, String beforeCursor, String afterCursor, int total) {
-      super(data, beforeCursor, afterCursor, total);
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/dashboards/DashboardResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/dashboards/DashboardResource.java
@@ -23,7 +23,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
-import java.util.List;
 import java.util.UUID;
 import javax.json.JsonPatch;
 import javax.validation.Valid;
@@ -83,10 +82,6 @@ public class DashboardResource extends EntityResource<Dashboard, DashboardReposi
     @SuppressWarnings("unused")
     DashboardList() {
       // Empty constructor needed for deserialization
-    }
-
-    public DashboardList(List<Dashboard> data, String beforeCursor, String afterCursor, int total) {
-      super(data, beforeCursor, afterCursor, total);
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/DatabaseResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/DatabaseResource.java
@@ -23,7 +23,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
-import java.util.List;
 import java.util.UUID;
 import javax.json.JsonPatch;
 import javax.validation.Valid;
@@ -83,10 +82,6 @@ public class DatabaseResource extends EntityResource<Database, DatabaseRepositor
   public static class DatabaseList extends ResultList<Database> {
     @SuppressWarnings("unused") // Empty constructor needed for deserialization
     DatabaseList() {}
-
-    public DatabaseList(List<Database> data, String beforeCursor, String afterCursor, int total) {
-      super(data, beforeCursor, afterCursor, total);
-    }
   }
 
   static final String FIELDS = "owner,databaseSchemas,usageSummary,location";

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/DatabaseSchemaResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/DatabaseSchemaResource.java
@@ -23,7 +23,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
-import java.util.List;
 import java.util.UUID;
 import javax.json.JsonPatch;
 import javax.validation.Valid;
@@ -82,10 +81,6 @@ public class DatabaseSchemaResource extends EntityResource<DatabaseSchema, Datab
   public static class DatabaseSchemaList extends ResultList<DatabaseSchema> {
     @SuppressWarnings("unused") // Empty constructor needed for deserialization
     DatabaseSchemaList() {}
-
-    public DatabaseSchemaList(List<DatabaseSchema> data, String beforeCursor, String afterCursor, int total) {
-      super(data, beforeCursor, afterCursor, total);
-    }
   }
 
   static final String FIELDS = "owner,tables,usageSummary";

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/TableResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/TableResource.java
@@ -125,10 +125,6 @@ public class TableResource extends EntityResource<Table, TableRepository> {
     public TableList() {
       /* Required for serde */
     }
-
-    public TableList(List<Table> data, String beforeCursor, String afterCursor, int total) {
-      super(data, beforeCursor, afterCursor, total);
-    }
   }
 
   public static class TableProfileList extends ResultList<TableProfile> {
@@ -136,20 +132,12 @@ public class TableResource extends EntityResource<Table, TableRepository> {
     public TableProfileList() {
       /* Required for serde */
     }
-
-    public TableProfileList(List<TableProfile> data, String beforeCursor, String afterCursor, int total) {
-      super(data, beforeCursor, afterCursor, total);
-    }
   }
 
   public static class ColumnProfileList extends ResultList<ColumnProfile> {
     @SuppressWarnings("unused")
     public ColumnProfileList() {
       /* Required for serde */
-    }
-
-    public ColumnProfileList(List<ColumnProfile> data, String beforeCursor, String afterCursor, int total) {
-      super(data, beforeCursor, afterCursor, total);
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/TableResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/TableResource.java
@@ -760,7 +760,8 @@ public class TableResource extends EntityResource<Table, TableRepository> {
       @Parameter(description = "Id of the table", schema = @Schema(type = "UUID")) @PathParam("id") UUID id,
       @Valid SQLQuery sqlQuery)
       throws IOException {
-    authorizer.authorizeAdmin(securityContext, true);
+    OperationContext operationContext = new OperationContext(entityType, MetadataOperation.EDIT_ALL);
+    authorizer.authorize(securityContext, operationContext, getResourceContextById(id));
     Table table = dao.addQuery(id, sqlQuery);
     return addHref(uriInfo, table);
   }
@@ -784,7 +785,8 @@ public class TableResource extends EntityResource<Table, TableRepository> {
       @Parameter(description = "Id of the table", schema = @Schema(type = "string")) @PathParam("id") UUID id,
       @Valid DataModel dataModel)
       throws IOException {
-    authorizer.authorizeAdmin(securityContext, true);
+    OperationContext operationContext = new OperationContext(entityType, MetadataOperation.EDIT_ALL);
+    authorizer.authorize(securityContext, operationContext, getResourceContextById(id));
     Table table = dao.addDataModel(id, dataModel);
     return addHref(uriInfo, table);
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResource.java
@@ -454,7 +454,9 @@ public class TestCaseResource extends EntityResource<TestCase, TestCaseRepositor
           String fqn,
       @Valid TestCaseResult testCaseResult)
       throws IOException {
-    authorizer.authorizeAdmin(securityContext, true);
+    ResourceContextInterface resourceContext = TestCaseResourceContext.builder().name(fqn).build();
+    OperationContext operationContext = new OperationContext(Entity.TABLE, MetadataOperation.EDIT_TESTS);
+    authorizer.authorize(securityContext, operationContext, resourceContext);
     return dao.addTestCaseResult(uriInfo, fqn, testCaseResult).toResponse();
   }
 
@@ -522,7 +524,9 @@ public class TestCaseResource extends EntityResource<TestCase, TestCaseRepositor
           @PathParam("timestamp")
           Long timestamp)
       throws IOException {
-    authorizer.authorizeAdmin(securityContext, true);
+    ResourceContextInterface resourceContext = TestCaseResourceContext.builder().name(fqn).build();
+    OperationContext operationContext = new OperationContext(Entity.TABLE, MetadataOperation.EDIT_TESTS);
+    authorizer.authorize(securityContext, operationContext, resourceContext);
     return dao.deleteTestCaseResult(fqn, timestamp).toResponse();
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResource.java
@@ -13,7 +13,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 import java.util.UUID;
 import javax.json.JsonPatch;
 import javax.validation.Valid;
@@ -92,20 +91,12 @@ public class TestCaseResource extends EntityResource<TestCase, TestCaseRepositor
     public TestCaseList() {
       // Empty constructor needed for deserialization
     }
-
-    public TestCaseList(List<TestCase> data, String beforeCursor, String afterCursor, int total) {
-      super(data, beforeCursor, afterCursor, total);
-    }
   }
 
   public static class TestCaseResultList extends ResultList<TestCaseResult> {
     @SuppressWarnings("unused")
     public TestCaseResultList() {
       /* Required for serde */
-    }
-
-    public TestCaseResultList(List<TestCaseResult> data, String beforeCursor, String afterCursor, int total) {
-      super(data, beforeCursor, afterCursor, total);
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestDefinitionResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestDefinitionResource.java
@@ -88,10 +88,6 @@ public class TestDefinitionResource extends EntityResource<TestDefinition, TestD
     public TestDefinitionList() {
       // Empty constructor needed for deserialization
     }
-
-    public TestDefinitionList(List<TestDefinition> data, String beforeCursor, String afterCursor, int total) {
-      super(data, beforeCursor, afterCursor, total);
-    }
   }
 
   @GET

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestSuiteResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestSuiteResource.java
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
-import java.util.List;
 import java.util.UUID;
 import javax.json.JsonPatch;
 import javax.validation.Valid;
@@ -75,10 +74,6 @@ public class TestSuiteResource extends EntityResource<TestSuite, TestSuiteReposi
     @SuppressWarnings("unused")
     public TestSuiteList() {
       // Empty constructor needed for deserialization
-    }
-
-    public TestSuiteList(List<TestSuite> data, String beforeCursor, String afterCursor, int total) {
-      super(data, beforeCursor, afterCursor, total);
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/elasticsearch/BuildSearchIndexResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/elasticsearch/BuildSearchIndexResource.java
@@ -125,7 +125,7 @@ public class BuildSearchIndexResource {
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateEventPublisherJob createRequest)
       throws IOException {
     // Only admins  can issue a reindex request
-    authorizer.authorizeAdmin(securityContext, false);
+    authorizer.authorizeAdmin(securityContext);
     User user =
         userRepository.getByName(null, securityContext.getUserPrincipal().getName(), userRepository.getFields("id"));
     if (createRequest.getRunMode() == RunMode.BATCH) {
@@ -150,7 +150,7 @@ public class BuildSearchIndexResource {
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @PathParam("runMode") String runMode)
       throws IOException {
     // Only admins  can issue a reindex request
-    authorizer.authorizeAdmin(securityContext, false);
+    authorizer.authorizeAdmin(securityContext);
     // Check if there is a running job for reindex for requested entity
     String record;
     if (runMode.equals(RunMode.BATCH.toString())) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/events/WebhookResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/events/WebhookResource.java
@@ -82,10 +82,6 @@ public class WebhookResource extends EntityResource<Webhook, WebhookRepository> 
 
     @SuppressWarnings("unused") /* Required for tests */
     public WebhookList() {}
-
-    public WebhookList(List<Webhook> data, String beforeCursor, String afterCursor, int total) {
-      super(data, beforeCursor, afterCursor, total);
-    }
   }
 
   public WebhookResource(CollectionDAO dao, Authorizer authorizer) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/feeds/FeedResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/feeds/FeedResource.java
@@ -69,6 +69,7 @@ import org.openmetadata.service.jdbi3.FeedRepository;
 import org.openmetadata.service.jdbi3.FeedRepository.FilterType;
 import org.openmetadata.service.jdbi3.FeedRepository.PaginationType;
 import org.openmetadata.service.resources.Collection;
+import org.openmetadata.service.resources.feeds.FeedResource.ThreadList;
 import org.openmetadata.service.resources.feeds.MessageParser.EntityLink;
 import org.openmetadata.service.security.Authorizer;
 import org.openmetadata.service.security.policyevaluator.OperationContext;
@@ -109,19 +110,11 @@ public class FeedResource {
   static class ThreadList extends ResultList<Thread> {
     @SuppressWarnings("unused") // Used for deserialization
     ThreadList() {}
-
-    ThreadList(List<Thread> data) {
-      super(data);
-    }
   }
 
   public static class PostList extends ResultList<Post> {
     @SuppressWarnings("unused") /* Required for tests */
     public PostList() {}
-
-    public PostList(List<Post> data, String beforeCursor, String afterCursor, int total) {
-      super(data, beforeCursor, afterCursor, total);
-    }
 
     public PostList(List<Post> listPosts) {
       super(listPosts);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/feeds/FeedResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/feeds/FeedResource.java
@@ -357,7 +357,7 @@ public class FeedResource {
         // don't throw any exception
       } else {
         // Only admins or bots can close or resolve task other than the above-mentioned users
-        authorizer.authorizeAdmin(securityContext, true);
+        authorizer.authorizeAdmin(securityContext);
       }
     }
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/glossary/GlossaryResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/glossary/GlossaryResource.java
@@ -24,7 +24,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
-import java.util.List;
 import java.util.UUID;
 import javax.json.JsonPatch;
 import javax.validation.Valid;
@@ -85,10 +84,6 @@ public class GlossaryResource extends EntityResource<Glossary, GlossaryRepositor
     @SuppressWarnings("unused")
     GlossaryList() {
       // Empty constructor needed for deserialization
-    }
-
-    public GlossaryList(List<Glossary> data, String beforeCursor, String afterCursor, int total) {
-      super(data, beforeCursor, afterCursor, total);
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/glossary/GlossaryTermResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/glossary/GlossaryTermResource.java
@@ -24,7 +24,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
-import java.util.List;
 import java.util.UUID;
 import javax.json.JsonPatch;
 import javax.validation.Valid;
@@ -92,10 +91,6 @@ public class GlossaryTermResource extends EntityResource<GlossaryTerm, GlossaryT
     @SuppressWarnings("unused")
     GlossaryTermList() {
       // Empty constructor needed for deserialization
-    }
-
-    public GlossaryTermList(List<GlossaryTerm> data, String beforeCursor, String afterCursor, int total) {
-      super(data, beforeCursor, afterCursor, total);
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/locations/LocationResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/locations/LocationResource.java
@@ -85,10 +85,6 @@ public class LocationResource extends EntityResource<Location, LocationRepositor
   public static class LocationList extends ResultList<Location> {
     @SuppressWarnings("unused") /* Required for tests */
     public LocationList() {}
-
-    public LocationList(List<Location> data, String beforeCursor, String afterCursor, int total) {
-      super(data, beforeCursor, afterCursor, total);
-    }
   }
 
   static final String FIELDS = "owner,followers,tags,path";

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/mlmodels/MlModelResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/mlmodels/MlModelResource.java
@@ -23,7 +23,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
-import java.util.List;
 import java.util.UUID;
 import javax.json.JsonPatch;
 import javax.validation.Valid;
@@ -86,10 +85,6 @@ public class MlModelResource extends EntityResource<MlModel, MlModelRepository> 
     @SuppressWarnings("unused")
     MlModelList() {
       // Empty constructor needed for deserialization
-    }
-
-    public MlModelList(List<MlModel> data, String beforeCursor, String afterCursor, int total) {
-      super(data, beforeCursor, afterCursor, total);
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/pipelines/PipelineResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/pipelines/PipelineResource.java
@@ -52,6 +52,7 @@ import org.openmetadata.schema.entity.data.PipelineStatus;
 import org.openmetadata.schema.type.ChangeEvent;
 import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.Include;
+import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.ListFilter;
@@ -60,6 +61,7 @@ import org.openmetadata.service.resources.Collection;
 import org.openmetadata.service.resources.EntityResource;
 import org.openmetadata.service.resources.dqtests.TestCaseResource;
 import org.openmetadata.service.security.Authorizer;
+import org.openmetadata.service.security.policyevaluator.OperationContext;
 import org.openmetadata.service.util.RestUtil;
 import org.openmetadata.service.util.ResultList;
 
@@ -362,7 +364,8 @@ public class PipelineResource extends EntityResource<Pipeline, PipelineRepositor
       @Parameter(description = "Id of the pipeline", schema = @Schema(type = "string")) @PathParam("fqn") String fqn,
       @Valid PipelineStatus pipelineStatus)
       throws IOException {
-    authorizer.authorizeAdmin(securityContext, true);
+    OperationContext operationContext = new OperationContext(entityType, MetadataOperation.EDIT_STATUS);
+    authorizer.authorize(securityContext, operationContext, getResourceContextByName(fqn));
     Pipeline pipeline = dao.addPipelineStatus(fqn, pipelineStatus);
     return addHref(uriInfo, pipeline);
   }
@@ -427,7 +430,8 @@ public class PipelineResource extends EntityResource<Pipeline, PipelineRepositor
           @PathParam("timestamp")
           Long timestamp)
       throws IOException {
-    authorizer.authorizeAdmin(securityContext, true);
+    OperationContext operationContext = new OperationContext(entityType, MetadataOperation.EDIT_STATUS);
+    authorizer.authorize(securityContext, operationContext, getResourceContextByName(fqn));
     Pipeline pipeline = dao.deletePipelineStatus(fqn, timestamp);
     return addHref(uriInfo, pipeline);
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/pipelines/PipelineResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/pipelines/PipelineResource.java
@@ -23,7 +23,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
-import java.util.List;
 import java.util.UUID;
 import javax.json.JsonPatch;
 import javax.validation.Valid;
@@ -91,20 +90,12 @@ public class PipelineResource extends EntityResource<Pipeline, PipelineRepositor
     PipelineList() {
       // Empty constructor needed for deserialization
     }
-
-    public PipelineList(List<Pipeline> data, String beforeCursor, String afterCursor, int total) {
-      super(data, beforeCursor, afterCursor, total);
-    }
   }
 
   public static class PipelineStatusList extends ResultList<PipelineStatus> {
     @SuppressWarnings("unused")
     public PipelineStatusList() {
       /* Required for serde */
-    }
-
-    public PipelineStatusList(List<PipelineStatus> data, String beforeCursor, String afterCursor, int total) {
-      super(data, beforeCursor, afterCursor, total);
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/policies/PolicyResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/policies/PolicyResource.java
@@ -107,10 +107,6 @@ public class PolicyResource extends EntityResource<Policy, PolicyRepository> {
     PolicyList() {
       // Empty constructor needed for deserialization
     }
-
-    public PolicyList(List<Policy> data, String beforeCursor, String afterCursor, int total) {
-      super(data, beforeCursor, afterCursor, total);
-    }
   }
 
   public static class ResourceDescriptorList extends ResultList<ResourceDescriptor> {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/ServiceEntityResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/ServiceEntityResource.java
@@ -27,7 +27,6 @@ import org.openmetadata.service.jdbi3.ServiceEntityRepository;
 import org.openmetadata.service.resources.EntityResource;
 import org.openmetadata.service.secrets.SecretsManager;
 import org.openmetadata.service.secrets.SecretsManagerFactory;
-import org.openmetadata.service.security.AuthorizationException;
 import org.openmetadata.service.security.Authorizer;
 import org.openmetadata.service.util.JsonUtils;
 import org.openmetadata.service.util.ResultList;
@@ -50,10 +49,7 @@ public abstract class ServiceEntityResource<
   }
 
   protected T decryptOrNullify(SecurityContext securityContext, T service) {
-    SecretsManager secretsManager = SecretsManagerFactory.getSecretsManager();
-    try {
-      authorizer.authorizeAdmin(securityContext, secretsManager.isLocal());
-    } catch (AuthorizationException e) {
+    if (!authorizer.decryptSecret(securityContext)) {
       return nullifyRequiredConnectionParameters(service);
     }
     service.getConnection().setConfig(retrieveServiceConnectionConfig(service));

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/dashboard/DashboardServiceResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/dashboard/DashboardServiceResource.java
@@ -85,10 +85,6 @@ public class DashboardServiceResource
   public static class DashboardServiceList extends ResultList<DashboardService> {
     @SuppressWarnings("unused") /* Required for tests */
     public DashboardServiceList() {}
-
-    public DashboardServiceList(List<DashboardService> data, String beforeCursor, String afterCursor, int total) {
-      super(data, beforeCursor, afterCursor, total);
-    }
   }
 
   @GET

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/database/DatabaseServiceResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/database/DatabaseServiceResource.java
@@ -86,10 +86,6 @@ public class DatabaseServiceResource
   public static class DatabaseServiceList extends ResultList<DatabaseService> {
     @SuppressWarnings("unused") /* Required for tests */
     public DatabaseServiceList() {}
-
-    public DatabaseServiceList(List<DatabaseService> data, String beforeCursor, String afterCursor, int total) {
-      super(data, beforeCursor, afterCursor, total);
-    }
   }
 
   @GET

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/ingestionpipelines/IngestionPipelineResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/ingestionpipelines/IngestionPipelineResource.java
@@ -110,10 +110,6 @@ public class IngestionPipelineResource extends EntityResource<IngestionPipeline,
     public IngestionPipelineList() {
       // Empty constructor needed for deserialization
     }
-
-    public IngestionPipelineList(List<IngestionPipeline> data, String beforeCursor, String afterCursor, int total) {
-      super(data, beforeCursor, afterCursor, total);
-    }
   }
 
   static final String FIELDS = FIELD_OWNER;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/messaging/MessagingServiceResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/messaging/MessagingServiceResource.java
@@ -85,10 +85,6 @@ public class MessagingServiceResource
   public static class MessagingServiceList extends ResultList<MessagingService> {
     @SuppressWarnings("unused") /* Required for tests */
     public MessagingServiceList() {}
-
-    public MessagingServiceList(List<MessagingService> data, String beforeCursor, String afterCursor, int total) {
-      super(data, beforeCursor, afterCursor, total);
-    }
   }
 
   @GET

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/mlmodel/MlModelServiceResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/mlmodel/MlModelServiceResource.java
@@ -84,10 +84,6 @@ public class MlModelServiceResource
   public static class MlModelServiceList extends ResultList<MlModelService> {
     @SuppressWarnings("unused") /* Required for tests */
     public MlModelServiceList() {}
-
-    public MlModelServiceList(List<MlModelService> data, String beforeCursor, String afterCursor, int total) {
-      super(data, beforeCursor, afterCursor, total);
-    }
   }
 
   @GET

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/pipeline/PipelineServiceResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/pipeline/PipelineServiceResource.java
@@ -83,10 +83,6 @@ public class PipelineServiceResource
   public static class PipelineServiceList extends ResultList<PipelineService> {
     @SuppressWarnings("unused") /* Required for tests */
     public PipelineServiceList() {}
-
-    public PipelineServiceList(List<PipelineService> data, String beforeCursor, String afterCursor, int total) {
-      super(data, beforeCursor, afterCursor, total);
-    }
   }
 
   @GET

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/storage/StorageServiceResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/storage/StorageServiceResource.java
@@ -22,7 +22,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
-import java.util.List;
 import java.util.UUID;
 import javax.validation.Valid;
 import javax.validation.constraints.Max;
@@ -80,10 +79,6 @@ public class StorageServiceResource extends EntityResource<StorageService, Stora
   public static class StorageServiceList extends ResultList<StorageService> {
     @SuppressWarnings("unused") /* Required for tests */
     public StorageServiceList() {}
-
-    public StorageServiceList(List<StorageService> data, String beforeCursor, String afterCursor, int total) {
-      super(data, beforeCursor, afterCursor, total);
-    }
   }
 
   @GET

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/settings/SettingsResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/settings/SettingsResource.java
@@ -118,10 +118,6 @@ public class SettingsResource {
     public SettingsList() {
       /* Required for serde */
     }
-
-    public SettingsList(List<Settings> data) {
-      super(data);
-    }
   }
 
   public SettingsResource(CollectionDAO dao, Authorizer authorizer) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/settings/SettingsResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/settings/SettingsResource.java
@@ -245,7 +245,6 @@ public class SettingsResource {
           @PathParam("entityName")
           String entityName,
       @Valid List<Filters> newFilter) {
-    authorizer.authorizeAdmin(securityContext, false);
     return settingsRepository.updateEntityFilter(entityName, newFilter);
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/settings/SettingsResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/settings/SettingsResource.java
@@ -58,16 +58,16 @@ import org.openmetadata.service.util.FilterUtil;
 import org.openmetadata.service.util.JsonUtils;
 import org.openmetadata.service.util.ResultList;
 
+/**
+ * Resource for managing OpenMetadata settings that an admin can change. Example - using APIs here, the conversation
+ * thread notification can be changed to include only events that an organization uses.
+ */
 @Path("/v1/settings")
 @Api(value = "Settings Collection", tags = "Settings collection")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 @Collection(name = "settings")
 @Slf4j
-/**
- * Resource for managing OpenMetadata settings that an admin can change. Example - using APIs here, the conversation
- * thread notification can be changed to include only events that an organization uses.
- */
 public class SettingsResource {
   private final SettingsRepository settingsRepository;
   private final Authorizer authorizer;
@@ -144,7 +144,7 @@ public class SettingsResource {
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = SettingsList.class)))
       })
   public ResultList<Settings> list(@Context UriInfo uriInfo, @Context SecurityContext securityContext) {
-    authorizer.authorizeAdmin(securityContext, false);
+    authorizer.authorizeAdmin(securityContext);
     return settingsRepository.listAllConfigs();
   }
 
@@ -162,7 +162,7 @@ public class SettingsResource {
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = SettingsList.class)))
       })
   public List<EventFilter> getBootstrapFilters(@Context UriInfo uriInfo, @Context SecurityContext securityContext) {
-    authorizer.authorizeAdmin(securityContext, false);
+    authorizer.authorizeAdmin(securityContext);
     return bootStrappedFilters;
   }
 
@@ -180,7 +180,7 @@ public class SettingsResource {
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = SettingsList.class)))
       })
   public Response resetFilters(@Context UriInfo uriInfo, @Context SecurityContext securityContext) {
-    authorizer.authorizeAdmin(securityContext, false);
+    authorizer.authorizeAdmin(securityContext);
     Settings settings =
         new Settings().withConfigType(ACTIVITY_FEED_FILTER_SETTING).withConfigValue(bootStrappedFilters);
     return settingsRepository.createNewSetting(settings);
@@ -203,7 +203,7 @@ public class SettingsResource {
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
       @PathParam("settingName") String settingName) {
-    authorizer.authorizeAdmin(securityContext, false);
+    authorizer.authorizeAdmin(securityContext);
     return settingsRepository.getConfigWithKey(settingName);
   }
 
@@ -221,7 +221,7 @@ public class SettingsResource {
       })
   public Response createOrUpdateSetting(
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid Settings settingName) {
-    authorizer.authorizeAdmin(securityContext, false);
+    authorizer.authorizeAdmin(securityContext);
     return settingsRepository.createOrUpdate(settingName);
   }
 
@@ -271,7 +271,7 @@ public class SettingsResource {
                         @ExampleObject("[" + "{op:remove, path:/a}," + "{op:add, path: /b, value: val}" + "]")
                       }))
           JsonPatch patch) {
-    authorizer.authorizeAdmin(securityContext, false);
+    authorizer.authorizeAdmin(securityContext);
     return settingsRepository.patchSetting(settingName, patch);
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/tags/TagResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/tags/TagResource.java
@@ -81,10 +81,6 @@ public class TagResource {
   static class CategoryList extends ResultList<TagCategory> {
     @SuppressWarnings("unused") // Empty constructor needed for deserialization
     CategoryList() {}
-
-    CategoryList(List<TagCategory> data) {
-      super(data);
-    }
   }
 
   public TagResource(CollectionDAO collectionDAO, Authorizer authorizer) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/RoleResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/RoleResource.java
@@ -105,10 +105,6 @@ public class RoleResource extends EntityResource<Role, RoleRepository> {
   public static class RoleList extends ResultList<Role> {
     @SuppressWarnings("unused") /* Required for tests */
     RoleList() {}
-
-    public RoleList(List<Role> roles, String beforeCursor, String afterCursor, int total) {
-      super(roles, beforeCursor, afterCursor, total);
-    }
   }
 
   public static final String FIELDS = "policies,teams,users";

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/TeamResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/TeamResource.java
@@ -27,7 +27,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
-import java.util.List;
 import java.util.UUID;
 import javax.json.JsonPatch;
 import javax.validation.Valid;
@@ -99,10 +98,6 @@ public class TeamResource extends EntityResource<Team, TeamRepository> {
   public static class TeamList extends ResultList<Team> {
     @SuppressWarnings("unused") /* Required for tests */
     TeamList() {}
-
-    public TeamList(List<Team> teams, String beforeCursor, String afterCursor, int total) {
-      super(teams, beforeCursor, afterCursor, total);
-    }
   }
 
   public static class TeamHierarchyList extends ResultList<TeamHierarchy> {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java
@@ -184,10 +184,6 @@ public class UserResource extends EntityResource<User, UserRepository> {
   public static class UserList extends ResultList<User> {
     @SuppressWarnings("unused") // Used for deserialization
     public UserList() {}
-
-    public UserList(List<User> users, String beforeCursor, String afterCursor, int total) {
-      super(users, beforeCursor, afterCursor, total);
-    }
   }
 
   static final String FIELDS = "profile,roles,teams,follows,owns";

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java
@@ -590,7 +590,7 @@ public class UserResource extends EntityResource<User, UserRepository> {
       @Valid GenerateTokenRequest generateTokenRequest)
       throws IOException {
     User user = dao.get(uriInfo, id, Fields.EMPTY_FIELDS);
-    authorizer.authorizeAdminOrBot(securityContext);
+    authorizer.authorizeAdmin(securityContext);
     jwtTokenGenerator.setAuthMechanism(user, generateTokenRequest);
     User updatedUser = dao.createOrUpdate(uriInfo, user).getEntity();
     return Response.status(Response.Status.OK).entity(jwtTokenGenerator.getAuthMechanism(updatedUser)).build();
@@ -615,7 +615,7 @@ public class UserResource extends EntityResource<User, UserRepository> {
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @PathParam("id") UUID id) throws IOException {
 
     User user = dao.get(uriInfo, id, Fields.EMPTY_FIELDS);
-    authorizer.authorizeAdminOrBot(securityContext);
+    authorizer.authorizeAdmin(securityContext);
     JWTAuthMechanism jwtAuthMechanism = new JWTAuthMechanism().withJWTToken(StringUtils.EMPTY);
     AuthenticationMechanism authenticationMechanism =
         new AuthenticationMechanism().withConfig(jwtAuthMechanism).withAuthType(JWT);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java
@@ -286,7 +286,7 @@ public class UserResource extends EntityResource<User, UserRepository> {
       description = "Generate a random pwd",
       responses = {@ApiResponse(responseCode = "200", description = "Random pwd")})
   public Response generateRandomPassword(@Context UriInfo uriInfo, @Context SecurityContext securityContext) {
-    authorizer.authorizeAdmin(securityContext, false);
+    authorizer.authorizeAdmin(securityContext);
     return Response.status(OK).entity(PasswordUtil.generateRandomPassword()).build();
   }
 
@@ -485,7 +485,7 @@ public class UserResource extends EntityResource<User, UserRepository> {
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @Valid CreateUser create) throws IOException {
     User user = getUser(securityContext, create);
     if (Boolean.TRUE.equals(create.getIsAdmin())) {
-      authorizer.authorizeAdmin(securityContext, true);
+      authorizer.authorizeAdmin(securityContext);
     }
     if (Boolean.TRUE.equals(create.getIsBot())) {
       addAuthMechanismToBot(user, create, uriInfo);
@@ -552,8 +552,8 @@ public class UserResource extends EntityResource<User, UserRepository> {
     MetadataOperation operation = resourceContext.getEntity() == null ? CREATE : EDIT_ALL;
 
     dao.prepare(user);
-    if (Boolean.TRUE.equals(create.getIsAdmin()) || Boolean.TRUE.equals(create.getIsBot())) {
-      authorizer.authorizeAdmin(securityContext, true);
+    if (Boolean.TRUE.equals(create.getIsAdmin())) {
+      authorizer.authorizeAdmin(securityContext);
     } else if (!securityContext.getUserPrincipal().getName().equals(user.getName())) {
       // doing authorization check outside of authorizer here. We are checking if the logged-in user same as the user
       // we are trying to update. One option is to set users.owner as user, however that is not supported for User.
@@ -590,17 +590,10 @@ public class UserResource extends EntityResource<User, UserRepository> {
       @Valid GenerateTokenRequest generateTokenRequest)
       throws IOException {
     User user = dao.get(uriInfo, id, Fields.EMPTY_FIELDS);
-    authorizeGenerateJWT(user);
-    authorizer.authorizeAdmin(securityContext, false);
-    JWTAuthMechanism jwtAuthMechanism =
-        jwtTokenGenerator.generateJWTToken(user, generateTokenRequest.getJWTTokenExpiry());
-    AuthenticationMechanism authenticationMechanism =
-        new AuthenticationMechanism().withConfig(jwtAuthMechanism).withAuthType(AuthenticationMechanism.AuthType.JWT);
-    user.setAuthenticationMechanism(authenticationMechanism);
+    authorizer.authorizeAdminOrBot(securityContext);
+    jwtTokenGenerator.setAuthMechanism(user, generateTokenRequest);
     User updatedUser = dao.createOrUpdate(uriInfo, user).getEntity();
-    jwtAuthMechanism =
-        JsonUtils.convertValue(updatedUser.getAuthenticationMechanism().getConfig(), JWTAuthMechanism.class);
-    return Response.status(Response.Status.OK).entity(jwtAuthMechanism).build();
+    return Response.status(Response.Status.OK).entity(jwtTokenGenerator.getAuthMechanism(updatedUser)).build();
   }
 
   @PUT
@@ -622,8 +615,7 @@ public class UserResource extends EntityResource<User, UserRepository> {
       @Context UriInfo uriInfo, @Context SecurityContext securityContext, @PathParam("id") UUID id) throws IOException {
 
     User user = dao.get(uriInfo, id, Fields.EMPTY_FIELDS);
-    authorizeGenerateJWT(user);
-    authorizer.authorizeAdmin(securityContext, false);
+    authorizer.authorizeAdminOrBot(securityContext);
     JWTAuthMechanism jwtAuthMechanism = new JWTAuthMechanism().withJWTToken(StringUtils.EMPTY);
     AuthenticationMechanism authenticationMechanism =
         new AuthenticationMechanism().withConfig(jwtAuthMechanism).withAuthType(JWT);
@@ -658,7 +650,7 @@ public class UserResource extends EntityResource<User, UserRepository> {
       throw new IllegalArgumentException("JWT token is only supported for bot users");
     }
     decryptOrNullify(securityContext, user);
-    authorizer.authorizeAdmin(securityContext, false);
+    authorizer.authorizeAdmin(securityContext);
     AuthenticationMechanism authenticationMechanism = user.getAuthenticationMechanism();
     if (authenticationMechanism != null
         && authenticationMechanism.getConfig() != null
@@ -693,7 +685,7 @@ public class UserResource extends EntityResource<User, UserRepository> {
       throw new IllegalArgumentException("JWT token is only supported for bot users");
     }
     decryptOrNullify(securityContext, user);
-    authorizer.authorizeAdmin(securityContext, false);
+    authorizer.authorizeAdmin(securityContext);
     return user.getAuthenticationMechanism();
   }
 
@@ -724,8 +716,8 @@ public class UserResource extends EntityResource<User, UserRepository> {
       JsonObject patchOpObject = patchOp.asJsonObject();
       if (patchOpObject.containsKey("path") && patchOpObject.containsKey("value")) {
         String path = patchOpObject.getString("path");
-        if (path.equals("/isAdmin") || path.equals("/isBot")) {
-          authorizer.authorizeAdmin(securityContext, true);
+        if (path.equals("/isAdmin")) {
+          authorizer.authorizeAdmin(securityContext);
         }
         // if path contains team, check if team is joinable by any user
         if (patchOpObject.containsKey("op")
@@ -742,7 +734,7 @@ public class UserResource extends EntityResource<User, UserRepository> {
             dao.validateTeamAddition(id, UUID.fromString(teamId));
             if (!dao.isTeamJoinable(teamId)) {
               // Only admin can join closed teams
-              authorizer.authorizeAdmin(securityContext, false);
+              authorizer.authorizeAdmin(securityContext);
             }
           }
         }
@@ -1001,7 +993,7 @@ public class UserResource extends EntityResource<User, UserRepository> {
         return Response.status(403).entity(new ErrorMessage(403, "Old Password is not correct")).build();
       }
     } else {
-      authorizer.authorizeAdmin(securityContext, false);
+      authorizer.authorizeAdmin(securityContext);
       User storedUser = dao.getByName(uriInfo, request.getUsername(), new Fields(fields, String.join(",", fields)));
       String newHashedPassword = BCrypt.withDefaults().hashToString(12, request.getNewPassword().toCharArray());
       // Admin is allowed to set password for User directly
@@ -1189,12 +1181,6 @@ public class UserResource extends EntityResource<User, UserRepository> {
         .withUpdatedAt(System.currentTimeMillis())
         .withTeams(EntityUtil.toEntityReferences(create.getTeams(), Entity.TEAM))
         .withRoles(EntityUtil.toEntityReferences(create.getRoles(), Entity.ROLE));
-  }
-
-  private void authorizeGenerateJWT(User user) {
-    if (!Boolean.TRUE.equals(user.getIsBot())) {
-      throw new IllegalArgumentException("Generating JWT token is only supported for bot users");
-    }
   }
 
   public User registerUser(UriInfo uriInfo, RegistrationRequest newRegistrationRequest) throws IOException {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/topics/TopicResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/topics/TopicResource.java
@@ -24,7 +24,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
-import java.util.List;
 import java.util.UUID;
 import javax.json.JsonPatch;
 import javax.validation.Valid;
@@ -88,10 +87,6 @@ public class TopicResource extends EntityResource<Topic, TopicRepository> {
     @SuppressWarnings("unused")
     public TopicList() {
       // Empty constructor needed for deserialization
-    }
-
-    public TopicList(List<Topic> data, String beforeCursor, String afterCursor, int total) {
-      super(data, beforeCursor, afterCursor, total);
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/topics/TopicResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/topics/TopicResource.java
@@ -51,6 +51,7 @@ import org.openmetadata.schema.entity.data.Topic;
 import org.openmetadata.schema.type.ChangeEvent;
 import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.Include;
+import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.schema.type.topic.TopicSampleData;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.CollectionDAO;
@@ -59,6 +60,7 @@ import org.openmetadata.service.jdbi3.TopicRepository;
 import org.openmetadata.service.resources.Collection;
 import org.openmetadata.service.resources.EntityResource;
 import org.openmetadata.service.security.Authorizer;
+import org.openmetadata.service.security.policyevaluator.OperationContext;
 import org.openmetadata.service.util.ResultList;
 
 @Path("/v1/topics")
@@ -344,7 +346,8 @@ public class TopicResource extends EntityResource<Topic, TopicRepository> {
       @Parameter(description = "Id of the topic", schema = @Schema(type = "string")) @PathParam("id") UUID id,
       @Valid TopicSampleData sampleData)
       throws IOException {
-    authorizer.authorizeAdmin(securityContext, true);
+    OperationContext operationContext = new OperationContext(entityType, MetadataOperation.EDIT_SAMPLE_DATA);
+    authorizer.authorize(securityContext, operationContext, getResourceContextById(id));
     Topic topic = dao.addSampleData(id, sampleData);
     return addHref(uriInfo, topic);
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/types/TypeResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/types/TypeResource.java
@@ -56,6 +56,7 @@ import org.openmetadata.schema.entity.type.Category;
 import org.openmetadata.schema.entity.type.CustomProperty;
 import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.Include;
+import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
 import org.openmetadata.service.jdbi3.CollectionDAO;
@@ -64,6 +65,7 @@ import org.openmetadata.service.jdbi3.TypeRepository;
 import org.openmetadata.service.resources.Collection;
 import org.openmetadata.service.resources.EntityResource;
 import org.openmetadata.service.security.Authorizer;
+import org.openmetadata.service.security.policyevaluator.OperationContext;
 import org.openmetadata.service.util.EntityUtil.Fields;
 import org.openmetadata.service.util.JsonUtils;
 import org.openmetadata.service.util.RestUtil.PutResponse;
@@ -389,7 +391,9 @@ public class TypeResource extends EntityResource<Type, TypeRepository> {
       @Parameter(description = "Type Id", schema = @Schema(type = "string")) @PathParam("id") UUID id,
       @Valid CustomProperty property)
       throws IOException {
-    authorizer.authorizeAdmin(securityContext, false);
+    // TODO fix this is the typeID correct? Why are we not doing this by name?
+    OperationContext operationContext = new OperationContext(entityType, MetadataOperation.CREATE);
+    authorizer.authorize(securityContext, operationContext, getResourceContextById(id));
     PutResponse<Type> response =
         dao.addCustomProperty(uriInfo, securityContext.getUserPrincipal().getName(), id, property);
     addHref(uriInfo, response.getEntity());

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/types/TypeResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/types/TypeResource.java
@@ -125,10 +125,6 @@ public class TypeResource extends EntityResource<Type, TypeRepository> {
     TypeList() {
       // Empty constructor needed for deserialization
     }
-
-    public TypeList(List<Type> data, String beforeCursor, String afterCursor, int total) {
-      super(data, beforeCursor, afterCursor, total);
-    }
   }
 
   public static final String PROPERTIES = "customProperties";

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/Authorizer.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/Authorizer.java
@@ -41,5 +41,10 @@ public interface Authorizer {
       SecurityContext securityContext, OperationContext operationContext, ResourceContextInterface resourceContext)
       throws IOException;
 
-  void authorizeAdmin(SecurityContext securityContext, boolean allowBots);
+  void authorizeAdmin(SecurityContext securityContext);
+
+  // TODO delete this and move the operation that depends on this authorization to be based on Roles and Policies
+  void authorizeAdminOrBot(SecurityContext securityContext);
+
+  boolean decryptSecret(SecurityContext securityContext);
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/Authorizer.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/Authorizer.java
@@ -43,8 +43,5 @@ public interface Authorizer {
 
   void authorizeAdmin(SecurityContext securityContext);
 
-  // TODO delete this and move the operation that depends on this authorization to be based on Roles and Policies
-  void authorizeAdminOrBot(SecurityContext securityContext);
-
   boolean decryptSecret(SecurityContext securityContext);
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/DefaultAuthorizer.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/DefaultAuthorizer.java
@@ -22,7 +22,6 @@ import static org.openmetadata.schema.teams.authn.SSOAuthMechanism.SsoServiceTyp
 import static org.openmetadata.schema.teams.authn.SSOAuthMechanism.SsoServiceType.OKTA;
 import static org.openmetadata.service.Entity.ADMIN_USER_NAME;
 import static org.openmetadata.service.exception.CatalogExceptionMessage.notAdmin;
-import static org.openmetadata.service.exception.CatalogExceptionMessage.notAdminOrBot;
 import static org.openmetadata.service.resources.teams.UserResource.USER_PROTECTED_FIELDS;
 
 import at.favre.lib.crypto.bcrypt.BCrypt;
@@ -236,15 +235,6 @@ public class DefaultAuthorizer implements Authorizer {
       return;
     }
     throw new AuthorizationException(notAdmin(securityContext.getUserPrincipal().getName()));
-  }
-
-  @Override
-  public void authorizeAdminOrBot(SecurityContext securityContext) {
-    SubjectContext subjectContext = getSubjectContext(securityContext);
-    if (subjectContext.isAdmin() || subjectContext.isBot()) {
-      return;
-    }
-    throw new AuthorizationException(notAdminOrBot(securityContext.getUserPrincipal().getName()));
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/NoopAuthorizer.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/NoopAuthorizer.java
@@ -95,7 +95,17 @@ public class NoopAuthorizer implements Authorizer {
   }
 
   @Override
-  public void authorizeAdmin(SecurityContext securityContext, boolean allowBots) {
+  public void authorizeAdmin(SecurityContext securityContext) {
     /* Always authorize */
+  }
+
+  @Override
+  public void authorizeAdminOrBot(SecurityContext securityContext) {
+    /* Always authorize */
+  }
+
+  @Override
+  public boolean decryptSecret(SecurityContext securityContext) {
+    return true; // Always decrypt
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/NoopAuthorizer.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/NoopAuthorizer.java
@@ -100,11 +100,6 @@ public class NoopAuthorizer implements Authorizer {
   }
 
   @Override
-  public void authorizeAdminOrBot(SecurityContext securityContext) {
-    /* Always authorize */
-  }
-
-  @Override
   public boolean decryptSecret(SecurityContext securityContext) {
     return true; // Always decrypt
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/jwt/JWTTokenGenerator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/jwt/JWTTokenGenerator.java
@@ -20,10 +20,13 @@ import java.util.List;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.api.security.jwt.JWTTokenConfiguration;
+import org.openmetadata.schema.entity.teams.AuthenticationMechanism;
 import org.openmetadata.schema.entity.teams.User;
+import org.openmetadata.schema.teams.authn.GenerateTokenRequest;
 import org.openmetadata.schema.teams.authn.JWTAuthMechanism;
 import org.openmetadata.schema.teams.authn.JWTTokenExpiry;
 import org.openmetadata.service.security.AuthenticationException;
+import org.openmetadata.service.util.JsonUtils;
 
 @Slf4j
 public class JWTTokenGenerator {
@@ -63,6 +66,17 @@ public class JWTTokenGenerator {
     } catch (Exception ex) {
       LOG.error("Failed to initialize JWTTokenGenerator ", ex);
     }
+  }
+
+  public void setAuthMechanism(User user, GenerateTokenRequest generateTokenRequest) {
+    JWTAuthMechanism jwtAuthMechanism = generateJWTToken(user, generateTokenRequest.getJWTTokenExpiry());
+    AuthenticationMechanism authenticationMechanism =
+        new AuthenticationMechanism().withConfig(jwtAuthMechanism).withAuthType(AuthenticationMechanism.AuthType.JWT);
+    user.setAuthenticationMechanism(authenticationMechanism);
+  }
+
+  public JWTAuthMechanism getAuthMechanism(User user) {
+    return JsonUtils.convertValue(user.getAuthenticationMechanism().getConfig(), JWTAuthMechanism.class);
   }
 
   public JWTAuthMechanism generateJWTToken(User user, JWTTokenExpiry expiry) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/OperationContext.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/OperationContext.java
@@ -39,6 +39,10 @@ public class OperationContext {
     return operations;
   }
 
+  public boolean isCreateOperation() {
+    return operations.contains(MetadataOperation.CREATE);
+  }
+
   public static boolean isEditOperation(MetadataOperation operation) {
     return operation.value().startsWith("Edit");
   }

--- a/openmetadata-service/src/main/resources/json/data/ResourceDescriptors.json
+++ b/openmetadata-service/src/main/resources/json/data/ResourceDescriptors.json
@@ -462,5 +462,16 @@
       "EditDescription",
       "EditDisplayName"
     ]
+  },
+  {
+    "name" : "type",
+    "operations" : [
+      "Create",
+      "Delete",
+      "ViewAll",
+      "EditAll",
+      "EditDescription",
+      "EditDisplayName"
+    ]
   }
 ]

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/teams/UserResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/teams/UserResourceTest.java
@@ -82,6 +82,7 @@ import org.openmetadata.schema.auth.LoginRequest;
 import org.openmetadata.schema.auth.RegistrationRequest;
 import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.schema.entity.teams.AuthenticationMechanism;
+import org.openmetadata.schema.entity.teams.AuthenticationMechanism.AuthType;
 import org.openmetadata.schema.entity.teams.Role;
 import org.openmetadata.schema.entity.teams.Team;
 import org.openmetadata.schema.entity.teams.User;
@@ -90,6 +91,7 @@ import org.openmetadata.schema.teams.authn.GenerateTokenRequest;
 import org.openmetadata.schema.teams.authn.JWTAuthMechanism;
 import org.openmetadata.schema.teams.authn.JWTTokenExpiry;
 import org.openmetadata.schema.teams.authn.SSOAuthMechanism;
+import org.openmetadata.schema.teams.authn.SSOAuthMechanism.SsoServiceType;
 import org.openmetadata.schema.type.ChangeDescription;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.ImageList;
@@ -418,12 +420,7 @@ public class UserResourceTest extends EntityResourceTest<User, CreateUser> {
   }
 
   private CreateUser createBotUserRequest(TestInfo test, int index) {
-    return createRequest(test, index)
-        .withIsBot(true)
-        .withAuthenticationMechanism(
-            new AuthenticationMechanism()
-                .withAuthType(AuthenticationMechanism.AuthType.JWT)
-                .withConfig(new JWTAuthMechanism().withJWTTokenExpiry(JWTTokenExpiry.Unlimited)));
+    return createBotUserRequest(getEntityName(test, index));
   }
 
   @Test
@@ -685,21 +682,18 @@ public class UserResourceTest extends EntityResourceTest<User, CreateUser> {
 
   @Test
   void put_generateToken_bot_user_200_ok(TestInfo test) throws HttpResponseException {
-    User user =
-        createEntity(
-            createRequest(test, 6)
-                .withName("ingestion-bot-jwt")
-                .withDisplayName("ingestion-bot-jwt")
-                .withEmail("ingestion-bot-jwt@email.com")
-                .withIsBot(true)
-                .withAuthenticationMechanism(
-                    new AuthenticationMechanism()
-                        .withAuthType(AuthenticationMechanism.AuthType.SSO)
-                        .withConfig(
-                            new SSOAuthMechanism()
-                                .withSsoServiceType(SSOAuthMechanism.SsoServiceType.GOOGLE)
-                                .withAuthConfig(new GoogleSSOClientConfig().withSecretKey("/path/to/secret.json")))),
-            authHeaders("ingestion-bot-jwt@email.com"));
+    AuthenticationMechanism authMechanism =
+        new AuthenticationMechanism()
+            .withAuthType(AuthType.SSO)
+            .withConfig(
+                new SSOAuthMechanism()
+                    .withSsoServiceType(SsoServiceType.GOOGLE)
+                    .withAuthConfig(new GoogleSSOClientConfig().withSecretKey("/path/to/secret.json")));
+    CreateUser create =
+        createBotUserRequest("ingestion-bot-jwt")
+            .withEmail("ingestion-bot-jwt@email.com")
+            .withAuthenticationMechanism(authMechanism);
+    User user = createEntity(create, authHeaders("ingestion-bot-jwt@email.com"));
     TestUtils.put(
         getResource(String.format("users/generateToken/%s", user.getId())),
         new GenerateTokenRequest().withJWTTokenExpiry(JWTTokenExpiry.Seven),
@@ -865,14 +859,14 @@ public class UserResourceTest extends EntityResourceTest<User, CreateUser> {
     BotResourceTest botResourceTest = new BotResourceTest();
     String botName = "test-bot-user-fail";
     // create bot user
-    CreateUser createBotUser = creatBotUserRequest("test-bot-user", true).withBotName(botName);
+    CreateUser createBotUser = createBotUserRequest("test-bot-user").withBotName(botName);
     User botUser = updateEntity(createBotUser, CREATED, ADMIN_AUTH_HEADERS);
     EntityReference botUserRef = Objects.requireNonNull(botUser).getEntityReference();
     // assign bot user to a bot
     CreateBot create = botResourceTest.createRequest(test).withBotUser(botUserRef).withName(botName);
     botResourceTest.createEntity(create, ADMIN_AUTH_HEADERS);
     // put user with a different bot name
-    CreateUser createWrongBotUser = creatBotUserRequest("test-bot-user", true).withBotName("test-bot-user-fail-2");
+    CreateUser createWrongBotUser = createBotUserRequest("test-bot-user").withBotName("test-bot-user-fail-2");
     assertResponse(
         () -> updateEntity(createWrongBotUser, BAD_REQUEST, ADMIN_AUTH_HEADERS),
         BAD_REQUEST,
@@ -884,14 +878,14 @@ public class UserResourceTest extends EntityResourceTest<User, CreateUser> {
     BotResourceTest botResourceTest = new BotResourceTest();
     String botName = "test-bot-ok";
     // create bot user
-    CreateUser createBotUser = creatBotUserRequest("test-bot-user-ok", true).withBotName(botName);
+    CreateUser createBotUser = createBotUserRequest("test-bot-user-ok").withBotName(botName);
     User botUser = updateEntity(createBotUser, CREATED, ADMIN_AUTH_HEADERS);
     EntityReference botUserRef = Objects.requireNonNull(botUser).getEntityReference();
     // assign bot user to a bot
     CreateBot create = botResourceTest.createRequest(test).withBotUser(botUserRef).withName(botName);
     botResourceTest.createEntity(create, ADMIN_AUTH_HEADERS);
     // put again user with same bot name
-    CreateUser createDifferentBotUser = creatBotUserRequest("test-bot-user-ok", true).withBotName(botName);
+    CreateUser createDifferentBotUser = createBotUserRequest("test-bot-user-ok").withBotName(botName);
     updateEntity(createDifferentBotUser, OK, ADMIN_AUTH_HEADERS);
     assertNotNull(createDifferentBotUser);
   }
@@ -1044,19 +1038,18 @@ public class UserResourceTest extends EntityResourceTest<User, CreateUser> {
     return String.join(",", allowedFields);
   }
 
-  public User createUser(String botName, boolean isBot) {
+  public User createUser(String userName, boolean isBot) {
     try {
-      CreateUser createUser = creatBotUserRequest(botName, isBot);
+      CreateUser createUser = createBotUserRequest(userName).withIsBot(isBot);
       return createEntity(createUser, ADMIN_AUTH_HEADERS);
     } catch (Exception ignore) {
       return null;
     }
   }
 
-  private CreateUser creatBotUserRequest(String botUserName, boolean isBot) {
+  private CreateUser createBotUserRequest(String botUserName) {
     return createRequest(botUserName, "", "", null)
-        .withIsBot(isBot)
-        .withIsAdmin(false)
+        .withIsBot(true)
         .withAuthenticationMechanism(
             new AuthenticationMechanism()
                 .withAuthType(AuthenticationMechanism.AuthType.JWT)


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Constructor methods that implement ResultList for listing APIs are unused. Remove them.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
