### PR TITLE
Deduplicate stl_querytext rows, fixes #8867

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/redshift/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/redshift/queries.py
@@ -32,8 +32,10 @@ REDSHIFT_SQL_STATEMENT = textwrap.dedent(
           LIMIT {result_limit}
   ),
   deduped_querytext AS ( -- In some instances, rows are duplicated, causing LISTAGG to fail due to exceeding the maximum str length of 65535.
-    SELECT DISTINCT *
-    FROM pg_catalog.stl_querytext
+    SELECT DISTINCT qt.*
+    FROM pg_catalog.stl_querytext AS qt
+        INNER JOIN queries AS q
+            ON qt.query = q.query
   ),
   full_queries AS (
     SELECT

--- a/ingestion/src/metadata/ingestion/source/database/redshift/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/redshift/queries.py
@@ -31,7 +31,8 @@ REDSHIFT_SQL_STATEMENT = textwrap.dedent(
           AND starttime < '{end_time}'
           LIMIT {result_limit}
   ),
-  deduped_querytext AS ( -- In some instances, rows are duplicated, causing LISTAGG to fail due to exceeding the maximum str length of 65535.
+  deduped_querytext AS (
+    -- Sometimes rows are duplicated, causing LISTAGG to fail in the full_queries CTE.
     SELECT DISTINCT qt.*
     FROM pg_catalog.stl_querytext AS qt
         INNER JOIN queries AS q


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the #8867 issue because we have the same issue in our deployment

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
Ingestion: @open-metadata/ingestion
