### PR TITLE
Fix #8540 Session ID does not reset for web analytic

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/package.json
+++ b/openmetadata-ui/src/main/resources/ui/package.json
@@ -12,6 +12,7 @@
     "directory": "openmetadata-ui/src/main/resources/ui"
   },
   "dependencies": {
+    "@analytics/session-utils": "^0.1.17",
     "@ant-design/icons": "^4.7.0",
     "@apidevtools/json-schema-ref-parser": "^9.0.9",
     "@auth0/auth0-react": "^1.9.0",

--- a/openmetadata-ui/src/main/resources/ui/src/@types/web-analytics.d.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/@types/web-analytics.d.ts
@@ -1,0 +1,23 @@
+declare module '@analytics/session-utils' {
+  export type Session = {
+    id: string;
+    created: number;
+    createdAt: string;
+    expires: number;
+    expiresAt: string;
+    elapsed: number;
+    remaining: number;
+    isNew: boolean;
+  };
+
+  export const getSession: (
+    minutes?: number,
+    persistedOnly?: boolean
+  ) => Session;
+
+  export const setSession: (
+    minutes?: number,
+    extra = {},
+    extend?: boolean
+  ) => Session;
+}

--- a/openmetadata-ui/src/main/resources/ui/yarn.lock
+++ b/openmetadata-ui/src/main/resources/ui/yarn.lock
@@ -47,6 +47,16 @@
   dependencies:
     "@analytics/global-storage-utils" "^0.1.5"
 
+"@analytics/session-utils@^0.1.17":
+  version "0.1.17"
+  resolved "https://registry.yarnpkg.com/@analytics/session-utils/-/session-utils-0.1.17.tgz#556fc15bd30aaec5e71e422fbad1463f1c6a0bc1"
+  integrity sha512-QAOZIRTTg238klYRhEVlOtRKJGwAfUWTfrjLgw7RHbFM7DU6whohi8HPffiChDjOwuhUsG55ymQPxSuco7DsKA==
+  dependencies:
+    "@analytics/cookie-utils" "^0.2.10"
+    "@analytics/global-storage-utils" "^0.1.5"
+    "@analytics/session-storage-utils" "^0.0.5"
+    analytics-utils "^1.0.10"
+
 "@analytics/storage-utils@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@analytics/storage-utils/-/storage-utils-0.4.0.tgz#12e5c0683f0124e189650a4989a627f3318d7995"


### PR DESCRIPTION
Closes #8540 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on issue #8540, which includes.

- Default we will set the expiry of 30 minutes
- If the user is inactive for 30 minutes then the session will expire and a new session will be created.
- If the user is active and interacting with pages then we will reset the expiration by extending the expiry to the next 30 minutes from the current timestamp.

Example :
Let's say the expiry is at "5:45:23 PM", and the user spent some time and then Interact with other pages in 2 minutes so the expiry time will be extended to "5:47:23 PM".
In case of inactivity expiry will remain at "5:45:23 PM".

cc: @harshach @TeddyCr 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] Improvement


#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
