### PR TITLE
ui: entity summary panel improvements

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/SummaryList/SummaryList.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/SummaryList/SummaryList.interface.ts
@@ -15,7 +15,11 @@ import { ReactNode } from 'react';
 import { SummaryEntityType } from '../../../../enums/EntitySummary.enum';
 import { ChartType } from '../../../../generated/entity/data/chart';
 import { FeatureType } from '../../../../generated/entity/data/mlmodel';
-import { Constraint, DataType } from '../../../../generated/entity/data/table';
+import {
+  Constraint,
+  DataType,
+  TableConstraint,
+} from '../../../../generated/entity/data/table';
 import { TagLabel } from '../../../../generated/type/tagLabel';
 
 export interface BasicEntityInfo {
@@ -25,7 +29,8 @@ export interface BasicEntityInfo {
   type?: DataType | ChartType | FeatureType | string;
   tags?: TagLabel[];
   description?: string;
-  constraint?: Constraint;
+  columnConstraint?: Constraint;
+  tableConstraints?: TableConstraint[];
   children?: BasicEntityInfo[];
 }
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/SummaryList/SummaryListItems/SummaryListItems.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/SummaryList/SummaryListItems/SummaryListItems.component.tsx
@@ -37,8 +37,8 @@ function SummaryListItem({
           {isColumnsData &&
             prepareConstraintIcon(
               entityDetails.name,
-              entityDetails.constraint,
-              undefined,
+              entityDetails.columnConstraint,
+              entityDetails.tableConstraints,
               'm-r-xss',
               '14px'
             )}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/TableSummary/TableSummary.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/TableSummary/TableSummary.component.tsx
@@ -47,7 +47,7 @@ import { BasicTableInfo, TableSummaryProps } from './TableSummary.interface';
 
 function TableSummary({ entityDetails }: TableSummaryProps) {
   const { t } = useTranslation();
-  const [TableDetails, setTableDetails] = useState<Table>(entityDetails);
+  const [tableDetails, setTableDetails] = useState<Table>(entityDetails);
   const [tableTests, setTableTests] = useState<TableTestsType>({
     tests: [],
     results: INITIAL_TEST_RESULT_SUMMARY,
@@ -116,27 +116,27 @@ function TableSummary({ entityDetails }: TableSummaryProps) {
   };
 
   const overallSummary: OverallTableSummeryType[] | undefined = useMemo(() => {
-    if (isUndefined(TableDetails.profile)) {
+    if (isUndefined(tableDetails.profile)) {
       return undefined;
     }
 
     return [
       {
         title: t('label.row-count'),
-        value: formatNumberWithComma(TableDetails?.profile?.rowCount ?? 0),
+        value: formatNumberWithComma(tableDetails?.profile?.rowCount ?? 0),
       },
       {
         title: t('label.column-entity', {
           entity: t('label.count'),
         }),
         value:
-          TableDetails?.profile?.columnCount ?? entityDetails.columns.length,
+          tableDetails?.profile?.columnCount ?? entityDetails.columns.length,
       },
       {
         title: `${t('label.table-entity-text', {
           entityText: t('label.sample'),
         })} %`,
-        value: `${TableDetails?.profile?.profileSample ?? 100}%`,
+        value: `${tableDetails?.profile?.profileSample ?? 100}%`,
       },
       {
         title: `${t('label.test-plural')} ${t('label.passed')}`,
@@ -154,9 +154,9 @@ function TableSummary({ entityDetails }: TableSummaryProps) {
         className: 'failed',
       },
     ];
-  }, [TableDetails, tableTests]);
+  }, [tableDetails, tableTests]);
 
-  const { tableType, columns, tableQueries } = TableDetails;
+  const { tableType, columns, tableQueries } = tableDetails;
 
   const basicTableInfo: BasicTableInfo = useMemo(
     () => ({
@@ -168,8 +168,13 @@ function TableSummary({ entityDetails }: TableSummaryProps) {
   );
 
   const formattedColumnsData: BasicEntityInfo[] = useMemo(
-    () => getFormattedEntityData(SummaryEntityType.COLUMN, columns),
-    [columns]
+    () =>
+      getFormattedEntityData(
+        SummaryEntityType.COLUMN,
+        columns,
+        tableDetails.tableConstraints
+      ),
+    [columns, tableDetails]
   );
 
   useEffect(() => {
@@ -187,7 +192,7 @@ function TableSummary({ entityDetails }: TableSummaryProps) {
           <TableDataCardTitle
             dataTestId="summary-panel-title"
             searchIndex={SearchIndex.TABLE}
-            source={TableDetails}
+            source={tableDetails}
           />
         </Col>
         <Col span={24}>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/Explore.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/Explore.component.tsx
@@ -227,6 +227,9 @@ const Explore: React.FC<ExploreProps> = ({
         searchResults?.hits?.hits[0]._source as EntityDetailsType,
         tab
       );
+    } else {
+      setShowSummaryPanel(false);
+      setEntityDetails(undefined);
     }
   }, [tab, searchResults]);
 

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntitySummaryPanelUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntitySummaryPanelUtils.tsx
@@ -20,7 +20,7 @@ import { SummaryEntityType } from '../enums/EntitySummary.enum';
 import { Chart } from '../generated/entity/data/chart';
 import { MlFeature } from '../generated/entity/data/mlmodel';
 import { Task } from '../generated/entity/data/pipeline';
-import { Column } from '../generated/entity/data/table';
+import { Column, TableConstraint } from '../generated/entity/data/table';
 import { Field } from '../generated/entity/data/topic';
 import { getEntityName } from './CommonUtils';
 import SVGIcons from './SvgUtils';
@@ -29,7 +29,8 @@ const { Text } = Typography;
 
 export const getFormattedEntityData = (
   entityType: SummaryEntityType,
-  entityInfo?: Column[] | Field[] | Chart[] | Task[] | MlFeature[]
+  entityInfo?: Column[] | Field[] | Chart[] | Task[] | MlFeature[],
+  tableConstraints?: TableConstraint[]
 ): BasicEntityInfo[] => {
   if (isEmpty(entityInfo)) {
     return [];
@@ -42,7 +43,8 @@ export const getFormattedEntityData = (
         type: column.dataType,
         tags: column.tags,
         description: column.description,
-        constraint: column.constraint,
+        columnConstraint: column.constraint,
+        tableConstraints: tableConstraints,
         children: getFormattedEntityData(
           SummaryEntityType.COLUMN,
           column.children

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntitySummaryPanelUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntitySummaryPanelUtils.tsx
@@ -29,7 +29,7 @@ const { Text } = Typography;
 
 export const getFormattedEntityData = (
   entityType: SummaryEntityType,
-  entityInfo?: Column[] | Field[] | Chart[] | Task[] | MlFeature[],
+  entityInfo?: Array<Column | Field | Chart | Task | MlFeature>,
   tableConstraints?: TableConstraint[]
 ): BasicEntityInfo[] => {
   if (isEmpty(entityInfo)) {


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->

- [x] Fixed the bug where table constraints were not displaying in the entity summary panel
- [x] Fixed the bug with summary panel not hiding in case of no results are present

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<p align="center">

**Constraint Icons:**
**Before:**
<img width="400" alt="Screenshot 2023-01-25 at 8 08 27 PM" src="https://user-images.githubusercontent.com/51777795/214592162-e6127b8a-18fb-4c24-80e8-f9d005ab66fa.png">

**After:**
<img width="398" alt="Screenshot 2023-01-25 at 8 08 50 PM" src="https://user-images.githubusercontent.com/51777795/214592198-59b8f90e-0ffa-4fde-82d4-a0e825f14d05.png">

**Summary panel hiding:**

https://user-images.githubusercontent.com/51777795/214601123-d65931c5-cb8c-463b-946a-387f2a792c6d.mov


</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @open-metadata/ui 
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->

