### PR TITLE
Fix #8884 & #9460 - View lineage happens in the lineage workflow

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/common_db_source.py
+++ b/ingestion/src/metadata/ingestion/source/database/common_db_source.py
@@ -27,7 +27,6 @@ from metadata.generated.schema.api.data.createDatabaseSchema import (
     CreateDatabaseSchemaRequest,
 )
 from metadata.generated.schema.api.data.createTable import CreateTableRequest
-from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
 from metadata.generated.schema.entity.data.table import Table, TablePartition, TableType
 from metadata.generated.schema.entity.services.connections.metadata.openMetadataConnection import (
     OpenMetadataConnection,
@@ -39,11 +38,6 @@ from metadata.generated.schema.metadataIngestion.workflow import (
     Source as WorkflowSource,
 )
 from metadata.generated.schema.type.entityReference import EntityReference
-from metadata.ingestion.lineage.parser import LineageParser
-from metadata.ingestion.lineage.sql_lineage import (
-    get_lineage_by_query,
-    get_lineage_via_table_entity,
-)
 from metadata.ingestion.models.ometa_classification import OMetaTagAndClassification
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.connections import get_connection, get_test_connection_fn

--- a/ingestion/src/metadata/ingestion/source/database/common_db_source.py
+++ b/ingestion/src/metadata/ingestion/source/database/common_db_source.py
@@ -96,7 +96,6 @@ class CommonDbSourceService(
         self._connection = None  # Lazy init as well
         self.table_constraints = None
         self.database_source_state = set()
-        self.context.table_views = []
         super().__init__()
 
     def set_inspector(self, database_name: str) -> None:
@@ -373,7 +372,6 @@ class CommonDbSourceService(
                     "schema_name": schema_name,
                     "db_name": db_name,
                 }
-                self.context.table_views.append(table_view)
 
             yield table_request
             self.register_record(table_request=table_request)

--- a/ingestion/src/metadata/ingestion/source/database/common_db_source.py
+++ b/ingestion/src/metadata/ingestion/source/database/common_db_source.py
@@ -65,7 +65,6 @@ class TableNameAndType(BaseModel):
     type_: TableType = TableType.Regular
 
 
-# pylint: disable=too-many-public-methods
 class CommonDbSourceService(
     DatabaseServiceSource, SqlColumnHandlerMixin, SqlAlchemySource, ABC
 ):
@@ -364,14 +363,6 @@ class CommonDbSourceService(
             if is_partitioned:
                 table_request.tableType = TableType.Partitioned.value
                 table_request.tablePartition = partition_details
-
-            if table_type == TableType.View or view_definition:
-                table_view = {
-                    "table_name": table_name,
-                    "table_type": table_type,
-                    "schema_name": schema_name,
-                    "db_name": db_name,
-                }
 
             yield table_request
             self.register_record(table_request=table_request)

--- a/ingestion/src/metadata/ingestion/source/database/database_service.py
+++ b/ingestion/src/metadata/ingestion/source/database/database_service.py
@@ -23,7 +23,6 @@ from metadata.generated.schema.api.data.createDatabaseSchema import (
 )
 from metadata.generated.schema.api.data.createLocation import CreateLocationRequest
 from metadata.generated.schema.api.data.createTable import CreateTableRequest
-from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
 from metadata.generated.schema.api.services.createStorageService import (
     CreateStorageServiceRequest,
 )

--- a/ingestion/src/metadata/ingestion/source/database/database_service.py
+++ b/ingestion/src/metadata/ingestion/source/database/database_service.py
@@ -119,9 +119,6 @@ class DatabaseServiceTopology(ServiceTopology):
             ),
         ],
         children=["database"],
-        post_process=[
-            "yield_view_lineage",
-        ],
     )
     database = TopologyNode(
         producer="get_database_names",
@@ -301,13 +298,6 @@ class DatabaseServiceSource(
         """
         if self.source_config.includeTags:
             yield from self.yield_tag(schema_name) or []
-
-    @abstractmethod
-    def yield_view_lineage(self) -> Optional[Iterable[AddLineageRequest]]:
-        """
-        From topology.
-        Parses view definition to get lineage information
-        """
 
     @abstractmethod
     def yield_table(

--- a/ingestion/src/metadata/ingestion/source/database/datalake/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/datalake/metadata.py
@@ -20,7 +20,6 @@ from metadata.generated.schema.api.data.createDatabaseSchema import (
     CreateDatabaseSchemaRequest,
 )
 from metadata.generated.schema.api.data.createTable import CreateTableRequest
-from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
 from metadata.generated.schema.entity.data.databaseSchema import DatabaseSchema
 from metadata.generated.schema.entity.data.table import (
     Column,

--- a/ingestion/src/metadata/ingestion/source/database/datalake/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/datalake/metadata.py
@@ -567,9 +567,6 @@ class DatalakeSource(DatabaseServiceSource):  # pylint: disable=too-many-public-
 
         return cols
 
-    def yield_view_lineage(self) -> Optional[Iterable[AddLineageRequest]]:
-        yield from []
-
     def yield_tag(self, schema_name: str) -> Iterable[OMetaTagAndClassification]:
         pass
 

--- a/ingestion/src/metadata/ingestion/source/database/deltalake/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/deltalake/metadata.py
@@ -395,9 +395,6 @@ class DeltalakeSource(DatabaseServiceSource):
 
         return parsed_columns
 
-    def yield_view_lineage(self) -> Optional[Iterable[AddLineageRequest]]:
-        yield from []
-
     def yield_tag(self, schema_name: str) -> Iterable[OMetaTagAndClassification]:
         pass
 

--- a/ingestion/src/metadata/ingestion/source/database/deltalake/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/deltalake/metadata.py
@@ -23,7 +23,6 @@ from metadata.generated.schema.api.data.createDatabaseSchema import (
     CreateDatabaseSchemaRequest,
 )
 from metadata.generated.schema.api.data.createTable import CreateTableRequest
-from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
 from metadata.generated.schema.entity.data.databaseSchema import DatabaseSchema
 from metadata.generated.schema.entity.data.table import Column, Table, TableType
 from metadata.generated.schema.entity.services.connections.database.deltaLakeConnection import (

--- a/ingestion/src/metadata/ingestion/source/database/domodatabase/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/domodatabase/metadata.py
@@ -22,7 +22,6 @@ from metadata.generated.schema.api.data.createDatabaseSchema import (
     CreateDatabaseSchemaRequest,
 )
 from metadata.generated.schema.api.data.createTable import CreateTableRequest
-from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
 from metadata.generated.schema.entity.data.table import Column, Table, TableType
 from metadata.generated.schema.entity.services.connections.database.domoDatabaseConnection import (
     DomoDatabaseConnection,

--- a/ingestion/src/metadata/ingestion/source/database/domodatabase/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/domodatabase/metadata.py
@@ -190,9 +190,6 @@ class DomodatabaseSource(DatabaseServiceSource):
     def yield_tag(self, schema_name: str) -> Iterable[OMetaTagAndClassification]:
         pass
 
-    def yield_view_lineage(self) -> Optional[Iterable[AddLineageRequest]]:
-        yield from []
-
     def standardize_table_name(  # pylint: disable=unused-argument
         self, schema: str, table: str
     ) -> str:

--- a/ingestion/src/metadata/ingestion/source/database/dynamodb/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/dynamodb/metadata.py
@@ -20,7 +20,6 @@ from metadata.generated.schema.api.data.createDatabaseSchema import (
     CreateDatabaseSchemaRequest,
 )
 from metadata.generated.schema.api.data.createTable import CreateTableRequest
-from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
 from metadata.generated.schema.entity.data.table import Column, Table, TableType
 from metadata.generated.schema.entity.services.connections.database.dynamoDBConnection import (
     DynamoDBConnection,

--- a/ingestion/src/metadata/ingestion/source/database/dynamodb/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/dynamodb/metadata.py
@@ -214,9 +214,6 @@ class DynamodbSource(DatabaseServiceSource):
             logger.warning(f"Unexpected exception to yield table [{table_name}]: {exc}")
             self.status.failures.append(f"{self.config.serviceName}.{table_name}")
 
-    def yield_view_lineage(self) -> Optional[Iterable[AddLineageRequest]]:
-        yield from []
-
     def yield_tag(self, schema_name: str) -> Iterable[OMetaTagAndClassification]:
         pass
 

--- a/ingestion/src/metadata/ingestion/source/database/glue/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/glue/metadata.py
@@ -20,7 +20,6 @@ from metadata.generated.schema.api.data.createDatabaseSchema import (
 )
 from metadata.generated.schema.api.data.createLocation import CreateLocationRequest
 from metadata.generated.schema.api.data.createTable import CreateTableRequest
-from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
 from metadata.generated.schema.entity.data.database import Database
 from metadata.generated.schema.entity.data.databaseSchema import DatabaseSchema
 from metadata.generated.schema.entity.data.location import Location, LocationType

--- a/ingestion/src/metadata/ingestion/source/database/glue/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/glue/metadata.py
@@ -373,9 +373,6 @@ class GlueSource(DatabaseServiceSource):
     def standardize_table_name(self, _: str, table: str) -> str:
         return table[:128]
 
-    def yield_view_lineage(self) -> Optional[Iterable[AddLineageRequest]]:
-        yield from []
-
     def yield_tag(self, schema_name: str) -> Iterable[OMetaTagAndClassification]:
         pass
 

--- a/ingestion/src/metadata/ingestion/source/database/lineage_source.py
+++ b/ingestion/src/metadata/ingestion/source/database/lineage_source.py
@@ -149,10 +149,7 @@ class LineageSource(QueryParserSource, ABC):
         for table_entity in self.get_all_tables_from_api():
             # We only pick up views whose viewDefinition is informed
             if (
-                (
-                    table_entity.tableType == TableType.View
-                    or table_entity.tableType == TableType.MaterializedView
-                )
+                table_entity.tableType in {TableType.View, TableType.MaterializedView}
                 and table_entity.viewDefinition
                 and table_entity.viewDefinition.__root__
             ):

--- a/ingestion/src/metadata/ingestion/source/database/lineage_source.py
+++ b/ingestion/src/metadata/ingestion/source/database/lineage_source.py
@@ -17,8 +17,14 @@ from abc import ABC
 from typing import Iterable, Iterator, Optional
 
 from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
+from metadata.generated.schema.entity.data.database import Database
+from metadata.generated.schema.entity.data.table import Table, TableType
 from metadata.generated.schema.type.tableQuery import TableQuery
-from metadata.ingestion.lineage.sql_lineage import get_lineage_by_query
+from metadata.ingestion.lineage.parser import LineageParser
+from metadata.ingestion.lineage.sql_lineage import (
+    get_lineage_by_query,
+    get_lineage_via_table_entity,
+)
 from metadata.ingestion.source.connections import get_connection
 from metadata.ingestion.source.database.query_parser_source import QueryParserSource
 from metadata.utils.logger import ingestion_logger
@@ -88,11 +94,39 @@ class LineageSource(QueryParserSource, ABC):
                 logger.debug(traceback.format_exc())
                 logger.error(f"Source usage processing error: {exc}")
 
-    def next_record(self) -> Iterable[AddLineageRequest]:
+    def get_database_fqns(self):
         """
-        Based on the query logs, prepare the lineage
-        and send it to the sink
+        List all service databases
         """
+        return [
+            database.fullyQualifiedName.__root__
+            for database in self.metadata.list_all_entities(
+                entity=Database,
+                params={"service": self.config.serviceName},
+            )
+        ]
+
+    def get_all_tables_from_api(self) -> Iterable[Table]:
+        """
+        Get all the views from the API with their viewDefinition
+        """
+        for database_fqn in self.get_database_fqns():
+            logger.info(f"Getting view lineage from {database_fqn}")
+            yield from self.metadata.list_all_entities(
+                entity=Table,
+                fields=[
+                    "viewDefinition",
+                ],
+                params={"service": self.config.serviceName, "database": database_fqn},
+            )
+
+    def yield_table_query(self):
+        """
+        Basic generator getting lineage from
+        table queries that we pick up from the
+        service database
+        """
+        logger.info("Processing query history lineage...")
         for table_query in self.get_table_query():
 
             lineages = get_lineage_by_query(
@@ -105,3 +139,57 @@ class LineageSource(QueryParserSource, ABC):
 
             for lineage_request in lineages or []:
                 yield lineage_request
+
+    def yield_view_ddl(self):
+        """
+        Obtain the tables' viewDefinition to pick
+        up the lineage from its DDL
+        """
+        logger.info("Processing view lineage...")
+        for table_entity in self.get_all_tables_from_api():
+            # We only pick up views whose viewDefinition is informed
+            if (
+                (
+                    table_entity.tableType == TableType.View
+                    or table_entity.tableType == TableType.MaterializedView
+                )
+                and table_entity.viewDefinition
+                and table_entity.viewDefinition.__root__
+            ):
+
+                try:
+
+                    lineage_parser = LineageParser(table_entity.viewDefinition.__root__)
+                    if lineage_parser.source_tables and lineage_parser.target_tables:
+                        yield from get_lineage_by_query(
+                            self.metadata,
+                            query=table_entity.viewDefinition.__root__,
+                            service_name=self.config.serviceName,
+                            database_name=table_entity.database.name,
+                            schema_name=table_entity.databaseSchema.name,
+                        ) or []
+
+                    else:
+                        yield from get_lineage_via_table_entity(
+                            self.metadata,
+                            table_entity=table_entity,
+                            service_name=self.config.serviceName,
+                            database_name=table_entity.database.name,
+                            schema_name=table_entity.databaseSchema.name,
+                            query=table_entity.viewDefinition.__root__,
+                        ) or []
+
+                except Exception as exc:
+                    logger.debug(traceback.format_exc())
+                    logger.warning(
+                        f"Could not parse query [{table_entity.viewDefinition.__root__}]."
+                        f" Ingesting lineage failed due to: {exc}"
+                    )
+
+    def next_record(self) -> Iterable[AddLineageRequest]:
+        """
+        Based on the query logs, prepare the lineage
+        and send it to the sink
+        """
+        yield from self.yield_table_query()
+        yield from self.yield_view_ddl()

--- a/ingestion/src/metadata/ingestion/source/database/salesforce/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/salesforce/metadata.py
@@ -19,7 +19,6 @@ from metadata.generated.schema.api.data.createDatabaseSchema import (
     CreateDatabaseSchemaRequest,
 )
 from metadata.generated.schema.api.data.createTable import CreateTableRequest
-from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
 from metadata.generated.schema.entity.data.table import (
     Column,
     Constraint,

--- a/ingestion/src/metadata/ingestion/source/database/salesforce/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/salesforce/metadata.py
@@ -247,9 +247,6 @@ class SalesforceSource(DatabaseServiceSource):
             return "INT"
         return "VARCHAR"
 
-    def yield_view_lineage(self) -> Optional[Iterable[AddLineageRequest]]:
-        yield from []
-
     def yield_tag(self, schema_name: str) -> Iterable[OMetaTagAndClassification]:
         pass
 


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Fix #8884
Fix #9460 

Moved the View Lineage from the metadata ingestion to the lineage workflow. Reasons:
1. We centralize lineage processing in a single place. Makes it easier to debug. The lineage was a `post_processing` at the service level anyway as it required ALL the metadata to be available.
2. There was a bug where we picked up the view definition (twice) and using the latest inspector instead of the one for each database. This simplifies the logic as we just get the tables from the API.

Further work: It would be interesting to add a query parameter for `tableType` when listing tables in the API to only fetch views in these scenarios.

#8884 also listed moving dbt lineage to the lineage workflow. The reason not to is to maintain all the catalog and manifest information when processing the lineage. Whenever we jump to grabbing lineage in cases where `A -> TMP -> B` for non-materialized models we might need the catalog nodes. If, after revisiting the dbt lineage for non-materialized models, we see that we have all the required information just in the API, then we can move it to the lineage workflow, but I would not jump to that before properly analyzing the situation.

Thanks


#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
