### PR TITLE
UI : fix the explore page history once return from entity details page

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/Explore.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/Explore.component.tsx
@@ -236,23 +236,50 @@ const Explore: React.FC<ExploreProps> = ({
     setEntityDetails(source);
   };
 
+  const handleAdvanceSearchFilter = (data: ExploreQuickFilterField[]) => {
+    const term = {} as Record<string, unknown>;
+
+    data.forEach((filter) => {
+      if (filter.key) {
+        term[filter.key] = filter.value;
+      }
+    });
+
+    onChangeAdvancedSearchQueryFilter(
+      isEmpty(term)
+        ? undefined
+        : {
+            query: { bool: { must: [{ term }] } },
+          }
+    );
+  };
+
   const handleAdvanceFieldClear = () => {
     setSelectedQuickFilters([]);
   };
 
   const handleAdvanceFieldRemove = (value: string) => {
-    setSelectedQuickFilters((prev) => prev.filter((p) => p.key !== value));
+    setSelectedQuickFilters((prev) => {
+      const data = prev.filter((p) => p.key !== value);
+      handleAdvanceSearchFilter(data);
+
+      return data;
+    });
   };
 
   const handleAdvanceFieldValueSelect = (field: ExploreQuickFilterField) => {
     setSelectedQuickFilters((pre) => {
-      return pre.map((preField) => {
+      const data = pre.map((preField) => {
         if (preField.key === field.key) {
           return field;
         } else {
           return preField;
         }
       });
+
+      handleAdvanceSearchFilter(data);
+
+      return data;
     });
   };
 
@@ -278,23 +305,6 @@ const Explore: React.FC<ExploreProps> = ({
       document.removeEventListener('keydown', escapeKeyHandler);
     };
   }, []);
-
-  useEffect(() => {
-    const term = {} as Record<string, unknown>;
-    selectedQuickFilters.map((filter) => {
-      if (filter.key) {
-        term[filter.key] = filter.value;
-      }
-    });
-
-    onChangeAdvancedSearchQueryFilter(
-      isEmpty(term)
-        ? undefined
-        : {
-            query: { bool: { must: [{ term }] } },
-          }
-    );
-  }, [selectedQuickFilters]);
 
   return (
     <PageLayoutV1

--- a/openmetadata-ui/src/main/resources/ui/src/pages/explore/ExplorePage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/explore/ExplorePage.component.tsx
@@ -96,6 +96,7 @@ const ExplorePage: FunctionComponent = () => {
       pathname: `/explore/${tabsInfo[nSearchIndex].path}/${searchQueryParam}`,
       search: Qs.stringify({ page: 1 }),
     });
+    setAdvancedSearchQueryFilter(undefined);
   };
 
   const handleQueryFilterChange: ExploreProps['onChangeAdvancedSearchJsonTree'] =


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
- fix the explore page history once return from entity details page

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :


https://user-images.githubusercontent.com/66266464/203494869-880c438c-1d29-4a98-8991-b4ba24f1926d.mov



#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
