### PR TITLE
Update GID used in ingestion docker images

### DIFF
--- a/ingestion/Dockerfile
+++ b/ingestion/Dockerfile
@@ -46,11 +46,11 @@ RUN apt-get update \
     bind9=1:9.18.4-2~bpo11+1
 
 # Required for Starting Ingestion Container in Docker Compose
-COPY --chown=airflow:airflow ingestion/ingestion_dependency.sh /opt/airflow
+COPY --chown=airflow:0 ingestion/ingestion_dependency.sh /opt/airflow
 # Required for Ingesting Sample Data
-COPY --chown=airflow:airflow ingestion/examples/sample_data /home/airflow/ingestion/examples/sample_data
+COPY --chown=airflow:0 ingestion/examples/sample_data /home/airflow/ingestion/examples/sample_data
 # Required for Airflow DAGs of Sample Data
-COPY --chown=airflow:airflow ingestion/examples/airflow/dags /opt/airflow/dags
+COPY --chown=airflow:0 ingestion/examples/airflow/dags /opt/airflow/dags
 # Provide Execute Permissions to shell script
 RUN chmod +x /opt/airflow/ingestion_dependency.sh
 USER airflow

--- a/ingestion/Dockerfile.ci
+++ b/ingestion/Dockerfile.ci
@@ -48,13 +48,13 @@ RUN apt-get update \
     bind9=1:9.18.4-2~bpo11+1
 
 # Required for Starting Ingestion Container in Docker Compose
-COPY --chown=airflow:airflow ingestion/ingestion_dependency.sh /opt/airflow
+COPY --chown=airflow:0 ingestion/ingestion_dependency.sh /opt/airflow
 # Required for Ingesting Sample Data
-COPY --chown=airflow:airflow ingestion /home/airflow/ingestion
+COPY --chown=airflow:0 ingestion /home/airflow/ingestion
 
-COPY --chown=airflow:airflow openmetadata-airflow-apis /home/airflow/openmetadata-airflow-apis
+COPY --chown=airflow:0 openmetadata-airflow-apis /home/airflow/openmetadata-airflow-apis
 # Required for Airflow DAGs of Sample Data
-COPY --chown=airflow:airflow ingestion/examples/airflow/dags /opt/airflow/dags
+COPY --chown=airflow:0 ingestion/examples/airflow/dags /opt/airflow/dags
 # Provide Execute Permissions to shell script
 RUN chmod +x /opt/airflow/ingestion_dependency.sh
 USER airflow


### PR DESCRIPTION
### Describe your changes :
Changed the GID used in the ingestion docker images that are causing an error during the following Snyk scan:

```
Step 8/20 : COPY --chown=airflow:airflow ingestion/ingestion_dependency.sh /opt/airflow
unable to convert uid/gid chown string to host mapping: can't find gid for group airflow: no such group: airflow
make[1]: *** [Makefile:231: snyk-ingestion-report] Error 1
make[1]: Leaving directory '/home/runner/work/OpenMetadata/OpenMetadata'
make: *** [Makefile:269: snyk-report] Error 2
```

### Type of change :
- [x] Improvement

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

### Reviewers
Ingestion: @open-metadata/ingestion
