### PR TITLE
Fix #8924  KPI completness width should be `currentValue/targetValue`

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/KPILatestResults.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/KPILatestResults.tsx
@@ -38,13 +38,7 @@ const KPILatestResults: FC<Props> = ({ kpiLatestResultsRecord }) => {
 
         const suffix = isPercentage ? '%' : '';
 
-        // value for percentage metric
-        const calculatedPercentage =
-          toNumber(targetPercentValue) +
-          (100 - toNumber(targetMetPercentValue));
-
-        // value for number metric
-        const calculatedNumberValue = (targetValue / targetMetValue) * 100;
+        const currentProgress = (targetValue / targetMetValue) * 100;
 
         const daysLeft = getNumberOfDaysForTimestamp(resultData.endDate);
 
@@ -63,12 +57,7 @@ const KPILatestResults: FC<Props> = ({ kpiLatestResultsRecord }) => {
                 isPercentage ? targetMetPercentValue : targetMetValue
               }${suffix}`}</Typography.Text>
             </Space>
-            <Progress
-              percent={
-                isPercentage ? calculatedPercentage : calculatedNumberValue
-              }
-              showInfo={isTargetMet}
-            />
+            <Progress percent={currentProgress} showInfo={isTargetMet} />
             <Typography.Text className="data-insight-label-text">
               {getKpiResultFeedback(daysLeft, Boolean(isTargetMet))}
             </Typography.Text>


### PR DESCRIPTION
Fixes #8924 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on issue #8924 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :
<img width="1428" alt="image" src="https://user-images.githubusercontent.com/59080942/203061692-a0b3fd44-0795-4df1-8c0f-424af7aa4f17.png">


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
