### PR TITLE
Fix UI(#8467) : Only allow admins to create and update bot and user entities

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/BotListV1/BotListV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BotListV1/BotListV1.component.tsx
@@ -16,6 +16,7 @@ import { ColumnsType } from 'antd/lib/table';
 import { AxiosError } from 'axios';
 import { isEmpty, lowerCase } from 'lodash';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { getBots } from '../../axiosAPIs/botsAPI';
 import {
@@ -30,11 +31,10 @@ import {
 } from '../../constants/HelperTextUtil';
 import { EntityType } from '../../enums/entity.enum';
 import { Bot, ProviderType } from '../../generated/entity/bot';
-import { Operation } from '../../generated/entity/policies/accessControl/rule';
 import { Include } from '../../generated/type/include';
 import { Paging } from '../../generated/type/paging';
+import { useAuth } from '../../hooks/authHooks';
 import { getEntityName } from '../../utils/CommonUtils';
-import { checkPermission } from '../../utils/PermissionsUtils';
 import SVGIcons, { Icons } from '../../utils/SvgUtils';
 import { showErrorToast } from '../../utils/ToastUtils';
 import DeleteWidgetModal from '../common/DeleteWidget/DeleteWidgetModal';
@@ -43,8 +43,6 @@ import NextPrevious from '../common/next-previous/NextPrevious';
 import RichTextEditorPreviewer from '../common/rich-text-editor/RichTextEditorPreviewer';
 import Searchbar from '../common/searchbar/Searchbar';
 import Loader from '../Loader/Loader';
-import { usePermissionProvider } from '../PermissionProvider/PermissionProvider';
-import { ResourceEntity } from '../PermissionProvider/PermissionProvider.interface';
 import { BotListV1Props } from './BotListV1.interfaces';
 
 const BotListV1 = ({
@@ -52,7 +50,8 @@ const BotListV1 = ({
   handleAddBotClick,
   handleShowDeleted,
 }: BotListV1Props) => {
-  const { permissions } = usePermissionProvider();
+  const { isAdminUser } = useAuth();
+  const { t } = useTranslation();
   const [botUsers, setBotUsers] = useState<Bot[]>([]);
   const [paging, setPaging] = useState<Paging>({} as Paging);
   const [selectedUser, setSelectedUser] = useState<Bot>();
@@ -61,22 +60,6 @@ const BotListV1 = ({
 
   const [handleErrorPlaceholder, setHandleErrorPlaceholder] = useState(false);
   const [searchedData, setSearchedData] = useState<Bot[]>([]);
-
-  /**
-   * Bot creation is two step process so here we should check for
-   * Create User and Create Bot both permissions
-   */
-  const createPermission = useMemo(
-    () =>
-      checkPermission(Operation.Create, ResourceEntity.BOT, permissions) &&
-      checkPermission(Operation.Create, ResourceEntity.USER, permissions),
-    [permissions]
-  );
-
-  const deletePermission = useMemo(
-    () => checkPermission(Operation.Delete, ResourceEntity.BOT, permissions),
-    [permissions]
-  );
 
   /**
    *
@@ -111,7 +94,7 @@ const BotListV1 = ({
   const columns: ColumnsType<Bot> = useMemo(
     () => [
       {
-        title: 'Name',
+        title: t('label.name'),
         dataIndex: 'displayName',
         key: 'displayName',
         render: (_, record) => (
@@ -124,18 +107,20 @@ const BotListV1 = ({
         ),
       },
       {
-        title: 'Description',
+        title: t('label.description'),
         dataIndex: 'description',
         key: 'description',
         render: (_, record) =>
           record?.description ? (
             <RichTextEditorPreviewer markdown={record?.description || ''} />
           ) : (
-            <span data-testid="no-description">No Description</span>
+            <span data-testid="no-description">
+              {t('label.no-description')}
+            </span>
           ),
       },
       {
-        title: 'Actions',
+        title: t('label.actions'),
         dataIndex: 'id',
         key: 'id',
         width: 90,
@@ -143,10 +128,10 @@ const BotListV1 = ({
           const isSystemBot = record.provider === ProviderType.System;
           const title = isSystemBot
             ? INGESTION_BOT_CANT_BE_DELETED
-            : deletePermission
-            ? 'Delete'
+            : isAdminUser
+            ? t('label.delete')
             : NO_PERMISSION_FOR_ACTION;
-          const isDisabled = !deletePermission || isSystemBot;
+          const isDisabled = !isAdminUser || isSystemBot;
 
           return (
             <Space align="center" size={8}>
@@ -220,7 +205,7 @@ const BotListV1 = ({
             size="small"
             onClick={handleShowDeleted}
           />
-          <label htmlFor="switch-deleted">Show deleted</label>
+          <label htmlFor="switch-deleted">{t('label.show-deleted')}</label>
         </Space>
       </Col>
       <Col className="w-full">
@@ -229,14 +214,16 @@ const BotListV1 = ({
             <div className="tw-text-lg tw-text-center">
               <Tooltip
                 placement="left"
-                title={createPermission ? 'Add Bot' : NO_PERMISSION_FOR_ACTION}>
+                title={
+                  isAdminUser ? t('label.add-bot') : NO_PERMISSION_FOR_ACTION
+                }>
                 <Button
                   ghost
                   data-testid="add-bot"
-                  disabled={!createPermission}
+                  disabled={!isAdminUser}
                   type="primary"
                   onClick={handleAddBotClick}>
-                  Add Bot
+                  {t('label.add-bot')}
                 </Button>
               </Tooltip>
             </div>
@@ -252,7 +239,7 @@ const BotListV1 = ({
       <Col span={8}>
         <Searchbar
           removeMargin
-          placeholder="Search for bots..."
+          placeholder={t('label.search-for-bots')}
           typingInterval={500}
           onSearch={handleSearch}
         />
@@ -265,17 +252,17 @@ const BotListV1 = ({
               id="switch-deleted"
               onClick={handleShowDeleted}
             />
-            <label htmlFor="switch-deleted">Show deleted</label>
+            <label htmlFor="switch-deleted">{t('label.show-deleted')}</label>
           </Space>
 
           <Tooltip
-            title={createPermission ? 'Add Bot' : NO_PERMISSION_FOR_ACTION}>
+            title={isAdminUser ? t('label.add-bot') : NO_PERMISSION_FOR_ACTION}>
             <Button
               data-testid="add-bot"
-              disabled={!createPermission}
+              disabled={!isAdminUser}
               type="primary"
               onClick={handleAddBotClick}>
-              Add Bot
+              {t('label.add-bot')}
             </Button>
           </Tooltip>
         </Space>

--- a/openmetadata-ui/src/main/resources/ui/src/components/BotListV1/BotListV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BotListV1/BotListV1.component.tsx
@@ -26,8 +26,8 @@ import {
 } from '../../constants/constants';
 import { BOTS_DOCS } from '../../constants/docs.constants';
 import {
+  ADMIN_ONLY_ACTION,
   INGESTION_BOT_CANT_BE_DELETED,
-  NO_PERMISSION_FOR_ACTION,
 } from '../../constants/HelperTextUtil';
 import { EntityType } from '../../enums/entity.enum';
 import { Bot, ProviderType } from '../../generated/entity/bot';
@@ -130,7 +130,7 @@ const BotListV1 = ({
             ? INGESTION_BOT_CANT_BE_DELETED
             : isAdminUser
             ? t('label.delete')
-            : NO_PERMISSION_FOR_ACTION;
+            : ADMIN_ONLY_ACTION;
           const isDisabled = !isAdminUser || isSystemBot;
 
           return (
@@ -214,9 +214,7 @@ const BotListV1 = ({
             <div className="tw-text-lg tw-text-center">
               <Tooltip
                 placement="left"
-                title={
-                  isAdminUser ? t('label.add-bot') : NO_PERMISSION_FOR_ACTION
-                }>
+                title={isAdminUser ? t('label.add-bot') : ADMIN_ONLY_ACTION}>
                 <Button
                   ghost
                   data-testid="add-bot"
@@ -255,8 +253,7 @@ const BotListV1 = ({
             <label htmlFor="switch-deleted">{t('label.show-deleted')}</label>
           </Space>
 
-          <Tooltip
-            title={isAdminUser ? t('label.add-bot') : NO_PERMISSION_FOR_ACTION}>
+          <Tooltip title={isAdminUser ? t('label.add-bot') : ADMIN_ONLY_ACTION}>
             <Button
               data-testid="add-bot"
               disabled={!isAdminUser}

--- a/openmetadata-ui/src/main/resources/ui/src/components/UserList/UserListV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/UserList/UserListV1.tsx
@@ -22,15 +22,14 @@ import { updateUser } from '../../axiosAPIs/userAPI';
 import { PAGE_SIZE_MEDIUM, ROUTES } from '../../constants/constants';
 import { NO_PERMISSION_FOR_ACTION } from '../../constants/HelperTextUtil';
 import { CreateUser } from '../../generated/api/teams/createUser';
-import { Operation } from '../../generated/entity/policies/policy';
 import { User } from '../../generated/entity/teams/user';
 import { Paging } from '../../generated/type/paging';
+import { useAuth } from '../../hooks/authHooks';
 import jsonData from '../../jsons/en';
 import {
   commonUserDetailColumns,
   getEntityName,
 } from '../../utils/CommonUtils';
-import { checkPermission } from '../../utils/PermissionsUtils';
 import SVGIcons, { Icons } from '../../utils/SvgUtils';
 import { showErrorToast, showSuccessToast } from '../../utils/ToastUtils';
 import DeleteWidgetModal from '../common/DeleteWidget/DeleteWidgetModal';
@@ -38,8 +37,6 @@ import ErrorPlaceHolder from '../common/error-with-placeholder/ErrorPlaceHolder'
 import NextPrevious from '../common/next-previous/NextPrevious';
 import Searchbar from '../common/searchbar/Searchbar';
 import Loader from '../Loader/Loader';
-import { usePermissionProvider } from '../PermissionProvider/PermissionProvider';
-import { ResourceEntity } from '../PermissionProvider/PermissionProvider.interface';
 import './usersList.less';
 
 interface UserListV1Props {
@@ -67,24 +64,14 @@ const UserListV1: FC<UserListV1Props> = ({
   onPagingChange,
   afterDeleteAction,
 }) => {
+  const { isAdminUser } = useAuth();
   const { t } = useTranslation();
-  const { permissions } = usePermissionProvider();
   const history = useHistory();
   const [selectedUser, setSelectedUser] = useState<User>();
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showReactiveModal, setShowReactiveModal] = useState(false);
   const showRestore = showDeletedUser && !isDataLoading;
   const [isLoading, setIsLoading] = useState(false);
-
-  const createPermission = useMemo(
-    () => checkPermission(Operation.Create, ResourceEntity.USER, permissions),
-    [permissions]
-  );
-
-  const deletePermission = useMemo(
-    () => checkPermission(Operation.Delete, ResourceEntity.USER, permissions),
-    [permissions]
-  );
 
   const handleAddNewUser = () => {
     history.push(ROUTES.CREATE_USER);
@@ -165,10 +152,10 @@ const UserListV1: FC<UserListV1Props> = ({
             <Tooltip
               placement="bottom"
               title={
-                deletePermission ? t('label.delete') : NO_PERMISSION_FOR_ACTION
+                isAdminUser ? t('label.delete') : NO_PERMISSION_FOR_ACTION
               }>
               <Button
-                disabled={!deletePermission}
+                disabled={!isAdminUser}
                 icon={
                   <SVGIcons
                     alt="Delete"
@@ -212,7 +199,7 @@ const UserListV1: FC<UserListV1Props> = ({
                 <Button
                   ghost
                   data-testid="add-user"
-                  disabled={!createPermission}
+                  disabled={!isAdminUser}
                   type="primary"
                   onClick={handleAddNewUser}>
                   {t('label.add-user')}
@@ -254,11 +241,11 @@ const UserListV1: FC<UserListV1Props> = ({
           </span>
           <Tooltip
             title={
-              createPermission ? t('label.add-user') : NO_PERMISSION_FOR_ACTION
+              isAdminUser ? t('label.add-user') : NO_PERMISSION_FOR_ACTION
             }>
             <Button
               data-testid="add-user"
-              disabled={!createPermission}
+              disabled={!isAdminUser}
               type="primary"
               onClick={handleAddNewUser}>
               {t('label.add-user')}

--- a/openmetadata-ui/src/main/resources/ui/src/components/UserList/UserListV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/UserList/UserListV1.tsx
@@ -20,7 +20,7 @@ import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { updateUser } from '../../axiosAPIs/userAPI';
 import { PAGE_SIZE_MEDIUM, ROUTES } from '../../constants/constants';
-import { NO_PERMISSION_FOR_ACTION } from '../../constants/HelperTextUtil';
+import { ADMIN_ONLY_ACTION } from '../../constants/HelperTextUtil';
 import { CreateUser } from '../../generated/api/teams/createUser';
 import { User } from '../../generated/entity/teams/user';
 import { Paging } from '../../generated/type/paging';
@@ -151,9 +151,7 @@ const UserListV1: FC<UserListV1Props> = ({
             )}
             <Tooltip
               placement="bottom"
-              title={
-                isAdminUser ? t('label.delete') : NO_PERMISSION_FOR_ACTION
-              }>
+              title={isAdminUser ? t('label.delete') : ADMIN_ONLY_ACTION}>
               <Button
                 disabled={!isAdminUser}
                 icon={
@@ -240,9 +238,7 @@ const UserListV1: FC<UserListV1Props> = ({
             <span className="tw-ml-2">{t('label.deleted-users')}</span>
           </span>
           <Tooltip
-            title={
-              isAdminUser ? t('label.add-user') : NO_PERMISSION_FOR_ACTION
-            }>
+            title={isAdminUser ? t('label.add-user') : ADMIN_ONLY_ACTION}>
             <Button
               data-testid="add-user"
               disabled={!isAdminUser}

--- a/openmetadata-ui/src/main/resources/ui/src/constants/HelperTextUtil.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/HelperTextUtil.ts
@@ -57,3 +57,5 @@ export const INGESTION_BOT_CANT_BE_DELETED =
 
 export const BOT_ACCOUNT_EMAIL_CHANGE_CONFIRMATION =
   'Changing account email will update or create a new bot user';
+
+export const ADMIN_ONLY_ACTION = 'Only admin can perform this action.';

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
@@ -195,7 +195,10 @@
     "unpause": "UnPause",
     "execution-date": "Execution Date",
     "start-date": "Start Date",
-    "end-date": "End Date"
+    "end-date": "End Date",
+    "show-deleted": "Show deleted",
+    "add-bot": "Add Bot",
+    "search-for-bots": "Search for bots..."
   },
   "message": {
     "service-email-required": "Service account Email is required",


### PR DESCRIPTION
Closes #8467

### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on issue #8467 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] Improvement


#
### Frontend Preview (Screenshots) :


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
