### PR TITLE
Fix #8396 Multiple webanalytics events send per single page load

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/router/AppRouter.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/router/AppRouter.tsx
@@ -103,6 +103,11 @@ const AppRouter = () => {
 
   useEffect(() => {
     const { pathname } = location;
+
+    /**
+     * Ignore the slash path because we are treating my data as
+     * default path.
+     */
     if (pathname !== '/') {
       // track page view on route change
       analytics.page();

--- a/openmetadata-ui/src/main/resources/ui/src/router/AppRouter.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/router/AppRouter.tsx
@@ -102,9 +102,12 @@ const AppRouter = () => {
     ) : null;
 
   useEffect(() => {
-    // track page view on route change
-    analytics.page();
-  }, [location]);
+    const { pathname } = location;
+    if (pathname !== '/') {
+      // track page view on route change
+      analytics.page();
+    }
+  }, [location.pathname]);
 
   return loading ? (
     <Loader />

--- a/openmetadata-ui/src/main/resources/ui/src/utils/WebAnalyticsUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/WebAnalyticsUtils.ts
@@ -64,10 +64,7 @@ export const trackPageView = async (pageData: WebPageData, userId: string) => {
   const { payload } = pageData;
 
   const { location, navigator, performance, document } = window;
-  const { hostname, pathname } = location;
-
-  // store the current path reference
-  let currentPathRef = pathname;
+  const { hostname } = location;
 
   const pageLoadTime = getPageLoadTime(performance);
 
@@ -75,43 +72,33 @@ export const trackPageView = async (pageData: WebPageData, userId: string) => {
 
   const referrer = properties.referrer ?? document.referrer;
 
-  const previousPathRef = getReferrerPath(referrer);
-
   // timestamp for the current event
   const timestamp = meta.ts;
 
   if (userId) {
-    /**
-     *  Check if the previous path and current path is not matching
-     *  then only collect the data
-     */
-    if (currentPathRef !== previousPathRef) {
-      currentPathRef = previousPathRef;
+    const pageViewEvent: PageViewEvent = {
+      fullUrl: properties.url,
+      url: properties.path,
+      hostname,
+      language: navigator.language,
+      screenSize: `${properties.width}x${properties.height}`,
+      userId,
+      sessionId: anonymousId,
+      referrer,
+      pageLoadTime,
+    };
 
-      const pageViewEvent: PageViewEvent = {
-        fullUrl: properties.url,
-        url: properties.path,
-        hostname,
-        language: navigator.language,
-        screenSize: `${properties.width}x${properties.height}`,
-        userId,
-        sessionId: anonymousId,
-        referrer,
-        pageLoadTime,
-      };
+    const webAnalyticEventData: WebAnalyticEventData = {
+      eventType: WebAnalyticEventType.PageView,
+      eventData: pageViewEvent,
+      timestamp,
+    };
 
-      const webAnalyticEventData: WebAnalyticEventData = {
-        eventType: WebAnalyticEventType.PageView,
-        eventData: pageViewEvent,
-        timestamp,
-      };
-
-      try {
-        // collect the page event
-        await postPageView(webAnalyticEventData);
-      } catch (error) {
-        showErrorToast(error as AxiosError);
-      }
+    try {
+      // collect the page event
+      await postPageView(webAnalyticEventData);
+    } catch (error) {
+      showErrorToast(error as AxiosError);
     }
   }
 };

--- a/openmetadata-ui/src/main/resources/ui/src/utils/WebAnalyticsUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/WebAnalyticsUtils.ts
@@ -12,7 +12,6 @@
  */
 
 import Analytics, { AnalyticsInstance } from 'analytics';
-import { AxiosError } from 'axios';
 import { postPageView } from '../axiosAPIs/WebAnalyticsAPI';
 import { WebPageData } from '../components/WebAnalytics/WebAnalytics.interface';
 import { PageViewEvent } from '../generated/analytics/pageViewEvent';
@@ -20,7 +19,6 @@ import {
   WebAnalyticEventData,
   WebAnalyticEventType,
 } from '../generated/analytics/webAnalyticEventData';
-import { showErrorToast } from './ToastUtils';
 
 /**
  * Check if url is valid or not and return the pathname
@@ -97,8 +95,8 @@ export const trackPageView = async (pageData: WebPageData, userId: string) => {
     try {
       // collect the page event
       await postPageView(webAnalyticEventData);
-    } catch (error) {
-      showErrorToast(error as AxiosError);
+    } catch (_error) {
+      // handle page view error
     }
   }
 };


### PR DESCRIPTION
Closes #8396 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on issue #8396 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] Improvement


#
### Frontend Preview (Screenshots) :

https://user-images.githubusercontent.com/59080942/198370521-4fef9c43-8941-4e99-9532-29b140f38b80.mov



#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
