### PR TITLE
UI : Fix the count in Data Insights page on Tier

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/DataInsightProgressBar.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/DataInsightProgressBar.test.tsx
@@ -1,0 +1,72 @@
+/*
+ *  Copyright 2022 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { act } from 'react-test-renderer';
+import DataInsightProgressBar from './DataInsightProgressBar';
+
+jest.mock('./ChangeInValueIndicator', () => {
+  return jest.fn().mockReturnValue(<p>ChangeInValueIndicator</p>);
+});
+
+const MOCK_DATA = {
+  changeInValue: -0.32000000000000006,
+  className: 'm-b-md',
+  duration: 30,
+  label: undefined,
+  progress: 99.66,
+  showEndValueAsLabel: true,
+  showLabel: false,
+  showSuccessInfo: false,
+  startValue: undefined,
+  successValue: 'No Tier',
+  suffix: '%',
+  target: 55.00000000000001,
+  width: 100,
+};
+
+describe('Test DataInsightProgressBar Component', () => {
+  it('Should render the ProgressBar Component', async () => {
+    await act(async () => {
+      render(<DataInsightProgressBar {...MOCK_DATA} />, {
+        wrapper: MemoryRouter,
+      });
+    });
+
+    const progressBarContainer = screen.getByTestId('progress-bar-container');
+
+    expect(progressBarContainer).toBeInTheDocument();
+  });
+
+  it('render value pass into component', async () => {
+    await act(async () => {
+      render(<DataInsightProgressBar {...MOCK_DATA} />, {
+        wrapper: MemoryRouter,
+      });
+    });
+
+    const progressBarContainer = screen.getByTestId('progress-bar-container');
+
+    expect(progressBarContainer).toBeInTheDocument();
+
+    const progressBarLabel = screen.getByTestId('progress-bar-label');
+    const progressBarValue = screen.getByTestId('progress-bar-value');
+
+    expect(progressBarLabel).toBeInTheDocument();
+    expect(progressBarValue).toBeInTheDocument();
+    expect(progressBarLabel).toHaveTextContent('No Tier');
+    expect(progressBarValue).toHaveTextContent('99.66%');
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/DataInsightProgressBar.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/DataInsightProgressBar.tsx
@@ -53,7 +53,10 @@ const DataInsightProgressBar = ({
   const { t } = useTranslation();
 
   return (
-    <div className={classNames(className)} style={{ width }}>
+    <div
+      className={classNames(className)}
+      data-testid="progress-bar-container"
+      style={{ width }}>
       {showLabel && (
         <Typography.Paragraph className="data-insight-label-text">
           {label ?? t('label.latest')}
@@ -64,7 +67,7 @@ const DataInsightProgressBar = ({
           className="data-insight-progress-bar"
           format={(per) => (
             <>
-              <span>
+              <span data-testid="progress-bar-value">
                 {startValue ?? per}
                 {suffix}
               </span>
@@ -78,7 +81,7 @@ const DataInsightProgressBar = ({
                   </span>
                 </span>
               )}
-              <span>
+              <span data-testid="progress-bar-label">
                 {successValue}
                 {showEndValueAsLabel ? '' : suffix}
               </span>

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/TierInsight.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataInsightDetail/TierInsight.tsx
@@ -202,7 +202,7 @@ const TierInsight: FC<Props> = ({ chartFilter, selectedDays }) => {
                       showEndValueAsLabel
                       progress={latestData[tiers]}
                       showLabel={false}
-                      startValue={Number(latestData[tiers]).toFixed(2)}
+                      startValue={Number(latestData[tiers] || 0).toFixed(2)}
                       successValue={TIER_DATA[tiers as keyof typeof TIER_DATA]}
                     />
                   </Col>


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
- Issue : https://github.com/open-metadata/OpenMetadata/issues/9535#issue-1512549001
- Fix the count in Data Insights page on Tier

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/66266464/212735159-b6e39a19-5def-4713-9f4e-a8c3acd266de.png">


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
 @open-metadata/ui 
