### PR TITLE
Fix : Logs screen for data insight pipeline is hanging

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/LogsViewer/LogsViewer.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/LogsViewer/LogsViewer.component.test.tsx
@@ -29,13 +29,15 @@ jest.mock(
 );
 
 jest.mock('react-lazylog', () => ({
-  LazyLog: jest.fn().mockImplementation(() => <div>LazyLog</div>),
+  LazyLog: jest
+    .fn()
+    .mockImplementation(() => <div data-testid="logs">LazyLog</div>),
 }));
 
 jest.mock('../../axiosAPIs/ingestionPipelineAPI', () => ({
   getIngestionPipelineLogById: jest
     .fn()
-    .mockImplementation(() => Promise.resolve(mockLogsData)),
+    .mockImplementation(() => Promise.resolve({ data: mockLogsData })),
   getIngestionPipelineByName: jest
     .fn()
     .mockImplementation(() => Promise.resolve(mockIngestionPipeline)),
@@ -63,5 +65,9 @@ describe('LogsViewer.component', () => {
     expect(
       await screen.findByText('test-redshift_metadata_ZeCajs9g')
     ).toBeInTheDocument();
+
+    const logElement = await screen.findByTestId('logs');
+
+    expect(logElement).toBeInTheDocument();
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/pages/LogsViewer/LogsViewer.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/LogsViewer/LogsViewer.component.tsx
@@ -89,6 +89,10 @@ const LogsViewer = () => {
           setLogs(logs.concat(res.data?.test_suite_task || ''));
 
           break;
+        case PipelineType.DataInsight:
+          setLogs(logs.concat(res.data?.data_insight_task || ''));
+
+          break;
 
         default:
           setLogs('');

--- a/openmetadata-ui/src/main/resources/ui/src/pages/LogsViewer/LogsViewer.interfaces.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/LogsViewer/LogsViewer.interfaces.ts
@@ -16,6 +16,7 @@ export interface IngestionPipelineLogByIdInterface {
   usage_task?: string;
   lineage_task?: string;
   test_suite_task?: string;
+  data_insight_task?: string;
   total?: string;
   after?: string;
 }


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on fixing the issue mentioned here https://github.com/open-metadata/OpenMetadata/issues/8996#issuecomment-1334138065

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :
![image](https://user-images.githubusercontent.com/59080942/205842360-1b4e16a4-5db0-456a-b6e6-95e1e5ca7d82.png)


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
