### PR TITLE
Fixed: Enabled skipped unit test and deprecated svgUtils.tsx

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DashboardDetails/DashboardDetails.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DashboardDetails/DashboardDetails.test.tsx
@@ -18,6 +18,8 @@ import {
   fireEvent,
   render,
 } from '@testing-library/react';
+import { mockGlossaryList } from 'mocks/Glossary.mock';
+import { mockTagList } from 'mocks/Tags.mock';
 import { TagOption } from 'Models';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
@@ -62,6 +64,7 @@ const DashboardDetailsProps = {
       chartType: 'Area',
       displayName: 'Test chart',
       id: '1',
+      deleted: false,
     },
   ] as ChartType[],
   serviceType: '',
@@ -111,56 +114,6 @@ const DashboardDetailsProps = {
 
 const mockObserve = jest.fn();
 const mockunObserve = jest.fn();
-
-const mockTagList = [
-  {
-    id: 'tagCatId1',
-    name: 'TagCat1',
-    description: '',
-    children: [
-      {
-        id: 'tagId1',
-        name: 'Tag1',
-        fullyQualifiedName: 'TagCat1.Tag1',
-        description: '',
-        deprecated: false,
-        deleted: false,
-      },
-    ],
-  },
-  {
-    id: 'tagCatId2',
-    name: 'TagCat2',
-    description: '',
-    children: [
-      {
-        id: 'tagId2',
-        name: 'Tag2',
-        fullyQualifiedName: 'TagCat2.Tag2',
-        description: '',
-        deprecated: false,
-        deleted: false,
-      },
-    ],
-  },
-];
-
-const mockGlossaryList = [
-  {
-    name: 'Tag1',
-    displayName: 'Tag1',
-    fullyQualifiedName: 'Glossary.Tag1',
-    type: 'glossaryTerm',
-    id: 'glossaryTagId1',
-  },
-  {
-    name: 'Tag2',
-    displayName: 'Tag2',
-    fullyQualifiedName: 'Glossary.Tag2',
-    type: 'glossaryTerm',
-    id: 'glossaryTagId2',
-  },
-];
 
 window.IntersectionObserver = jest.fn().mockImplementation(() => ({
   observe: mockObserve,
@@ -239,6 +192,9 @@ jest.mock('../../utils/GlossaryUtils', () => ({
 
 jest.mock('../../utils/TagsUtils', () => ({
   getClassifications: jest.fn(() => Promise.resolve({ data: mockTagList })),
+  getTaglist: jest.fn(() =>
+    Promise.resolve(['PersonalData.Personal', 'PersonalData.SpecialCategory'])
+  ),
 }));
 
 describe('Test DashboardDetails component', () => {
@@ -330,7 +286,7 @@ describe('Test DashboardDetails component', () => {
     expect(mockObserve).toHaveBeenCalled();
   });
 
-  it.skip('Check if tags and glossary-terms are present', async () => {
+  it('Check if tags and glossary-terms are present', async () => {
     const { getByTestId, findByText } = render(
       <DashboardDetails {...DashboardDetailsProps} />,
       {
@@ -339,19 +295,18 @@ describe('Test DashboardDetails component', () => {
     );
 
     const tagWrapper = getByTestId('tags-wrapper');
-    fireEvent.click(
-      tagWrapper,
-      new MouseEvent('click', { bubbles: true, cancelable: true })
-    );
+    await act(async () => {
+      fireEvent.click(tagWrapper);
+    });
 
-    const tag1 = await findByText('TagCat1.Tag1');
+    const tag1 = await findByText('PersonalData.Personal');
     const glossaryTerm1 = await findByText('Glossary.Tag1');
 
     expect(tag1).toBeInTheDocument();
     expect(glossaryTerm1).toBeInTheDocument();
   });
 
-  it.skip('Check if only tags are present', async () => {
+  it('Check if only tags are present', async () => {
     (fetchGlossaryTerms as jest.Mock).mockImplementationOnce(() =>
       Promise.reject()
     );
@@ -363,12 +318,11 @@ describe('Test DashboardDetails component', () => {
     );
 
     const tagWrapper = getByTestId('tags-wrapper');
-    fireEvent.click(
-      tagWrapper,
-      new MouseEvent('click', { bubbles: true, cancelable: true })
-    );
+    await act(async () => {
+      fireEvent.click(tagWrapper);
+    });
 
-    const tag1 = await findByText('TagCat1.Tag1');
+    const tag1 = await findByText('PersonalData.Personal');
     const glossaryTerm1 = queryByText('Glossary.Tag1');
 
     expect(tag1).toBeInTheDocument();

--- a/openmetadata-ui/src/main/resources/ui/src/mocks/Glossary.mock.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/mocks/Glossary.mock.ts
@@ -84,3 +84,20 @@ export const mockedGlossaries = [
     version: 0.1,
   },
 ];
+
+export const mockGlossaryList = [
+  {
+    name: 'Tag1',
+    displayName: 'Tag1',
+    fullyQualifiedName: 'Glossary.Tag1',
+    type: 'glossaryTerm',
+    id: 'glossaryTagId1',
+  },
+  {
+    name: 'Tag2',
+    displayName: 'Tag2',
+    fullyQualifiedName: 'Glossary.Tag2',
+    type: 'glossaryTerm',
+    id: 'glossaryTagId2',
+  },
+];

--- a/openmetadata-ui/src/main/resources/ui/src/mocks/Tags.mock.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/mocks/Tags.mock.ts
@@ -1,0 +1,28 @@
+/*
+ *  Copyright 2023 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+export const mockTagList = [
+  {
+    id: 'e649c601-44d3-449d-bc04-fbbaf83baf19',
+    name: 'PersonalData',
+    fullyQualifiedName: 'PersonalData',
+    description: 'description',
+    version: 0.1,
+    updatedAt: 1672922279939,
+    updatedBy: 'admin',
+    href: 'http://localhost:8585/api/v1/classifications/e649c601-44d3-449d-bc04-fbbaf83baf19',
+    deleted: false,
+    provider: 'system',
+    mutuallyExclusive: true,
+  },
+];

--- a/openmetadata-ui/src/main/resources/ui/src/utils/SvgUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/SvgUtils.tsx
@@ -403,6 +403,11 @@ export const Icons = {
   DRAG: 'drag',
 };
 
+/**
+ * @deprecated SVGIcons is deprecated, Please use SVG image as ReactComponent wherever it is required
+ * e.g import { ReactComponent as Icon } from '<PATH_NAME>';
+ */
+
 const SVGIcons: FunctionComponent<Props> = ({ icon, ...props }: Props) => {
   let IconComponent;
   switch (icon) {


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
- Deprecated SvgUtils.tsx file
- Fixed skip unit test 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement


#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
