### PR TITLE
Feat #8639 UI : Show charts latest value in data insight overview card and rename datasets to data assets

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/DailyActiveUsersChart.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/DailyActiveUsersChart.tsx
@@ -79,6 +79,7 @@ const DailyActiveUsersChart: FC<Props> = ({ chartFilter }) => {
     <Card
       className="data-insight-card"
       data-testid="entity-active-user-card"
+      id={DataInsightChartType.DailyActiveUsers}
       loading={isLoading}
       title={
         <>

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/DataInsightDetail.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/DataInsightDetail.less
@@ -12,6 +12,7 @@
  */
 
 @label-color: #37352f90;
+@summary-card-bg-hover: #f0f1f3;
 
 .data-insight-card {
   .ant-card-head {
@@ -21,4 +22,13 @@
 
 .ant-typography.data-insight-label-text {
   color: @label-color;
+}
+
+.summary-card-item {
+  cursor: pointer;
+  padding: 8px;
+  &:hover {
+    background-color: @summary-card-bg-hover;
+    border-radius: 6px;
+  }
 }

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/DataInsightSummary.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/DataInsightSummary.test.tsx
@@ -14,6 +14,7 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { act } from 'react-test-renderer';
+import { DataInsightChartType } from '../../generated/dataInsight/dataInsightChartResult';
 import DataInsightSummary from './DataInsightSummary';
 
 jest.mock('react-i18next', () => ({
@@ -27,6 +28,8 @@ const mockFilter = {
   endTs: 1668000248671,
 };
 
+const mockScrollFunction = jest.fn();
+
 jest.mock('../../axiosAPIs/DataInsightAPI', () => ({
   getAggregateChartData: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
@@ -34,14 +37,21 @@ jest.mock('../../axiosAPIs/DataInsightAPI', () => ({
 describe('Test DataInsightSummary Component', () => {
   it('Should render the overview data', async () => {
     await act(async () => {
-      render(<DataInsightSummary chartFilter={mockFilter} />);
+      render(
+        <DataInsightSummary
+          chartFilter={mockFilter}
+          onScrollToChart={mockScrollFunction}
+        />
+      );
     });
 
     const summaryCard = screen.getByTestId('summary-card');
 
-    const allEntityCount = screen.getByTestId('summary-item-latest');
+    const totalEntitiesByType = screen.getByTestId(
+      `summary-item-${DataInsightChartType.TotalEntitiesByType}`
+    );
 
     expect(summaryCard).toBeInTheDocument();
-    expect(allEntityCount).toBeInTheDocument();
+    expect(totalEntitiesByType).toBeInTheDocument();
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/DataInsightSummary.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/DataInsightSummary.tsx
@@ -81,13 +81,15 @@ const DataInsightSummary: FC<Props> = ({ chartFilter, onScrollToChart }) => {
 
       const responses = await Promise.allSettled(promises);
 
-      const chartDataList = responses.map((response) => {
-        if (response.status === 'fulfilled') {
-          return response.value;
-        }
+      const chartDataList = responses
+        .map((response) => {
+          if (response.status === 'fulfilled') {
+            return response.value;
+          }
 
-        return;
-      });
+          return;
+        })
+        .filter(Boolean);
 
       setEntitiesChart(chartDataList);
     } catch (error) {
@@ -130,13 +132,15 @@ const DataInsightSummary: FC<Props> = ({ chartFilter, onScrollToChart }) => {
 
       const responses = await Promise.allSettled(promises);
 
-      const chartDataList = responses.map((response) => {
-        if (response.status === 'fulfilled') {
-          return response.value;
-        }
+      const chartDataList = responses
+        .map((response) => {
+          if (response.status === 'fulfilled') {
+            return response.value;
+          }
 
-        return;
-      });
+          return;
+        })
+        .filter(Boolean);
 
       setWebCharts(chartDataList);
     } catch (error) {

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/DataInsightSummary.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/DataInsightSummary.tsx
@@ -103,6 +103,7 @@ const DataInsightSummary: FC<Props> = ({ chartFilter, onScrollToChart }) => {
             </Typography.Text>
             <Typography className="font-semibold text-2xl m--ml-0.5">
               {summary.latest}
+              {summary.id.startsWith('Percentage') ? '%' : ''}
             </Typography>
           </Col>
         ))}

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/DescriptionInsight.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/DescriptionInsight.tsx
@@ -93,6 +93,7 @@ const DescriptionInsight: FC<Props> = ({ chartFilter }) => {
     <Card
       className="data-insight-card"
       data-testid="entity-description-percentage-card"
+      id={DataInsightChartType.PercentageOfEntitiesWithDescriptionByType}
       loading={isLoading}
       title={
         <>

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/OwnerInsight.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/OwnerInsight.tsx
@@ -93,6 +93,7 @@ const OwnerInsight: FC<Props> = ({ chartFilter }) => {
     <Card
       className="data-insight-card"
       data-testid="entity-summary-card-percentage"
+      id={DataInsightChartType.PercentageOfEntitiesWithOwnerByType}
       loading={isLoading}
       title={
         <>

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/PageViewsByEntitiesChart.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/PageViewsByEntitiesChart.tsx
@@ -90,6 +90,7 @@ const PageViewsByEntitiesChart: FC<Props> = ({ chartFilter }) => {
     <Card
       className="data-insight-card"
       data-testid="entity-page-views-card"
+      id={DataInsightChartType.PageViewsByEntities}
       loading={isLoading}
       title={
         <>

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/TierInsight.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/TierInsight.tsx
@@ -89,6 +89,7 @@ const TierInsight: FC<Props> = ({ chartFilter }) => {
     <Card
       className="data-insight-card"
       data-testid="entity-summary-card-percentage"
+      id={DataInsightChartType.TotalEntitiesByTier}
       loading={isLoading}
       title={
         <>

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/TopViewEntities.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/TopViewEntities.tsx
@@ -64,9 +64,9 @@ const TopViewEntities: FC<Props> = ({ chartFilter }) => {
   const columns: ColumnsType<MostViewedEntities> = useMemo(
     () => [
       {
-        title: t('label.entity-name'),
+        title: t('label.data-asset'),
         dataIndex: 'entityFqn',
-        key: 'entityName',
+        key: 'dataAsset',
         render: (entityFqn: string) => (
           <Typography.Text>{getDecodedFqn(entityFqn)}</Typography.Text>
         ),
@@ -107,7 +107,7 @@ const TopViewEntities: FC<Props> = ({ chartFilter }) => {
             {t('label.data-insight-top-viewed-entity-summary')}
           </Typography.Title>
           <Typography.Text className="data-insight-label-text">
-            {t('message.most-viewed-datasets')}
+            {t('message.most-viewed-data-assets')}
           </Typography.Text>
         </>
       }>

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/TopViewEntities.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/TopViewEntities.tsx
@@ -82,7 +82,7 @@ const TopViewEntities: FC<Props> = ({ chartFilter }) => {
               <Typography.Text>{owner}</Typography.Text>
             </Space>
           ) : (
-            <Typography.Text>{t('label.no-owner')}</Typography.Text>
+            <Typography.Text>--</Typography.Text>
           ),
       },
       {

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/TotalEntityInsight.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/TotalEntityInsight.tsx
@@ -92,6 +92,7 @@ const TotalEntityInsight: FC<Props> = ({ chartFilter }) => {
     <Card
       className="data-insight-card"
       data-testid="entity-summary-card"
+      id={DataInsightChartType.TotalEntitiesByType}
       loading={isLoading}
       title={
         <>

--- a/openmetadata-ui/src/main/resources/ui/src/constants/DataInsight.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/DataInsight.constants.ts
@@ -134,7 +134,7 @@ export const WEB_CHARTS = [
   },
   {
     chart: DataInsightChartType.DailyActiveUsers,
-    index: DataReportIndex.WebAnalyticEntityViewReportDataIndex,
+    index: DataReportIndex.WebAnalyticUserActivityReportDataIndex,
   },
 ];
 

--- a/openmetadata-ui/src/main/resources/ui/src/constants/DataInsight.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/DataInsight.constants.ts
@@ -13,6 +13,7 @@
 
 import i18n from 'i18next';
 import { Margin } from 'recharts/types/util/types';
+import { DataReportIndex } from '../generated/dataInsight/dataInsightChart';
 import { DataInsightChartType } from '../generated/dataInsight/dataInsightChartResult';
 import { ChartFilter } from '../interface/data-insight.interface';
 import {
@@ -119,11 +120,35 @@ export const INITIAL_CHART_FILTER: ChartFilter = {
   endTs: getCurrentDateTimeMillis(),
 };
 
-export const ENTITIES_CHARTS_NAMES = [
+export const ENTITIES_CHARTS = [
   DataInsightChartType.TotalEntitiesByType,
   DataInsightChartType.PercentageOfEntitiesWithDescriptionByType,
   DataInsightChartType.PercentageOfEntitiesWithOwnerByType,
   DataInsightChartType.TotalEntitiesByTier,
+];
+
+export const WEB_CHARTS = [
+  {
+    chart: DataInsightChartType.PageViewsByEntities,
+    index: DataReportIndex.WebAnalyticEntityViewReportDataIndex,
+  },
+  {
+    chart: DataInsightChartType.DailyActiveUsers,
+    index: DataReportIndex.WebAnalyticEntityViewReportDataIndex,
+  },
+];
+
+export const WEB_SUMMARY_LIST = [
+  {
+    label: i18n.t('label.page-views-by-entities'),
+    latest: 0,
+    id: DataInsightChartType.PageViewsByEntities,
+  },
+  {
+    label: i18n.t('label.daily-active-user'),
+    latest: 0,
+    id: DataInsightChartType.DailyActiveUsers,
+  },
 ];
 
 export const ENTITIES_SUMMARY_LIST = [

--- a/openmetadata-ui/src/main/resources/ui/src/constants/DataInsight.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/DataInsight.constants.ts
@@ -13,6 +13,7 @@
 
 import i18n from 'i18next';
 import { Margin } from 'recharts/types/util/types';
+import { DataInsightChartType } from '../generated/dataInsight/dataInsightChartResult';
 import { ChartFilter } from '../interface/data-insight.interface';
 import {
   getCurrentDateTimeMillis,
@@ -117,3 +118,33 @@ export const INITIAL_CHART_FILTER: ChartFilter = {
   startTs: getPastDaysDateTimeMillis(DEFAULT_DAYS),
   endTs: getCurrentDateTimeMillis(),
 };
+
+export const ENTITIES_CHARTS_NAMES = [
+  DataInsightChartType.TotalEntitiesByType,
+  DataInsightChartType.PercentageOfEntitiesWithDescriptionByType,
+  DataInsightChartType.PercentageOfEntitiesWithOwnerByType,
+  DataInsightChartType.TotalEntitiesByTier,
+];
+
+export const ENTITIES_SUMMARY_LIST = [
+  {
+    label: i18n.t('label.total-data-assets'),
+    latest: 0,
+    id: DataInsightChartType.TotalEntitiesByType,
+  },
+  {
+    label: i18n.t('label.data-assets-with-field', { field: 'description' }),
+    latest: 0,
+    id: DataInsightChartType.PercentageOfEntitiesWithDescriptionByType,
+  },
+  {
+    label: i18n.t('label.data-assets-with-field', { field: 'owners' }),
+    latest: 0,
+    id: DataInsightChartType.PercentageOfEntitiesWithOwnerByType,
+  },
+  {
+    label: i18n.t('label.total-data-assets-with-tiers'),
+    latest: 0,
+    id: DataInsightChartType.TotalEntitiesByTier,
+  },
+];

--- a/openmetadata-ui/src/main/resources/ui/src/constants/DataInsight.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/DataInsight.constants.ts
@@ -67,7 +67,7 @@ export const TIER_BAR_COLOR_MAP: Record<string, string> = {
 };
 
 export const DATA_INSIGHT_TAB = {
-  Datasets: 'Datasets',
+  DataAssets: 'Data assets',
   'Web Analytics': 'Web Analytics',
 };
 

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
@@ -175,12 +175,12 @@
     "scopes-comma-separated": "Scopes value comma separated",
     "find-in-table": "Find in table",
     "data-insight-summary": "OpenMetadata health at a glance",
-    "data-insight-description-summary": "Percentage of Datasets With Description",
-    "data-insight-owner-summary": "Percentage of Datasets With Owners",
-    "data-insight-tier-summary": "Total Datasets by Tier",
+    "data-insight-description-summary": "Percentage of Data assets With Description",
+    "data-insight-owner-summary": "Percentage of Data assets With Owners",
+    "data-insight-tier-summary": "Total Data assets by Tier",
     "data-insight-active-user-summary": "Most Active Users",
-    "data-insight-top-viewed-entity-summary": "Most Viewed Datasets",
-    "data-insight-total-entity-summary": "Total Datasets",
+    "data-insight-top-viewed-entity-summary": "Most Viewed Data assets",
+    "data-insight-total-entity-summary": "Total Data assets",
     "user": "User",
     "team": "Team",
     "most-recent-session": "Most Recent Session",
@@ -225,12 +225,13 @@
     "function": "Function",
     "edge-information": "Edge Information",
     "no-owner": "No Owner",
-    "page-views-by-entities": "Page views by datasets",
+    "page-views-by-entities": "Page views by data assets",
     "daily-active-user": "Daily active users on the platform",
     "collapse-all": "Collapse All",
     "expand-all": "Expand All",
     "search-lineage": "Search Lineage",
-    "edit-lineage": "Edit Lineage"
+    "edit-lineage": "Edit Lineage",
+    "data-asset": "Data asset"
   },
   "message": {
     "service-email-required": "Service account Email is required",
@@ -253,11 +254,11 @@
     "no-ingestion-description": "To view Ingestion Data, run the MetaData Ingestion. Please refer to this doc to schedule the",
     "fetch-pipeline-status-error": "Error while fetching pipeline status.",
     "data-insight-page-views": "Displays the number of time an dataset type was viewed.",
-    "field-insight": "Display the percentage of datasets with {{field}} by type.",
-    "total-entity-insight": "Display the total of datasets by type.",
+    "field-insight": "Display the percentage of data assets with {{field}} by type.",
+    "total-entity-insight": "Display the total of data assets by type.",
     "active-users": "Display the number of users active.",
     "most-active-users": "Displays the most active users on the platform based on page views.",
-    "most-viewed-datasets": "Displays the most viewed datasets."
+    "most-viewed-data-assets": "Displays the most viewed data assets."
   },
   "server": {
     "no-followed-entities": "You have not followed anything yet.",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
@@ -231,7 +231,10 @@
     "expand-all": "Expand All",
     "search-lineage": "Search Lineage",
     "edit-lineage": "Edit Lineage",
-    "data-asset": "Data asset"
+    "data-asset": "Data asset",
+    "total-data-assets": "Total data assets",
+    "data-assets-with-field": "Data assets with {{field}}",
+    "total-data-assets-with-tiers": "Total Data assets with tiers"
   },
   "message": {
     "service-email-required": "Service account Email is required",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
@@ -234,7 +234,8 @@
     "data-asset": "Data asset",
     "total-data-assets": "Total data assets",
     "data-assets-with-field": "Data assets with {{field}}",
-    "total-data-assets-with-tiers": "Total Data assets with tiers"
+    "total-data-assets-with-tiers": "Total Data assets with tiers",
+    "most-active-user": "Most active user"
   },
   "message": {
     "service-email-required": "Service account Email is required",

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/DataInsightPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/DataInsightPage.component.tsx
@@ -44,6 +44,7 @@ import {
   TIER_FILTER,
 } from '../../constants/DataInsight.constants';
 import { SearchIndex } from '../../enums/search.enum';
+import { DataInsightChartType } from '../../generated/dataInsight/dataInsightChartResult';
 import { ChartFilter } from '../../interface/data-insight.interface';
 import { getTeamFilter } from '../../utils/DataInsightUtils';
 import {
@@ -120,6 +121,13 @@ const DataInsightPage = () => {
     }
   };
 
+  const handleScrollToChart = (chartType: DataInsightChartType) => {
+    const element = document.getElementById(chartType);
+    if (element) {
+      element.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    }
+  };
+
   useEffect(() => {
     fetchDefaultTeamOptions();
   }, []);
@@ -187,7 +195,10 @@ const DataInsightPage = () => {
           </Card>
         </Col>
         <Col span={24}>
-          <DataInsightSummary chartFilter={chartFilter} />
+          <DataInsightSummary
+            chartFilter={chartFilter}
+            onScrollToChart={handleScrollToChart}
+          />
         </Col>
         <Col span={24}>
           <Radio.Group

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/DataInsightPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/DataInsightPage.component.tsx
@@ -22,7 +22,7 @@ import {
   Space,
   Typography,
 } from 'antd';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useState } from 'react';
 import { searchQuery } from '../../axiosAPIs/searchAPI';
 
 import { autocomplete } from '../../components/AdvancedSearch/AdvancedSearch.constants';
@@ -40,6 +40,7 @@ import {
   DATA_INSIGHT_TAB,
   DAY_FILTER,
   DEFAULT_DAYS,
+  ENTITIES_CHARTS,
   INITIAL_CHART_FILTER,
   TIER_FILTER,
 } from '../../constants/DataInsight.constants';
@@ -61,6 +62,8 @@ const DataInsightPage = () => {
   const [activeTab, setActiveTab] = useState(DATA_INSIGHT_TAB.DataAssets);
   const [chartFilter, setChartFilter] =
     useState<ChartFilter>(INITIAL_CHART_FILTER);
+
+  const [selectedChart, setSelectedChart] = useState<DataInsightChartType>();
 
   useEffect(() => {
     setChartFilter(INITIAL_CHART_FILTER);
@@ -122,11 +125,23 @@ const DataInsightPage = () => {
   };
 
   const handleScrollToChart = (chartType: DataInsightChartType) => {
-    const element = document.getElementById(chartType);
-    if (element) {
-      element.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    if (ENTITIES_CHARTS.includes(chartType)) {
+      setActiveTab(DATA_INSIGHT_TAB.DataAssets);
+    } else {
+      setActiveTab(DATA_INSIGHT_TAB['Web Analytics']);
     }
+    setSelectedChart(chartType);
   };
+
+  useLayoutEffect(() => {
+    if (selectedChart) {
+      const element = document.getElementById(selectedChart);
+      if (element) {
+        element.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        setSelectedChart(undefined);
+      }
+    }
+  }, [selectedChart]);
 
   useEffect(() => {
     fetchDefaultTeamOptions();
@@ -236,10 +251,10 @@ const DataInsightPage = () => {
               <PageViewsByEntitiesChart chartFilter={chartFilter} />
             </Col>
             <Col span={24}>
-              <TopActiveUsers chartFilter={chartFilter} />
+              <DailyActiveUsersChart chartFilter={chartFilter} />
             </Col>
             <Col span={24}>
-              <DailyActiveUsersChart chartFilter={chartFilter} />
+              <TopActiveUsers chartFilter={chartFilter} />
             </Col>
           </>
         )}

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/DataInsightPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/DataInsightPage.component.tsx
@@ -57,7 +57,7 @@ const fetchTeamSuggestions = autocomplete(SearchIndex.TEAM);
 
 const DataInsightPage = () => {
   const [teamsOptions, setTeamOptions] = useState<SelectProps['options']>([]);
-  const [activeTab, setActiveTab] = useState(DATA_INSIGHT_TAB.Datasets);
+  const [activeTab, setActiveTab] = useState(DATA_INSIGHT_TAB.DataAssets);
   const [chartFilter, setChartFilter] =
     useState<ChartFilter>(INITIAL_CHART_FILTER);
 
@@ -200,7 +200,7 @@ const DataInsightPage = () => {
             onChange={(e) => setActiveTab(e.target.value)}
           />
         </Col>
-        {activeTab === DATA_INSIGHT_TAB.Datasets && (
+        {activeTab === DATA_INSIGHT_TAB.DataAssets && (
           <>
             <Col span={24}>
               <TotalEntityInsight chartFilter={chartFilter} />

--- a/openmetadata-ui/src/main/resources/ui/src/styles/spacing.less
+++ b/openmetadata-ui/src/main/resources/ui/src/styles/spacing.less
@@ -397,3 +397,7 @@
 .m--ml-1 {
   margin-left: -0.25rem /* -4px */;
 }
+
+.m--ml-0\.5 {
+  margin-left: -0.125rem /* -2px */;
+}

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataInsightUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataInsightUtils.tsx
@@ -12,10 +12,11 @@
  */
 
 import { Card, Typography } from 'antd';
-import { isInteger, last, toNumber } from 'lodash';
+import { isInteger, isUndefined, last, toNumber } from 'lodash';
 import React from 'react';
 import { ListItem, ListValues } from 'react-awesome-query-builder';
 import { LegendProps, Surface } from 'recharts';
+import { ENTITIES_SUMMARY_LIST } from '../constants/DataInsight.constants';
 import {
   DataInsightChartResult,
   DataInsightChartType,
@@ -242,3 +243,33 @@ export const getFormattedActiveUsersData = (activeUsers: DailyActiveUsers[]) =>
       ? getFormattedDateFromMilliSeconds(user.timestamp)
       : '',
   }));
+
+export const getEntitiesChartSummary = (
+  chartResults: (DataInsightChartResult | undefined)[]
+) => {
+  const updatedSummaryList = ENTITIES_SUMMARY_LIST.map((summary) => {
+    // grab the current chart type
+    const chartData = chartResults.find(
+      (chart) => chart?.chartType === summary.id
+    );
+
+    // return default summary if chart data is undefined else calculate the latest count for chartType
+    if (isUndefined(chartData)) return summary;
+    else {
+      if (chartData.chartType === DataInsightChartType.TotalEntitiesByTier) {
+        const { total } = getGraphDataByTierType(chartData.data ?? []);
+
+        return { ...summary, latest: total };
+      } else {
+        const { total } = getGraphDataByEntityType(
+          chartData.data ?? [],
+          chartData.chartType
+        );
+
+        return { ...summary, latest: total };
+      }
+    }
+  });
+
+  return updatedSummaryList;
+};

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataInsightUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataInsightUtils.tsx
@@ -16,7 +16,10 @@ import { isInteger, isUndefined, last, toNumber } from 'lodash';
 import React from 'react';
 import { ListItem, ListValues } from 'react-awesome-query-builder';
 import { LegendProps, Surface } from 'recharts';
-import { ENTITIES_SUMMARY_LIST } from '../constants/DataInsight.constants';
+import {
+  ENTITIES_SUMMARY_LIST,
+  WEB_SUMMARY_LIST,
+} from '../constants/DataInsight.constants';
 import {
   DataInsightChartResult,
   DataInsightChartType,
@@ -272,4 +275,33 @@ export const getEntitiesChartSummary = (
   });
 
   return updatedSummaryList;
+};
+
+export const getWebChartSummary = (
+  chartResults: (DataInsightChartResult | undefined)[]
+) => {
+  const updatedSummary = WEB_SUMMARY_LIST.map((summary) => {
+    // grab the current chart type
+    const chartData = chartResults.find(
+      (chart) => chart?.chartType === summary.id
+    );
+    // return default summary if chart data is undefined else calculate the latest count for chartType
+    if (isUndefined(chartData)) return summary;
+    else {
+      if (chartData.chartType === DataInsightChartType.DailyActiveUsers) {
+        const latestData = last(chartData.data);
+
+        return { ...summary, latest: latestData?.activeUsers ?? 0 };
+      } else {
+        const { total } = getGraphDataByEntityType(
+          chartData.data ?? [],
+          chartData.chartType
+        );
+
+        return { ...summary, latest: total };
+      }
+    }
+  });
+
+  return updatedSummary;
 };


### PR DESCRIPTION
Fixes #8639

### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on issue #8639, which includes,
- Showing overview of entities and web charts
- On click of overview scroll down to a particular chart
- Showing most active user with hover over the card


#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] New feature


#
### Frontend Preview (Screenshots) :

![image](https://user-images.githubusercontent.com/59080942/201119659-5eb3fba1-db6c-4536-96b2-c92c7eab232c.png)



![image](https://user-images.githubusercontent.com/59080942/201119540-2fa1296b-9802-42c2-a3e0-843223e74c73.png)



https://user-images.githubusercontent.com/59080942/201112686-a395f71f-2158-4d9d-b415-ecfe9875cf73.mov



#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
