### PR TITLE
fix(ui): wrong relative time being rendered

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedList/ActivityFeedList.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedList/ActivityFeedList.tsx
@@ -253,7 +253,7 @@ const ActivityFeedList: FC<ActivityFeedListProp> = ({
             return (
               <div data-testid={`feed${i}`} key={i}>
                 <FeedListSeparator
-                  className="tw-relative tw-mt-3 tw-mb-3.5"
+                  className="relative m-y-xs"
                   relativeDay={d}
                 />
                 <FeedListBody

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedList/ActivityFeedList.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedList/ActivityFeedList.tsx
@@ -37,6 +37,7 @@ import {
   threadFilterList,
 } from './ActivityFeedList.util';
 import FeedListBody from './FeedListBody';
+import FeedListSeparator from './FeedListSeparator';
 
 const ActivityFeedList: FC<ActivityFeedListProp> = ({
   className,
@@ -251,6 +252,10 @@ const ActivityFeedList: FC<ActivityFeedListProp> = ({
           {relativeDays.map((d, i) => {
             return (
               <div data-testid={`feed${i}`} key={i}>
+                <FeedListSeparator
+                  className="tw-relative tw-mt-3 tw-mb-3.5"
+                  relativeDay={d}
+                />
                 <FeedListBody
                   deletePostHandler={deletePostHandler}
                   isEntityFeed={isEntityFeed}

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TimeUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TimeUtils.test.ts
@@ -1,0 +1,38 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { getRelativeDateByTimeStamp } from './TimeUtils';
+
+describe('TimeUtils tests', () => {
+  it("getRelativeDateByTimeStamp should return Today for currentDay's date", () => {
+    expect(getRelativeDateByTimeStamp(Date.now())).toBe('Today');
+  });
+
+  it("getRelativeDateByTimeStamp should return Yesterday for yesterday's date", () => {
+    expect(
+      getRelativeDateByTimeStamp(
+        new Date('2020/01/01').valueOf(),
+        new Date('2020/01/02').valueOf()
+      )
+    ).toBe('Yesterday');
+  });
+
+  it('getRelativeDateByTimeStamp should return Last month for past months date', () => {
+    expect(
+      getRelativeDateByTimeStamp(
+        new Date('2020/01/01').valueOf(),
+        new Date('2020/02/01').valueOf()
+      )
+    ).toBe('Last month');
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TimeUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TimeUtils.ts
@@ -17,8 +17,15 @@ import { DateTime, Duration } from 'luxon';
 export const getTimeByTimeStamp = (timeStamp: number): string =>
   DateTime.fromMillis(timeStamp).toFormat('hh:mm a');
 
-export const getRelativeDateByTimeStamp = (timeStamp: number): string => {
-  return capitalize(DateTime.fromMillis(timeStamp).toRelativeCalendar() || '');
+export const getRelativeDateByTimeStamp = (
+  timeStamp: number,
+  baseTimeStamp?: number
+): string => {
+  return capitalize(
+    DateTime.fromMillis(timeStamp).toRelativeCalendar({
+      base: baseTimeStamp ? DateTime.fromMillis(baseTimeStamp) : DateTime.now(),
+    }) || ''
+  );
 };
 
 export const getDayTimeByTimeStamp = (timeStamp: number): string => {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TimeUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TimeUtils.ts
@@ -11,145 +11,18 @@
  *  limitations under the License.
  */
 
-import { isNil, toInteger, toNumber } from 'lodash';
+import { capitalize, isNil, toInteger, toNumber } from 'lodash';
 import { DateTime, Duration } from 'luxon';
-
-const msPerSecond = 1000;
-const msPerMinute = 60 * msPerSecond;
-const msPerHour = msPerMinute * 60;
-const msPerDay = msPerHour * 24;
-const msPerMonth = msPerDay * 30;
-const msPerYear = msPerDay * 365;
-
-const formattingObj = {
-  sameDay: "'Today'",
-  lastDay: "'Yesterday'",
-  lastWeek: "DDD 'at' hh:mm a",
-  sameElse: "DDD 'at' hh:mm a",
-};
-
-const activityFeedTimeFormat = {
-  sameDay: "'Today at' hh:mm a",
-  lastDay: "'Yesterday at' hh:mm a",
-  lastWeek: "'Last' EEEE 'at' hh:mm a",
-  sameElse: "DDD 'at' hh:mm a",
-};
-
-/**
- * If the difference between the two dates is less than -1, return 'lastWeek'. If the difference is
- * less than 0, return 'lastDay'. If the difference is less than 1, return 'sameDay'. Otherwise, return
- * 'sameElse'.
- * @param {DateTime} myDateTime - The date you want to format.
- * @param {DateTime} now - The current date and time.
- * @returns A string
- */
-const getCalendarFormat = (myDateTime: DateTime, now: DateTime): string => {
-  const diff = myDateTime.diff(now.startOf('day'), 'days').as('days');
-
-  if (diff < -7) return 'sameElse';
-  else if (diff < 0) return 'lastWeek';
-  else if (diff < 1) return 'lastDay';
-
-  return 'sameDay';
-};
-
-export const getRelativeTimeDifference = (
-  current: number,
-  previous: number
-): string => {
-  const elapsed = current - previous;
-
-  if (elapsed <= msPerSecond) {
-    return 'now';
-  } else if (elapsed < msPerMinute / 5) {
-    return 'a few seconds ago';
-  } else if (elapsed < msPerMinute) {
-    const relativeTime = Math.round(elapsed / msPerSecond);
-
-    return `${relativeTime} second${relativeTime > 1 ? 's' : ''} ago`;
-  } else if (elapsed < msPerHour) {
-    const relativeTime = Math.round(elapsed / msPerMinute);
-
-    return `${relativeTime} minute${relativeTime > 1 ? 's' : ''} ago`;
-  } else if (elapsed < msPerDay) {
-    const relativeTime = Math.round(elapsed / msPerHour);
-
-    return `${relativeTime} hour${relativeTime > 1 ? 's' : ''} ago`;
-  } else if (elapsed < msPerMonth) {
-    const relativeTime = Math.round(elapsed / msPerDay);
-
-    return `${relativeTime} day${relativeTime > 1 ? 's' : ''} ago`;
-  } else if (elapsed < msPerYear) {
-    const relativeTime = Math.round(elapsed / msPerMonth);
-
-    return `${relativeTime} month${relativeTime > 1 ? 's' : ''} ago`;
-  } else {
-    const relativeTime = Math.round(elapsed / msPerYear);
-
-    return `${relativeTime} year${relativeTime > 1 ? 's' : ''} ago`;
-  }
-};
-
-export const getRelativeDayDifference = (
-  current: number,
-  previous: number
-): string => {
-  const elapsed = current - previous;
-
-  if (elapsed < msPerDay / 6) {
-    return 'in last few hours';
-  } else if (elapsed < msPerDay) {
-    return 'today';
-  } else if (elapsed < msPerMonth) {
-    const relativeTime = Math.round(elapsed / msPerDay);
-
-    return `in last ${relativeTime} day${relativeTime > 1 ? 's' : ''}`;
-  } else if (elapsed < msPerYear) {
-    const relativeTime = Math.round(elapsed / msPerMonth);
-
-    return `${relativeTime} month${relativeTime > 1 ? 's' : ''} ago`;
-  } else {
-    const relativeTime = Math.round(elapsed / msPerYear);
-
-    return `${relativeTime} year${relativeTime > 1 ? 's' : ''} ago`;
-  }
-};
-
-export const getRelativeTime = (timestamp: number): string => {
-  return getRelativeTimeDifference(Date.now(), timestamp);
-};
-
-const getFormattedDateTime = (
-  dt1: DateTime,
-  dt2: DateTime,
-  formattingRulesObj: Record<string, string>
-) => {
-  const format = getCalendarFormat(dt1, dt2) || 'sameElse';
-
-  return dt1.toFormat(formattingRulesObj[format]);
-};
-
-export const getRelativeDay = (timestamp: number): string => {
-  return getRelativeDayDifference(Date.now(), timestamp);
-};
-
-export const getRelativeDateByTimeStamp = (timeStamp: number): string => {
-  return getFormattedDateTime(
-    DateTime.fromMillis(timeStamp),
-    DateTime.now(),
-    formattingObj
-  );
-};
 
 export const getTimeByTimeStamp = (timeStamp: number): string =>
   DateTime.fromMillis(timeStamp).toFormat('hh:mm a');
 
+export const getRelativeDateByTimeStamp = (timeStamp: number): string => {
+  return capitalize(DateTime.fromMillis(timeStamp).toRelativeCalendar() || '');
+};
+
 export const getDayTimeByTimeStamp = (timeStamp: number): string => {
-  return getFormattedDateTime(
-    DateTime.fromMillis(timeStamp),
-    DateTime.now(),
-    activityFeedTimeFormat
-  );
+  return DateTime.fromMillis(timeStamp).toRelative() || '';
 };
 
 export const getUTCDateTime = (dateTime: string) => {
@@ -197,8 +70,8 @@ export const getDateByTimeStamp = (
  * It takes a timestamp and returns a relative date time string
  * @param {number} timestamp - number - The timestamp to convert to a relative date time.
  */
-export const getRelativeDateTimeByTimeStamp = (timestamp: number) =>
-  DateTime.fromMillis(timestamp as number).toRelative();
+export const getRelativeDateTimeByTimeStamp = (timestamp: number): string =>
+  DateTime.fromMillis(timestamp as number).toRelative() || '';
 
 export const getLocaleDateFromTimeStamp = (timeStamp: number): string => {
   return DateTime.fromMillis(timeStamp).toISO({ includeOffset: false });


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the fixing relative time related issue on the feeds page
#9089 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
<img width="1800" alt="Screenshot 2022-12-01 at 2 48 36 PM" src="https://user-images.githubusercontent.com/12962843/205014183-361e5680-44f5-4a0b-a3af-c7e6d2c2091e.png">


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
