### PR TITLE
Fix #8579: Add unit test to cover the cases where columnProfile is null or not being sent by client

### DIFF
--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/databases/TableResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/databases/TableResourceTest.java
@@ -1253,11 +1253,19 @@ public class TableResourceTest extends EntityResourceTest<Table, CreateTable> {
     table1 = getEntity(table1.getId(), "*", authHeaders);
     verifyTableProfile(table1.getProfile(), table1ProfileList.get(table1ProfileList.size() - 1));
 
-    // Table profile without column profile
+    // Table profile with column profile as null
     timestamp = TestUtils.dateToTimestamp("2022-09-09");
     tableProfile =
         new TableProfile().withRowCount(6.0).withColumnCount(3.0).withTimestamp(timestamp).withProfileSample(10.0);
     createTableProfile = new CreateTableProfile().withTableProfile(tableProfile).withColumnProfile(null);
+    putResponse = putTableProfileData(table.getId(), createTableProfile, authHeaders);
+    verifyTableProfile(putResponse.getProfile(), createTableProfile.getTableProfile());
+
+    // Table profile without column profile
+    timestamp = TestUtils.dateToTimestamp("2022-10-09");
+    tableProfile =
+        new TableProfile().withRowCount(6.0).withColumnCount(3.0).withTimestamp(timestamp).withProfileSample(10.0);
+    createTableProfile = new CreateTableProfile().withTableProfile(tableProfile);
     putResponse = putTableProfileData(table.getId(), createTableProfile, authHeaders);
     verifyTableProfile(putResponse.getProfile(), createTableProfile.getTableProfile());
   }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/databases/TableResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/databases/TableResourceTest.java
@@ -1252,6 +1252,14 @@ public class TableResourceTest extends EntityResourceTest<Table, CreateTable> {
 
     table1 = getEntity(table1.getId(), "*", authHeaders);
     verifyTableProfile(table1.getProfile(), table1ProfileList.get(table1ProfileList.size() - 1));
+
+    // Table profile without column profile
+    timestamp = TestUtils.dateToTimestamp("2022-09-09");
+    tableProfile =
+        new TableProfile().withRowCount(6.0).withColumnCount(3.0).withTimestamp(timestamp).withProfileSample(10.0);
+    createTableProfile = new CreateTableProfile().withTableProfile(tableProfile).withColumnProfile(null);
+    putResponse = putTableProfileData(table.getId(), createTableProfile, authHeaders);
+    verifyTableProfile(putResponse.getProfile(), createTableProfile.getTableProfile());
   }
 
   @Test


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the ..... because ...

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
