### PR TITLE
UI: Added more information for table columns in summary panel.

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/EntityTable/EntityTable.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/EntityTable/EntityTable.component.tsx
@@ -44,10 +44,10 @@ import {
 } from '../../utils/GlossaryUtils';
 import SVGIcons, { Icons } from '../../utils/SvgUtils';
 import {
-  getConstraintIcon,
   getDataTypeString,
   getTableExpandableConfig,
   makeData,
+  prepareConstraintIcon,
 } from '../../utils/TableUtils';
 import { getTagCategories, getTaglist } from '../../utils/TagsUtils';
 import {
@@ -329,32 +329,6 @@ const EntityTable = ({
     );
   };
 
-  const prepareConstraintIcon = (
-    columnName: string,
-    columnConstraint?: string
-  ) => {
-    // get the table constraint for column
-    const tableConstraint = tableConstraints?.find((constraint) =>
-      constraint.columns?.includes(columnName)
-    );
-
-    // prepare column constraint element
-    const columnConstraintEl = columnConstraint
-      ? getConstraintIcon(columnConstraint, 'tw-mr-2')
-      : null;
-
-    // prepare table constraint element
-    const tableConstraintEl = tableConstraint
-      ? getConstraintIcon(tableConstraint.constraintType, 'tw-mr-2')
-      : null;
-
-    return (
-      <span data-testid="constraints">
-        {columnConstraintEl} {tableConstraintEl}
-      </span>
-    );
-  };
-
   const handleUpdate = (column: Column, index: number) => {
     handleEditColumn(column, index);
   };
@@ -629,7 +603,7 @@ const EntityTable = ({
         width: 220,
         render: (name: Column['name'], record: Column) => (
           <Popover destroyTooltipOnHide content={name} trigger="hover">
-            {prepareConstraintIcon(name, record.constraint)}
+            {prepareConstraintIcon(name, record.constraint, tableConstraints)}
             <span>{name}</span>
           </Popover>
         ),

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/SummaryList/SummaryList.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/SummaryList/SummaryList.component.tsx
@@ -131,7 +131,7 @@ export default function SummaryList({
                           <Text className="text-gray">{`${t(
                             'label.algorithm'
                           )}:`}</Text>
-                          <Text className="text-semi-bold">
+                          <Text className="font-medium">
                             {entity.algorithm}
                           </Text>
                         </Space>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/SummaryList/SummaryList.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/SummaryList/SummaryList.component.tsx
@@ -20,6 +20,7 @@ import { ReactComponent as IconTagGrey } from '../../../../assets/svg/tag-grey.s
 import { MAX_CHAR_LIMIT_ENTITY_SUMMARY } from '../../../../constants/constants';
 import { getEntityName, getTagValue } from '../../../../utils/CommonUtils';
 import SVGIcons from '../../../../utils/SvgUtils';
+import { prepareConstraintIcon } from '../../../../utils/TableUtils';
 import RichTextEditorPreviewer from '../../../common/rich-text-editor/RichTextEditorPreviewer';
 import TagsViewer from '../../../tags-viewer/tags-viewer';
 import { BasicColumnInfo, SummaryListProps } from './SummaryList.interface';
@@ -42,6 +43,7 @@ export default function SummaryList({
         type: column.dataType,
         tags: column.tags,
         description: column.description,
+        constraint: column.constraint,
       }));
     } else if (charts) {
       return charts.map((chart) => ({
@@ -95,7 +97,17 @@ export default function SummaryList({
         formattedColumnsData.map((entity) => (
           <Col key={entity.name} span={24}>
             <Row gutter={[0, 4]}>
-              <Col span={24}>{entity.title}</Col>
+              <Col span={24}>
+                {columns &&
+                  prepareConstraintIcon(
+                    entity.name,
+                    entity.constraint,
+                    undefined,
+                    'm-r-xss',
+                    '14px'
+                  )}
+                {entity.title}
+              </Col>
               <Col span={24}>
                 <Row className="text-xs font-300" gutter={[4, 4]}>
                   <Col>
@@ -104,7 +116,7 @@ export default function SummaryList({
                         <Text className="text-gray">{`${t(
                           'label.type'
                         )}:`}</Text>
-                        <Text className="text-semi-bold">{entity.type}</Text>
+                        <Text className="font-medium">{entity.type}</Text>
                       </Space>
                     )}
                   </Col>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/SummaryList/SummaryList.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/SummaryList/SummaryList.interface.ts
@@ -18,7 +18,11 @@ import {
   MlFeature,
 } from '../../../../generated/entity/data/mlmodel';
 import { Task } from '../../../../generated/entity/data/pipeline';
-import { Column, DataType } from '../../../../generated/entity/data/table';
+import {
+  Column,
+  Constraint,
+  DataType,
+} from '../../../../generated/entity/data/table';
 import { TagLabel } from '../../../../generated/type/tagLabel';
 
 export interface SummaryListProps {
@@ -35,4 +39,5 @@ export interface BasicColumnInfo {
   type?: DataType | ChartType | FeatureType | string;
   tags?: TagLabel[];
   description?: string;
+  constraint?: Constraint;
 }

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TableUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TableUtils.tsx
@@ -42,7 +42,11 @@ import { GlobalSettingsMenuCategory } from '../constants/GlobalSettings.constant
 import { EntityType, FqnPart } from '../enums/entity.enum';
 import { SearchIndex } from '../enums/search.enum';
 import { ConstraintTypes, PrimaryTableDataTypes } from '../enums/table.enum';
-import { Column, DataType } from '../generated/entity/data/table';
+import {
+  Column,
+  DataType,
+  TableConstraint,
+} from '../generated/entity/data/table';
 import { TestCaseStatus } from '../generated/tests/testCase';
 import { TagLabel } from '../generated/type/tagLabel';
 import {
@@ -135,7 +139,11 @@ export const getSearchTableTagsWithoutTier = (
   );
 };
 
-export const getConstraintIcon = (constraint = '', className = '') => {
+export const getConstraintIcon = (
+  constraint = '',
+  className = '',
+  width = '16px'
+) => {
   let title: string, icon: string;
   switch (constraint) {
     case ConstraintTypes.PRIMARY_KEY:
@@ -177,7 +185,7 @@ export const getConstraintIcon = (constraint = '', className = '') => {
       size="small"
       title={title}
       trigger="mouseenter">
-      <SVGIcons alt={title} icon={icon} width="16px" />
+      <SVGIcons alt={title} icon={icon} width={width} />
     </PopOver>
   );
 };
@@ -377,3 +385,36 @@ export function getTableExpandableConfig<T>(): ExpandableConfig<T> {
 
   return expandableConfig;
 }
+
+export const prepareConstraintIcon = (
+  columnName: string,
+  columnConstraint?: string,
+  tableConstraints?: TableConstraint[],
+  iconClassName?: string,
+  iconWidth?: string
+) => {
+  // get the table constraint for column
+  const tableConstraint = tableConstraints?.find((constraint) =>
+    constraint.columns?.includes(columnName)
+  );
+
+  // prepare column constraint element
+  const columnConstraintEl = columnConstraint
+    ? getConstraintIcon(columnConstraint, iconClassName || 'tw-mr-2', iconWidth)
+    : null;
+
+  // prepare table constraint element
+  const tableConstraintEl = tableConstraint
+    ? getConstraintIcon(
+        tableConstraint.constraintType,
+        iconClassName || 'tw-mr-2',
+        iconWidth
+      )
+    : null;
+
+  return (
+    <span data-testid="constraints">
+      {columnConstraintEl} {tableConstraintEl}
+    </span>
+  );
+};


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on:
- Adding more information such as Primary key, Not null, etc. for columns
- Font weight for types fixed

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement

#
### Frontend Preview (Screenshots) :
<p align="center">

<img width="900" alt="Screenshot 2022-12-20 at 4 09 23 PM" src="https://user-images.githubusercontent.com/51777795/208648114-1c4c2aea-8d9f-44b2-a3aa-ee1d96d09eec.png">
<img width="422" alt="Screenshot 2022-12-20 at 6 03 07 PM" src="https://user-images.githubusercontent.com/51777795/208668348-301b8396-a320-44bb-92b6-3ec36d09ab7e.png">


</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @open-metadata/ui 
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
