### PR TITLE
Fix #8083: Adding a child term to a parent term in glossary produces error

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
@@ -102,6 +102,10 @@ public class GlossaryTermRepository extends EntityRepository<GlossaryTerm> {
 
   @Override
   public void prepare(GlossaryTerm entity) throws IOException {
+    // Validate parent term
+    EntityReference parentTerm = Entity.getEntityReference(entity.getParent());
+    entity.setParent(parentTerm);
+
     validateHierarchy(entity);
 
     // Validate glossary
@@ -110,10 +114,6 @@ public class GlossaryTermRepository extends EntityRepository<GlossaryTerm> {
 
     // If reviewers is not set in the glossary term, then carry it from the glossary
     entity.setReviewers(entity.getReviewers() == null ? glossary.getReviewers() : entity.getReviewers());
-
-    // Validate parent term
-    EntityReference parentTerm = Entity.getEntityReference(entity.getParent());
-    entity.setParent(parentTerm);
 
     // Validate related terms
     EntityUtil.populateEntityReferences(entity.getRelatedTerms());

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/glossary/GlossaryTermResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/glossary/GlossaryTermResourceTest.java
@@ -32,7 +32,6 @@ import static org.openmetadata.service.resources.databases.TableResourceTest.get
 import static org.openmetadata.service.util.EntityUtil.fieldAdded;
 import static org.openmetadata.service.util.EntityUtil.fieldDeleted;
 import static org.openmetadata.service.util.EntityUtil.fieldUpdated;
-import static org.openmetadata.service.util.EntityUtil.getEntityReference;
 import static org.openmetadata.service.util.EntityUtil.getId;
 import static org.openmetadata.service.util.EntityUtil.toTagLabels;
 import static org.openmetadata.service.util.TestUtils.ADMIN_AUTH_HEADERS;
@@ -366,7 +365,7 @@ public class GlossaryTermResourceTest extends EntityResourceTest<GlossaryTerm, C
   public GlossaryTerm createTerm(
       Glossary glossary, GlossaryTerm parent, String termName, List<EntityReference> reviewers) throws IOException {
     EntityReference glossaryRef = glossary.getEntityReference();
-    //sending required fields only for entity reference
+    // sending required fields only for entity reference
     EntityReference parentRef = null;
     if (parent != null) {
       parentRef = new EntityReference().withId(parent.getId()).withType(GLOSSARY_TERM);

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/glossary/GlossaryTermResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/glossary/GlossaryTermResourceTest.java
@@ -366,7 +366,11 @@ public class GlossaryTermResourceTest extends EntityResourceTest<GlossaryTerm, C
   public GlossaryTerm createTerm(
       Glossary glossary, GlossaryTerm parent, String termName, List<EntityReference> reviewers) throws IOException {
     EntityReference glossaryRef = glossary.getEntityReference();
-    EntityReference parentRef = getEntityReference(parent);
+    //sending required fields only for entity reference
+    EntityReference parentRef = null;
+    if (parent != null) {
+      parentRef = new EntityReference().withId(parent.getId()).withType(GLOSSARY_TERM);
+    }
     CreateGlossaryTerm createGlossaryTerm =
         createRequest(termName, "", "", null).withGlossary(glossaryRef).withParent(parentRef).withReviewers(reviewers);
     return createAndCheckEntity(createGlossaryTerm, ADMIN_AUTH_HEADERS);


### PR DESCRIPTION

### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the ..... because ...

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
