### PR TITLE
Fix race condition between Authorizer and BotResource

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/OpenMetadataApplication.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/OpenMetadataApplication.java
@@ -130,7 +130,7 @@ public class OpenMetadataApplication extends Application<OpenMetadataApplication
     registerAuthorizer(catalogConfig, environment);
 
     // Register Authenticator
-    registerAuthenticator(catalogConfig, jdbi);
+    registerAuthenticator(catalogConfig);
 
     // Unregister dropwizard default exception mappers
     ((DefaultServerFactory) catalogConfig.getServerFactory()).setRegisterDefaultExceptionMappers(false);
@@ -150,20 +150,20 @@ public class OpenMetadataApplication extends Application<OpenMetadataApplication
     // start event hub before registering publishers
     EventPubSub.start();
 
-    registerResources(catalogConfig, environment, jdbi);
-
     // Register Event Handler
     registerEventFilter(catalogConfig, environment, jdbi);
     environment.lifecycle().manage(new ManagedShutdown());
     // Register Event publishers
     registerEventPublisher(catalogConfig, jdbi);
 
-    // update entities secrets if required
-    new SecretsManagerUpdateService(secretsManager, catalogConfig.getClusterName()).updateEntities();
-
     // start authorizer after event publishers
     // authorizer creates admin/bot users, ES publisher should start before to index users created by authorizer
     authorizer.init(catalogConfig, jdbi);
+
+    registerResources(catalogConfig, environment, jdbi);
+
+    // update entities secrets if required
+    new SecretsManagerUpdateService(secretsManager, catalogConfig.getClusterName()).updateEntities();
 
     // authenticationHandler Handles auth related activities
     authenticatorHandler.init(catalogConfig, jdbi);
@@ -276,7 +276,7 @@ public class OpenMetadataApplication extends Application<OpenMetadataApplication
     }
   }
 
