### PR TITLE
Improvements(UI): My data and Following section improvements

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/EntityList/EntityList.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/EntityList/EntityList.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { Button, Card, Typography } from 'antd';
+import { Button, Card, Skeleton, Typography } from 'antd';
 import React, { Fragment, FunctionComponent } from 'react';
 import { Link } from 'react-router-dom';
 import { EntityReference } from '../../generated/type/entityReference';
@@ -27,6 +27,7 @@ interface Prop {
 }
 
 interface AntdEntityListProp {
+  isLoadingOwnedData?: boolean;
   entityList: Array<EntityReference>;
   headerText?: string | JSX.Element;
   headerTextLabel: string;
@@ -86,45 +87,50 @@ export const EntityListWithAntd: FunctionComponent<AntdEntityListProp> = ({
   headerTextLabel,
   noDataPlaceholder,
   testIDText,
+  isLoadingOwnedData,
 }: AntdEntityListProp) => {
   return (
     <Card
       extra={headerText}
       style={leftPanelAntCardStyle}
       title={headerTextLabel}>
-      {entityList.length
-        ? entityList.map((item, index) => {
-            return (
-              <div
-                className="flex items-center justify-between"
-                data-testid={`${testIDText}-${getEntityName(
-                  item as unknown as EntityReference
-                )}`}
-                key={index}>
-                <div className="flex items-center">
-                  {getEntityIcon(item.type || '')}
-                  <Link
-                    className="font-medium"
-                    to={getEntityLink(
-                      item.type || '',
-                      item.fullyQualifiedName as string
-                    )}>
-                    <Button
-                      className="entity-button"
-                      title={getEntityName(item as unknown as EntityReference)}
-                      type="text">
-                      <Typography.Text
-                        className="w-48 text-left"
-                        ellipsis={{ tooltip: true }}>
-                        {getEntityName(item as unknown as EntityReference)}
-                      </Typography.Text>
-                    </Button>
-                  </Link>
-                </div>
+      {isLoadingOwnedData ? (
+        <Skeleton active />
+      ) : entityList.length ? (
+        entityList.map((item, index) => {
+          return (
+            <div
+              className="flex items-center justify-between"
+              data-testid={`${testIDText}-${getEntityName(
+                item as unknown as EntityReference
+              )}`}
+              key={index}>
+              <div className="flex items-center">
+                {getEntityIcon(item.type || '')}
+                <Link
+                  className="font-medium"
+                  to={getEntityLink(
+                    item.type || '',
+                    item.fullyQualifiedName as string
+                  )}>
+                  <Button
+                    className="entity-button"
+                    title={getEntityName(item as unknown as EntityReference)}
+                    type="text">
+                    <Typography.Text
+                      className="w-48 text-left"
+                      ellipsis={{ tooltip: true }}>
+                      {getEntityName(item as unknown as EntityReference)}
+                    </Typography.Text>
+                  </Button>
+                </Link>
               </div>
-            );
-          })
-        : noDataPlaceholder}
+            </div>
+          );
+        })
+      ) : (
+        noDataPlaceholder
+      )}
     </Card>
   );
 };

--- a/openmetadata-ui/src/main/resources/ui/src/components/MyData/MyData.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MyData/MyData.component.tsx
@@ -60,6 +60,7 @@ const MyData: React.FC<MyDataProps> = ({
   fetchFeedHandler,
   paging,
   updateThreadHandler,
+  isLoadingOwnedData,
 }: MyDataProps): React.ReactElement => {
   const isMounted = useRef(false);
   const [elementRef, isInView] = useInfiniteScroll(observerOptions);
@@ -138,6 +139,7 @@ const MyData: React.FC<MyDataProps> = ({
               </>
             }
             headerTextLabel="My Data"
+            isLoadingOwnedData={isLoadingOwnedData}
             noDataPlaceholder={<>You have not owned anything yet.</>}
             testIDText="My data"
           />
@@ -166,6 +168,7 @@ const MyData: React.FC<MyDataProps> = ({
               </>
             }
             headerTextLabel="Following"
+            isLoadingOwnedData={isLoadingOwnedData}
             noDataPlaceholder={<>You have not followed anything yet.</>}
             testIDText="Following data"
           />
@@ -173,7 +176,7 @@ const MyData: React.FC<MyDataProps> = ({
         <div className="tw-mt-5" />
       </>
     );
-  }, [ownedData, followedData, pendingTaskCount]);
+  }, [ownedData, followedData, pendingTaskCount, isLoadingOwnedData]);
 
   const fetchMoreFeed = useCallback(
     (isElementInView: boolean, pagingObj: Paging) => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/MyData/MyData.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MyData/MyData.interface.ts
@@ -31,6 +31,7 @@ export interface MyDataProps {
   userDetails?: User;
   ownedData: Array<EntityReference>;
   followedData: Array<EntityReference>;
+  isLoadingOwnedData: boolean;
   feedData: Thread[];
   paging: Paging;
   isFeedLoading: boolean;

--- a/openmetadata-ui/src/main/resources/ui/src/components/MyData/MyData.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MyData/MyData.test.tsx
@@ -340,6 +340,7 @@ const mockProp: MyDataProps = {
   fetchFeedHandler: mockFetchFeedHandler,
   followedData: currentUserMockData,
   isFeedLoading: false,
+  isLoadingOwnedData: false,
   ownedData: currentUserMockData,
   paging: mockPaging,
   postFeedHandler: postFeed,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/MyDataPage/MyDataPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/MyDataPage/MyDataPage.component.tsx
@@ -60,6 +60,7 @@ const MyDataPage = () => {
 
   const [entityThread, setEntityThread] = useState<Thread[]>([]);
   const [isFeedLoading, setIsFeedLoading] = useState<boolean>(false);
+  const [isLoadingOwnedData, setIsLoadingOwnedData] = useState<boolean>(false);
   const [isSandbox, setIsSandbox] = useState<boolean>(false);
 
   const [activityFeeds, setActivityFeeds] = useState<Thread[]>([]);
@@ -104,6 +105,7 @@ const MyDataPage = () => {
     if (!currentUser || !currentUser.id) {
       return;
     }
+    setIsLoadingOwnedData(true);
     try {
       const userData = await getUserById(currentUser?.id, 'follows, owns');
 
@@ -112,15 +114,15 @@ const MyDataPage = () => {
         const owns: EntityReference[] = userData.owns ?? [];
         const follows: EntityReference[] = userData.follows ?? [];
 
-        setFollowedDataCount(follows.length);
-        setOwnedDataCount(owns.length);
-
-        const includedOwnsData = owns.filter((data) =>
-          includeData.includes(data.type as AssetsType)
-        );
         const includedFollowsData = follows.filter((data) =>
           includeData.includes(data.type as AssetsType)
         );
+        const includedOwnsData = owns.filter((data) =>
+          includeData.includes(data.type as AssetsType)
+        );
+
+        setFollowedDataCount(includedFollowsData.length);
+        setOwnedDataCount(includedOwnsData.length);
 
         setFollowedData(includedFollowsData.slice(0, 8));
         setOwnedData(includedOwnsData.slice(0, 8));
@@ -128,6 +130,8 @@ const MyDataPage = () => {
     } catch (err) {
       setOwnedData([]);
       setFollowedData([]);
+    } finally {
+      setIsLoadingOwnedData(false);
     }
   };
 
@@ -307,6 +311,7 @@ const MyDataPage = () => {
             followedData={followedData || []}
             followedDataCount={followedDataCount}
             isFeedLoading={isFeedLoading}
+            isLoadingOwnedData={isLoadingOwnedData}
             ownedData={ownedData || []}
             ownedDataCount={ownedDataCount}
             paging={paging}

--- a/openmetadata-ui/src/main/resources/ui/src/pages/tour-page/TourPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/tour-page/TourPage.component.tsx
@@ -139,6 +139,7 @@ const TourPage = () => {
             followedData={[]}
             followedDataCount={1}
             isFeedLoading={false}
+            isLoadingOwnedData={false}
             ownedData={[]}
             ownedDataCount={1}
             paging={{} as Paging}


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on:

- Added skeleton loader for 'My Data' and 'Following' Section on the home page

https://user-images.githubusercontent.com/51777795/209053084-9b1252c7-88d0-45f9-9a08-9ceba10ca036.mov



- Fixed counts mismatch for the view all button in the 'My Data' Section
<img width="267" alt="Screenshot 2022-12-22 at 9 24 37 AM" src="https://user-images.githubusercontent.com/51777795/209052409-7154f823-2d34-4f03-97eb-7b0445dbc64d.png">

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @open-metadata/ui 
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
