### PR TITLE
chore(ui) : Organize imports from baseURL with tsconfig-paths-webpack-plugin

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/jest.config.js
+++ b/openmetadata-ui/src/main/resources/ui/jest.config.js
@@ -60,9 +60,6 @@ module.exports = {
     '@fortawesome/react-fontawesome':
       '<rootDir>/src/test/unit/mocks/fontawesome.mock.js',
     '@github/g-emoji-element': '<rootDir>/src/test/unit/mocks/gemoji.mock.js',
-    '^@rest/(.*)$': '<rootDir>/src/rest/$1',
-    '^@pages/(.*)$': '<rootDir>/src/pages/$1',
-    '^@components/(.*)$': '<rootDir>/src/components/$1',
   },
 
   // TypeScript
@@ -76,4 +73,6 @@ module.exports = {
 
   // use fake timers
   timers: 'fake',
+
+  moduleDirectories: ['node_modules', 'src'],
 };

--- a/openmetadata-ui/src/main/resources/ui/package.json
+++ b/openmetadata-ui/src/main/resources/ui/package.json
@@ -208,6 +208,7 @@
     "style-loader": "^3.3.1",
     "ts-jest": "^26.4.4",
     "ts-loader": "^8.0.14",
+    "tsconfig-paths-webpack-plugin": "^4.0.0",
     "tslib": "^2.4.1",
     "typescript": "^4.2.4",
     "url-loader": "^4.1.1",

--- a/openmetadata-ui/src/main/resources/ui/src/App.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/App.test.tsx
@@ -11,22 +11,22 @@
  *  limitations under the License.
  */
 
-import { AuthContext } from '@components/authentication/auth-provider/AuthProvider';
 import { render } from '@testing-library/react';
+import { AuthContext } from 'components/authentication/auth-provider/AuthProvider';
 import React from 'react';
 import App from './App';
 
 const authContext = jest.fn();
 
-jest.mock('@components/router/AppRouter', () => {
+jest.mock('components/router/AppRouter', () => {
   return jest.fn().mockReturnValue(<p>AppRouter</p>);
 });
 
-jest.mock('@components/app-bar/Appbar', () => {
+jest.mock('components/app-bar/Appbar', () => {
   return jest.fn().mockReturnValue(<p>AppBar</p>);
 });
 
-jest.mock('@components/authentication/auth-provider/AuthProvider', () => {
+jest.mock('components/authentication/auth-provider/AuthProvider', () => {
   return {
     AuthProvider: jest
       .fn()

--- a/openmetadata-ui/src/main/resources/ui/src/App.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/App.tsx
@@ -11,14 +11,6 @@
  *  limitations under the License.
  */
 
-import Appbar from '@components/app-bar/Appbar';
-import { AuthProvider } from '@components/authentication/auth-provider/AuthProvider';
-import ErrorBoundry from '@components/ErrorBoundry/ErrorBoundry';
-import GlobalSearchProvider from '@components/GlobalSearchProvider/GlobalSearchProvider';
-import PermissionProvider from '@components/PermissionProvider/PermissionProvider';
-import AppRouter from '@components/router/AppRouter';
-import WebSocketProvider from '@components/web-scoket/web-scoket.provider';
-import WebAnalyticsProvider from '@components/WebAnalytics/WebAnalyticsProvider';
 import { library } from '@fortawesome/fontawesome-svg-core';
 import {
   faCheck,
@@ -32,11 +24,19 @@ import {
   faSearch,
   faTimes,
 } from '@fortawesome/free-solid-svg-icons';
+import Appbar from 'components/app-bar/Appbar';
+import { AuthProvider } from 'components/authentication/auth-provider/AuthProvider';
+import ErrorBoundry from 'components/ErrorBoundry/ErrorBoundry';
+import GlobalSearchProvider from 'components/GlobalSearchProvider/GlobalSearchProvider';
+import PermissionProvider from 'components/PermissionProvider/PermissionProvider';
+import AppRouter from 'components/router/AppRouter';
+import WebSocketProvider from 'components/web-scoket/web-scoket.provider';
+import WebAnalyticsProvider from 'components/WebAnalytics/WebAnalyticsProvider';
+import { TOAST_OPTIONS } from 'constants/Toasts.constants';
 import React, { FunctionComponent } from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.min.css';
-import { TOAST_OPTIONS } from './constants/Toasts.constants';
 
 const App: FunctionComponent = () => {
   library.add(

--- a/openmetadata-ui/src/main/resources/ui/src/AppState.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/AppState.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { EntityData } from '@components/common/PopOverCard/EntityPopOverCard';
+import { EntityData } from 'components/common/PopOverCard/EntityPopOverCard';
 import { isEmpty, isNil, isUndefined } from 'lodash';
 import { action, makeAutoObservable } from 'mobx';
 import { ClientAuth, NewUser } from 'Models';

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCard/FeedCardHeader/FeedCardHeader.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCard/FeedCardHeader/FeedCardHeader.test.tsx
@@ -26,7 +26,7 @@ const FQN = 'service.database.schema.table';
 const type = 'table';
 const expectedDisplayName = 'database.schema.table';
 
-jest.mock('@rest/userAPI', () => ({
+jest.mock('rest/userAPI', () => ({
   getUserByName: jest.fn().mockReturnValue({}),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedPanel/ActivityFeedPanel.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedPanel/ActivityFeedPanel.test.tsx
@@ -75,7 +75,7 @@ jest.mock('./FeedPanelOverlay', () => {
   return jest.fn().mockReturnValue(<p>FeedPanelOverlay</p>);
 });
 
-jest.mock('@rest/feedsAPI', () => ({
+jest.mock('rest/feedsAPI', () => ({
   getFeedById: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedPanel/ActivityFeedPanel.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedPanel/ActivityFeedPanel.tsx
@@ -11,10 +11,10 @@
  *  limitations under the License.
  */
 
-import { getFeedById } from '@rest/feedsAPI';
 import { AxiosError } from 'axios';
 import classNames from 'classnames';
 import React, { FC, useEffect, useState } from 'react';
+import { getFeedById } from 'rest/feedsAPI';
 import { confirmStateInitialValue } from '../../../constants/Feeds.constants';
 import { Thread } from '../../../generated/entity/feed/thread';
 import jsonData from '../../../jsons/en';

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityThreadPanel/ActivityThread.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityThreadPanel/ActivityThread.test.tsx
@@ -28,7 +28,7 @@ const mockActivityThreadProp = {
   updateThreadHandler: jest.fn(),
 };
 
-jest.mock('@rest/feedsAPI', () => ({
+jest.mock('rest/feedsAPI', () => ({
   getFeedById: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityThreadPanel/ActivityThread.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityThreadPanel/ActivityThread.tsx
@@ -11,10 +11,10 @@
  *  limitations under the License.
  */
 
-import { getFeedById } from '@rest/feedsAPI';
 import { AxiosError } from 'axios';
 import React, { FC, Fragment, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { getFeedById } from 'rest/feedsAPI';
 import {
   Post,
   Thread,

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityThreadPanel/ActivityThreadPanel.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityThreadPanel/ActivityThreadPanel.test.tsx
@@ -33,7 +33,7 @@ const mockActivityThreadPanelProp = {
   updateThreadHandler: jest.fn(),
 };
 
-jest.mock('@rest/feedsAPI', () => ({
+jest.mock('rest/feedsAPI', () => ({
   getAllFeeds: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityThreadPanel/ActivityThreadPanelBody.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityThreadPanel/ActivityThreadPanelBody.test.tsx
@@ -28,7 +28,7 @@ const mockActivityThreadPanelBodyBodyProp = {
   threadType: ThreadType.Conversation,
 };
 
-jest.mock('@rest/feedsAPI', () => ({
+jest.mock('rest/feedsAPI', () => ({
   getAllFeeds: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityThreadPanel/ActivityThreadPanelBody.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityThreadPanel/ActivityThreadPanelBody.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 
-import { getAllFeeds } from '@rest/feedsAPI';
 import { Button, Switch } from 'antd';
 import { AxiosError } from 'axios';
 import classNames from 'classnames';
@@ -19,6 +18,7 @@ import { Operation } from 'fast-json-patch';
 import { isEqual, isUndefined } from 'lodash';
 import React, { FC, Fragment, RefObject, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { getAllFeeds } from 'rest/feedsAPI';
 import AppState from '../../../AppState';
 import { confirmStateInitialValue } from '../../../constants/Feeds.constants';
 import { observerOptions } from '../../../constants/Mydata.constants';

--- a/openmetadata-ui/src/main/resources/ui/src/components/AddDataQualityTest/AddDataQualityTestV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AddDataQualityTest/AddDataQualityTestV1.tsx
@@ -11,12 +11,12 @@
  *  limitations under the License.
  */
 
-import { createTestCase, createTestSuites } from '@rest/testAPI';
 import { Col, Row, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import { isUndefined } from 'lodash';
 import React, { useCallback, useMemo, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
+import { createTestCase, createTestSuites } from 'rest/testAPI';
 import {
   getDatabaseDetailsPath,
   getDatabaseSchemaDetailsPath,

--- a/openmetadata-ui/src/main/resources/ui/src/components/AddDataQualityTest/EditTestCaseModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AddDataQualityTest/EditTestCaseModal.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 
-import { getTestDefinitionById, updateTestCaseById } from '@rest/testAPI';
 import { Form, FormProps, Input } from 'antd';
 import Modal from 'antd/lib/modal/Modal';
 import { AxiosError } from 'axios';
@@ -24,6 +23,7 @@ import React, {
   useState,
 } from 'react';
 import { useTranslation } from 'react-i18next';
+import { getTestDefinitionById, updateTestCaseById } from 'rest/testAPI';
 import { CSMode } from '../../enums/codemirror.enum';
 import { TestCaseParameterValue } from '../../generated/tests/testCase';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/components/AddDataQualityTest/TestSuiteIngestion.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AddDataQualityTest/TestSuiteIngestion.tsx
@@ -11,16 +11,16 @@
  *  limitations under the License.
  */
 
-import {
-  addIngestionPipeline,
-  deployIngestionPipelineById,
-  updateIngestionPipeline as putIngestionPipeline,
-} from '@rest/ingestionPipelineAPI';
 import { Col, Row, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import { camelCase, isEmpty } from 'lodash';
 import React, { useMemo, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
+import {
+  addIngestionPipeline,
+  deployIngestionPipelineById,
+  updateIngestionPipeline as putIngestionPipeline,
+} from 'rest/ingestionPipelineAPI';
 import {
   DEPLOYED_PROGRESS_VAL,
   INGESTION_PROGRESS_END_VAL,

--- a/openmetadata-ui/src/main/resources/ui/src/components/AddDataQualityTest/components/SelectTestSuite.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AddDataQualityTest/components/SelectTestSuite.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 
-import { getListTestSuites } from '@rest/testAPI';
 import {
   Button,
   Divider,
@@ -28,6 +27,7 @@ import { AxiosError } from 'axios';
 import { isEmpty } from 'lodash';
 import React, { useEffect, useRef, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
+import { getListTestSuites } from 'rest/testAPI';
 import {
   API_RES_MAX_SIZE,
   getTableTabPath,

--- a/openmetadata-ui/src/main/resources/ui/src/components/AddDataQualityTest/components/TestCaseForm.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AddDataQualityTest/components/TestCaseForm.tsx
@@ -11,12 +11,12 @@
  *  limitations under the License.
  */
 
-import { getListTestCase, getListTestDefinitions } from '@rest/testAPI';
 import { Button, Form, FormProps, Input, Select, Space } from 'antd';
 import { AxiosError } from 'axios';
 import { isEmpty } from 'lodash';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { getListTestCase, getListTestDefinitions } from 'rest/testAPI';
 import { API_RES_MAX_SIZE } from '../../../constants/constants';
 import { CSMode } from '../../../enums/codemirror.enum';
 import { ProfilerDashboardType } from '../../../enums/table.enum';

--- a/openmetadata-ui/src/main/resources/ui/src/components/AddGlossary/AddGlossary.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AddGlossary/AddGlossary.test.tsx
@@ -37,7 +37,7 @@ jest.mock('../common/rich-text-editor/RichTextEditor', () => {
   );
 });
 
-jest.mock('@rest/glossaryAPI', () => ({
+jest.mock('rest/glossaryAPI', () => ({
   addGlossaries: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/AddGlossaryTerm/AddGlossaryTerm.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AddGlossaryTerm/AddGlossaryTerm.test.tsx
@@ -20,7 +20,7 @@ import {
 } from '../../mocks/Glossary.mock';
 import AddGlossaryTerm from './AddGlossaryTerm.component';
 
-jest.mock('@rest/glossaryAPI', () => ({
+jest.mock('rest/glossaryAPI', () => ({
   addGlossaries: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/BotDetails/AuthMechanismForm.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BotDetails/AuthMechanismForm.tsx
@@ -11,14 +11,14 @@
  *  limitations under the License.
  */
 
-import { checkEmailInUse } from '@rest/auth-API';
-import { createBotWithPut } from '@rest/botsAPI';
-import { createUserWithPut, getUserByName } from '@rest/userAPI';
 import { Button, Form, Input, Modal, Select, Space, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import { isEmpty } from 'lodash';
 import React, { FC, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { checkEmailInUse } from 'rest/auth-API';
+import { createBotWithPut } from 'rest/botsAPI';
+import { createUserWithPut, getUserByName } from 'rest/userAPI';
 import { validEmailRegEx } from '../../constants/regex.constants';
 import { EntityType } from '../../enums/entity.enum';
 import { SsoServiceType } from '../../generated/auth/ssoAuth';

--- a/openmetadata-ui/src/main/resources/ui/src/components/BotDetails/BotDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BotDetails/BotDetails.component.tsx
@@ -11,17 +11,17 @@
  *  limitations under the License.
  */
 
-import { createBotWithPut } from '@rest/botsAPI';
-import {
-  createUserWithPut,
-  getAuthMechanismForBotUser,
-  getRoles,
-} from '@rest/userAPI';
 import { Card, Col, Row, Space, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import { toLower } from 'lodash';
 import React, { FC, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { createBotWithPut } from 'rest/botsAPI';
+import {
+  createUserWithPut,
+  getAuthMechanismForBotUser,
+  getRoles,
+} from 'rest/userAPI';
 import { TERM_ADMIN } from '../../constants/constants';
 import {
   GlobalSettingOptions,

--- a/openmetadata-ui/src/main/resources/ui/src/components/BotDetails/BotDetails.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BotDetails/BotDetails.test.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 
-import { getAuthMechanismForBotUser } from '@rest/userAPI';
 import {
   act,
   findByTestId,
@@ -21,6 +20,7 @@ import {
 } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
+import { getAuthMechanismForBotUser } from 'rest/userAPI';
 import { OperationPermission } from '../PermissionProvider/PermissionProvider.interface';
 import BotDetails from './BotDetails.component';
 
@@ -99,7 +99,7 @@ jest.mock('../../utils/PermissionsUtils', () => ({
   checkPermission: jest.fn().mockReturnValue(true),
 }));
 
-jest.mock('@rest/userAPI', () => {
+jest.mock('rest/userAPI', () => {
   return {
     createUserWithPut: jest
       .fn()

--- a/openmetadata-ui/src/main/resources/ui/src/components/BotListV1/BotListV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BotListV1/BotListV1.component.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 
-import { getBots } from '@rest/botsAPI';
 import { Button, Col, Row, Space, Switch, Table, Tooltip } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
 import { AxiosError } from 'axios';
@@ -19,6 +18,7 @@ import { isEmpty, lowerCase } from 'lodash';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
+import { getBots } from 'rest/botsAPI';
 import {
   getBotsPath,
   INITIAL_PAGING_VALUE,

--- a/openmetadata-ui/src/main/resources/ui/src/components/CreateUser/CreateUser.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/CreateUser/CreateUser.component.tsx
@@ -12,7 +12,6 @@
  */
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { checkEmailInUse, generateRandomPwd } from '@rest/auth-API';
 import {
   Button,
   Form,
@@ -28,6 +27,7 @@ import classNames from 'classnames';
 import { isUndefined, trim } from 'lodash';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { checkEmailInUse, generateRandomPwd } from 'rest/auth-API';
 import { getBotsPagePath, getUsersPagePath } from '../../constants/constants';
 import { passwordErrorMessage } from '../../constants/ErrorMessages.constant';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/components/CustomEntityDetail/AddCustomProperty/AddCustomProperty.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/CustomEntityDetail/AddCustomProperty/AddCustomProperty.test.tsx
@@ -11,10 +11,10 @@
  *  limitations under the License.
  */
 
-import { addPropertyToEntity } from '@rest/metadataTypeAPI';
 import { findByTestId, fireEvent, render } from '@testing-library/react';
 import React, { forwardRef } from 'react';
 import { MemoryRouter } from 'react-router-dom';
+import { addPropertyToEntity } from 'rest/metadataTypeAPI';
 import AddCustomProperty from './AddCustomProperty';
 
 const mockPropertyTypes = [
@@ -184,7 +184,7 @@ jest.mock('react-router-dom', () => ({
   }),
 }));
 
-jest.mock('@rest/metadataTypeAPI', () => ({
+jest.mock('rest/metadataTypeAPI', () => ({
   addPropertyToEntity: jest
     .fn()
     .mockImplementation(() => Promise.resolve(mockPropertyTypes[0])),

--- a/openmetadata-ui/src/main/resources/ui/src/components/CustomEntityDetail/AddCustomProperty/AddCustomProperty.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/CustomEntityDetail/AddCustomProperty/AddCustomProperty.tsx
@@ -11,16 +11,16 @@
  *  limitations under the License.
  */
 
-import {
-  addPropertyToEntity,
-  getTypeByFQN,
-  getTypeListByCategory,
-} from '@rest/metadataTypeAPI';
 import { AxiosError } from 'axios';
 import { uniqueId } from 'lodash';
 import { FormErrorData } from 'Models';
 import React, { useEffect, useRef, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
+import {
+  addPropertyToEntity,
+  getTypeByFQN,
+  getTypeListByCategory,
+} from 'rest/metadataTypeAPI';
 import { SUPPORTED_FIELD_TYPES } from '../../../constants/constants';
 import { PageLayoutType } from '../../../enums/layout.enum';
 import { Category, Type } from '../../../generated/entity/type';

--- a/openmetadata-ui/src/main/resources/ui/src/components/DashboardDetails/DashboardDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DashboardDetails/DashboardDetails.component.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 
-import { restoreDashboard } from '@rest/dashboardAPI';
 import { Space, Table, Tooltip } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
 import { AxiosError } from 'axios';
@@ -27,6 +26,7 @@ import React, {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useHistory } from 'react-router-dom';
+import { restoreDashboard } from 'rest/dashboardAPI';
 import { FQN_SEPARATOR_CHAR } from '../../constants/char.constants';
 import { EntityField } from '../../constants/Feeds.constants';
 import { observerOptions } from '../../constants/Mydata.constants';

--- a/openmetadata-ui/src/main/resources/ui/src/components/DashboardVersion/DashboardVersion.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DashboardVersion/DashboardVersion.component.tsx
@@ -14,7 +14,7 @@
 import { Space, Table } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
 import classNames from 'classnames';
-import PageContainerV1 from 'components/containers/PageContainerV1';
+import PageContainer from 'components/containers/PageContainer';
 import { isUndefined } from 'lodash';
 import { ExtraInfo } from 'Models';
 import React, { FC, useEffect, useMemo, useState } from 'react';
@@ -260,7 +260,7 @@ const DashboardVersion: FC<DashboardVersionProp> = ({
   );
 
   return (
-    <PageContainerV1>
+    <PageContainer>
       <div
         className={classNames(
           'tw-px-6 tw-w-full tw-h-full tw-flex tw-flex-col tw-relative'
@@ -321,7 +321,7 @@ const DashboardVersion: FC<DashboardVersionProp> = ({
           onBack={backHandler}
         />
       </div>
-    </PageContainerV1>
+    </PageContainer>
   );
 };
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DashboardVersion/DashboardVersion.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DashboardVersion/DashboardVersion.component.tsx
@@ -14,6 +14,7 @@
 import { Space, Table } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
 import classNames from 'classnames';
+import PageContainerV1 from 'components/containers/PageContainerV1';
 import { isUndefined } from 'lodash';
 import { ExtraInfo } from 'Models';
 import React, { FC, useEffect, useMemo, useState } from 'react';
@@ -39,7 +40,6 @@ import Description from '../common/description/Description';
 import EntityPageInfo from '../common/entityPageInfo/EntityPageInfo';
 import RichTextEditorPreviewer from '../common/rich-text-editor/RichTextEditorPreviewer';
 import TabsPane from '../common/TabsPane/TabsPane';
-import PageContainer from '../containers/PageContainer';
 import EntityVersionTimeLine from '../EntityVersionTimeLine/EntityVersionTimeLine';
 import Loader from '../Loader/Loader';
 import { DashboardVersionProp } from './DashboardVersion.interface';
@@ -260,7 +260,7 @@ const DashboardVersion: FC<DashboardVersionProp> = ({
   );
 
   return (
-    <PageContainer>
+    <PageContainerV1>
       <div
         className={classNames(
           'tw-px-6 tw-w-full tw-h-full tw-flex tw-flex-col tw-relative'
@@ -321,7 +321,7 @@ const DashboardVersion: FC<DashboardVersionProp> = ({
           onBack={backHandler}
         />
       </div>
-    </PageContainer>
+    </PageContainerV1>
   );
 };
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DashboardVersion/DashboardVersion.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DashboardVersion/DashboardVersion.interface.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { VersionData } from '@pages/EntityVersionPage/EntityVersionPage.component';
+import { VersionData } from 'pages/EntityVersionPage/EntityVersionPage.component';
 import { Dashboard } from '../../generated/entity/data/dashboard';
 import { EntityHistory } from '../../generated/type/entityHistory';
 import { TagLabel } from '../../generated/type/tagLabel';

--- a/openmetadata-ui/src/main/resources/ui/src/components/DashboardVersion/dashboardVersion.mock.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DashboardVersion/dashboardVersion.mock.ts
@@ -12,7 +12,7 @@
  */
 /* eslint-disable max-len */
 
-import { VersionData } from '@pages/EntityVersionPage/EntityVersionPage.component';
+import { VersionData } from 'pages/EntityVersionPage/EntityVersionPage.component';
 import { DashboardVersionProp } from './DashboardVersion.interface';
 
 export const dashboardVersionProps = {

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/DailyActiveUsersChart.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/DailyActiveUsersChart.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 
-import { getAggregateChartData } from '@rest/DataInsightAPI';
 import { Card, Col, Row, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import React, { FC, useEffect, useMemo, useState } from 'react';
@@ -27,6 +26,7 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
+import { getAggregateChartData } from 'rest/DataInsightAPI';
 import { GRAPH_BACKGROUND_COLOR } from '../../constants/constants';
 import {
   BAR_CHART_MARGIN,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/DataInsightSummary.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/DataInsightSummary.test.tsx
@@ -36,7 +36,7 @@ jest.mock('react-router-dom', () => ({
   })),
 }));
 
-jest.mock('@rest/DataInsightAPI', () => ({
+jest.mock('rest/DataInsightAPI', () => ({
   getAggregateChartData: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/DataInsightSummary.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/DataInsightSummary.tsx
@@ -11,13 +11,13 @@
  *  limitations under the License.
  */
 
-import { getAggregateChartData } from '@rest/DataInsightAPI';
-import { getTeamByName } from '@rest/teamsAPI';
 import { Card, Col, Row, Space, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import React, { FC, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useParams } from 'react-router-dom';
+import { getAggregateChartData } from 'rest/DataInsightAPI';
+import { getTeamByName } from 'rest/teamsAPI';
 import { getUserPath } from '../../constants/constants';
 import {
   ENTITIES_CHARTS,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/DescriptionInsight.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/DescriptionInsight.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 
-import { getAggregateChartData } from '@rest/DataInsightAPI';
 import { Card, Col, Row, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import { isEmpty, uniqueId } from 'lodash';
@@ -28,6 +27,7 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
+import { getAggregateChartData } from 'rest/DataInsightAPI';
 import {
   DEFAULT_CHART_OPACITY,
   GRAPH_BACKGROUND_COLOR,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/KPIChart.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/KPIChart.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 
-import { getLatestKpiResult, getListKpiResult } from '@rest/KpiAPI';
 import {
   Button,
   Card,
@@ -37,6 +36,7 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
+import { getLatestKpiResult, getListKpiResult } from 'rest/KpiAPI';
 import {
   DEFAULT_CHART_OPACITY,
   GRAPH_BACKGROUND_COLOR,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/OwnerInsight.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/OwnerInsight.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 
-import { getAggregateChartData } from '@rest/DataInsightAPI';
 import { Card, Col, Row, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import { isEmpty, uniqueId } from 'lodash';
@@ -28,6 +27,7 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
+import { getAggregateChartData } from 'rest/DataInsightAPI';
 import {
   DEFAULT_CHART_OPACITY,
   GRAPH_BACKGROUND_COLOR,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/PageViewsByEntitiesChart.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/PageViewsByEntitiesChart.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 
-import { getAggregateChartData } from '@rest/DataInsightAPI';
 import { Card, Col, Row, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import { isEmpty, uniqueId } from 'lodash';
@@ -28,6 +27,7 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
+import { getAggregateChartData } from 'rest/DataInsightAPI';
 import {
   DEFAULT_CHART_OPACITY,
   GRAPH_BACKGROUND_COLOR,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/TierInsight.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/TierInsight.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 
-import { getAggregateChartData } from '@rest/DataInsightAPI';
 import { Card, Col, Row, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import { isEmpty, uniqueId } from 'lodash';
@@ -28,6 +27,7 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
+import { getAggregateChartData } from 'rest/DataInsightAPI';
 import {
   DEFAULT_CHART_OPACITY,
   GRAPH_BACKGROUND_COLOR,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/TopActiveUsers.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/TopActiveUsers.tsx
@@ -11,13 +11,13 @@
  *  limitations under the License.
  */
 
-import { getAggregateChartData } from '@rest/DataInsightAPI';
 import { Card, Space, Table, Typography } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
 import { AxiosError } from 'axios';
 import React, { FC, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
+import { getAggregateChartData } from 'rest/DataInsightAPI';
 import { getUserPath } from '../../constants/constants';
 import { DataReportIndex } from '../../generated/dataInsight/dataInsightChart';
 import { DataInsightChartType } from '../../generated/dataInsight/dataInsightChartResult';

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/TopViewEntities.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/TopViewEntities.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 
-import { getAggregateChartData } from '@rest/DataInsightAPI';
 import { Card, Space, Table, Typography } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
 import { AxiosError } from 'axios';
@@ -19,6 +18,7 @@ import { isUndefined } from 'lodash';
 import React, { FC, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
+import { getAggregateChartData } from 'rest/DataInsightAPI';
 import { DataReportIndex } from '../../generated/dataInsight/dataInsightChart';
 import { DataInsightChartType } from '../../generated/dataInsight/dataInsightChartResult';
 import { MostViewedEntities } from '../../generated/dataInsight/type/mostViewedEntities';

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/TotalEntityInsight.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/TotalEntityInsight.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 
-import { getAggregateChartData } from '@rest/DataInsightAPI';
 import { Card, Col, Row, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import { isEmpty, uniqueId } from 'lodash';
@@ -28,6 +27,7 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
+import { getAggregateChartData } from 'rest/DataInsightAPI';
 import {
   DEFAULT_CHART_OPACITY,
   GRAPH_BACKGROUND_COLOR,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DatasetDetails/DatasetDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DatasetDetails/DatasetDetails.component.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 
-import { restoreTable } from '@rest/tableAPI';
 import { Col, Row } from 'antd';
 import { AxiosError } from 'axios';
 import classNames from 'classnames';
@@ -20,6 +19,7 @@ import { EntityTags, ExtraInfo } from 'Models';
 import React, { RefObject, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
+import { restoreTable } from 'rest/tableAPI';
 import { FQN_SEPARATOR_CHAR } from '../../constants/char.constants';
 import { ROUTES } from '../../constants/constants';
 import { EntityField } from '../../constants/Feeds.constants';

--- a/openmetadata-ui/src/main/resources/ui/src/components/DatasetVersion/DatasetVersion.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DatasetVersion/DatasetVersion.component.tsx
@@ -12,7 +12,7 @@
  */
 
 import classNames from 'classnames';
-import PageContainerV1 from 'components/containers/PageContainerV1';
+import PageContainer from 'components/containers/PageContainer';
 
 import { cloneDeep, isEqual, isUndefined } from 'lodash';
 import { ExtraInfo } from 'Models';
@@ -376,7 +376,7 @@ const DatasetVersion: React.FC<DatasetVersionProp> = ({
   }, [currentVersionData]);
 
   return (
-    <PageContainerV1>
+    <PageContainer>
       <div
         className={classNames(
           'tw-px-6 tw-w-full tw-h-full tw-flex tw-flex-col tw-relative'
@@ -435,7 +435,7 @@ const DatasetVersion: React.FC<DatasetVersionProp> = ({
           onBack={backHandler}
         />
       </div>
-    </PageContainerV1>
+    </PageContainer>
   );
 };
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DatasetVersion/DatasetVersion.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DatasetVersion/DatasetVersion.component.tsx
@@ -12,6 +12,8 @@
  */
 
 import classNames from 'classnames';
+import PageContainerV1 from 'components/containers/PageContainerV1';
+
 import { cloneDeep, isEqual, isUndefined } from 'lodash';
 import { ExtraInfo } from 'Models';
 import React, { useEffect, useState } from 'react';
@@ -38,7 +40,6 @@ import { TagLabelWithStatus } from '../../utils/EntityVersionUtils.interface';
 import Description from '../common/description/Description';
 import EntityPageInfo from '../common/entityPageInfo/EntityPageInfo';
 import TabsPane from '../common/TabsPane/TabsPane';
-import PageContainer from '../containers/PageContainer';
 import EntityVersionTimeLine from '../EntityVersionTimeLine/EntityVersionTimeLine';
 import Loader from '../Loader/Loader';
 import VersionTable from '../VersionTable/VersionTable.component';
@@ -375,7 +376,7 @@ const DatasetVersion: React.FC<DatasetVersionProp> = ({
   }, [currentVersionData]);
 
   return (
-    <PageContainer>
+    <PageContainerV1>
       <div
         className={classNames(
           'tw-px-6 tw-w-full tw-h-full tw-flex tw-flex-col tw-relative'
@@ -434,7 +435,7 @@ const DatasetVersion: React.FC<DatasetVersionProp> = ({
           onBack={backHandler}
         />
       </div>
-    </PageContainer>
+    </PageContainerV1>
   );
 };
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DatasetVersion/DatasetVersion.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DatasetVersion/DatasetVersion.interface.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { VersionData } from '@pages/EntityVersionPage/EntityVersionPage.component';
+import { VersionData } from 'pages/EntityVersionPage/EntityVersionPage.component';
 import { Table } from '../../generated/entity/data/table';
 import { EntityHistory } from '../../generated/type/entityHistory';
 import { TagLabel } from '../../generated/type/tagLabel';

--- a/openmetadata-ui/src/main/resources/ui/src/components/EntityInfoDrawer/EntityInfoDrawer.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/EntityInfoDrawer/EntityInfoDrawer.component.tsx
@@ -12,15 +12,15 @@
  */
 
 import { CloseOutlined } from '@ant-design/icons';
-import { getDashboardByFqn } from '@rest/dashboardAPI';
-import { getPipelineByFqn } from '@rest/pipelineAPI';
-import { getServiceById } from '@rest/serviceAPI';
-import { getTableDetailsByFQN } from '@rest/tableAPI';
 import { Divider, Drawer } from 'antd';
 import { AxiosError } from 'axios';
 import classNames from 'classnames';
 import React, { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { getDashboardByFqn } from 'rest/dashboardAPI';
+import { getPipelineByFqn } from 'rest/pipelineAPI';
+import { getServiceById } from 'rest/serviceAPI';
+import { getTableDetailsByFQN } from 'rest/tableAPI';
 import { EntityType } from '../../enums/entity.enum';
 import { Dashboard } from '../../generated/entity/data/dashboard';
 import { Pipeline } from '../../generated/entity/data/pipeline';

--- a/openmetadata-ui/src/main/resources/ui/src/components/EntityLineage/EntityLineage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/EntityLineage/EntityLineage.component.tsx
@@ -11,8 +11,6 @@
  *  limitations under the License.
  */
 
-import { searchData } from '@rest/miscAPI';
-import { getTableDetails } from '@rest/tableAPI';
 import { Modal } from 'antd';
 import { AxiosError } from 'axios';
 import {
@@ -49,6 +47,8 @@ import ReactFlow, {
   useEdgesState,
   useNodesState,
 } from 'reactflow';
+import { searchData } from 'rest/miscAPI';
+import { getTableDetails } from 'rest/tableAPI';
 import { PAGE_SIZE } from '../../constants/constants';
 import {
   ELEMENT_DELETE_STATE,

--- a/openmetadata-ui/src/main/resources/ui/src/components/EntityLineage/NodeSuggestions.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/EntityLineage/NodeSuggestions.component.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 
-import { searchData } from '@rest/miscAPI';
 import { Empty } from 'antd';
 import { AxiosError } from 'axios';
 import { capitalize, debounce } from 'lodash';
@@ -23,6 +22,7 @@ import React, {
   useEffect,
   useState,
 } from 'react';
+import { searchData } from 'rest/miscAPI';
 import { FQN_SEPARATOR_CHAR } from '../../constants/char.constants';
 import { PAGE_SIZE } from '../../constants/constants';
 import { EntityType, FqnPart } from '../../enums/entity.enum';

--- a/openmetadata-ui/src/main/resources/ui/src/components/EntityLineage/NodeSuggestions.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/EntityLineage/NodeSuggestions.test.tsx
@@ -11,9 +11,9 @@
  *  limitations under the License.
  */
 
-import { searchData } from '@rest/miscAPI';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
+import { searchData } from 'rest/miscAPI';
 import { SearchIndex } from '../../enums/search.enum';
 import NodeSuggestions from './NodeSuggestions.component';
 
@@ -24,7 +24,7 @@ const mockProps = {
 
 const entityType = ['TABLE', 'TOPIC', 'DASHBOARD', 'MLMODEL'];
 
-jest.mock('@rest/miscAPI', () => ({
+jest.mock('rest/miscAPI', () => ({
   searchData: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Execution/Execution.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Execution/Execution.component.tsx
@@ -12,7 +12,6 @@
  */
 
 import { CloseCircleOutlined } from '@ant-design/icons';
-import { getPipelineStatus } from '@rest/pipelineAPI';
 import {
   Button,
   Col,
@@ -30,6 +29,7 @@ import classNames from 'classnames';
 import { isNaN, map } from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { getPipelineStatus } from 'rest/pipelineAPI';
 import { ReactComponent as Calendar } from '../../assets/svg/calendar.svg';
 import { ReactComponent as FilterIcon } from '../../assets/svg/filter.svg';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/DashboardSummary/DashboardSummary.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/DashboardSummary/DashboardSummary.component.tsx
@@ -11,9 +11,9 @@
  *  limitations under the License.
  */
 
-import { ChartType } from '@pages/DashboardDetailsPage/DashboardDetailsPage.component';
 import { Col, Divider, Row, Space, Typography } from 'antd';
 import { AxiosError } from 'axios';
+import { ChartType } from 'pages/DashboardDetailsPage/DashboardDetailsPage.component';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/TableSummary/TableSummary.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/TableSummary/TableSummary.component.tsx
@@ -11,17 +11,17 @@
  *  limitations under the License.
  */
 
-import {
-  getLatestTableProfileByFqn,
-  getTableQueryByTableId,
-} from '@rest/tableAPI';
-import { getListTestCase } from '@rest/testAPI';
 import { Col, Divider, Row, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import classNames from 'classnames';
 import { isEmpty, isUndefined } from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import {
+  getLatestTableProfileByFqn,
+  getTableQueryByTableId,
+} from 'rest/tableAPI';
+import { getListTestCase } from 'rest/testAPI';
 import { API_RES_MAX_SIZE } from '../../../../constants/constants';
 import { INITIAL_TEST_RESULT_SUMMARY } from '../../../../constants/profiler.constant';
 import { SearchIndex } from '../../../../enums/search.enum';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/Explore.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/Explore.component.tsx
@@ -11,14 +11,14 @@
  *  limitations under the License.
  */
 
-import FacetFilter from '@components/common/facetfilter/FacetFilter';
-import SearchedData from '@components/searched-data/SearchedData';
 import {
   faSortAmountDownAlt,
   faSortAmountUpAlt,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Card, Col, Row, Tabs } from 'antd';
+import FacetFilter from 'components/common/facetfilter/FacetFilter';
+import SearchedData from 'components/searched-data/SearchedData';
 import unique from 'fork-ts-checker-webpack-plugin/lib/utils/array/unique';
 import {
   isEmpty,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/Explore.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/Explore.test.tsx
@@ -37,7 +37,7 @@ jest.mock('../../utils/FilterUtils', () => ({
   getFilterCount: jest.fn().mockImplementation(() => 10),
 }));
 
-jest.mock('@components/searched-data/SearchedData', () => {
+jest.mock('components/searched-data/SearchedData', () => {
   return jest
     .fn()
     .mockImplementation(({ children }: { children: React.ReactNode }) => (

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.test.tsx
@@ -11,10 +11,10 @@
  *  limitations under the License.
  */
 
-import { getAdvancedFieldDefaultOptions } from '@rest/miscAPI';
 import { act, fireEvent, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
+import { getAdvancedFieldDefaultOptions } from 'rest/miscAPI';
 import { SearchIndex } from '../../enums/search.enum';
 import { ExploreQuickFilterField } from '../Explore/explore.interface';
 import { SearchDropdownProps } from '../SearchDropdown/SearchDropdown.interface';
@@ -67,7 +67,7 @@ jest.mock('./AdvanceSearchModal.component', () => ({
   AdvanceSearchModal: jest.fn().mockReturnValue(<p>AdvanceSearchModal</p>),
 }));
 
-jest.mock('@rest/miscAPI', () => ({
+jest.mock('rest/miscAPI', () => ({
   getAdvancedFieldDefaultOptions: jest
     .fn()
     .mockImplementation(() => Promise.resolve(mockAdvancedFieldDefaultOptions)),

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx
@@ -11,17 +11,17 @@
  *  limitations under the License.
  */
 
-import {
-  getAdvancedFieldDefaultOptions,
-  getAdvancedFieldOptions,
-  getTagSuggestions,
-  getUserSuggestions,
-} from '@rest/miscAPI';
 import { Divider, Space } from 'antd';
 import { AxiosError } from 'axios';
 import { isUndefined } from 'lodash';
 import React, { FC, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import {
+  getAdvancedFieldDefaultOptions,
+  getAdvancedFieldOptions,
+  getTagSuggestions,
+  getUserSuggestions,
+} from 'rest/miscAPI';
 import { MISC_FIELDS } from '../../constants/AdvancedSearch.constants';
 import {
   getAdvancedField,

--- a/openmetadata-ui/src/main/resources/ui/src/components/GlobalSearchProvider/GlobalSearchSuggestions/GlobalSearchSuggestions.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/GlobalSearchProvider/GlobalSearchSuggestions/GlobalSearchSuggestions.tsx
@@ -11,12 +11,12 @@
  *  limitations under the License.
  */
 
-import { getSuggestions } from '@rest/miscAPI';
 import { Select, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import { isEmpty } from 'lodash';
 import React, { useEffect, useRef, useState } from 'react';
 import { Link, useHistory } from 'react-router-dom';
+import { getSuggestions } from 'rest/miscAPI';
 import { FQN_SEPARATOR_CHAR } from '../../../constants/char.constants';
 import { FqnPart } from '../../../enums/entity.enum';
 import { SearchIndex } from '../../../enums/search.enum';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/Glossary.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/Glossary.test.tsx
@@ -80,14 +80,14 @@ jest.mock('react-router-dom', () => ({
   }),
 }));
 
-jest.mock('@components/GlossaryDetails/GlossaryDetails.component', () => {
+jest.mock('components/GlossaryDetails/GlossaryDetails.component', () => {
   return jest.fn().mockReturnValue(<>Glossary-Details component</>);
 });
 jest.mock('react-router-dom', () => ({
   Link: jest.fn().mockImplementation(({ children }) => <a>{children}</a>),
 }));
 
-jest.mock('@components/GlossaryTerms/GlossaryTermsV1.component', () => {
+jest.mock('components/GlossaryTerms/GlossaryTermsV1.component', () => {
   return jest.fn().mockReturnValue(<>Glossary-Term component</>);
 });
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryV1.component.tsx
@@ -12,7 +12,6 @@
  */
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { ModifiedGlossaryData } from '@pages/GlossaryPage/GlossaryPageV1.component';
 import {
   Button as ButtonAntd,
   Col,
@@ -29,6 +28,7 @@ import { DataNode, EventDataNode } from 'antd/lib/tree';
 import { AxiosError } from 'axios';
 import { cloneDeep, isEmpty } from 'lodash';
 import { AssetsDataType, LoadingState } from 'Models';
+import { ModifiedGlossaryData } from 'pages/GlossaryPage/GlossaryPageV1.component';
 import React, { Fragment, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';

--- a/openmetadata-ui/src/main/resources/ui/src/components/GlossaryDetails/GlossaryDetails.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/GlossaryDetails/GlossaryDetails.test.tsx
@@ -24,11 +24,11 @@ jest.mock('react-router-dom', () => ({
   }),
 }));
 
-jest.mock('@components/tags-container/tags-container', () => {
+jest.mock('components/tags-container/tags-container', () => {
   return jest.fn().mockReturnValue(<>Tags-container component</>);
 });
 
-jest.mock('@components/common/description/DescriptionV1', () => {
+jest.mock('components/common/description/DescriptionV1', () => {
   return jest.fn().mockReturnValue(<>Description component</>);
 });
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/GlossaryTerms/GlossaryTerms.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/GlossaryTerms/GlossaryTerms.test.tsx
@@ -68,7 +68,7 @@ jest.mock('react-router-dom', () => ({
   }),
 }));
 
-jest.mock('@components/tags-container/tags-container', () => {
+jest.mock('components/tags-container/tags-container', () => {
   return jest.fn().mockReturnValue(<>Tags-container component</>);
 });
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/GlossaryTerms/tabs/RelatedTerms.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/GlossaryTerms/tabs/RelatedTerms.tsx
@@ -11,10 +11,10 @@
  *  limitations under the License.
  */
 
-import { searchData } from '@rest/miscAPI';
 import { Select, Spin, Typography } from 'antd';
 import { cloneDeep, debounce, includes } from 'lodash';
 import React, { Fragment, useCallback, useEffect, useState } from 'react';
+import { searchData } from 'rest/miscAPI';
 import { PAGE_SIZE } from '../../../constants/constants';
 import { SearchIndex } from '../../../enums/search.enum';
 import { GlossaryTerm } from '../../../generated/entity/data/glossaryTerm';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Ingestion/Ingestion.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Ingestion/Ingestion.test.tsx
@@ -101,7 +101,7 @@ jest.mock('./IngestionRecentRun/IngestionRecentRuns.component', () => ({
     .mockImplementation(() => <p>IngestionRecentRuns</p>),
 }));
 
-jest.mock('@components/PermissionProvider/PermissionProvider', () => ({
+jest.mock('components/PermissionProvider/PermissionProvider', () => ({
   usePermissionProvider: jest.fn().mockReturnValue({
     getEntityPermissionByFqn: jest.fn().mockReturnValue({
       Create: true,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Ingestion/IngestionRecentRun/IngestionRecentRun.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Ingestion/IngestionRecentRun/IngestionRecentRun.test.tsx
@@ -11,13 +11,13 @@
  *  limitations under the License.
  */
 
-import { getRunHistoryForPipeline } from '@rest/ingestionPipelineAPI';
 import { act, render, screen } from '@testing-library/react';
 import React from 'react';
+import { getRunHistoryForPipeline } from 'rest/ingestionPipelineAPI';
 import { IngestionPipeline } from '../../../generated/entity/services/ingestionPipelines/ingestionPipeline';
 import { IngestionRecentRuns } from './IngestionRecentRuns.component';
 
-jest.mock('@rest/ingestionPipelineAPI', () => ({
+jest.mock('rest/ingestionPipelineAPI', () => ({
   getRunHistoryForPipeline: jest.fn().mockImplementation(() =>
     Promise.resolve({
       data: [

--- a/openmetadata-ui/src/main/resources/ui/src/components/Ingestion/IngestionRecentRun/IngestionRecentRuns.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Ingestion/IngestionRecentRun/IngestionRecentRuns.component.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 
-import { getRunHistoryForPipeline } from '@rest/ingestionPipelineAPI';
 import { Popover, Skeleton, Space } from 'antd';
 import { capitalize, isEmpty } from 'lodash';
 import React, {
@@ -21,6 +20,7 @@ import React, {
   useState,
 } from 'react';
 import { useTranslation } from 'react-i18next';
+import { getRunHistoryForPipeline } from 'rest/ingestionPipelineAPI';
 import {
   IngestionPipeline,
   PipelineStatus,

--- a/openmetadata-ui/src/main/resources/ui/src/components/MlModelDetail/MlModelDetail.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MlModelDetail/MlModelDetail.component.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 
-import { restoreMlmodel } from '@rest/mlModelAPI';
 import { Col, Row, Table } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
 import { AxiosError } from 'axios';
@@ -30,6 +29,7 @@ import React, {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
+import { restoreMlmodel } from 'rest/mlModelAPI';
 import AppState from '../../AppState';
 import { FQN_SEPARATOR_CHAR } from '../../constants/char.constants';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/AnnouncementModal/AddAnnouncementModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/AnnouncementModal/AddAnnouncementModal.test.tsx
@@ -26,7 +26,7 @@ jest.mock('../../../AppState', () => ({
   getCurrentUserDetails: jest.fn(),
 }));
 
-jest.mock('@rest/feedsAPI', () => ({
+jest.mock('rest/feedsAPI', () => ({
   postThread: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/AnnouncementModal/AddAnnouncementModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/AnnouncementModal/AddAnnouncementModal.tsx
@@ -11,12 +11,12 @@
  *  limitations under the License.
  */
 
-import { postThread } from '@rest/feedsAPI';
 import { Form, Input, Modal, Space } from 'antd';
 import { AxiosError } from 'axios';
 import { observer } from 'mobx-react';
 import React, { FC, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { postThread } from 'rest/feedsAPI';
 import AppState from '../../../AppState';
 import {
   CreateThread,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/KillIngestionPipelineModal/KillIngestionModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/KillIngestionPipelineModal/KillIngestionModal.test.tsx
@@ -11,9 +11,9 @@
  *  limitations under the License.
  */
 
-import { postKillIngestionPipelineById } from '@rest/ingestionPipelineAPI';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
+import { postKillIngestionPipelineById } from 'rest/ingestionPipelineAPI';
 import KillIngestionModal from './KillIngestionPipelineModal';
 
 const mockHandleClose = jest.fn();
@@ -27,7 +27,7 @@ const mockProps = {
   onIngestionWorkflowsUpdate: mockUpdateWorkflows,
 };
 
-jest.mock('@rest/ingestionPipelineAPI', () => ({
+jest.mock('rest/ingestionPipelineAPI', () => ({
   postKillIngestionPipelineById: jest
     .fn()
     .mockImplementation(() => Promise.resolve()),

--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/KillIngestionPipelineModal/KillIngestionPipelineModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/KillIngestionPipelineModal/KillIngestionPipelineModal.tsx
@@ -11,11 +11,11 @@
  *  limitations under the License.
  */
 
-import { postKillIngestionPipelineById } from '@rest/ingestionPipelineAPI';
 import { Modal, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import React, { FC, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { postKillIngestionPipelineById } from 'rest/ingestionPipelineAPI';
 import { showErrorToast, showSuccessToast } from '../../../utils/ToastUtils';
 
 interface KillIngestionModalProps {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/RelatedTermsModal/RelatedTermsModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/RelatedTermsModal/RelatedTermsModal.tsx
@@ -11,12 +11,12 @@
  *  limitations under the License.
  */
 
-import CheckboxUserCard from '@pages/teams/CheckboxUserCard';
-import { searchData } from '@rest/miscAPI';
 import { Button, Col, Modal, Row, Typography } from 'antd';
 import { t } from 'i18next';
 import { isUndefined, uniqueId } from 'lodash';
+import CheckboxUserCard from 'pages/teams/CheckboxUserCard';
 import React, { useEffect, useState } from 'react';
+import { searchData } from 'rest/miscAPI';
 import { PAGE_SIZE } from '../../../constants/constants';
 import { SearchIndex } from '../../../enums/search.enum';
 import { GlossaryTerm } from '../../../generated/entity/data/glossaryTerm';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/ReviewerModal/ReviewerModal.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/ReviewerModal/ReviewerModal.component.tsx
@@ -11,13 +11,13 @@
  *  limitations under the License.
  */
 
-import CheckboxUserCard from '@pages/teams/CheckboxUserCard';
-import { getSuggestedUsers, searchData } from '@rest/miscAPI';
 import { Button, Col, Row, Typography } from 'antd';
 import Modal from 'antd/lib/modal/Modal';
 import { isUndefined, uniqueId } from 'lodash';
+import CheckboxUserCard from 'pages/teams/CheckboxUserCard';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { getSuggestedUsers, searchData } from 'rest/miscAPI';
 import { WILD_CARD_CHAR } from '../../../constants/char.constants';
 import { SearchIndex } from '../../../enums/search.enum';
 import { User } from '../../../generated/entity/teams/user';

--- a/openmetadata-ui/src/main/resources/ui/src/components/MyData/MyData.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MyData/MyData.test.tsx
@@ -230,13 +230,13 @@ const currentUserMockData = {
   href: 'http://localhost:8585/api/v1/tables/7b26a534-25e8-4112-ae08-ee059f8918c4',
 } as EntityReference;
 
-jest.mock('@rest/miscAPI', () => ({
+jest.mock('rest/miscAPI', () => ({
   searchData: jest
     .fn()
     .mockImplementation(() => Promise.resolve({ data: mockData })),
 }));
 
-jest.mock('@components/searched-data/SearchedData', () => {
+jest.mock('components/searched-data/SearchedData', () => {
   return jest
     .fn()
     .mockImplementation(({ children }: { children: React.ReactNode }) => (

--- a/openmetadata-ui/src/main/resources/ui/src/components/NotificationBox/NotificationBox.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/NotificationBox/NotificationBox.component.tsx
@@ -11,12 +11,12 @@
  *  limitations under the License.
  */
 
-import { getFeedsWithFilter } from '@rest/feedsAPI';
 import { Badge, Button, List, Tabs, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import { isEmpty } from 'lodash';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { getFeedsWithFilter } from 'rest/feedsAPI';
 import AppState from '../../AppState';
 import {
   getUserPath,

--- a/openmetadata-ui/src/main/resources/ui/src/components/PermissionProvider/PermissionProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/PermissionProvider/PermissionProvider.tsx
@@ -11,12 +11,6 @@
  *  limitations under the License.
  */
 
-import {
-  getEntityPermissionByFqn,
-  getEntityPermissionById,
-  getLoggedInUserPermissions,
-  getResourcePermission,
-} from '@rest/permissionAPI';
 import { CookieStorage } from 'cookie-storage';
 import { observer } from 'mobx-react';
 import React, {
@@ -29,6 +23,12 @@ import React, {
   useState,
 } from 'react';
 import { useHistory } from 'react-router-dom';
+import {
+  getEntityPermissionByFqn,
+  getEntityPermissionById,
+  getLoggedInUserPermissions,
+  getResourcePermission,
+} from 'rest/permissionAPI';
 import AppState from '../../AppState';
 import { REDIRECT_PATHNAME } from '../../constants/constants';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/components/PipelineDetails/PipelineDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/PipelineDetails/PipelineDetails.component.tsx
@@ -11,9 +11,6 @@
  *  limitations under the License.
  */
 
-import { getAllFeeds, postFeedById, postThread } from '@rest/feedsAPI';
-import { getLineageByFQN } from '@rest/lineageAPI';
-import { restorePipeline } from '@rest/pipelineAPI';
 import { Card, Col, Radio, Row, Space, Table, Tabs, Tooltip } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
 import { AxiosError } from 'axios';
@@ -29,6 +26,9 @@ import React, {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, Redirect, useHistory, useParams } from 'react-router-dom';
+import { getAllFeeds, postFeedById, postThread } from 'rest/feedsAPI';
+import { getLineageByFQN } from 'rest/lineageAPI';
+import { restorePipeline } from 'rest/pipelineAPI';
 import AppState from '../../AppState';
 import { FQN_SEPARATOR_CHAR } from '../../constants/char.constants';
 import { getPipelineDetailsPath, ROUTES } from '../../constants/constants';

--- a/openmetadata-ui/src/main/resources/ui/src/components/PipelineVersion/PipelineVersion.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/PipelineVersion/PipelineVersion.component.tsx
@@ -14,7 +14,7 @@
 import { Space, Table } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
 import classNames from 'classnames';
-import PageContainerV1 from 'components/containers/PageContainerV1';
+import PageContainer from 'components/containers/PageContainer';
 import { isUndefined } from 'lodash';
 import { ExtraInfo } from 'Models';
 import React, { FC, useEffect, useMemo, useState } from 'react';
@@ -255,7 +255,7 @@ const PipelineVersion: FC<PipelineVersionProp> = ({
   );
 
   return (
-    <PageContainerV1>
+    <PageContainer>
       <div
         className={classNames(
           'tw-px-6 tw-w-full tw-h-full tw-flex tw-flex-col tw-relative'
@@ -313,7 +313,7 @@ const PipelineVersion: FC<PipelineVersionProp> = ({
           onBack={backHandler}
         />
       </div>
-    </PageContainerV1>
+    </PageContainer>
   );
 };
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/PipelineVersion/PipelineVersion.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/PipelineVersion/PipelineVersion.component.tsx
@@ -14,6 +14,7 @@
 import { Space, Table } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
 import classNames from 'classnames';
+import PageContainerV1 from 'components/containers/PageContainerV1';
 import { isUndefined } from 'lodash';
 import { ExtraInfo } from 'Models';
 import React, { FC, useEffect, useMemo, useState } from 'react';
@@ -39,7 +40,6 @@ import Description from '../common/description/Description';
 import EntityPageInfo from '../common/entityPageInfo/EntityPageInfo';
 import RichTextEditorPreviewer from '../common/rich-text-editor/RichTextEditorPreviewer';
 import TabsPane from '../common/TabsPane/TabsPane';
-import PageContainer from '../containers/PageContainer';
 import EntityVersionTimeLine from '../EntityVersionTimeLine/EntityVersionTimeLine';
 import Loader from '../Loader/Loader';
 import { PipelineVersionProp } from './PipelineVersion.interface';
@@ -255,7 +255,7 @@ const PipelineVersion: FC<PipelineVersionProp> = ({
   );
 
   return (
-    <PageContainer>
+    <PageContainerV1>
       <div
         className={classNames(
           'tw-px-6 tw-w-full tw-h-full tw-flex tw-flex-col tw-relative'
@@ -313,7 +313,7 @@ const PipelineVersion: FC<PipelineVersionProp> = ({
           onBack={backHandler}
         />
       </div>
-    </PageContainer>
+    </PageContainerV1>
   );
 };
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/PipelineVersion/PipelineVersion.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/PipelineVersion/PipelineVersion.interface.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { VersionData } from '@pages/EntityVersionPage/EntityVersionPage.component';
+import { VersionData } from 'pages/EntityVersionPage/EntityVersionPage.component';
 import { Pipeline } from '../../generated/entity/data/pipeline';
 import { EntityHistory } from '../../generated/type/entityHistory';
 import { TagLabel } from '../../generated/type/tagLabel';

--- a/openmetadata-ui/src/main/resources/ui/src/components/ProfilerDashboard/ProfilerDashboard.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ProfilerDashboard/ProfilerDashboard.test.tsx
@@ -83,7 +83,7 @@ jest.mock('./component/DataQualityTab', () => {
     .mockImplementation(() => <div>DataQualityTab component</div>);
 });
 
-jest.mock('@components/PermissionProvider/PermissionProvider', () => {
+jest.mock('components/PermissionProvider/PermissionProvider', () => {
   return {
     usePermissionProvider: jest.fn().mockImplementation(() => ({
       getEntityPermission: jest.fn().mockImplementation(() => ({

--- a/openmetadata-ui/src/main/resources/ui/src/components/ProfilerDashboard/ProfilerDashboard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ProfilerDashboard/ProfilerDashboard.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 
-import { addFollower, removeFollower } from '@rest/tableAPI';
 import {
   Button,
   Col,
@@ -29,6 +28,7 @@ import { AxiosError } from 'axios';
 import { EntityTags, ExtraInfo } from 'Models';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
+import { addFollower, removeFollower } from 'rest/tableAPI';
 import { FQN_SEPARATOR_CHAR } from '../../constants/char.constants';
 import {
   getDatabaseDetailsPath,

--- a/openmetadata-ui/src/main/resources/ui/src/components/ProfilerDashboard/component/ProfilerTab.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ProfilerDashboard/component/ProfilerTab.test.tsx
@@ -11,10 +11,10 @@
  *  limitations under the License.
  */
 
-import { getListTestCase } from '@rest/testAPI';
 import { act, render, screen } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
+import { getListTestCase } from 'rest/testAPI';
 import { Column } from '../../../generated/entity/data/table';
 import {
   COLUMN_PROFILER_RESULT,
@@ -30,7 +30,7 @@ const profilerTabProps: ProfilerTabProps = {
   tableProfile: MOCK_TABLE.profile,
 };
 
-jest.mock('@rest/testAPI', () => {
+jest.mock('rest/testAPI', () => {
   return {
     getListTestCase: jest
       .fn()

--- a/openmetadata-ui/src/main/resources/ui/src/components/ProfilerDashboard/component/ProfilerTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ProfilerDashboard/component/ProfilerTab.tsx
@@ -11,13 +11,13 @@
  *  limitations under the License.
  */
 
-import { getListTestCase } from '@rest/testAPI';
 import { Card, Col, Row, Statistic, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import { sortBy } from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
+import { getListTestCase } from 'rest/testAPI';
 import { API_RES_MAX_SIZE } from '../../../constants/constants';
 import {
   INITIAL_COUNT_METRIC_VALUE,

--- a/openmetadata-ui/src/main/resources/ui/src/components/ProfilerDashboard/component/TestSummary.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ProfilerDashboard/component/TestSummary.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 
-import { getListTestCaseResults } from '@rest/testAPI';
 import { Col, Row, Select, Space, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import { isEmpty } from 'lodash';
@@ -27,6 +26,7 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
+import { getListTestCaseResults } from 'rest/testAPI';
 import {
   COLORS,
   PROFILER_FILTER_RANGE,

--- a/openmetadata-ui/src/main/resources/ui/src/components/ProfilerDashboard/profilerDashboard.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ProfilerDashboard/profilerDashboard.interface.ts
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import { ListTestCaseParams } from '@rest/testAPI';
 import { CurveType } from 'recharts/types/shape/Curve';
+import { ListTestCaseParams } from 'rest/testAPI';
 import {
   Column,
   ColumnProfile,

--- a/openmetadata-ui/src/main/resources/ui/src/components/SampleDataTable/SampleDataTable.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/SampleDataTable/SampleDataTable.component.tsx
@@ -16,7 +16,6 @@ import {
   faChevronRight,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { getSampleDataByTableId } from '@rest/tableAPI';
 import { Space, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import classNames from 'classnames';
@@ -29,6 +28,7 @@ import React, {
   useState,
 } from 'react';
 import { Link } from 'react-router-dom';
+import { getSampleDataByTableId } from 'rest/tableAPI';
 import { WORKFLOWS_PROFILER_DOCS } from '../../constants/docs.constants';
 import { Table, TableData } from '../../generated/entity/data/table';
 import { withLoader } from '../../hoc/withLoader';

--- a/openmetadata-ui/src/main/resources/ui/src/components/SampleDataTable/SampleDataTable.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/SampleDataTable/SampleDataTable.test.tsx
@@ -20,7 +20,7 @@ jest.mock('react-router-dom', () => ({
   Link: jest.fn().mockImplementation(({ children }) => <span>{children}</span>),
 }));
 
-jest.mock('@rest/tableAPI', () => ({
+jest.mock('rest/tableAPI', () => ({
   getSampleDataByTableId: jest
     .fn()
     .mockImplementation(() => Promise.resolve(MOCK_TABLE)),

--- a/openmetadata-ui/src/main/resources/ui/src/components/ServiceConfig/ConnectionConfigForm.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ServiceConfig/ConnectionConfigForm.tsx
@@ -11,11 +11,11 @@
  *  limitations under the License.
  */
 
-import { TestConnection } from '@rest/serviceAPI';
 import { ISubmitEvent } from '@rjsf/core';
 import { cloneDeep, isNil } from 'lodash';
 import { LoadingState } from 'Models';
 import React, { Fragment, FunctionComponent, useMemo } from 'react';
+import { TestConnection } from 'rest/serviceAPI';
 import { ServiceCategory } from '../../enums/service.enum';
 import { MetadataServiceType } from '../../generated/api/services/createMetadataService';
 import { MlModelServiceType } from '../../generated/api/services/createMlModelService';

--- a/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/Component/ProfilerSettingsModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/Component/ProfilerSettingsModal.test.tsx
@@ -26,7 +26,7 @@ jest.mock('antd/lib/grid', () => ({
     )),
 }));
 
-jest.mock('@rest/tableAPI', () => ({
+jest.mock('rest/tableAPI', () => ({
   getTableProfilerConfig: jest
     .fn()
     .mockImplementation(() => Promise.resolve(MOCK_TABLE)),

--- a/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/Component/ProfilerSettingsModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/Component/ProfilerSettingsModal.tsx
@@ -12,7 +12,6 @@
  */
 
 import { PlusOutlined } from '@ant-design/icons';
-import { getTableProfilerConfig, putTableProfileConfig } from '@rest/tableAPI';
 import {
   Button,
   InputNumber,
@@ -32,6 +31,7 @@ import { isEmpty, isEqual, isUndefined, omit, startCase } from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
 import { Controlled as CodeMirror } from 'react-codemirror2';
 import { useTranslation } from 'react-i18next';
+import { getTableProfilerConfig, putTableProfileConfig } from 'rest/tableAPI';
 import {
   codeMirrorOption,
   DEFAULT_INCLUDE_PROFILE,

--- a/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/Component/TableProfilerChart.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/Component/TableProfilerChart.test.tsx
@@ -11,9 +11,9 @@
  *  limitations under the License.
  */
 
-import { getSystemProfileList, getTableProfilesList } from '@rest/tableAPI';
 import { act, render, screen } from '@testing-library/react';
 import React from 'react';
+import { getSystemProfileList, getTableProfilesList } from 'rest/tableAPI';
 import {
   getPastDatesTimeStampFromCurrentDate,
   getPastDaysDateTimeMillis,
@@ -45,7 +45,7 @@ jest.mock('../../../utils/TimeUtils', () => ({
     .fn()
     .mockImplementation(() => mockTimeValue.startMilli),
 }));
-jest.mock('@rest/tableAPI');
+jest.mock('rest/tableAPI');
 jest.mock('../../ProfilerDashboard/component/ProfilerLatestValue', () => {
   return jest.fn().mockImplementation(() => <div>ProfilerLatestValue</div>);
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/Component/TableProfilerChart.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/Component/TableProfilerChart.tsx
@@ -11,11 +11,11 @@
  *  limitations under the License.
  */
 
-import { getSystemProfileList, getTableProfilesList } from '@rest/tableAPI';
 import { Card, Col, Row } from 'antd';
 import { AxiosError } from 'axios';
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { getSystemProfileList, getTableProfilesList } from 'rest/tableAPI';
 import {
   INITIAL_OPERATION_METRIC_VALUE,
   INITIAL_ROW_METRIC_VALUE,

--- a/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/TableProfilerV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/TableProfilerV1.test.tsx
@@ -57,7 +57,7 @@ jest.mock('../../utils/CommonUtils', () => ({
   getStatisticsDisplayValue: jest.fn(),
 }));
 
-jest.mock('@rest/testAPI', () => ({
+jest.mock('rest/testAPI', () => ({
   getListTestCase: jest
     .fn()
     .mockImplementation(() => Promise.resolve(TEST_CASE)),

--- a/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/TableProfilerV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/TableProfilerV1.tsx
@@ -11,8 +11,6 @@
  *  limitations under the License.
  */
 
-import { getLatestTableProfileByFqn } from '@rest/tableAPI';
-import { getListTestCase, ListTestCaseParams } from '@rest/testAPI';
 import {
   Button,
   Col,
@@ -33,6 +31,8 @@ import { isUndefined, map } from 'lodash';
 import React, { FC, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useParams } from 'react-router-dom';
+import { getLatestTableProfileByFqn } from 'rest/tableAPI';
+import { getListTestCase, ListTestCaseParams } from 'rest/testAPI';
 import { ReactComponent as ColumnProfileIcon } from '../../assets/svg/column-profile.svg';
 import { ReactComponent as DataQualityIcon } from '../../assets/svg/data-quality.svg';
 import { ReactComponent as SettingIcon } from '../../assets/svg/ic-settings-primery.svg';

--- a/openmetadata-ui/src/main/resources/ui/src/components/TableQueries/TableQueries.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TableQueries/TableQueries.test.tsx
@@ -29,7 +29,7 @@ const mockTableQueriesProp = {
 jest.mock('./QueryCard', () => {
   return jest.fn().mockReturnValue(<p>QueryCard</p>);
 });
-jest.mock('@rest/tableAPI', () => ({
+jest.mock('rest/tableAPI', () => ({
   getTableQueryByTableId: jest
     .fn()
     .mockImplementation(() => Promise.resolve(MOCK_TABLE)),

--- a/openmetadata-ui/src/main/resources/ui/src/components/TableQueries/TableQueries.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TableQueries/TableQueries.tsx
@@ -11,11 +11,11 @@
  *  limitations under the License.
  */
 
-import { getTableQueryByTableId } from '@rest/tableAPI';
 import { Col, Row } from 'antd';
 import { AxiosError } from 'axios';
 import { isEmpty } from 'lodash';
 import React, { FC, useEffect, useState } from 'react';
+import { getTableQueryByTableId } from 'rest/tableAPI';
 import { Table } from '../../generated/entity/data/table';
 import { withLoader } from '../../hoc/withLoader';
 import { showErrorToast } from '../../utils/ToastUtils';

--- a/openmetadata-ui/src/main/resources/ui/src/components/TeamDetails/Form.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TeamDetails/Form.test.tsx
@@ -18,7 +18,7 @@ import Form from './Form';
 
 const mockFunction = jest.fn();
 
-jest.mock('@components/common/rich-text-editor/RichTextEditor', () => {
+jest.mock('components/common/rich-text-editor/RichTextEditor', () => {
   return forwardRef(
     jest.fn().mockImplementation(({ initialValue }, ref) => {
       return <div ref={ref}>{initialValue}MarkdownWithPreview component</div>;

--- a/openmetadata-ui/src/main/resources/ui/src/components/TeamDetails/Form.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TeamDetails/Form.tsx
@@ -13,7 +13,7 @@
 
 /* eslint-disable @typescript-eslint/ban-types */
 
-import RichTextEditor from '@components/common/rich-text-editor/RichTextEditor';
+import RichTextEditor from 'components/common/rich-text-editor/RichTextEditor';
 import { FormErrorData } from 'Models';
 import React, {
   forwardRef,

--- a/openmetadata-ui/src/main/resources/ui/src/components/TeamDetails/TeamDetailsV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TeamDetails/TeamDetailsV1.tsx
@@ -12,8 +12,6 @@
  */
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import AddAttributeModal from '@pages/RolesPage/AddAttributeModal/AddAttributeModal';
-import { restoreTeam } from '@rest/teamsAPI';
 import {
   Button as ButtonAntd,
   Col,
@@ -33,9 +31,11 @@ import classNames from 'classnames';
 import { compare } from 'fast-json-patch';
 import { cloneDeep, isEmpty, isUndefined, orderBy, uniqueId } from 'lodash';
 import { ExtraInfo } from 'Models';
+import AddAttributeModal from 'pages/RolesPage/AddAttributeModal/AddAttributeModal';
 import React, { Fragment, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
+import { restoreTeam } from 'rest/teamsAPI';
 import AppState from '../../AppState';
 import {
   getTeamAndUserDetailsPath,

--- a/openmetadata-ui/src/main/resources/ui/src/components/TeamDetails/TeamHierarchy.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TeamDetails/TeamHierarchy.test.tsx
@@ -37,7 +37,7 @@ jest.mock('../../utils/TeamUtils', () => ({
   getMovedTeamData: jest.fn().mockReturnValue([]),
 }));
 
-jest.mock('@rest/teamsAPI', () => ({
+jest.mock('rest/teamsAPI', () => ({
   updateTeam: jest
     .fn()
     .mockImplementation(() => Promise.resolve(MOCK_CURRENT_TEAM)),

--- a/openmetadata-ui/src/main/resources/ui/src/components/TeamDetails/TeamHierarchy.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TeamDetails/TeamHierarchy.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 
-import { getTeamByName, updateTeam } from '@rest/teamsAPI';
 import { Modal, Table, Typography } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
 import { ExpandableConfig } from 'antd/lib/table/interface';
@@ -22,6 +21,7 @@ import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
+import { getTeamByName, updateTeam } from 'rest/teamsAPI';
 import { TABLE_CONSTANTS } from '../../constants/Teams.constants';
 import { Team } from '../../generated/entity/teams/team';
 import { getEntityName } from '../../utils/CommonUtils';

--- a/openmetadata-ui/src/main/resources/ui/src/components/TeamsSelectable/TeamsSelectable.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TeamsSelectable/TeamsSelectable.test.tsx
@@ -30,7 +30,7 @@ jest.mock('antd', () => ({
     )),
 }));
 
-jest.mock('@rest/teamsAPI', () => ({
+jest.mock('rest/teamsAPI', () => ({
   getTeamsHierarchy: jest.fn().mockImplementation(() =>
     Promise.resolve({
       data: [],

--- a/openmetadata-ui/src/main/resources/ui/src/components/TeamsSelectable/TeamsSelectable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TeamsSelectable/TeamsSelectable.tsx
@@ -11,9 +11,9 @@
  *  limitations under the License.
  */
 
-import { getTeamsHierarchy } from '@rest/teamsAPI';
 import { TreeSelect } from 'antd';
 import React, { useEffect, useState } from 'react';
+import { getTeamsHierarchy } from 'rest/teamsAPI';
 import { TeamHierarchy } from '../../generated/entity/teams/teamHierarchy';
 import { getEntityName } from '../../utils/CommonUtils';
 import SVGIcons from '../../utils/SvgUtils';

--- a/openmetadata-ui/src/main/resources/ui/src/components/TestSuitePipelineTab/TestSuitePipelineTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TestSuitePipelineTab/TestSuitePipelineTab.component.tsx
@@ -12,14 +12,6 @@
  */
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import {
-  deleteIngestionPipelineById,
-  deployIngestionPipelineById,
-  enableDisableIngestionPipelineById,
-  getIngestionPipelines,
-  triggerIngestionPipelineById,
-} from '@rest/ingestionPipelineAPI';
-import { fetchAirflowConfig } from '@rest/miscAPI';
 import { Button, Col, Popover, Row, Table, Tooltip } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
 import { AxiosError } from 'axios';
@@ -27,6 +19,14 @@ import cronstrue from 'cronstrue';
 import React, { Fragment, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
+import {
+  deleteIngestionPipelineById,
+  deployIngestionPipelineById,
+  enableDisableIngestionPipelineById,
+  getIngestionPipelines,
+  triggerIngestionPipelineById,
+} from 'rest/ingestionPipelineAPI';
+import { fetchAirflowConfig } from 'rest/miscAPI';
 import { Operation } from '../../generated/entity/policies/policy';
 import { IngestionPipeline } from '../../generated/entity/services/ingestionPipelines/ingestionPipeline';
 import { useAirflowStatus } from '../../hooks/useAirflowStatus';

--- a/openmetadata-ui/src/main/resources/ui/src/components/TopicDetails/TopicDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TopicDetails/TopicDetails.component.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 
-import { restoreTopic } from '@rest/topicsAPI';
 import { AxiosError } from 'axios';
 import { isEmpty } from 'lodash';
 import { EntityTags, ExtraInfo } from 'Models';
@@ -24,6 +23,7 @@ import React, {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
+import { restoreTopic } from 'rest/topicsAPI';
 import { FQN_SEPARATOR_CHAR } from '../../constants/char.constants';
 import { EntityField } from '../../constants/Feeds.constants';
 import { observerOptions } from '../../constants/Mydata.constants';

--- a/openmetadata-ui/src/main/resources/ui/src/components/TopicVersion/TopicVersion.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TopicVersion/TopicVersion.component.tsx
@@ -12,7 +12,7 @@
  */
 
 import classNames from 'classnames';
-import PageContainerV1 from 'components/containers/PageContainerV1';
+import PageContainer from 'components/containers/PageContainer';
 import { isUndefined } from 'lodash';
 import { ExtraInfo } from 'Models';
 import React, { FC, useEffect, useState } from 'react';
@@ -254,7 +254,7 @@ const TopicVersion: FC<TopicVersionProp> = ({
   }, [currentVersionData]);
 
   return (
-    <PageContainerV1>
+    <PageContainer>
       <div
         className={classNames(
           'tw-px-6 tw-w-full tw-h-full tw-flex tw-flex-col tw-relative'
@@ -318,7 +318,7 @@ const TopicVersion: FC<TopicVersionProp> = ({
           onBack={backHandler}
         />
       </div>
-    </PageContainerV1>
+    </PageContainer>
   );
 };
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/TopicVersion/TopicVersion.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TopicVersion/TopicVersion.component.tsx
@@ -12,6 +12,7 @@
  */
 
 import classNames from 'classnames';
+import PageContainerV1 from 'components/containers/PageContainerV1';
 import { isUndefined } from 'lodash';
 import { ExtraInfo } from 'Models';
 import React, { FC, useEffect, useState } from 'react';
@@ -31,7 +32,6 @@ import { bytesToSize } from '../../utils/StringsUtils';
 import Description from '../common/description/Description';
 import EntityPageInfo from '../common/entityPageInfo/EntityPageInfo';
 import TabsPane from '../common/TabsPane/TabsPane';
-import PageContainer from '../containers/PageContainer';
 import EntityVersionTimeLine from '../EntityVersionTimeLine/EntityVersionTimeLine';
 import Loader from '../Loader/Loader';
 import SchemaEditor from '../schema-editor/SchemaEditor';
@@ -254,7 +254,7 @@ const TopicVersion: FC<TopicVersionProp> = ({
   }, [currentVersionData]);
 
   return (
-    <PageContainer>
+    <PageContainerV1>
       <div
         className={classNames(
           'tw-px-6 tw-w-full tw-h-full tw-flex tw-flex-col tw-relative'
@@ -318,7 +318,7 @@ const TopicVersion: FC<TopicVersionProp> = ({
           onBack={backHandler}
         />
       </div>
-    </PageContainer>
+    </PageContainerV1>
   );
 };
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/TopicVersion/TopicVersion.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TopicVersion/TopicVersion.interface.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { VersionData } from '@pages/EntityVersionPage/EntityVersionPage.component';
+import { VersionData } from 'pages/EntityVersionPage/EntityVersionPage.component';
 import { Topic } from '../../generated/entity/data/topic';
 import { EntityHistory } from '../../generated/type/entityHistory';
 import { TagLabel } from '../../generated/type/tagLabel';

--- a/openmetadata-ui/src/main/resources/ui/src/components/UserList/UserListV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/UserList/UserListV1.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 
-import { updateUser } from '@rest/userAPI';
 import { Button, Col, Modal, Row, Space, Switch, Table, Tooltip } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
 import { AxiosError } from 'axios';
@@ -19,6 +18,7 @@ import { isEmpty, isUndefined } from 'lodash';
 import React, { FC, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
+import { updateUser } from 'rest/userAPI';
 import { PAGE_SIZE_MEDIUM, ROUTES } from '../../constants/constants';
 import { ADMIN_ONLY_ACTION } from '../../constants/HelperTextUtil';
 import { PAGE_HEADERS } from '../../constants/PageHeaders.constant';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.test.tsx
@@ -30,7 +30,7 @@ import {
 } from './mocks/User.mocks';
 import Users from './Users.component';
 
-jest.mock('@rest/rolesAPIV1.ts', () => ({
+jest.mock('rest/rolesAPIV1.ts', () => ({
   getRoles: jest.fn().mockImplementation(() => Promise.resolve(mockUserRole)),
 }));
 
@@ -38,7 +38,7 @@ jest.mock('../common/ProfilePicture/ProfilePicture', () => {
   return jest.fn().mockReturnValue(<p>ProfilePicture</p>);
 });
 
-jest.mock('@pages/teams/UserCard', () => {
+jest.mock('pages/teams/UserCard', () => {
   return jest.fn().mockReturnValue(<p>UserCard</p>);
 });
 
@@ -50,7 +50,7 @@ jest.mock('../ActivityFeed/ActivityFeedList/ActivityFeedList.tsx', () => {
   return jest.fn().mockReturnValue(<p>FeedCards</p>);
 });
 
-jest.mock('@rest/teamsAPI', () => ({
+jest.mock('rest/teamsAPI', () => ({
   getTeams: jest.fn().mockImplementation(() => Promise.resolve(mockTeamsData)),
 }));
 
@@ -119,7 +119,7 @@ const mockProp = {
   onSwitchChange: jest.fn(),
 };
 
-jest.mock('@rest/userAPI', () => ({
+jest.mock('rest/userAPI', () => ({
   checkValidImage: jest.fn().mockImplementation(() => Promise.resolve(true)),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
@@ -12,9 +12,6 @@
  */
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { changePassword } from '@rest/auth-API';
-import { getRoles } from '@rest/rolesAPIV1';
-import { getTeams } from '@rest/teamsAPI';
 import {
   Button as AntDButton,
   Card,
@@ -37,6 +34,9 @@ import React, {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory, useLocation } from 'react-router-dom';
+import { changePassword } from 'rest/auth-API';
+import { getRoles } from 'rest/rolesAPIV1';
+import { getTeams } from 'rest/teamsAPI';
 import {
   getUserPath,
   PAGE_SIZE,

--- a/openmetadata-ui/src/main/resources/ui/src/components/app-bar/Appbar.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/app-bar/Appbar.test.tsx
@@ -43,7 +43,7 @@ jest.mock('../nav-bar/NavBar', () => {
   return jest.fn().mockReturnValue(<p>NavBar</p>);
 });
 
-jest.mock('@rest/miscAPI', () => ({
+jest.mock('rest/miscAPI', () => ({
   getVersion: jest.fn().mockImplementation(() =>
     Promise.resolve({
       data: {

--- a/openmetadata-ui/src/main/resources/ui/src/components/app-bar/Appbar.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/app-bar/Appbar.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 
-import { getVersion } from '@rest/miscAPI';
 import { Button, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import { CookieStorage } from 'cookie-storage';
@@ -20,6 +19,7 @@ import { observer } from 'mobx-react';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useHistory, useLocation, useRouteMatch } from 'react-router-dom';
+import { getVersion } from 'rest/miscAPI';
 import appState from '../../AppState';
 import {
   getExplorePathWithSearch,

--- a/openmetadata-ui/src/main/resources/ui/src/components/app-bar/Suggestions.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/app-bar/Suggestions.tsx
@@ -11,10 +11,10 @@
  *  limitations under the License.
  */
 
-import { getSuggestions } from '@rest/miscAPI';
 import { AxiosError } from 'axios';
 import React, { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { getSuggestions } from 'rest/miscAPI';
 import { FQN_SEPARATOR_CHAR } from '../../constants/char.constants';
 import { FqnPart } from '../../enums/entity.enum';
 import { SearchIndex } from '../../enums/search.enum';

--- a/openmetadata-ui/src/main/resources/ui/src/components/authentication/auth-provider/AuthProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/authentication/auth-provider/AuthProvider.tsx
@@ -16,9 +16,6 @@ import { Auth0Provider } from '@auth0/auth0-react';
 import { Configuration } from '@azure/msal-browser';
 import { MsalProvider } from '@azure/msal-react';
 import { LoginCallback } from '@okta/okta-react';
-import axiosClient from '@rest/index';
-import { fetchAuthenticationConfig } from '@rest/miscAPI';
-import { getLoggedInUser, getUserByName, updateUser } from '@rest/userAPI';
 import { AxiosError } from 'axios';
 import { CookieStorage } from 'cookie-storage';
 import { isEmpty, isNil } from 'lodash';
@@ -34,6 +31,9 @@ import React, {
   useState,
 } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
+import axiosClient from 'rest/index';
+import { fetchAuthenticationConfig } from 'rest/miscAPI';
+import { getLoggedInUser, getUserByName, updateUser } from 'rest/userAPI';
 import appState from '../../../AppState';
 import { NO_AUTH } from '../../../constants/auth.constants';
 import { REDIRECT_PATHNAME, ROUTES } from '../../../constants/constants';

--- a/openmetadata-ui/src/main/resources/ui/src/components/authentication/auth-provider/basic-auth.provider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/authentication/auth-provider/basic-auth.provider.tsx
@@ -11,6 +11,10 @@
  *  limitations under the License.
  */
 
+import { AxiosError } from 'axios';
+import { JwtPayload } from 'jwt-decode';
+import React, { createContext, ReactNode, useContext, useState } from 'react';
+import { useHistory } from 'react-router-dom';
 import {
   basicAuthRegister,
   basicAuthSignIn,
@@ -18,11 +22,7 @@ import {
   generatePasswordResetLink,
   logoutUser,
   resetPassword,
-} from '@rest/auth-API';
-import { AxiosError } from 'axios';
-import { JwtPayload } from 'jwt-decode';
-import React, { createContext, ReactNode, useContext, useState } from 'react';
-import { useHistory } from 'react-router-dom';
+} from 'rest/auth-API';
 import {
   HTTP_STATUS_CODE,
   LOGIN_FAILED_ERROR,

--- a/openmetadata-ui/src/main/resources/ui/src/components/authentication/authenticators/OidcAuthenticator.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/authentication/authenticators/OidcAuthenticator.tsx
@@ -11,10 +11,10 @@
  *  limitations under the License.
  */
 
-import SigninPage from '@pages/login';
-import PageNotFound from '@pages/page-not-found';
 import { isEmpty } from 'lodash';
 import { UserManager, WebStorageStateStore } from 'oidc-client';
+import SigninPage from 'pages/login';
+import PageNotFound from 'pages/page-not-found';
 import React, {
   ComponentType,
   forwardRef,

--- a/openmetadata-ui/src/main/resources/ui/src/components/authentication/authenticators/basic-auth.authenticator.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/authentication/authenticators/basic-auth.authenticator.tsx
@@ -11,13 +11,13 @@
  *  limitations under the License.
  */
 
-import { AccessTokenResponse, getAccessTokenOnExpiry } from '@rest/auth-API';
 import React, {
   forwardRef,
   Fragment,
   ReactNode,
   useImperativeHandle,
 } from 'react';
+import { AccessTokenResponse, getAccessTokenOnExpiry } from 'rest/auth-API';
 import { AuthTypes } from '../../../enums/signin.enum';
 import localState from '../../../utils/LocalStorageUtils';
 import { useAuthContext } from '../auth-provider/AuthProvider';

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/CustomPropertyTable.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/CustomPropertyTable.test.tsx
@@ -11,9 +11,9 @@
  *  limitations under the License.
  */
 
-import { getTypeByFQN } from '@rest/metadataTypeAPI';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { getTypeByFQN } from 'rest/metadataTypeAPI';
 import { EntityType } from '../../../enums/entity.enum';
 import { Dashboard } from '../../../generated/entity/data/dashboard';
 import { Mlmodel } from '../../../generated/entity/data/mlmodel';
@@ -54,7 +54,7 @@ jest.mock('../error-with-placeholder/ErrorPlaceHolder', () => {
   return jest.fn().mockReturnValue(<div>ErrorPlaceHolder.component</div>);
 });
 
-jest.mock('@rest/metadataTypeAPI', () => ({
+jest.mock('rest/metadataTypeAPI', () => ({
   getTypeByFQN: jest.fn().mockImplementation(() =>
     Promise.resolve({
       customProperties: mockCustomProperties,

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/CustomPropertyTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/CustomPropertyTable.tsx
@@ -11,12 +11,12 @@
  *  limitations under the License.
  */
 
-import { getTypeByFQN } from '@rest/metadataTypeAPI';
 import { Table } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
 import { AxiosError } from 'axios';
 import { isEmpty } from 'lodash';
 import React, { FC, useEffect, useMemo, useState } from 'react';
+import { getTypeByFQN } from 'rest/metadataTypeAPI';
 import { CustomProperty, Type } from '../../../generated/entity/type';
 import { showErrorToast } from '../../../utils/ToastUtils';
 import ErrorPlaceHolder from '../error-with-placeholder/ErrorPlaceHolder';

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/DeleteWidget/DeleteWidgetModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/DeleteWidget/DeleteWidgetModal.test.tsx
@@ -34,7 +34,7 @@ jest.mock('react-router-dom', () => ({
   useHistory: jest.fn(),
 }));
 
-jest.mock('@rest/miscAPI', () => ({
+jest.mock('rest/miscAPI', () => ({
   deleteEntity: jest.fn().mockImplementation(() => Promise.resolve({})),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/DeleteWidget/DeleteWidgetModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/DeleteWidget/DeleteWidgetModal.tsx
@@ -11,12 +11,12 @@
  *  limitations under the License.
  */
 
-import { deleteEntity } from '@rest/miscAPI';
 import { Modal, Radio, RadioChangeEvent } from 'antd';
 import { AxiosError } from 'axios';
 import { startCase } from 'lodash';
 import React, { ChangeEvent, useCallback, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
+import { deleteEntity } from 'rest/miscAPI';
 import { ENTITY_DELETE_STATE } from '../../../constants/entity.constants';
 import { EntityType } from '../../../enums/entity.enum';
 import jsonData from '../../../jsons/en';

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/FormBuilder/FormBuilder.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/FormBuilder/FormBuilder.tsx
@@ -12,13 +12,13 @@
  */
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { getPipelineServiceHostIp } from '@rest/ingestionPipelineAPI';
 import Form from '@rjsf/antd';
 import CoreForm, { AjvError, FormProps, IChangeEvent } from '@rjsf/core';
 import classNames from 'classnames';
 import { isEmpty, startCase } from 'lodash';
 import { LoadingState } from 'Models';
 import React, { FunctionComponent, useEffect, useRef, useState } from 'react';
+import { getPipelineServiceHostIp } from 'rest/ingestionPipelineAPI';
 import { ConfigData } from '../../../interface/service.interface';
 import { formatFormDataForRender } from '../../../utils/JSONSchemaFormUtils';
 import SVGIcons, { Icons } from '../../../utils/SvgUtils';

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/OwnerWidget/OwnerWidgetWrapper.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/OwnerWidget/OwnerWidgetWrapper.component.tsx
@@ -11,11 +11,11 @@
  *  limitations under the License.
  */
 
-import { getGroupTypeTeams } from '@rest/userAPI';
 import { AxiosError } from 'axios';
 import { debounce, isEqual, lowerCase } from 'lodash';
 import { LoadingState } from 'Models';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { getGroupTypeTeams } from 'rest/userAPI';
 import { default as AppState, default as appState } from '../../../AppState';
 import { WILD_CARD_CHAR } from '../../../constants/char.constants';
 import { Table } from '../../../generated/entity/data/table';

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/PopOverCard/EntityPopOverCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/PopOverCard/EntityPopOverCard.tsx
@@ -11,15 +11,6 @@
  *  limitations under the License.
  */
 
-import { getDashboardByFqn } from '@rest/dashboardAPI';
-import {
-  getDatabaseDetailsByFQN,
-  getDatabaseSchemaDetailsByFQN,
-} from '@rest/databaseAPI';
-import { getMlModelByFQN } from '@rest/mlModelAPI';
-import { getPipelineByFqn } from '@rest/pipelineAPI';
-import { getTableDetailsByFQN } from '@rest/tableAPI';
-import { getTopicByFqn } from '@rest/topicsAPI';
 import { Button, Divider, Popover, Space, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import { uniqueId } from 'lodash';
@@ -27,6 +18,15 @@ import { EntityTags } from 'Models';
 import React, { FC, HTMLAttributes, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
+import { getDashboardByFqn } from 'rest/dashboardAPI';
+import {
+  getDatabaseDetailsByFQN,
+  getDatabaseSchemaDetailsByFQN,
+} from 'rest/databaseAPI';
+import { getMlModelByFQN } from 'rest/mlModelAPI';
+import { getPipelineByFqn } from 'rest/pipelineAPI';
+import { getTableDetailsByFQN } from 'rest/tableAPI';
+import { getTopicByFqn } from 'rest/topicsAPI';
 import AppState from '../../../AppState';
 import { FQN_SEPARATOR_CHAR } from '../../../constants/char.constants';
 import { EntityType } from '../../../enums/entity.enum';

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/PopOverCard/UserPopOverCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/PopOverCard/UserPopOverCard.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 
-import { getUserByName } from '@rest/userAPI';
 import { Popover } from 'antd';
 import { isEmpty } from 'lodash';
 import React, {
@@ -22,6 +21,7 @@ import React, {
   useState,
 } from 'react';
 import { useHistory } from 'react-router-dom';
+import { getUserByName } from 'rest/userAPI';
 import AppState from '../../../AppState';
 import { getUserPath, TERM_ADMIN } from '../../../constants/constants';
 import { User } from '../../../generated/entity/teams/user';

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/TierCard/TierCard.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/TierCard/TierCard.test.tsx
@@ -31,7 +31,7 @@ const mockTierData = [
   },
 ];
 
-jest.mock('@rest/tagAPI', () => ({
+jest.mock('rest/tagAPI', () => ({
   getTags: jest.fn().mockResolvedValue({ data: mockTierData }),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/TierCard/TierCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/TierCard/TierCard.tsx
@@ -11,12 +11,12 @@
  *  limitations under the License.
  */
 
-import { getTags } from '@rest/tagAPI';
 import { Button, Card, Col, Popover, Row, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import classNames from 'classnames';
 import { LoadingState, TableDetail } from 'Models';
 import React, { useEffect, useState } from 'react';
+import { getTags } from 'rest/tagAPI';
 import { FQN_SEPARATOR_CHAR } from '../../../constants/char.constants';
 import { EntityReference } from '../../../generated/type/entityReference';
 import jsonData from '../../../jsons/en';

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/entityPageInfo/AnnouncementDrawer/AnnouncementDrawer.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/entityPageInfo/AnnouncementDrawer/AnnouncementDrawer.tsx
@@ -12,13 +12,13 @@
  */
 
 import { CloseOutlined } from '@ant-design/icons';
-import { postFeedById, postThread } from '@rest/feedsAPI';
 import { Button, Drawer, Space, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import { Operation } from 'fast-json-patch';
 import { uniqueId } from 'lodash';
 import { observer } from 'mobx-react';
 import React, { FC, useMemo, useState } from 'react';
+import { postFeedById, postThread } from 'rest/feedsAPI';
 import AppState from '../../../../AppState';
 import {
   CreateThread,

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/entityPageInfo/EntityPageInfo.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/entityPageInfo/EntityPageInfo.test.tsx
@@ -240,7 +240,7 @@ jest.mock('./AnnouncementDrawer/AnnouncementDrawer', () => {
   return jest.fn().mockReturnValue(<div>AnnouncementDrawer</div>);
 });
 
-jest.mock('@rest/feedsAPI', () => ({
+jest.mock('rest/feedsAPI', () => ({
   getActiveAnnouncement: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/entityPageInfo/EntityPageInfo.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/entityPageInfo/EntityPageInfo.tsx
@@ -13,7 +13,6 @@
 
 import { faExclamationCircle, faStar } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { getActiveAnnouncement } from '@rest/feedsAPI';
 import { Button, Popover, Space, Tooltip } from 'antd';
 import { AxiosError } from 'axios';
 import classNames from 'classnames';
@@ -22,6 +21,7 @@ import { cloneDeep, isEmpty, isUndefined } from 'lodash';
 import { EntityTags, ExtraInfo, TagOption } from 'Models';
 import React, { Fragment, useCallback, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
+import { getActiveAnnouncement } from 'rest/feedsAPI';
 import { FQN_SEPARATOR_CHAR } from '../../../constants/char.constants';
 import { FOLLOWERS_VIEW_CAP } from '../../../constants/constants';
 import { EntityType } from '../../../enums/entity.enum';

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/entityPageInfo/FollowersModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/entityPageInfo/FollowersModal.tsx
@@ -11,9 +11,9 @@
  *  limitations under the License.
  */
 
-import UserCard from '@pages/teams/UserCard';
 import { Col, Modal, Row, Typography } from 'antd';
 import { t } from 'i18next';
+import UserCard from 'pages/teams/UserCard';
 import React, { useState } from 'react';
 import { getEntityName } from '../../../utils/CommonUtils';
 import Searchbar from '../searchbar/Searchbar';

--- a/openmetadata-ui/src/main/resources/ui/src/components/containers/PageContainer.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/containers/PageContainer.tsx
@@ -12,12 +12,21 @@
  */
 
 import classnames from 'classnames';
-import PropTypes from 'prop-types';
-import React from 'react';
+import React, { FC, ReactNode } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useAuth } from '../../hooks/authHooks';
 
-const PageContainer = ({ children, leftPanelContent, className }) => {
+interface Props {
+  children: ReactNode;
+  leftPanelContent?: ReactNode;
+  className?: string;
+}
+
+const PageContainer: FC<Props> = ({
+  children,
+  leftPanelContent,
+  className,
+}) => {
   const location = useLocation();
   const { isAuthenticatedRoute } = useAuth(location.pathname);
 
@@ -37,18 +46,6 @@ const PageContainer = ({ children, leftPanelContent, className }) => {
       </div>
     </div>
   );
-};
-
-PageContainer.propTypes = {
-  children: PropTypes.oneOfType([
-    PropTypes.node,
-    PropTypes.arrayOf(PropTypes.node),
-  ]).isRequired,
-  leftPanelContent: PropTypes.oneOfType([
-    PropTypes.node,
-    PropTypes.arrayOf(PropTypes.node),
-  ]),
-  className: PropTypes.string,
 };
 
 export default PageContainer;

--- a/openmetadata-ui/src/main/resources/ui/src/components/router/AppRouter.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/router/AppRouter.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import AccountActivationConfirmation from '@pages/signup/account-activation-confirmation.component';
+import AccountActivationConfirmation from 'pages/signup/account-activation-confirmation.component';
 import React, { useEffect } from 'react';
 import { Redirect, Route, Switch, useLocation } from 'react-router-dom';
 import { useAnalytics } from 'use-analytics';
@@ -26,22 +26,22 @@ const AuthenticatedAppRouter = withSuspenseFallback(
   React.lazy(() => import('./AuthenticatedAppRouter'))
 );
 const SigninPage = withSuspenseFallback(
-  React.lazy(() => import('@pages/login'))
+  React.lazy(() => import('pages/login'))
 );
 const PageNotFound = withSuspenseFallback(
-  React.lazy(() => import('@pages/page-not-found'))
+  React.lazy(() => import('pages/page-not-found'))
 );
 
 const ForgotPassword = withSuspenseFallback(
-  React.lazy(() => import('@pages/forgot-password/forgot-password.component'))
+  React.lazy(() => import('pages/forgot-password/forgot-password.component'))
 );
 
 const ResetPassword = withSuspenseFallback(
-  React.lazy(() => import('@pages/reset-password/reset-password.component'))
+  React.lazy(() => import('pages/reset-password/reset-password.component'))
 );
 
 const BasicSignupPage = withSuspenseFallback(
-  React.lazy(() => import('@pages/signup/basic-signup.component'))
+  React.lazy(() => import('pages/signup/basic-signup.component'))
 );
 
 const AppRouter = () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/router/AuthenticatedAppRouter.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/router/AuthenticatedAppRouter.tsx
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import LineagePage from '@pages/LineagePage/LineagePage';
 import { isEmpty } from 'lodash';
+import LineagePage from 'pages/LineagePage/LineagePage';
 import React, { FunctionComponent, useMemo } from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import AppState from '../../AppState';
@@ -25,28 +25,28 @@ import AdminProtectedRoute from './AdminProtectedRoute';
 import withSuspenseFallback from './withSuspenseFallback';
 
 const GlobalSettingPage = withSuspenseFallback(
-  React.lazy(() => import('@pages/GlobalSettingPage/GlobalSettingPage'))
+  React.lazy(() => import('pages/GlobalSettingPage/GlobalSettingPage'))
 );
 
 const ProfilerDashboardPage = withSuspenseFallback(
-  React.lazy(() => import('@pages/ProfilerDashboardPage/ProfilerDashboardPage'))
+  React.lazy(() => import('pages/ProfilerDashboardPage/ProfilerDashboardPage'))
 );
 
 const TestSuiteIngestionPage = withSuspenseFallback(
   React.lazy(
-    () => import('@pages/TestSuiteIngestionPage/TestSuiteIngestionPage')
+    () => import('pages/TestSuiteIngestionPage/TestSuiteIngestionPage')
   )
 );
 
 const TestSuiteDetailsPage = withSuspenseFallback(
   React.lazy(
-    () => import('@pages/TestSuiteDetailsPage/TestSuiteDetailsPage.component')
+    () => import('pages/TestSuiteDetailsPage/TestSuiteDetailsPage.component')
   )
 );
 
 const AddDataQualityTestPage = withSuspenseFallback(
   React.lazy(
-    () => import('@pages/AddDataQualityTestPage/AddDataQualityTestPage')
+    () => import('pages/AddDataQualityTestPage/AddDataQualityTestPage')
   )
 );
 
@@ -57,163 +57,161 @@ const AddCustomProperty = withSuspenseFallback(
 );
 
 const MyDataPage = withSuspenseFallback(
-  React.lazy(() => import('@pages/MyDataPage/MyDataPage.component'))
+  React.lazy(() => import('pages/MyDataPage/MyDataPage.component'))
 );
 
 const PipelineDetailsPage = withSuspenseFallback(
   React.lazy(
-    () => import('@pages/PipelineDetails/PipelineDetailsPage.component')
+    () => import('pages/PipelineDetails/PipelineDetailsPage.component')
   )
 );
 const BotDetailsPage = withSuspenseFallback(
-  React.lazy(() => import('@pages/BotDetailsPage/BotDetailsPage'))
+  React.lazy(() => import('pages/BotDetailsPage/BotDetailsPage'))
 );
 const ServicePage = withSuspenseFallback(
-  React.lazy(() => import('@pages/service'))
+  React.lazy(() => import('pages/service'))
 );
 const SignupPage = withSuspenseFallback(
-  React.lazy(() => import('@pages/signup'))
+  React.lazy(() => import('pages/signup'))
 );
 const SwaggerPage = withSuspenseFallback(
-  React.lazy(() => import('@pages/swagger'))
+  React.lazy(() => import('pages/swagger'))
 );
-const TagsPage = withSuspenseFallback(React.lazy(() => import('@pages/tags')));
+const TagsPage = withSuspenseFallback(React.lazy(() => import('pages/tags')));
 const TopicDetailsPage = withSuspenseFallback(
-  React.lazy(() => import('@pages/TopicDetails/TopicDetailsPage.component'))
+  React.lazy(() => import('pages/TopicDetails/TopicDetailsPage.component'))
 );
 const TourPageComponent = withSuspenseFallback(
-  React.lazy(() => import('@pages/tour-page/TourPage.component'))
+  React.lazy(() => import('pages/tour-page/TourPage.component'))
 );
 const UserPage = withSuspenseFallback(
-  React.lazy(() => import('@pages/UserPage/UserPage.component'))
+  React.lazy(() => import('pages/UserPage/UserPage.component'))
 );
 
 const AddGlossaryPage = withSuspenseFallback(
-  React.lazy(() => import('@pages/AddGlossary/AddGlossaryPage.component'))
+  React.lazy(() => import('pages/AddGlossary/AddGlossaryPage.component'))
 );
 const AddGlossaryTermPage = withSuspenseFallback(
   React.lazy(
-    () => import('@pages/AddGlossaryTermPage/AddGlossaryTermPage.component')
+    () => import('pages/AddGlossaryTermPage/AddGlossaryTermPage.component')
   )
 );
 const AddIngestionPage = withSuspenseFallback(
-  React.lazy(() => import('@pages/AddIngestionPage/AddIngestionPage.component'))
+  React.lazy(() => import('pages/AddIngestionPage/AddIngestionPage.component'))
 );
 const AddServicePage = withSuspenseFallback(
-  React.lazy(() => import('@pages/AddServicePage/AddServicePage.component'))
+  React.lazy(() => import('pages/AddServicePage/AddServicePage.component'))
 );
 const EditConnectionFormPage = withSuspenseFallback(
   React.lazy(
     () =>
-      import('@pages/EditConnectionFormPage/EditConnectionFormPage.component')
+      import('pages/EditConnectionFormPage/EditConnectionFormPage.component')
   )
 );
 
 const CreateUserPage = withSuspenseFallback(
-  React.lazy(() => import('@pages/CreateUserPage/CreateUserPage.component'))
+  React.lazy(() => import('pages/CreateUserPage/CreateUserPage.component'))
 );
 const DashboardDetailsPage = withSuspenseFallback(
   React.lazy(
-    () => import('@pages/DashboardDetailsPage/DashboardDetailsPage.component')
+    () => import('pages/DashboardDetailsPage/DashboardDetailsPage.component')
   )
 );
 const DatabaseDetails = withSuspenseFallback(
-  React.lazy(() => import('@pages/database-details/index'))
+  React.lazy(() => import('pages/database-details/index'))
 );
 const DatabaseSchemaPageComponent = withSuspenseFallback(
   React.lazy(
-    () => import('@pages/DatabaseSchemaPage/DatabaseSchemaPage.component')
+    () => import('pages/DatabaseSchemaPage/DatabaseSchemaPage.component')
   )
 );
 const DatasetDetailsPage = withSuspenseFallback(
   React.lazy(
-    () => import('@pages/DatasetDetailsPage/DatasetDetailsPage.component')
+    () => import('pages/DatasetDetailsPage/DatasetDetailsPage.component')
   )
 );
 const EditIngestionPage = withSuspenseFallback(
   React.lazy(
-    () => import('@pages/EditIngestionPage/EditIngestionPage.component')
+    () => import('pages/EditIngestionPage/EditIngestionPage.component')
   )
 );
 const EntityVersionPage = withSuspenseFallback(
   React.lazy(
-    () => import('@pages/EntityVersionPage/EntityVersionPage.component')
+    () => import('pages/EntityVersionPage/EntityVersionPage.component')
   )
 );
 const ExplorePage = withSuspenseFallback(
-  React.lazy(() => import('@pages/explore/ExplorePage.component'))
+  React.lazy(() => import('pages/explore/ExplorePage.component'))
 );
 const GlossaryPageV1 = withSuspenseFallback(
-  React.lazy(() => import('@pages/GlossaryPage/GlossaryPageV1.component'))
+  React.lazy(() => import('pages/GlossaryPage/GlossaryPageV1.component'))
 );
 
 const MlModelPage = withSuspenseFallback(
-  React.lazy(() => import('@pages/MlModelPage/MlModelPage.component'))
+  React.lazy(() => import('pages/MlModelPage/MlModelPage.component'))
 );
 
 const RequestDescriptionPage = withSuspenseFallback(
   React.lazy(
     () =>
-      import('@pages/TasksPage/RequestDescriptionPage/RequestDescriptionPage')
+      import('pages/TasksPage/RequestDescriptionPage/RequestDescriptionPage')
   )
 );
 
 const RequestTagsPage = withSuspenseFallback(
-  React.lazy(() => import('@pages/TasksPage/RequestTagPage/RequestTagPage'))
+  React.lazy(() => import('pages/TasksPage/RequestTagPage/RequestTagPage'))
 );
 
 const UpdateDescriptionPage = withSuspenseFallback(
   React.lazy(
-    () => import('@pages/TasksPage/UpdateDescriptionPage/UpdateDescriptionPage')
+    () => import('pages/TasksPage/UpdateDescriptionPage/UpdateDescriptionPage')
   )
 );
 
 const UpdateTagsPage = withSuspenseFallback(
-  React.lazy(() => import('@pages/TasksPage/UpdateTagPage/UpdateTagPage'))
+  React.lazy(() => import('pages/TasksPage/UpdateTagPage/UpdateTagPage'))
 );
 
 const TaskDetailPage = withSuspenseFallback(
-  React.lazy(() => import('@pages/TasksPage/TaskDetailPage/TaskDetailPage'))
+  React.lazy(() => import('pages/TasksPage/TaskDetailPage/TaskDetailPage'))
 );
 
 const AddRolePage = withSuspenseFallback(
-  React.lazy(() => import('@pages/RolesPage/AddRolePage/AddRolePage'))
+  React.lazy(() => import('pages/RolesPage/AddRolePage/AddRolePage'))
 );
 const AddPolicyPage = withSuspenseFallback(
-  React.lazy(() => import('@pages/PoliciesPage/AddPolicyPage/AddPolicyPage'))
+  React.lazy(() => import('pages/PoliciesPage/AddPolicyPage/AddPolicyPage'))
 );
 
 const AddRulePage = withSuspenseFallback(
-  React.lazy(() => import('@pages/PoliciesPage/PoliciesDetailPage/AddRulePage'))
+  React.lazy(() => import('pages/PoliciesPage/PoliciesDetailPage/AddRulePage'))
 );
 const EditRulePage = withSuspenseFallback(
-  React.lazy(
-    () => import('@pages/PoliciesPage/PoliciesDetailPage/EditRulePage')
-  )
+  React.lazy(() => import('pages/PoliciesPage/PoliciesDetailPage/EditRulePage'))
 );
 
 const TestSuitePage = withSuspenseFallback(
-  React.lazy(() => import('@pages/TestSuitePage/TestSuitePage'))
+  React.lazy(() => import('pages/TestSuitePage/TestSuitePage'))
 );
 
 const LogsViewer = withSuspenseFallback(
-  React.lazy(() => import('@pages/LogsViewer/LogsViewer.component'))
+  React.lazy(() => import('pages/LogsViewer/LogsViewer.component'))
 );
 
 const DataInsightPage = withSuspenseFallback(
-  React.lazy(() => import('@pages/DataInsightPage/DataInsightPage.component'))
+  React.lazy(() => import('pages/DataInsightPage/DataInsightPage.component'))
 );
 
 const AddKPIPage = withSuspenseFallback(
-  React.lazy(() => import('@pages/KPIPage/AddKPIPage'))
+  React.lazy(() => import('pages/KPIPage/AddKPIPage'))
 );
 
 const EditKPIPage = withSuspenseFallback(
-  React.lazy(() => import('@pages/KPIPage/EditKPIPage'))
+  React.lazy(() => import('pages/KPIPage/EditKPIPage'))
 );
 
 const AddTestSuitePage = withSuspenseFallback(
-  React.lazy(() => import('@pages/TestSuitePage/TestSuiteStepper'))
+  React.lazy(() => import('pages/TestSuitePage/TestSuiteStepper'))
 );
 
 const AuthenticatedAppRouter: FunctionComponent = () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/router/GlobalSettingRouter.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/router/GlobalSettingRouter.tsx
@@ -32,64 +32,64 @@ import AdminProtectedRoute from './AdminProtectedRoute';
 import withSuspenseFallback from './withSuspenseFallback';
 
 const AddAlertPage = withSuspenseFallback(
-  React.lazy(() => import('@pages/AddAlertPage/AddAlertPage'))
+  React.lazy(() => import('pages/AddAlertPage/AddAlertPage'))
 );
 
 const AlertDetailsPage = withSuspenseFallback(
-  React.lazy(() => import('@pages/AlertDetailsPage/AlertDetailsPage'))
+  React.lazy(() => import('pages/AlertDetailsPage/AlertDetailsPage'))
 );
 
 const AlertsActivityFeedPage = withSuspenseFallback(
   React.lazy(
-    () => import('@pages/AlertsActivityFeedPage/AlertsActivityFeedPage')
+    () => import('pages/AlertsActivityFeedPage/AlertsActivityFeedPage')
   )
 );
 
 const AlertsPage = withSuspenseFallback(
-  React.lazy(() => import('@pages/AlertsPage/AlertsPage'))
+  React.lazy(() => import('pages/AlertsPage/AlertsPage'))
 );
 
 const TeamsPage = withSuspenseFallback(
-  React.lazy(() => import('@pages/teams/TeamsPage'))
+  React.lazy(() => import('pages/teams/TeamsPage'))
 );
 
 const ServicesPage = withSuspenseFallback(
-  React.lazy(() => import('@pages/services/ServicesPage'))
+  React.lazy(() => import('pages/services/ServicesPage'))
 );
 const BotsPageV1 = withSuspenseFallback(
-  React.lazy(() => import('@pages/BotsPageV1/BotsPageV1.component'))
+  React.lazy(() => import('pages/BotsPageV1/BotsPageV1.component'))
 );
 const CustomPropertiesPageV1 = withSuspenseFallback(
   React.lazy(
-    () => import('@pages/CustomPropertiesPageV1/CustomPropertiesPageV1')
+    () => import('pages/CustomPropertiesPageV1/CustomPropertiesPageV1')
   )
 );
 const RolesListPage = withSuspenseFallback(
-  React.lazy(() => import('@pages/RolesPage/RolesListPage/RolesListPage'))
+  React.lazy(() => import('pages/RolesPage/RolesListPage/RolesListPage'))
 );
 const RolesDetailPage = withSuspenseFallback(
-  React.lazy(() => import('@pages/RolesPage/RolesDetailPage/RolesDetailPage'))
+  React.lazy(() => import('pages/RolesPage/RolesDetailPage/RolesDetailPage'))
 );
 
 const PoliciesDetailPage = withSuspenseFallback(
   React.lazy(
-    () => import('@pages/PoliciesPage/PoliciesDetailPage/PoliciesDetailPage')
+    () => import('pages/PoliciesPage/PoliciesDetailPage/PoliciesDetailPage')
   )
 );
 const PoliciesListPage = withSuspenseFallback(
   React.lazy(
-    () => import('@pages/PoliciesPage/PoliciesListPage/PoliciesListPage')
+    () => import('pages/PoliciesPage/PoliciesListPage/PoliciesListPage')
   )
 );
 
 const UserListPageV1 = withSuspenseFallback(
-  React.lazy(() => import('@pages/UserListPage/UserListPageV1'))
+  React.lazy(() => import('pages/UserListPage/UserListPageV1'))
 );
 
 const ElasticSearchIndexPage = withSuspenseFallback(
   React.lazy(
     () =>
-      import('@pages/ElasticSearchIndexPage/ElasticSearchReIndexPage.component')
+      import('pages/ElasticSearchIndexPage/ElasticSearchReIndexPage.component')
   )
 );
 

--- a/openmetadata-ui/src/main/resources/ui/src/constants/AdvancedSearch.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/AdvancedSearch.constants.ts
@@ -11,8 +11,6 @@
  *  limitations under the License.
  */
 
-import { getAdvancedFieldDefaultOptions } from '@rest/miscAPI';
-import { suggestQuery } from '@rest/searchAPI';
 import i18next from 'i18next';
 import { isUndefined, uniq } from 'lodash';
 import {
@@ -23,6 +21,8 @@ import {
   Utils as QbUtils,
 } from 'react-awesome-query-builder';
 import AntdConfig from 'react-awesome-query-builder/lib/config/antd';
+import { getAdvancedFieldDefaultOptions } from 'rest/miscAPI';
+import { suggestQuery } from 'rest/searchAPI';
 import { EntityFields, SuggestionField } from '../enums/AdvancedSearch.enum';
 import { SearchIndex } from '../enums/search.enum';
 import { renderAdvanceSearchButtons } from '../utils/AdvancedSearchUtils';

--- a/openmetadata-ui/src/main/resources/ui/src/constants/GlobalSettings.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/GlobalSettings.constants.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { ResourceEntity } from '@components/PermissionProvider/PermissionProvider.interface';
+import { ResourceEntity } from 'components/PermissionProvider/PermissionProvider.interface';
 
 export enum GlobalSettingsMenuCategory {
   ACCESS = 'access',

--- a/openmetadata-ui/src/main/resources/ui/src/constants/Glossary.constant.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/Glossary.constant.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { AddGlossaryError } from '@components/AddGlossary/AddGlossary.interface';
+import { AddGlossaryError } from 'components/AddGlossary/AddGlossary.interface';
 import { t } from 'i18next';
 import { errorMsg } from '../utils/CommonUtils';
 

--- a/openmetadata-ui/src/main/resources/ui/src/constants/Lineage.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/Lineage.constants.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { ElementLoadingState } from '@components/EntityLineage/EntityLineage.interface';
+import { ElementLoadingState } from 'components/EntityLineage/EntityLineage.interface';
 import { capitalize } from 'lodash';
 import { EntityType } from '../enums/entity.enum';
 

--- a/openmetadata-ui/src/main/resources/ui/src/constants/Teams.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/Teams.constants.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import DraggableBodyRow from '@components/TeamDetails/DraggableBodyRow';
+import DraggableBodyRow from 'components/TeamDetails/DraggableBodyRow';
 
 export const DRAGGABLE_BODY_ROW = 'DraggableBodyRow';
 

--- a/openmetadata-ui/src/main/resources/ui/src/constants/constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/constants.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { COOKIE_VERSION } from '@components/Modals/WhatsNewModal/whatsNewData';
+import { COOKIE_VERSION } from 'components/Modals/WhatsNewModal/whatsNewData';
 import { getSettingPath } from '../utils/RouterUtils';
 import { getEncodedFqn } from '../utils/StringsUtils';
 import { FQN_SEPARATOR_CHAR } from './char.constants';

--- a/openmetadata-ui/src/main/resources/ui/src/constants/explore.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/explore.constants.ts
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import { ExploreSearchIndex } from '@components/Explore/explore.interface';
-import { SortingField } from '@components/Explore/SortingDropDown';
+import { ExploreSearchIndex } from 'components/Explore/explore.interface';
+import { SortingField } from 'components/Explore/SortingDropDown';
 import { t } from 'i18next';
 import { SearchIndex } from '../enums/search.enum';
 import { Icons } from '../utils/SvgUtils';

--- a/openmetadata-ui/src/main/resources/ui/src/constants/mockTourData.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/mockTourData.constants.ts
@@ -13,7 +13,7 @@
 
 /* eslint-disable max-len */
 
-import { ExploreSearchIndex } from '@components/Explore/explore.interface';
+import { ExploreSearchIndex } from 'components/Explore/explore.interface';
 import { SearchIndex } from '../enums/search.enum';
 import {
   Constraint,

--- a/openmetadata-ui/src/main/resources/ui/src/hoc/withLoader.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/hoc/withLoader.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import Loader from '@components/Loader/Loader';
+import Loader from 'components/Loader/Loader';
 import PropTypes from 'prop-types';
 import React, { ComponentType, PropsWithChildren } from 'react';
 

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useAirflowStatus.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useAirflowStatus.ts
@@ -11,9 +11,9 @@
  *  limitations under the License.
  */
 
-import { checkAirflowStatus } from '@rest/ingestionPipelineAPI';
 import { AxiosError } from 'axios';
 import { useEffect, useState } from 'react';
+import { checkAirflowStatus } from 'rest/ingestionPipelineAPI';
 
 interface UseAirflowStatusProps {
   isFetchingStatus: boolean;

--- a/openmetadata-ui/src/main/resources/ui/src/pages/AddAlertPage/AddAlertPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/AddAlertPage/AddAlertPage.tsx
@@ -12,18 +12,6 @@
  *  limitations under the License.
  */
 import { PlusOutlined } from '@ant-design/icons';
-import { AsyncSelect } from '@components/AsyncSelect/AsyncSelect';
-import { createAlertAction, updateAlertAction } from '@rest/alertActionAPI';
-import {
-  createAlert,
-  getAlertActionForAlerts,
-  getAlertsFromId,
-  getDefaultTriggerConfigs,
-  getEntityFilterFunctions,
-  getFilterFunctions,
-  updateAlert,
-} from '@rest/alertsAPI';
-import { getSearchedUsersAndTeams, getSuggestions } from '@rest/miscAPI';
 import {
   Button,
   Card,
@@ -40,10 +28,22 @@ import {
 } from 'antd';
 import { useForm } from 'antd/lib/form/Form';
 import { DefaultOptionType } from 'antd/lib/select';
+import { AsyncSelect } from 'components/AsyncSelect/AsyncSelect';
 import { get, intersection, isEmpty, map, pick, startCase, trim } from 'lodash';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory, useParams } from 'react-router-dom';
+import { createAlertAction, updateAlertAction } from 'rest/alertActionAPI';
+import {
+  createAlert,
+  getAlertActionForAlerts,
+  getAlertsFromId,
+  getDefaultTriggerConfigs,
+  getEntityFilterFunctions,
+  getFilterFunctions,
+  updateAlert,
+} from 'rest/alertsAPI';
+import { getSearchedUsersAndTeams, getSuggestions } from 'rest/miscAPI';
 import {
   GlobalSettingOptions,
   GlobalSettingsMenuCategory,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/AddDataQualityTestPage/AddDataQualityTestPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/AddDataQualityTestPage/AddDataQualityTestPage.tsx
@@ -11,12 +11,12 @@
  *  limitations under the License.
  */
 
-import AddDataQualityTestV1 from '@components/AddDataQualityTest/AddDataQualityTestV1';
-import PageContainerV1 from '@components/containers/PageContainerV1';
-import { getTableDetailsByFQN } from '@rest/tableAPI';
 import { AxiosError } from 'axios';
+import AddDataQualityTestV1 from 'components/AddDataQualityTest/AddDataQualityTestV1';
+import PageContainerV1 from 'components/containers/PageContainerV1';
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { getTableDetailsByFQN } from 'rest/tableAPI';
 import { ProfilerDashboardType } from '../../enums/table.enum';
 import { Table } from '../../generated/entity/data/table';
 import { getTableFQNFromColumnFQN } from '../../utils/CommonUtils';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/AddGlossary/AddGlossaryPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/AddGlossary/AddGlossaryPage.component.tsx
@@ -11,13 +11,12 @@
  *  limitations under the License.
  */
 
-import AddGlossary from '@components/AddGlossary/AddGlossary.component';
-import { TitleBreadcrumbProps } from '@components/common/title-breadcrumb/title-breadcrumb.interface';
-import PageContainerV1 from '@components/containers/PageContainerV1';
-import { usePermissionProvider } from '@components/PermissionProvider/PermissionProvider';
-import { ResourceEntity } from '@components/PermissionProvider/PermissionProvider.interface';
-import { addGlossaries } from '@rest/glossaryAPI';
 import { AxiosError } from 'axios';
+import AddGlossary from 'components/AddGlossary/AddGlossary.component';
+import { TitleBreadcrumbProps } from 'components/common/title-breadcrumb/title-breadcrumb.interface';
+import PageContainerV1 from 'components/containers/PageContainerV1';
+import { usePermissionProvider } from 'components/PermissionProvider/PermissionProvider';
+import { ResourceEntity } from 'components/PermissionProvider/PermissionProvider.interface';
 import { LoadingState } from 'Models';
 import React, {
   FunctionComponent,
@@ -28,6 +27,7 @@ import React, {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
+import { addGlossaries } from 'rest/glossaryAPI';
 import { CreateGlossary } from '../../generated/api/data/createGlossary';
 import { Operation } from '../../generated/entity/policies/policy';
 import jsonData from '../../jsons/en';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/AddGlossary/AddGlossaryPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/AddGlossary/AddGlossaryPage.test.tsx
@@ -19,11 +19,11 @@ jest.mock('react-router-dom', () => ({
   useHistory: jest.fn(),
 }));
 
-jest.mock('@components/AddGlossary/AddGlossary.component', () => {
+jest.mock('components/AddGlossary/AddGlossary.component', () => {
   return jest.fn().mockReturnValue(<div>AddGlossary.component</div>);
 });
 
-jest.mock('@rest/glossaryAPI', () => ({
+jest.mock('rest/glossaryAPI', () => ({
   addGlossaries: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/AddGlossaryTermPage/AddGlossaryTermPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/AddGlossaryTermPage/AddGlossaryTermPage.component.tsx
@@ -11,22 +11,22 @@
  *  limitations under the License.
  */
 
-import AddGlossaryTerm from '@components/AddGlossaryTerm/AddGlossaryTerm.component';
-import { TitleBreadcrumbProps } from '@components/common/title-breadcrumb/title-breadcrumb.interface';
-import PageContainerV1 from '@components/containers/PageContainerV1';
-import Loader from '@components/Loader/Loader';
-import { usePermissionProvider } from '@components/PermissionProvider/PermissionProvider';
-import { ResourceEntity } from '@components/PermissionProvider/PermissionProvider.interface';
-import {
-  addGlossaryTerm,
-  getGlossariesByName,
-  getGlossaryTermByFQN,
-} from '@rest/glossaryAPI';
 import { AxiosError } from 'axios';
+import AddGlossaryTerm from 'components/AddGlossaryTerm/AddGlossaryTerm.component';
+import { TitleBreadcrumbProps } from 'components/common/title-breadcrumb/title-breadcrumb.interface';
+import PageContainerV1 from 'components/containers/PageContainerV1';
+import Loader from 'components/Loader/Loader';
+import { usePermissionProvider } from 'components/PermissionProvider/PermissionProvider';
+import { ResourceEntity } from 'components/PermissionProvider/PermissionProvider.interface';
 import { cloneDeep, get, isUndefined } from 'lodash';
 import { LoadingState } from 'Models';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
+import {
+  addGlossaryTerm,
+  getGlossariesByName,
+  getGlossaryTermByFQN,
+} from 'rest/glossaryAPI';
 import { CreateGlossaryTerm } from '../../generated/api/data/createGlossaryTerm';
 import { Glossary } from '../../generated/entity/data/glossary';
 import { GlossaryTerm } from '../../generated/entity/data/glossaryTerm';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/AddGlossaryTermPage/AddGlossaryTermPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/AddGlossaryTermPage/AddGlossaryTermPage.test.tsx
@@ -29,7 +29,7 @@ jest.mock('react-router', () => ({
   })),
 }));
 
-jest.mock('@components/AddGlossaryTerm/AddGlossaryTerm.component', () => {
+jest.mock('components/AddGlossaryTerm/AddGlossaryTerm.component', () => {
   return jest.fn().mockImplementation(({ onCancel, onSave }) => (
     <div
       data-testid="add-glossary-term"
@@ -44,7 +44,7 @@ jest.mock('../../utils/RouterUtils', () => ({
   getGlossaryPath: jest.fn(),
 }));
 
-jest.mock('@rest/glossaryAPI', () => ({
+jest.mock('rest/glossaryAPI', () => ({
   addGlossaryTerm: jest.fn().mockImplementation(() => Promise.resolve()),
   getGlossariesByName: jest.fn().mockImplementation(() => Promise.resolve()),
   getGlossaryTermByFQN: jest.fn().mockImplementation(() => Promise.resolve()),

--- a/openmetadata-ui/src/main/resources/ui/src/pages/AddIngestionPage/AddIngestionPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/AddIngestionPage/AddIngestionPage.component.tsx
@@ -11,26 +11,26 @@
  *  limitations under the License.
  */
 
-import AddIngestion from '@components/AddIngestion/AddIngestion.component';
-import ErrorPlaceHolder from '@components/common/error-with-placeholder/ErrorPlaceHolder';
-import TitleBreadcrumb from '@components/common/title-breadcrumb/title-breadcrumb.component';
-import { TitleBreadcrumbProps } from '@components/common/title-breadcrumb/title-breadcrumb.interface';
-import PageContainerV1 from '@components/containers/PageContainerV1';
-import PageLayoutV1 from '@components/containers/PageLayoutV1';
-import Loader from '@components/Loader/Loader';
-import {
-  addIngestionPipeline,
-  deployIngestionPipelineById,
-  getIngestionPipelineByFqn,
-} from '@rest/ingestionPipelineAPI';
-import { getServiceByFQN } from '@rest/serviceAPI';
 import { Space } from 'antd';
 import { AxiosError } from 'axios';
+import AddIngestion from 'components/AddIngestion/AddIngestion.component';
+import ErrorPlaceHolder from 'components/common/error-with-placeholder/ErrorPlaceHolder';
+import TitleBreadcrumb from 'components/common/title-breadcrumb/title-breadcrumb.component';
+import { TitleBreadcrumbProps } from 'components/common/title-breadcrumb/title-breadcrumb.interface';
+import PageContainerV1 from 'components/containers/PageContainerV1';
+import PageLayoutV1 from 'components/containers/PageLayoutV1';
+import Loader from 'components/Loader/Loader';
 import { startCase } from 'lodash';
 import { ServiceTypes } from 'Models';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory, useParams } from 'react-router-dom';
+import {
+  addIngestionPipeline,
+  deployIngestionPipelineById,
+  getIngestionPipelineByFqn,
+} from 'rest/ingestionPipelineAPI';
+import { getServiceByFQN } from 'rest/serviceAPI';
 import {
   DEPLOYED_PROGRESS_VAL,
   getServiceDetailsPath,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/AddServicePage/AddServicePage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/AddServicePage/AddServicePage.component.tsx
@@ -11,20 +11,20 @@
  *  limitations under the License.
  */
 
-import AddService from '@components/AddService/AddService.component';
-import { TitleBreadcrumbProps } from '@components/common/title-breadcrumb/title-breadcrumb.interface';
-import PageContainerV1 from '@components/containers/PageContainerV1';
-import {
-  addIngestionPipeline,
-  deployIngestionPipelineById,
-  getIngestionPipelineByFqn,
-} from '@rest/ingestionPipelineAPI';
-import { postService } from '@rest/serviceAPI';
 import { AxiosError } from 'axios';
+import AddService from 'components/AddService/AddService.component';
+import { TitleBreadcrumbProps } from 'components/common/title-breadcrumb/title-breadcrumb.interface';
+import PageContainerV1 from 'components/containers/PageContainerV1';
 import { startCase } from 'lodash';
 import { ServicesUpdateRequest, ServiceTypes } from 'Models';
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import {
+  addIngestionPipeline,
+  deployIngestionPipelineById,
+  getIngestionPipelineByFqn,
+} from 'rest/ingestionPipelineAPI';
+import { postService } from 'rest/serviceAPI';
 import {
   DEPLOYED_PROGRESS_VAL,
   INGESTION_PROGRESS_END_VAL,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/AddServicePage/AddServicePage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/AddServicePage/AddServicePage.test.tsx
@@ -19,7 +19,7 @@ const mockParam = {
   serviceCategory: 'databaseServices',
 };
 
-jest.mock('@components/containers/PageContainerV1', () => {
+jest.mock('components/containers/PageContainerV1', () => {
   return jest
     .fn()
     .mockImplementation(({ children }: { children: ReactNode }) => (
@@ -27,7 +27,7 @@ jest.mock('@components/containers/PageContainerV1', () => {
     ));
 });
 
-jest.mock('@components/AddService/AddService.component', () => {
+jest.mock('components/AddService/AddService.component', () => {
   return jest.fn().mockImplementation(() => <div>AddService.component</div>);
 });
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/AlertDetailsPage/AlertDetailsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/AlertDetailsPage/AlertDetailsPage.tsx
@@ -11,14 +11,14 @@
  *  limitations under the License.
  */
 
-import { AlertDetailsComponent } from '@components/Alerts/AlertsDetails/AlertDetails.component';
-import DeleteWidgetModal from '@components/common/DeleteWidget/DeleteWidgetModal';
-import { getAlertActionForAlerts, getAlertsFromId } from '@rest/alertsAPI';
 import { Card } from 'antd';
+import { AlertDetailsComponent } from 'components/Alerts/AlertsDetails/AlertDetails.component';
+import DeleteWidgetModal from 'components/common/DeleteWidget/DeleteWidgetModal';
 import { trim } from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
+import { getAlertActionForAlerts, getAlertsFromId } from 'rest/alertsAPI';
 import {
   GlobalSettingOptions,
   GlobalSettingsMenuCategory,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/AlertsActivityFeedPage/AlertsActivityFeedPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/AlertsActivityFeedPage/AlertsActivityFeedPage.tsx
@@ -11,13 +11,13 @@
  *  limitations under the License.
  */
 
-import { AlertDetailsComponent } from '@components/Alerts/AlertsDetails/AlertDetails.component';
-import Loader from '@components/Loader/Loader';
-import { getAlertActionForAlerts, getAlertsFromName } from '@rest/alertsAPI';
 import { Card } from 'antd';
+import { AlertDetailsComponent } from 'components/Alerts/AlertsDetails/AlertDetails.component';
+import Loader from 'components/Loader/Loader';
 import { noop, trim } from 'lodash';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { getAlertActionForAlerts, getAlertsFromName } from 'rest/alertsAPI';
 import { AlertAction } from '../../generated/alerts/alertAction';
 import { AlertFilterRule, Alerts } from '../../generated/alerts/alerts';
 import { getEntityName } from '../../utils/CommonUtils';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/AlertsPage/AlertsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/AlertsPage/AlertsPage.tsx
@@ -10,15 +10,15 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import DeleteWidgetModal from '@components/common/DeleteWidget/DeleteWidgetModal';
-import NextPrevious from '@components/common/next-previous/NextPrevious';
-import Loader from '@components/Loader/Loader';
-import { getAllAlerts } from '@rest/alertsAPI';
 import { Button, Col, Row, Table, Tooltip, Typography } from 'antd';
+import DeleteWidgetModal from 'components/common/DeleteWidget/DeleteWidgetModal';
+import NextPrevious from 'components/common/next-previous/NextPrevious';
+import Loader from 'components/Loader/Loader';
 import { isNil } from 'lodash';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
+import { getAllAlerts } from 'rest/alertsAPI';
 import { PAGE_SIZE_MEDIUM } from '../../constants/constants';
 import {
   GlobalSettingOptions,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/BotDetailsPage/BotDetailsPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/BotDetailsPage/BotDetailsPage.test.tsx
@@ -11,10 +11,10 @@
  *  limitations under the License.
  */
 
-import { getUserByName } from '@rest/userAPI';
 import { render } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
+import { getUserByName } from 'rest/userAPI';
 import BotDetailsPage from './BotDetailsPage';
 
 const mockUserDetail = {
@@ -51,20 +51,20 @@ const botData = {
   deleted: false,
 };
 
-jest.mock('@components/BotDetails/BotDetails.component', () => {
+jest.mock('components/BotDetails/BotDetails.component', () => {
   return jest
     .fn()
     .mockReturnValue(<div data-testid="bots-details">BotsDetails</div>);
 });
 
-jest.mock('@rest/userAPI', () => ({
+jest.mock('rest/userAPI', () => ({
   getBotByName: jest.fn().mockImplementation(() => Promise.resolve(botData)),
   getUserByName: jest.fn().mockImplementation(() => Promise.resolve()),
   revokeUserToken: jest.fn().mockImplementation(() => Promise.resolve()),
   updateUserDetail: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
 
-jest.mock('@components/PermissionProvider/PermissionProvider', () => ({
+jest.mock('components/PermissionProvider/PermissionProvider', () => ({
   usePermissionProvider: jest.fn().mockReturnValue({
     getEntityPermissionByFqn: jest.fn().mockReturnValue({
       Create: true,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/BotDetailsPage/BotDetailsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/BotDetailsPage/BotDetailsPage.tsx
@@ -11,29 +11,29 @@
  *  limitations under the License.
  */
 
-import BotDetails from '@components/BotDetails/BotDetails.component';
-import ErrorPlaceHolder from '@components/common/error-with-placeholder/ErrorPlaceHolder';
-import PageContainerV1 from '@components/containers/PageContainerV1';
-import Loader from '@components/Loader/Loader';
-import { usePermissionProvider } from '@components/PermissionProvider/PermissionProvider';
+import { Typography } from 'antd';
+import { AxiosError } from 'axios';
+import BotDetails from 'components/BotDetails/BotDetails.component';
+import ErrorPlaceHolder from 'components/common/error-with-placeholder/ErrorPlaceHolder';
+import PageContainerV1 from 'components/containers/PageContainerV1';
+import Loader from 'components/Loader/Loader';
+import { usePermissionProvider } from 'components/PermissionProvider/PermissionProvider';
 import {
   OperationPermission,
   ResourceEntity,
-} from '@components/PermissionProvider/PermissionProvider.interface';
-import { UserDetails } from '@components/Users/Users.interface';
+} from 'components/PermissionProvider/PermissionProvider.interface';
+import { UserDetails } from 'components/Users/Users.interface';
+import { compare } from 'fast-json-patch';
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
 import {
   getBotByName,
   getUserByName,
   revokeUserToken,
   updateBotDetail,
   updateUserDetail,
-} from '@rest/userAPI';
-import { Typography } from 'antd';
-import { AxiosError } from 'axios';
-import { compare } from 'fast-json-patch';
-import React, { useEffect, useState } from 'react';
-import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom';
+} from 'rest/userAPI';
 import { NO_PERMISSION_TO_VIEW } from '../../constants/HelperTextUtil';
 import { Bot } from '../../generated/entity/bot';
 import { User } from '../../generated/entity/teams/user';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/BotsPageV1/BotsPageV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/BotsPageV1/BotsPageV1.component.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import BotListV1 from '@components/BotListV1/BotListV1.component';
+import BotListV1 from 'components/BotListV1/BotListV1.component';
 import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { getCreateUserPath } from '../../constants/constants';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/CreateUserPage/CreateUserPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/CreateUserPage/CreateUserPage.component.tsx
@@ -11,16 +11,16 @@
  *  limitations under the License.
  */
 
-import PageContainerV1 from '@components/containers/PageContainerV1';
-import CreateUserComponent from '@components/CreateUser/CreateUser.component';
-import { createBotWithPut } from '@rest/botsAPI';
-import { getRoles } from '@rest/rolesAPIV1';
-import { createUser, createUserWithPut, getBotByName } from '@rest/userAPI';
 import { AxiosError } from 'axios';
+import PageContainerV1 from 'components/containers/PageContainerV1';
+import CreateUserComponent from 'components/CreateUser/CreateUser.component';
 import { observer } from 'mobx-react';
 import { LoadingState } from 'Models';
 import React, { useEffect, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
+import { createBotWithPut } from 'rest/botsAPI';
+import { getRoles } from 'rest/rolesAPIV1';
+import { createUser, createUserWithPut, getBotByName } from 'rest/userAPI';
 import { PAGE_SIZE_LARGE } from '../../constants/constants';
 import {
   GlobalSettingOptions,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/CreateUserPage/CreateUserPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/CreateUserPage/CreateUserPage.test.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 
-import { createUser } from '@rest/userAPI';
 import {
   act,
   findByTestId,
@@ -21,6 +20,7 @@ import {
 } from '@testing-library/react';
 import React, { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
+import { createUser } from 'rest/userAPI';
 import AddUserPageComponent from './CreateUserPage.component';
 
 const mockUserRole = {
@@ -45,11 +45,11 @@ const mockUserRole = {
   },
 };
 
-jest.mock('@rest/rolesAPIV1', () => ({
+jest.mock('rest/rolesAPIV1', () => ({
   getRoles: jest.fn().mockImplementation(() => Promise.resolve(mockUserRole)),
 }));
 
-jest.mock('@components/containers/PageContainerV1', () => {
+jest.mock('components/containers/PageContainerV1', () => {
   return jest
     .fn()
     .mockImplementation(({ children }: { children: ReactNode }) => (
@@ -61,7 +61,7 @@ jest.mock('../../hooks/authHooks', () => ({
   useAuth: jest.fn().mockReturnValue({ isAdminUser: true }),
 }));
 
-jest.mock('@components/CreateUser/CreateUser.component', () => {
+jest.mock('components/CreateUser/CreateUser.component', () => {
   return jest
     .fn()
     .mockImplementation(({ onSave }) => (
@@ -69,7 +69,7 @@ jest.mock('@components/CreateUser/CreateUser.component', () => {
     ));
 });
 
-jest.mock('@rest/userAPI', () => ({
+jest.mock('rest/userAPI', () => ({
   createUser: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/CustomPropertiesPageV1/CustomPropertiesPageV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/CustomPropertiesPageV1/CustomPropertiesPageV1.tsx
@@ -11,25 +11,25 @@
  *  limitations under the License.
  */
 
-import { Button } from '@components/buttons/Button/Button';
-import ErrorPlaceHolder from '@components/common/error-with-placeholder/ErrorPlaceHolder';
-import TabsPane from '@components/common/TabsPane/TabsPane';
-import { CustomPropertyTable } from '@components/CustomEntityDetail/CustomPropertyTable';
-import PageHeader from '@components/header/PageHeader.component';
-import Loader from '@components/Loader/Loader';
-import { usePermissionProvider } from '@components/PermissionProvider/PermissionProvider';
+import { Button as ButtonAntd, Col, Row, Tooltip } from 'antd';
+import { AxiosError } from 'axios';
+import { Button } from 'components/buttons/Button/Button';
+import ErrorPlaceHolder from 'components/common/error-with-placeholder/ErrorPlaceHolder';
+import TabsPane from 'components/common/TabsPane/TabsPane';
+import { CustomPropertyTable } from 'components/CustomEntityDetail/CustomPropertyTable';
+import PageHeader from 'components/header/PageHeader.component';
+import Loader from 'components/Loader/Loader';
+import { usePermissionProvider } from 'components/PermissionProvider/PermissionProvider';
 import {
   OperationPermission,
   ResourceEntity,
-} from '@components/PermissionProvider/PermissionProvider.interface';
-import SchemaEditor from '@components/schema-editor/SchemaEditor';
-import { getTypeByFQN, updateType } from '@rest/metadataTypeAPI';
-import { Button as ButtonAntd, Col, Row, Tooltip } from 'antd';
-import { AxiosError } from 'axios';
+} from 'components/PermissionProvider/PermissionProvider.interface';
+import SchemaEditor from 'components/schema-editor/SchemaEditor';
 import { compare } from 'fast-json-patch';
 import { isEmpty, isUndefined } from 'lodash';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
+import { getTypeByFQN, updateType } from 'rest/metadataTypeAPI';
 import {
   ENTITY_PATH,
   getAddCustomPropertyPath,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DashboardDetailsPage/DashboardDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DashboardDetailsPage/DashboardDetailsPage.component.tsx
@@ -11,36 +11,36 @@
  *  limitations under the License.
  */
 
-import ErrorPlaceHolder from '@components/common/error-with-placeholder/ErrorPlaceHolder';
-import { TitleBreadcrumbProps } from '@components/common/title-breadcrumb/title-breadcrumb.interface';
-import DashboardDetails from '@components/DashboardDetails/DashboardDetails.component';
+import { AxiosError } from 'axios';
+import ErrorPlaceHolder from 'components/common/error-with-placeholder/ErrorPlaceHolder';
+import { TitleBreadcrumbProps } from 'components/common/title-breadcrumb/title-breadcrumb.interface';
+import DashboardDetails from 'components/DashboardDetails/DashboardDetails.component';
 import {
   Edge,
   EdgeData,
   LeafNodes,
   LineagePos,
   LoadingNodeState,
-} from '@components/EntityLineage/EntityLineage.interface';
-import Loader from '@components/Loader/Loader';
-import { usePermissionProvider } from '@components/PermissionProvider/PermissionProvider';
-import { ResourceEntity } from '@components/PermissionProvider/PermissionProvider.interface';
-import { updateChart } from '@rest/chartAPI';
-import {
-  addFollower,
-  getDashboardByFqn,
-  patchDashboardDetails,
-  removeFollower,
-} from '@rest/dashboardAPI';
-import { getAllFeeds, postFeedById, postThread } from '@rest/feedsAPI';
-import { getLineageByFQN } from '@rest/lineageAPI';
-import { addLineage, deleteLineageEdge } from '@rest/miscAPI';
-import { getServiceByFQN } from '@rest/serviceAPI';
-import { AxiosError } from 'axios';
+} from 'components/EntityLineage/EntityLineage.interface';
+import Loader from 'components/Loader/Loader';
+import { usePermissionProvider } from 'components/PermissionProvider/PermissionProvider';
+import { ResourceEntity } from 'components/PermissionProvider/PermissionProvider.interface';
 import { compare, Operation } from 'fast-json-patch';
 import { isEmpty, isUndefined, omitBy } from 'lodash';
 import { EntityTags } from 'Models';
 import React, { useEffect, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
+import { updateChart } from 'rest/chartAPI';
+import {
+  addFollower,
+  getDashboardByFqn,
+  patchDashboardDetails,
+  removeFollower,
+} from 'rest/dashboardAPI';
+import { getAllFeeds, postFeedById, postThread } from 'rest/feedsAPI';
+import { getLineageByFQN } from 'rest/lineageAPI';
+import { addLineage, deleteLineageEdge } from 'rest/miscAPI';
+import { getServiceByFQN } from 'rest/serviceAPI';
 import AppState from '../../AppState';
 import {
   getDashboardDetailsPath,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/DataInsight.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/DataInsight.interface.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { SearchDropdownOption } from '@components/SearchDropdown/SearchDropdown.interface';
+import { SearchDropdownOption } from 'components/SearchDropdown/SearchDropdown.interface';
 
 export type TeamStateType = {
   defaultOptions: SearchDropdownOption[];

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/DataInsightLeftPanel.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/DataInsightLeftPanel.tsx
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import LeftPanelCard from '@components/common/LeftPanelCard/LeftPanelCard';
 import { Menu, MenuProps } from 'antd';
+import LeftPanelCard from 'components/common/LeftPanelCard/LeftPanelCard';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory, useParams } from 'react-router-dom';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/DataInsightPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/DataInsightPage.component.tsx
@@ -11,21 +11,6 @@
  *  limitations under the License.
  */
 
-import PageLayoutV1 from '@components/containers/PageLayoutV1';
-import DailyActiveUsersChart from '@components/DataInsightDetail/DailyActiveUsersChart';
-import DataInsightSummary from '@components/DataInsightDetail/DataInsightSummary';
-import DescriptionInsight from '@components/DataInsightDetail/DescriptionInsight';
-import KPIChart from '@components/DataInsightDetail/KPIChart';
-import OwnerInsight from '@components/DataInsightDetail/OwnerInsight';
-import PageViewsByEntitiesChart from '@components/DataInsightDetail/PageViewsByEntitiesChart';
-import TierInsight from '@components/DataInsightDetail/TierInsight';
-import TopActiveUsers from '@components/DataInsightDetail/TopActiveUsers';
-import TopViewEntities from '@components/DataInsightDetail/TopViewEntities';
-import TotalEntityInsight from '@components/DataInsightDetail/TotalEntityInsight';
-import SearchDropdown from '@components/SearchDropdown/SearchDropdown';
-import { SearchDropdownOption } from '@components/SearchDropdown/SearchDropdown.interface';
-import { getListKPIs } from '@rest/KpiAPI';
-import { searchQuery } from '@rest/searchAPI';
 import {
   Button,
   Card,
@@ -36,11 +21,26 @@ import {
   Tooltip,
   Typography,
 } from 'antd';
+import PageLayoutV1 from 'components/containers/PageLayoutV1';
+import DailyActiveUsersChart from 'components/DataInsightDetail/DailyActiveUsersChart';
+import DataInsightSummary from 'components/DataInsightDetail/DataInsightSummary';
+import DescriptionInsight from 'components/DataInsightDetail/DescriptionInsight';
+import KPIChart from 'components/DataInsightDetail/KPIChart';
+import OwnerInsight from 'components/DataInsightDetail/OwnerInsight';
+import PageViewsByEntitiesChart from 'components/DataInsightDetail/PageViewsByEntitiesChart';
+import TierInsight from 'components/DataInsightDetail/TierInsight';
+import TopActiveUsers from 'components/DataInsightDetail/TopActiveUsers';
+import TopViewEntities from 'components/DataInsightDetail/TopViewEntities';
+import TotalEntityInsight from 'components/DataInsightDetail/TotalEntityInsight';
+import SearchDropdown from 'components/SearchDropdown/SearchDropdown';
+import { SearchDropdownOption } from 'components/SearchDropdown/SearchDropdown.interface';
 import { t } from 'i18next';
 import { isEmpty } from 'lodash';
 import React, { useEffect, useLayoutEffect, useMemo, useState } from 'react';
 import { ListItem } from 'react-awesome-query-builder';
 import { useHistory, useParams } from 'react-router-dom';
+import { getListKPIs } from 'rest/KpiAPI';
+import { searchQuery } from 'rest/searchAPI';
 import { autocomplete } from '../../constants/AdvancedSearch.constants';
 import { PAGE_SIZE, ROUTES } from '../../constants/constants';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/DataInsightPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/DataInsightPage.test.tsx
@@ -24,11 +24,11 @@ jest.mock('react-router-dom', () => ({
   useParams: jest.fn().mockImplementation(() => ({ tab: activeTab })),
 }));
 
-jest.mock('@components/containers/PageLayoutV1', () =>
+jest.mock('components/containers/PageLayoutV1', () =>
   jest.fn().mockImplementation(({ children }) => <>{children}</>)
 );
 
-jest.mock('@components/DataInsightDetail/DataInsightSummary', () =>
+jest.mock('components/DataInsightDetail/DataInsightSummary', () =>
   jest
     .fn()
     .mockReturnValue(
@@ -36,7 +36,7 @@ jest.mock('@components/DataInsightDetail/DataInsightSummary', () =>
     )
 );
 
-jest.mock('@components/DataInsightDetail/DescriptionInsight', () =>
+jest.mock('components/DataInsightDetail/DescriptionInsight', () =>
   jest
     .fn()
     .mockReturnValue(
@@ -44,21 +44,21 @@ jest.mock('@components/DataInsightDetail/DescriptionInsight', () =>
     )
 );
 
-jest.mock('@components/DataInsightDetail/OwnerInsight', () =>
+jest.mock('components/DataInsightDetail/OwnerInsight', () =>
   jest.fn().mockReturnValue(<div data-testid="owner-insight">OwnerInsight</div>)
 );
 
-jest.mock('@components/DataInsightDetail/TierInsight', () =>
+jest.mock('components/DataInsightDetail/TierInsight', () =>
   jest.fn().mockReturnValue(<div data-testid="tier-insight">TierInsight</div>)
 );
 
-jest.mock('@components/DataInsightDetail/TopActiveUsers', () =>
+jest.mock('components/DataInsightDetail/TopActiveUsers', () =>
   jest
     .fn()
     .mockReturnValue(<div data-testid="top-active-user">TopActiveUsers</div>)
 );
 
-jest.mock('@components/DataInsightDetail/TopViewEntities', () =>
+jest.mock('components/DataInsightDetail/TopViewEntities', () =>
   jest
     .fn()
     .mockReturnValue(
@@ -66,7 +66,7 @@ jest.mock('@components/DataInsightDetail/TopViewEntities', () =>
     )
 );
 
-jest.mock('@components/DataInsightDetail/TotalEntityInsight', () =>
+jest.mock('components/DataInsightDetail/TotalEntityInsight', () =>
   jest
     .fn()
     .mockReturnValue(
@@ -78,21 +78,21 @@ jest.mock('../../utils/DataInsightUtils', () => ({
   getTeamFilter: jest.fn().mockReturnValue([]),
 }));
 
-jest.mock('@components/DataInsightDetail/DailyActiveUsersChart', () =>
+jest.mock('components/DataInsightDetail/DailyActiveUsersChart', () =>
   jest
     .fn()
     .mockReturnValue(
       <div data-testid="daily-active-users">DailyActiveUsersChart</div>
     )
 );
-jest.mock('@components/DataInsightDetail/PageViewsByEntitiesChart', () =>
+jest.mock('components/DataInsightDetail/PageViewsByEntitiesChart', () =>
   jest
     .fn()
     .mockReturnValue(
       <div data-testid="entities-page-views">PageViewsByEntitiesChart</div>
     )
 );
-jest.mock('@components/DataInsightDetail/KPIChart', () =>
+jest.mock('components/DataInsightDetail/KPIChart', () =>
   jest.fn().mockReturnValue(<div data-testid="kpi-chart">KPIChart</div>)
 );
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/KPIList.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/KPIList.test.tsx
@@ -31,21 +31,21 @@ jest.mock('react-router-dom', () => ({
     )),
 }));
 
-jest.mock('@components/common/DeleteWidget/DeleteWidgetModal', () =>
+jest.mock('components/common/DeleteWidget/DeleteWidgetModal', () =>
   jest.fn().mockReturnValue(<div data-testid="delete-modal">Delete Modal</div>)
 );
 
-jest.mock('@components/common/next-previous/NextPrevious', () =>
+jest.mock('components/common/next-previous/NextPrevious', () =>
   jest
     .fn()
     .mockReturnValue(<div data-testid="next-previous">Next Previous</div>)
 );
 
-jest.mock('@components/common/rich-text-editor/RichTextEditorPreviewer', () =>
+jest.mock('components/common/rich-text-editor/RichTextEditorPreviewer', () =>
   jest.fn().mockReturnValue(<div data-testid="editor">Editor</div>)
 );
 
-jest.mock('@components/Loader/Loader', () =>
+jest.mock('components/Loader/Loader', () =>
   jest.fn().mockReturnValue(<div data-testid="loader">Loader</div>)
 );
 
@@ -57,7 +57,7 @@ jest.mock('../../utils/TimeUtils', () => ({
   formatDateTime: jest.fn().mockReturnValue('7 Dec 2022, 00:00'),
 }));
 
-jest.mock('@rest/KpiAPI', () => ({
+jest.mock('rest/KpiAPI', () => ({
   getListKPIs: jest
     .fn()
     .mockImplementation(() => Promise.resolve({ data: KPI_DATA })),

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/KPIList.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/KPIList.tsx
@@ -11,17 +11,17 @@
  *  limitations under the License.
  */
 
-import DeleteWidgetModal from '@components/common/DeleteWidget/DeleteWidgetModal';
-import NextPrevious from '@components/common/next-previous/NextPrevious';
-import RichTextEditorPreviewer from '@components/common/rich-text-editor/RichTextEditorPreviewer';
-import Loader from '@components/Loader/Loader';
-import { getListKPIs } from '@rest/KpiAPI';
 import { Button, Col, Space, Table, Tooltip, Typography } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
+import DeleteWidgetModal from 'components/common/DeleteWidget/DeleteWidgetModal';
+import NextPrevious from 'components/common/next-previous/NextPrevious';
+import RichTextEditorPreviewer from 'components/common/rich-text-editor/RichTextEditorPreviewer';
+import Loader from 'components/Loader/Loader';
 import { isUndefined } from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useHistory } from 'react-router-dom';
+import { getListKPIs } from 'rest/KpiAPI';
 import {
   getKpiPath,
   INITIAL_PAGING_VALUE,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaPage/DatabaseSchemaPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaPage/DatabaseSchemaPage.component.tsx
@@ -11,38 +11,27 @@
  *  limitations under the License.
  */
 
-import ActivityFeedList from '@components/ActivityFeed/ActivityFeedList/ActivityFeedList';
-import ActivityThreadPanel from '@components/ActivityFeed/ActivityThreadPanel/ActivityThreadPanel';
-import Description from '@components/common/description/Description';
-import ManageButton from '@components/common/entityPageInfo/ManageButton/ManageButton';
-import EntitySummaryDetails from '@components/common/EntitySummaryDetails/EntitySummaryDetails';
-import ErrorPlaceHolder from '@components/common/error-with-placeholder/ErrorPlaceHolder';
-import NextPrevious from '@components/common/next-previous/NextPrevious';
-import RichTextEditorPreviewer from '@components/common/rich-text-editor/RichTextEditorPreviewer';
-import TabsPane from '@components/common/TabsPane/TabsPane';
-import TitleBreadcrumb from '@components/common/title-breadcrumb/title-breadcrumb.component';
-import { TitleBreadcrumbProps } from '@components/common/title-breadcrumb/title-breadcrumb.interface';
-import PageContainerV1 from '@components/containers/PageContainerV1';
-import Loader from '@components/Loader/Loader';
-import { usePermissionProvider } from '@components/PermissionProvider/PermissionProvider';
-import {
-  OperationPermission,
-  ResourceEntity,
-} from '@components/PermissionProvider/PermissionProvider.interface';
-import {
-  getDatabaseSchemaDetailsByFQN,
-  patchDatabaseSchemaDetails,
-} from '@rest/databaseAPI';
-import {
-  getAllFeeds,
-  getFeedCount,
-  postFeedById,
-  postThread,
-} from '@rest/feedsAPI';
-import { searchQuery } from '@rest/searchAPI';
 import { Col, Row, Space, Table as TableAntd } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
 import { AxiosError } from 'axios';
+import ActivityFeedList from 'components/ActivityFeed/ActivityFeedList/ActivityFeedList';
+import ActivityThreadPanel from 'components/ActivityFeed/ActivityThreadPanel/ActivityThreadPanel';
+import Description from 'components/common/description/Description';
+import ManageButton from 'components/common/entityPageInfo/ManageButton/ManageButton';
+import EntitySummaryDetails from 'components/common/EntitySummaryDetails/EntitySummaryDetails';
+import ErrorPlaceHolder from 'components/common/error-with-placeholder/ErrorPlaceHolder';
+import NextPrevious from 'components/common/next-previous/NextPrevious';
+import RichTextEditorPreviewer from 'components/common/rich-text-editor/RichTextEditorPreviewer';
+import TabsPane from 'components/common/TabsPane/TabsPane';
+import TitleBreadcrumb from 'components/common/title-breadcrumb/title-breadcrumb.component';
+import { TitleBreadcrumbProps } from 'components/common/title-breadcrumb/title-breadcrumb.interface';
+import PageContainerV1 from 'components/containers/PageContainerV1';
+import Loader from 'components/Loader/Loader';
+import { usePermissionProvider } from 'components/PermissionProvider/PermissionProvider';
+import {
+  OperationPermission,
+  ResourceEntity,
+} from 'components/PermissionProvider/PermissionProvider.interface';
 import { compare, Operation } from 'fast-json-patch';
 import { isUndefined, startCase, toNumber } from 'lodash';
 import { observer } from 'mobx-react';
@@ -58,6 +47,17 @@ import React, {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useHistory, useParams } from 'react-router-dom';
+import {
+  getDatabaseSchemaDetailsByFQN,
+  patchDatabaseSchemaDetails,
+} from 'rest/databaseAPI';
+import {
+  getAllFeeds,
+  getFeedCount,
+  postFeedById,
+  postThread,
+} from 'rest/feedsAPI';
+import { searchQuery } from 'rest/searchAPI';
 import { default as AppState, default as appState } from '../../AppState';
 import { FQN_SEPARATOR_CHAR } from '../../constants/char.constants';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaPage/DatabaseSchemaPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaPage/DatabaseSchemaPage.test.tsx
@@ -11,11 +11,11 @@
  *  limitations under the License.
  */
 
-import { usePermissionProvider } from '@components/PermissionProvider/PermissionProvider';
-import { getDatabaseSchemaDetailsByFQN } from '@rest/databaseAPI';
 import { act, fireEvent, render, screen } from '@testing-library/react';
+import { usePermissionProvider } from 'components/PermissionProvider/PermissionProvider';
 import React from 'react';
 import { MemoryRouter, useParams } from 'react-router-dom';
+import { getDatabaseSchemaDetailsByFQN } from 'rest/databaseAPI';
 import DatabaseSchemaPageComponent from './DatabaseSchemaPage.component';
 import {
   mockEntityPermissions,
@@ -34,11 +34,11 @@ jest.mock('../../utils/ToastUtils', () => ({
     .mockImplementation(({ children }) => <div>{children}</div>),
 }));
 
-jest.mock('@components/Loader/Loader', () =>
+jest.mock('components/Loader/Loader', () =>
   jest.fn().mockImplementation(() => <div data-testid="Loader">Loader</div>)
 );
 
-jest.mock('@components/containers/PageContainerV1', () =>
+jest.mock('components/containers/PageContainerV1', () =>
   jest
     .fn()
     .mockImplementation(({ children }) => (
@@ -46,21 +46,19 @@ jest.mock('@components/containers/PageContainerV1', () =>
     ))
 );
 
-jest.mock(
-  '@components/common/title-breadcrumb/title-breadcrumb.component',
-  () =>
-    jest
-      .fn()
-      .mockImplementation(() => (
-        <div data-testid="TitleBreadcrumb">titleBreadcrumb</div>
-      ))
+jest.mock('components/common/title-breadcrumb/title-breadcrumb.component', () =>
+  jest
+    .fn()
+    .mockImplementation(() => (
+      <div data-testid="TitleBreadcrumb">titleBreadcrumb</div>
+    ))
 );
 
-jest.mock('@components/common/TabsPane/TabsPane', () =>
+jest.mock('components/common/TabsPane/TabsPane', () =>
   jest.fn().mockImplementation(() => <div data-testid="TabsPane">TabsPane</div>)
 );
 
-jest.mock('@components/common/rich-text-editor/RichTextEditorPreviewer', () =>
+jest.mock('components/common/rich-text-editor/RichTextEditorPreviewer', () =>
   jest
     .fn()
     .mockImplementation(() => (
@@ -68,7 +66,7 @@ jest.mock('@components/common/rich-text-editor/RichTextEditorPreviewer', () =>
     ))
 );
 
-jest.mock('@components/common/next-previous/NextPrevious', () =>
+jest.mock('components/common/next-previous/NextPrevious', () =>
   jest
     .fn()
     .mockImplementation(() => (
@@ -76,14 +74,14 @@ jest.mock('@components/common/next-previous/NextPrevious', () =>
     ))
 );
 
-jest.mock('@components/common/error-with-placeholder/ErrorPlaceHolder', () =>
+jest.mock('components/common/error-with-placeholder/ErrorPlaceHolder', () =>
   jest
     .fn()
     .mockImplementation(({ children }) => (
       <div data-testid="ErrorPlaceHolder">{children}</div>
     ))
 );
-jest.mock('@components/common/EntitySummaryDetails/EntitySummaryDetails', () =>
+jest.mock('components/common/EntitySummaryDetails/EntitySummaryDetails', () =>
   jest
     .fn()
     .mockImplementation(() => (
@@ -91,7 +89,7 @@ jest.mock('@components/common/EntitySummaryDetails/EntitySummaryDetails', () =>
     ))
 );
 
-jest.mock('@components/common/entityPageInfo/ManageButton/ManageButton', () =>
+jest.mock('components/common/entityPageInfo/ManageButton/ManageButton', () =>
   jest
     .fn()
     .mockImplementation(() => (
@@ -99,7 +97,7 @@ jest.mock('@components/common/entityPageInfo/ManageButton/ManageButton', () =>
     ))
 );
 
-jest.mock('@components/common/description/Description', () =>
+jest.mock('components/common/description/Description', () =>
   jest
     .fn()
     .mockImplementation(
@@ -118,7 +116,7 @@ jest.mock('@components/common/description/Description', () =>
 );
 
 jest.mock(
-  '@components/ActivityFeed/ActivityThreadPanel/ActivityThreadPanel',
+  'components/ActivityFeed/ActivityThreadPanel/ActivityThreadPanel',
   () =>
     jest
       .fn()
@@ -127,7 +125,7 @@ jest.mock(
       ))
 );
 
-jest.mock('@components/ActivityFeed/ActivityFeedList/ActivityFeedList', () =>
+jest.mock('components/ActivityFeed/ActivityFeedList/ActivityFeedList', () =>
   jest
     .fn()
     .mockImplementation(() => (
@@ -135,7 +133,7 @@ jest.mock('@components/ActivityFeed/ActivityFeedList/ActivityFeedList', () =>
     ))
 );
 
-jest.mock('@components/PermissionProvider/PermissionProvider', () => ({
+jest.mock('components/PermissionProvider/PermissionProvider', () => ({
   usePermissionProvider: jest.fn().mockImplementation(() => ({
     getEntityPermissionByFqn: jest
       .fn()
@@ -143,13 +141,13 @@ jest.mock('@components/PermissionProvider/PermissionProvider', () => ({
   })),
 }));
 
-jest.mock('@rest/searchAPI', () => ({
+jest.mock('rest/searchAPI', () => ({
   searchQuery: jest
     .fn()
     .mockImplementation(() => Promise.resolve(mockSearchQueryData)),
 }));
 
-jest.mock('@rest/feedsAPI', () => ({
+jest.mock('rest/feedsAPI', () => ({
   getAllFeeds: jest
     .fn()
     .mockImplementation(() => Promise.resolve(mockGetAllFeedsData)),
@@ -164,7 +162,7 @@ jest.mock('@rest/feedsAPI', () => ({
     .mockImplementation(() => Promise.resolve(mockPostThreadData)),
 }));
 
-jest.mock('@rest/databaseAPI', () => ({
+jest.mock('rest/databaseAPI', () => ({
   getDatabaseSchemaDetailsByFQN: jest
     .fn()
     .mockImplementation(() =>

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatasetDetailsPage/DatasetDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatasetDetailsPage/DatasetDetailsPage.component.tsx
@@ -11,38 +11,38 @@
  *  limitations under the License.
  */
 
-import ErrorPlaceHolder from '@components/common/error-with-placeholder/ErrorPlaceHolder';
-import { TitleBreadcrumbProps } from '@components/common/title-breadcrumb/title-breadcrumb.interface';
-import DatasetDetails from '@components/DatasetDetails/DatasetDetails.component';
+import { AxiosError } from 'axios';
+import ErrorPlaceHolder from 'components/common/error-with-placeholder/ErrorPlaceHolder';
+import { TitleBreadcrumbProps } from 'components/common/title-breadcrumb/title-breadcrumb.interface';
+import DatasetDetails from 'components/DatasetDetails/DatasetDetails.component';
 import {
   Edge,
   EdgeData,
   LeafNodes,
   LineagePos,
   LoadingNodeState,
-} from '@components/EntityLineage/EntityLineage.interface';
-import Loader from '@components/Loader/Loader';
-import { usePermissionProvider } from '@components/PermissionProvider/PermissionProvider';
+} from 'components/EntityLineage/EntityLineage.interface';
+import Loader from 'components/Loader/Loader';
+import { usePermissionProvider } from 'components/PermissionProvider/PermissionProvider';
 import {
   OperationPermission,
   ResourceEntity,
-} from '@components/PermissionProvider/PermissionProvider.interface';
-import { getAllFeeds, postFeedById, postThread } from '@rest/feedsAPI';
-import { getLineageByFQN } from '@rest/lineageAPI';
-import { addLineage, deleteLineageEdge } from '@rest/miscAPI';
-import {
-  addFollower,
-  getTableDetailsByFQN,
-  patchTableDetails,
-  removeFollower,
-} from '@rest/tableAPI';
-import { AxiosError } from 'axios';
+} from 'components/PermissionProvider/PermissionProvider.interface';
 import { compare, Operation } from 'fast-json-patch';
 import { isEmpty, isUndefined } from 'lodash';
 import { observer } from 'mobx-react';
 import { EntityTags } from 'Models';
 import React, { FunctionComponent, useEffect, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
+import { getAllFeeds, postFeedById, postThread } from 'rest/feedsAPI';
+import { getLineageByFQN } from 'rest/lineageAPI';
+import { addLineage, deleteLineageEdge } from 'rest/miscAPI';
+import {
+  addFollower,
+  getTableDetailsByFQN,
+  patchTableDetails,
+  removeFollower,
+} from 'rest/tableAPI';
 import AppState from '../../AppState';
 import { FQN_SEPARATOR_CHAR } from '../../constants/char.constants';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatasetDetailsPage/DatasetDetailsPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatasetDetailsPage/DatasetDetailsPage.test.tsx
@@ -12,20 +12,6 @@
  */
 
 import {
-  getAllFeeds,
-  getFeedCount,
-  postFeedById,
-  postThread,
-} from '@rest/feedsAPI';
-import { getLineageByFQN } from '@rest/lineageAPI';
-import { addLineage, deleteLineageEdge } from '@rest/miscAPI';
-import {
-  addFollower,
-  getTableDetailsByFQN,
-  patchTableDetails,
-  removeFollower,
-} from '@rest/tableAPI';
-import {
   act,
   findByTestId,
   findByText,
@@ -34,6 +20,20 @@ import {
 } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router';
+import {
+  getAllFeeds,
+  getFeedCount,
+  postFeedById,
+  postThread,
+} from 'rest/feedsAPI';
+import { getLineageByFQN } from 'rest/lineageAPI';
+import { addLineage, deleteLineageEdge } from 'rest/miscAPI';
+import {
+  addFollower,
+  getTableDetailsByFQN,
+  patchTableDetails,
+  removeFollower,
+} from 'rest/tableAPI';
 import { deletePost, getUpdatedThread } from '../../utils/FeedUtils';
 import DatasetDetailsPage from './DatasetDetailsPage.component';
 import {
@@ -66,7 +66,7 @@ jest.mock('../../AppState', () => ({
   ],
 }));
 
-jest.mock('@components/PermissionProvider/PermissionProvider', () => ({
+jest.mock('components/PermissionProvider/PermissionProvider', () => ({
   usePermissionProvider: jest.fn().mockImplementation(() => ({
     permissions: {},
     getEntityPermission: jest.fn().mockResolvedValue({
@@ -119,7 +119,7 @@ jest.mock('../../utils/PermissionsUtils', () => ({
   },
 }));
 
-jest.mock('@components/DatasetDetails/DatasetDetails.component', () => {
+jest.mock('components/DatasetDetails/DatasetDetails.component', () => {
   return jest
     .fn()
     .mockImplementation(
@@ -236,7 +236,7 @@ jest.mock('@components/DatasetDetails/DatasetDetails.component', () => {
     );
 });
 
-jest.mock('@components/common/error-with-placeholder/ErrorPlaceHolder', () => {
+jest.mock('components/common/error-with-placeholder/ErrorPlaceHolder', () => {
   return jest.fn().mockReturnValue(<div>ErrorPlaceHolder.component</div>);
 });
 
@@ -244,7 +244,7 @@ jest.mock('fast-json-patch', () => ({
   compare: jest.fn(),
 }));
 
-jest.mock('@rest/tableAPI', () => ({
+jest.mock('rest/tableAPI', () => ({
   addColumnTestCase: jest
     .fn()
     .mockImplementation(() => Promise.resolve(updateTagRes)),
@@ -274,7 +274,7 @@ jest.mock('../../utils/FeedUtils', () => ({
     .mockImplementation(() => Promise.resolve({ id: 'test', posts: [] })),
 }));
 
-jest.mock('@rest/feedsAPI', () => ({
+jest.mock('rest/feedsAPI', () => ({
   getAllFeeds: jest
     .fn()
     .mockImplementation(() => Promise.resolve({ data: { data: [] } })),
@@ -299,13 +299,13 @@ jest.mock('@rest/feedsAPI', () => ({
     .mockImplementation(() => Promise.resolve({ data: createPostRes })),
 }));
 
-jest.mock('@rest/lineageAPI', () => ({
+jest.mock('rest/lineageAPI', () => ({
   getLineageByFQN: jest
     .fn()
     .mockImplementation(() => Promise.resolve({ data: mockLineageRes })),
 }));
 
-jest.mock('@rest/miscAPI', () => ({
+jest.mock('rest/miscAPI', () => ({
   addLineage: jest.fn().mockImplementation(() => Promise.resolve()),
   deleteLineageEdge: jest.fn().mockImplementation(() => Promise.resolve()),
 }));

--- a/openmetadata-ui/src/main/resources/ui/src/pages/EditConnectionFormPage/EditConnectionFormPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/EditConnectionFormPage/EditConnectionFormPage.component.tsx
@@ -11,20 +11,20 @@
  *  limitations under the License.
  */
 
-import ErrorPlaceHolder from '@components/common/error-with-placeholder/ErrorPlaceHolder';
-import TitleBreadcrumb from '@components/common/title-breadcrumb/title-breadcrumb.component';
-import { TitleBreadcrumbProps } from '@components/common/title-breadcrumb/title-breadcrumb.interface';
-import PageContainerV1 from '@components/containers/PageContainerV1';
-import PageLayoutV1 from '@components/containers/PageLayoutV1';
-import Loader from '@components/Loader/Loader';
-import ServiceConfig from '@components/ServiceConfig/ServiceConfig';
-import { getServiceByFQN, updateService } from '@rest/serviceAPI';
 import { Space, Typography } from 'antd';
 import { AxiosError } from 'axios';
+import ErrorPlaceHolder from 'components/common/error-with-placeholder/ErrorPlaceHolder';
+import TitleBreadcrumb from 'components/common/title-breadcrumb/title-breadcrumb.component';
+import { TitleBreadcrumbProps } from 'components/common/title-breadcrumb/title-breadcrumb.interface';
+import PageContainerV1 from 'components/containers/PageContainerV1';
+import PageLayoutV1 from 'components/containers/PageLayoutV1';
+import Loader from 'components/Loader/Loader';
+import ServiceConfig from 'components/ServiceConfig/ServiceConfig';
 import { startCase } from 'lodash';
 import { ServicesData, ServicesUpdateRequest, ServiceTypes } from 'Models';
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { getServiceByFQN, updateService } from 'rest/serviceAPI';
 import { GlobalSettingsMenuCategory } from '../../constants/GlobalSettings.constants';
 import { addServiceGuide } from '../../constants/service-guide.constant';
 import { OPENMETADATA } from '../../constants/Services.constant';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/EditIngestionPage/EditIngestionPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/EditIngestionPage/EditIngestionPage.component.tsx
@@ -11,25 +11,25 @@
  *  limitations under the License.
  */
 
-import AddIngestion from '@components/AddIngestion/AddIngestion.component';
-import ErrorPlaceHolder from '@components/common/error-with-placeholder/ErrorPlaceHolder';
-import TitleBreadcrumb from '@components/common/title-breadcrumb/title-breadcrumb.component';
-import { TitleBreadcrumbProps } from '@components/common/title-breadcrumb/title-breadcrumb.interface';
-import PageContainerV1 from '@components/containers/PageContainerV1';
-import PageLayoutV1 from '@components/containers/PageLayoutV1';
-import Loader from '@components/Loader/Loader';
-import {
-  deployIngestionPipelineById,
-  getIngestionPipelineByFqn,
-  updateIngestionPipeline,
-} from '@rest/ingestionPipelineAPI';
-import { getServiceByFQN } from '@rest/serviceAPI';
 import { Space } from 'antd';
 import { AxiosError } from 'axios';
+import AddIngestion from 'components/AddIngestion/AddIngestion.component';
+import ErrorPlaceHolder from 'components/common/error-with-placeholder/ErrorPlaceHolder';
+import TitleBreadcrumb from 'components/common/title-breadcrumb/title-breadcrumb.component';
+import { TitleBreadcrumbProps } from 'components/common/title-breadcrumb/title-breadcrumb.interface';
+import PageContainerV1 from 'components/containers/PageContainerV1';
+import PageLayoutV1 from 'components/containers/PageLayoutV1';
+import Loader from 'components/Loader/Loader';
 import { startCase } from 'lodash';
 import { ServicesUpdateRequest, ServiceTypes } from 'Models';
 import React, { useEffect, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
+import {
+  deployIngestionPipelineById,
+  getIngestionPipelineByFqn,
+  updateIngestionPipeline,
+} from 'rest/ingestionPipelineAPI';
+import { getServiceByFQN } from 'rest/serviceAPI';
 import {
   DEPLOYED_PROGRESS_VAL,
   getServiceDetailsPath,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ElasticSearchIndexPage/ElasticSearchReIndexPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ElasticSearchIndexPage/ElasticSearchReIndexPage.component.tsx
@@ -12,16 +12,16 @@
  */
 
 import { ReloadOutlined } from '@ant-design/icons';
-import RichTextEditorPreviewer from '@components/common/rich-text-editor/RichTextEditorPreviewer';
-import { useWebSocketConnector } from '@components/web-scoket/web-scoket.provider';
+import { Badge, Button, Card, Col, Divider, Row, Space } from 'antd';
+import { AxiosError } from 'axios';
+import RichTextEditorPreviewer from 'components/common/rich-text-editor/RichTextEditorPreviewer';
+import { useWebSocketConnector } from 'components/web-scoket/web-scoket.provider';
+import { isEmpty, startCase } from 'lodash';
+import React, { useEffect, useState } from 'react';
 import {
   getAllReIndexStatus,
   reIndexByPublisher,
-} from '@rest/elasticSearchReIndexAPI';
-import { Badge, Button, Card, Col, Divider, Row, Space } from 'antd';
-import { AxiosError } from 'axios';
-import { isEmpty, startCase } from 'lodash';
-import React, { useEffect, useState } from 'react';
+} from 'rest/elasticSearchReIndexAPI';
 import { SOCKET_EVENTS } from '../../constants/constants';
 import { CreateEventPublisherJob } from '../../generated/api/createEventPublisherJob';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/EntityVersionPage/EntityVersionPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/EntityVersionPage/EntityVersionPage.component.tsx
@@ -11,35 +11,35 @@
  *  limitations under the License.
  */
 
-import { TitleBreadcrumbProps } from '@components/common/title-breadcrumb/title-breadcrumb.interface';
-import DashboardVersion from '@components/DashboardVersion/DashboardVersion.component';
-import DatasetVersion from '@components/DatasetVersion/DatasetVersion.component';
-import Loader from '@components/Loader/Loader';
-import PipelineVersion from '@components/PipelineVersion/PipelineVersion.component';
-import TopicVersion from '@components/TopicVersion/TopicVersion.component';
+import { AxiosError } from 'axios';
+import { TitleBreadcrumbProps } from 'components/common/title-breadcrumb/title-breadcrumb.interface';
+import DashboardVersion from 'components/DashboardVersion/DashboardVersion.component';
+import DatasetVersion from 'components/DatasetVersion/DatasetVersion.component';
+import Loader from 'components/Loader/Loader';
+import PipelineVersion from 'components/PipelineVersion/PipelineVersion.component';
+import TopicVersion from 'components/TopicVersion/TopicVersion.component';
+import React, { FunctionComponent, useEffect, useState } from 'react';
+import { useHistory, useParams } from 'react-router-dom';
 import {
   getDashboardByFqn,
   getDashboardVersion,
   getDashboardVersions,
-} from '@rest/dashboardAPI';
+} from 'rest/dashboardAPI';
 import {
   getPipelineByFqn,
   getPipelineVersion,
   getPipelineVersions,
-} from '@rest/pipelineAPI';
+} from 'rest/pipelineAPI';
 import {
   getTableDetailsByFQN,
   getTableVersion,
   getTableVersions,
-} from '@rest/tableAPI';
+} from 'rest/tableAPI';
 import {
   getTopicByFqn,
   getTopicVersion,
   getTopicVersions,
-} from '@rest/topicsAPI';
-import { AxiosError } from 'axios';
-import React, { FunctionComponent, useEffect, useState } from 'react';
-import { useHistory, useParams } from 'react-router-dom';
+} from 'rest/topicsAPI';
 import { FQN_SEPARATOR_CHAR } from '../../constants/char.constants';
 import {
   getDashboardDetailsPath,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/EntityVersionPage/EntityVersionPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/EntityVersionPage/EntityVersionPage.test.tsx
@@ -27,35 +27,35 @@ jest.mock('react-router-dom', () => ({
   useParams: jest.fn().mockImplementation(() => mockParams),
 }));
 
-jest.mock('@components/DatasetVersion/DatasetVersion.component', () => {
+jest.mock('components/DatasetVersion/DatasetVersion.component', () => {
   return jest.fn().mockReturnValue(<div>DatasetVersion component</div>);
 });
-jest.mock('@components/DashboardVersion/DashboardVersion.component', () => {
+jest.mock('components/DashboardVersion/DashboardVersion.component', () => {
   return jest.fn().mockReturnValue(<div>DashboardVersion component</div>);
 });
-jest.mock('@components/PipelineVersion/PipelineVersion.component', () => {
+jest.mock('components/PipelineVersion/PipelineVersion.component', () => {
   return jest.fn().mockReturnValue(<div>PipelineVersion component</div>);
 });
-jest.mock('@components/TopicVersion/TopicVersion.component', () => {
+jest.mock('components/TopicVersion/TopicVersion.component', () => {
   return jest.fn().mockReturnValue(<div>TopicVersion component</div>);
 });
 
-jest.mock('@rest/dashboardAPI', () => ({
+jest.mock('rest/dashboardAPI', () => ({
   getDashboardByFqn: jest.fn().mockImplementation(() => Promise.resolve()),
   getDashboardVersion: jest.fn().mockImplementation(() => Promise.resolve()),
   getDashboardVersions: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
-jest.mock('@rest/pipelineAPI', () => ({
+jest.mock('rest/pipelineAPI', () => ({
   getPipelineByFqn: jest.fn().mockImplementation(() => Promise.resolve()),
   getPipelineVersion: jest.fn().mockImplementation(() => Promise.resolve()),
   getPipelineVersions: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
-jest.mock('@rest/tableAPI', () => ({
+jest.mock('rest/tableAPI', () => ({
   getTableDetailsByFQN: jest.fn().mockImplementation(() => Promise.resolve()),
   getTableVersion: jest.fn().mockImplementation(() => Promise.resolve()),
   getTableVersions: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
-jest.mock('@rest/topicsAPI', () => ({
+jest.mock('rest/topicsAPI', () => ({
   getTopicByFqn: jest.fn().mockImplementation(() => Promise.resolve()),
   getTopicVersion: jest.fn().mockImplementation(() => Promise.resolve()),
   getTopicVersions: jest.fn().mockImplementation(() => Promise.resolve()),

--- a/openmetadata-ui/src/main/resources/ui/src/pages/GlobalSettingPage/GlobalSettingPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/GlobalSettingPage/GlobalSettingPage.tsx
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import PageContainerV1 from '@components/containers/PageContainerV1';
-import GlobalSetting from '@components/GlobalSetting/GlobalSetting';
+import PageContainerV1 from 'components/containers/PageContainerV1';
+import GlobalSetting from 'components/GlobalSetting/GlobalSetting';
 import React from 'react';
 
 const GlobalSettingPage = () => {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/GlossaryPage/GlossaryPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/GlossaryPage/GlossaryPage.test.tsx
@@ -11,13 +11,13 @@
  *  limitations under the License.
  */
 
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
 import {
   deleteGlossary,
   deleteGlossaryTerm,
   patchGlossaryTerm,
-} from '@rest/glossaryAPI';
-import { act, fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
+} from 'rest/glossaryAPI';
 import { MOCK_GLOSSARY } from './glossary.mock';
 import GlossaryPageV1 from './GlossaryPageV1.component';
 
@@ -227,13 +227,13 @@ jest.mock('react-router-dom', () => ({
   }),
 }));
 
-jest.mock('@rest/miscAPI', () => ({
+jest.mock('rest/miscAPI', () => ({
   searchData: jest
     .fn()
     .mockImplementation(() => Promise.resolve(mockSearchData)),
 }));
 
-jest.mock('@components/Glossary/GlossaryV1.component', () => {
+jest.mock('components/Glossary/GlossaryV1.component', () => {
   return jest.fn().mockImplementation((props) => (
     <div>
       <p> Glossary.component</p>
@@ -306,7 +306,7 @@ jest.mock('@components/Glossary/GlossaryV1.component', () => {
   ));
 });
 
-jest.mock('@rest/glossaryAPI', () => ({
+jest.mock('rest/glossaryAPI', () => ({
   deleteGlossary: jest.fn().mockImplementation(() => Promise.resolve()),
   deleteGlossaryTerm: jest.fn().mockImplementation(() => Promise.resolve()),
   patchGlossaryTerm: jest

--- a/openmetadata-ui/src/main/resources/ui/src/pages/GlossaryPage/GlossaryPageV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/GlossaryPage/GlossaryPageV1.component.tsx
@@ -11,9 +11,16 @@
  *  limitations under the License.
  */
 
-import PageContainerV1 from '@components/containers/PageContainerV1';
-import GlossaryV1 from '@components/Glossary/GlossaryV1.component';
-import Loader from '@components/Loader/Loader';
+import { AxiosError } from 'axios';
+import PageContainerV1 from 'components/containers/PageContainerV1';
+import GlossaryV1 from 'components/Glossary/GlossaryV1.component';
+import Loader from 'components/Loader/Loader';
+import { compare } from 'fast-json-patch';
+import { cloneDeep, extend, isEmpty } from 'lodash';
+import { AssetsDataType, LoadingState } from 'Models';
+import React, { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useHistory, useParams } from 'react-router-dom';
 import {
   deleteGlossary,
   deleteGlossaryTerm,
@@ -21,15 +28,8 @@ import {
   getGlossaryTermByFQN,
   patchGlossaries,
   patchGlossaryTerm,
-} from '@rest/glossaryAPI';
-import { searchData } from '@rest/miscAPI';
-import { AxiosError } from 'axios';
-import { compare } from 'fast-json-patch';
-import { cloneDeep, extend, isEmpty } from 'lodash';
-import { AssetsDataType, LoadingState } from 'Models';
-import React, { useCallback, useEffect, useState } from 'react';
-import { useTranslation } from 'react-i18next';
-import { useHistory, useParams } from 'react-router-dom';
+} from 'rest/glossaryAPI';
+import { searchData } from 'rest/miscAPI';
 import { FQN_SEPARATOR_CHAR } from '../../constants/char.constants';
 import { getUserPath, PAGE_SIZE, ROUTES } from '../../constants/constants';
 import { myDataSearchIndex } from '../../constants/Mydata.constants';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/KPIPage/AddKPIPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/KPIPage/AddKPIPage.test.tsx
@@ -33,23 +33,21 @@ jest.mock('react-router-dom', () => ({
   }),
 }));
 
-jest.mock('@rest/DataInsightAPI', () => ({
+jest.mock('rest/DataInsightAPI', () => ({
   getListDataInsightCharts: jest
     .fn()
     .mockImplementation(() => Promise.resolve({ data: KPI_CHARTS })),
 }));
 
-jest.mock('@components/common/rich-text-editor/RichTextEditor', () =>
+jest.mock('components/common/rich-text-editor/RichTextEditor', () =>
   jest.fn().mockReturnValue(<div data-testid="editor">Editor</div>)
 );
 
-jest.mock(
-  '@components/common/title-breadcrumb/title-breadcrumb.component',
-  () =>
-    jest.fn().mockReturnValue(<div data-testid="breadcrumb">BreadCrumb</div>)
+jest.mock('components/common/title-breadcrumb/title-breadcrumb.component', () =>
+  jest.fn().mockReturnValue(<div data-testid="breadcrumb">BreadCrumb</div>)
 );
 
-jest.mock('@rest/KpiAPI', () => ({
+jest.mock('rest/KpiAPI', () => ({
   getListKPIs: jest
     .fn()
     .mockImplementation(() => Promise.resolve({ data: KPI_LIST })),

--- a/openmetadata-ui/src/main/resources/ui/src/pages/KPIPage/AddKPIPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/KPIPage/AddKPIPage.tsx
@@ -11,10 +11,6 @@
  *  limitations under the License.
  */
 
-import RichTextEditor from '@components/common/rich-text-editor/RichTextEditor';
-import TitleBreadcrumb from '@components/common/title-breadcrumb/title-breadcrumb.component';
-import { getListDataInsightCharts } from '@rest/DataInsightAPI';
-import { getListKPIs, postKPI } from '@rest/KpiAPI';
 import {
   Button,
   Card,
@@ -31,11 +27,15 @@ import {
   Typography,
 } from 'antd';
 import { AxiosError } from 'axios';
+import RichTextEditor from 'components/common/rich-text-editor/RichTextEditor';
+import TitleBreadcrumb from 'components/common/title-breadcrumb/title-breadcrumb.component';
 import { t } from 'i18next';
 import { isUndefined, kebabCase } from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
+import { getListDataInsightCharts } from 'rest/DataInsightAPI';
+import { getListKPIs, postKPI } from 'rest/KpiAPI';
 import { ROUTES } from '../../constants/constants';
 import {
   KPI_DATES,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/KPIPage/EditKPIPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/KPIPage/EditKPIPage.test.tsx
@@ -26,27 +26,25 @@ jest.mock('react-router-dom', () => ({
   useParams: jest.fn().mockReturnValue({ useParams: 'description-kpi' }),
 }));
 
-jest.mock('@rest/DataInsightAPI', () => ({
+jest.mock('rest/DataInsightAPI', () => ({
   getChartById: jest
     .fn()
     .mockImplementation(() => Promise.resolve(DESCRIPTION_CHART)),
 }));
 
-jest.mock('@components/common/rich-text-editor/RichTextEditor', () =>
+jest.mock('components/common/rich-text-editor/RichTextEditor', () =>
   jest.fn().mockReturnValue(<div data-testid="editor">Editor</div>)
 );
 
-jest.mock(
-  '@components/common/title-breadcrumb/title-breadcrumb.component',
-  () =>
-    jest.fn().mockReturnValue(<div data-testid="breadcrumb">BreadCrumb</div>)
+jest.mock('components/common/title-breadcrumb/title-breadcrumb.component', () =>
+  jest.fn().mockReturnValue(<div data-testid="breadcrumb">BreadCrumb</div>)
 );
 
-jest.mock('@components/Loader/Loader', () =>
+jest.mock('components/Loader/Loader', () =>
   jest.fn().mockReturnValue(<div data-testid="loader">Loader</div>)
 );
 
-jest.mock('@rest/KpiAPI', () => ({
+jest.mock('rest/KpiAPI', () => ({
   getKPIByName: jest.fn().mockImplementation(() => Promise.resolve(KPI_DATA)),
   patchKPI: jest.fn().mockImplementation(() => Promise.resolve(KPI_DATA)),
 }));

--- a/openmetadata-ui/src/main/resources/ui/src/pages/KPIPage/EditKPIPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/KPIPage/EditKPIPage.tsx
@@ -11,12 +11,6 @@
  *  limitations under the License.
  */
 
-import ErrorPlaceHolder from '@components/common/error-with-placeholder/ErrorPlaceHolder';
-import RichTextEditor from '@components/common/rich-text-editor/RichTextEditor';
-import TitleBreadcrumb from '@components/common/title-breadcrumb/title-breadcrumb.component';
-import Loader from '@components/Loader/Loader';
-import { getChartById } from '@rest/DataInsightAPI';
-import { getKPIByName, patchKPI } from '@rest/KpiAPI';
 import {
   Button,
   Card,
@@ -33,12 +27,18 @@ import {
   Typography,
 } from 'antd';
 import { AxiosError } from 'axios';
+import ErrorPlaceHolder from 'components/common/error-with-placeholder/ErrorPlaceHolder';
+import RichTextEditor from 'components/common/rich-text-editor/RichTextEditor';
+import TitleBreadcrumb from 'components/common/title-breadcrumb/title-breadcrumb.component';
+import Loader from 'components/Loader/Loader';
 import { compare } from 'fast-json-patch';
 import { isUndefined, toInteger, toNumber } from 'lodash';
 import moment from 'moment';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory, useParams } from 'react-router-dom';
+import { getChartById } from 'rest/DataInsightAPI';
+import { getKPIByName, patchKPI } from 'rest/KpiAPI';
 import { ROUTES } from '../../constants/constants';
 import {
   KPI_DATES,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/LineagePage/LineagePage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/LineagePage/LineagePage.tsx
@@ -11,29 +11,29 @@
  *  limitations under the License.
  */
 
-import TitleBreadcrumb from '@components/common/title-breadcrumb/title-breadcrumb.component';
-import { TitleBreadcrumbProps } from '@components/common/title-breadcrumb/title-breadcrumb.interface';
-import PageContainerV1 from '@components/containers/PageContainerV1';
-import PageLayoutV1 from '@components/containers/PageLayoutV1';
-import EntityLineageComponent from '@components/EntityLineage/EntityLineage.component';
+import { Card } from 'antd';
+import { AxiosError } from 'axios';
+import TitleBreadcrumb from 'components/common/title-breadcrumb/title-breadcrumb.component';
+import { TitleBreadcrumbProps } from 'components/common/title-breadcrumb/title-breadcrumb.interface';
+import PageContainerV1 from 'components/containers/PageContainerV1';
+import PageLayoutV1 from 'components/containers/PageLayoutV1';
+import EntityLineageComponent from 'components/EntityLineage/EntityLineage.component';
 import {
   Edge,
   EdgeData,
   LeafNodes,
   LineagePos,
   LoadingNodeState,
-} from '@components/EntityLineage/EntityLineage.interface';
-import { getDashboardByFqn } from '@rest/dashboardAPI';
-import { getLineageByFQN } from '@rest/lineageAPI';
-import { addLineage, deleteLineageEdge } from '@rest/miscAPI';
-import { getMlModelByFQN } from '@rest/mlModelAPI';
-import { getPipelineByFqn } from '@rest/pipelineAPI';
-import { getTableDetailsByFQN } from '@rest/tableAPI';
-import { getTopicByFqn } from '@rest/topicsAPI';
-import { Card } from 'antd';
-import { AxiosError } from 'axios';
+} from 'components/EntityLineage/EntityLineage.interface';
 import React, { useEffect, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
+import { getDashboardByFqn } from 'rest/dashboardAPI';
+import { getLineageByFQN } from 'rest/lineageAPI';
+import { addLineage, deleteLineageEdge } from 'rest/miscAPI';
+import { getMlModelByFQN } from 'rest/mlModelAPI';
+import { getPipelineByFqn } from 'rest/pipelineAPI';
+import { getTableDetailsByFQN } from 'rest/tableAPI';
+import { getTopicByFqn } from 'rest/topicsAPI';
 import {
   getDashboardDetailsPath,
   getDatabaseDetailsPath,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/LogsViewer/LogsViewer.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/LogsViewer/LogsViewer.component.test.tsx
@@ -24,7 +24,7 @@ jest.mock('react-router-dom', () => ({
 }));
 
 jest.mock(
-  '@components/common/title-breadcrumb/title-breadcrumb.component',
+  'components/common/title-breadcrumb/title-breadcrumb.component',
   () => () => <>TitleBreadcrumb.component</>
 );
 
@@ -34,7 +34,7 @@ jest.mock('react-lazylog', () => ({
     .mockImplementation(() => <div data-testid="logs">LazyLog</div>),
 }));
 
-jest.mock('@rest/ingestionPipelineAPI', () => ({
+jest.mock('rest/ingestionPipelineAPI', () => ({
   getIngestionPipelineLogById: jest
     .fn()
     .mockImplementation(() => Promise.resolve({ data: mockLogsData })),
@@ -44,7 +44,7 @@ jest.mock('@rest/ingestionPipelineAPI', () => ({
 }));
 
 jest.mock(
-  '@components/Ingestion/IngestionRecentRun/IngestionRecentRuns.component',
+  'components/Ingestion/IngestionRecentRun/IngestionRecentRuns.component',
   () => ({
     IngestionRecentRuns: jest
       .fn()

--- a/openmetadata-ui/src/main/resources/ui/src/pages/LogsViewer/LogsViewer.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/LogsViewer/LogsViewer.component.tsx
@@ -11,16 +11,12 @@
  *  limitations under the License.
  */
 
-import { CopyToClipboardButton } from '@components/buttons/CopyToClipboardButton/CopyToClipboardButton';
-import TitleBreadcrumb from '@components/common/title-breadcrumb/title-breadcrumb.component';
-import { IngestionRecentRuns } from '@components/Ingestion/IngestionRecentRun/IngestionRecentRuns.component';
-import Loader from '@components/Loader/Loader';
-import {
-  getIngestionPipelineByName,
-  getIngestionPipelineLogById,
-} from '@rest/ingestionPipelineAPI';
 import { Button, Card, Col, Row, Space, Typography } from 'antd';
 import { AxiosError } from 'axios';
+import { CopyToClipboardButton } from 'components/buttons/CopyToClipboardButton/CopyToClipboardButton';
+import TitleBreadcrumb from 'components/common/title-breadcrumb/title-breadcrumb.component';
+import { IngestionRecentRuns } from 'components/Ingestion/IngestionRecentRun/IngestionRecentRuns.component';
+import Loader from 'components/Loader/Loader';
 import { isEmpty, isNil, isUndefined, toNumber } from 'lodash';
 import React, {
   Fragment,
@@ -32,6 +28,10 @@ import React, {
 import { useTranslation } from 'react-i18next';
 import { LazyLog } from 'react-lazylog';
 import { useParams } from 'react-router-dom';
+import {
+  getIngestionPipelineByName,
+  getIngestionPipelineLogById,
+} from 'rest/ingestionPipelineAPI';
 import { PipelineType } from '../../generated/api/services/ingestionPipelines/createIngestionPipeline';
 import { IngestionPipeline } from '../../generated/entity/services/ingestionPipelines/ingestionPipeline';
 import { Paging } from '../../generated/type/paging';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/MlModelPage/MlModelPage.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/MlModelPage/MlModelPage.component.test.tsx
@@ -11,10 +11,10 @@
  *  limitations under the License.
  */
 
-import { getMlModelByFQN } from '@rest/mlModelAPI';
 import { findByTestId, render } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
+import { getMlModelByFQN } from 'rest/mlModelAPI';
 import MlModelPageComponent from './MlModelPage.component';
 
 const mockData = {
@@ -132,7 +132,7 @@ const mockData = {
   deleted: false,
 };
 
-jest.mock('@rest/mlModelAPI', () => ({
+jest.mock('rest/mlModelAPI', () => ({
   getMlModelByFQN: jest
     .fn()
     .mockImplementation(() => Promise.resolve({ data: mockData })),
@@ -147,13 +147,13 @@ jest.mock('@rest/mlModelAPI', () => ({
     .mockImplementation(() => Promise.resolve({ data: mockData })),
 }));
 
-jest.mock('@components/MlModelDetail/MlModelDetail.component', () => {
+jest.mock('components/MlModelDetail/MlModelDetail.component', () => {
   return jest
     .fn()
     .mockReturnValue(<div data-testid="mlmodel-details">MlModelDetails</div>);
 });
 
-jest.mock('@components/PermissionProvider/PermissionProvider', () => ({
+jest.mock('components/PermissionProvider/PermissionProvider', () => ({
   usePermissionProvider: jest.fn().mockImplementation(() => ({
     permissions: {},
     getEntityPermission: jest.fn().mockResolvedValue({

--- a/openmetadata-ui/src/main/resources/ui/src/pages/MlModelPage/MlModelPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/MlModelPage/MlModelPage.component.tsx
@@ -11,31 +11,31 @@
  *  limitations under the License.
  */
 
-import ErrorPlaceHolder from '@components/common/error-with-placeholder/ErrorPlaceHolder';
+import { AxiosError } from 'axios';
+import ErrorPlaceHolder from 'components/common/error-with-placeholder/ErrorPlaceHolder';
 import {
   Edge,
   EdgeData,
   LeafNodes,
   LineagePos,
   LoadingNodeState,
-} from '@components/EntityLineage/EntityLineage.interface';
-import Loader from '@components/Loader/Loader';
-import MlModelDetailComponent from '@components/MlModelDetail/MlModelDetail.component';
-import { usePermissionProvider } from '@components/PermissionProvider/PermissionProvider';
-import { ResourceEntity } from '@components/PermissionProvider/PermissionProvider.interface';
-import { getAllFeeds, postFeedById, postThread } from '@rest/feedsAPI';
-import { getLineageByFQN } from '@rest/lineageAPI';
-import { addLineage, deleteLineageEdge } from '@rest/miscAPI';
+} from 'components/EntityLineage/EntityLineage.interface';
+import Loader from 'components/Loader/Loader';
+import MlModelDetailComponent from 'components/MlModelDetail/MlModelDetail.component';
+import { usePermissionProvider } from 'components/PermissionProvider/PermissionProvider';
+import { ResourceEntity } from 'components/PermissionProvider/PermissionProvider.interface';
+import { compare, Operation } from 'fast-json-patch';
+import { isEmpty, isNil, isUndefined, omitBy } from 'lodash';
+import { observer } from 'mobx-react';
+import { getAllFeeds, postFeedById, postThread } from 'rest/feedsAPI';
+import { getLineageByFQN } from 'rest/lineageAPI';
+import { addLineage, deleteLineageEdge } from 'rest/miscAPI';
 import {
   addFollower,
   getMlModelByFQN,
   patchMlModelDetails,
   removeFollower,
-} from '@rest/mlModelAPI';
-import { AxiosError } from 'axios';
-import { compare, Operation } from 'fast-json-patch';
-import { isEmpty, isNil, isUndefined, omitBy } from 'lodash';
-import { observer } from 'mobx-react';
+} from 'rest/mlModelAPI';
 
 import React, { Fragment, useEffect, useMemo, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/MyDataPage/MyDataPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/MyDataPage/MyDataPage.component.tsx
@@ -11,15 +11,12 @@
  *  limitations under the License.
  */
 
-import PageContainerV1 from '@components/containers/PageContainerV1';
-import GithubStarButton from '@components/GithubStarButton/GithubStarButton';
-import Loader from '@components/Loader/Loader';
-import MyData from '@components/MyData/MyData.component';
-import { useWebSocketConnector } from '@components/web-scoket/web-scoket.provider';
-import { getFeedsWithFilter, postFeedById } from '@rest/feedsAPI';
-import { fetchSandboxConfig, getAllEntityCount } from '@rest/miscAPI';
-import { getUserById } from '@rest/userAPI';
 import { AxiosError } from 'axios';
+import PageContainerV1 from 'components/containers/PageContainerV1';
+import GithubStarButton from 'components/GithubStarButton/GithubStarButton';
+import Loader from 'components/Loader/Loader';
+import MyData from 'components/MyData/MyData.component';
+import { useWebSocketConnector } from 'components/web-scoket/web-scoket.provider';
 import { Operation } from 'fast-json-patch';
 import { isEmpty, isNil, isUndefined } from 'lodash';
 import { observer } from 'mobx-react';
@@ -31,6 +28,9 @@ import React, {
   useState,
 } from 'react';
 import { useLocation } from 'react-router-dom';
+import { getFeedsWithFilter, postFeedById } from 'rest/feedsAPI';
+import { fetchSandboxConfig, getAllEntityCount } from 'rest/miscAPI';
+import { getUserById } from 'rest/userAPI';
 import AppState from '../../AppState';
 import { SOCKET_EVENTS } from '../../constants/constants';
 import { AssetsType } from '../../enums/entity.enum';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/MyDataPage/MyDataPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/MyDataPage/MyDataPage.test.tsx
@@ -11,9 +11,9 @@
  *  limitations under the License.
  */
 
-import { fetchSandboxConfig, getAllEntityCount } from '@rest/miscAPI';
 import { findByText, queryByText, render } from '@testing-library/react';
 import React, { ReactNode } from 'react';
+import { fetchSandboxConfig, getAllEntityCount } from 'rest/miscAPI';
 import MyDataPageComponent from './MyDataPage.component';
 
 const mockAuth = {
@@ -24,13 +24,13 @@ const mockErrors = {
   sandboxMode: 'SandboxModeError',
 };
 
-jest.mock('@components/MyData/MyData.component', () => {
+jest.mock('components/MyData/MyData.component', () => {
   return jest
     .fn()
     .mockReturnValue(<p data-testid="my-data-component">Mydata component</p>);
 });
 
-jest.mock('@rest/miscAPI', () => ({
+jest.mock('rest/miscAPI', () => ({
   fetchSandboxConfig: jest.fn().mockImplementation(() =>
     Promise.resolve({
       data: {
@@ -54,7 +54,7 @@ jest.mock('@rest/miscAPI', () => ({
   ),
 }));
 
-jest.mock('@rest/feedsAPI', () => ({
+jest.mock('rest/feedsAPI', () => ({
   getFeedsWithFilter: jest.fn().mockImplementation(() =>
     Promise.resolve({
       data: {
@@ -82,7 +82,7 @@ jest.mock('../../utils/APIUtils', () => ({
   formatDataResponse: jest.fn(),
 }));
 
-jest.mock('@components/containers/PageContainerV1', () => {
+jest.mock('components/containers/PageContainerV1', () => {
   return jest
     .fn()
     .mockImplementation(({ children }: { children: ReactNode }) => (
@@ -90,11 +90,11 @@ jest.mock('@components/containers/PageContainerV1', () => {
     ));
 });
 
-jest.mock('@components/MyData/MyData.component', () => {
+jest.mock('components/MyData/MyData.component', () => {
   return jest.fn().mockImplementation(() => <p>MyData.component</p>);
 });
 
-jest.mock('@components/GithubStarButton/GithubStarButton', () => {
+jest.mock('components/GithubStarButton/GithubStarButton', () => {
   return jest.fn().mockImplementation(() => <p>GithubStarButton.component</p>);
 });
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PipelineDetails/PipelineDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PipelineDetails/PipelineDetailsPage.component.tsx
@@ -11,34 +11,34 @@
  *  limitations under the License.
  */
 
-import ErrorPlaceHolder from '@components/common/error-with-placeholder/ErrorPlaceHolder';
-import { TitleBreadcrumbProps } from '@components/common/title-breadcrumb/title-breadcrumb.interface';
+import { AxiosError } from 'axios';
+import ErrorPlaceHolder from 'components/common/error-with-placeholder/ErrorPlaceHolder';
+import { TitleBreadcrumbProps } from 'components/common/title-breadcrumb/title-breadcrumb.interface';
 import {
   Edge,
   EdgeData,
   LeafNodes,
   LineagePos,
   LoadingNodeState,
-} from '@components/EntityLineage/EntityLineage.interface';
-import Loader from '@components/Loader/Loader';
-import { usePermissionProvider } from '@components/PermissionProvider/PermissionProvider';
-import { ResourceEntity } from '@components/PermissionProvider/PermissionProvider.interface';
-import PipelineDetails from '@components/PipelineDetails/PipelineDetails.component';
-import { getLineageByFQN } from '@rest/lineageAPI';
-import { addLineage, deleteLineageEdge } from '@rest/miscAPI';
-import {
-  addFollower,
-  getPipelineByFqn,
-  patchPipelineDetails,
-  removeFollower,
-} from '@rest/pipelineAPI';
-import { getServiceByFQN } from '@rest/serviceAPI';
-import { AxiosError } from 'axios';
+} from 'components/EntityLineage/EntityLineage.interface';
+import Loader from 'components/Loader/Loader';
+import { usePermissionProvider } from 'components/PermissionProvider/PermissionProvider';
+import { ResourceEntity } from 'components/PermissionProvider/PermissionProvider.interface';
+import PipelineDetails from 'components/PipelineDetails/PipelineDetails.component';
 import { compare, Operation } from 'fast-json-patch';
 import { isUndefined, omitBy } from 'lodash';
 import { observer } from 'mobx-react';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
+import { getLineageByFQN } from 'rest/lineageAPI';
+import { addLineage, deleteLineageEdge } from 'rest/miscAPI';
+import {
+  addFollower,
+  getPipelineByFqn,
+  patchPipelineDetails,
+  removeFollower,
+} from 'rest/pipelineAPI';
+import { getServiceByFQN } from 'rest/serviceAPI';
 import {
   getServiceDetailsPath,
   getVersionPath,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PipelineDetails/PipelineDetailsPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PipelineDetails/PipelineDetailsPage.test.tsx
@@ -24,31 +24,31 @@ jest.mock('react-router-dom', () => ({
   }),
 }));
 
-jest.mock('@rest/lineageAPI', () => ({
+jest.mock('rest/lineageAPI', () => ({
   getLineageByFQN: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
 
-jest.mock('@rest/miscAPI', () => ({
+jest.mock('rest/miscAPI', () => ({
   addLineage: jest.fn(),
   deleteLineageEdge: jest.fn(),
 }));
 
-jest.mock('@rest/pipelineAPI', () => ({
+jest.mock('rest/pipelineAPI', () => ({
   addFollower: jest.fn(),
   patchPipelineDetails: jest.fn(),
   removeFollower: jest.fn(),
   getPipelineByFqn: jest.fn().mockImplementation(() => Promise.resolve({})),
 }));
 
-jest.mock('@components/PipelineDetails/PipelineDetails.component', () => {
+jest.mock('components/PipelineDetails/PipelineDetails.component', () => {
   return jest.fn().mockReturnValue(<div>PipelineDetails.component</div>);
 });
 
-jest.mock('@components/common/error-with-placeholder/ErrorPlaceHolder', () => {
+jest.mock('components/common/error-with-placeholder/ErrorPlaceHolder', () => {
   return jest.fn().mockReturnValue(<div>ErrorPlaceHolder.component</div>);
 });
 
-jest.mock('@components/PermissionProvider/PermissionProvider', () => ({
+jest.mock('components/PermissionProvider/PermissionProvider', () => ({
   usePermissionProvider: jest.fn().mockImplementation(() => ({
     permissions: {},
     getEntityPermission: jest.fn().mockResolvedValue({

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/AddPolicyPage/AddPolicyPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/AddPolicyPage/AddPolicyPage.test.tsx
@@ -22,18 +22,16 @@ jest.mock('react-router-dom', () => ({
   }),
 }));
 
-jest.mock('@rest/rolesAPIV1', () => ({
+jest.mock('rest/rolesAPIV1', () => ({
   addPolicy: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
 
-jest.mock('@components/common/rich-text-editor/RichTextEditor', () =>
+jest.mock('components/common/rich-text-editor/RichTextEditor', () =>
   jest.fn().mockReturnValue(<div data-testid="editor">Editor</div>)
 );
 
-jest.mock(
-  '@components/common/title-breadcrumb/title-breadcrumb.component',
-  () =>
-    jest.fn().mockReturnValue(<div data-testid="breadcrumb">BreadCrumb</div>)
+jest.mock('components/common/title-breadcrumb/title-breadcrumb.component', () =>
+  jest.fn().mockReturnValue(<div data-testid="breadcrumb">BreadCrumb</div>)
 );
 
 jest.mock('../../../utils/RouterUtils', () => ({

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/AddPolicyPage/AddPolicyPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/AddPolicyPage/AddPolicyPage.tsx
@@ -11,10 +11,6 @@
  *  limitations under the License.
  */
 
-import RichTextEditor from '@components/common/rich-text-editor/RichTextEditor';
-import TitleBreadcrumb from '@components/common/title-breadcrumb/title-breadcrumb.component';
-import PageLayoutV1 from '@components/containers/PageLayoutV1';
-import { addPolicy } from '@rest/rolesAPIV1';
 import {
   Button,
   Card,
@@ -27,10 +23,14 @@ import {
   Typography,
 } from 'antd';
 import { AxiosError } from 'axios';
+import RichTextEditor from 'components/common/rich-text-editor/RichTextEditor';
+import TitleBreadcrumb from 'components/common/title-breadcrumb/title-breadcrumb.component';
+import PageLayoutV1 from 'components/containers/PageLayoutV1';
 import { t } from 'i18next';
 import { trim } from 'lodash';
 import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
+import { addPolicy } from 'rest/rolesAPIV1';
 import { GlobalSettingOptions } from '../../../constants/GlobalSettings.constants';
 import { allowedNameRegEx } from '../../../constants/regex.constants';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/AddRulePage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/AddRulePage.test.tsx
@@ -23,20 +23,18 @@ jest.mock('react-router-dom', () => ({
   useParams: jest.fn().mockReturnValue({ fqn: 'data-consumer' }),
 }));
 
-jest.mock('@rest/rolesAPIV1', () => ({
+jest.mock('rest/rolesAPIV1', () => ({
   getPolicyByName: jest
     .fn()
     .mockImplementation(() => Promise.resolve(POLICY_DATA)),
   patchPolicy: jest.fn().mockImplementation(() => Promise.resolve(POLICY_DATA)),
 }));
 
-jest.mock(
-  '@components/common/title-breadcrumb/title-breadcrumb.component',
-  () =>
-    jest.fn().mockReturnValue(<div data-testid="breadcrumb">BreadCrumb</div>)
+jest.mock('components/common/title-breadcrumb/title-breadcrumb.component', () =>
+  jest.fn().mockReturnValue(<div data-testid="breadcrumb">BreadCrumb</div>)
 );
 
-jest.mock('@components/Loader/Loader', () =>
+jest.mock('components/Loader/Loader', () =>
   jest.fn().mockReturnValue(<div data-testid="loader">Loader</div>)
 );
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/AddRulePage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/AddRulePage.tsx
@@ -11,15 +11,15 @@
  *  limitations under the License.
  */
 
-import TitleBreadcrumb from '@components/common/title-breadcrumb/title-breadcrumb.component';
-import Loader from '@components/Loader/Loader';
-import { getPolicyByName, patchPolicy } from '@rest/rolesAPIV1';
 import { Button, Card, Col, Form, Row, Space, Typography } from 'antd';
 import { AxiosError } from 'axios';
+import TitleBreadcrumb from 'components/common/title-breadcrumb/title-breadcrumb.component';
+import Loader from 'components/Loader/Loader';
 import { compare } from 'fast-json-patch';
 import { trim } from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
+import { getPolicyByName, patchPolicy } from 'rest/rolesAPIV1';
 import { GlobalSettingOptions } from '../../../constants/GlobalSettings.constants';
 import { Effect, Rule } from '../../../generated/api/policies/createPolicy';
 import { Policy } from '../../../generated/entity/policies/policy';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/EditRulePage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/EditRulePage.test.tsx
@@ -23,20 +23,18 @@ jest.mock('react-router-dom', () => ({
   useParams: jest.fn().mockReturnValue({ fqn: 'data-consumer' }),
 }));
 
-jest.mock('@rest/rolesAPIV1', () => ({
+jest.mock('rest/rolesAPIV1', () => ({
   getPolicyByName: jest
     .fn()
     .mockImplementation(() => Promise.resolve(POLICY_DATA)),
   patchPolicy: jest.fn().mockImplementation(() => Promise.resolve(POLICY_DATA)),
 }));
 
-jest.mock(
-  '@components/common/title-breadcrumb/title-breadcrumb.component',
-  () =>
-    jest.fn().mockReturnValue(<div data-testid="breadcrumb">BreadCrumb</div>)
+jest.mock('components/common/title-breadcrumb/title-breadcrumb.component', () =>
+  jest.fn().mockReturnValue(<div data-testid="breadcrumb">BreadCrumb</div>)
 );
 
-jest.mock('@components/Loader/Loader', () =>
+jest.mock('components/Loader/Loader', () =>
   jest.fn().mockReturnValue(<div data-testid="loader">Loader</div>)
 );
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/EditRulePage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/EditRulePage.tsx
@@ -11,15 +11,15 @@
  *  limitations under the License.
  */
 
-import TitleBreadcrumb from '@components/common/title-breadcrumb/title-breadcrumb.component';
-import Loader from '@components/Loader/Loader';
-import { getPolicyByName, patchPolicy } from '@rest/rolesAPIV1';
 import { Button, Card, Col, Form, Row, Space, Typography } from 'antd';
 import { AxiosError } from 'axios';
+import TitleBreadcrumb from 'components/common/title-breadcrumb/title-breadcrumb.component';
+import Loader from 'components/Loader/Loader';
 import { compare } from 'fast-json-patch';
 import { trim } from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
+import { getPolicyByName, patchPolicy } from 'rest/rolesAPIV1';
 import { GlobalSettingOptions } from '../../../constants/GlobalSettings.constants';
 import { Effect, Rule } from '../../../generated/api/policies/createPolicy';
 import { Policy } from '../../../generated/entity/policies/policy';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/PoliciesDetailPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/PoliciesDetailPage.test.tsx
@@ -21,7 +21,7 @@ jest.mock('react-router-dom', () => ({
   useParams: jest.fn().mockReturnValue({ fqn: 'policy' }),
 }));
 
-jest.mock('@rest/rolesAPIV1', () => ({
+jest.mock('rest/rolesAPIV1', () => ({
   getPolicyByName: jest
     .fn()
     .mockImplementation(() => Promise.resolve(POLICY_DATA)),
@@ -30,36 +30,34 @@ jest.mock('@rest/rolesAPIV1', () => ({
   patchRole: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
 
-jest.mock('@rest/teamsAPI', () => ({
+jest.mock('rest/teamsAPI', () => ({
   getTeamByName: jest.fn().mockImplementation(() => Promise.resolve()),
   patchTeamDetail: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
 
-jest.mock('@components/common/description/Description', () =>
+jest.mock('components/common/description/Description', () =>
   jest
     .fn()
     .mockReturnValue(<div data-testid="description-data">Description</div>)
 );
 
-jest.mock('@components/common/error-with-placeholder/ErrorPlaceHolder', () =>
+jest.mock('components/common/error-with-placeholder/ErrorPlaceHolder', () =>
   jest.fn().mockReturnValue(<div>ErrorPlaceholder</div>)
 );
 
-jest.mock('@components/common/rich-text-editor/RichTextEditorPreviewer', () =>
+jest.mock('components/common/rich-text-editor/RichTextEditorPreviewer', () =>
   jest.fn().mockReturnValue(<div data-testid="previewer">Previewer</div>)
 );
 
-jest.mock(
-  '@components/common/title-breadcrumb/title-breadcrumb.component',
-  () =>
-    jest.fn().mockReturnValue(<div data-testid="breadcrumb">BreadCrumb</div>)
+jest.mock('components/common/title-breadcrumb/title-breadcrumb.component', () =>
+  jest.fn().mockReturnValue(<div data-testid="breadcrumb">BreadCrumb</div>)
 );
 
-jest.mock('@components/Loader/Loader', () =>
+jest.mock('components/Loader/Loader', () =>
   jest.fn().mockReturnValue(<div>Loader</div>)
 );
 
-jest.mock('@components/PermissionProvider/PermissionProvider', () => ({
+jest.mock('components/PermissionProvider/PermissionProvider', () => ({
   usePermissionProvider: jest.fn().mockReturnValue({
     getEntityPermissionByFqn: jest.fn().mockReturnValue({
       Create: true,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/PoliciesDetailPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/PoliciesDetailPage.tsx
@@ -11,24 +11,7 @@
  *  limitations under the License.
  */
 
-import Description from '@components/common/description/Description';
-import ErrorPlaceHolder from '@components/common/error-with-placeholder/ErrorPlaceHolder';
-import RichTextEditorPreviewer from '@components/common/rich-text-editor/RichTextEditorPreviewer';
-import TitleBreadcrumb from '@components/common/title-breadcrumb/title-breadcrumb.component';
-import Loader from '@components/Loader/Loader';
-import { usePermissionProvider } from '@components/PermissionProvider/PermissionProvider';
-import {
-  OperationPermission,
-  ResourceEntity,
-} from '@components/PermissionProvider/PermissionProvider.interface';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import {
-  getPolicyByName,
-  getRoleByName,
-  patchPolicy,
-  patchRole,
-} from '@rest/rolesAPIV1';
-import { getTeamByName, patchTeamDetail } from '@rest/teamsAPI';
 import {
   Button,
   Card,
@@ -43,11 +26,28 @@ import {
   Typography,
 } from 'antd';
 import { AxiosError } from 'axios';
+import Description from 'components/common/description/Description';
+import ErrorPlaceHolder from 'components/common/error-with-placeholder/ErrorPlaceHolder';
+import RichTextEditorPreviewer from 'components/common/rich-text-editor/RichTextEditorPreviewer';
+import TitleBreadcrumb from 'components/common/title-breadcrumb/title-breadcrumb.component';
+import Loader from 'components/Loader/Loader';
+import { usePermissionProvider } from 'components/PermissionProvider/PermissionProvider';
+import {
+  OperationPermission,
+  ResourceEntity,
+} from 'components/PermissionProvider/PermissionProvider.interface';
 import { compare } from 'fast-json-patch';
 import { isEmpty, isUndefined, startCase } from 'lodash';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory, useParams } from 'react-router-dom';
+import {
+  getPolicyByName,
+  getRoleByName,
+  patchPolicy,
+  patchRole,
+} from 'rest/rolesAPIV1';
+import { getTeamByName, patchTeamDetail } from 'rest/teamsAPI';
 import {
   GlobalSettingOptions,
   GlobalSettingsMenuCategory,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/PoliciesDetailsList.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/PoliciesDetailsList.component.tsx
@@ -11,9 +11,9 @@
  *  limitations under the License.
  */
 
-import RichTextEditorPreviewer from '@components/common/rich-text-editor/RichTextEditorPreviewer';
 import { Button, Tooltip } from 'antd';
 import Table, { ColumnsType } from 'antd/lib/table';
+import RichTextEditorPreviewer from 'components/common/rich-text-editor/RichTextEditorPreviewer';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesListPage/PoliciesList.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesListPage/PoliciesList.test.tsx
@@ -25,15 +25,15 @@ jest.mock('react-router-dom', () => ({
   )),
 }));
 
-jest.mock('@components/common/DeleteWidget/DeleteWidgetModal', () =>
+jest.mock('components/common/DeleteWidget/DeleteWidgetModal', () =>
   jest.fn().mockReturnValue(<div>Delete Widget</div>)
 );
 
-jest.mock('@components/common/rich-text-editor/RichTextEditorPreviewer', () =>
+jest.mock('components/common/rich-text-editor/RichTextEditorPreviewer', () =>
   jest.fn().mockReturnValue(<div data-testid="previewer">Previewer</div>)
 );
 
-jest.mock('@components/PermissionProvider/PermissionProvider', () => ({
+jest.mock('components/PermissionProvider/PermissionProvider', () => ({
   usePermissionProvider: jest.fn().mockReturnValue({
     permissions: {
       policy: {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesListPage/PoliciesList.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesListPage/PoliciesList.tsx
@@ -11,12 +11,12 @@
  *  limitations under the License.
  */
 
-import DeleteWidgetModal from '@components/common/DeleteWidget/DeleteWidgetModal';
-import RichTextEditorPreviewer from '@components/common/rich-text-editor/RichTextEditorPreviewer';
-import { usePermissionProvider } from '@components/PermissionProvider/PermissionProvider';
-import { ResourceEntity } from '@components/PermissionProvider/PermissionProvider.interface';
 import { Button, Popover, Space, Table, Tag, Tooltip } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
+import DeleteWidgetModal from 'components/common/DeleteWidget/DeleteWidgetModal';
+import RichTextEditorPreviewer from 'components/common/rich-text-editor/RichTextEditorPreviewer';
+import { usePermissionProvider } from 'components/PermissionProvider/PermissionProvider';
+import { ResourceEntity } from 'components/PermissionProvider/PermissionProvider.interface';
 import { isEmpty, isUndefined, uniqueId } from 'lodash';
 import React, { FC, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesListPage/PoliciesListPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesListPage/PoliciesListPage.test.tsx
@@ -24,17 +24,17 @@ jest.mock('react-router-dom', () => ({
   })),
 }));
 
-jest.mock('@rest/rolesAPIV1', () => ({
+jest.mock('rest/rolesAPIV1', () => ({
   getPolicies: jest
     .fn()
     .mockImplementation(() => Promise.resolve(POLICY_LIST_WITH_PAGING)),
 }));
 
-jest.mock('@components/common/next-previous/NextPrevious', () =>
+jest.mock('components/common/next-previous/NextPrevious', () =>
   jest.fn().mockReturnValue(<div>NextPrevious</div>)
 );
 
-jest.mock('@components/Loader/Loader', () =>
+jest.mock('components/Loader/Loader', () =>
   jest.fn().mockReturnValue(<div>Loader</div>)
 );
 
@@ -46,7 +46,7 @@ jest.mock('../../../utils/PermissionsUtils', () => ({
   checkPermission: jest.fn().mockReturnValue(true),
 }));
 
-jest.mock('@components/PermissionProvider/PermissionProvider', () => ({
+jest.mock('components/PermissionProvider/PermissionProvider', () => ({
   usePermissionProvider: jest.fn().mockReturnValue({
     permissions: {
       policy: {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesListPage/PoliciesListPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesListPage/PoliciesListPage.tsx
@@ -11,18 +11,18 @@
  *  limitations under the License.
  */
 
-import ErrorPlaceHolder from '@components/common/error-with-placeholder/ErrorPlaceHolder';
-import NextPrevious from '@components/common/next-previous/NextPrevious';
-import PageHeader from '@components/header/PageHeader.component';
-import Loader from '@components/Loader/Loader';
-import { usePermissionProvider } from '@components/PermissionProvider/PermissionProvider';
-import { ResourceEntity } from '@components/PermissionProvider/PermissionProvider.interface';
-import { getPolicies } from '@rest/rolesAPIV1';
 import { Button, Col, Row, Space, Tooltip } from 'antd';
 import { AxiosError } from 'axios';
+import ErrorPlaceHolder from 'components/common/error-with-placeholder/ErrorPlaceHolder';
+import NextPrevious from 'components/common/next-previous/NextPrevious';
+import PageHeader from 'components/header/PageHeader.component';
+import Loader from 'components/Loader/Loader';
+import { usePermissionProvider } from 'components/PermissionProvider/PermissionProvider';
+import { ResourceEntity } from 'components/PermissionProvider/PermissionProvider.interface';
 import { isEmpty } from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useHistory } from 'react-router-dom';
+import { getPolicies } from 'rest/rolesAPIV1';
 import {
   INITIAL_PAGING_VALUE,
   PAGE_SIZE_MEDIUM,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/RuleForm/RuleForm.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/RuleForm/RuleForm.test.tsx
@@ -17,13 +17,13 @@ import React from 'react';
 import { Rule } from '../../../generated/api/policies/createPolicy';
 import RuleForm, { RuleFormProps } from './RuleForm';
 
-jest.mock('@rest/rolesAPIV1', () => ({
+jest.mock('rest/rolesAPIV1', () => ({
   getPolicyFunctions: jest.fn().mockImplementation(() => Promise.resolve()),
   getPolicyResources: jest.fn().mockImplementation(() => Promise.resolve()),
   validateRuleCondition: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
 
-jest.mock('@components/common/rich-text-editor/RichTextEditor', () =>
+jest.mock('components/common/rich-text-editor/RichTextEditor', () =>
   jest.fn().mockReturnValue(<div data-testid="editor">Editor</div>)
 );
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/RuleForm/RuleForm.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/RuleForm/RuleForm.tsx
@@ -12,18 +12,18 @@
  *  limitations under the License.
  */
 
-import RichTextEditor from '@components/common/rich-text-editor/RichTextEditor';
+import { AutoComplete, Form, Input, Select, TreeSelect } from 'antd';
+import { BaseOptionType } from 'antd/lib/select';
+import { AxiosError } from 'axios';
+import RichTextEditor from 'components/common/rich-text-editor/RichTextEditor';
+import { capitalize, startCase, uniq, uniqBy } from 'lodash';
+import React, { FC, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   getPolicyFunctions,
   getPolicyResources,
   validateRuleCondition,
-} from '@rest/rolesAPIV1';
-import { AutoComplete, Form, Input, Select, TreeSelect } from 'antd';
-import { BaseOptionType } from 'antd/lib/select';
-import { AxiosError } from 'axios';
-import { capitalize, startCase, uniq, uniqBy } from 'lodash';
-import React, { FC, useEffect, useMemo, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+} from 'rest/rolesAPIV1';
 import { allowedNameRegEx } from '../../../constants/regex.constants';
 import {
   Effect,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ProfilerDashboardPage/ProfilerDashboardPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ProfilerDashboardPage/ProfilerDashboardPage.test.tsx
@@ -11,11 +11,11 @@
  *  limitations under the License.
  */
 
-import { ProfilerDashboardTab } from '@components/ProfilerDashboard/profilerDashboard.interface';
-import { getTableDetailsByFQN } from '@rest/tableAPI';
 import { act, cleanup, render, screen } from '@testing-library/react';
+import { ProfilerDashboardTab } from 'components/ProfilerDashboard/profilerDashboard.interface';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
+import { getTableDetailsByFQN } from 'rest/tableAPI';
 import { ProfilerDashboardType } from '../../enums/table.enum';
 import { MOCK_TABLE } from '../../mocks/TableData.mock';
 import ProfilerDashboardPage from './ProfilerDashboardPage';
@@ -32,7 +32,7 @@ jest.mock('react-router-dom', () => {
   };
 });
 
-jest.mock('@rest/tableAPI', () => {
+jest.mock('rest/tableAPI', () => {
   return {
     getColumnProfilerList: jest
       .fn()
@@ -44,14 +44,14 @@ jest.mock('@rest/tableAPI', () => {
   };
 });
 
-jest.mock('@rest/testAPI', () => {
+jest.mock('rest/testAPI', () => {
   return {
     getListTestCase: jest.fn().mockImplementation(() => Promise.resolve()),
     ListTestCaseParams: jest.fn().mockImplementation(() => Promise.resolve()),
   };
 });
 
-jest.mock('@components/PermissionProvider/PermissionProvider', () => {
+jest.mock('components/PermissionProvider/PermissionProvider', () => {
   return {
     usePermissionProvider: jest.fn().mockImplementation(() => ({
       getEntityPermission: jest.fn().mockImplementation(() => ({
@@ -64,11 +64,11 @@ jest.mock('@components/PermissionProvider/PermissionProvider', () => {
   };
 });
 
-jest.mock('@components/common/error-with-placeholder/ErrorPlaceHolder', () => {
+jest.mock('components/common/error-with-placeholder/ErrorPlaceHolder', () => {
   return jest.fn().mockImplementation(() => <div>No data placeholder</div>);
 });
 
-jest.mock('@components/containers/PageContainerV1', () => {
+jest.mock('components/containers/PageContainerV1', () => {
   return jest
     .fn()
     .mockImplementation(({ children }) => (
@@ -76,11 +76,11 @@ jest.mock('@components/containers/PageContainerV1', () => {
     ));
 });
 
-jest.mock('@components/Loader/Loader', () => {
+jest.mock('components/Loader/Loader', () => {
   return jest.fn().mockImplementation(() => <p data-testid="loader">Loader</p>);
 });
 
-jest.mock('@components/ProfilerDashboard/ProfilerDashboard', () => {
+jest.mock('components/ProfilerDashboard/ProfilerDashboard', () => {
   return jest
     .fn()
     .mockImplementation(() => (

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ProfilerDashboardPage/ProfilerDashboardPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ProfilerDashboardPage/ProfilerDashboardPage.tsx
@@ -11,27 +11,27 @@
  *  limitations under the License.
  */
 
-import ErrorPlaceHolder from '@components/common/error-with-placeholder/ErrorPlaceHolder';
-import PageContainerV1 from '@components/containers/PageContainerV1';
-import Loader from '@components/Loader/Loader';
-import { usePermissionProvider } from '@components/PermissionProvider/PermissionProvider';
+import { AxiosError } from 'axios';
+import ErrorPlaceHolder from 'components/common/error-with-placeholder/ErrorPlaceHolder';
+import PageContainerV1 from 'components/containers/PageContainerV1';
+import Loader from 'components/Loader/Loader';
+import { usePermissionProvider } from 'components/PermissionProvider/PermissionProvider';
 import {
   OperationPermission,
   ResourceEntity,
-} from '@components/PermissionProvider/PermissionProvider.interface';
-import ProfilerDashboard from '@components/ProfilerDashboard/ProfilerDashboard';
-import { ProfilerDashboardTab } from '@components/ProfilerDashboard/profilerDashboard.interface';
-import {
-  getColumnProfilerList,
-  getTableDetailsByFQN,
-  patchTableDetails,
-} from '@rest/tableAPI';
-import { getListTestCase, ListTestCaseParams } from '@rest/testAPI';
-import { AxiosError } from 'axios';
+} from 'components/PermissionProvider/PermissionProvider.interface';
+import ProfilerDashboard from 'components/ProfilerDashboard/ProfilerDashboard';
+import { ProfilerDashboardTab } from 'components/ProfilerDashboard/profilerDashboard.interface';
 import { compare } from 'fast-json-patch';
 import { isEmpty } from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import {
+  getColumnProfilerList,
+  getTableDetailsByFQN,
+  patchTableDetails,
+} from 'rest/tableAPI';
+import { getListTestCase, ListTestCaseParams } from 'rest/testAPI';
 import { API_RES_MAX_SIZE } from '../../constants/constants';
 import { ProfilerDashboardType } from '../../enums/table.enum';
 import { ColumnProfile, Table } from '../../generated/entity/data/table';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/AddAttributeModal/AddAttributeModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/AddAttributeModal/AddAttributeModal.test.tsx
@@ -17,7 +17,7 @@ import { EntityType } from '../../../enums/entity.enum';
 import { POLICY_LIST_WITH_PAGING, ROLES_LIST_WITH_PAGING } from '../Roles.mock';
 import AddAttributeModal from './AddAttributeModal';
 
-jest.mock('@rest/rolesAPIV1', () => ({
+jest.mock('rest/rolesAPIV1', () => ({
   getPolicies: jest
     .fn()
     .mockImplementation(() => Promise.resolve(POLICY_LIST_WITH_PAGING)),
@@ -26,11 +26,11 @@ jest.mock('@rest/rolesAPIV1', () => ({
     .mockImplementation(() => Promise.resolve(ROLES_LIST_WITH_PAGING)),
 }));
 
-jest.mock('@components/common/rich-text-editor/RichTextEditorPreviewer', () =>
+jest.mock('components/common/rich-text-editor/RichTextEditorPreviewer', () =>
   jest.fn().mockReturnValue(<div data-testid="previewer">Previewer</div>)
 );
 
-jest.mock('@components/Loader/Loader', () =>
+jest.mock('components/Loader/Loader', () =>
   jest.fn().mockReturnValue(<div data-testid="loader">Loader</div>)
 );
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/AddAttributeModal/AddAttributeModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/AddAttributeModal/AddAttributeModal.tsx
@@ -11,14 +11,14 @@
  *  limitations under the License.
  */
 
-import RichTextEditorPreviewer from '@components/common/rich-text-editor/RichTextEditorPreviewer';
-import Loader from '@components/Loader/Loader';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { getPolicies, getRoles } from '@rest/rolesAPIV1';
 import { Col, Input, Modal, Row } from 'antd';
 import { AxiosError } from 'axios';
 import classNames from 'classnames';
+import RichTextEditorPreviewer from 'components/common/rich-text-editor/RichTextEditorPreviewer';
+import Loader from 'components/Loader/Loader';
 import React, { FC, useEffect, useState } from 'react';
+import { getPolicies, getRoles } from 'rest/rolesAPIV1';
 import { EntityType } from '../../../enums/entity.enum';
 import { Policy } from '../../../generated/entity/policies/policy';
 import { Role } from '../../../generated/entity/teams/role';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/AddRolePage/AddRolePage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/AddRolePage/AddRolePage.test.tsx
@@ -22,19 +22,17 @@ jest.mock('react-router-dom', () => ({
   }),
 }));
 
-jest.mock('@rest/rolesAPIV1', () => ({
+jest.mock('rest/rolesAPIV1', () => ({
   addRole: jest.fn().mockImplementation(() => Promise.resolve()),
   getPolicies: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
 
-jest.mock('@components/common/rich-text-editor/RichTextEditor', () =>
+jest.mock('components/common/rich-text-editor/RichTextEditor', () =>
   jest.fn().mockReturnValue(<div data-testid="editor">Editor</div>)
 );
 
-jest.mock(
-  '@components/common/title-breadcrumb/title-breadcrumb.component',
-  () =>
-    jest.fn().mockReturnValue(<div data-testid="breadcrumb">BreadCrumb</div>)
+jest.mock('components/common/title-breadcrumb/title-breadcrumb.component', () =>
+  jest.fn().mockReturnValue(<div data-testid="breadcrumb">BreadCrumb</div>)
 );
 
 jest.mock('../../../utils/RouterUtils', () => ({

--- a/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/AddRolePage/AddRolePage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/AddRolePage/AddRolePage.tsx
@@ -11,16 +11,16 @@
  *  limitations under the License.
  */
 
-import RichTextEditor from '@components/common/rich-text-editor/RichTextEditor';
-import TitleBreadcrumb from '@components/common/title-breadcrumb/title-breadcrumb.component';
-import PageLayoutV1 from '@components/containers/PageLayoutV1';
-import { addRole, getPolicies } from '@rest/rolesAPIV1';
 import { Button, Card, Form, Input, Select, Space, Typography } from 'antd';
 import { AxiosError } from 'axios';
+import RichTextEditor from 'components/common/rich-text-editor/RichTextEditor';
+import TitleBreadcrumb from 'components/common/title-breadcrumb/title-breadcrumb.component';
+import PageLayoutV1 from 'components/containers/PageLayoutV1';
 import { t } from 'i18next';
 import { trim } from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
+import { addRole, getPolicies } from 'rest/rolesAPIV1';
 import { GlobalSettingOptions } from '../../../constants/GlobalSettings.constants';
 import { allowedNameRegEx } from '../../../constants/regex.constants';
 import { Policy } from '../../../generated/entity/policies/policy';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/RolesDetailPage/RolesDetailPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/RolesDetailPage/RolesDetailPage.test.tsx
@@ -11,9 +11,9 @@
  *  limitations under the License.
  */
 
-import { getRoleByName } from '@rest/rolesAPIV1';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { getRoleByName } from 'rest/rolesAPIV1';
 import { ROLE_DATA } from '../Roles.mock';
 import RolesDetailPage from './RolesDetailPage';
 
@@ -25,26 +25,24 @@ jest.mock('react-router-dom', () => ({
   Link: jest.fn().mockImplementation(({ to }) => <a href={to}>link</a>),
 }));
 
-jest.mock('@rest/rolesAPIV1', () => ({
+jest.mock('rest/rolesAPIV1', () => ({
   getRoleByName: jest.fn().mockImplementation(() => Promise.resolve(ROLE_DATA)),
   patchRole: jest.fn().mockImplementation(() => Promise.resolve(ROLE_DATA)),
 }));
 
-jest.mock('@components/common/description/Description', () =>
+jest.mock('components/common/description/Description', () =>
   jest.fn().mockReturnValue(<div data-testid="description">Description</div>)
 );
 
-jest.mock('@components/common/rich-text-editor/RichTextEditorPreviewer', () =>
+jest.mock('components/common/rich-text-editor/RichTextEditorPreviewer', () =>
   jest.fn().mockReturnValue(<div data-testid="previewer">Previewer</div>)
 );
 
-jest.mock(
-  '@components/common/title-breadcrumb/title-breadcrumb.component',
-  () =>
-    jest.fn().mockReturnValue(<div data-testid="breadcrumb">Breadcrumb</div>)
+jest.mock('components/common/title-breadcrumb/title-breadcrumb.component', () =>
+  jest.fn().mockReturnValue(<div data-testid="breadcrumb">Breadcrumb</div>)
 );
 
-jest.mock('@components/Loader/Loader', () =>
+jest.mock('components/Loader/Loader', () =>
   jest.fn().mockReturnValue(<div data-testid="loader">Loader</div>)
 );
 
@@ -62,7 +60,7 @@ jest.mock('../../../utils/RouterUtils', () => ({
   getTeamsWithFqnPath: jest.fn(),
 }));
 
-jest.mock('@components/PermissionProvider/PermissionProvider', () => ({
+jest.mock('components/PermissionProvider/PermissionProvider', () => ({
   usePermissionProvider: jest.fn().mockReturnValue({
     getEntityPermissionByFqn: jest.fn().mockReturnValue({
       Create: true,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/RolesDetailPage/RolesDetailPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/RolesDetailPage/RolesDetailPage.tsx
@@ -11,25 +11,25 @@
  *  limitations under the License.
  */
 
-import Description from '@components/common/description/Description';
-import ErrorPlaceHolder from '@components/common/error-with-placeholder/ErrorPlaceHolder';
-import TitleBreadcrumb from '@components/common/title-breadcrumb/title-breadcrumb.component';
-import Loader from '@components/Loader/Loader';
-import { usePermissionProvider } from '@components/PermissionProvider/PermissionProvider';
+import { Button, Modal, Space, Tabs, Tooltip, Typography } from 'antd';
+import { AxiosError } from 'axios';
+import Description from 'components/common/description/Description';
+import ErrorPlaceHolder from 'components/common/error-with-placeholder/ErrorPlaceHolder';
+import TitleBreadcrumb from 'components/common/title-breadcrumb/title-breadcrumb.component';
+import Loader from 'components/Loader/Loader';
+import { usePermissionProvider } from 'components/PermissionProvider/PermissionProvider';
 import {
   OperationPermission,
   ResourceEntity,
-} from '@components/PermissionProvider/PermissionProvider.interface';
-import { getRoleByName, patchRole } from '@rest/rolesAPIV1';
-import { getTeamByName, patchTeamDetail } from '@rest/teamsAPI';
-import { getUserByName, updateUserDetail } from '@rest/userAPI';
-import { Button, Modal, Space, Tabs, Tooltip, Typography } from 'antd';
-import { AxiosError } from 'axios';
+} from 'components/PermissionProvider/PermissionProvider.interface';
 import { compare } from 'fast-json-patch';
 import { isEmpty, isUndefined } from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory, useParams } from 'react-router-dom';
+import { getRoleByName, patchRole } from 'rest/rolesAPIV1';
+import { getTeamByName, patchTeamDetail } from 'rest/teamsAPI';
+import { getUserByName, updateUserDetail } from 'rest/userAPI';
 import {
   GlobalSettingOptions,
   GlobalSettingsMenuCategory,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/RolesDetailPage/RolesDetailPageList.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/RolesDetailPage/RolesDetailPageList.component.tsx
@@ -11,9 +11,9 @@
  *  limitations under the License.
  */
 
-import RichTextEditorPreviewer from '@components/common/rich-text-editor/RichTextEditorPreviewer';
 import { Button, Table, Tooltip } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
+import RichTextEditorPreviewer from 'components/common/rich-text-editor/RichTextEditorPreviewer';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/RolesListPage/RolesList.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/RolesListPage/RolesList.test.tsx
@@ -24,13 +24,13 @@ jest.mock('react-router-dom', () => ({
   )),
 }));
 
-jest.mock('@components/common/DeleteWidget/DeleteWidgetModal', () =>
+jest.mock('components/common/DeleteWidget/DeleteWidgetModal', () =>
   jest
     .fn()
     .mockReturnValue(<div data-testid="delete-modal">DeletWdigetModal</div>)
 );
 
-jest.mock('@components/common/rich-text-editor/RichTextEditorPreviewer', () =>
+jest.mock('components/common/rich-text-editor/RichTextEditorPreviewer', () =>
   jest.fn().mockReturnValue(<div data-testid="previewer">Previewer</div>)
 );
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/RolesListPage/RolesList.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/RolesListPage/RolesList.tsx
@@ -11,12 +11,12 @@
  *  limitations under the License.
  */
 
-import DeleteWidgetModal from '@components/common/DeleteWidget/DeleteWidgetModal';
-import RichTextEditorPreviewer from '@components/common/rich-text-editor/RichTextEditorPreviewer';
-import { usePermissionProvider } from '@components/PermissionProvider/PermissionProvider';
-import { ResourceEntity } from '@components/PermissionProvider/PermissionProvider.interface';
 import { Button, Popover, Space, Table, Tag, Tooltip } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
+import DeleteWidgetModal from 'components/common/DeleteWidget/DeleteWidgetModal';
+import RichTextEditorPreviewer from 'components/common/rich-text-editor/RichTextEditorPreviewer';
+import { usePermissionProvider } from 'components/PermissionProvider/PermissionProvider';
+import { ResourceEntity } from 'components/PermissionProvider/PermissionProvider.interface';
 import { isEmpty, isUndefined, uniqueId } from 'lodash';
 import React, { FC, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/RolesListPage/RolesListPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/RolesListPage/RolesListPage.test.tsx
@@ -24,17 +24,17 @@ jest.mock('react-router-dom', () => ({
   })),
 }));
 
-jest.mock('@rest/rolesAPIV1', () => ({
+jest.mock('rest/rolesAPIV1', () => ({
   getRoles: jest
     .fn()
     .mockImplementation(() => Promise.resolve(ROLES_LIST_WITH_PAGING)),
 }));
 
-jest.mock('@components/common/next-previous/NextPrevious', () =>
+jest.mock('components/common/next-previous/NextPrevious', () =>
   jest.fn().mockReturnValue(<div>NextPrevious</div>)
 );
 
-jest.mock('@components/Loader/Loader', () =>
+jest.mock('components/Loader/Loader', () =>
   jest.fn().mockReturnValue(<div>Loader</div>)
 );
 
@@ -46,7 +46,7 @@ jest.mock('../../../utils/PermissionsUtils', () => ({
   checkPermission: jest.fn().mockReturnValue(true),
 }));
 
-jest.mock('@components/PermissionProvider/PermissionProvider', () => ({
+jest.mock('components/PermissionProvider/PermissionProvider', () => ({
   usePermissionProvider: jest.fn().mockReturnValue({
     permissions: {
       role: {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/RolesListPage/RolesListPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/RolesListPage/RolesListPage.tsx
@@ -11,18 +11,18 @@
  *  limitations under the License.
  */
 
-import ErrorPlaceHolder from '@components/common/error-with-placeholder/ErrorPlaceHolder';
-import NextPrevious from '@components/common/next-previous/NextPrevious';
-import PageHeader from '@components/header/PageHeader.component';
-import Loader from '@components/Loader/Loader';
-import { usePermissionProvider } from '@components/PermissionProvider/PermissionProvider';
-import { ResourceEntity } from '@components/PermissionProvider/PermissionProvider.interface';
-import { getRoles } from '@rest/rolesAPIV1';
 import { Button, Col, Row, Space, Tooltip } from 'antd';
 import { AxiosError } from 'axios';
+import ErrorPlaceHolder from 'components/common/error-with-placeholder/ErrorPlaceHolder';
+import NextPrevious from 'components/common/next-previous/NextPrevious';
+import PageHeader from 'components/header/PageHeader.component';
+import Loader from 'components/Loader/Loader';
+import { usePermissionProvider } from 'components/PermissionProvider/PermissionProvider';
+import { ResourceEntity } from 'components/PermissionProvider/PermissionProvider.interface';
 import { isEmpty } from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useHistory } from 'react-router-dom';
+import { getRoles } from 'rest/rolesAPIV1';
 import {
   INITIAL_PAGING_VALUE,
   PAGE_SIZE_MEDIUM,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/RequestDescriptionPage/RequestDescriptionPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/RequestDescriptionPage/RequestDescriptionPage.tsx
@@ -11,14 +11,13 @@
  *  limitations under the License.
  */
 
-import ProfilePicture from '@components/common/ProfilePicture/ProfilePicture';
-import RichTextEditor from '@components/common/rich-text-editor/RichTextEditor';
-import { EditorContentRef } from '@components/common/rich-text-editor/RichTextEditor.interface';
-import TitleBreadcrumb from '@components/common/title-breadcrumb/title-breadcrumb.component';
-import { postThread } from '@rest/feedsAPI';
 import { Button, Card, Form, FormProps, Input, Space } from 'antd';
 import { useForm } from 'antd/lib/form/Form';
 import { AxiosError } from 'axios';
+import ProfilePicture from 'components/common/ProfilePicture/ProfilePicture';
+import RichTextEditor from 'components/common/rich-text-editor/RichTextEditor';
+import { EditorContentRef } from 'components/common/rich-text-editor/RichTextEditor.interface';
+import TitleBreadcrumb from 'components/common/title-breadcrumb/title-breadcrumb.component';
 import { capitalize, isNil } from 'lodash';
 import { observer } from 'mobx-react';
 import { EntityTags } from 'Models';
@@ -30,6 +29,7 @@ import React, {
   useState,
 } from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
+import { postThread } from 'rest/feedsAPI';
 import AppState from '../../../AppState';
 import { FQN_SEPARATOR_CHAR } from '../../../constants/char.constants';
 import { EntityField } from '../../../constants/Feeds.constants';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/RequestTagPage/RequestTagPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/RequestTagPage/RequestTagPage.tsx
@@ -11,17 +11,17 @@
  *  limitations under the License.
  */
 
-import ProfilePicture from '@components/common/ProfilePicture/ProfilePicture';
-import TitleBreadcrumb from '@components/common/title-breadcrumb/title-breadcrumb.component';
-import { postThread } from '@rest/feedsAPI';
 import { Button, Card, Form, FormProps, Input, Space } from 'antd';
 import { useForm } from 'antd/lib/form/Form';
 import { AxiosError } from 'axios';
+import ProfilePicture from 'components/common/ProfilePicture/ProfilePicture';
+import TitleBreadcrumb from 'components/common/title-breadcrumb/title-breadcrumb.component';
 import { capitalize, isNil } from 'lodash';
 import { observer } from 'mobx-react';
 import { EntityTags } from 'Models';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
+import { postThread } from 'rest/feedsAPI';
 import AppState from '../../../AppState';
 import { FQN_SEPARATOR_CHAR } from '../../../constants/char.constants';
 import { EntityField } from '../../../constants/Feeds.constants';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/TaskDetailPage/TaskDetailPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/TaskDetailPage/TaskDetailPage.tsx
@@ -11,18 +11,27 @@
  *  limitations under the License.
  */
 
-import ActivityFeedEditor from '@components/ActivityFeed/ActivityFeedEditor/ActivityFeedEditor';
-import FeedPanelBody from '@components/ActivityFeed/ActivityFeedPanel/FeedPanelBody';
-import ActivityThreadPanelBody from '@components/ActivityFeed/ActivityThreadPanel/ActivityThreadPanelBody';
-import { useAuthContext } from '@components/authentication/auth-provider/AuthProvider';
-import AssigneeList from '@components/common/AssigneeList/AssigneeList';
-import ErrorPlaceHolder from '@components/common/error-with-placeholder/ErrorPlaceHolder';
-import UserPopOverCard from '@components/common/PopOverCard/UserPopOverCard';
-import ProfilePicture from '@components/common/ProfilePicture/ProfilePicture';
-import TitleBreadcrumb from '@components/common/title-breadcrumb/title-breadcrumb.component';
-import Loader from '@components/Loader/Loader';
 import { faChevronDown } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Button, Card, Dropdown, Layout, MenuProps, Tabs } from 'antd';
+import { AxiosError } from 'axios';
+import classNames from 'classnames';
+import ActivityFeedEditor from 'components/ActivityFeed/ActivityFeedEditor/ActivityFeedEditor';
+import FeedPanelBody from 'components/ActivityFeed/ActivityFeedPanel/FeedPanelBody';
+import ActivityThreadPanelBody from 'components/ActivityFeed/ActivityThreadPanel/ActivityThreadPanelBody';
+import { useAuthContext } from 'components/authentication/auth-provider/AuthProvider';
+import AssigneeList from 'components/common/AssigneeList/AssigneeList';
+import ErrorPlaceHolder from 'components/common/error-with-placeholder/ErrorPlaceHolder';
+import UserPopOverCard from 'components/common/PopOverCard/UserPopOverCard';
+import ProfilePicture from 'components/common/ProfilePicture/ProfilePicture';
+import TitleBreadcrumb from 'components/common/title-breadcrumb/title-breadcrumb.component';
+import Loader from 'components/Loader/Loader';
+import { compare, Operation } from 'fast-json-patch';
+import { isEmpty, isEqual, toLower } from 'lodash';
+import { observer } from 'mobx-react';
+import React, { Fragment, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useHistory, useParams } from 'react-router-dom';
 import {
   getFeedById,
   getTask,
@@ -31,16 +40,7 @@ import {
   updatePost,
   updateTask,
   updateThread,
-} from '@rest/feedsAPI';
-import { Button, Card, Dropdown, Layout, MenuProps, Tabs } from 'antd';
-import { AxiosError } from 'axios';
-import classNames from 'classnames';
-import { compare, Operation } from 'fast-json-patch';
-import { isEmpty, isEqual, toLower } from 'lodash';
-import { observer } from 'mobx-react';
-import React, { Fragment, useEffect, useMemo, useState } from 'react';
-import { useTranslation } from 'react-i18next';
-import { useHistory, useParams } from 'react-router-dom';
+} from 'rest/feedsAPI';
 import AppState from '../../../AppState';
 import { FQN_SEPARATOR_CHAR } from '../../../constants/char.constants';
 import { PanelTab, TaskOperation } from '../../../constants/Feeds.constants';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/UpdateDescriptionPage/UpdateDescriptionPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/UpdateDescriptionPage/UpdateDescriptionPage.tsx
@@ -11,13 +11,12 @@
  *  limitations under the License.
  */
 
-import ProfilePicture from '@components/common/ProfilePicture/ProfilePicture';
-import { EditorContentRef } from '@components/common/rich-text-editor/RichTextEditor.interface';
-import TitleBreadcrumb from '@components/common/title-breadcrumb/title-breadcrumb.component';
-import { postThread } from '@rest/feedsAPI';
 import { Button, Card, Form, FormProps, Input, Space } from 'antd';
 import { useForm } from 'antd/lib/form/Form';
 import { AxiosError } from 'axios';
+import ProfilePicture from 'components/common/ProfilePicture/ProfilePicture';
+import { EditorContentRef } from 'components/common/rich-text-editor/RichTextEditor.interface';
+import TitleBreadcrumb from 'components/common/title-breadcrumb/title-breadcrumb.component';
 import { capitalize, isEmpty, isNil, isUndefined } from 'lodash';
 import { EntityTags } from 'Models';
 import React, {
@@ -28,6 +27,7 @@ import React, {
   useState,
 } from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
+import { postThread } from 'rest/feedsAPI';
 import AppState from '../../../AppState';
 import { FQN_SEPARATOR_CHAR } from '../../../constants/char.constants';
 import { EntityField } from '../../../constants/Feeds.constants';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/UpdateTagPage/UpdateTagPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/UpdateTagPage/UpdateTagPage.tsx
@@ -11,17 +11,17 @@
  *  limitations under the License.
  */
 
-import ProfilePicture from '@components/common/ProfilePicture/ProfilePicture';
-import TitleBreadcrumb from '@components/common/title-breadcrumb/title-breadcrumb.component';
-import { postThread } from '@rest/feedsAPI';
 import { Button, Card, Form, FormProps, Input, Space } from 'antd';
 import { useForm } from 'antd/lib/form/Form';
 import { AxiosError } from 'axios';
+import ProfilePicture from 'components/common/ProfilePicture/ProfilePicture';
+import TitleBreadcrumb from 'components/common/title-breadcrumb/title-breadcrumb.component';
 import { capitalize, isEmpty, isNil, isUndefined } from 'lodash';
 import { observer } from 'mobx-react';
 import { EntityTags } from 'Models';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
+import { postThread } from 'rest/feedsAPI';
 import AppState from '../../../AppState';
 import { FQN_SEPARATOR_CHAR } from '../../../constants/char.constants';
 import { EntityField } from '../../../constants/Feeds.constants';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/Assignees.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/Assignees.test.tsx
@@ -50,7 +50,7 @@ const mockProps = {
   onChange: jest.fn(),
 };
 
-jest.mock('@components/common/UserTag/UserTag.component', () => ({
+jest.mock('components/common/UserTag/UserTag.component', () => ({
   UserTag: jest.fn().mockReturnValue(<div>UserTag</div>),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/Assignees.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/Assignees.tsx
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import { UserTag } from '@components/common/UserTag/UserTag.component';
 import { Select } from 'antd';
+import { UserTag } from 'components/common/UserTag/UserTag.component';
 import React, { FC } from 'react';
 import { Option } from '../TasksPage.interface';
 import './Assignee.less';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/ClosedTask.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/ClosedTask.test.tsx
@@ -45,7 +45,7 @@ const mockTask = {
   newValue: '**Column for storing product data.**',
 } as Thread['task'];
 
-jest.mock('@components/common/PopOverCard/UserPopOverCard', () =>
+jest.mock('components/common/PopOverCard/UserPopOverCard', () =>
   jest.fn().mockImplementation(({ children }) => {
     return <div data-testid="userPopOverCard">{children}</div>;
   })

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/ClosedTask.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/ClosedTask.tsx
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import UserPopOverCard from '@components/common/PopOverCard/UserPopOverCard';
-import ProfilePicture from '@components/common/ProfilePicture/ProfilePicture';
+import UserPopOverCard from 'components/common/PopOverCard/UserPopOverCard';
+import ProfilePicture from 'components/common/ProfilePicture/ProfilePicture';
 import { toLower } from 'lodash';
 import React, { FC } from 'react';
 import { Thread } from '../../../generated/entity/feed/thread';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/CommentModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/CommentModal.test.tsx
@@ -69,7 +69,7 @@ const mockProps = {
   isLoading: false,
 };
 
-jest.mock('@components/common/rich-text-editor/RichTextEditor', () =>
+jest.mock('components/common/rich-text-editor/RichTextEditor', () =>
   jest
     .fn()
     .mockReturnValue(<div data-testid="richTextEditor">RichTextEditor</div>)

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/CommentModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/CommentModal.tsx
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import RichTextEditor from '@components/common/rich-text-editor/RichTextEditor';
 import { Modal } from 'antd';
+import RichTextEditor from 'components/common/rich-text-editor/RichTextEditor';
 import React, { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Thread } from '../../../generated/entity/feed/thread';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/DescriptionTabs.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/DescriptionTabs.test.tsx
@@ -19,7 +19,7 @@ jest.mock('../../../utils/TasksUtils', () => ({
   getDescriptionDiff: jest.fn().mockReturnValue([]),
 }));
 
-jest.mock('@components/common/rich-text-editor/RichTextEditor', () => {
+jest.mock('components/common/rich-text-editor/RichTextEditor', () => {
   return forwardRef(
     jest.fn().mockImplementation(({ initialValue }) => {
       return (
@@ -35,7 +35,7 @@ jest.mock('@components/common/rich-text-editor/RichTextEditor', () => {
   );
 });
 
-jest.mock('@components/common/rich-text-editor/RichTextEditorPreviewer', () =>
+jest.mock('components/common/rich-text-editor/RichTextEditorPreviewer', () =>
   jest
     .fn()
     .mockReturnValue(

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/DescriptionTabs.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/DescriptionTabs.tsx
@@ -11,10 +11,10 @@
  *  limitations under the License.
  */
 
-import RichTextEditor from '@components/common/rich-text-editor/RichTextEditor';
-import { EditorContentRef } from '@components/common/rich-text-editor/RichTextEditor.interface';
-import RichTextEditorPreviewer from '@components/common/rich-text-editor/RichTextEditorPreviewer';
 import { Tabs } from 'antd';
+import RichTextEditor from 'components/common/rich-text-editor/RichTextEditor';
+import { EditorContentRef } from 'components/common/rich-text-editor/RichTextEditor.interface';
+import RichTextEditorPreviewer from 'components/common/rich-text-editor/RichTextEditorPreviewer';
 import { Change } from 'diff';
 import { isEqual } from 'lodash';
 import React, { useState } from 'react';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/DescriptionTask.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/DescriptionTask.tsx
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import RichTextEditor from '@components/common/rich-text-editor/RichTextEditor';
-import { EditorContentRef } from '@components/common/rich-text-editor/RichTextEditor.interface';
+import RichTextEditor from 'components/common/rich-text-editor/RichTextEditor';
+import { EditorContentRef } from 'components/common/rich-text-editor/RichTextEditor.interface';
 import { isEqual } from 'lodash';
 import React, { FC, Fragment, useRef } from 'react';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/EntityDetail.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/EntityDetail.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import ProfilePicture from '@components/common/ProfilePicture/ProfilePicture';
+import ProfilePicture from 'components/common/ProfilePicture/ProfilePicture';
 import { EntityTags } from 'Models';
 import React, { useMemo } from 'react';
 import { FQN_SEPARATOR_CHAR } from '../../../constants/char.constants';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/TagSuggestion.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/TagSuggestion.tsx
@@ -11,11 +11,11 @@
  *  limitations under the License.
  */
 
-import { getTagSuggestions } from '@rest/miscAPI';
 import { Select } from 'antd';
 import { AxiosError } from 'axios';
 import { isEmpty, isEqual } from 'lodash';
 import React, { useEffect, useState } from 'react';
+import { getTagSuggestions } from 'rest/miscAPI';
 import {
   LabelType,
   State,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TestSuiteDetailsPage/TestSuiteDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TestSuiteDetailsPage/TestSuiteDetailsPage.component.tsx
@@ -11,32 +11,32 @@
  *  limitations under the License.
  */
 
-import ErrorPlaceHolder from '@components/common/error-with-placeholder/ErrorPlaceHolder';
-import TabsPane from '@components/common/TabsPane/TabsPane';
-import { TitleBreadcrumbProps } from '@components/common/title-breadcrumb/title-breadcrumb.interface';
-import PageContainer from '@components/containers/PageContainer';
-import Loader from '@components/Loader/Loader';
-import { usePermissionProvider } from '@components/PermissionProvider/PermissionProvider';
+import { Col, Row } from 'antd';
+import { AxiosError } from 'axios';
+import ErrorPlaceHolder from 'components/common/error-with-placeholder/ErrorPlaceHolder';
+import TabsPane from 'components/common/TabsPane/TabsPane';
+import { TitleBreadcrumbProps } from 'components/common/title-breadcrumb/title-breadcrumb.interface';
+import PageContainerV1 from 'components/containers/PageContainerV1';
+import Loader from 'components/Loader/Loader';
+import { usePermissionProvider } from 'components/PermissionProvider/PermissionProvider';
 import {
   OperationPermission,
   ResourceEntity,
-} from '@components/PermissionProvider/PermissionProvider.interface';
-import TestCasesTab from '@components/TestCasesTab/TestCasesTab.component';
-import TestSuiteDetails from '@components/TestSuiteDetails/TestSuiteDetails.component';
-import TestSuitePipelineTab from '@components/TestSuitePipelineTab/TestSuitePipelineTab.component';
-import {
-  getListTestCase,
-  getTestSuiteByName,
-  ListTestCaseParams,
-  updateTestSuiteById,
-} from '@rest/testAPI';
-import { Col, Row } from 'antd';
-import { AxiosError } from 'axios';
+} from 'components/PermissionProvider/PermissionProvider.interface';
+import TestCasesTab from 'components/TestCasesTab/TestCasesTab.component';
+import TestSuiteDetails from 'components/TestSuiteDetails/TestSuiteDetails.component';
+import TestSuitePipelineTab from 'components/TestSuitePipelineTab/TestSuitePipelineTab.component';
 import { compare } from 'fast-json-patch';
 import { camelCase, startCase } from 'lodash';
 import { ExtraInfo } from 'Models';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import {
+  getListTestCase,
+  getTestSuiteByName,
+  ListTestCaseParams,
+  updateTestSuiteById,
+} from 'rest/testAPI';
 import {
   getTeamAndUserDetailsPath,
   INITIAL_PAGING_VALUE,
@@ -306,7 +306,7 @@ const TestSuiteDetailsPage = () => {
   return (
     <>
       {testSuitePermissions.ViewAll || testSuitePermissions.ViewBasic ? (
-        <PageContainer>
+        <PageContainerV1>
           <Row className="tw-px-6 tw-w-full">
             <Col span={24}>
               <TestSuiteDetails
@@ -345,7 +345,7 @@ const TestSuiteDetailsPage = () => {
               </div>
             </Col>
           </Row>
-        </PageContainer>
+        </PageContainerV1>
       ) : (
         <ErrorPlaceHolder>{NO_PERMISSION_TO_VIEW}</ErrorPlaceHolder>
       )}

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TestSuiteIngestionPage/TestSuiteIngestionPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TestSuiteIngestionPage/TestSuiteIngestionPage.tsx
@@ -10,21 +10,21 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import RightPanel from '@components/AddDataQualityTest/components/RightPanel';
-import { INGESTION_DATA } from '@components/AddDataQualityTest/rightPanelData';
-import TestSuiteIngestion from '@components/AddDataQualityTest/TestSuiteIngestion';
-import ErrorPlaceHolder from '@components/common/error-with-placeholder/ErrorPlaceHolder';
-import TitleBreadcrumb from '@components/common/title-breadcrumb/title-breadcrumb.component';
-import { TitleBreadcrumbProps } from '@components/common/title-breadcrumb/title-breadcrumb.interface';
-import PageContainerV1 from '@components/containers/PageContainerV1';
-import PageLayout from '@components/containers/PageLayout';
-import Loader from '@components/Loader/Loader';
-import { getIngestionPipelineByFqn } from '@rest/ingestionPipelineAPI';
-import { getTestSuiteByName } from '@rest/testAPI';
 import { AxiosError } from 'axios';
+import RightPanel from 'components/AddDataQualityTest/components/RightPanel';
+import { INGESTION_DATA } from 'components/AddDataQualityTest/rightPanelData';
+import TestSuiteIngestion from 'components/AddDataQualityTest/TestSuiteIngestion';
+import ErrorPlaceHolder from 'components/common/error-with-placeholder/ErrorPlaceHolder';
+import TitleBreadcrumb from 'components/common/title-breadcrumb/title-breadcrumb.component';
+import { TitleBreadcrumbProps } from 'components/common/title-breadcrumb/title-breadcrumb.interface';
+import PageContainerV1 from 'components/containers/PageContainerV1';
+import PageLayout from 'components/containers/PageLayout';
+import Loader from 'components/Loader/Loader';
 import { isUndefined, startCase } from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
+import { getIngestionPipelineByFqn } from 'rest/ingestionPipelineAPI';
+import { getTestSuiteByName } from 'rest/testAPI';
 import { ROUTES } from '../../constants/constants';
 import { PageLayoutType } from '../../enums/layout.enum';
 import { IngestionPipeline } from '../../generated/entity/services/ingestionPipelines/ingestionPipeline';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TestSuitePage/AddTestSuiteForm.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TestSuitePage/AddTestSuiteForm.test.tsx
@@ -19,7 +19,7 @@ import AddTestSuiteForm from './AddTestSuiteForm';
 
 const mockOnSubmit = jest.fn();
 
-jest.mock('@rest/testAPI', () => ({
+jest.mock('rest/testAPI', () => ({
   getListTestSuites: jest
     .fn()
     .mockImplementation(() => Promise.resolve(MOCK_TABLE_DATA)),
@@ -31,11 +31,11 @@ jest.mock('react-router-dom', () => ({
   })),
 }));
 
-jest.mock('@components/common/rich-text-editor/RichTextEditor', () =>
+jest.mock('components/common/rich-text-editor/RichTextEditor', () =>
   jest.fn().mockReturnValue(<>RichTextEditor</>)
 );
 
-jest.mock('@components/Loader/Loader', () => {
+jest.mock('components/Loader/Loader', () => {
   return jest.fn().mockReturnValue(<div>Loader</div>);
 });
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TestSuitePage/AddTestSuiteForm.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TestSuitePage/AddTestSuiteForm.tsx
@@ -11,13 +11,13 @@
  *  limitations under the License.
  */
 
-import RichTextEditor from '@components/common/rich-text-editor/RichTextEditor';
-import Loader from '@components/Loader/Loader';
-import { getListTestSuites } from '@rest/testAPI';
 import { Button, Form, Input, Space } from 'antd';
+import RichTextEditor from 'components/common/rich-text-editor/RichTextEditor';
+import Loader from 'components/Loader/Loader';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
+import { getListTestSuites } from 'rest/testAPI';
 import { PAGE_SIZE_MEDIUM, ROUTES } from '../../constants/constants';
 import { TestSuite } from '../../generated/tests/testSuite';
 import jsonData from '../../jsons/en';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TestSuitePage/TestSuitePage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TestSuitePage/TestSuitePage.test.tsx
@@ -11,14 +11,14 @@
  *  limitations under the License.
  */
 
-import { getListTestSuites } from '@rest/testAPI';
 import { act, render, screen } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
+import { getListTestSuites } from 'rest/testAPI';
 import { MOCK_TABLE_DATA } from '../../mocks/TestSuite.mock';
 import TestSuitePage from './TestSuitePage';
 
-jest.mock('@rest/testAPI', () => ({
+jest.mock('rest/testAPI', () => ({
   getListTestSuites: jest
     .fn()
     .mockImplementation(() => Promise.resolve(MOCK_TABLE_DATA)),
@@ -33,7 +33,7 @@ jest.mock('react-router-dom', () => ({
     .mockImplementation(({ children }) => <a href="#">{children}</a>),
 }));
 
-jest.mock('@components/containers/PageLayoutV1', () =>
+jest.mock('components/containers/PageLayoutV1', () =>
   jest
     .fn()
     .mockImplementation(({ children }) => (
@@ -50,26 +50,26 @@ jest.mock('../../utils/CommonUtils', () => ({
   pluralize: jest.fn().mockReturnValue('0 Test'),
 }));
 
-jest.mock('@components/common/error-with-placeholder/ErrorPlaceHolder', () =>
+jest.mock('components/common/error-with-placeholder/ErrorPlaceHolder', () =>
   jest.fn().mockReturnValue(<div>ErrorPlaceHolder</div>)
 );
 
-jest.mock('@components/Loader/Loader', () => {
+jest.mock('components/Loader/Loader', () => {
   return jest.fn().mockReturnValue(<div>Loader</div>);
 });
 
 jest.mock(
-  '@components/common/title-breadcrumb/title-breadcrumb.component',
+  'components/common/title-breadcrumb/title-breadcrumb.component',
   () => {
     return jest.fn().mockReturnValue(<p>TitleBreadCrumb</p>);
   }
 );
 
-jest.mock('@components/common/next-previous/NextPrevious', () => {
+jest.mock('components/common/next-previous/NextPrevious', () => {
   return jest.fn().mockImplementation(() => <div>NextPrevious</div>);
 });
 
-jest.mock('@components/common/next-previous/NextPrevious', () =>
+jest.mock('components/common/next-previous/NextPrevious', () =>
   jest.fn().mockReturnValue(<p>NextPrevious</p>)
 );
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TestSuitePage/TestSuitePage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TestSuitePage/TestSuitePage.tsx
@@ -11,18 +11,18 @@
  *  limitations under the License.
  */
 
-import ErrorPlaceHolder from '@components/common/error-with-placeholder/ErrorPlaceHolder';
-import NextPrevious from '@components/common/next-previous/NextPrevious';
-import TitleBreadcrumb from '@components/common/title-breadcrumb/title-breadcrumb.component';
-import PageLayoutV1 from '@components/containers/PageLayoutV1';
-import Loader from '@components/Loader/Loader';
-import { getListTestSuites } from '@rest/testAPI';
 import { Button, Col, Row, Space, Table, Typography } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
+import ErrorPlaceHolder from 'components/common/error-with-placeholder/ErrorPlaceHolder';
+import NextPrevious from 'components/common/next-previous/NextPrevious';
+import TitleBreadcrumb from 'components/common/title-breadcrumb/title-breadcrumb.component';
+import PageLayoutV1 from 'components/containers/PageLayoutV1';
+import Loader from 'components/Loader/Loader';
 import { isEmpty } from 'lodash';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useHistory } from 'react-router-dom';
+import { getListTestSuites } from 'rest/testAPI';
 import {
   INITIAL_PAGING_VALUE,
   PAGE_SIZE_MEDIUM,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TestSuitePage/TestSuiteStepper.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TestSuitePage/TestSuiteStepper.test.tsx
@@ -16,11 +16,11 @@ import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import TestSuiteStepper from './TestSuiteStepper';
 
-jest.mock('@rest/ingestionPipelineAPI', () => ({
+jest.mock('rest/ingestionPipelineAPI', () => ({
   checkAirflowStatus: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
 
-jest.mock('@rest/testAPI', () => ({
+jest.mock('rest/testAPI', () => ({
   createTestSuites: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
 
@@ -30,7 +30,7 @@ jest.mock('react-router-dom', () => ({
   })),
 }));
 
-jest.mock('@components/AddDataQualityTest/rightPanelData', () => ({
+jest.mock('components/AddDataQualityTest/rightPanelData', () => ({
   getRightPanelForAddTestSuitePage: jest.fn().mockReturnValue('Add test suite'),
 }));
 
@@ -42,7 +42,7 @@ jest.mock('../../utils/RouterUtils', () => ({
   getTestSuitePath: jest.fn().mockReturnValue('/'),
 }));
 
-jest.mock('@components/AddDataQualityTest/components/RightPanel', () =>
+jest.mock('components/AddDataQualityTest/components/RightPanel', () =>
   jest.fn().mockReturnValue(<div>RightPanel</div>)
 );
 
@@ -50,20 +50,20 @@ jest.mock('./AddTestSuiteForm', () =>
   jest.fn().mockReturnValue(<div>AddTestSuiteForm</div>)
 );
 
-jest.mock('@components/AddDataQualityTest/TestSuiteIngestion', () => {
+jest.mock('components/AddDataQualityTest/TestSuiteIngestion', () => {
   return jest.fn().mockReturnValue(<div>TestSuiteIngestion</div>);
 });
 
-jest.mock('@components/common/success-screen/SuccessScreen', () => {
+jest.mock('components/common/success-screen/SuccessScreen', () => {
   return jest.fn().mockReturnValue(<div>SuccessScreen</div>);
 });
 
-jest.mock('@components/IngestionStepper/IngestionStepper.component', () => {
+jest.mock('components/IngestionStepper/IngestionStepper.component', () => {
   return jest.fn().mockReturnValue(<div>Ingestion Stepper</div>);
 });
 
 jest.mock(
-  '@components/common/title-breadcrumb/title-breadcrumb.component',
+  'components/common/title-breadcrumb/title-breadcrumb.component',
   () => {
     return jest.fn().mockReturnValue(<div>Title Breadcrumb</div>);
   }

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TestSuitePage/TestSuiteStepper.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TestSuitePage/TestSuiteStepper.tsx
@@ -11,22 +11,22 @@
  *  limitations under the License.
  */
 
-import RightPanel from '@components/AddDataQualityTest/components/RightPanel';
+import { Col, Row, Space, Typography } from 'antd';
+import { AxiosError } from 'axios';
+import RightPanel from 'components/AddDataQualityTest/components/RightPanel';
 import {
   getRightPanelForAddTestSuitePage,
   INGESTION_DATA,
-} from '@components/AddDataQualityTest/rightPanelData';
-import TestSuiteIngestion from '@components/AddDataQualityTest/TestSuiteIngestion';
-import SuccessScreen from '@components/common/success-screen/SuccessScreen';
-import TitleBreadcrumb from '@components/common/title-breadcrumb/title-breadcrumb.component';
-import PageLayoutV1 from '@components/containers/PageLayoutV1';
-import IngestionStepper from '@components/IngestionStepper/IngestionStepper.component';
-import { createTestSuites } from '@rest/testAPI';
-import { Col, Row, Space, Typography } from 'antd';
-import { AxiosError } from 'axios';
+} from 'components/AddDataQualityTest/rightPanelData';
+import TestSuiteIngestion from 'components/AddDataQualityTest/TestSuiteIngestion';
+import SuccessScreen from 'components/common/success-screen/SuccessScreen';
+import TitleBreadcrumb from 'components/common/title-breadcrumb/title-breadcrumb.component';
+import PageLayoutV1 from 'components/containers/PageLayoutV1';
+import IngestionStepper from 'components/IngestionStepper/IngestionStepper.component';
 import React, { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
+import { createTestSuites } from 'rest/testAPI';
 import {
   STEPS_FOR_ADD_TEST_SUITE,
   TEST_SUITE_STEPPER_BREADCRUMB,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TopicDetails/TopicDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TopicDetails/TopicDetailsPage.component.tsx
@@ -11,38 +11,38 @@
  *  limitations under the License.
  */
 
-import ErrorPlaceHolder from '@components/common/error-with-placeholder/ErrorPlaceHolder';
-import { TitleBreadcrumbProps } from '@components/common/title-breadcrumb/title-breadcrumb.interface';
+import { AxiosError } from 'axios';
+import ErrorPlaceHolder from 'components/common/error-with-placeholder/ErrorPlaceHolder';
+import { TitleBreadcrumbProps } from 'components/common/title-breadcrumb/title-breadcrumb.interface';
 import {
   Edge,
   EdgeData,
   LeafNodes,
   LineagePos,
   LoadingNodeState,
-} from '@components/EntityLineage/EntityLineage.interface';
-import Loader from '@components/Loader/Loader';
-import { usePermissionProvider } from '@components/PermissionProvider/PermissionProvider';
+} from 'components/EntityLineage/EntityLineage.interface';
+import Loader from 'components/Loader/Loader';
+import { usePermissionProvider } from 'components/PermissionProvider/PermissionProvider';
 import {
   OperationPermission,
   ResourceEntity,
-} from '@components/PermissionProvider/PermissionProvider.interface';
-import TopicDetails from '@components/TopicDetails/TopicDetails.component';
-import { getAllFeeds, postFeedById, postThread } from '@rest/feedsAPI';
-import { getLineageByFQN } from '@rest/lineageAPI';
-import { addLineage, deleteLineageEdge } from '@rest/miscAPI';
-import {
-  addFollower,
-  getTopicByFqn,
-  patchTopicDetails,
-  removeFollower,
-} from '@rest/topicsAPI';
-import { AxiosError } from 'axios';
+} from 'components/PermissionProvider/PermissionProvider.interface';
+import TopicDetails from 'components/TopicDetails/TopicDetails.component';
 import { compare, Operation } from 'fast-json-patch';
 import { isEmpty, isUndefined, omitBy } from 'lodash';
 import { observer } from 'mobx-react';
 import { EntityTags } from 'Models';
 import React, { FunctionComponent, useEffect, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
+import { getAllFeeds, postFeedById, postThread } from 'rest/feedsAPI';
+import { getLineageByFQN } from 'rest/lineageAPI';
+import { addLineage, deleteLineageEdge } from 'rest/miscAPI';
+import {
+  addFollower,
+  getTopicByFqn,
+  patchTopicDetails,
+  removeFollower,
+} from 'rest/topicsAPI';
 import AppState from '../../AppState';
 import {
   getServiceDetailsPath,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TopicDetails/TopicDetailsPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TopicDetails/TopicDetailsPage.test.tsx
@@ -16,11 +16,11 @@ import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import TopicDetailsPageComponent from './TopicDetailsPage.component';
 
-jest.mock('@components/TopicDetails/TopicDetails.component', () => {
+jest.mock('components/TopicDetails/TopicDetails.component', () => {
   return jest.fn().mockReturnValue(<div>TopicDetails.component</div>);
 });
 
-jest.mock('@rest/topicsAPI', () => ({
+jest.mock('rest/topicsAPI', () => ({
   addFollower: jest.fn(),
   getTopicByFqn: jest.fn().mockImplementation(() => Promise.resolve({})),
   patchTopicDetails: jest.fn(),
@@ -34,7 +34,7 @@ jest.mock('react-router-dom', () => ({
   useHistory: jest.fn(),
 }));
 
-jest.mock('@components/PermissionProvider/PermissionProvider', () => ({
+jest.mock('components/PermissionProvider/PermissionProvider', () => ({
   usePermissionProvider: jest.fn().mockImplementation(() => ({
     permissions: {},
     getEntityPermission: jest.fn().mockResolvedValue({

--- a/openmetadata-ui/src/main/resources/ui/src/pages/UserListPage/UserListPageV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/UserListPage/UserListPageV1.test.tsx
@@ -11,8 +11,6 @@
  *  limitations under the License.
  */
 
-import { searchData } from '@rest/miscAPI';
-import { getUsers } from '@rest/userAPI';
 import {
   act,
   cleanup,
@@ -22,6 +20,8 @@ import {
   waitForDomChange,
 } from '@testing-library/react';
 import React from 'react';
+import { searchData } from 'rest/miscAPI';
+import { getUsers } from 'rest/userAPI';
 import { GlobalSettingOptions } from '../../constants/GlobalSettings.constants';
 import { MOCK_USER_DATA } from './mockUserData';
 import UserListPageV1 from './UserListPageV1';
@@ -44,14 +44,14 @@ jest.mock('react-router-dom', () => ({
   useHistory: jest.fn().mockImplementation(() => mockHistory),
   useLocation: jest.fn().mockImplementation(() => mockLocation),
 }));
-jest.mock('@rest/userAPI', () => ({
+jest.mock('rest/userAPI', () => ({
   getUsers: jest.fn().mockImplementation(() =>
     Promise.resolve({
       MOCK_USER_DATA,
     })
   ),
 }));
-jest.mock('@rest/miscAPI', () => ({
+jest.mock('rest/miscAPI', () => ({
   searchData: jest.fn().mockImplementation(() =>
     Promise.resolve({
       data: MOCK_USER_DATA,
@@ -59,7 +59,7 @@ jest.mock('@rest/miscAPI', () => ({
   ),
 }));
 
-jest.mock('@components/UserList/UserListV1', () => {
+jest.mock('components/UserList/UserListV1', () => {
   return jest.fn().mockImplementation((prop) => (
     <div>
       <p>UserList.component</p>
@@ -80,7 +80,7 @@ jest.mock('@components/UserList/UserListV1', () => {
     </div>
   ));
 });
-jest.mock('@components/Loader/Loader', () => {
+jest.mock('components/Loader/Loader', () => {
   return jest.fn().mockImplementation(() => <div>Loader.component</div>);
 });
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/UserListPage/UserListPageV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/UserListPage/UserListPageV1.tsx
@@ -11,13 +11,13 @@
  *  limitations under the License.
  */
 
-import Loader from '@components/Loader/Loader';
-import UserListV1 from '@components/UserList/UserListV1';
-import { searchData } from '@rest/miscAPI';
-import { getUsers } from '@rest/userAPI';
 import { AxiosError } from 'axios';
+import Loader from 'components/Loader/Loader';
+import UserListV1 from 'components/UserList/UserListV1';
 import React, { useEffect, useState } from 'react';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
+import { searchData } from 'rest/miscAPI';
+import { getUsers } from 'rest/userAPI';
 import { WILD_CARD_CHAR } from '../../constants/char.constants';
 import {
   INITIAL_PAGING_VALUE,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/UserPage/UserPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/UserPage/UserPage.component.tsx
@@ -11,15 +11,12 @@
  *  limitations under the License.
  */
 
-import { useAuthContext } from '@components/authentication/auth-provider/AuthProvider';
-import PageContainerV1 from '@components/containers/PageContainerV1';
-import Loader from '@components/Loader/Loader';
-import Users from '@components/Users/Users.component';
-import { UserDetails } from '@components/Users/Users.interface';
-import { getFeedsWithFilter, postFeedById } from '@rest/feedsAPI';
-import { searchData } from '@rest/miscAPI';
-import { getUserByName, updateUserDetail } from '@rest/userAPI';
 import { AxiosError } from 'axios';
+import { useAuthContext } from 'components/authentication/auth-provider/AuthProvider';
+import PageContainerV1 from 'components/containers/PageContainerV1';
+import Loader from 'components/Loader/Loader';
+import Users from 'components/Users/Users.component';
+import { UserDetails } from 'components/Users/Users.interface';
 import { compare, Operation } from 'fast-json-patch';
 import { isEmpty, isEqual } from 'lodash';
 import { observer } from 'mobx-react';
@@ -34,6 +31,9 @@ import React, {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useParams } from 'react-router-dom';
+import { getFeedsWithFilter, postFeedById } from 'rest/feedsAPI';
+import { searchData } from 'rest/miscAPI';
+import { getUserByName, updateUserDetail } from 'rest/userAPI';
 import AppState from '../../AppState';
 import { PAGE_SIZE } from '../../constants/constants';
 import { myDataSearchIndex } from '../../constants/Mydata.constants';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/UserPage/UserPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/UserPage/UserPage.test.tsx
@@ -11,10 +11,10 @@
  *  limitations under the License.
  */
 
-import { getUserByName } from '@rest/userAPI';
 import { findByTestId, findByText, render } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
+import { getUserByName } from 'rest/userAPI';
 import UserPage from './UserPage.component';
 
 const mockUserData = {
@@ -91,7 +91,7 @@ const mockUserData = {
   ],
 };
 
-jest.mock('@components/authentication/auth-provider/AuthProvider', () => {
+jest.mock('components/authentication/auth-provider/AuthProvider', () => {
   return {
     useAuthContext: jest.fn(() => ({
       isAuthDisabled: true,
@@ -104,28 +104,28 @@ jest.mock('react-router-dom', () => ({
   useLocation: jest.fn().mockImplementation(() => new URLSearchParams()),
 }));
 
-jest.mock('@components/Loader/Loader', () => {
+jest.mock('components/Loader/Loader', () => {
   return jest.fn().mockReturnValue(<p>Loader</p>);
 });
 
-jest.mock('@components/Users/Users.component', () => {
+jest.mock('components/Users/Users.component', () => {
   return jest.fn().mockReturnValue(<p>User Component</p>);
 });
 
-jest.mock('@rest/userAPI', () => ({
+jest.mock('rest/userAPI', () => ({
   getUserByName: jest
     .fn()
     .mockImplementation(() => Promise.resolve({ data: mockUserData })),
 }));
 
-jest.mock('@rest/userAPI', () => ({
+jest.mock('rest/userAPI', () => ({
   getUserByName: jest
     .fn()
     .mockImplementation(() => Promise.resolve({ data: mockUserData })),
   updateUserDetail: jest.fn(),
 }));
 
-jest.mock('@rest/feedsAPI', () => ({
+jest.mock('rest/feedsAPI', () => ({
   getFeedsWithFilter: jest.fn().mockImplementation(() =>
     Promise.resolve({
       data: {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/database-details/index.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/database-details/index.test.tsx
@@ -11,13 +11,13 @@
  *  limitations under the License.
  */
 
-import {
-  getDatabaseDetailsByFQN,
-  patchDatabaseDetails,
-} from '@rest/databaseAPI';
 import { findByTestId, findByText, render } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router';
+import {
+  getDatabaseDetailsByFQN,
+  patchDatabaseDetails,
+} from 'rest/databaseAPI';
 import DatabaseDetails from './';
 
 const mockDatabase = {
@@ -179,7 +179,7 @@ const mockFeedCount = {
   ],
 };
 
-jest.mock('@components/PermissionProvider/PermissionProvider', () => ({
+jest.mock('components/PermissionProvider/PermissionProvider', () => ({
   usePermissionProvider: jest.fn().mockReturnValue({
     getEntityPermissionByFqn: jest.fn().mockReturnValue({
       Create: true,
@@ -193,7 +193,7 @@ jest.mock('@components/PermissionProvider/PermissionProvider', () => ({
   }),
 }));
 
-jest.mock('@components/common/rich-text-editor/RichTextEditorPreviewer', () => {
+jest.mock('components/common/rich-text-editor/RichTextEditorPreviewer', () => {
   return jest.fn().mockImplementation(({ markdown }) => <p>{markdown}</p>);
 });
 
@@ -215,7 +215,7 @@ jest.mock('../../AppState', () => {
   });
 });
 
-jest.mock('@rest/databaseAPI', () => ({
+jest.mock('rest/databaseAPI', () => ({
   getDatabaseDetailsByFQN: jest
     .fn()
     .mockImplementation(() => Promise.resolve(mockDatabase)),
@@ -228,7 +228,7 @@ jest.mock('@rest/databaseAPI', () => ({
     .mockImplementation(() => Promise.resolve(mockSchemaData)),
 }));
 
-jest.mock('@rest/feedsAPI', () => ({
+jest.mock('rest/feedsAPI', () => ({
   getAllFeeds: jest
     .fn()
     .mockImplementation(() => Promise.resolve(mockAllFeeds)),
@@ -241,7 +241,7 @@ jest.mock('@rest/feedsAPI', () => ({
   postThread: jest.fn().mockImplementation(() => Promise.resolve({})),
 }));
 
-jest.mock('@components/containers/PageContainer', () => {
+jest.mock('components/containers/PageContainer', () => {
   return jest
     .fn()
     .mockImplementation(({ children }: { children: React.ReactNode }) => (
@@ -249,7 +249,7 @@ jest.mock('@components/containers/PageContainer', () => {
     ));
 });
 
-jest.mock('@rest/serviceAPI', () => ({
+jest.mock('rest/serviceAPI', () => ({
   getServiceById: jest
     .fn()
     .mockImplementation(() => Promise.resolve({ data: mockServiceData })),
@@ -272,26 +272,26 @@ jest.mock('../../utils/CommonUtils', () => ({
   getEntityName: jest.fn().mockReturnValue('entityname'),
 }));
 
-jest.mock('@components/tags/tags', () => {
+jest.mock('components/tags/tags', () => {
   return jest.fn().mockReturnValue(<span>Tag</span>);
 });
 
-jest.mock('@components/common/next-previous/NextPrevious', () => {
+jest.mock('components/common/next-previous/NextPrevious', () => {
   return jest.fn().mockReturnValue(<div>NextPrevious</div>);
 });
 
 jest.mock(
-  '@components/common/title-breadcrumb/title-breadcrumb.component',
+  'components/common/title-breadcrumb/title-breadcrumb.component',
   () => {
     return jest.fn().mockReturnValue(<div>TitleBreadcrumb</div>);
   }
 );
 
-jest.mock('@components/common/TabsPane/TabsPane', () => {
+jest.mock('components/common/TabsPane/TabsPane', () => {
   return jest.fn().mockReturnValue(<div>TabsPane</div>);
 });
 
-jest.mock('@components/FeedEditor/FeedEditor', () => {
+jest.mock('components/FeedEditor/FeedEditor', () => {
   return jest.fn().mockReturnValue(<p>FeedEditor</p>);
 });
 
@@ -306,7 +306,7 @@ jest.mock('../../utils/TagsUtils', () => ({
 }));
 
 jest.mock(
-  '@components/Modals/ModalWithMarkdownEditor/ModalWithMarkdownEditor',
+  'components/Modals/ModalWithMarkdownEditor/ModalWithMarkdownEditor',
   () => ({
     ModalWithMarkdownEditor: jest
       .fn()
@@ -314,24 +314,19 @@ jest.mock(
   })
 );
 
-jest.mock('@components/common/description/Description', () => {
+jest.mock('components/common/description/Description', () => {
   return jest.fn().mockReturnValue(<p>Description</p>);
 });
 
-jest.mock(
-  '@components/common/EntitySummaryDetails/EntitySummaryDetails',
-  () => {
-    return jest
-      .fn()
-      .mockReturnValue(
-        <p data-testid="entity-summary-details">
-          EntitySummaryDetails component
-        </p>
-      );
-  }
-);
+jest.mock('components/common/EntitySummaryDetails/EntitySummaryDetails', () => {
+  return jest
+    .fn()
+    .mockReturnValue(
+      <p data-testid="entity-summary-details">EntitySummaryDetails component</p>
+    );
+});
 
-jest.mock('@components/common/DeleteWidget/DeleteWidgetModal', () => {
+jest.mock('components/common/DeleteWidget/DeleteWidgetModal', () => {
   return jest
     .fn()
     .mockReturnValue(

--- a/openmetadata-ui/src/main/resources/ui/src/pages/database-details/index.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/database-details/index.tsx
@@ -11,38 +11,27 @@
  *  limitations under the License.
  */
 
-import ActivityFeedList from '@components/ActivityFeed/ActivityFeedList/ActivityFeedList';
-import ActivityThreadPanel from '@components/ActivityFeed/ActivityThreadPanel/ActivityThreadPanel';
-import Description from '@components/common/description/Description';
-import ManageButton from '@components/common/entityPageInfo/ManageButton/ManageButton';
-import EntitySummaryDetails from '@components/common/EntitySummaryDetails/EntitySummaryDetails';
-import ErrorPlaceHolder from '@components/common/error-with-placeholder/ErrorPlaceHolder';
-import NextPrevious from '@components/common/next-previous/NextPrevious';
-import RichTextEditorPreviewer from '@components/common/rich-text-editor/RichTextEditorPreviewer';
-import TabsPane from '@components/common/TabsPane/TabsPane';
-import TitleBreadcrumb from '@components/common/title-breadcrumb/title-breadcrumb.component';
-import { TitleBreadcrumbProps } from '@components/common/title-breadcrumb/title-breadcrumb.interface';
-import PageContainerV1 from '@components/containers/PageContainerV1';
-import Loader from '@components/Loader/Loader';
-import { usePermissionProvider } from '@components/PermissionProvider/PermissionProvider';
-import {
-  OperationPermission,
-  ResourceEntity,
-} from '@components/PermissionProvider/PermissionProvider.interface';
-import {
-  getDatabaseDetailsByFQN,
-  getDatabaseSchemas,
-  patchDatabaseDetails,
-} from '@rest/databaseAPI';
-import {
-  getAllFeeds,
-  getFeedCount,
-  postFeedById,
-  postThread,
-} from '@rest/feedsAPI';
 import { Col, Row, Space, Table } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
 import { AxiosError } from 'axios';
+import ActivityFeedList from 'components/ActivityFeed/ActivityFeedList/ActivityFeedList';
+import ActivityThreadPanel from 'components/ActivityFeed/ActivityThreadPanel/ActivityThreadPanel';
+import Description from 'components/common/description/Description';
+import ManageButton from 'components/common/entityPageInfo/ManageButton/ManageButton';
+import EntitySummaryDetails from 'components/common/EntitySummaryDetails/EntitySummaryDetails';
+import ErrorPlaceHolder from 'components/common/error-with-placeholder/ErrorPlaceHolder';
+import NextPrevious from 'components/common/next-previous/NextPrevious';
+import RichTextEditorPreviewer from 'components/common/rich-text-editor/RichTextEditorPreviewer';
+import TabsPane from 'components/common/TabsPane/TabsPane';
+import TitleBreadcrumb from 'components/common/title-breadcrumb/title-breadcrumb.component';
+import { TitleBreadcrumbProps } from 'components/common/title-breadcrumb/title-breadcrumb.interface';
+import PageContainerV1 from 'components/containers/PageContainerV1';
+import Loader from 'components/Loader/Loader';
+import { usePermissionProvider } from 'components/PermissionProvider/PermissionProvider';
+import {
+  OperationPermission,
+  ResourceEntity,
+} from 'components/PermissionProvider/PermissionProvider.interface';
 import { compare, Operation } from 'fast-json-patch';
 import { isNil, startCase } from 'lodash';
 import { observer } from 'mobx-react';
@@ -58,6 +47,17 @@ import React, {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useHistory, useParams } from 'react-router-dom';
+import {
+  getDatabaseDetailsByFQN,
+  getDatabaseSchemas,
+  patchDatabaseDetails,
+} from 'rest/databaseAPI';
+import {
+  getAllFeeds,
+  getFeedCount,
+  postFeedById,
+  postThread,
+} from 'rest/feedsAPI';
 import { default as AppState, default as appState } from '../../AppState';
 import { FQN_SEPARATOR_CHAR } from '../../constants/char.constants';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/explore/ExplorePage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/explore/ExplorePage.component.tsx
@@ -11,20 +11,20 @@
  *  limitations under the License.
  */
 
-import PageContainerV1 from '@components/containers/PageContainerV1';
-import Explore from '@components/Explore/Explore.component';
+import PageContainerV1 from 'components/containers/PageContainerV1';
+import Explore from 'components/Explore/Explore.component';
 import {
   ExploreProps,
   ExploreSearchIndex,
   SearchHitCounts,
   UrlParams,
-} from '@components/Explore/explore.interface';
-import { searchQuery } from '@rest/searchAPI';
+} from 'components/Explore/explore.interface';
 import { isNil, isString } from 'lodash';
 import Qs from 'qs';
 import React, { FunctionComponent, useEffect, useMemo, useState } from 'react';
 import { JsonTree, Utils as QbUtils } from 'react-awesome-query-builder';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
+import { searchQuery } from 'rest/searchAPI';
 import useDeepCompareEffect from 'use-deep-compare-effect';
 import AppState from '../../AppState';
 import { PAGE_SIZE } from '../../constants/constants';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/explore/ExplorePage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/explore/ExplorePage.test.tsx
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import { ExploreSearchIndex } from '@components/Explore/explore.interface';
 import { findByText, render } from '@testing-library/react';
+import { ExploreSearchIndex } from 'components/Explore/explore.interface';
 import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { SearchIndex } from '../../enums/search.enum';
@@ -292,11 +292,11 @@ jest.mock('../../AppState', () => ({
   updateExplorePageTab: jest.fn().mockReturnValue(''),
 }));
 
-jest.mock('@components/Explore/Explore.component', () => {
+jest.mock('components/Explore/Explore.component', () => {
   return jest.fn().mockReturnValue(<p>Explore Component</p>);
 });
 
-jest.mock('@rest/searchAPI', () => ({
+jest.mock('rest/searchAPI', () => ({
   searchQuery: jest
     .fn()
     .mockImplementation(

--- a/openmetadata-ui/src/main/resources/ui/src/pages/forgot-password/forgot-password.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/forgot-password/forgot-password.component.tsx
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import { useBasicAuth } from '@components/authentication/auth-provider/basic-auth.provider';
 import { Button, Card, Col, Divider, Form, Input, Row, Typography } from 'antd';
+import { useBasicAuth } from 'components/authentication/auth-provider/basic-auth.provider';
 import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { ROUTES } from '../../constants/constants';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/login/index.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/login/index.test.tsx
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import { useAuthContext } from '@components/authentication/auth-provider/AuthProvider';
 import { findByTestId, findByText, render } from '@testing-library/react';
+import { useAuthContext } from 'components/authentication/auth-provider/AuthProvider';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import SigninPage from './index';
@@ -23,12 +23,12 @@ jest.mock('react-router-dom', () => ({
   useHistory: jest.fn(),
 }));
 
-jest.mock('@components/authentication/auth-provider/AuthProvider', () => ({
+jest.mock('components/authentication/auth-provider/AuthProvider', () => ({
   useAuthContext: jest.fn(),
 }));
 
 jest.mock(
-  '@components/containers/PageContainer',
+  'components/containers/PageContainer',
   () =>
     ({ children }: { children: React.ReactNode }) =>
       <div data-testid="PageContainer">{children}</div>

--- a/openmetadata-ui/src/main/resources/ui/src/pages/login/index.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/login/index.tsx
@@ -11,12 +11,12 @@
  *  limitations under the License.
  */
 
-import { useAuthContext } from '@components/authentication/auth-provider/AuthProvider';
-import { useBasicAuth } from '@components/authentication/auth-provider/basic-auth.provider';
-import Loader from '@components/Loader/Loader';
-import LoginButton from '@components/LoginButton/LoginButton';
 import { Button, Col, Divider, Form, Input, Row, Typography } from 'antd';
 import classNames from 'classnames';
+import { useAuthContext } from 'components/authentication/auth-provider/AuthProvider';
+import { useBasicAuth } from 'components/authentication/auth-provider/basic-auth.provider';
+import Loader from 'components/Loader/Loader';
+import LoginButton from 'components/LoginButton/LoginButton';
 import jwtDecode, { JwtPayload } from 'jwt-decode';
 import { observer } from 'mobx-react';
 import React, { useEffect, useMemo, useState } from 'react';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/reset-password/reset-password.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/reset-password/reset-password.component.tsx
@@ -11,9 +11,9 @@
  *  limitations under the License.
  */
 
-import { useBasicAuth } from '@components/authentication/auth-provider/basic-auth.provider';
 import { Alert, Button, Card, Col, Form, Input, Row, Typography } from 'antd';
 import { AxiosError } from 'axios';
+import { useBasicAuth } from 'components/authentication/auth-provider/basic-auth.provider';
 import React, { useEffect, useMemo } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import { VALIDATION_MESSAGES } from '../../constants/auth.constants';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/service/index.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/service/index.test.tsx
@@ -50,7 +50,7 @@ jest.mock('../../utils/PermissionsUtils', () => ({
   },
 }));
 
-jest.mock('@components/PermissionProvider/PermissionProvider', () => ({
+jest.mock('components/PermissionProvider/PermissionProvider', () => ({
   usePermissionProvider: jest.fn().mockReturnValue({
     getEntityPermissionByFqn: jest.fn().mockReturnValue({
       Create: true,
@@ -64,7 +64,7 @@ jest.mock('@components/PermissionProvider/PermissionProvider', () => ({
   }),
 }));
 
-jest.mock('@rest/ingestionPipelineAPI', () => ({
+jest.mock('rest/ingestionPipelineAPI', () => ({
   getIngestionPipelines: jest.fn().mockImplementation(() =>
     Promise.resolve({
       data: {
@@ -90,23 +90,23 @@ jest.mock('@rest/ingestionPipelineAPI', () => ({
   }),
 }));
 
-jest.mock('@rest/miscAPI', () => ({
+jest.mock('rest/miscAPI', () => ({
   fetchAirflowConfig: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
 
-jest.mock('@rest/mlModelAPI', () => ({
+jest.mock('rest/mlModelAPI', () => ({
   getMlmodels: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
 
-jest.mock('@rest/pipelineAPI', () => ({
+jest.mock('rest/pipelineAPI', () => ({
   getPipelines: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
 
-jest.mock('@rest/topicsAPI', () => ({
+jest.mock('rest/topicsAPI', () => ({
   getTopics: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
 
-jest.mock('@rest/dashboardAPI', () => ({
+jest.mock('rest/dashboardAPI', () => ({
   getDashboards: jest.fn().mockImplementation(() =>
     Promise.resolve({
       data: DASHBOARD_DATA,
@@ -118,7 +118,7 @@ jest.mock('@rest/dashboardAPI', () => ({
   ),
 }));
 
-jest.mock('@rest/serviceAPI', () => ({
+jest.mock('rest/serviceAPI', () => ({
   getServiceByFQN: jest
     .fn()
     .mockImplementation(() => Promise.resolve(mockData)),
@@ -126,13 +126,13 @@ jest.mock('@rest/serviceAPI', () => ({
   TestConnection: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
 
-jest.mock('@rest/databaseAPI', () => ({
+jest.mock('rest/databaseAPI', () => ({
   getDatabases: jest
     .fn()
     .mockImplementation(() => Promise.resolve({ ...mockDatabase })),
 }));
 
-jest.mock('@components/common/rich-text-editor/RichTextEditorPreviewer', () => {
+jest.mock('components/common/rich-text-editor/RichTextEditorPreviewer', () => {
   return jest.fn().mockReturnValue(<div>RichTextEditorPreviewer</div>);
 });
 
@@ -146,7 +146,7 @@ jest.mock('react-router-dom', () => ({
   useParams: jest.fn().mockImplementation(() => mockParams),
 }));
 
-jest.mock('@components/containers/PageContainer', () => {
+jest.mock('components/containers/PageContainer', () => {
   return jest
     .fn()
     .mockImplementation(({ children }: { children: React.ReactNode }) => (
@@ -186,22 +186,22 @@ jest.mock('../../utils/ServiceUtils', () => ({
 }));
 
 jest.mock(
-  '@components/common/title-breadcrumb/title-breadcrumb.component',
+  'components/common/title-breadcrumb/title-breadcrumb.component',
   () => {
     return jest.fn().mockReturnValue(<div>TitleBreadcrumb</div>);
   }
 );
 
-jest.mock('@components/common/description/Description', () => {
+jest.mock('components/common/description/Description', () => {
   return jest.fn().mockReturnValue(<div>Description_component</div>);
 });
 
-jest.mock('@components/common/TabsPane/TabsPane', () => {
+jest.mock('components/common/TabsPane/TabsPane', () => {
   return jest.fn().mockReturnValue(<div>TabsPane_component</div>);
 });
 
 jest.mock(
-  '@components/Modals/ModalWithMarkdownEditor/ModalWithMarkdownEditor',
+  'components/Modals/ModalWithMarkdownEditor/ModalWithMarkdownEditor',
   () => ({
     ModalWithMarkdownEditor: jest
       .fn()
@@ -209,25 +209,25 @@ jest.mock(
   })
 );
 
-jest.mock('@components/common/EntitySummaryDetails/EntitySummaryDetails', () =>
+jest.mock('components/common/EntitySummaryDetails/EntitySummaryDetails', () =>
   jest.fn().mockReturnValue(<div>EntitySummaryDetails</div>)
 );
 
-jest.mock('@components/ServiceConfig/ServiceConfig', () => {
+jest.mock('components/ServiceConfig/ServiceConfig', () => {
   return jest.fn().mockReturnValue(<div>ServiceConfig</div>);
 });
 
-jest.mock('@components/common/entityPageInfo/ManageButton/ManageButton', () => {
+jest.mock('components/common/entityPageInfo/ManageButton/ManageButton', () => {
   return jest.fn().mockReturnValue(<div>ManageButton</div>);
 });
-jest.mock('@components/Ingestion/Ingestion.component', () => {
+jest.mock('components/Ingestion/Ingestion.component', () => {
   return jest
     .fn()
     .mockReturnValue(<div data-testid="ingestions">Ingestion</div>);
 });
 
 jest.mock(
-  '@components/ServiceConnectionDetails/ServiceConnectionDetails.component',
+  'components/ServiceConnectionDetails/ServiceConnectionDetails.component',
   () => {
     return jest
       .fn()
@@ -237,13 +237,13 @@ jest.mock(
   }
 );
 
-jest.mock('@components/tags-viewer/tags-viewer', () => {
+jest.mock('components/tags-viewer/tags-viewer', () => {
   return jest
     .fn()
     .mockReturnValue(<div data-testid="tag-viewer">Tag Viewer</div>);
 });
 
-jest.mock('@components/common/ProfilePicture/ProfilePicture', () => {
+jest.mock('components/common/ProfilePicture/ProfilePicture', () => {
   return jest.fn().mockImplementation(({ name }) => {
     return <div data-testid={`${name}-profile`}>{name}</div>;
   });

--- a/openmetadata-ui/src/main/resources/ui/src/pages/service/index.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/service/index.tsx
@@ -11,51 +11,51 @@
  *  limitations under the License.
  */
 
-import { Button as LegacyButton } from '@components/buttons/Button/Button';
-import DeleteWidgetModal from '@components/common/DeleteWidget/DeleteWidgetModal';
-import Description from '@components/common/description/Description';
-import EntitySummaryDetails from '@components/common/EntitySummaryDetails/EntitySummaryDetails';
-import ErrorPlaceHolder from '@components/common/error-with-placeholder/ErrorPlaceHolder';
-import ErrorPlaceHolderIngestion from '@components/common/error-with-placeholder/ErrorPlaceHolderIngestion';
-import NextPrevious from '@components/common/next-previous/NextPrevious';
-import ProfilePicture from '@components/common/ProfilePicture/ProfilePicture';
-import RichTextEditorPreviewer from '@components/common/rich-text-editor/RichTextEditorPreviewer';
-import TabsPane from '@components/common/TabsPane/TabsPane';
-import TitleBreadcrumb from '@components/common/title-breadcrumb/title-breadcrumb.component';
-import { TitleBreadcrumbProps } from '@components/common/title-breadcrumb/title-breadcrumb.interface';
-import PageContainerV1 from '@components/containers/PageContainerV1';
-import Ingestion from '@components/Ingestion/Ingestion.component';
-import Loader from '@components/Loader/Loader';
-import { usePermissionProvider } from '@components/PermissionProvider/PermissionProvider';
-import { OperationPermission } from '@components/PermissionProvider/PermissionProvider.interface';
-import ServiceConnectionDetails from '@components/ServiceConnectionDetails/ServiceConnectionDetails.component';
-import TagsViewer from '@components/tags-viewer/tags-viewer';
-import { getDashboards } from '@rest/dashboardAPI';
-import { getDatabases } from '@rest/databaseAPI';
+import { Button, Col, Row, Space, Tooltip, Typography } from 'antd';
+import Table, { ColumnsType } from 'antd/lib/table';
+import { AxiosError } from 'axios';
+import { Button as LegacyButton } from 'components/buttons/Button/Button';
+import DeleteWidgetModal from 'components/common/DeleteWidget/DeleteWidgetModal';
+import Description from 'components/common/description/Description';
+import EntitySummaryDetails from 'components/common/EntitySummaryDetails/EntitySummaryDetails';
+import ErrorPlaceHolder from 'components/common/error-with-placeholder/ErrorPlaceHolder';
+import ErrorPlaceHolderIngestion from 'components/common/error-with-placeholder/ErrorPlaceHolderIngestion';
+import NextPrevious from 'components/common/next-previous/NextPrevious';
+import ProfilePicture from 'components/common/ProfilePicture/ProfilePicture';
+import RichTextEditorPreviewer from 'components/common/rich-text-editor/RichTextEditorPreviewer';
+import TabsPane from 'components/common/TabsPane/TabsPane';
+import TitleBreadcrumb from 'components/common/title-breadcrumb/title-breadcrumb.component';
+import { TitleBreadcrumbProps } from 'components/common/title-breadcrumb/title-breadcrumb.interface';
+import PageContainerV1 from 'components/containers/PageContainerV1';
+import Ingestion from 'components/Ingestion/Ingestion.component';
+import Loader from 'components/Loader/Loader';
+import { usePermissionProvider } from 'components/PermissionProvider/PermissionProvider';
+import { OperationPermission } from 'components/PermissionProvider/PermissionProvider.interface';
+import ServiceConnectionDetails from 'components/ServiceConnectionDetails/ServiceConnectionDetails.component';
+import TagsViewer from 'components/tags-viewer/tags-viewer';
+import { t } from 'i18next';
+import { isEmpty, isNil, isUndefined, startCase, toLower } from 'lodash';
+import { ExtraInfo, ServicesUpdateRequest, ServiceTypes } from 'Models';
+import React, { FunctionComponent, useEffect, useMemo, useState } from 'react';
+import { Link, useHistory, useParams } from 'react-router-dom';
+import { getDashboards } from 'rest/dashboardAPI';
+import { getDatabases } from 'rest/databaseAPI';
 import {
   deleteIngestionPipelineById,
   deployIngestionPipelineById,
   enableDisableIngestionPipelineById,
   getIngestionPipelines,
   triggerIngestionPipelineById,
-} from '@rest/ingestionPipelineAPI';
-import { fetchAirflowConfig } from '@rest/miscAPI';
-import { getMlmodels } from '@rest/mlModelAPI';
-import { getPipelines } from '@rest/pipelineAPI';
+} from 'rest/ingestionPipelineAPI';
+import { fetchAirflowConfig } from 'rest/miscAPI';
+import { getMlmodels } from 'rest/mlModelAPI';
+import { getPipelines } from 'rest/pipelineAPI';
 import {
   getServiceByFQN,
   TestConnection,
   updateService,
-} from '@rest/serviceAPI';
-import { getTopics } from '@rest/topicsAPI';
-import { Button, Col, Row, Space, Tooltip, Typography } from 'antd';
-import Table, { ColumnsType } from 'antd/lib/table';
-import { AxiosError } from 'axios';
-import { t } from 'i18next';
-import { isEmpty, isNil, isUndefined, startCase, toLower } from 'lodash';
-import { ExtraInfo, ServicesUpdateRequest, ServiceTypes } from 'Models';
-import React, { FunctionComponent, useEffect, useMemo, useState } from 'react';
-import { Link, useHistory, useParams } from 'react-router-dom';
+} from 'rest/serviceAPI';
+import { getTopics } from 'rest/topicsAPI';
 import {
   getServiceDetailsPath,
   getTeamAndUserDetailsPath,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/services/ServicesPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/services/ServicesPage.tsx
@@ -11,16 +11,16 @@
  *  limitations under the License.
  */
 
-import ErrorPlaceHolder from '@components/common/error-with-placeholder/ErrorPlaceHolder';
-import Loader from '@components/Loader/Loader';
-import { usePermissionProvider } from '@components/PermissionProvider/PermissionProvider';
-import Services from '@components/Services/Services';
-import { getServices } from '@rest/serviceAPI';
 import { Col, Row } from 'antd';
 import { AxiosError } from 'axios';
+import ErrorPlaceHolder from 'components/common/error-with-placeholder/ErrorPlaceHolder';
+import Loader from 'components/Loader/Loader';
+import { usePermissionProvider } from 'components/PermissionProvider/PermissionProvider';
+import Services from 'components/Services/Services';
 import { isEmpty } from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { getServices } from 'rest/serviceAPI';
 import { pagingObject, SERVICE_VIEW_CAP } from '../../constants/constants';
 import { NO_PERMISSION_TO_VIEW } from '../../constants/HelperTextUtil';
 import { SERVICE_CATEGORY } from '../../constants/Services.constant';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/signup/account-activation-confirmation.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/signup/account-activation-confirmation.component.tsx
@@ -11,12 +11,12 @@
  *  limitations under the License.
  */
 
-import { confirmRegistration } from '@rest/auth-API';
 import { Alert, Card, Space, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import { isEmpty } from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
+import { confirmRegistration } from 'rest/auth-API';
 import { ROUTES } from '../../constants/constants';
 import jsonData from '../../jsons/en';
 import { showErrorToast, showSuccessToast } from '../../utils/ToastUtils';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/signup/basic-signup.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/signup/basic-signup.component.tsx
@@ -11,9 +11,9 @@
  *  limitations under the License.
  */
 
-import { useAuthContext } from '@components/authentication/auth-provider/AuthProvider';
-import { useBasicAuth } from '@components/authentication/auth-provider/basic-auth.provider';
 import { Button, Col, Divider, Form, Input, Row, Typography } from 'antd';
+import { useAuthContext } from 'components/authentication/auth-provider/AuthProvider';
+import { useBasicAuth } from 'components/authentication/auth-provider/basic-auth.provider';
 import { isEmpty } from 'lodash';
 import React, { useMemo } from 'react';
 import { useHistory } from 'react-router-dom';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/signup/index.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/signup/index.test.tsx
@@ -11,9 +11,9 @@
  *  limitations under the License.
  */
 
-import { createUser } from '@rest/userAPI';
 import { act, fireEvent, render } from '@testing-library/react';
 import React, { ReactNode } from 'react';
+import { createUser } from 'rest/userAPI';
 import Signup from '.';
 import AppState from '../../AppState';
 import { getImages } from '../../utils/CommonUtils';
@@ -29,17 +29,17 @@ jest.mock('react-router-dom', () => ({
   }),
 }));
 
-jest.mock('@components/authentication/auth-provider/AuthProvider', () => ({
+jest.mock('components/authentication/auth-provider/AuthProvider', () => ({
   useAuthContext: jest.fn(() => ({
     setIsSigningIn: jest.fn(),
   })),
 }));
 
-jest.mock('@components/TeamsSelectable/TeamsSelectable', () => {
+jest.mock('components/TeamsSelectable/TeamsSelectable', () => {
   return jest.fn().mockImplementation(() => <div>TeamSelectable</div>);
 });
 
-jest.mock('@components/buttons/Button/Button', () => ({
+jest.mock('components/buttons/Button/Button', () => ({
   Button: jest
     .fn()
     .mockImplementation(({ children }) => (
@@ -47,7 +47,7 @@ jest.mock('@components/buttons/Button/Button', () => ({
     )),
 }));
 
-jest.mock('@components/containers/PageContainer', () => {
+jest.mock('components/containers/PageContainer', () => {
   return jest
     .fn()
     .mockImplementation(({ children }: { children: ReactNode }) => (
@@ -55,7 +55,7 @@ jest.mock('@components/containers/PageContainer', () => {
     ));
 });
 
-jest.mock('@rest/userAPI', () => ({
+jest.mock('rest/userAPI', () => ({
   createUser: jest
     .fn()
     .mockImplementation(() => Promise.resolve(mockCreateUser)),

--- a/openmetadata-ui/src/main/resources/ui/src/pages/signup/index.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/signup/index.tsx
@@ -11,16 +11,16 @@
  *  limitations under the License.
  */
 
-import { useAuthContext } from '@components/authentication/auth-provider/AuthProvider';
-import { UserProfile } from '@components/authentication/auth-provider/AuthProvider.interface';
-import { Button } from '@components/buttons/Button/Button';
-import PageContainer from '@components/containers/PageContainer';
-import TeamsSelectable from '@components/TeamsSelectable/TeamsSelectable';
-import { createUser } from '@rest/userAPI';
 import { AxiosError } from 'axios';
+import { useAuthContext } from 'components/authentication/auth-provider/AuthProvider';
+import { UserProfile } from 'components/authentication/auth-provider/AuthProvider.interface';
+import { Button } from 'components/buttons/Button/Button';
+import PageContainerV1 from 'components/containers/PageContainerV1';
+import TeamsSelectable from 'components/TeamsSelectable/TeamsSelectable';
 import { CookieStorage } from 'cookie-storage';
 import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
+import { createUser } from 'rest/userAPI';
 import appState from '../../AppState';
 import { REDIRECT_PATHNAME, ROUTES } from '../../constants/constants';
 import { CreateUser } from '../../generated/api/teams/createUser';
@@ -99,7 +99,7 @@ const Signup = () => {
   return (
     <>
       {!loading && (
-        <PageContainer>
+        <PageContainerV1>
           <div className="tw-h-screen tw-flex tw-justify-center">
             <div className="tw-flex tw-flex-col tw-items-center signup-box">
               <div className="tw-flex tw-justify-center tw-items-center tw-my-7">
@@ -215,7 +215,7 @@ const Signup = () => {
               </div>
             </div>
           </div>
-        </PageContainer>
+        </PageContainerV1>
       )}
       {loading && (
         <p

--- a/openmetadata-ui/src/main/resources/ui/src/pages/swagger/index.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/swagger/index.tsx
@@ -12,22 +12,22 @@
  */
 
 import { RedocStandalone } from '@deuex-solutions/redoc';
+import PageContainerV1 from 'components/containers/PageContainerV1';
 import React from 'react';
-import PageContainer from '../../components/containers/PageContainer';
 
 const SwaggerPage = () => {
   // return (<RedocStandalone
   //   specUrl="https://raw.githubusercontent.com/deuex-solutions/redoc/master/demo/petstore.json"
   // />);
   return (
-    <PageContainer>
+    <PageContainerV1>
       <div className="container-fluid" data-testid="fluid-container">
         <RedocStandalone
           options={{ enableConsole: true }}
           specUrl="./swagger.json"
         />
       </div>
-    </PageContainer>
+    </PageContainerV1>
   );
 };
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/tags/Form.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/tags/Form.test.tsx
@@ -22,7 +22,7 @@ const mockInitialData = {
   name: '',
 };
 
-jest.mock('@components/common/rich-text-editor/RichTextEditor', () => {
+jest.mock('components/common/rich-text-editor/RichTextEditor', () => {
   return forwardRef(
     jest.fn().mockImplementation(({ initialValue }, ref) => {
       return <div ref={ref}>{initialValue}MarkdownWithPreview component</div>;

--- a/openmetadata-ui/src/main/resources/ui/src/pages/tags/Form.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/tags/Form.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import RichTextEditor from '@components/common/rich-text-editor/RichTextEditor';
+import RichTextEditor from 'components/common/rich-text-editor/RichTextEditor';
 import { FormErrorData } from 'Models';
 import React, {
   forwardRef,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/tags/index.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/tags/index.test.tsx
@@ -13,12 +13,6 @@
  */
 
 import {
-  deleteClassification,
-  deleteTag,
-  getAllClassifications,
-  updateClassification,
-} from '@rest/tagAPI';
-import {
   act,
   findAllByTestId,
   findByTestId,
@@ -29,6 +23,12 @@ import {
   screen,
 } from '@testing-library/react';
 import React, { ReactNode } from 'react';
+import {
+  deleteClassification,
+  deleteTag,
+  getAllClassifications,
+  updateClassification,
+} from 'rest/tagAPI';
 import TagsPage from '.';
 import { getClassifications } from '../../utils/TagsUtils';
 import {
@@ -154,7 +154,7 @@ const mockCategory = [
   },
 ];
 
-jest.mock('@components/PermissionProvider/PermissionProvider', () => ({
+jest.mock('components/PermissionProvider/PermissionProvider', () => ({
   usePermissionProvider: jest.fn().mockReturnValue({
     getEntityPermission: jest.fn().mockReturnValue({
       Create: true,
@@ -198,7 +198,7 @@ jest.mock('../../utils/PermissionsUtils', () => ({
   },
 }));
 
-jest.mock('@rest/tagAPI', () => ({
+jest.mock('rest/tagAPI', () => ({
   createTag: jest.fn(),
   createClassification: jest.fn(),
   updateTag: jest.fn(),
@@ -225,7 +225,7 @@ jest.mock('../../utils/TagsUtils', () => ({
 }));
 
 jest.mock(
-  '@components/containers/PageLayoutV1',
+  'components/containers/PageLayoutV1',
   () =>
     ({ children, leftPanel }: { children: ReactNode; leftPanel: ReactNode }) =>
       (
@@ -237,17 +237,17 @@ jest.mock(
 );
 
 jest.mock(
-  '@components/containers/PageContainerV1',
+  'components/containers/PageContainerV1',
   () =>
     ({ children }: { children: ReactNode }) =>
       <div data-testid="PageContainerV1">{children}</div>
 );
 
-jest.mock('@components/common/rich-text-editor/RichTextEditorPreviewer', () => {
+jest.mock('components/common/rich-text-editor/RichTextEditorPreviewer', () => {
   return jest.fn().mockReturnValue(<p>RichTextEditorPreviewer</p>);
 });
 
-jest.mock('@components/Modals/ConfirmationModal/ConfirmationModal', () => {
+jest.mock('components/Modals/ConfirmationModal/ConfirmationModal', () => {
   return jest.fn().mockImplementation(({ onCancel, onConfirm }) => (
     <div data-testid="confirmation-modal">
       <button data-testid="cancel-modal" onClick={onCancel}>
@@ -260,13 +260,13 @@ jest.mock('@components/Modals/ConfirmationModal/ConfirmationModal', () => {
   ));
 });
 
-jest.mock('@components/Modals/FormModal', () => {
+jest.mock('components/Modals/FormModal', () => {
   return jest
     .fn()
     .mockReturnValue(<p data-testid="modal-container">FormModal</p>);
 });
 
-jest.mock('@components/common/description/Description', () => {
+jest.mock('components/common/description/Description', () => {
   return jest.fn().mockReturnValue(<p>DescriptionComponent</p>);
 });
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/tags/index.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/tags/index.tsx
@@ -11,34 +11,7 @@
  *  limitations under the License.
  */
 
-import Description from '@components/common/description/Description';
-import ErrorPlaceHolder from '@components/common/error-with-placeholder/ErrorPlaceHolder';
-import LeftPanelCard from '@components/common/LeftPanelCard/LeftPanelCard';
-import NextPrevious from '@components/common/next-previous/NextPrevious';
-import RichTextEditorPreviewer from '@components/common/rich-text-editor/RichTextEditorPreviewer';
-import PageContainerV1 from '@components/containers/PageContainerV1';
-import PageLayoutV1 from '@components/containers/PageLayoutV1';
-import Loader from '@components/Loader/Loader';
-import ConfirmationModal from '@components/Modals/ConfirmationModal/ConfirmationModal';
-import FormModal from '@components/Modals/FormModal';
-import { ModalWithMarkdownEditor } from '@components/Modals/ModalWithMarkdownEditor/ModalWithMarkdownEditor';
-import { usePermissionProvider } from '@components/PermissionProvider/PermissionProvider';
-import {
-  OperationPermission,
-  ResourceEntity,
-} from '@components/PermissionProvider/PermissionProvider.interface';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import {
-  createClassification,
-  createTag,
-  deleteClassification,
-  deleteTag,
-  getAllClassifications,
-  getClassificationByName,
-  getTags,
-  patchClassification,
-  patchTag,
-} from '@rest/tagAPI';
 import {
   Button,
   Col,
@@ -52,12 +25,39 @@ import {
 } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
 import { AxiosError } from 'axios';
+import Description from 'components/common/description/Description';
+import ErrorPlaceHolder from 'components/common/error-with-placeholder/ErrorPlaceHolder';
+import LeftPanelCard from 'components/common/LeftPanelCard/LeftPanelCard';
+import NextPrevious from 'components/common/next-previous/NextPrevious';
+import RichTextEditorPreviewer from 'components/common/rich-text-editor/RichTextEditorPreviewer';
+import PageContainerV1 from 'components/containers/PageContainerV1';
+import PageLayoutV1 from 'components/containers/PageLayoutV1';
+import Loader from 'components/Loader/Loader';
+import ConfirmationModal from 'components/Modals/ConfirmationModal/ConfirmationModal';
+import FormModal from 'components/Modals/FormModal';
+import { ModalWithMarkdownEditor } from 'components/Modals/ModalWithMarkdownEditor/ModalWithMarkdownEditor';
+import { usePermissionProvider } from 'components/PermissionProvider/PermissionProvider';
+import {
+  OperationPermission,
+  ResourceEntity,
+} from 'components/PermissionProvider/PermissionProvider.interface';
 import { compare } from 'fast-json-patch';
 import { isEmpty, isUndefined, toLower, trim } from 'lodash';
 import { FormErrorData, LoadingState } from 'Models';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useHistory, useParams } from 'react-router-dom';
+import {
+  createClassification,
+  createTag,
+  deleteClassification,
+  deleteTag,
+  getAllClassifications,
+  getClassificationByName,
+  getTags,
+  patchClassification,
+  patchTag,
+} from 'rest/tagAPI';
 import {
   INITIAL_PAGING_VALUE,
   PAGE_SIZE,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/teams/AddTeamForm.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/teams/AddTeamForm.tsx
@@ -11,14 +11,14 @@
  *  limitations under the License.
  */
 
-import RichTextEditor from '@components/common/rich-text-editor/RichTextEditor';
-import { EditorContentRef } from '@components/common/rich-text-editor/RichTextEditor.interface';
-import { getTeams } from '@rest/teamsAPI';
 import { Form, Input, Modal, Select } from 'antd';
 import { AxiosError } from 'axios';
+import RichTextEditor from 'components/common/rich-text-editor/RichTextEditor';
+import { EditorContentRef } from 'components/common/rich-text-editor/RichTextEditor.interface';
 import { isUndefined, toLower, trim } from 'lodash';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { getTeams } from 'rest/teamsAPI';
 import { Team, TeamType } from '../../generated/entity/teams/team';
 import jsonData from '../../jsons/en';
 import { isUrlFriendlyName } from '../../utils/CommonUtils';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/teams/AddUsersModalV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/teams/AddUsersModalV1.test.tsx
@@ -101,7 +101,7 @@ const mockUserList = [
   },
 ];
 
-jest.mock('@components/common/searchbar/Searchbar', () => {
+jest.mock('components/common/searchbar/Searchbar', () => {
   return jest.fn().mockReturnValue(<p data-testid="searchbar">Searchbar</p>);
 });
 
@@ -111,7 +111,7 @@ jest.mock('./UserCard', () => {
     .mockImplementation(() => <p data-testid="user-card">UserCard</p>);
 });
 
-jest.mock('@rest/userAPI', () => {
+jest.mock('rest/userAPI', () => {
   return {
     getUsers: jest
       .fn()

--- a/openmetadata-ui/src/main/resources/ui/src/pages/teams/AddUsersModalV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/teams/AddUsersModalV1.tsx
@@ -11,14 +11,14 @@
  *  limitations under the License.
  */
 
-import Searchbar from '@components/common/searchbar/Searchbar';
-import { searchData } from '@rest/miscAPI';
-import { getUsers } from '@rest/userAPI';
 import { List, Modal } from 'antd';
 import { AxiosError } from 'axios';
+import Searchbar from 'components/common/searchbar/Searchbar';
 import { isUndefined } from 'lodash';
 import VirtualList from 'rc-virtual-list';
 import React, { useEffect, useState } from 'react';
+import { searchData } from 'rest/miscAPI';
+import { getUsers } from 'rest/userAPI';
 import {
   ADD_USER_CONTAINER_HEIGHT,
   PAGE_SIZE_MEDIUM,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/teams/CheckboxUserCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/teams/CheckboxUserCard.tsx
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import ProfilePicture from '@components/common/ProfilePicture/ProfilePicture';
 import classNames from 'classnames';
+import ProfilePicture from 'components/common/ProfilePicture/ProfilePicture';
 import { capitalize } from 'lodash';
 import React, { useState } from 'react';
 import { EntityReference } from '../../generated/type/entityReference';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/teams/TeamsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/teams/TeamsPage.tsx
@@ -11,30 +11,30 @@
  *  limitations under the License.
  */
 
-import { useAuthContext } from '@components/authentication/auth-provider/AuthProvider';
-import ErrorPlaceHolder from '@components/common/error-with-placeholder/ErrorPlaceHolder';
-import Loader from '@components/Loader/Loader';
-import { usePermissionProvider } from '@components/PermissionProvider/PermissionProvider';
+import { AxiosError } from 'axios';
+import { useAuthContext } from 'components/authentication/auth-provider/AuthProvider';
+import ErrorPlaceHolder from 'components/common/error-with-placeholder/ErrorPlaceHolder';
+import Loader from 'components/Loader/Loader';
+import { usePermissionProvider } from 'components/PermissionProvider/PermissionProvider';
 import {
   OperationPermission,
   ResourceEntity,
-} from '@components/PermissionProvider/PermissionProvider.interface';
-import TeamDetailsV1 from '@components/TeamDetails/TeamDetailsV1';
-import { searchData } from '@rest/miscAPI';
-import {
-  createTeam,
-  getTeamByName,
-  getTeams,
-  patchTeamDetail,
-} from '@rest/teamsAPI';
-import { getUsers, updateUserDetail } from '@rest/userAPI';
-import { AxiosError } from 'axios';
+} from 'components/PermissionProvider/PermissionProvider.interface';
+import TeamDetailsV1 from 'components/TeamDetails/TeamDetailsV1';
 import { compare, Operation } from 'fast-json-patch';
 import { cloneDeep, isEmpty, isUndefined } from 'lodash';
 import { AssetsDataType, FormattedTableData } from 'Models';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory, useParams } from 'react-router-dom';
+import { searchData } from 'rest/miscAPI';
+import {
+  createTeam,
+  getTeamByName,
+  getTeams,
+  patchTeamDetail,
+} from 'rest/teamsAPI';
+import { getUsers, updateUserDetail } from 'rest/userAPI';
 import AppState from '../../AppState';
 import {
   INITIAL_PAGING_VALUE,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/teams/UserCard.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/teams/UserCard.test.tsx
@@ -25,7 +25,7 @@ const mockItem = {
 
 const mockRemove = jest.fn();
 
-jest.mock('@components/PermissionProvider/PermissionProvider', () => ({
+jest.mock('components/PermissionProvider/PermissionProvider', () => ({
   usePermissionProvider: jest.fn().mockReturnValue({
     permissions: {
       user: {
@@ -45,7 +45,7 @@ jest.mock('../../utils/PermissionsUtils', () => ({
   checkPermission: jest.fn().mockReturnValue(true),
 }));
 
-jest.mock('@components/common/ProfilePicture/ProfilePicture', () => {
+jest.mock('components/common/ProfilePicture/ProfilePicture', () => {
   return jest
     .fn()
     .mockReturnValue(<p data-testid="profile-picture">ProfilePicture</p>);

--- a/openmetadata-ui/src/main/resources/ui/src/pages/teams/UserCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/teams/UserCard.tsx
@@ -11,12 +11,12 @@
  *  limitations under the License.
  */
 
-import ProfilePicture from '@components/common/ProfilePicture/ProfilePicture';
-import { usePermissionProvider } from '@components/PermissionProvider/PermissionProvider';
-import { ResourceEntity } from '@components/PermissionProvider/PermissionProvider.interface';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Button, Tooltip, Typography } from 'antd';
 import classNames from 'classnames';
+import ProfilePicture from 'components/common/ProfilePicture/ProfilePicture';
+import { usePermissionProvider } from 'components/PermissionProvider/PermissionProvider';
+import { ResourceEntity } from 'components/PermissionProvider/PermissionProvider.interface';
 import { capitalize } from 'lodash';
 import React, { Fragment, useMemo } from 'react';
 import { Link } from 'react-router-dom';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/tour-page/TourPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/tour-page/TourPage.component.tsx
@@ -11,13 +11,13 @@
  *  limitations under the License.
  */
 
-import DatasetDetails from '@components/DatasetDetails/DatasetDetails.component';
-import { LeafNodes } from '@components/EntityLineage/EntityLineage.interface';
-import Explore from '@components/Explore/Explore.component';
-import MyData from '@components/MyData/MyData.component';
-import { MyDataProps } from '@components/MyData/MyData.interface';
-import NavBar from '@components/nav-bar/NavBar';
-import Tour from '@components/tour/Tour';
+import DatasetDetails from 'components/DatasetDetails/DatasetDetails.component';
+import { LeafNodes } from 'components/EntityLineage/EntityLineage.interface';
+import Explore from 'components/Explore/Explore.component';
+import MyData from 'components/MyData/MyData.component';
+import { MyDataProps } from 'components/MyData/MyData.interface';
+import NavBar from 'components/nav-bar/NavBar';
+import Tour from 'components/tour/Tour';
 import { noop } from 'lodash';
 import { observer } from 'mobx-react';
 import React, { useEffect, useState } from 'react';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/tour-page/TourPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/tour-page/TourPage.test.tsx
@@ -17,27 +17,27 @@ import { MemoryRouter } from 'react-router-dom';
 import { CurrentTourPageType } from '../../enums/tour.enum';
 import TourPageComponent from './TourPage.component';
 
-jest.mock('@components/nav-bar/NavBar', () => {
+jest.mock('components/nav-bar/NavBar', () => {
   return jest.fn().mockReturnValue(<div>NavBarComponent</div>);
 });
 
-jest.mock('@components/tour/Tour', () => {
+jest.mock('components/tour/Tour', () => {
   return jest.fn().mockReturnValue(<div>TourComponent</div>);
 });
 
-jest.mock('@components/MyData/MyData.component', () => {
+jest.mock('components/MyData/MyData.component', () => {
   return jest.fn().mockReturnValue(<div>MyDataComponent</div>);
 });
 
-jest.mock('@components/MyData/MyData.component', () => {
+jest.mock('components/MyData/MyData.component', () => {
   return jest.fn().mockReturnValue(<div>MyDataComponent</div>);
 });
 
-jest.mock('@components/Explore/Explore.component', () => {
+jest.mock('components/Explore/Explore.component', () => {
   return jest.fn().mockReturnValue(<div>ExploreComponent</div>);
 });
 
-jest.mock('@components/DatasetDetails/DatasetDetails.component', () => {
+jest.mock('components/DatasetDetails/DatasetDetails.component', () => {
   return jest.fn().mockReturnValue(<div>DatasetDetailsComponent</div>);
 });
 

--- a/openmetadata-ui/src/main/resources/ui/src/rest/chartAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/chartAPI.ts
@@ -11,9 +11,9 @@
  *  limitations under the License.
  */
 
-import { ChartType } from '@pages/DashboardDetailsPage/DashboardDetailsPage.component';
 import { AxiosResponse } from 'axios';
 import { Operation } from 'fast-json-patch';
+import { ChartType } from 'pages/DashboardDetailsPage/DashboardDetailsPage.component';
 import { getURLWithQueryFields } from '../utils/APIUtils';
 import APIClient from './index';
 

--- a/openmetadata-ui/src/main/resources/ui/src/rest/dashboardAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/dashboardAPI.ts
@@ -11,10 +11,10 @@
  *  limitations under the License.
  */
 
-import { ServicePageData } from '@pages/service';
 import { AxiosResponse } from 'axios';
 import { Operation } from 'fast-json-patch';
 import { RestoreRequestType } from 'Models';
+import { ServicePageData } from 'pages/service';
 import { Dashboard } from '../generated/entity/data/dashboard';
 import { EntityHistory } from '../generated/type/entityHistory';
 import { EntityReference } from '../generated/type/entityReference';

--- a/openmetadata-ui/src/main/resources/ui/src/rest/glossaryAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/glossaryAPI.ts
@@ -11,9 +11,9 @@
  *  limitations under the License.
  */
 
-import { ModifiedGlossaryData } from '@pages/GlossaryPage/GlossaryPageV1.component';
 import { AxiosResponse } from 'axios';
 import { Operation } from 'fast-json-patch';
+import { ModifiedGlossaryData } from 'pages/GlossaryPage/GlossaryPageV1.component';
 import { CreateGlossary } from '../generated/api/data/createGlossary';
 import { CreateGlossaryTerm } from '../generated/api/data/createGlossaryTerm';
 import { Glossary } from '../generated/entity/data/glossary';

--- a/openmetadata-ui/src/main/resources/ui/src/rest/ingestionPipelineAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/ingestionPipelineAPI.ts
@@ -11,10 +11,10 @@
  *  limitations under the License.
  */
 
-import { IngestionPipelineLogByIdInterface } from '@pages/LogsViewer/LogsViewer.interfaces';
 import { AxiosResponse } from 'axios';
 import { Operation } from 'fast-json-patch';
 import { PagingResponse } from 'Models';
+import { IngestionPipelineLogByIdInterface } from 'pages/LogsViewer/LogsViewer.interfaces';
 import { CreateIngestionPipeline } from '../generated/api/services/ingestionPipelines/createIngestionPipeline';
 import { PipelineStatus } from '../generated/entity/data/pipeline';
 import { IngestionPipeline } from '../generated/entity/services/ingestionPipelines/ingestionPipeline';

--- a/openmetadata-ui/src/main/resources/ui/src/rest/miscAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/miscAPI.ts
@@ -11,9 +11,9 @@
  *  limitations under the License.
  */
 
-import { Edge } from '@components/EntityLineage/EntityLineage.interface';
-import { ExploreSearchIndex } from '@components/Explore/explore.interface';
 import { AxiosResponse } from 'axios';
+import { Edge } from 'components/EntityLineage/EntityLineage.interface';
+import { ExploreSearchIndex } from 'components/Explore/explore.interface';
 import { SearchIndex } from '../enums/search.enum';
 import { AirflowConfiguration } from '../generated/configuration/airflowConfiguration';
 import { AuthenticationConfiguration } from '../generated/configuration/authenticationConfiguration';

--- a/openmetadata-ui/src/main/resources/ui/src/rest/mlModelAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/mlModelAPI.ts
@@ -11,10 +11,10 @@
  *  limitations under the License.
  */
 
-import { ServicePageData } from '@pages/service';
 import { AxiosResponse } from 'axios';
 import { Operation } from 'fast-json-patch';
 import { RestoreRequestType } from 'Models';
+import { ServicePageData } from 'pages/service';
 import { Mlmodel } from '../generated/entity/data/mlmodel';
 import { EntityReference } from '../generated/type/entityReference';
 import { Include } from '../generated/type/include';

--- a/openmetadata-ui/src/main/resources/ui/src/rest/permissionAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/permissionAPI.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { ResourceEntity } from '@components/PermissionProvider/PermissionProvider.interface';
+import { ResourceEntity } from 'components/PermissionProvider/PermissionProvider.interface';
 import { ResourcePermission } from '../generated/entity/policies/accessControl/resourcePermission';
 import { Paging } from '../generated/type/paging';
 import APIClient from './index';

--- a/openmetadata-ui/src/main/resources/ui/src/rest/pipelineAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/pipelineAPI.ts
@@ -11,10 +11,10 @@
  *  limitations under the License.
  */
 
-import { ServicePageData } from '@pages/service';
 import { AxiosResponse } from 'axios';
 import { Operation } from 'fast-json-patch';
 import { PagingResponse, RestoreRequestType } from 'Models';
+import { ServicePageData } from 'pages/service';
 import { Pipeline, PipelineStatus } from '../generated/entity/data/pipeline';
 import { EntityHistory } from '../generated/type/entityHistory';
 import { EntityReference } from '../generated/type/entityReference';

--- a/openmetadata-ui/src/main/resources/ui/src/rest/topicsAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/topicsAPI.ts
@@ -11,10 +11,10 @@
  *  limitations under the License.
  */
 
-import { ServicePageData } from '@pages/service';
 import { AxiosResponse } from 'axios';
 import { Operation } from 'fast-json-patch';
 import { RestoreRequestType } from 'Models';
+import { ServicePageData } from 'pages/service';
 import { TabSpecificField } from '../enums/entity.enum';
 import { Topic } from '../generated/entity/data/topic';
 import { EntityHistory } from '../generated/type/entityHistory';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchUtils.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchUtils.test.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { SearchDropdownOption } from '@components/SearchDropdown/SearchDropdown.interface';
+import { SearchDropdownOption } from 'components/SearchDropdown/SearchDropdown.interface';
 import {
   getSearchDropdownLabels,
   getSelectedOptionLabelString,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchUtils.tsx
@@ -12,9 +12,9 @@
  */
 
 import Icon, { CloseCircleOutlined, PlusOutlined } from '@ant-design/icons';
-import { FormattedSuggestResponseObject } from '@components/Explore/ExploreQuickFilters.interface';
-import { SearchDropdownOption } from '@components/SearchDropdown/SearchDropdown.interface';
 import { Button, Checkbox, MenuProps, Space, Typography } from 'antd';
+import { FormattedSuggestResponseObject } from 'components/Explore/ExploreQuickFilters.interface';
+import { SearchDropdownOption } from 'components/SearchDropdown/SearchDropdown.interface';
 import i18next from 'i18next';
 import { isArray, isUndefined } from 'lodash';
 import React from 'react';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AuthProvider.util.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AuthProvider.util.ts
@@ -21,7 +21,7 @@ import {
 import {
   JWT_PRINCIPAL_CLAIMS,
   UserProfile,
-} from '@components/authentication/auth-provider/AuthProvider.interface';
+} from 'components/authentication/auth-provider/AuthProvider.interface';
 import jwtDecode, { JwtPayload } from 'jwt-decode';
 import { first, isNil } from 'lodash';
 import { WebStorageStateStore } from 'oidc-client';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CommonUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CommonUtils.tsx
@@ -13,17 +13,16 @@
 
 /* eslint-disable @typescript-eslint/ban-types */
 
-import {
-  getDayCron,
-  getHourCron,
-} from '@components/common/CronEditor/CronEditor.constant';
-import ErrorPlaceHolder from '@components/common/error-with-placeholder/ErrorPlaceHolder';
-import Loader from '@components/Loader/Loader';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { getFeedCount } from '@rest/feedsAPI';
 import { Typography } from 'antd';
 import { AxiosError } from 'axios';
 import classNames from 'classnames';
+import {
+  getDayCron,
+  getHourCron,
+} from 'components/common/CronEditor/CronEditor.constant';
+import ErrorPlaceHolder from 'components/common/error-with-placeholder/ErrorPlaceHolder';
+import Loader from 'components/Loader/Loader';
 import { t } from 'i18next';
 import {
   capitalize,
@@ -46,6 +45,7 @@ import {
 import React from 'react';
 import { Trans } from 'react-i18next';
 import { reactLocalStorage } from 'reactjs-localstorage';
+import { getFeedCount } from 'rest/feedsAPI';
 import AppState from '../AppState';
 import { FQN_SEPARATOR_CHAR } from '../constants/char.constants';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CronUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CronUtils.ts
@@ -18,8 +18,8 @@ import {
   getMonthCron,
   getWeekCron,
   getYearCron,
-} from '@components/common/CronEditor/CronEditor.constant';
-import { StateValue } from '@components/common/CronEditor/CronEditor.interface';
+} from 'components/common/CronEditor/CronEditor.constant';
+import { StateValue } from 'components/common/CronEditor/CronEditor.interface';
 
 export const getCron = (state: StateValue) => {
   const {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DBTConfigFormUtil.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DBTConfigFormUtil.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { ModifiedDbtConfig } from '@components/AddIngestion/addIngestion.interface';
+import { ModifiedDbtConfig } from 'components/AddIngestion/addIngestion.interface';
 import {
   DbtConfigCloud,
   DbtConfigCloudReq,
@@ -24,7 +24,7 @@ import {
   ErrorDbtHttp,
   ErrorDbtLocal,
   ErrorDbtS3,
-} from '@components/common/DBTConfigFormBuilder/DBTConfigForm.interface';
+} from 'components/common/DBTConfigFormBuilder/DBTConfigForm.interface';
 import {
   reqDBTCloudFields,
   reqDBTHttpFields,
@@ -32,11 +32,11 @@ import {
   reqDBTS3Fields,
   rulesDBTGCSCredsFields,
   rulesDBTS3CredsFields,
-} from '@components/common/DBTConfigFormBuilder/DBTFormConstants';
+} from 'components/common/DBTConfigFormBuilder/DBTFormConstants';
 import {
   DBT_SOURCES,
   GCS_CONFIG,
-} from '@components/common/DBTConfigFormBuilder/DBTFormEnum';
+} from 'components/common/DBTConfigFormBuilder/DBTFormEnum';
 import { isEmpty, isNil, isString } from 'lodash';
 import { FormValidationRulesType } from '../enums/form.enum';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DashboardDetailsUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DashboardDetailsUtils.ts
@@ -11,10 +11,10 @@
  *  limitations under the License.
  */
 
-import { ChartType } from '@pages/DashboardDetailsPage/DashboardDetailsPage.component';
-import { getChartById } from '@rest/chartAPI';
 import { AxiosError } from 'axios';
 import i18next from 'i18next';
+import { ChartType } from 'pages/DashboardDetailsPage/DashboardDetailsPage.component';
+import { getChartById } from 'rest/chartAPI';
 import { TabSpecificField } from '../enums/entity.enum';
 import { Dashboard } from '../generated/entity/data/dashboard';
 import { sortTagsCaseInsensitive } from './CommonUtils';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataInsightUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataInsightUtils.tsx
@@ -11,9 +11,9 @@
  *  limitations under the License.
  */
 
-import { SearchDropdownOption } from '@components/SearchDropdown/SearchDropdown.interface';
 import { Card, Typography } from 'antd';
 import { RangePickerProps } from 'antd/lib/date-picker';
+import { SearchDropdownOption } from 'components/SearchDropdown/SearchDropdown.interface';
 import { t } from 'i18next';
 import {
   first,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataQualityAndProfilerUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataQualityAndProfilerUtils.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { TableTestsType } from '@components/TableProfiler/TableProfiler.interface';
+import { TableTestsType } from 'components/TableProfiler/TableProfiler.interface';
 import { TestCaseStatus } from '../generated/tests/testCase';
 
 export const updateTestResults = (

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageUtils.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageUtils.test.tsx
@@ -15,7 +15,7 @@ import {
   CustomEdgeData,
   EdgeTypeEnum,
   SelectedEdge,
-} from '@components/EntityLineage/EntityLineage.interface';
+} from 'components/EntityLineage/EntityLineage.interface';
 import { Edge } from 'reactflow';
 import { LineageDetails } from '../generated/api/lineage/addLineage';
 import { EntityLineage } from '../generated/type/entityLineage';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageUtils.tsx
@@ -12,6 +12,11 @@
  */
 
 import {
+  faChevronLeft,
+  faChevronRight,
+} from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
   CustomEdgeData,
   CustomElement,
   CustomFlow,
@@ -23,14 +28,9 @@ import {
   ModifiedColumn,
   SelectedEdge,
   SelectedNode,
-} from '@components/EntityLineage/EntityLineage.interface';
-import LineageNodeLabel from '@components/EntityLineage/LineageNodeLabel';
-import Loader from '@components/Loader/Loader';
-import {
-  faChevronLeft,
-  faChevronRight,
-} from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+} from 'components/EntityLineage/EntityLineage.interface';
+import LineageNodeLabel from 'components/EntityLineage/LineageNodeLabel';
+import Loader from 'components/Loader/Loader';
 import dagre from 'dagre';
 import { t } from 'i18next';
 import { isEmpty, isNil, isUndefined } from 'lodash';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityUtils.tsx
@@ -11,13 +11,13 @@
  *  limitations under the License.
  */
 
-import { EntityData } from '@components/common/PopOverCard/EntityPopOverCard';
+import { Popover } from 'antd';
+import { EntityData } from 'components/common/PopOverCard/EntityPopOverCard';
 import {
   LeafNodes,
   LineagePos,
-} from '@components/EntityLineage/EntityLineage.interface';
-import { ResourceEntity } from '@components/PermissionProvider/PermissionProvider.interface';
-import { Popover } from 'antd';
+} from 'components/EntityLineage/EntityLineage.interface';
+import { ResourceEntity } from 'components/PermissionProvider/PermissionProvider.interface';
 import i18next from 'i18next';
 import { isEmpty, isNil, isUndefined, lowerCase, startCase } from 'lodash';
 import { Bucket } from 'Models';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ExplorePage/ExplorePageUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ExplorePage/ExplorePageUtils.test.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { QueryFilterInterface } from '@pages/explore/ExplorePage.interface';
+import { QueryFilterInterface } from 'pages/explore/ExplorePage.interface';
 import { QueryFilterFieldsEnum } from '../../enums/Explore.enum';
 import {
   getCombinedFields,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ExplorePage/ExplorePageUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ExplorePage/ExplorePageUtils.ts
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 
-import { QueryFilterInterface } from '@pages/explore/ExplorePage.interface';
 import { isEmpty, isUndefined } from 'lodash';
+import { QueryFilterInterface } from 'pages/explore/ExplorePage.interface';
 import { QueryFilterFieldsEnum } from '../../enums/Explore.enum';
 
 export const getQueryFiltersArray = (

--- a/openmetadata-ui/src/main/resources/ui/src/utils/FeedUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/FeedUtils.tsx
@@ -13,23 +13,23 @@
 
 import { faAngleRight } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { AxiosError } from 'axios';
+import { Operation } from 'fast-json-patch';
+import i18next from 'i18next';
+import { isEqual } from 'lodash';
 import {
   deletePostById,
   deleteThread,
   getFeedById,
   updatePost,
   updateThread,
-} from '@rest/feedsAPI';
+} from 'rest/feedsAPI';
 import {
   getSearchedUsers,
   getSuggestions,
   getUserSuggestions,
   searchData,
-} from '@rest/miscAPI';
-import { AxiosError } from 'axios';
-import { Operation } from 'fast-json-patch';
-import i18next from 'i18next';
-import { isEqual } from 'lodash';
+} from 'rest/miscAPI';
 
 import React from 'react';
 import Showdown from 'showdown';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/FilterUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/FilterUtils.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { FilterObject } from '@components/AdvancedSearch/AdvancedSearch.interface';
+import { FilterObject } from 'components/AdvancedSearch/AdvancedSearch.interface';
 import { isArray, isNil, isObject, isString } from 'lodash';
 
 export function isFilterObject(obj: unknown): obj is FilterObject {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/GlobalSettingsUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/GlobalSettingsUtils.tsx
@@ -11,12 +11,12 @@
  *  limitations under the License.
  */
 
+import { Badge } from 'antd';
+import { ItemType } from 'antd/lib/menu/hooks/useItems';
 import {
   ResourceEntity,
   UIPermission,
-} from '@components/PermissionProvider/PermissionProvider.interface';
-import { Badge } from 'antd';
-import { ItemType } from 'antd/lib/menu/hooks/useItems';
+} from 'components/PermissionProvider/PermissionProvider.interface';
 import i18next from 'i18next';
 import { camelCase } from 'lodash';
 import React, { ReactNode } from 'react';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/GlossaryUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/GlossaryUtils.ts
@@ -11,17 +11,17 @@
  *  limitations under the License.
  */
 
-import { ModifiedGlossaryData } from '@pages/GlossaryPage/GlossaryPageV1.component';
+import { AxiosError } from 'axios';
+import { t } from 'i18next';
+import { cloneDeep, isEmpty } from 'lodash';
+import { ModifiedGlossaryData } from 'pages/GlossaryPage/GlossaryPageV1.component';
+import { DataNode } from 'rc-tree/lib/interface';
 import {
   getGlossaries,
   getGlossaryTermByFQN,
   getGlossaryTerms,
-} from '@rest/glossaryAPI';
-import { searchData } from '@rest/miscAPI';
-import { AxiosError } from 'axios';
-import { t } from 'i18next';
-import { cloneDeep, isEmpty } from 'lodash';
-import { DataNode } from 'rc-tree/lib/interface';
+} from 'rest/glossaryAPI';
+import { searchData } from 'rest/miscAPI';
 import {
   FQN_SEPARATOR_CHAR,
   WILD_CARD_CHAR,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/PermissionsUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/PermissionsUtils.ts
@@ -15,7 +15,7 @@ import {
   OperationPermission,
   ResourceEntity,
   UIPermission,
-} from '@components/PermissionProvider/PermissionProvider.interface';
+} from 'components/PermissionProvider/PermissionProvider.interface';
 import AppState from '../AppState';
 import {
   Access,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/RouterUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/RouterUtils.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { ProfilerDashboardTab } from '@components/ProfilerDashboard/profilerDashboard.interface';
+import { ProfilerDashboardTab } from 'components/ProfilerDashboard/profilerDashboard.interface';
 import { isUndefined } from 'lodash';
 import { ServiceTypes } from 'Models';
 import { FQN_SEPARATOR_CHAR } from '../constants/char.constants';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ServiceUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ServiceUtils.tsx
@@ -11,12 +11,11 @@
  *  limitations under the License.
  */
 
+import { AxiosError } from 'axios';
 import {
   OperationPermission,
   ResourceEntity,
-} from '@components/PermissionProvider/PermissionProvider.interface';
-import { getEntityCount } from '@rest/miscAPI';
-import { AxiosError } from 'axios';
+} from 'components/PermissionProvider/PermissionProvider.interface';
 import cryptoRandomString from 'crypto-random-string-with-promisify-polyfill';
 import { t } from 'i18next';
 import {
@@ -26,6 +25,7 @@ import {
   ServiceTypes,
 } from 'Models';
 import React from 'react';
+import { getEntityCount } from 'rest/miscAPI';
 import { GlobalSettingOptions } from '../constants/GlobalSettings.constants';
 import {
   addDBTIngestionGuide,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TableProfilerUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TableProfilerUtils.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { MetricChartType } from '@components/ProfilerDashboard/profilerDashboard.interface';
+import { MetricChartType } from 'components/ProfilerDashboard/profilerDashboard.interface';
 import { findLast, sortBy } from 'lodash';
 import { SystemProfile } from '../generated/api/data/createTableProfile';
 import { TableProfile } from '../generated/entity/data/table';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TagsUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TagsUtils.ts
@@ -11,14 +11,14 @@
  *  limitations under the License.
  */
 
+import { AxiosError } from 'axios';
+import { isEmpty } from 'lodash';
+import { Bucket, EntityTags, TagOption } from 'Models';
 import {
   getAllClassifications,
   getClassificationByName,
   getTags,
-} from '@rest/tagAPI';
-import { AxiosError } from 'axios';
-import { isEmpty } from 'lodash';
-import { Bucket, EntityTags, TagOption } from 'Models';
+} from 'rest/tagAPI';
 import { TAG_VIEW_CAP } from '../constants/constants';
 import { SettledStatus } from '../enums/axios.enum';
 import { Classification } from '../generated/entity/classification/classification';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TasksUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TasksUtils.ts
@@ -11,22 +11,22 @@
  *  limitations under the License.
  */
 
+import { AxiosError } from 'axios';
+import { Change, diffWordsWithSpace } from 'diff';
+import i18Next from 'i18next';
+import { isEqual, isUndefined } from 'lodash';
 import {
   EntityData,
   Option,
   TaskAction,
   TaskActionMode,
-} from '@pages/TasksPage/TasksPage.interface';
-import { getDashboardByFqn } from '@rest/dashboardAPI';
-import { getUserSuggestions } from '@rest/miscAPI';
-import { getMlModelByFQN } from '@rest/mlModelAPI';
-import { getPipelineByFqn } from '@rest/pipelineAPI';
-import { getTableDetailsByFQN } from '@rest/tableAPI';
-import { getTopicByFqn } from '@rest/topicsAPI';
-import { AxiosError } from 'axios';
-import { Change, diffWordsWithSpace } from 'diff';
-import i18Next from 'i18next';
-import { isEqual, isUndefined } from 'lodash';
+} from 'pages/TasksPage/TasksPage.interface';
+import { getDashboardByFqn } from 'rest/dashboardAPI';
+import { getUserSuggestions } from 'rest/miscAPI';
+import { getMlModelByFQN } from 'rest/mlModelAPI';
+import { getPipelineByFqn } from 'rest/pipelineAPI';
+import { getTableDetailsByFQN } from 'rest/tableAPI';
+import { getTopicByFqn } from 'rest/topicsAPI';
 import {
   getDatabaseDetailsPath,
   getDatabaseSchemaDetailsPath,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TopicDetailsUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TopicDetailsUtils.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { TopicConfigObjectInterface } from '@components/TopicDetails/TopicDetails.interface';
+import { TopicConfigObjectInterface } from 'components/TopicDetails/TopicDetails.interface';
 import { t } from 'i18next';
 import { TabSpecificField } from '../enums/entity.enum';
 import { Topic } from '../generated/entity/data/topic';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/UserDataUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/UserDataUtils.ts
@@ -11,17 +11,17 @@
  *  limitations under the License.
  */
 
-import { OidcUser } from '@components/authentication/auth-provider/AuthProvider.interface';
+import { AxiosError } from 'axios';
+import { OidcUser } from 'components/authentication/auth-provider/AuthProvider.interface';
+import { isEqual, isUndefined } from 'lodash';
+import { SearchedUsersAndTeams } from 'Models';
 import {
   getSearchedTeams,
   getSearchedUsers,
   getSuggestedTeams,
   getSuggestedUsers,
-} from '@rest/miscAPI';
-import { getUserById, getUserByName, getUsers } from '@rest/userAPI';
-import { AxiosError } from 'axios';
-import { isEqual, isUndefined } from 'lodash';
-import { SearchedUsersAndTeams } from 'Models';
+} from 'rest/miscAPI';
+import { getUserById, getUserByName, getUsers } from 'rest/userAPI';
 import AppState from '../AppState';
 import { WILD_CARD_CHAR } from '../constants/char.constants';
 import { SettledStatus } from '../enums/axios.enum';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/WebAnalyticsUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/WebAnalyticsUtils.ts
@@ -16,9 +16,9 @@ import {
   removeSession,
   setSession,
 } from '@analytics/session-utils';
-import { WebPageData } from '@components/WebAnalytics/WebAnalytics.interface';
-import { postPageView } from '@rest/WebAnalyticsAPI';
 import Analytics, { AnalyticsInstance } from 'analytics';
+import { WebPageData } from 'components/WebAnalytics/WebAnalytics.interface';
+import { postPageView } from 'rest/WebAnalyticsAPI';
 import {
   WebAnalyticEventData,
   WebAnalyticEventType,

--- a/openmetadata-ui/src/main/resources/ui/tsconfig.json
+++ b/openmetadata-ui/src/main/resources/ui/tsconfig.json
@@ -3,11 +3,6 @@
     "outDir": "./build",
     "rootDir": "./src",
     "baseUrl": "./src",
-    "paths": {
-      "@rest/*": ["rest/*"],
-      "@components/*": ["components/*"],
-      "@pages/*": ["pages/*"]
-    },
     "typeRoots": ["./src/@types", "./node_modules/@types"],
     "incremental": true,
     "target": "ES5",

--- a/openmetadata-ui/src/main/resources/ui/webpack.config.dev.js
+++ b/openmetadata-ui/src/main/resources/ui/webpack.config.dev.js
@@ -19,6 +19,7 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 const WebpackBar = require('webpackbar');
 const webpack = require('webpack');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 
 const outputPath = path.join(__dirname, 'build');
 
@@ -173,11 +174,7 @@ module.exports = {
       fs: false,
       url: require.resolve('url/'),
     },
-    alias: {
-      '@rest': path.resolve(__dirname, 'src/rest'),
-      '@components': path.resolve(__dirname, 'src/components'),
-      '@pages': path.resolve(__dirname, 'src/pages'),
-    },
+    plugins: [new TsconfigPathsPlugin()],
   },
 
   plugins: [

--- a/openmetadata-ui/src/main/resources/ui/webpack.config.prod.js
+++ b/openmetadata-ui/src/main/resources/ui/webpack.config.prod.js
@@ -20,6 +20,7 @@ const webpack = require('webpack');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const BundleAnalyzerPlugin =
   require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 
 const outputPath = path.join(__dirname, 'dist/assets');
 
@@ -174,11 +175,7 @@ module.exports = {
       fs: false,
       url: require.resolve('url/'),
     },
-    alias: {
-      '@rest': path.resolve(__dirname, 'src/rest'),
-      '@components': path.resolve(__dirname, 'src/components'),
-      '@pages': path.resolve(__dirname, 'src/pages'),
-    },
+    plugins: [new TsconfigPathsPlugin()],
   },
 
   plugins: [

--- a/openmetadata-ui/src/main/resources/ui/yarn.lock
+++ b/openmetadata-ui/src/main/resources/ui/yarn.lock
@@ -6757,7 +6757,7 @@ enhanced-resolve@^4.0.0:
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
-enhanced-resolve@^5.9.2:
+enhanced-resolve@^5.7.0, enhanced-resolve@^5.9.2:
   version "5.12.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz#300e1c90228f5b570c4d35babf263f6da7155634"
   integrity sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==
@@ -9546,7 +9546,7 @@ json2mq@^0.2.0:
   dependencies:
     string-convert "^0.2.0"
 
-json5@2.x, json5@^2.1.2, json5@^2.2.1:
+json5@2.x, json5@^2.1.2, json5@^2.2.1, json5@^2.2.2:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
@@ -14068,6 +14068,24 @@ ts-morph@^15.0.0:
   dependencies:
     "@ts-morph/common" "~0.16.0"
     code-block-writer "^11.0.0"
+
+tsconfig-paths-webpack-plugin@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.0.0.tgz#84008fc3e3e0658fdb0262758b07b4da6265ff1a"
+  integrity sha512-fw/7265mIWukrSHd0i+wSwx64kYUSAKPfxRDksjKIYTxSAp9W9/xcZVBF4Kl0eqQd5eBpAQ/oQrc5RyM/0c1GQ==
+  dependencies:
+    chalk "^4.1.0"
+    enhanced-resolve "^5.7.0"
+    tsconfig-paths "^4.0.0"
+
+tsconfig-paths@^4.0.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-4.1.2.tgz#4819f861eef82e6da52fb4af1e8c930a39ed979a"
+  integrity sha512-uhxiMgnXQp1IR622dUXI+9Ehnws7i/y6xvpZB9IbUVOPy0muvdvgXeZOn88UcGPiT98Vp3rJPTa8bFoalZ3Qhw==
+  dependencies:
+    json5 "^2.2.2"
+    minimist "^1.2.6"
+    strip-bom "^3.0.0"
 
 tsconfig@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION

### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on Organizing imports from baseURL with tsconfig-paths-webpack-plugin.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] Improvement


#
### Frontend Preview (Screenshots) :


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
