### PR TITLE
Fix #8450 Explore page pagination not working

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/package.json
+++ b/openmetadata-ui/src/main/resources/ui/package.json
@@ -96,7 +96,8 @@
     "to-arraybuffer": "^1.0.1",
     "turndown": "^7.1.1",
     "url": "^0.11.0",
-    "use-analytics": "^0.0.5"
+    "use-analytics": "^0.0.5",
+    "use-deep-compare-effect": "^1.8.1"
   },
   "scripts": {
     "start": "NODE_ENV=development BABEL_ENV=development webpack serve --config ./webpack.config.dev.js --env development",

--- a/openmetadata-ui/src/main/resources/ui/src/pages/explore/ExplorePage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/explore/ExplorePage.component.tsx
@@ -29,6 +29,7 @@ import { SearchIndex } from '../../enums/search.enum';
 import { SearchResponse } from '../../interface/search.interface';
 
 import { JsonTree, Utils as QbUtils } from 'react-awesome-query-builder';
+import useDeepCompareEffect from 'use-deep-compare-effect';
 import { PAGE_SIZE } from '../../constants/constants';
 import {
   INITIAL_SORT_FIELD,
@@ -170,7 +171,7 @@ const ExplorePage: FunctionComponent = () => {
     return showDeletedParam === 'true';
   }, [parsedSearch.showDeleted]);
 
-  useEffect(() => {
+  useDeepCompareEffect(() => {
     setIsLoading(true);
     Promise.all([
       searchQuery({
@@ -238,7 +239,7 @@ const ExplorePage: FunctionComponent = () => {
   ]);
 
   // Return to first page on filter change
-  useEffect(
+  useDeepCompareEffect(
     () => handlePageChange(1),
     [
       searchIndex,

--- a/openmetadata-ui/src/main/resources/ui/yarn.lock
+++ b/openmetadata-ui/src/main/resources/ui/yarn.lock
@@ -6424,6 +6424,11 @@ dequal@^2.0.0:
   resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.2.tgz#85ca22025e3a87e65ef75a7a437b35284a7e319d"
   integrity sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==
 
+dequal@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
+  integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+
 destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
@@ -14763,6 +14768,14 @@ use-analytics@^0.0.5:
     hoist-non-react-statics "^3.3.2"
     mini-create-react-context "^0.4.1"
     tiny-invariant "^1.1.0"
+
+use-deep-compare-effect@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/use-deep-compare-effect/-/use-deep-compare-effect-1.8.1.tgz#ef0ce3b3271edb801da1ec23bf0754ef4189d0c6"
+  integrity sha512-kbeNVZ9Zkc0RFGpfMN3MNfaKNvcLNyxOAAd9O4CBZ+kCBXXscn9s/4I+8ytUER4RDpEYs5+O6Rs4PqiZ+rHr5Q==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    dequal "^2.0.2"
 
 use-sync-external-store@1.2.0:
   version "1.2.0"


### PR DESCRIPTION

### Describe your changes :
Fix the issue with `ExplorePage` pagination when filters are applied by adding `useDeepCompareEffect` package to handle effects with objects as dependencies.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Video of the problem:
[openmetadata_broken_pagination.webm](https://user-images.githubusercontent.com/88427079/199027272-0a59a59b-db74-47a9-95fb-4e6808e23f04.webm)


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @open-metadata/ui
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
