### PR TITLE
Fix(UI) #8563: Fixed field name in announcement modal.

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/AnnouncementModal/AddAnnouncementModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/AnnouncementModal/AddAnnouncementModal.tsx
@@ -114,6 +114,7 @@ const AddAnnouncementModal: FC<Props> = ({
         onFinish={handleCreateAnnouncement}>
         <Form.Item
           label="Title:"
+          messageVariables={{ fieldName: 'title' }}
           name="title"
           rules={[
             {
@@ -132,6 +133,7 @@ const AddAnnouncementModal: FC<Props> = ({
         <Space className="announcement-date-space" size={16}>
           <Form.Item
             label={`Start Date: (${getTimeZone()})`}
+            messageVariables={{ fieldName: 'startDate' }}
             name="startDate"
             rules={[
               {
@@ -146,6 +148,7 @@ const AddAnnouncementModal: FC<Props> = ({
           </Form.Item>
           <Form.Item
             label={`End Date: (${getTimeZone()})`}
+            messageVariables={{ fieldName: 'endtDate' }}
             name="endtDate"
             rules={[
               {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/AnnouncementModal/EditAnnouncementModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/AnnouncementModal/EditAnnouncementModal.tsx
@@ -96,6 +96,7 @@ const EditAnnouncementModal: FC<Props> = ({
         onFinish={handleConfirm}>
         <Form.Item
           label="Title:"
+          messageVariables={{ fieldName: 'title' }}
           name="title"
           rules={[
             {
@@ -114,6 +115,7 @@ const EditAnnouncementModal: FC<Props> = ({
         <Space className="announcement-date-space" size={16}>
           <Form.Item
             label={`Start Date: (${getTimeZone()})`}
+            messageVariables={{ fieldName: 'startDate' }}
             name="startDate"
             rules={[
               {
@@ -128,6 +130,7 @@ const EditAnnouncementModal: FC<Props> = ({
           </Form.Item>
           <Form.Item
             label={`End Date: (${getTimeZone()})`}
+            messageVariables={{ fieldName: 'endDate' }}
             name="endDate"
             rules={[
               {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AnnouncementsUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AnnouncementsUtils.ts
@@ -9,9 +9,9 @@ export const ANNOUNCEMENT_ENTITIES = [
 ];
 
 export const validateMessages = {
-  required: '${name} is required!',
+  required: '${fieldName} is required!',
   string: {
-    range: '${name} must be between ${min} and ${max} character.',
+    range: '${fieldName} must be between ${min} and ${max} character.',
   },
 };
 


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the fixing wrong field names showing in the validation messages for add and edit announcement modal.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<p align="center">
<img width="597" alt="Screenshot 2022-11-07 at 7 26 24 PM" src="https://user-images.githubusercontent.com/51777795/200328029-49649dfa-0f79-4bdc-9b01-cb2eece0434a.png">

</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @open-metadata/ui
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
