### PR TITLE
UI : fix the search bar issue having quote in the search text

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/axiosAPIs/searchAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/axiosAPIs/searchAPI.ts
@@ -13,7 +13,6 @@
 
 import { AxiosResponse } from 'axios';
 import { isArray, isNil } from 'lodash';
-import { getQueryWithSlash } from '../constants/constants';
 import { SearchIndex } from '../enums/search.enum';
 import {
   Aggregations,
@@ -26,6 +25,7 @@ import {
   SuggestResponse,
 } from '../interface/search.interface';
 import { omitDeep } from '../utils/APIUtils';
+import { getQueryWithSlash } from '../utils/SearchUtils';
 import APIClient from './index';
 
 const getSearchIndexParam: (

--- a/openmetadata-ui/src/main/resources/ui/src/axiosAPIs/searchAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/axiosAPIs/searchAPI.ts
@@ -13,6 +13,7 @@
 
 import { AxiosResponse } from 'axios';
 import { isArray, isNil } from 'lodash';
+import { getQueryWithSlash } from '../constants/constants';
 import { SearchIndex } from '../enums/search.enum';
 import {
   Aggregations,
@@ -167,7 +168,7 @@ export const rawSearchQuery = <
     >
   >('/search/query', {
     params: {
-      q: query,
+      q: getQueryWithSlash(query || ''),
       index: getSearchIndexParam(searchIndex),
       from: (pageNumber - 1) * pageSize,
       size: pageSize,

--- a/openmetadata-ui/src/main/resources/ui/src/components/app-bar/Appbar.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/app-bar/Appbar.tsx
@@ -282,7 +282,7 @@ const Appbar: React.FC = (): JSX.Element => {
     addToRecentSearched(value);
     history.push({
       pathname: getExplorePathWithSearch(
-        value,
+        encodeURIComponent(value),
         // this is for if user is searching from another page
         location.pathname.startsWith(ROUTES.EXPLORE)
           ? appState.explorePageTab
@@ -317,7 +317,7 @@ const Appbar: React.FC = (): JSX.Element => {
   };
 
   useEffect(() => {
-    setSearchValue(searchQuery);
+    setSearchValue(decodeURIComponent(searchQuery || ''));
   }, [searchQuery]);
 
   useEffect(() => {

--- a/openmetadata-ui/src/main/resources/ui/src/constants/constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/constants.ts
@@ -525,7 +525,3 @@ export const ENTITY_PATH = {
   pipelines: 'pipeline',
   mlmodels: 'mlmodel',
 };
-
-// will add back slash "\" before quote in string if present
-export const getQueryWithSlash = (query: string): string =>
-  query.replace(/["']/g, '\\$&');

--- a/openmetadata-ui/src/main/resources/ui/src/constants/constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/constants.ts
@@ -525,3 +525,7 @@ export const ENTITY_PATH = {
   pipelines: 'pipeline',
   mlmodels: 'mlmodel',
 };
+
+// will add back slash "\" before quote in string if present
+export const getQueryWithSlash = (query: string): string =>
+  query.replace(/["']/g, '\\$&');

--- a/openmetadata-ui/src/main/resources/ui/src/utils/SearchUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/SearchUtils.ts
@@ -39,3 +39,7 @@ export const getSearchAPIQuery = (
     searchIndex ? `&index=${searchIndex}` : ''
   }${trackTotalHits ? '&track_total_hits=true' : ''}`;
 };
+
+// will add back slash "\" before quote in string if present
+export const getQueryWithSlash = (query: string): string =>
+  query.replace(/["']/g, '\\$&');


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
- Closes #6811
- fix the search bar issue of having quotes in the search text
- fix the search text having `/` in it

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
Before : 
<img width="1099" alt="image" src="https://user-images.githubusercontent.com/66266464/203957398-8c7fe3c1-d32f-4890-a642-2049755fbdbe.png">

After :
<img width="1099" alt="image" src="https://user-images.githubusercontent.com/66266464/203957333-9444e0d5-049d-48be-91db-8b8fcce0a7aa.png">


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
