### PR TITLE
Fix: Downgrade version of wait-on-check-action to 1.0.0

### DIFF
--- a/.github/workflows/airflow-apis-tests-3_9.yml
+++ b/.github/workflows/airflow-apis-tests-3_9.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
 
     - name: Wait for the labeler
-      uses: lewagon/wait-on-check-action@v1.2.0
+      uses: lewagon/wait-on-check-action@0179dfc359f90a703c41240506f998ee1603f9ea  #v1.0.0
       if: ${{ github.event_name == 'pull_request_target' }}
       with:
         ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/cypress-integration-tests-mysql.yml
+++ b/.github/workflows/cypress-integration-tests-mysql.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
 
       - name: Wait for the labeler
-        uses: lewagon/wait-on-check-action@v1.2.0
+        uses: lewagon/wait-on-check-action@0179dfc359f90a703c41240506f998ee1603f9ea  #v1.0.0
         if: ${{ github.event_name == 'pull_request_target' }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/cypress-integration-tests-postgresql.yml
+++ b/.github/workflows/cypress-integration-tests-postgresql.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
 
       - name: Wait for the labeler
-        uses: lewagon/wait-on-check-action@v1.2.0
+        uses: lewagon/wait-on-check-action@0179dfc359f90a703c41240506f998ee1603f9ea  #v1.0.0
         if: ${{ github.event_name == 'pull_request_target' }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/java-checkstyle.yml
+++ b/.github/workflows/java-checkstyle.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
 
       - name: Wait for the labeler
-        uses: lewagon/wait-on-check-action@v1.2.0
+        uses: lewagon/wait-on-check-action@0179dfc359f90a703c41240506f998ee1603f9ea  #v1.0.0
         if: ${{ github.event_name == 'pull_request_target' }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
 
       - name: Wait for the labeler
-        uses: lewagon/wait-on-check-action@v1.2.0
+        uses: lewagon/wait-on-check-action@0179dfc359f90a703c41240506f998ee1603f9ea  #v1.0.0
         if: ${{ github.event_name == 'pull_request_target' }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/py-checkstyle.yml
+++ b/.github/workflows/py-checkstyle.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
 
       - name: Wait for the labeler
-        uses: lewagon/wait-on-check-action@v1.2.0
+        uses: lewagon/wait-on-check-action@0179dfc359f90a703c41240506f998ee1603f9ea  #v1.0.0
         if: ${{ github.event_name == 'pull_request_target' }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
 
     - name: Wait for the labeler
-      uses: lewagon/wait-on-check-action@v1.2.0
+      uses: lewagon/wait-on-check-action@0179dfc359f90a703c41240506f998ee1603f9ea  #v1.0.0
       if: ${{ github.event_name == 'pull_request_target' }}
       with:
         ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/yarn-coverage.yml
+++ b/.github/workflows/yarn-coverage.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
 
     - name: Wait for the labeler
-      uses: lewagon/wait-on-check-action@v1.2.0
+      uses: lewagon/wait-on-check-action@0179dfc359f90a703c41240506f998ee1603f9ea  #v1.0.0
       if: ${{ github.event_name == 'pull_request_target' }}
       with:
         ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
### Describe your changes :
Downgrade version of wait-on-check-action to 1.0.0 which current version is failing on clean up with the following error:

![image](https://user-images.githubusercontent.com/11074908/202767502-ea5b8357-49a4-4d5b-8d86-381b47d77bef.png)

Version [1.0.0](https://github.com/lewagon/wait-on-check-action/commit/0179dfc359f90a703c41240506f998ee1603f9ea) does not include this part of the code that seems to be the cause of the error:

```yaml
    - name: Cache Ruby Gems
      uses: actions/cache@v2
      with:
        path: ${{ github.action_path }}
        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
        restore-keys: ${{ runner.os }}-gems-
```

### Type of change :
- [x] Bug fix

### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

### Reviewers
ngestion: @open-metadata/ingestion
