### PR TITLE
Fixed incorrect const import in cmd.py

### DIFF
--- a/ingestion/src/metadata/cmd.py
+++ b/ingestion/src/metadata/cmd.py
@@ -21,7 +21,6 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import List, Optional, Tuple
 
 import click
-import const
 
 from metadata.__version__ import get_metadata_version
 from metadata.cli.backup import UploadDestinationType, run_backup
@@ -286,7 +285,7 @@ def docker(
 @click.option(
     "--upload_destination_type",
     help="AWS or AZURE",
-    type=click.Choice(const.Upload_Destination_Type),
+    type=click.Choice(UploadDestinationType.__members__),
     default=None,
     required=False,
 )


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Fixed incorrect const import in `cmd.py`
There is no library named `const` which was imported here and this import is causing cli ingestions to fail with below error.

<img width="1267" alt="image" src="https://user-images.githubusercontent.com/28966081/198201526-5bab9da8-04b1-4c10-851d-524d838e174d.png">

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
@open-metadata/ingestion