### PR TITLE
fix(ui): disabled profiler calls for deleted tables for summary panel details

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/TableSummary/TableSummary.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/TableSummary/TableSummary.component.tsx
@@ -53,6 +53,8 @@ function TableSummary({ entityDetails }: TableSummaryProps) {
     results: INITIAL_TEST_RESULT_SUMMARY,
   });
 
+  const isTableDeleted = useMemo(() => entityDetails.deleted, [entityDetails]);
+
   const fetchAllTests = async () => {
     try {
       const { data } = await getListTestCase({
@@ -174,7 +176,7 @@ function TableSummary({ entityDetails }: TableSummaryProps) {
     if (!isEmpty(entityDetails)) {
       setTableDetails(entityDetails);
       fetchAllTests();
-      fetchProfilerData();
+      !isTableDeleted && fetchProfilerData();
     }
   }, [entityDetails]);
 


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on disabling profiler API calls for deleted tables for summary panel details to eliminate errors thrown.
closes #9768 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<p align="center">
Before:

https://user-images.githubusercontent.com/51777795/212962017-814ba6e8-9e8c-401d-af0e-c86e0cfcd696.mov

After:

https://user-images.githubusercontent.com/51777795/212962045-e54872b4-8f0c-4901-94f8-d604b6e3bd36.mov


</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @open-metadata/ui 
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
