### PR TITLE
UI : Fix the non-selected card color while search in Explore page

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/Explore.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/Explore.component.tsx
@@ -333,7 +333,7 @@ const Explore: React.FC<ExploreProps> = ({
                       onChangePage(Number.parseInt(value));
                     }
                   }}
-                  selectedEntityName={entityDetails?.details.name || ''}
+                  selectedEntityId={entityDetails?.details.id || ''}
                   totalValue={searchResults?.hits.total.value ?? 0}
                 />
               ) : (

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/table-data-card-v2/TableDataCardV2.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/table-data-card-v2/TableDataCardV2.test.tsx
@@ -48,6 +48,7 @@ describe('Test TableDataCard Component', () => {
         id="1"
         searchIndex={SearchIndex.TABLE}
         source={{
+          id: '1',
           name: 'Name1',
         }}
       />,
@@ -65,6 +66,7 @@ describe('Test TableDataCard Component', () => {
         id="1"
         searchIndex={SearchIndex.TABLE}
         source={{
+          id: '2',
           name: 'Name2',
           deleted: true,
         }}

--- a/openmetadata-ui/src/main/resources/ui/src/components/searched-data/SearchedData.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/searched-data/SearchedData.interface.ts
@@ -47,6 +47,7 @@ export type SourceType = (
       Fields
     >
 ) & {
+  id: string;
   tier?: string | Pick<TagLabel, 'tagFQN'>;
   tags?: string[] | TagLabel[];
   owner?: Partial<
@@ -59,7 +60,7 @@ export type SourceType = (
 
 export interface SearchedDataProps {
   children?: ReactNode;
-  selectedEntityName: string;
+  selectedEntityId: string;
   data: SearchHitBody<ExploreSearchIndex, SourceType>[];
   currentPage: number;
   isLoading?: boolean;

--- a/openmetadata-ui/src/main/resources/ui/src/components/searched-data/SearchedData.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/searched-data/SearchedData.test.tsx
@@ -27,6 +27,7 @@ const mockData: SearchedDataProps['data'] = [
   {
     _index: SearchIndex.TABLE,
     _source: {
+      id: '1',
       name: 'name1',
       description: 'description1',
       fullyQualifiedName: 'fullyQualifiedName1',
@@ -42,6 +43,7 @@ const mockData: SearchedDataProps['data'] = [
   {
     _index: SearchIndex.TABLE,
     _source: {
+      id: '2',
       name: 'name2',
       description: 'description2',
       fullyQualifiedName: 'fullyQualifiedName2',
@@ -53,6 +55,7 @@ const mockData: SearchedDataProps['data'] = [
   {
     _index: SearchIndex.TABLE,
     _source: {
+      id: '3',
       name: 'name3',
       description: 'description3',
       fullyQualifiedName: 'fullyQualifiedName3',
@@ -94,7 +97,7 @@ describe('Test SearchedData Component', () => {
         data={mockData}
         handleSummaryPanelDisplay={mockHandleSummaryPanelDisplay}
         paginate={mockPaginate}
-        selectedEntityName="name1"
+        selectedEntityId="name1"
         totalValue={10}
       />,
       {
@@ -116,7 +119,7 @@ describe('Test SearchedData Component', () => {
         data={mockData}
         handleSummaryPanelDisplay={mockHandleSummaryPanelDisplay}
         paginate={mockPaginate}
-        selectedEntityName="name1"
+        selectedEntityId="name1"
         totalValue={10}
       />,
       {
@@ -138,7 +141,7 @@ describe('Test SearchedData Component', () => {
         data={mockData}
         handleSummaryPanelDisplay={mockHandleSummaryPanelDisplay}
         paginate={mockPaginate}
-        selectedEntityName="name1"
+        selectedEntityId="name1"
         totalValue={10}>
         <p>hello world</p>
       </SearchedData>,
@@ -159,7 +162,7 @@ describe('Test SearchedData Component', () => {
         data={mockData}
         handleSummaryPanelDisplay={mockHandleSummaryPanelDisplay}
         paginate={mockPaginate}
-        selectedEntityName="name1"
+        selectedEntityId="name1"
         totalValue={11}>
         <p>hello world</p>
       </SearchedData>,
@@ -181,7 +184,7 @@ describe('Test SearchedData Component', () => {
         data={[]}
         handleSummaryPanelDisplay={mockHandleSummaryPanelDisplay}
         paginate={mockPaginate}
-        selectedEntityName="name1"
+        selectedEntityId="name1"
         totalValue={0}
       />,
       {
@@ -201,7 +204,7 @@ describe('Test SearchedData Component', () => {
         data={[]}
         handleSummaryPanelDisplay={mockHandleSummaryPanelDisplay}
         paginate={mockPaginate}
-        selectedEntityName="name1"
+        selectedEntityId="name1"
         totalValue={0}
       />,
       {

--- a/openmetadata-ui/src/main/resources/ui/src/components/searched-data/SearchedData.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/searched-data/SearchedData.tsx
@@ -46,7 +46,7 @@ const SearchedData: React.FC<SearchedDataProps> = ({
   isFilterSelected,
   isSummaryPanelVisible,
   searchText,
-  selectedEntityName,
+  selectedEntityId,
   handleSummaryPanelDisplay,
 }) => {
   const highlightSearchResult = () => {
@@ -94,7 +94,7 @@ const SearchedData: React.FC<SearchedDataProps> = ({
         <div className="tw-mb-3" key={index}>
           <TableDataCardV2
             className={classNames(
-              name === selectedEntityName && isSummaryPanelVisible
+              table.id === selectedEntityId && isSummaryPanelVisible
                 ? 'highlight-card'
                 : ''
             )}


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
- Issue :  https://github.com/open-metadata/OpenMetadata/issues/9535#issue-1512549001
- Fix the non-selected card color while search in Explore page
#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/66266464/212725537-45cb1df5-d927-4fae-a6bb-326e790cac06.png">

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
