### PR TITLE
UI: Improved topic summary panel content

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/SummaryList/SummaryList.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/SummaryList/SummaryList.component.tsx
@@ -32,6 +32,7 @@ export default function SummaryList({
   charts,
   tasks,
   mlFeatures,
+  schemaFields,
 }: SummaryListProps) {
   const { t } = useTranslation();
 
@@ -84,8 +85,16 @@ export default function SummaryList({
         tags: feature.tags,
         description: feature.description,
       }));
+    } else if (schemaFields) {
+      return schemaFields.map((field) => ({
+        name: field.name,
+        title: <Text className="entity-title">{field.name}</Text>,
+        type: field.dataType,
+        description: field.description,
+        tags: field.tags,
+      }));
     } else return [];
-  }, [columns, charts, tasks, mlFeatures]);
+  }, [columns, charts, tasks, mlFeatures, schemaFields]);
 
   return (
     <Row>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/SummaryList/SummaryList.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/SummaryList/SummaryList.interface.ts
@@ -23,6 +23,7 @@ import {
   Constraint,
   DataType,
 } from '../../../../generated/entity/data/table';
+import { Field } from '../../../../generated/entity/data/topic';
 import { TagLabel } from '../../../../generated/type/tagLabel';
 
 export interface SummaryListProps {
@@ -30,6 +31,7 @@ export interface SummaryListProps {
   charts?: Chart[];
   tasks?: Task[];
   mlFeatures?: MlFeature[];
+  schemaFields?: Field[];
 }
 
 export interface BasicColumnInfo {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/TopicSummary/TopicSummary.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/TopicSummary/TopicSummary.component.tsx
@@ -20,8 +20,8 @@ import { Topic } from '../../../../generated/entity/data/topic';
 import { bytesToSize } from '../../../../utils/StringsUtils';
 import { getConfigObject } from '../../../../utils/TopicDetailsUtils';
 import TableDataCardTitle from '../../../common/table-data-card-v2/TableDataCardTitle.component';
-import SchemaEditor from '../../../schema-editor/SchemaEditor';
 import { TopicConfigObjectInterface } from '../../../TopicDetails/TopicDetails.interface';
+import SummaryList from '../SummaryList/SummaryList.component';
 
 interface TopicSummaryProps {
   entityDetails: Topic;
@@ -73,17 +73,16 @@ function TopicSummary({ entityDetails }: TopicSummaryProps) {
         </Col>
       </Row>
       <Divider className="m-0" />
-      <Row className="m-md">
+      <Row className="m-md" gutter={[0, 16]}>
         <Col span={24}>
           <Typography.Text className="section-header">
             {t('label.schema')}
           </Typography.Text>
         </Col>
         <Col span={24}>
-          {entityDetails.messageSchema?.schemaText ? (
-            <SchemaEditor
-              editorClass="summary-schema-editor"
-              value={entityDetails.messageSchema.schemaText}
+          {entityDetails.messageSchema?.schemaFields ? (
+            <SummaryList
+              schemaFields={entityDetails.messageSchema?.schemaFields || []}
             />
           ) : (
             <div className="m-y-md">


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on improving summary panel content for topics

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement

#
### Frontend Preview (Screenshots) :
<p align="center">
<img width="1155" alt="Screenshot 2022-12-21 at 10 07 53 PM" src="https://user-images.githubusercontent.com/51777795/208958130-c295fa1c-5063-4b1e-9aaa-16b9e264f64d.png">
<img width="1150" alt="Screenshot 2022-12-21 at 10 08 06 PM" src="https://user-images.githubusercontent.com/51777795/208958147-6148b9c3-7f35-4b19-a57f-9346b4967600.png">

</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @open-metadata/ui 
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