-  private void registerAuthenticator(OpenMetadataApplicationConfig catalogConfig, Jdbi jdbi) {
+  private void registerAuthenticator(OpenMetadataApplicationConfig catalogConfig) {
     AuthenticationConfiguration authenticationConfiguration = catalogConfig.getAuthenticationConfiguration();
     switch (authenticationConfiguration.getProvider()) {
       case "basic":

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/NoopAuthorizer.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/NoopAuthorizer.java
@@ -37,7 +37,7 @@ import org.openmetadata.service.util.RestUtil;
 public class NoopAuthorizer implements Authorizer {
   @Override
   public void init(OpenMetadataApplicationConfig openMetadataApplicationConfig, Jdbi jdbi) {
-    SubjectCache.initialize();
+    SubjectCache.initialize(jdbi);
     addAnonymousUser();
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/PolicyCache.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/PolicyCache.java
@@ -24,11 +24,13 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import javax.annotation.CheckForNull;
 import lombok.extern.slf4j.Slf4j;
+import org.jdbi.v3.core.Jdbi;
 import org.openmetadata.schema.entity.policies.Policy;
 import org.openmetadata.schema.entity.policies.accessControl.Rule;
-import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.EntityNotFoundException;
+import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.EntityRepository;
+import org.openmetadata.service.jdbi3.PolicyRepository;
 import org.openmetadata.service.util.EntityUtil.Fields;
 
 /** Subject context used for Access Control Policies */
@@ -46,10 +48,10 @@ public class PolicyCache {
   }
 
   /** To be called during application startup by Default Authorizer */
-  public static void initialize() {
+  public static void initialize(Jdbi jdbi) {
     if (!INITIALIZED) {
       POLICY_CACHE = CacheBuilder.newBuilder().maximumSize(100).build(new PolicyLoader());
-      POLICY_REPOSITORY = Entity.getEntityRepository(Entity.POLICY);
+      POLICY_REPOSITORY = new PolicyRepository(jdbi.onDemand(CollectionDAO.class));
       FIELDS = POLICY_REPOSITORY.getFields("rules");
       INITIALIZED = true;
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/RoleCache.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/RoleCache.java
@@ -22,10 +22,12 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import javax.annotation.CheckForNull;
 import lombok.extern.slf4j.Slf4j;
+import org.jdbi.v3.core.Jdbi;
 import org.openmetadata.schema.entity.teams.Role;
-import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.EntityNotFoundException;
+import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.EntityRepository;
+import org.openmetadata.service.jdbi3.RoleRepository;
 import org.openmetadata.service.util.EntityUtil.Fields;
 
 /** Subject context used for Access Control Policies */
@@ -42,10 +44,10 @@ public class RoleCache {
   }
 
   /** To be called only once during the application start from DefaultAuthorizer */
-  public static void initialize() {
+  public static void initialize(Jdbi jdbi) {
     if (!INITIALIZED) {
       ROLE_CACHE = CacheBuilder.newBuilder().maximumSize(100).build(new RoleLoader());
-      ROLE_REPOSITORY = Entity.getEntityRepository(Entity.ROLE);
+      ROLE_REPOSITORY = new RoleRepository(jdbi.onDemand(CollectionDAO.class));
       FIELDS = ROLE_REPOSITORY.getFields("policies");
       INITIALIZED = true;
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/SubjectCache.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/SubjectCache.java
@@ -29,22 +29,18 @@ import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
-import org.jdbi.v3.core.Jdbi;
 import org.openmetadata.schema.entity.teams.Team;
 import org.openmetadata.schema.entity.teams.User;
 import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.EntityNotFoundException;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.EntityRepository;
-import org.openmetadata.service.jdbi3.TeamRepository;
-import org.openmetadata.service.jdbi3.UserRepository;
 import org.openmetadata.service.util.EntityUtil.Fields;
 
 /** Subject context used for Access Control Policies */
 @Slf4j
 public class SubjectCache {
-  private static SubjectCache INSTANCE;
-  private static volatile boolean INITIALIZED = false;
+  private static SubjectCache INSTANCE = null;
 
   protected static LoadingCache<String, SubjectContext> USER_CACHE;
   protected static LoadingCache<UUID, Team> TEAM_CACHE;
@@ -55,25 +51,22 @@ public class SubjectCache {
   protected static Fields TEAM_FIELDS;
 
   // Expected to be called only once from the DefaultAuthorizer
-  public static void initialize(Jdbi jdbi) {
-    if (!INITIALIZED) {
-      USER_CACHE =
-          CacheBuilder.newBuilder().maximumSize(1000).expireAfterAccess(1, TimeUnit.MINUTES).build(new UserLoader());
-      TEAM_CACHE =
-          CacheBuilder.newBuilder().maximumSize(1000).expireAfterAccess(1, TimeUnit.MINUTES).build(new TeamLoader());
-      USER_REPOSITORY = new UserRepository(jdbi.onDemand(CollectionDAO.class));
-      USER_FIELDS = USER_REPOSITORY.getFields("roles, teams");
-      TEAM_REPOSITORY = new TeamRepository(jdbi.onDemand(CollectionDAO.class));
-      TEAM_FIELDS = TEAM_REPOSITORY.getFields("defaultRoles, policies, parents");
-      INSTANCE = new SubjectCache();
-      INITIALIZED = true;
-      LOG.info("Subject cache is initialized");
-    } else {
-      LOG.info("Subject cache is already initialized");
-    }
+  private SubjectCache() {
+    USER_CACHE =
+        CacheBuilder.newBuilder().maximumSize(1000).expireAfterAccess(1, TimeUnit.MINUTES).build(new UserLoader());
+    TEAM_CACHE =
+        CacheBuilder.newBuilder().maximumSize(1000).expireAfterAccess(1, TimeUnit.MINUTES).build(new TeamLoader());
+    USER_REPOSITORY = Entity.getEntityRepository(Entity.USER);
+    USER_FIELDS = USER_REPOSITORY.getFields("roles, teams");
+    TEAM_REPOSITORY = Entity.getEntityRepository(Entity.TEAM);
+    TEAM_FIELDS = TEAM_REPOSITORY.getFields("defaultRoles, policies, parents");
+    LOG.info("Subject cache is initialized");
   }
 
   public static SubjectCache getInstance() {
+    if (INSTANCE == null) {
+      INSTANCE = new SubjectCache();
+    }
     return INSTANCE;
   }
 
@@ -97,7 +90,7 @@ public class SubjectCache {
     LOG.info("Subject cache is cleaned up");
     USER_CACHE.invalidateAll();
     TEAM_CACHE.invalidateAll();
-    INITIALIZED = false;
+    INSTANCE = null;
   }
 
   public void invalidateUser(String userName) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/SubjectContextTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/SubjectContextTest.java
@@ -15,15 +15,18 @@ package org.openmetadata.service.security.policyevaluator;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
+import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.entity.policies.Policy;
 import org.openmetadata.schema.entity.policies.accessControl.Rule;
@@ -32,14 +35,8 @@ import org.openmetadata.schema.entity.teams.Team;
 import org.openmetadata.schema.entity.teams.User;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.jdbi3.CollectionDAO.PolicyDAO;
-import org.openmetadata.service.jdbi3.CollectionDAO.RoleDAO;
+import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.CollectionDAO.TeamDAO;
-import org.openmetadata.service.jdbi3.CollectionDAO.UserDAO;
-import org.openmetadata.service.jdbi3.PolicyRepository;
-import org.openmetadata.service.jdbi3.RoleRepository;
-import org.openmetadata.service.jdbi3.TeamRepository;
-import org.openmetadata.service.jdbi3.UserRepository;
 import org.openmetadata.service.security.policyevaluator.SubjectContext.PolicyContext;
 
 public class SubjectContextTest {
@@ -63,14 +60,13 @@ public class SubjectContextTest {
 
   @BeforeAll
   public static void setup() {
-    Entity.registerEntity(User.class, Entity.USER, Mockito.mock(UserDAO.class), Mockito.mock(UserRepository.class));
-    Entity.registerEntity(Team.class, Entity.TEAM, Mockito.mock(TeamDAO.class), Mockito.mock(TeamRepository.class));
-    Entity.registerEntity(
-        Policy.class, Entity.POLICY, Mockito.mock(PolicyDAO.class), Mockito.mock(PolicyRepository.class));
-    Entity.registerEntity(Role.class, Entity.ROLE, Mockito.mock(RoleDAO.class), Mockito.mock(RoleRepository.class));
-    PolicyCache.initialize();
-    RoleCache.initialize();
-    SubjectCache.initialize();
+    Jdbi jdbiMock = mock(Jdbi.class);
+    CollectionDAO collectionDAOMock = mock(CollectionDAO.class);
+    when(collectionDAOMock.teamDAO()).thenReturn(mock(TeamDAO.class));
+    when(jdbiMock.onDemand(any())).thenReturn(collectionDAOMock);
+    PolicyCache.initialize(jdbiMock);
+    RoleCache.initialize(jdbiMock);
+    SubjectCache.initialize(jdbiMock);
 
     // Create team hierarchy:
     // team1, has  team11, team12, team13 as children

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/SubjectContextTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/SubjectContextTest.java
@@ -15,18 +15,15 @@ package org.openmetadata.service.security.policyevaluator;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
-import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.entity.policies.Policy;
 import org.openmetadata.schema.entity.policies.accessControl.Rule;
@@ -35,8 +32,14 @@ import org.openmetadata.schema.entity.teams.Team;
 import org.openmetadata.schema.entity.teams.User;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.jdbi3.CollectionDAO;
+import org.openmetadata.service.jdbi3.CollectionDAO.PolicyDAO;
+import org.openmetadata.service.jdbi3.CollectionDAO.RoleDAO;
 import org.openmetadata.service.jdbi3.CollectionDAO.TeamDAO;
+import org.openmetadata.service.jdbi3.CollectionDAO.UserDAO;
+import org.openmetadata.service.jdbi3.PolicyRepository;
+import org.openmetadata.service.jdbi3.RoleRepository;
+import org.openmetadata.service.jdbi3.TeamRepository;
+import org.openmetadata.service.jdbi3.UserRepository;
 import org.openmetadata.service.security.policyevaluator.SubjectContext.PolicyContext;
 
 public class SubjectContextTest {
@@ -60,13 +63,11 @@ public class SubjectContextTest {
 
   @BeforeAll
   public static void setup() {
-    Jdbi jdbiMock = mock(Jdbi.class);
-    CollectionDAO collectionDAOMock = mock(CollectionDAO.class);
-    when(collectionDAOMock.teamDAO()).thenReturn(mock(TeamDAO.class));
-    when(jdbiMock.onDemand(any())).thenReturn(collectionDAOMock);
-    PolicyCache.initialize(jdbiMock);
-    RoleCache.initialize(jdbiMock);
-    SubjectCache.initialize(jdbiMock);
+    Entity.registerEntity(User.class, Entity.USER, Mockito.mock(UserDAO.class), Mockito.mock(UserRepository.class));
+    Entity.registerEntity(Team.class, Entity.TEAM, Mockito.mock(TeamDAO.class), Mockito.mock(TeamRepository.class));
+    Entity.registerEntity(
+        Policy.class, Entity.POLICY, Mockito.mock(PolicyDAO.class), Mockito.mock(PolicyRepository.class));
+    Entity.registerEntity(Role.class, Entity.ROLE, Mockito.mock(RoleDAO.class), Mockito.mock(RoleRepository.class));
 
     // Create team hierarchy:
     // team1, has  team11, team12, team13 as children


### PR DESCRIPTION
### Describe your changes :
`BotResource` depended on `DefaultAuthorizer` for adding the roles to the bot's users, but `DefaultAuthorizer` initialization happened after `BotResource` ones. Due to this bug, the `EntityUpdater` class instantiation failed with an NPE when the updating user of the updated entity was not an `admin` since the `SubjectCache` instance was initialized by the `DefaultAuthorizer`.

### Type of change :
- [x] Bug fix

### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

### Reviewers
Backend: @open-metadata/backend
