### PR TITLE
Fix 9093 : Search Card Link to smoothly route instead of loading the whole page

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/table-data-card-v2/TableDataCardTitle.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/table-data-card-v2/TableDataCardTitle.component.tsx
@@ -39,6 +39,12 @@ const TableDataCardTitle = ({
   handleLinkClick,
 }: TableDataCardTitleProps) => {
   const title = (
+    <Typography.Title level={5}>{stringToHTML(source.name)}</Typography.Title>
+  );
+
+  const isTourRoute = location.pathname.includes(ROUTES.TOUR);
+
+  return isTourRoute ? (
     <Button
       className="tw-text-grey-body tw-font-semibold"
       data-testid={`${getPartialNameFromTableFQN(
@@ -48,15 +54,9 @@ const TableDataCardTitle = ({
       id={`${id}Title`}
       type="link"
       onClick={handleLinkClick}>
-      <Typography.Title level={5}>{stringToHTML(source.name)}</Typography.Title>
+      {title}
     </Button>
-  );
-
-  if (location.pathname.includes(ROUTES.TOUR)) {
-    return title;
-  }
-
-  return (
+  ) : (
     <Link
       className="table-data-card-title-container"
       to={getEntityLink(searchIndex, source.fullyQualifiedName ?? '')}>

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/table-data-card-v2/TableDataCardTitle.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/table-data-card-v2/TableDataCardTitle.component.tsx
@@ -38,13 +38,9 @@ const TableDataCardTitle = ({
   source,
   handleLinkClick,
 }: TableDataCardTitleProps) => {
-  const title = (
-    <Typography.Title level={5}>{stringToHTML(source.name)}</Typography.Title>
-  );
-
   const isTourRoute = location.pathname.includes(ROUTES.TOUR);
 
-  return isTourRoute ? (
+  const title = (
     <Button
       className="tw-text-grey-body tw-font-semibold"
       data-testid={`${getPartialNameFromTableFQN(
@@ -53,10 +49,16 @@ const TableDataCardTitle = ({
       )}-${getNameFromFQN(source.fullyQualifiedName ?? '')}`}
       id={`${id}Title`}
       type="link"
-      onClick={handleLinkClick}>
-      {title}
+      onClick={isTourRoute ? handleLinkClick : undefined}>
+      <Typography.Title level={5}>{stringToHTML(source.name)}</Typography.Title>
     </Button>
-  ) : (
+  );
+
+  if (isTourRoute) {
+    return title;
+  }
+
+  return (
     <Link
       className="table-data-card-title-container"
       to={getEntityLink(searchIndex, source.fullyQualifiedName ?? '')}>


### PR DESCRIPTION
Fixes #9093 
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on issue #9093 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix



#
### Frontend Preview (Screenshots) :

https://user-images.githubusercontent.com/59080942/204971175-7d711864-18f2-43e6-af66-a1384650bec5.mov



#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
