### PR TITLE
fix: start date should be less than end date on KPI page

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/KPIPage/AddKPIPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/KPIPage/AddKPIPage.tsx
@@ -26,11 +26,13 @@ import {
   Space,
   Typography,
 } from 'antd';
+import { useForm } from 'antd/lib/form/Form';
 import { AxiosError } from 'axios';
 import RichTextEditor from 'components/common/rich-text-editor/RichTextEditor';
 import TitleBreadcrumb from 'components/common/title-breadcrumb/title-breadcrumb.component';
 import { t } from 'i18next';
 import { isUndefined, kebabCase } from 'lodash';
+import moment from 'moment';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
@@ -38,7 +40,6 @@ import { getListDataInsightCharts } from 'rest/DataInsightAPI';
 import { getListKPIs, postKPI } from 'rest/KpiAPI';
 import { ROUTES } from '../../constants/constants';
 import {
-  KPI_DATES,
   KPI_DATE_PICKER_FORMAT,
   SUPPORTED_CHARTS_FOR_KPI,
   VALIDATE_MESSAGES,
@@ -55,14 +56,12 @@ import {
 } from '../../generated/dataInsight/dataInsightChart';
 import { DataInsightChartType } from '../../generated/dataInsight/dataInsightChartResult';
 import { Kpi } from '../../generated/dataInsight/kpi/kpi';
-import { KpiDate, KpiDates } from '../../interface/data-insight.interface';
 import {
   getDisabledDates,
-  getKPIFormattedDates,
   getKpiTargetValueByMetricType,
 } from '../../utils/DataInsightUtils';
-import { getTimeStampByDateTime } from '../../utils/TimeUtils';
 import { showErrorToast } from '../../utils/ToastUtils';
+import { KPIFormValues } from './KPIPage.interface';
 import './KPIPage.less';
 
 const { Option } = Select;
@@ -86,6 +85,8 @@ const breadcrumb = [
 const AddKPIPage = () => {
   const { t } = useTranslation();
   const history = useHistory();
+  const [form] = useForm<KPIFormValues>();
+
   const [dataInsightCharts, setDataInsightCharts] = useState<
     DataInsightChart[]
   >([]);
@@ -94,7 +95,6 @@ const AddKPIPage = () => {
   const [selectedMetric, setSelectedMetric] = useState<ChartParameterValues>();
   const [metricValue, setMetricValue] = useState<number>(0);
   const [isCreatingKPI, setIsCreatingKPI] = useState<boolean>(false);
-  const [kpiDates, setKpiDates] = useState<KpiDates>(KPI_DATES);
   const [kpiList, setKpiList] = useState<Array<Kpi>>([]);
 
   const metricTypes = useMemo(
@@ -157,15 +157,35 @@ const AddKPIPage = () => {
 
   const handleCancel = () => history.goBack();
 
-  const handleDateChange = (dateString: string, key: KpiDate) => {
-    setKpiDates((previous) => ({ ...previous, [key]: dateString }));
+  const handleFormValuesChange = (
+    changedValues: Partial<KPIFormValues>,
+    allValues: KPIFormValues
+  ) => {
+    if (changedValues.startDate) {
+      const startDate = moment(changedValues.startDate).startOf('day');
+      form.setFieldsValue({ startDate });
+      if (changedValues.startDate > allValues.endDate) {
+        form.setFieldsValue({
+          endDate: '',
+        });
+      }
+    }
+
+    if (changedValues.endDate) {
+      let endDate = moment(changedValues.endDate).endOf('day');
+      form.setFieldsValue({ endDate });
+      if (changedValues.endDate < allValues.startDate) {
+        endDate = moment(changedValues.endDate).startOf('day');
+        form.setFieldsValue({
+          startDate: endDate,
+        });
+      }
+    }
   };
 
   const handleSubmit: FormProps['onFinish'] = async (values) => {
-    const formattedDates = getKPIFormattedDates(kpiDates);
-
-    const startDate = getTimeStampByDateTime(formattedDates.startDate);
-    const endDate = getTimeStampByDateTime(formattedDates.endDate);
+    const startDate = values.startDate.valueOf();
+    const endDate = values.endDate.valueOf();
     const metricType =
       selectedMetric?.chartDataType as unknown as KpiTargetType;
 
@@ -218,10 +238,12 @@ const AddKPIPage = () => {
           </Typography.Paragraph>
           <Form
             data-testid="kpi-form"
+            form={form}
             id="kpi-form"
             layout="vertical"
             validateMessages={VALIDATE_MESSAGES}
-            onFinish={handleSubmit}>
+            onFinish={handleSubmit}
+            onValuesChange={handleFormValuesChange}>
             <Form.Item
               label={t('label.select-a-chart')}
               name="dataInsightChart"
@@ -370,9 +392,6 @@ const AddKPIPage = () => {
                     data-testid="start-date"
                     disabledDate={getDisabledDates}
                     format={KPI_DATE_PICKER_FORMAT}
-                    onChange={(_, dateString) =>
-                      handleDateChange(dateString, KpiDate.START_DATE)
-                    }
                   />
                 </Form.Item>
               </Col>
@@ -394,9 +413,6 @@ const AddKPIPage = () => {
                     data-testid="end-date"
                     disabledDate={getDisabledDates}
                     format={KPI_DATE_PICKER_FORMAT}
-                    onChange={(_, dateString) =>
-                      handleDateChange(dateString, KpiDate.END_DATE)
-                    }
                   />
                 </Form.Item>
               </Col>

--- a/openmetadata-ui/src/main/resources/ui/src/pages/KPIPage/KPIPage.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/KPIPage/KPIPage.interface.ts
@@ -1,0 +1,20 @@
+/*
+ *  Copyright 2023 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+export interface KPIFormValues {
+  dataInsightChart: string;
+  displayName: string;
+  metricType: string;
+  metricValue: number;
+  endDate: moment.Moment;
+  startDate: moment.Moment;
+}


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the 
issues of Data insight page mentioned in #9819 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

![image](https://user-images.githubusercontent.com/33024356/214221534-a59f5888-cc23-485a-b81b-a90e43beca14.png)


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @open-metadata/ui 
