### PR TITLE
Add analyzer to search in Japanese

### DIFF
--- a/openmetadata-service/src/main/resources/elasticsearch/table_index_mapping.json
+++ b/openmetadata-service/src/main/resources/elasticsearch/table_index_mapping.json
@@ -17,6 +17,16 @@
             "lowercase",
             "om_stemmer"
           ]
+        },
+        "om_analyzer_ja" : {
+          "tokenizer" : "kuromoji_tokenizer",
+          "type" : "custom",
+          "filter" : [
+            "kuromoji_baseform",
+            "kuromoji_part_of_speech",
+            "kuromoji_number",
+            "kuromoji_stemmer"
+          ]
         }
       },
       "filter": {
@@ -51,9 +61,7 @@
       },
       "description": {
         "type": "text",
-        "index_options": "docs",
-        "analyzer": "om_analyzer",
-        "norms": false
+        "analyzer": "om_analyzer_ja"
       },
       "version": {
         "type": "float"
@@ -87,9 +95,7 @@
           },
           "description": {
             "type": "text",
-            "index_options": "docs",
-            "analyzer": "om_analyzer",
-            "norms": false
+            "analyzer": "om_analyzer_ja"
           },
           "fullyQualifiedName": {
             "type": "text"


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->

I changed OpenMetadata to be able to search in Japanese only for description fields of table and column.  
Added Japanese analyzer to table_search_index and changed it to map to description fields.

> __Warning__  
[kuromoji](https://www.elastic.co/guide/en/elasticsearch/plugins/current/analysis-kuromoji.html) must be installed on Elasticsearch to enable this setting.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :

![image001](https://user-images.githubusercontent.com/8586013/205284745-a6e9d1d8-c6dd-472e-8833-bb111fe20db1.png)

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->

@harshach 
