### PR TITLE
fix(#9775): UI - Teams owner can only be another user not another team

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/cypress/common/common.js
+++ b/openmetadata-ui/src/main/resources/ui/cypress/common/common.js
@@ -805,7 +805,7 @@ export const deleteCreatedProperty = (propertyName) => {
     .should('be.visible');
 };
 
-export const updateOwner = () => {
+export const updateOwner = (isAddingOwnerToTeam = false) => {
   cy.get('[data-testid="avatar"]').should('be.visible').click();
   cy.get('[data-testid="user-name"]')
     .should('exist')
@@ -822,12 +822,14 @@ export const updateOwner = () => {
 
       verifyResponseStatusCode('@getTeams', 200);
 
-      // Clicking on users tab
-      cy.get('button[data-testid="dropdown-tab"]')
-        .should('exist')
-        .should('be.visible')
-        .contains('Users')
-        .click();
+      if (!isAddingOwnerToTeam) {
+        // Clicking on users tab
+        cy.get('button[data-testid="dropdown-tab"]')
+          .should('exist')
+          .should('be.visible')
+          .contains('Users')
+          .click();
+      }
 
       cy.get('[data-testid="list-item"]')
         .first()

--- a/openmetadata-ui/src/main/resources/ui/cypress/e2e/Pages/Teams.spec.js
+++ b/openmetadata-ui/src/main/resources/ui/cypress/e2e/Pages/Teams.spec.js
@@ -74,7 +74,7 @@ describe('Teams flow should work properly', () => {
     cy.get(`[data-row-key="${TEAM_DETAILS.name}"]`)
       .contains(TEAM_DETAILS.name)
       .click();
-    updateOwner();
+    updateOwner(true);
   });
 
   it('Add user to created team', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/TeamDetails/TeamDetailsV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TeamDetails/TeamDetailsV1.tsx
@@ -1119,6 +1119,7 @@ const TeamDetailsV1 = ({
             {extraInfo.map((info, index) => (
               <Fragment key={uniqueId()}>
                 <EntitySummaryDetails
+                  allowTeamOwner={false}
                   currentOwner={currentTeam.owner}
                   data={info}
                   isGroupType={isGroupType}

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/EntitySummaryDetails/EntitySummaryDetails.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/EntitySummaryDetails/EntitySummaryDetails.tsx
@@ -45,6 +45,7 @@ export interface GetInfoElementsProps {
   currentOwner?: Dashboard['owner'];
   removeTier?: () => void;
   deleted?: boolean;
+  allowTeamOwner?: boolean;
 }
 
 const EditIcon = ({ iconClasses }: { iconClasses?: string }): JSX.Element => (
@@ -80,6 +81,7 @@ const EntitySummaryDetails = ({
   removeTier,
   currentOwner,
   deleted = false,
+  allowTeamOwner = true,
 }: GetInfoElementsProps) => {
   let retVal = <></>;
   const { t } = useTranslation();
@@ -360,6 +362,7 @@ const EntitySummaryDetails = ({
         </>
       )}
       <OwnerWidgetWrapper
+        allowTeamOwner={allowTeamOwner}
         currentUser={currentOwner}
         hideWidget={() => setShow(false)}
         removeOwner={removeOwner}

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/OwnerWidget/OwnerWidgetWrapper.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/OwnerWidget/OwnerWidgetWrapper.component.tsx
@@ -204,9 +204,9 @@ const OwnerWidgetWrapper = ({
     }
   }, [searchText]);
 
-  const getOwnerGroup = () => {
+  const ownerGroupList = useMemo(() => {
     return allowTeamOwner ? ['Teams', 'Users'] : ['Users'];
-  };
+  }, [allowTeamOwner]);
 
   const handleSearchOwnerDropdown = (text: string) => {
     setSearchText(text);
@@ -237,9 +237,9 @@ const OwnerWidgetWrapper = ({
       controlledSearchStr={searchText}
       dropDownList={listOwners}
       getTotalCountForGroup={handleTotalCountForGroup}
-      groupType="tab"
+      groupType={ownerGroupList.length > 1 ? 'tab' : 'label'}
       isLoading={isUserLoading}
-      listGroups={getOwnerGroup()}
+      listGroups={ownerGroupList}
       removeOwner={handleRemoveOwner}
       showSearchBar={isCurrentUserAdmin()}
       value={owner?.id || ''}


### PR DESCRIPTION
Fixes #9775 

### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on issue #9775 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] Improvement


#
### Frontend Preview (Screenshots) :


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
