### PR TITLE
doc : add doc link for custom properties

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/constants/docs.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/docs.constants.ts
@@ -19,3 +19,6 @@ export const TEAMS_DOCS = 'https://docs.open-metadata.org/openmetadata/users';
 
 export const WEBHOOK_DOCS =
   'https://docs.open-metadata.org/developers/webhooks';
+
+export const CUSTOM_PROPERTIES_DOCS =
+  'https://docs.open-metadata.org/how-to-guides/how-to-add-custom-property-to-an-entity';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/CustomPropertiesPageV1/CustomPropertiesPageV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/CustomPropertiesPageV1/CustomPropertiesPageV1.tsx
@@ -34,6 +34,7 @@ import {
   ENTITY_PATH,
   getAddCustomPropertyPath,
 } from '../../constants/constants';
+import { CUSTOM_PROPERTIES_DOCS } from '../../constants/docs.constants';
 import {
   NO_PERMISSION_FOR_ACTION,
   NO_PERMISSION_TO_VIEW,
@@ -205,6 +206,7 @@ const CustomEntityDetailV1 = () => {
                   </Tooltip>
                 }
                 dataTestId="custom-properties-no-data"
+                doc={CUSTOM_PROPERTIES_DOCS}
                 heading="Property"
                 type="ADD_DATA"
               />


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on adding the missing doc links for custom properties.
#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] Documentation

#
### Frontend Preview (Screenshots) :

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
