### PR TITLE
(UI) #7790 : Added support to preserve search text for users and admins list page

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/UserListPage/UserListPageV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/UserListPage/UserListPageV1.test.tsx
@@ -30,8 +30,19 @@ const mockParam = {
   tab: GlobalSettingOptions.USERS,
 };
 
+const mockHistory = {
+  replace: jest.fn(),
+};
+
+const mockLocation = {
+  pathname: 'pathname',
+  search: '',
+};
+
 jest.mock('react-router-dom', () => ({
   useParams: jest.fn().mockImplementation(() => mockParam),
+  useHistory: jest.fn().mockImplementation(() => mockHistory),
+  useLocation: jest.fn().mockImplementation(() => mockLocation),
 }));
 jest.mock('../../axiosAPIs/userAPI', () => ({
   getUsers: jest.fn().mockImplementation(() =>

--- a/openmetadata-ui/src/main/resources/ui/src/pages/UserListPage/UserListPageV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/UserListPage/UserListPageV1.tsx
@@ -14,7 +14,7 @@
 import { AxiosError } from 'axios';
 import { FormattedUsersData, SearchResponse } from 'Models';
 import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { searchData } from '../../axiosAPIs/miscAPI';
 import { getUsers } from '../../axiosAPIs/userAPI';
 import Loader from '../../components/Loader/Loader';
@@ -38,6 +38,8 @@ const teamsAndUsers = [GlobalSettingOptions.USERS, GlobalSettingOptions.ADMINS];
 
 const UserListPageV1 = () => {
   const { tab } = useParams<{ [key: string]: GlobalSettingOptions }>();
+  const history = useHistory();
+  const location = useLocation();
   const [isAdminPage, setIsAdminPage] = useState<boolean | undefined>(
     tab === GlobalSettingOptions.ADMINS || undefined
   );
@@ -172,6 +174,10 @@ const UserListPageV1 = () => {
   const handleSearch = (value: string) => {
     setSearchValue(value);
     setCurrentPage(INITIAL_PAGING_VALUE);
+    history.replace({
+      pathname: location.pathname,
+      search: value,
+    });
     if (value) {
       getSearchedUsers(value, INITIAL_PAGING_VALUE);
     } else {
@@ -182,7 +188,14 @@ const UserListPageV1 = () => {
   useEffect(() => {
     initialSetup();
     if (teamsAndUsers.includes(tab)) {
-      fetchUsersList(tab === GlobalSettingOptions.ADMINS || undefined);
+      if (location.search) {
+        const searchTerm = location.search.slice(1);
+        setSearchValue(searchTerm);
+        getSearchedUsers(searchTerm, 1);
+        setIsPageLoading(false);
+      } else {
+        fetchUsersList(tab === GlobalSettingOptions.ADMINS || undefined);
+      }
     } else {
       setIsPageLoading(false);
       setIsDataLoading(false);


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the adding support to preserve search text for users and admins list page
#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement

#
### Frontend Preview (Screenshots) :
<p align="center">


https://user-images.githubusercontent.com/51777795/199221466-4088aa98-f884-4d0b-ba39-642e92d2a850.mov


</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @open-metadata/ui
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
