### PR TITLE
fix(ui): topic entity summary panel not showing schema fields

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/TopicSummary/TopicSummary.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/TopicSummary/TopicSummary.component.tsx
@@ -12,7 +12,7 @@
  */
 
 import { Col, Divider, Row, Typography } from 'antd';
-import { isArray } from 'lodash';
+import { isArray, isEmpty } from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getTopicByFqn } from 'rest/topicsAPI';
@@ -62,9 +62,9 @@ function TopicSummary({ entityDetails }: TopicSummaryProps) {
         ''
       );
 
-      const { partitions } = res;
+      const { partitions, messageSchema } = res;
 
-      setTopicDetails({ ...entityDetails, partitions });
+      setTopicDetails({ ...entityDetails, partitions, messageSchema });
     } catch {
       showErrorToast(
         t('server.entity-details-fetch-error', {
@@ -126,9 +126,7 @@ function TopicSummary({ entityDetails }: TopicSummaryProps) {
           </Typography.Text>
         </Col>
         <Col span={24}>
-          {entityDetails.messageSchema?.schemaFields ? (
-            <SummaryList formattedEntityData={formattedSchemaFieldsData} />
-          ) : (
+          {isEmpty(topicDetails.messageSchema?.schemaFields) ? (
             <div className="m-y-md">
               <Typography.Text
                 className="text-gray"
@@ -136,6 +134,8 @@ function TopicSummary({ entityDetails }: TopicSummaryProps) {
                 {t('message.no-data-available')}
               </Typography.Text>
             </div>
+          ) : (
+            <SummaryList formattedEntityData={formattedSchemaFieldsData} />
           )}
         </Col>
       </Row>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/TopicSummary/TopicSummary.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/TopicSummary/TopicSummary.test.tsx
@@ -14,7 +14,10 @@
 import { act, render, screen } from '@testing-library/react';
 import React from 'react';
 import { getTopicByFqn } from 'rest/topicsAPI';
-import { mockTopicEntityDetails } from '../mocks/TopicSummary.mock';
+import {
+  mockTopicByFqnResponse,
+  mockTopicEntityDetails,
+} from '../mocks/TopicSummary.mock';
 import TopicSummary from './TopicSummary.component';
 
 jest.mock(
@@ -34,7 +37,7 @@ jest.mock('../SummaryList/SummaryList.component', () =>
 );
 
 jest.mock('rest/topicsAPI', () => ({
-  getTopicByFqn: jest.fn().mockImplementation(() => ({ partitions: 128 })),
+  getTopicByFqn: jest.fn().mockImplementation(() => mockTopicByFqnResponse),
 }));
 
 describe('TopicSummary component tests', () => {
@@ -76,19 +79,11 @@ describe('TopicSummary component tests', () => {
     expect(summaryList).toBeInTheDocument();
   });
 
-  it('No data message should be shown in case not schemaFields are available in topic details', async () => {
+  it('No data message should be shown in case no schemaFields are available in topic details', async () => {
+    (getTopicByFqn as jest.Mock).mockImplementation(() => Promise.resolve({}));
+
     await act(async () => {
-      render(
-        <TopicSummary
-          entityDetails={{
-            ...mockTopicEntityDetails,
-            messageSchema: {
-              ...mockTopicEntityDetails.messageSchema,
-              schemaFields: undefined,
-            },
-          }}
-        />
-      );
+      render(<TopicSummary entityDetails={mockTopicEntityDetails} />);
     });
 
     const summaryList = screen.queryByTestId('SummaryList');

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/mocks/TopicSummary.mock.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/mocks/TopicSummary.mock.ts
@@ -38,6 +38,17 @@ export const mockTopicEntityDetails: Topic = {
     deleted: false,
     href: 'http://openmetadata-server:8585/api/v1/services/messagingServices/5d6f73f0-1811-49c8-8d1d-7a478ffd8177',
   },
+  partitions: 0,
+  cleanupPolicies: [CleanupPolicy.Delete],
+  replicationFactor: 4,
+  maximumMessageSize: 208,
+  retentionSize: 1068320655,
+  tags: [],
+  followers: [],
+};
+
+export const mockTopicByFqnResponse = {
+  partitions: 128,
   messageSchema: {
     schemaText:
       '{"namespace":"openmetadata.kafka","type":"record","name":"Product","fields":[{"name":"product_id","type":"int"}]}',
@@ -90,11 +101,4 @@ export const mockTopicEntityDetails: Topic = {
       },
     ],
   },
-  partitions: 0,
-  cleanupPolicies: [CleanupPolicy.Delete],
-  replicationFactor: 4,
-  maximumMessageSize: 208,
-  retentionSize: 1068320655,
-  tags: [],
-  followers: [],
 };


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on fixing the issue with the topic entity summary panel not showing schema fields

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<p align="center">

https://user-images.githubusercontent.com/51777795/214218132-51a6b792-8483-4dc0-9841-0541691c7648.mov


</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @open-metadata/ui 
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
