### PR TITLE
fix redirection issue from entity details page to profiler page

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/ProfilerDashboardPage/ProfilerDashboardPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ProfilerDashboardPage/ProfilerDashboardPage.tsx
@@ -136,8 +136,9 @@ const ProfilerDashboardPage = () => {
   const fetchTableEntity = async () => {
     try {
       const fqn = isColumnView
-        ? getTableFQNFromColumnFQN(decodedEntityFQN)
-        : decodedEntityFQN;
+        ? getTableFQNFromColumnFQN(entityTypeFQN)
+        : entityTypeFQN;
+
       const field = `tags, usageSummary, owner, followers${
         isColumnView ? ', profile' : ''
       }`;


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
fix redirection issue from entity details page to profiler page

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :


https://user-images.githubusercontent.com/71748675/209129183-8aa88012-6fb3-42e0-843f-13c0cd262fdb.mov


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
