### PR TITLE
fix(ui): update default status to empty instead queued

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/cypress/common/common.js
+++ b/openmetadata-ui/src/main/resources/ui/cypress/common/common.js
@@ -53,11 +53,11 @@ export const handleIngestionRetry = (
     const rowIndex = ingestionType === 'metadata' ? 1 : 2;
 
     interceptURL('GET', '/api/v1/services/ingestionPipelines/*/pipelineStatus?*', 'pipelineStatuses')
-    
+
     // ingestions page
     let retryCount = count;
     const testIngestionsTab = () => {
-        
+
         cy.get('[data-testid="Ingestions"]').should('be.visible');
         cy.get('[data-testid="Ingestions"] >> [data-testid="filter-count"]').should(
             'have.text',
@@ -81,7 +81,7 @@ export const handleIngestionRetry = (
             ($ingestionStatus) => {
                 if (
                     ($ingestionStatus.text() === 'Running' ||
-                        $ingestionStatus.text() === 'Queued') &&
+                        $ingestionStatus.text() === 'Queued' || $ingestionStatus.text() === '--') &&
                     retryCount <= RETRY_TIMES
                 ) {
                     // retry after waiting for 20 seconds
@@ -136,7 +136,7 @@ export const testServiceCreationAndIngestion = (
     cy.get('[data-testid="service-name"]').should('exist').type(serviceName);
     interceptURL('GET', 'api/v1/services/ingestionPipelines/*', 'getIngestionPipelineStatus')
     cy.get('[data-testid="next-button"]').click();
-verifyResponseStatusCode('@getIngestionPipelineStatus', 200)
+    verifyResponseStatusCode('@getIngestionPipelineStatus', 200)
     // Connection Details in step 3
     cy.get('[data-testid="add-new-service-container"]')
         .parent()
@@ -163,7 +163,7 @@ verifyResponseStatusCode('@getIngestionPipelineStatus', 200)
     cy.contains('Connection test was successful').should('exist');
     interceptURL('GET', '/api/v1/services/ingestionPipelines/status', 'getIngestionPipelineStatus')
     cy.get('[data-testid="submit-btn"]').should('exist').click();
-verifyResponseStatusCode('@getIngestionPipelineStatus', 200);
+    verifyResponseStatusCode('@getIngestionPipelineStatus', 200);
     // check success
     cy.get('[data-testid="success-line"]').should('be.visible');
     cy.contains(`"${serviceName}"`).should('be.visible');
@@ -217,7 +217,7 @@ verifyResponseStatusCode('@getIngestionPipelineStatus', 200);
 
 export const deleteCreatedService = (typeOfService, service_Name, apiService) => {
     //Click on settings page
-    cy.get('[data-testid="appbar-item-settings"]').should('be.visible').click({force : true});
+    cy.get('[data-testid="appbar-item-settings"]').should('be.visible').click({ force: true });
 
     // Services page
     interceptURL('GET', '/api/v1/services/*', 'getServices');
@@ -272,7 +272,7 @@ export const deleteCreatedService = (typeOfService, service_Name, apiService) =>
 
     cy.get('[data-testid="confirm-button"]').should('be.visible').click();
     verifyResponseStatusCode('@deleteService', 200);
-    
+
     //Waiting to check if myData page redirection is proper after deleting service
     cy.get('[data-testid="tables"]').should('exist').should('be.visible');
 
@@ -280,10 +280,10 @@ export const deleteCreatedService = (typeOfService, service_Name, apiService) =>
     toastNotification(`${typeOfService} Service deleted successfully!`)
 
     //Checking if the service got deleted successfully
-    interceptURL('GET', '/api/v1/teams/name/Organization?fields=users,owns,defaultRoles,policies,owner,parents,childrenCount&include=all', 'getSettingsPage') 
+    interceptURL('GET', '/api/v1/teams/name/Organization?fields=users,owns,defaultRoles,policies,owner,parents,childrenCount&include=all', 'getSettingsPage')
     cy.get('[data-testid="appbar-item-settings"]').should('be.visible').click();
     verifyResponseStatusCode('@getSettingsPage', 200)
-    
+
     // Services page
     cy.get('[data-testid="settings-left-panel"]')
         .contains(typeOfService)
@@ -294,12 +294,12 @@ export const deleteCreatedService = (typeOfService, service_Name, apiService) =>
 };
 
 export const editOwnerforCreatedService = (
-  service_type,
-  service_Name,
-  api_services
+    service_type,
+    service_Name,
+    api_services
 ) => {
-  //Click on settings page
-  cy.get('[data-testid="appbar-item-settings"]').should('be.visible').click();
+    //Click on settings page
+    cy.get('[data-testid="appbar-item-settings"]').should('be.visible').click();
 
     // Services page
     cy.get('.ant-menu-title-content')
@@ -307,26 +307,26 @@ export const editOwnerforCreatedService = (
         .should('be.visible')
         .click();
 
-  interceptURL(
-    'GET',
-    `/api/v1/services/${api_services}/name/${service_Name}?fields=owner`,
-    'getSelectedService'
-  );
+    interceptURL(
+        'GET',
+        `/api/v1/services/${api_services}/name/${service_Name}?fields=owner`,
+        'getSelectedService'
+    );
 
-  interceptURL(
-    'GET',
-    `/api/v1/services/ingestionPipelines?fields=owner,pipelineStatuses&service=${service_Name}`,
-    'waitForIngestion'
-  );
+    interceptURL(
+        'GET',
+        `/api/v1/services/ingestionPipelines?fields=owner,pipelineStatuses&service=${service_Name}`,
+        'waitForIngestion'
+    );
 
-  //click on created service
-  cy.get(`[data-testid="service-name-${service_Name}"]`)
-    .should('exist')
-    .should('be.visible')
-    .click();
+    //click on created service
+    cy.get(`[data-testid="service-name-${service_Name}"]`)
+        .should('exist')
+        .should('be.visible')
+        .click();
 
-  verifyResponseStatusCode('@getSelectedService', 200);
-  verifyResponseStatusCode('@waitForIngestion', 200);
+    verifyResponseStatusCode('@getSelectedService', 200);
+    verifyResponseStatusCode('@waitForIngestion', 200);
 
     interceptURL(
         'GET',
@@ -334,12 +334,12 @@ export const editOwnerforCreatedService = (
         'waitForTeams'
     );
 
-  //Click on edit owner button
-  cy.get('[data-testid="edit-Owner-icon"]')
-    .should('exist')
-    .should('be.visible')
-    .trigger('mouseover')
-    .click();
+    //Click on edit owner button
+    cy.get('[data-testid="edit-Owner-icon"]')
+        .should('exist')
+        .should('be.visible')
+        .trigger('mouseover')
+        .click();
 
     verifyResponseStatusCode('@waitForTeams', 200);
 
@@ -621,7 +621,7 @@ export const restoreUser = (username) => {
         .should('exist')
         .should('be.visible')
         .click();
-    verifyResponseStatusCode('@restoreUser', 200);    
+    verifyResponseStatusCode('@restoreUser', 200);
     toastNotification('User restored successfully!');
 
     //Verifying the restored user
@@ -906,7 +906,7 @@ export const retryIngestionRun = () => {
             ($ingestionStatus) => {
                 if (
                     ($ingestionStatus.text() === 'Running' ||
-                        $ingestionStatus.text() === 'Queued') &&
+                        $ingestionStatus.text() === 'Queued' || $ingestionStatus.text() === '--') &&
                     retryCount <= RETRY_TIMES
                 ) {
                     // retry after waiting for 20 seconds

--- a/openmetadata-ui/src/main/resources/ui/src/components/Ingestion/IngestionRecentRun/IngestionRecentRuns.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Ingestion/IngestionRecentRun/IngestionRecentRuns.component.tsx
@@ -135,7 +135,7 @@ export const IngestionRecentRuns: FunctionComponent<Props> = ({
           ) : (
             status
           );
-        }) ?? 'Queued'
+        }) ?? '--'
       )}
     </Space>
   );


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the updating default status to "--" instead queued

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Frontend Preview (Screenshots) :
![image](https://user-images.githubusercontent.com/12962843/201670479-81d09379-b760-4862-bee7-7a4bebe65ec4.png)


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
