### PR TITLE
Fix(UI)#9017: Fixed description not rendering on explore page in Safari browser

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/rich-text-editor/RichTextEditorPreviewer.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/rich-text-editor/RichTextEditorPreviewer.less
@@ -71,7 +71,7 @@
     padding: 0px;
     margin: 0px;
     line-height: 0px;
-    height: auto;
+    height: 16px;
   }
 
   .ant-btn:focus,

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/rich-text-editor/RichTextEditorPreviewer.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/rich-text-editor/RichTextEditorPreviewer.tsx
@@ -53,7 +53,7 @@ const RichTextEditorPreviewer = ({
         <Viewer
           extendedAutolinks
           initialValue={
-            hideReadMoreText || !enableSeeMoreVariant
+            hideReadMoreText
               ? content
               : `${getTrimmedContent(content, maxLength)}...`
           }

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/table-data-card/TableDataCardBody.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/table-data-card/TableDataCardBody.tsx
@@ -56,6 +56,7 @@ const TableDataCardBody: FunctionComponent<Props> = ({
           <RichTextEditorPreviewer
             enableSeeMoreVariant={false}
             markdown={description}
+            maxLength={500}
           />
         ) : (
           <span className="tw-no-description">No description</span>

--- a/openmetadata-ui/src/main/resources/ui/src/styles/app.less
+++ b/openmetadata-ui/src/main/resources/ui/src/styles/app.less
@@ -273,3 +273,10 @@
   flex-direction: column;
   padding: 24px 16px 0px 16px;
 }
+
+.description-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  line-height: 18px;
+}

--- a/openmetadata-ui/src/main/resources/ui/src/styles/temp.css
+++ b/openmetadata-ui/src/main/resources/ui/src/styles/temp.css
@@ -672,15 +672,7 @@
   color: red;
   padding-left: 0.2rem;
 }
-.description-text {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  line-height: 18px;
-  max-height: 64px;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-}
+
 .asset-card-text {
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on #9017 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<p align="center">

Before: 

<img width="1440" alt="Screenshot 2022-12-05 at 4 16 11 PM" src="https://user-images.githubusercontent.com/51777795/205618692-d07a99d8-48da-40f6-bfea-9b41bce72f26.png">

After:

<img width="1440" alt="Screenshot 2022-12-05 at 4 18 24 PM" src="https://user-images.githubusercontent.com/51777795/205619060-dce3e451-d70c-4615-89ad-300563b04c10.png">

</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @open-metadata/ui 
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
