### PR TITLE
Fixed UI: Add owner for glossary is not showing option on initial open  #9602

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/GlossaryDetails/GlossaryDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/GlossaryDetails/GlossaryDetails.component.tsx
@@ -122,10 +122,6 @@ const GlossaryDetails = ({ permissions, glossary, updateGlossary }: props) => {
     setIsDescriptionEditable(false);
   };
 
-  const handleSelectOwnerDropdown = () => {
-    setListVisible((visible) => !visible);
-  };
-
   const getOwnerSearch = useCallback(
     (searchQuery = WILD_CARD_CHAR, from = 1) => {
       setIsUserLoading(true);
@@ -143,7 +139,17 @@ const GlossaryDetails = ({ permissions, glossary, updateGlossary }: props) => {
     },
     [setListOwners, setIsUserLoading]
   );
+  const handleSelectOwnerDropdown = () => {
+    setListVisible((visible) => {
+      const newState = !visible;
 
+      if (newState) {
+        getOwnerSearch();
+      }
+
+      return newState;
+    });
+  };
   const getOwnerSuggestion = useCallback(
     (qSearchText = '') => {
       setIsUserLoading(true);


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
UI: Add owner for glossary is not showing option on initial open
Closes #9602 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :


https://user-images.githubusercontent.com/71748675/211994334-cc523e94-ad77-4e1d-8ee7-1c1c3c4e0fdd.mov


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
