### PR TITLE
On init the auth provider 'openmetadata' must generate a JWT token if not present on config

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/DefaultAuthorizer.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/DefaultAuthorizer.java
@@ -13,6 +13,7 @@
 
 package org.openmetadata.service.security;
 
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 import static org.openmetadata.schema.auth.SSOAuthMechanism.SsoServiceType.AUTH_0;
 import static org.openmetadata.schema.auth.SSOAuthMechanism.SsoServiceType.AZURE;
 import static org.openmetadata.schema.auth.SSOAuthMechanism.SsoServiceType.CUSTOM_OIDC;
@@ -31,6 +32,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import javax.ws.rs.core.SecurityContext;
@@ -329,7 +331,7 @@ public class DefaultAuthorizer implements Authorizer {
   }
 
   private static JWTAuthMechanism buildJWTAuthMechanism(OpenMetadataJWTClientConfig jwtClientConfig, User user) {
-    return jwtClientConfig == null || jwtClientConfig.getJwtToken() == null
+    return Objects.isNull(jwtClientConfig) || nullOrEmpty(jwtClientConfig.getJwtToken())
         ? JWTTokenGenerator.getInstance().generateJWTToken(user, JWTTokenExpiry.Unlimited)
         : new JWTAuthMechanism()
             .withJWTToken(jwtClientConfig.getJwtToken())


### PR DESCRIPTION
### Describe your changes :
Setting up for the first time auth mechanism for bots could fail in case that `openmetadata` is the auth provider but there is no configuration.

### Type of change :
- [x] Bug fix

### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

### Reviewers
Backend: @open-metadata/backend
