### PR TITLE
Fix antlr version when publishing the ingestion package

### DIFF
--- a/.github/workflows/py-ingestion-publish.yml
+++ b/.github/workflows/py-ingestion-publish.yml
@@ -26,12 +26,15 @@ jobs:
           python-version: 3.9
       - name: Install Ubuntu related dependencies
         run: |
-          sudo apt-get install -y libsasl2-dev unixodbc-dev python3-venv antlr4
+          sudo apt-get install -y libsasl2-dev unixodbc-dev python3-venv
       - name: Install and Publish PyPi packages
         env:
           TWINE_USERNAME: '${{ secrets.TWINE_OPENMETADATA_INGESTION_USERNAME }}'
           TWINE_PASSWORD: '${{ secrets.TWINE_OPENMETADATA_INGESTION_PASSWORD }}'
         run: |
+          python3 -m venv env
+          source env/bin/activate
+          sudo make install_antlr_cli
           make install_dev generate install
           cd ingestion; \
             python setup.py install sdist bdist_wheel; \


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->

This was generated properly in the testing CI but not on the publish. Users kept getting `ANTLR runtime and generated code versions disagree: 4.9.2!=4.7.2` as we were not using the right installation recipe

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
