### PR TITLE
Fix(UI)#7173: Fixed issue where soft deleted tables were showing on schema details page

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaPage/DatabaseSchemaPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaPage/DatabaseSchemaPage.component.tsx
@@ -15,7 +15,7 @@ import { Col, Row, Space, Table as TableAntd } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
 import { AxiosError } from 'axios';
 import { compare, Operation } from 'fast-json-patch';
-import { startCase } from 'lodash';
+import { isEmpty, startCase, toNumber } from 'lodash';
 import { observer } from 'mobx-react';
 import { EntityFieldThreadCount, ExtraInfo } from 'Models';
 import React, {
@@ -325,11 +325,11 @@ const DatabaseSchemaPage: FunctionComponent = () => {
 
   const getSchemaTables = async (pageNumber: string | number) => {
     try {
-      setCurrentTablesPage(pageNumber as number);
+      setCurrentTablesPage(toNumber(pageNumber));
       const res = await searchQuery({
-        pageNumber: pageNumber as number,
+        pageNumber: toNumber(pageNumber),
         pageSize: PAGE_SIZE,
-        queryFilter: { 'databaseSchema.name': databaseSchema?.name },
+        queryFilter: { 'databaseSchema.name': databaseSchema?.name ?? '' },
         searchIndex: SearchIndex.TABLE,
         includeDeleted: false,
       });
@@ -643,10 +643,15 @@ const DatabaseSchemaPage: FunctionComponent = () => {
         activeTabHandler(1);
       }
       getDetailsByFQN();
-      getSchemaTables(INITIAL_PAGING_VALUE);
       getEntityFeedCount();
     }
   }, [databaseSchemaPermission, databaseSchemaFQN]);
+
+  useEffect(() => {
+    if (!isEmpty(databaseSchema)) {
+      getSchemaTables(INITIAL_PAGING_VALUE);
+    }
+  }, [databaseSchema]);
 
   useEffect(() => {
     fetchDatabaseSchemaPermission();

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DatabaseSchemaDetailsUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DatabaseSchemaDetailsUtils.ts
@@ -1,4 +1,9 @@
 import { TabSpecificField } from '../enums/entity.enum';
+import { SearchIndex } from '../enums/search.enum';
+import {
+  SearchResponse,
+  TableSearchSource,
+} from '../interface/search.interface';
 
 export const databaseSchemaDetailsTabs = [
   {
@@ -29,3 +34,7 @@ export const getCurrentDatabaseSchemaDetailsTab = (tab: string) => {
 
   return currentTab;
 };
+
+export const getTablesFromSearchResponse = (
+  res: SearchResponse<SearchIndex.TABLE, keyof TableSearchSource>
+) => res.hits.hits.map((hit) => hit._source);


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on fixing the issue with soft deleted tables showing on the schema details page.
I also added pagination support for the tables list.
closes #7173 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement

#
### Frontend Preview (Screenshots) :
<p align="center">

https://user-images.githubusercontent.com/51777795/205881365-6c43b862-80a2-494e-a978-d220851faf98.mov


</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @open-metadata/ui 
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
