### PR TITLE
UI: Fixed UI | Table Detail pane on the Lineage tab doesn't show the column count

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityUtils.tsx
@@ -21,6 +21,7 @@ import { ResourceEntity } from '../components/PermissionProvider/PermissionProvi
 import { FQN_SEPARATOR_CHAR } from '../constants/char.constants';
 import {
   getDatabaseDetailsPath,
+  getDatabaseSchemaDetailsPath,
   getServiceDetailsPath,
   getTableDetailsPath,
   getTeamAndUserDetailsPath,
@@ -91,11 +92,17 @@ export const getEntityOverview = (
 }> => {
   switch (type) {
     case EntityType.TABLE: {
-      const { fullyQualifiedName, owner, tags, usageSummary, profile } =
-        entityDetail as Table;
-      const [service, database] = getPartialNameFromTableFQN(
+      const {
+        fullyQualifiedName,
+        owner,
+        tags,
+        usageSummary,
+        profile,
+        columns,
+      } = entityDetail as Table;
+      const [service, database, schema] = getPartialNameFromTableFQN(
         fullyQualifiedName ?? '',
-        [FqnPart.Service, FqnPart.Database],
+        [FqnPart.Service, FqnPart.Database, FqnPart.Schema],
         FQN_SEPARATOR_CHAR
       ).split(FQN_SEPARATOR_CHAR);
       const tier = getTierFromTableTags(tags || []);
@@ -127,6 +134,18 @@ export const getEntityOverview = (
           isLink: true,
         },
         {
+          name: 'Schema',
+          value: schema,
+          url: getDatabaseSchemaDetailsPath(
+            getPartialNameFromTableFQN(
+              fullyQualifiedName ?? '',
+              [FqnPart.Service, FqnPart.Database, FqnPart.Schema],
+              FQN_SEPARATOR_CHAR
+            )
+          ),
+          isLink: true,
+        },
+        {
           name: 'Owner',
           value: getEntityName(owner) || '--',
           url: getTeamAndUserDetailsPath(owner?.name || ''),
@@ -149,7 +168,7 @@ export const getEntityOverview = (
         },
         {
           name: 'Columns',
-          value: profile && profile?.columnCount ? profile.columnCount : '--',
+          value: columns ? columns.length : '--',
           isLink: false,
         },
         {


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
 Fixed UI | Table Detail pane on the Lineage tab doesn't show the column count
 Closes #6947 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement


#
### Frontend Preview (Screenshots) :
![image](https://user-images.githubusercontent.com/71748675/201636124-c5d30a10-5bf3-43d7-b3a1-004bb63388e3.png)


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
