### PR TITLE
Fix issue with rebuilding ES web analytics report indices

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -3111,18 +3111,34 @@ public interface CollectionDAO {
     int listCount(@Bind("entityFQN") String entityFQN);
 
     @RegisterRowMapper(ReportDataMapper.class)
-    @SqlQuery(
-        "WITH data AS (SELECT ROW_NUMBER() OVER(ORDER BY timestamp ASC) AS row_num, json "
-            + "FROM entity_extension_time_series WHERE EntityFQN = :entityFQN) "
-            + "SELECT row_num, json FROM data WHERE row_num < :before LIMIT :limit")
+    @ConnectionAwareSqlQuery(
+        value =
+            "WITH data AS (SELECT ROW_NUMBER() OVER(ORDER BY timestamp ASC) AS row_num, json "
+                + "FROM entity_extension_time_series WHERE EntityFQN = :entityFQN) "
+                + "SELECT row_num, json FROM data WHERE row_num < :before LIMIT :limit",
+        connectionType = MYSQL)
+    @ConnectionAwareSqlQuery(
+        value =
+            "WITH data AS (SELECT ROW_NUMBER() OVER(ORDER BY timestamp ASC) AS row_num, json "
+                + "FROM entity_extension_time_series WHERE EntityFQN = :entityFQN) "
+                + "SELECT row_num, json FROM data WHERE row_num < (:before)::INTEGER LIMIT :limit",
+        connectionType = POSTGRES)
     List<ReportDataRow> getBeforeExtension(
         @Bind("entityFQN") String entityFQN, @Bind("limit") int limit, @Bind("before") String before);
 
     @RegisterRowMapper(ReportDataMapper.class)
-    @SqlQuery(
-        "WITH data AS (SELECT ROW_NUMBER() OVER(ORDER BY timestamp ASC) AS row_num, json "
-            + "FROM entity_extension_time_series WHERE EntityFQN = :entityFQN) "
-            + "SELECT row_num, json FROM data WHERE row_num > :after LIMIT :limit")
+    @ConnectionAwareSqlQuery(
+        value =
+            "WITH data AS (SELECT ROW_NUMBER() OVER(ORDER BY timestamp ASC) AS row_num, json "
+                + "FROM entity_extension_time_series WHERE EntityFQN = :entityFQN) "
+                + "SELECT row_num, json FROM data WHERE row_num > :after LIMIT :limit",
+        connectionType = MYSQL)
+    @ConnectionAwareSqlQuery(
+        value =
+            "WITH data AS (SELECT ROW_NUMBER() OVER(ORDER BY timestamp ASC) AS row_num, json "
+                + "FROM entity_extension_time_series WHERE EntityFQN = :entityFQN) "
+                + "SELECT row_num, json FROM data WHERE row_num > (:after)::INTEGER LIMIT :limit",
+        connectionType = POSTGRES)
     List<ReportDataRow> getAfterExtension(
         @Bind("entityFQN") String entityFQN, @Bind("limit") int limit, @Bind("after") String after);
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/elasticsearch/BuildSearchIndexResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/elasticsearch/BuildSearchIndexResource.java
@@ -272,7 +272,7 @@ public class BuildSearchIndexResource {
     } else {
       reportDataList =
           dao.entityExtensionTimeSeriesDao()
-              .getAfterExtension(entityFQN, limit + 1, after == null ? "" : RestUtil.decodeCursor(after));
+              .getAfterExtension(entityFQN, limit + 1, after == null ? "0" : RestUtil.decodeCursor(after));
     }
     ResultList<ReportData> reportDataResultList;
     if (before != null) {

--- a/openmetadata-ui/src/main/resources/ui/src/constants/elasticsearch.constant.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/elasticsearch.constant.ts
@@ -55,11 +55,11 @@ export const ELASTIC_SEARCH_INDEX_ENTITIES = [
     label: t('label.data-assets-report'),
   },
   {
-    value: 'webAnalyticEntityViewReport',
+    value: 'webAnalyticEntityViewReportData',
     label: t('label.web-analytics-report'),
   },
   {
-    value: 'webAnalyticUserActivityReport',
+    value: 'webAnalyticUserActivityReportData',
     label: t('label.user-analytics-report'),
   },
 ];
@@ -76,8 +76,8 @@ export const ELASTIC_SEARCH_INITIAL_VALUES = {
     'glossaryTerm',
     'tag',
     'entityReportData',
-    'webAnalyticEntityViewReport',
-    'webAnalyticUserActivityReport',
+    'webAnalyticEntityViewReportData',
+    'webAnalyticUserActivityReportData',
   ],
   batchSize: 100,
   flushIntervalInSec: 30,


### PR DESCRIPTION
### Describe your changes :
Rebuilding ES indices for web analytics reports on OpenMetadata version 0.13.1 running on Postgres runs into the following problem:

```
Failed in listing all ReportData
Reason : org.jdbi.v3.core.statement.UnableToExecuteStatementException: org.postgresql.util.PSQLException: ERROR: operator does not exist: bigint > character varying
Hint: No operator matches the given name and argument types. You might need to add explicit type casts.
Position: 235 [statement:"/* EntityExtensionTimeSeriesDAO.getAfterExtension */ WITH data AS (SELECT ROW_NUMBER() OVER(ORDER BY timestamp ASC) AS row_num, json FROM entity_extension_time_series WHERE EntityFQN = :entityFQN) SELECT row_num, json FROM data WHERE row_num > :after LIMIT :limit", arguments:{positional:{0:EntityReportData,1:101,2:}, named:{limit:101,entityFQN:EntityReportData,after:}, finder:[]}]
```

because Postgres does not cast strings to integers.

Another issue is caused by the wrong index name in the UI (missing the "Data" suffix):

```
ERROR [2023-01-03 17:46:51,499] [pool-5-thread-1] o.o.s.r.e.BuildSearchIndexResource - Reindexing intermittent failure for entityType : webAnalyticUserActivityReport
java.lang.RuntimeException: Failed to find index doc for type webAnalyticUserActivityReport
	at org.openmetadata.service.elasticsearch.ElasticSearchIndexDefinition.getIndexMappingByEntityType(ElasticSearchIndexDefinition.java:216)
	at org.openmetadata.service.resources.elasticsearch.BuildSearchIndexResource.updateEntityBatch(BuildSearchIndexResource.java:360)
	at org.openmetadata.service.resources.elasticsearch.BuildSearchIndexResource.submitBatchJob(BuildSearchIndexResource.java:258)
	at org.openmetadata.service.resources.elasticsearch.BuildSearchIndexResource.lambda$startReindexingBatchMode$2(BuildSearchIndexResource.java:194)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:264)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
Backend: @open-metadata/backend
<!--- Ingestion: @open-metadata/ingestion -->
