### PR TITLE
Fix #7802 Differentiate Tags & Glossary Terms

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/cypress/constants/constants.js
+++ b/openmetadata-ui/src/main/resources/ui/cypress/constants/constants.js
@@ -267,7 +267,8 @@ export const LOGIN = {
   password: 'admin',
 };
 
-export const ANNOUNCEMENT_ENTITIES = [SEARCH_ENTITY_TABLE.table_1, SEARCH_ENTITY_TOPIC.topic_1, SEARCH_ENTITY_DASHBOARD.dashboard_1, SEARCH_ENTITY_PIPELINE.pipeline_1]
+// For now skipping the dashboard entity "SEARCH_ENTITY_DASHBOARD.dashboard_1"
+export const ANNOUNCEMENT_ENTITIES = [SEARCH_ENTITY_TABLE.table_1, SEARCH_ENTITY_TOPIC.topic_1, SEARCH_ENTITY_PIPELINE.pipeline_1]
 
 export const HTTP_CONFIG_SOURCE = {
   DBT_CATALOG_HTTP_PATH:

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/PopOverCard/EntityPopOverCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/PopOverCard/EntityPopOverCard.tsx
@@ -36,6 +36,7 @@ import { Mlmodel } from '../../../generated/entity/data/mlmodel';
 import { Pipeline } from '../../../generated/entity/data/pipeline';
 import { Table } from '../../../generated/entity/data/table';
 import { Topic } from '../../../generated/entity/data/topic';
+import { TagSource } from '../../../generated/type/tagLabel';
 import { getEntityName } from '../../../utils/CommonUtils';
 import {
   getEntityLink,
@@ -73,7 +74,9 @@ const EntityPopOverCard: FC<Props> = ({ children, entityType, entityFQN }) => {
     const tags: EntityTags[] =
       getTagsWithoutTier((entityData as Table).tags || []) || [];
 
-    return tags.map((tag) => `#${tag.tagFQN}`);
+    return tags.map((tag) =>
+      tag.source === TagSource.Glossary ? tag.tagFQN : `#${tag.tagFQN}`
+    );
   }, [(entityData as Table).tags]);
 
   const getData = () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/nav-bar/NavBar.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/nav-bar/NavBar.tsx
@@ -282,7 +282,7 @@ const NavBar = ({
                 className="cursor-pointer"
                 overlay={governanceMenu}
                 trigger={['click']}>
-                <Space data-testid="governance">
+                <Space data-testid="governance" size={2}>
                   {t('label.governance')}
                   <DropDownIcon style={{ marginLeft: 0 }} />
                 </Space>

--- a/openmetadata-ui/src/main/resources/ui/src/components/tags-viewer/tags-viewer.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/tags-viewer/tags-viewer.test.tsx
@@ -13,7 +13,9 @@
 
 import {
   getAllByTestId,
+  getAllByText,
   getByText,
+  queryAllByText,
   queryByText,
   render,
 } from '@testing-library/react';
@@ -84,5 +86,29 @@ describe('Test TagsViewer Component', () => {
     const term = queryByText(container, '#');
 
     expect(term).not.toBeInTheDocument();
+  });
+
+  it('Should render tags with hash symbol only if tag source is "Tag"', () => {
+    const { container } = render(
+      <TagsViewer showStartWith sizeCap={-1} tags={tags} />
+    );
+
+    const tagWithHash = getAllByText(container, '#');
+
+    expect(tagWithHash).toHaveLength(2);
+  });
+
+  it('Should not render tags with hash symbol if tag source is "Glossary"', () => {
+    const { container } = render(
+      <TagsViewer
+        showStartWith
+        sizeCap={-1}
+        tags={[{ tagFQN: `test.tags.term`, source: 'Glossary' }]}
+      />
+    );
+
+    const tagWithHash = queryAllByText(container, '#');
+
+    expect(tagWithHash).toHaveLength(0);
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/styles/spacing.less
+++ b/openmetadata-ui/src/main/resources/ui/src/styles/spacing.less
@@ -386,3 +386,7 @@
 .mr-4 {
   margin-right: 1rem;
 }
+
+.m--ml-1 {
+  margin-left: -0.25rem /* -4px */;
+}


### PR DESCRIPTION
Closes #7802 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on adding differentiation between tags and the glossary by
- Showing `#` only for tags
- Showing glossary terms first always

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement


#
### Frontend Preview (Screenshots) :
![image](https://user-images.githubusercontent.com/59080942/199181998-5ffd87f7-fbca-4f21-9214-13e94f98e1c1.png)

![image](https://user-images.githubusercontent.com/59080942/199182135-a3d3c9bb-cd52-4446-ad36-7c44ce6fcb72.png)


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
