### PR TITLE
Remove count logic in custom sql test

### DIFF
--- a/ingestion/src/metadata/test_suite/validations/table/table_custom_sql_query.py
+++ b/ingestion/src/metadata/test_suite/validations/table/table_custom_sql_query.py
@@ -75,9 +75,6 @@ def table_custom_sql_query(
     if not rows:
         status = TestCaseStatus.Success
         result_value = 0
-    elif len(rows) == 1:
-        status = TestCaseStatus.Success if rows[0].count == 0 else TestCaseStatus.Failed
-        result_value = rows[0].count
     else:
         status = TestCaseStatus.Failed
         result_value = len(rows)

--- a/openmetadata-docs/content/connectors/ingestion/workflows/data-quality/tests.md
+++ b/openmetadata-docs/content/connectors/ingestion/workflows/data-quality/tests.md
@@ -225,9 +225,8 @@ parameterValues:
 ```
 
 ### Table Custom SQL Test
-Write you own SQL test. The test will pass if either of the following condition is met:
+Write you own SQL test. The test will pass if the following condition is met:
 - The query result return 0 row
-- The query expression `COUNT(<col>)` returns 0
 
 **Properties**
 
@@ -236,15 +235,16 @@ Write you own SQL test. The test will pass if either of the following condition 
 **Example**
 ```sql
 SELECT 
-COUNT(customer_tier)
+customer_id
 FROM DUAL 
-WHERE customer_tier = 'GOLD' and lifetime_value < 10000;
+WHERE lifetime_value < 0;
 ```
 
 ```sql
 SELECT 
 customer_id
-FROM DUAL 
+FROM DUAL d
+INNER JOIN OTHER o ON d.id = o.id
 WHERE lifetime_value < 0;
 ```
 
@@ -256,7 +256,7 @@ parameterValues:
     - name: sqlExpression
       value: >
         SELECT 
-        COUNT(customer_tier)
+        customer_tier
         FROM DUAL 
         WHERE customer_tier = 'GOLD' and lifetime_value < 10000;
 ```
@@ -269,7 +269,7 @@ parameterValues:
     "parameterValues": [
         {
             "name": "sqlExpression",
-            "value": "SELECT  COUNT(customer_tier) FROM DUAL  WHERE customer_tier = 'GOLD' and lifetime_value < 10000;\n"
+            "value": "SELECT  customer_tier FROM DUAL  WHERE customer_tier = 'GOLD' and lifetime_value < 10000;"
         }
     ]
 }


### PR DESCRIPTION
### Describe your changes :
The initial implementation of the custom SQL  test was written to support both:
1. no rows return by a query
2. COUNT(*) AS count returning 0

number 2)  is actually proving complex to test as count will depend on whether the `count` alias is set in the query. This particular COUNT(*) test seem to also create confusion from users (from support channel).

To simplify the test we decided to remove 2) and only check if a query retruns rows.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
