### PR TITLE
UI: Fixed test case value preserve issue and test case graph improvement

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/AddDataQualityTest/components/TestCaseForm.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AddDataQualityTest/components/TestCaseForm.tsx
@@ -241,6 +241,7 @@ const TestCaseForm: React.FC<TestCaseFormProps> = ({
       form={form}
       layout="vertical"
       name="tableTestForm"
+      preserve={false}
       onFinish={handleFormSubmit}
       onValuesChange={handleValueChange}>
       <Form.Item

--- a/openmetadata-ui/src/main/resources/ui/src/components/ProfilerDashboard/component/TestSummary.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ProfilerDashboard/component/TestSummary.tsx
@@ -38,6 +38,7 @@ import {
   TestCaseResult,
   TestCaseStatus,
 } from '../../../generated/tests/testCase';
+import { axisTickFormatter } from '../../../utils/ChartUtils';
 import { getEncodedFqn } from '../../../utils/StringsUtils';
 import {
   getCurrentDateTimeStamp,
@@ -205,7 +206,7 @@ const TestSummary: React.FC<TestSummaryProps> = ({ data }) => {
 
   return (
     <Row gutter={16}>
-      <Col span={14}>
+      <Col span={16}>
         {isLoading ? (
           <Loader />
         ) : (
@@ -232,7 +233,11 @@ const TestSummary: React.FC<TestSummaryProps> = ({ data }) => {
                     right: 8,
                   }}>
                   <XAxis dataKey="name" padding={{ left: 8, right: 8 }} />
-                  <YAxis allowDataOverflow padding={{ top: 8, bottom: 8 }} />
+                  <YAxis
+                    allowDataOverflow
+                    padding={{ top: 8, bottom: 8 }}
+                    tickFormatter={(value) => axisTickFormatter(value)}
+                  />
                   <Tooltip />
                   <Legend />
                   {data.parameterValues?.length === 2 && referenceArea()}
@@ -258,7 +263,7 @@ const TestSummary: React.FC<TestSummaryProps> = ({ data }) => {
           </div>
         )}
       </Col>
-      <Col span={10}>
+      <Col span={8}>
         <Row gutter={[8, 8]}>
           <Col span={24}>
             <Typography.Text type="secondary">Name: </Typography.Text>


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
- Fixed data preserved issue while creating test case
- fixed formatting for y axis tick on test case graph and space issue

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement


#
### Frontend Preview (Screenshots) :

https://user-images.githubusercontent.com/71748675/208465006-0c163248-a623-42cd-9839-5ab0b9c78118.mov

<img width="1476" alt="image" src="https://user-images.githubusercontent.com/71748675/208465486-c56f83a8-ac65-4bce-81b6-573dc2abed99.png">


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
