### PR TITLE
Fixes #8408 - added logic for modulo function for pyodbc driver

### DIFF
--- a/ingestion/src/metadata/orm_profiler/orm/functions/median.py
+++ b/ingestion/src/metadata/orm_profiler/orm/functions/median.py
@@ -58,7 +58,7 @@ def _(elements, compiler, **kwargs):
 @compiles(MedianFn, Dialects.MSSQL)
 def _(elements, compiler, **kwargs):
     """Median computation for MSSQL"""
-    col, _ = [compiler.process(element, **kwargs) for element in elements.clauses]
+    col = elements.clauses.clauses[0].name
     return "percentile_cont(0.5)  WITHIN GROUP (ORDER BY %s ASC) OVER()" % col
 
 

--- a/ingestion/src/metadata/orm_profiler/orm/functions/modulo.py
+++ b/ingestion/src/metadata/orm_profiler/orm/functions/modulo.py
@@ -74,3 +74,13 @@ def _(element, compiler, **kw):
     """SQLite modulo function"""
     value, base = validate_and_compile(element, compiler, **kw)
     return f"{value} % {base}"
+
+
+@compiles(ModuloFn, Dialects.MSSQL)
+def _(element, compiler, **kw):
+    """Azure SQL modulo function"""
+    value, base = validate_and_compile(element, compiler, **kw)
+    if compiler.dialect.driver == "pyodbc":
+        # pyodbc compiles to c++ code.
+        return f"{value} % {base}"
+    return f"{value} %% {base}"


### PR DESCRIPTION
### Describe your changes :
Fixes #8408  pyodbc compiles to c++. When passing `%%` to escape the `%` as per python logic this threw an error when the driver is pyodbc.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
