### PR TITLE
(UI) #8513: UI improvements - part 1

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/Explore.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/Explore.component.tsx
@@ -242,18 +242,18 @@ const Explore: React.FC<ExploreProps> = ({
   return (
     <PageLayoutV1
       leftPanel={
-        <div className="tw-h-full">
-          <Card data-testid="data-summary-container">
-            <FacetFilter
-              aggregations={searchResults?.aggregations}
-              filters={postFilter}
-              showDeleted={showDeleted}
-              onChangeShowDeleted={onChangeShowDeleted}
-              onClearFilter={handleFacetFilterClearFilter}
-              onSelectHandler={handleFacetFilterChange}
-            />
-          </Card>
-        </div>
+        <Card
+          className="page-layout-v1-left-panel page-layout-v1-vertical-scroll"
+          data-testid="data-summary-container">
+          <FacetFilter
+            aggregations={searchResults?.aggregations}
+            filters={postFilter}
+            showDeleted={showDeleted}
+            onChangeShowDeleted={onChangeShowDeleted}
+            onClearFilter={handleFacetFilterClearFilter}
+            onSelectHandler={handleFacetFilterChange}
+          />
+        </Card>
       }>
       <Tabs
         defaultActiveKey={defaultActiveTab}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryV1.component.tsx
@@ -367,6 +367,7 @@ const GlossaryV1 = ({
                 ) : (
                   <DirectoryTree
                     multiple
+                    className="glossary-tree-container"
                     expandedKeys={expandedKey}
                     loadedKeys={loadingKey}
                     selectedKeys={[selectedKey]}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryV1.style.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryV1.style.less
@@ -49,3 +49,14 @@
     padding: 5px 16px;
   }
 }
+.glossary-tree-container {
+  .ant-tree-node-content-wrapper {
+    overflow: hidden;
+    white-space: nowrap;
+    gap: 4px;
+  }
+
+  .ant-tree-title {
+    width: calc(100% - 8px);
+  }
+}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/ModalWithMarkdownEditor/ModalWithMarkdownEditor.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/ModalWithMarkdownEditor/ModalWithMarkdownEditor.tsx
@@ -16,12 +16,13 @@ import {
   faWindowMinimize,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Button } from 'antd';
 import { AxiosError } from 'axios';
 import classnames from 'classnames';
 import React, { FunctionComponent, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
+import { useTranslation } from 'react-i18next';
 import { showErrorToast } from '../../../utils/ToastUtils';
-import { Button } from '../../buttons/Button/Button';
 import RichTextEditor from '../../common/rich-text-editor/RichTextEditor';
 import Loader from '../../Loader/Loader';
 
@@ -35,19 +36,18 @@ type Props = {
   value: string;
   placeholder: string;
   onSave?: (text: string) => Promise<void>;
-  onSuggest?: (text: string) => void;
   onCancel?: () => void;
 };
 
 export const ModalWithMarkdownEditor: FunctionComponent<Props> = ({
   isExpandable = false,
   header,
-  // placeholder,
+  placeholder,
   value,
   onSave,
-  // onSuggest,
   onCancel,
 }: Props) => {
+  const { t } = useTranslation();
   const [expanded, setExpanded] = useState<boolean>(false);
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
@@ -86,7 +86,6 @@ export const ModalWithMarkdownEditor: FunctionComponent<Props> = ({
               <Button
                 className="tw-text-lg tw-text-gray-900 hover:tw-text-gray-900"
                 size="small"
-                variant="text"
                 onClick={() => setExpanded((value) => !value)}>
                 <FontAwesomeIcon
                   icon={expanded ? faWindowMinimize : faWindowMaximize}
@@ -109,26 +108,26 @@ export const ModalWithMarkdownEditor: FunctionComponent<Props> = ({
             </div>
           )}
         </div>
-        <div className="tw-modal-body tw-pt-0 tw-pb-1">
-          <RichTextEditor initialValue={value} ref={markdownRef} />
+        <div className="tw-modal-body">
+          <RichTextEditor
+            initialValue={value}
+            placeHolder={placeholder}
+            ref={markdownRef}
+          />
         </div>
         <div className="tw-modal-footer">
           <Button
             data-testid="cancel"
             disabled={isLoading}
-            size="regular"
-            theme="primary"
-            variant="link"
+            type="link"
             onClick={onCancel}>
-            Cancel
+            {t('label.cancel')}
           </Button>
           <Button
             data-testid="save"
-            size="regular"
-            theme="primary"
-            variant="contained"
+            type="primary"
             onClick={() => handleSaveData()}>
-            {isLoading ? <Loader size="small" type="white" /> : 'Save'}
+            {isLoading ? <Loader size="small" type="white" /> : t('label.save')}
           </Button>
         </div>
       </div>

--- a/openmetadata-ui/src/main/resources/ui/src/components/SchemaTab/SchemaTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/SchemaTab/SchemaTab.component.tsx
@@ -51,26 +51,24 @@ const SchemaTab: FunctionComponent<Props> = ({
         </div>
       </div>
       <div className="row">
-        {columns?.length > 0 ? (
-          <div className="col-sm-12">
-            <EntityTableV1
-              columnName={columnName}
-              entityFieldTasks={entityFieldTasks}
-              entityFieldThreads={entityFieldThreads}
-              entityFqn={entityFqn}
-              hasDescriptionEditAccess={hasDescriptionEditAccess}
-              hasTagEditAccess={hasTagEditAccess}
-              isReadOnly={isReadOnly}
-              joins={joins}
-              searchText={lowerCase(searchText)}
-              tableColumns={columns}
-              tableConstraints={tableConstraints}
-              onEntityFieldSelect={onEntityFieldSelect}
-              onThreadLinkSelect={onThreadLinkSelect}
-              onUpdate={onUpdate}
-            />
-          </div>
-        ) : null}
+        <div className="col-sm-12">
+          <EntityTableV1
+            columnName={columnName}
+            entityFieldTasks={entityFieldTasks}
+            entityFieldThreads={entityFieldThreads}
+            entityFqn={entityFqn}
+            hasDescriptionEditAccess={hasDescriptionEditAccess}
+            hasTagEditAccess={hasTagEditAccess}
+            isReadOnly={isReadOnly}
+            joins={joins}
+            searchText={lowerCase(searchText)}
+            tableColumns={columns}
+            tableConstraints={tableConstraints}
+            onEntityFieldSelect={onEntityFieldSelect}
+            onThreadLinkSelect={onThreadLinkSelect}
+            onUpdate={onUpdate}
+          />
+        </div>
       </div>
     </Fragment>
   );

--- a/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/TableProfilerV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/TableProfilerV1.tsx
@@ -343,7 +343,7 @@ const TableProfilerV1: FC<TableProfilerProps> = ({ table, permissions }) => {
               target="_blank"
               to={{
                 pathname:
-                  'https://docs.open-metadata.org/openmetadata/ingestion/workflows/profiler',
+                  'https://docs.open-metadata.org/connectors/ingestion/workflows/profiler',
               }}>
               here.
             </Link>

--- a/openmetadata-ui/src/main/resources/ui/src/pages/tags/index.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/tags/index.tsx
@@ -667,7 +667,6 @@ const TagsPage = () => {
                     data-testid="delete-tag-category-button"
                     disabled={!categoryPermissions.Delete}
                     size="small"
-                    type="primary"
                     onClick={() => {
                       deleteTagHandler();
                     }}>


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement

#
### Frontend Preview (Screenshots) :
<p align="center">

- [x] Change "Delete Catagory" button styling to outlined
<img width="369" alt="Screenshot 2022-11-10 at 6 26 02 PM" src="https://user-images.githubusercontent.com/51777795/201097851-cacdc5c4-555e-46e9-af78-9e2a27ee2d1d.png">

- [x] Left column styling made consistent with other pages
<img width="1440" alt="Screenshot 2022-11-10 at 6 26 28 PM" src="https://user-images.githubusercontent.com/51777795/201097901-1460e00f-56ab-4731-ba81-2c9d77308ab3.png">

- [x] Empty table will be shown for no data in the schema tab instead of blank space
<img width="1440" alt="Screenshot 2022-11-10 at 6 27 29 PM" src="https://user-images.githubusercontent.com/51777795/201098123-8280d77a-9199-4ad3-a144-892500eef57c.png">

- [x] Updated correct documentation link for profiler.
<img width="1378" alt="Screenshot 2022-11-10 at 6 27 51 PM" src="https://user-images.githubusercontent.com/51777795/201098202-a9b47e27-fb5f-4a1a-83ef-999db763ce2f.png">

- [x] Fixed spacing for update description modal and replaced deprecated components with antd
<img width="1341" alt="Screenshot 2022-11-10 at 6 28 43 PM" src="https://user-images.githubusercontent.com/51777795/201098306-fb110d11-7d53-44c4-aa98-238c84bfb376.png">

- [x] Glossary terms left panel alignment fixed and solved the long name issue
<img width="297" alt="Screenshot 2022-11-10 at 6 29 05 PM" src="https://user-images.githubusercontent.com/51777795/201098340-e864fe6a-0f58-4993-8731-050c6c155acd.png">

</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @open-metadata/ui
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
<img width="1440" alt="Screenshot 2022-11-10 at 6 27 29 PM" src="https://user-images.githubusercontent.com/51777795/201097927-d88ff267-a1cd-4b35-bee1-29ff536d157d.png">
