### PR TITLE
UI : Remove Y-axis for percentage charts on data insight page

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/DescriptionInsight.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/DescriptionInsight.tsx
@@ -25,7 +25,6 @@ import {
   ResponsiveContainer,
   Tooltip,
   XAxis,
-  YAxis,
 } from 'recharts';
 import { getAggregateChartData } from '../../axiosAPIs/DataInsightAPI';
 import {
@@ -114,8 +113,6 @@ const DescriptionInsight: FC<Props> = ({ chartFilter }) => {
           <BarChart data={data} margin={BAR_CHART_MARGIN}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="timestamp" />
-
-            <YAxis />
             <Tooltip content={<CustomTooltip isPercentage />} />
             <Legend
               align="left"

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/KPIChart.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/KPIChart.tsx
@@ -32,6 +32,7 @@ import {
   ResponsiveContainer,
   Tooltip,
   XAxis,
+  YAxis,
 } from 'recharts';
 import {
   getLatestKpiResult,
@@ -215,6 +216,7 @@ const KPIChart: FC<Props> = ({ chartFilter }) => {
                   <LineChart data={graphData} margin={BAR_CHART_MARGIN}>
                     <CartesianGrid strokeDasharray="3 3" />
                     <XAxis dataKey="timestamp" />
+                    <YAxis />
                     <Tooltip
                       content={
                         <CustomTooltip kpiTooltipRecord={kpiTooltipRecord} />

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/KPIChart.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/KPIChart.tsx
@@ -32,7 +32,6 @@ import {
   ResponsiveContainer,
   Tooltip,
   XAxis,
-  YAxis,
 } from 'recharts';
 import {
   getLatestKpiResult,
@@ -216,7 +215,6 @@ const KPIChart: FC<Props> = ({ chartFilter }) => {
                   <LineChart data={graphData} margin={BAR_CHART_MARGIN}>
                     <CartesianGrid strokeDasharray="3 3" />
                     <XAxis dataKey="timestamp" />
-                    <YAxis />
                     <Tooltip
                       content={
                         <CustomTooltip kpiTooltipRecord={kpiTooltipRecord} />

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/OwnerInsight.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/OwnerInsight.tsx
@@ -25,7 +25,6 @@ import {
   ResponsiveContainer,
   Tooltip,
   XAxis,
-  YAxis,
 } from 'recharts';
 import { getAggregateChartData } from '../../axiosAPIs/DataInsightAPI';
 import {
@@ -111,7 +110,6 @@ const OwnerInsight: FC<Props> = ({ chartFilter }) => {
           <BarChart data={data} margin={BAR_CHART_MARGIN}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="timestamp" />
-            <YAxis />
             <Tooltip content={<CustomTooltip isPercentage />} />
             <Legend
               align="left"

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/DataInsightLeftPanel.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/DataInsightLeftPanel.tsx
@@ -19,8 +19,8 @@ import { ReactComponent as AppAnalyticsIcon } from '../../assets/svg/app-analyti
 import { ReactComponent as DataAssetsIcon } from '../../assets/svg/data-asset.svg';
 import { ReactComponent as KPIIcon } from '../../assets/svg/kpi.svg';
 import LeftPanelCard from '../../components/common/LeftPanelCard/LeftPanelCard';
-import { ROUTES } from '../../constants/constants';
 import { DataInsightTabs } from '../../interface/data-insight.interface';
+import { getDataInsightPathWithFqn } from '../../utils/DataInsightUtils';
 
 const DataInsightLeftPanel = () => {
   const { tab } = useParams<{ tab: DataInsightTabs }>();
@@ -47,7 +47,7 @@ const DataInsightLeftPanel = () => {
   ];
 
   const handleMenuClick: MenuProps['onClick'] = (e) => {
-    history.push(`${ROUTES.DATA_INSIGHT}/${e.key}`);
+    history.push(getDataInsightPathWithFqn(e.key));
   };
 
   return (

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/DataInsightPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/DataInsightPage.component.tsx
@@ -54,7 +54,10 @@ import {
   ChartFilter,
   DataInsightTabs,
 } from '../../interface/data-insight.interface';
-import { getTeamFilter } from '../../utils/DataInsightUtils';
+import {
+  getDataInsightPathWithFqn,
+  getTeamFilter,
+} from '../../utils/DataInsightUtils';
 import {
   getCurrentDateTimeMillis,
   getFormattedDateFromMilliSeconds,
@@ -136,9 +139,9 @@ const DataInsightPage = () => {
 
   const handleScrollToChart = (chartType: DataInsightChartType) => {
     if (ENTITIES_CHARTS.includes(chartType)) {
-      history.push(DataInsightTabs.DATA_ASSETS);
+      history.push(getDataInsightPathWithFqn(DataInsightTabs.DATA_ASSETS));
     } else {
-      history.push(DataInsightTabs.APP_ANALYTICS);
+      history.push(getDataInsightPathWithFqn(DataInsightTabs.APP_ANALYTICS));
     }
     setSelectedChart(chartType);
   };

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataInsightUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataInsightUtils.tsx
@@ -521,6 +521,5 @@ export const getKpiResultFeedback = (day: number, isTargetMet: boolean) => {
   }
 };
 
-export const getDataInsightPathWithFqn = (fqn: string) => {
-  return ROUTES.DATA_INSIGHT_WITH_TAB.replace(PLACEHOLDER_ROUTE_TAB, fqn);
-};
+export const getDataInsightPathWithFqn = (fqn: string) =>
+  ROUTES.DATA_INSIGHT_WITH_TAB.replace(PLACEHOLDER_ROUTE_TAB, fqn);

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataInsightUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataInsightUtils.tsx
@@ -28,6 +28,7 @@ import moment from 'moment';
 import React from 'react';
 import { ListItem, ListValues } from 'react-awesome-query-builder';
 import { LegendProps, Surface } from 'recharts';
+import { PLACEHOLDER_ROUTE_TAB, ROUTES } from '../constants/constants';
 import {
   ENTITIES_SUMMARY_LIST,
   KPI_DATE_PICKER_FORMAT,
@@ -518,4 +519,8 @@ export const getKpiResultFeedback = (day: number, isTargetMet: boolean) => {
   } else {
     return t('label.day-left', { day: pluralize(day, 'day') });
   }
+};
+
+export const getDataInsightPathWithFqn = (fqn: string) => {
+  return ROUTES.DATA_INSIGHT_WITH_TAB.replace(PLACEHOLDER_ROUTE_TAB, fqn);
 };


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on removing Y-axis for percentage charts on data insight page

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement

#
### Frontend Preview (Screenshots) :
![image](https://user-images.githubusercontent.com/59080942/205927425-4cffe772-0a7f-498f-9700-51a762035931.png)

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
