### PR TITLE
cast to bigint to avoid overflow when summing

### DIFF
--- a/ingestion/src/metadata/orm_profiler/orm/functions/sum.py
+++ b/ingestion/src/metadata/orm_profiler/orm/functions/sum.py
@@ -42,6 +42,7 @@ def _(element, compiler, **kw):
     proc = compiler.process(element.clauses, **kw)
     return f"SUM(CAST({proc} AS NUMERIC))"
 
+
 @compiles(SumFn, Dialects.Snowflake)
 @compiles(SumFn, Dialects.Vertica)
 def _(element, compiler, **kw):

--- a/ingestion/src/metadata/orm_profiler/orm/functions/sum.py
+++ b/ingestion/src/metadata/orm_profiler/orm/functions/sum.py
@@ -31,9 +31,9 @@ class SumFn(GenericFunction):
 
 @compiles(SumFn)
 def _(element, compiler, **kw):
-    """Handle case for empty table. If empty, clickhouse returns NaN"""
+    """Cast to BIGINT to address overflow error from summing 32-bit int in most database dialects, #8430"""
     proc = compiler.process(element.clauses, **kw)
-    return f"SUM({proc})"
+    return f"SUM(CAST({proc} AS BIGINT))"
 
 
 @compiles(SumFn, Dialects.BigQuery)
@@ -41,3 +41,10 @@ def _(element, compiler, **kw):
     """Handle case where column type is INTEGER but SUM returns a NUMBER"""
     proc = compiler.process(element.clauses, **kw)
     return f"SUM(CAST({proc} AS NUMERIC))"
+
+@compiles(SumFn, Dialects.Snowflake)
+@compiles(SumFn, Dialects.Vertica)
+def _(element, compiler, **kw):
+    """These database types have all int types as alias for int64 so don't need a cast"""
+    proc = compiler.process(element.clauses, **kw)
+    return f"SUM({proc})"


### PR DESCRIPTION
### Describe your changes :
Fixes #8430

I'm experiencing this overflow often in my MSSQL logs, often when an ID value or other large int value is summed.  This increases the overflow threshold for `sum()` from 2 billion (2^31) to 9 quintillion (2^63).

Most database variants are affected by this (see the issue for specifics) so I made this the generic function and then created a variant-specific version that doesn't cast, for Snowflake and Vertica.  That may not be necessary if the CAST from int to bigint would be ignored but I couldn't find out and don't have a way to test.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@TeddyCr 