### PR TITLE
Fixes #9167 - Default value for SLACK_CHAT_SLACK_URL

### DIFF
--- a/conf/openmetadata.yaml
+++ b/conf/openmetadata.yaml
@@ -260,7 +260,7 @@ email:
 
 sandboxModeEnabled: ${SANDBOX_MODE_ENABLED:-false}
 slackChat:
-  slackUrl: ${SLACK_CHAT_SLACK_URL:-"https://openmetadata.slack.com/"}
+  slackUrl: ${SLACK_CHAT_SLACK_URL:-"https://slack.open-metadata.org/"}
 
 login:
   maxLoginFailAttempts: ${OM_MAX_FAILED_LOGIN_ATTEMPTS:-3}

--- a/conf/openmetadata.yaml
+++ b/conf/openmetadata.yaml
@@ -260,7 +260,7 @@ email:
 
 sandboxModeEnabled: ${SANDBOX_MODE_ENABLED:-false}
 slackChat:
-  slackUrl: ${SLACK_CHAT_SLACK_URL:-""}
+  slackUrl: ${SLACK_CHAT_SLACK_URL:-"https://openmetadata.slack.com/"}
 
 login:
   maxLoginFailAttempts: ${OM_MAX_FAILED_LOGIN_ATTEMPTS:-3}


### PR DESCRIPTION
### Describe your changes :
Fix for #9167 Added a default value for SLACK_CHAT_SLACK_URL which is : [https://slack.open-metadata.org/](https://slack.open-metadata.org/)

Files changed : 
- [conf/openmetadata.yaml](https://github.com/open-metadata/OpenMetadata/blob/main/conf/openmetadata.yaml)
#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
