### PR TITLE
Revert #7292 : Add ConditionalAllow check for Create Operation Permission

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/utils/PermissionsUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/PermissionsUtils.ts
@@ -87,16 +87,7 @@ export const getOperationPermissions = (
     (acc: OperationPermission, curr: Permission) => {
       return {
         ...acc,
-        [curr.operation as Operation]:
-          /**
-           * Check ConditionalAllow or Allow for Create Operation
-           * TODO: Remove this check once backend has fix for this
-           * https://github.com/open-metadata/OpenMetadata/issues/7004
-           */
-          curr.operation === Operation.Create
-            ? curr.access === Access.ConditionalAllow ||
-              curr.access === Access.Allow
-            : curr.access === Access.Allow,
+        [curr.operation as Operation]: curr.access === Access.Allow,
       };
     },
     {} as OperationPermission


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the removing ConditionalAllow check for Create Operation as we have fixed this issue https://github.com/open-metadata/OpenMetadata/issues/7004
#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Frontend Preview (Screenshots) :


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
