### PR TITLE
UI: Converted data insight dropdown to checkbox dropdown

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/constants/DataInsight.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/DataInsight.constants.ts
@@ -87,28 +87,13 @@ export const DAY_FILTER = [
   },
 ];
 
-export const TIER_FILTER = [
-  {
-    value: 'Tier.Tier1',
-    label: i18n.t('label.tier-number', { tier: 1 }),
-  },
-  {
-    value: 'Tier.Tier2',
-    label: i18n.t('label.tier-number', { tier: 2 }),
-  },
-  {
-    value: 'Tier.Tier3',
-    label: i18n.t('label.tier-number', { tier: 3 }),
-  },
-  {
-    value: 'Tier.Tier4',
-    label: i18n.t('label.tier-number', { tier: 4 }),
-  },
-  {
-    value: 'Tier.Tier5',
-    label: i18n.t('label.tier-number', { tier: 5 }),
-  },
-];
+export const TIER_FILTER = {
+  [i18n.t('label.tier-number', { tier: 1 })]: 'Tier.Tier1',
+  [i18n.t('label.tier-number', { tier: 2 })]: 'Tier.Tier2',
+  [i18n.t('label.tier-number', { tier: 3 })]: 'Tier.Tier3',
+  [i18n.t('label.tier-number', { tier: 4 })]: 'Tier.Tier4',
+  [i18n.t('label.tier-number', { tier: 5 })]: 'Tier.Tier5',
+};
 
 export const INITIAL_CHART_FILTER: ChartFilter = {
   startTs: getPastDaysDateTimeMillis(DEFAULT_DAYS),

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/DataInsight.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/DataInsight.interface.ts
@@ -1,0 +1,19 @@
+/*
+ *  Copyright 2022 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+export type TeamStateType = {
+  defaultOptions: string[];
+  selectedOptions: string[];
+  options: string[];
+};
+export type TierStateType = Omit<TeamStateType, 'defaultOptions'>;

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/DataInsightPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/DataInsightPage.component.tsx
@@ -24,6 +24,7 @@ import {
 import { t } from 'i18next';
 import { isEmpty } from 'lodash';
 import React, { useEffect, useLayoutEffect, useMemo, useState } from 'react';
+import { ListItem } from 'react-awesome-query-builder';
 import { useHistory, useParams } from 'react-router-dom';
 import { getListKPIs } from '../../axiosAPIs/KpiAPI';
 import { searchQuery } from '../../axiosAPIs/searchAPI';
@@ -150,8 +151,7 @@ const DataInsightPage = () => {
         const response = await fetchTeamSuggestions(query, PAGE_SIZE);
         setTeamOptions((prev) => ({
           ...prev,
-
-          options: getTeamFilter(response.values),
+          options: getTeamFilter(response.values as ListItem[]),
         }));
       } catch (_error) {
         // we will not show the toast error message for suggestion API
@@ -173,7 +173,7 @@ const DataInsightPage = () => {
         ),
       }));
     } else {
-      setTeamOptions((prev) => ({
+      setTierOptions((prev) => ({
         ...prev,
         options: defaultTierOptions,
       }));

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/DataInsightPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/DataInsightPage.component.tsx
@@ -17,12 +17,12 @@ import {
   Col,
   Row,
   Select,
-  SelectProps,
   Space,
   Tooltip,
   Typography,
 } from 'antd';
 import { t } from 'i18next';
+import { isEmpty } from 'lodash';
 import React, { useEffect, useLayoutEffect, useMemo, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import { getListKPIs } from '../../axiosAPIs/KpiAPI';
@@ -38,8 +38,9 @@ import TierInsight from '../../components/DataInsightDetail/TierInsight';
 import TopActiveUsers from '../../components/DataInsightDetail/TopActiveUsers';
 import TopViewEntities from '../../components/DataInsightDetail/TopViewEntities';
 import TotalEntityInsight from '../../components/DataInsightDetail/TotalEntityInsight';
+import SearchDropdown from '../../components/SearchDropdown/SearchDropdown';
 import { autocomplete } from '../../constants/AdvancedSearch.constants';
-import { ROUTES } from '../../constants/constants';
+import { PAGE_SIZE, ROUTES } from '../../constants/constants';
 import {
   DAY_FILTER,
   DEFAULT_DAYS,
@@ -65,6 +66,7 @@ import {
   getFormattedDateFromMilliSeconds,
   getPastDaysDateTimeMillis,
 } from '../../utils/TimeUtils';
+import { TeamStateType, TierStateType } from './DataInsight.interface';
 import './DataInsight.less';
 import DataInsightLeftPanel from './DataInsightLeftPanel';
 import KPIList from './KPIList';
@@ -77,13 +79,26 @@ const DataInsightPage = () => {
   const { isAdminUser } = useAuth();
   const history = useHistory();
 
-  const [teamsOptions, setTeamOptions] = useState<SelectProps['options']>([]);
+  const [teamsOptions, setTeamOptions] = useState<TeamStateType>({
+    defaultOptions: [],
+    selectedOptions: [],
+    options: [],
+  });
+  const [tierOptions, setTierOptions] = useState<TierStateType>({
+    selectedOptions: [],
+    options: [],
+  });
+
   const [activeTab, setActiveTab] = useState(DataInsightTabs.DATA_ASSETS);
   const [chartFilter, setChartFilter] =
     useState<ChartFilter>(INITIAL_CHART_FILTER);
   const [kpiList, setKpiList] = useState<Array<Kpi>>([]);
 
   const [selectedChart, setSelectedChart] = useState<DataInsightChartType>();
+
+  const defaultTierOptions = useMemo(() => {
+    return Object.keys(TIER_FILTER);
+  }, []);
 
   const { descriptionKpi, ownerKpi } = useMemo(() => {
     return {
@@ -101,9 +116,12 @@ const DataInsightPage = () => {
   }, [kpiList]);
 
   const handleTierChange = (tiers: string[] = []) => {
+    setTierOptions((prev) => ({ ...prev, selectedOptions: tiers }));
     setChartFilter((previous) => ({
       ...previous,
-      tier: tiers.length ? tiers.join(',') : undefined,
+      tier: tiers.length
+        ? tiers.map((tier) => TIER_FILTER[tier]).join(',')
+        : undefined,
     }));
   };
 
@@ -116,6 +134,10 @@ const DataInsightPage = () => {
   };
 
   const handleTeamChange = (teams: string[] = []) => {
+    setTeamOptions((prev) => ({
+      ...prev,
+      selectedOptions: teams,
+    }));
     setChartFilter((previous) => ({
       ...previous,
       team: teams.length ? teams.join(',') : undefined,
@@ -123,36 +145,78 @@ const DataInsightPage = () => {
   };
 
   const handleTeamSearch = async (query: string) => {
-    if (fetchTeamSuggestions) {
+    if (fetchTeamSuggestions && !isEmpty(query)) {
       try {
-        const response = await fetchTeamSuggestions(query, 5);
-        setTeamOptions(getTeamFilter(response.values));
+        const response = await fetchTeamSuggestions(query, PAGE_SIZE);
+        setTeamOptions((prev) => ({
+          ...prev,
+
+          options: getTeamFilter(response.values),
+        }));
       } catch (_error) {
         // we will not show the toast error message for suggestion API
       }
+    } else {
+      setTeamOptions((prev) => ({
+        ...prev,
+        options: prev.defaultOptions,
+      }));
+    }
+  };
+
+  const handleTierSearch = async (query: string) => {
+    if (query) {
+      setTierOptions((prev) => ({
+        ...prev,
+        options: prev.options.filter((value) =>
+          value.toLocaleLowerCase().includes(query.toLocaleLowerCase())
+        ),
+      }));
+    } else {
+      setTeamOptions((prev) => ({
+        ...prev,
+        options: defaultTierOptions,
+      }));
     }
   };
 
   const fetchDefaultTeamOptions = async () => {
+    if (teamsOptions.defaultOptions.length) {
+      setTeamOptions((prev) => ({
+        ...prev,
+        options: prev.defaultOptions,
+      }));
+
+      return;
+    }
+
     try {
       const response = await searchQuery({
         searchIndex: SearchIndex.TEAM,
         query: '*',
-        pageSize: 5,
+        pageSize: PAGE_SIZE,
       });
       const hits = response.hits.hits;
       const teamFilterOptions = hits.map((hit) => {
         const source = hit._source;
 
-        return {
-          label: source.displayName || source.name,
-          value: source.fullyQualifiedName || source.name,
-        };
+        return source.name;
       });
-      setTeamOptions(teamFilterOptions);
+      setTeamOptions((prev) => ({
+        ...prev,
+        defaultOptions: teamFilterOptions,
+        options: teamFilterOptions,
+      }));
     } catch (_error) {
       // we will not show the toast error message for search API
     }
+  };
+
+  const fetchDefaultTierOptions = () => {
+    setTierOptions((prev) => ({
+      ...prev,
+      options: defaultTierOptions,
+    }));
   };
 
   const fetchKpiList = async () => {
@@ -230,26 +294,24 @@ const DataInsightPage = () => {
           <Card>
             <Space className="w-full justify-between">
               <Space className="w-full">
-                <Select
-                  allowClear
-                  showArrow
-                  className="data-insight-select-dropdown"
-                  mode="multiple"
-                  notFoundContent={null}
-                  options={teamsOptions}
-                  placeholder={t('label.select-teams')}
+                <SearchDropdown
+                  label={t('label.team')}
+                  options={teamsOptions.options}
+                  searchKey="teams"
+                  selectedKeys={teamsOptions.selectedOptions}
                   onChange={handleTeamChange}
+                  onGetInitialOptions={fetchDefaultTeamOptions}
                   onSearch={handleTeamSearch}
                 />
-                <Select
-                  allowClear
-                  showArrow
-                  className="data-insight-select-dropdown"
-                  mode="multiple"
-                  notFoundContent={null}
-                  options={TIER_FILTER}
-                  placeholder={t('label.select-tiers')}
+
+                <SearchDropdown
+                  label={t('label.tier')}
+                  options={tierOptions.options}
+                  searchKey="tier"
+                  selectedKeys={tierOptions.selectedOptions}
                   onChange={handleTierChange}
+                  onGetInitialOptions={fetchDefaultTierOptions}
+                  onSearch={handleTierSearch}
                 />
               </Space>
               <Space>

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataInsightUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataInsightUtils.tsx
@@ -421,11 +421,10 @@ export const getGraphDataByTierType = (rawData: TotalEntitiesByTier[]) => {
   };
 };
 
-export const getTeamFilter = (suggestionValues: ListValues = []) => {
-  return (suggestionValues as ListItem[]).map((suggestion: ListItem) => ({
-    label: suggestion.title,
-    value: suggestion.value,
-  }));
+export const getTeamFilter = (suggestionValues: ListValues = []): string[] => {
+  return (suggestionValues as ListItem[]).map(
+    (suggestion: ListItem) => suggestion.value
+  );
 };
 
 export const getFormattedActiveUsersData = (

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataInsightUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataInsightUtils.tsx
@@ -26,7 +26,7 @@ import {
 } from 'lodash';
 import moment from 'moment';
 import React from 'react';
-import { ListItem, ListValues } from 'react-awesome-query-builder';
+import { ListItem } from 'react-awesome-query-builder';
 import { LegendProps, Surface } from 'recharts';
 import {
   GRAYED_OUT_COLOR,
@@ -421,10 +421,8 @@ export const getGraphDataByTierType = (rawData: TotalEntitiesByTier[]) => {
   };
 };
 
-export const getTeamFilter = (suggestionValues: ListValues = []): string[] => {
-  return (suggestionValues as ListItem[]).map(
-    (suggestion: ListItem) => suggestion.value
-  );
+export const getTeamFilter = (suggestionValues: ListItem[]): string[] => {
+  return suggestionValues.map((suggestion) => suggestion.value);
 };
 
 export const getFormattedActiveUsersData = (


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
issue: https://github.com/open-metadata/OpenMetadata/issues/8996#issuecomment-1327618489
Added checkbox dropdown for data insight filters

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement


#
### Frontend Preview (Screenshots) :
<img width="640" alt="image" src="https://user-images.githubusercontent.com/71748675/208229116-df1c4879-992c-4d5b-ab91-9acaf370f567.png">


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
