### PR TITLE
Fix: minor fix on text sent into slack when E2E fails

### DIFF
--- a/.github/workflows/py-cli-e2e-tests.yml
+++ b/.github/workflows/py-cli-e2e-tests.yml
@@ -76,7 +76,7 @@ jobs:
       with:
         payload: |
           {
-            "text": "🔥 Failed E2E Test for $E2E_TEST 🔥"
+            "text": "🔥 Failed E2E Test for: ${{ matrix.e2e-test }} 🔥"
           }
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.E2E_SLACK_WEBHOOK }}


### PR DESCRIPTION
### Describe your changes :
Minor fix on text sent into slack when E2E fails which was not taking into account the variable `$E2E_TEST`.

### Type of change :
- [x] Improvemention

### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

### Reviewers
Ingestion: @open-metadata/ingestion
