### PR TITLE
UI: Fixed filter issue on redirection from tags page to explore page

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/database-details/index.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/database-details/index.tsx
@@ -579,7 +579,7 @@ const DatabaseDetails: FunctionComponent = () => {
         getExplorePathWithInitFilters(
           appState.inPageSearchText,
           undefined,
-          `database=${databaseName}&service_type=${serviceType}`
+          `postFilter[serviceType][0]=${serviceType}&postFilter[database.name.keyword][0]=${databaseName}`
         )
       );
     }

--- a/openmetadata-ui/src/main/resources/ui/src/pages/tags/index.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/tags/index.tsx
@@ -424,11 +424,13 @@ const TagsPage = () => {
   };
 
   const getUsageCountLink = (tagFQN: string) => {
-    if (tagFQN.startsWith('Tier')) {
-      return getExplorePathWithInitFilters('', undefined, `tier=${tagFQN}`);
-    } else {
-      return getExplorePathWithInitFilters('', undefined, `tags=${tagFQN}`);
-    }
+    const type = tagFQN.startsWith('Tier') ? 'tier' : 'tags';
+
+    return getExplorePathWithInitFilters(
+      '',
+      undefined,
+      `postFilter[${type}.tagFQN][0]=${tagFQN}`
+    );
   };
 
   const handleActionDeleteTag = (record: TagClass) => {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CommonUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CommonUtils.tsx
@@ -88,11 +88,7 @@ import jsonData from '../jsons/en';
 import { getEntityFeedLink, getTitleCase } from './EntityUtils';
 import Fqn from './Fqn';
 import { LIST_CAP } from './PermissionsUtils';
-import {
-  getExplorePathWithInitFilters,
-  getRoleWithFqnPath,
-  getTeamsWithFqnPath,
-} from './RouterUtils';
+import { getRoleWithFqnPath, getTeamsWithFqnPath } from './RouterUtils';
 import { serviceTypeLogo } from './ServiceUtils';
 import SVGIcons, { Icons } from './SvgUtils';
 import { TASK_ENTITIES } from './TasksUtils';
@@ -699,18 +695,6 @@ export const getEntityDeleteMessage = (entity: string, dependents: string) => {
       entity
     )} will remove its metadata from OpenMetadata permanently.`;
   }
-};
-
-export const getExploreLinkByFilter = (
-  filter: Ownership,
-  userDetails: User,
-  nonSecureUserDetails: User
-) => {
-  return getExplorePathWithInitFilters(
-    '',
-    undefined,
-    `${filter}=${getOwnerIds(filter, userDetails, nonSecureUserDetails).join()}`
-  );
 };
 
 export const replaceSpaceWith_ = (text: string) => {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/RouterUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/RouterUtils.ts
@@ -38,7 +38,6 @@ import {
   PLACEHOLDER_TEST_SUITE_FQN,
   ROUTES,
 } from '../constants/constants';
-import { initialFilterQS } from '../constants/explore.constants';
 import {
   GlobalSettingOptions,
   GlobalSettingsMenuCategory,
@@ -152,9 +151,7 @@ export const getExplorePathWithInitFilters = (
     .replace(PLACEHOLDER_ROUTE_SEARCHQUERY, searchQuery)
     .replace(PLACEHOLDER_ROUTE_TAB, tab);
 
-  return filter
-    ? `${path}?${initialFilterQS}=${encodeURIComponent(filter)}`
-    : path;
+  return filter ? `${path}?${filter}` : path;
 };
 
 export const getGlossaryPath = (fqn?: string) => {


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Fixed the below issue:
- Fixed tags page cypress
- tags filter was not selected while redirecting from tags page (tags usage click) to explore page
- fixed database search was broken issue from database page

#8448

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :

https://user-images.githubusercontent.com/71748675/199013322-3e5ef32f-bd63-42fb-86b5-9dd7727e5e0e.mov


https://user-images.githubusercontent.com/71748675/199013961-82c43758-64cc-48b6-a15e-92e36bf39fa5.mov



#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
