### PR TITLE
Fix: Consider coverage on subprocess in E2E CLI tests

### DIFF
--- a/.github/workflows/py-cli-e2e-tests.yml
+++ b/.github/workflows/py-cli-e2e-tests.yml
@@ -103,7 +103,17 @@ jobs:
         E2E_MSSQL_DATABASE: ${{ secrets.E2E_MSSQL_DATABASE }}
       run: |
         source env/bin/activate
-        coverage run --rcfile ingestion/.coveragerc --data-file .coverage.$E2E_TEST -a --branch -m pytest -c ingestion/setup.cfg --junitxml=ingestion/junit/test-results-$E2E_TEST.xml --ignore=ingestion/tests/unit/source ingestion/tests/cli_e2e/test_cli_$E2E_TEST.py
+        export SITE_CUSTOMIZE_PATH=$(python -c "import site; import os; from pathlib import Path; print(os.path.relpath(site.getsitepackages()[0], str(Path.cwd())))")/sitecustomize.py
+        echo "import os" >> $SITE_CUSTOMIZE_PATH
+        echo "try:" >> $SITE_CUSTOMIZE_PATH
+        echo "    import coverage" >> $SITE_CUSTOMIZE_PATH
+        echo "    os.environ['COVERAGE_PROCESS_START'] = 'ingestion/.coveragerc'" >> $SITE_CUSTOMIZE_PATH
+        echo "    coverage.process_startup()" >> $SITE_CUSTOMIZE_PATH
+        echo "except ImportError:" >> $SITE_CUSTOMIZE_PATH
+        echo "    pass" >> $SITE_CUSTOMIZE_PATH
+        sed -i "5i concurrency = multiprocessing" ingestion/.coveragerc
+        coverage run --rcfile ingestion/.coveragerc -a --branch -m pytest -c ingestion/setup.cfg --junitxml=ingestion/junit/test-results-$E2E_TEST.xml --ignore=ingestion/tests/unit/source ingestion/tests/cli_e2e/test_cli_$E2E_TEST.py
+        coverage combine --data-file=.coverage.$E2E_TEST --rcfile=ingestion/.coveragerc --keep -a .coverage*   
         coverage report --rcfile ingestion/.coveragerc --data-file .coverage.$E2E_TEST || true
 
     - name: Upload coverage artifact for Python tests

--- a/ingestion/tests/cli_e2e/test_cli_db_base.py
+++ b/ingestion/tests/cli_e2e/test_cli_db_base.py
@@ -194,8 +194,9 @@ class CliDBBase(TestCase):
                 "-c",
                 self.test_file_path,
             ]
-            process_status = subprocess.run(args, capture_output=True)
-            return process_status.stderr.decode("utf-8")
+            process_status = subprocess.Popen(args, stderr=subprocess.PIPE)
+            process_status.wait()
+            return process_status.stderr.read().decode("utf-8")
 
         def build_config_file(
             self, test_type: E2EType = E2EType.INGEST, extra_args: dict = None

--- a/ingestion/tests/cli_e2e/test_cli_dbt_base.py
+++ b/ingestion/tests/cli_e2e/test_cli_dbt_base.py
@@ -104,8 +104,9 @@ class CliDBTBase(TestCase):
                 "-c",
                 file_path,
             ]
-            process_status = subprocess.run(args, capture_output=True)
-            return process_status.stderr.decode("utf-8")
+            process_status = subprocess.Popen(args, stderr=subprocess.PIPE)
+            process_status.wait()
+            return process_status.stderr.read().decode("utf-8")
 
         @staticmethod
         def retrieve_statuses(result):


### PR DESCRIPTION
### Describe your changes :
E2E was running tests using a subprocess, and the subprocess was not being considered to measure the coverage.

### Type of change :
- [x] Bug fix

### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

### Reviewers
Ingestion: @open-metadata/ingestion
