### PR TITLE
Fixes #8701 Unable to add condition for matchAnyTags condition policy…

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/RuleEvaluator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/RuleEvaluator.java
@@ -66,8 +66,8 @@ public class RuleEvaluator {
       name = "matchAnyTag",
       input = "List of comma separated tag or glossary fully qualified names",
       description = "Returns true if the entity being accessed has at least one of the tags given as input",
-      examples = {"matchAnyTags('PersonalData.Personal', 'Tier.Tier1', 'Business Glossary.Clothing')"})
-  public boolean matchAnyTag(List<String> tagFQNs) throws IOException {
+      examples = {"matchAnyTag('PersonalData.Personal', 'Tier.Tier1', 'Business Glossary.Clothing')"})
+  public boolean matchAnyTag(String... tagFQNs) throws IOException {
     if (resourceContext == null) {
       return false;
     }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/policies/PolicyResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/policies/PolicyResourceTest.java
@@ -143,6 +143,7 @@ public class PolicyResourceTest extends EntityResourceTest<Policy, CreatePolicy>
       EntityReference actualLocation = JsonUtils.readValue(actual.toString(), EntityReference.class);
       assertEquals(expectedLocation.getId(), actualLocation.getId());
     } else if (fieldName.equals("rules")) {
+      @SuppressWarnings("unchecked")
       List<Rule> expectedRule = (List<Rule>) expected;
       List<Rule> actualRule = JsonUtils.readObjects(actual.toString(), Rule.class);
       assertEquals(expectedRule, actualRule);
@@ -221,18 +222,12 @@ public class PolicyResourceTest extends EntityResourceTest<Policy, CreatePolicy>
     // Incomplete expressions
     failsToParse(policyName, "!");
 
-    // matchAnyTag() method does not input parameters
-    failsToEvaluate(policyName, "!matchAnyTag()");
-
     // isOwner() has Unexpected input parameter
     failsToEvaluate(policyName, "!isOwner('unexpectedParam')");
 
     // Invalid function name
     failsToEvaluate(policyName, "invalidFunction()");
     failsToEvaluate(policyName, "isOwner() || invalidFunction()");
-
-    // Function matchTags() has no input parameter
-    failsToEvaluate(policyName, "matchTags()");
 
     // Invalid text
     failsToEvaluate(policyName, "a");


### PR DESCRIPTION
… rule expression

### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
See #8701 

The name of the function is `matchAnyTag` without **s** at the end. Looks like in the example we have a typo. Fixed this issue in the new PR along with some improvements to the test. @harshach 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.
