### PR TITLE
Extra headers for metadata API

### DIFF
--- a/ingestion/src/metadata/ingestion/ometa/client.py
+++ b/ingestion/src/metadata/ingestion/ometa/client.py
@@ -165,10 +165,10 @@ class REST:
         # Example: "Proxy-Authorization": "%(Authorization)s"
         # This will result in the Authorization value being set for the Proxy-Authorization Extra Header
         if self.config.extra_headers:
-            extra_headers = self.config.extra_headers.get("__root__", {})
-            extra_headers = [extra_headers[eh] % headers for eh in extra_headers]
+            extra_headers: dict[str, str] = self.config.extra_headers
+            extra_headers = {k: (v % headers) for k, v in extra_headers.items()}
             logger.debug("Extra headers provided '%s'", extra_headers)
-            headers = headers | extra_headers
+            headers = {**headers, **extra_headers}
 
         opts = {
             "headers": headers,

--- a/ingestion/src/metadata/ingestion/ometa/client.py
+++ b/ingestion/src/metadata/ingestion/ometa/client.py
@@ -136,6 +136,7 @@ class REST:
         api_version: str = None,
         headers: dict = None,
     ):
+        # pylint: disable=too-many-locals
         if not headers:
             headers = {"Content-type": "application/json"}
         base_url = base_url or self._base_url

--- a/ingestion/src/metadata/ingestion/ometa/client.py
+++ b/ingestion/src/metadata/ingestion/ometa/client.py
@@ -101,6 +101,8 @@ class ClientConfig(ConfigModel):
     access_token: Optional[str] = None
     expires_in: Optional[int] = None
     auth_header: Optional[str] = None
+    extra_auth_header: Optional[str] = None
+    extra_auth_header_value: Optional[str] = None
     raw_data: Optional[bool] = False
     allow_redirects: Optional[bool] = False
     auth_token_mode: Optional[str] = "Bearer"
@@ -156,6 +158,16 @@ class REST:
         headers[
             self.config.auth_header
         ] = f"{self._auth_token_mode} {self.config.access_token}"
+
+        # Include extra auth header if specified,
+        # use Authorization header value if no value is provided
+        if self.config.extra_auth_header:
+            logger.debug(
+                "Extra auth header '%s' provided", self.config.extra_auth_header
+            )
+            headers[self.config.extra_auth_header] = (
+                self.config.extra_auth_header_value or headers[self.config.auth_header]
+            )
 
         opts = {
             "headers": headers,

--- a/ingestion/src/metadata/ingestion/ometa/ometa_api.py
+++ b/ingestion/src/metadata/ingestion/ometa/ometa_api.py
@@ -22,6 +22,8 @@ try:
 except ImportError:
     from typing_compat import get_args
 
+from os import getenv
+
 from pydantic import BaseModel
 from requests.utils import quote
 
@@ -194,6 +196,8 @@ class OpenMetadata(
             base_url=self.config.hostPort,
             api_version=self.config.apiVersion,
             auth_header="Authorization",
+            extra_auth_header=getenv("OMETA_HEADER_EXTRA_AUTH_NAME"),
+            extra_auth_header_value=getenv("OMETA_HEADER_EXTRA_AUTH_VALUE"),
             auth_token=self._auth_provider.get_access_token,
             verify=get_verify_ssl(self.config.sslConfig),
         )

--- a/ingestion/src/metadata/ingestion/ometa/ometa_api.py
+++ b/ingestion/src/metadata/ingestion/ometa/ometa_api.py
@@ -22,7 +22,6 @@ try:
 except ImportError:
     from typing_compat import get_args
 
-from os import getenv
 
 from pydantic import BaseModel
 from requests.utils import quote
@@ -196,8 +195,7 @@ class OpenMetadata(
             base_url=self.config.hostPort,
             api_version=self.config.apiVersion,
             auth_header="Authorization",
-            extra_auth_header=getenv("OMETA_HEADER_EXTRA_AUTH_NAME"),
-            extra_auth_header_value=getenv("OMETA_HEADER_EXTRA_AUTH_VALUE"),
+            extra_headers=self.config.extraHeaders,
             auth_token=self._auth_provider.get_access_token,
             verify=get_verify_ssl(self.config.sslConfig),
         )

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/metadata/openMetadataConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/metadata/openMetadataConnection.json
@@ -11,6 +11,13 @@
       "type": "string",
       "enum": ["OpenMetadata"],
       "default": "OpenMetadata"
+    },
+    "extraHeaders": {
+      "description": "Additional headers to be sent to the API endpoint.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
     }
   },
   "properties": {
@@ -191,6 +198,10 @@
     },
     "supportsElasticSearchReindexingExtraction": {
       "$ref": "../connectionBasicType.json#/definitions/supportsElasticSearchReindexingExtraction"
+    },
+    "extraHeaders": {
+      "title": "Extra Headers",
+      "$ref": "#/definitions/extraHeaders"
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
### Describe your changes :

- Allows for extra headers to be provided to the ometa API client
- Adds `extraHeaders` to the `workflowConfig.openMetadataServerConfig` schema
- Supports copying existing header values using string modulo format with the header dictionary

Example usage:

```yaml
  openMetadataServerConfig:
    hostPort: ${OMD_API_HOST}
    authProvider: google
    extraHeaders:
      Proxy-Authorization: "%(Authorization)s"
      Some-Env-Header: ${MY_ENV_VAR}
      Static-Header: my-value
```

The primary use case is for Google Cloud's Identity Aware Proxy (IAP) which allows secure access to private services but removes the Authorization header in the process. The `Proxy-Authorization` header gets forwarded along to the service as the `Authorization` header for the service behind IAP. In this case, the token is valid for Google SSO as well and can be passed through and enables "nested" authorization options.

Here's a [relevant StackOverflow](https://stackoverflow.com/questions/59297161/using-nested-authentication-with-google-iap) about the header.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ingestion
