### PR TITLE
fix(ui): search dropdown options case changing issue

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchUtils.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchUtils.test.tsx
@@ -14,9 +14,12 @@
 import { SearchDropdownOption } from 'components/SearchDropdown/SearchDropdown.interface';
 import {
   getSearchDropdownLabels,
+  getSearchLabel,
   getSelectedOptionLabelString,
 } from './AdvancedSearchUtils';
 import {
+  highlightedItemLabel,
+  mockItemLabel,
   mockLongOptionsArray,
   mockOptionsArray,
   mockShortOptionsArray,
@@ -69,5 +72,23 @@ describe('AdvancedSearchUtils tests', () => {
     );
 
     expect(resultOptionsString).toBe('');
+  });
+
+  it('Function getSearchLabel should return string with highlighted substring for matched searchKey', () => {
+    const resultSearchLabel = getSearchLabel(mockItemLabel, 'wa');
+
+    expect(resultSearchLabel).toBe(highlightedItemLabel);
+  });
+
+  it('Function getSearchLabel should return original string if searchKey is not matched', () => {
+    const resultSearchLabel = getSearchLabel(mockItemLabel, 'wo');
+
+    expect(resultSearchLabel).toBe(mockItemLabel);
+  });
+
+  it('Function getSearchLabel should return original string if searchKey is passed as an empty string', () => {
+    const resultSearchLabel = getSearchLabel(mockItemLabel, '');
+
+    expect(resultSearchLabel).toBe(mockItemLabel);
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchUtils.tsx
@@ -143,11 +143,15 @@ export const renderAdvanceSearchButtons: RenderSettings['renderButton'] = (
   return <></>;
 };
 
-const getSearchLabel = (itemLabel: string, searchKey: string) => {
+export const getSearchLabel = (itemLabel: string, searchKey: string) => {
   const regex = new RegExp(searchKey, 'gi');
-  const result = itemLabel.replace(regex, `<mark>${searchKey}</mark>`);
+  if (searchKey) {
+    const result = itemLabel.replace(regex, (match) => `<mark>${match}</mark>`);
 
-  return result;
+    return result;
+  } else {
+    return itemLabel;
+  }
 };
 
 export const getSearchDropdownLabels = (

--- a/openmetadata-ui/src/main/resources/ui/src/utils/mocks/AdvancedSearchUtils.mock.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/mocks/AdvancedSearchUtils.mock.ts
@@ -29,3 +29,8 @@ export const mockLongOptionsArray = [
   { key: 'string3', label: 'string3' },
   { key: 'string4', label: 'string4' },
 ];
+
+export const mockItemLabel = 'Aaron Warren and Aaron Warner';
+
+export const highlightedItemLabel =
+  'Aaron <mark>Wa</mark>rren and Aaron <mark>Wa</mark>rner';


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the issue where highlighted characters' cases were not proper in options for 'Search Dropdowns'.
Takes care of one issue in #9535 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement

#
### Frontend Preview (Screenshots) :
<p align="center">

Before:
<img width="252" alt="Screenshot 2023-01-16 at 7 50 04 PM" src="https://user-images.githubusercontent.com/51777795/212703579-1226104c-3fd8-47b5-9df5-8cfca7a99c9e.png">
<img width="239" alt="Screenshot 2023-01-16 at 7 50 20 PM" src="https://user-images.githubusercontent.com/51777795/212703589-acea7783-4611-45c3-897b-d44ed82f3586.png">

After:
<img width="229" alt="Screenshot 2023-01-16 at 8 07 44 PM" src="https://user-images.githubusercontent.com/51777795/212703490-e78dcd80-40ee-43f2-b8e2-fdf4c978359e.png">
<img width="233" alt="Screenshot 2023-01-16 at 8 07 52 PM" src="https://user-images.githubusercontent.com/51777795/212703499-7d468813-c4e3-4c85-be63-0c3dfd3d318c.png">

</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @open-metadata/ui 
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
