### PR TITLE
fix(ui): ui fixes for search dropdown suggestions API for owner and tag quick filters

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/cypress/common/advancedSearchQuickFilters.js
+++ b/openmetadata-ui/src/main/resources/ui/cypress/common/advancedSearchQuickFilters.js
@@ -11,14 +11,16 @@
  *  limitations under the License.
  */
 
+import { COMMON_DROPDOWN_ITEMS } from '../constants/advancedSearchQuickFilters.constants';
 import { interceptURL, verifyResponseStatusCode } from './common';
 
 export const openFilterDropdown = (asset, filter) => {
-  interceptURL(
-    'GET',
-    `http://localhost:8585/api/v1/search/aggregate?index=${asset.searchIndex}&field=${filter.key}`,
-    'aggregateAPI'
-  );
+  let aggregateAPIURL =
+    filter.key === COMMON_DROPDOWN_ITEMS[0].key
+      ? `/api/v1/search/aggregate?index=${filter.filterSearchIndex}&field=${filter.aggregateKey}`
+      : `/api/v1/search/aggregate?index=${asset.searchIndex}&field=${filter.key}`;
+
+  interceptURL('GET', aggregateAPIURL, 'aggregateAPI');
 
   // Click on desired dropdown
   cy.get(`[data-testid="search-dropdown-${filter.label}"]`)
@@ -37,11 +39,20 @@ export const searchAndClickOnOption = (
   checkedAfterClick
 ) => {
   // Search for filter
+
+  interceptURL(
+    'GET',
+    `/api/v1/search/suggest?*q=${encodeURI(optionName)}*`,
+    'suggestAPI'
+  );
+
   cy.get('[data-testid="search-input"]')
     .should('exist')
     .and('be.visible')
     .clear()
     .type(optionName);
+
+  verifyResponseStatusCode('@suggestAPI', 200);
 
   cy.get(`[data-testid="${optionTestId}"]`)
     .should('exist')

--- a/openmetadata-ui/src/main/resources/ui/cypress/constants/advancedSearchQuickFilters.constants.js
+++ b/openmetadata-ui/src/main/resources/ui/cypress/constants/advancedSearchQuickFilters.constants.js
@@ -17,6 +17,8 @@ export const COMMON_DROPDOWN_ITEMS = [
   {
     label: 'Owner',
     key: 'owner.displayName',
+    aggregateKey: 'displayName.keyword',
+    filterSearchIndex: 'user_search_index%2Cteam_search_index',
     selectOption1: 'admin',
     selectOptionTestId1: 'admin',
     selectOption2: 'Aaron Singh',
@@ -25,6 +27,7 @@ export const COMMON_DROPDOWN_ITEMS = [
   {
     label: 'Tag',
     key: 'tags.tagFQN',
+    filterSearchIndex: 'tag_search_index%2Cglossary_search_index',
     selectOption1: 'PersonalData.Personal',
     selectOptionTestId1: 'PersonalData.Personal',
     selectOption2: 'PII.Sensitive',

--- a/openmetadata-ui/src/main/resources/ui/cypress/e2e/Flow/AdvancedSearchQuickFilters.spec.js
+++ b/openmetadata-ui/src/main/resources/ui/cypress/e2e/Flow/AdvancedSearchQuickFilters.spec.js
@@ -54,7 +54,7 @@ QUICK_FILTERS_BY_ASSETS.map((asset) => {
 
         searchAndClickOnOption(optionName1, optionTestId1, true);
 
-        let querySearchURL = `http://localhost:8585/api/v1/search/query?*index=${
+        let querySearchURL = `/api/v1/search/query?*index=${
           asset.searchIndex
         }*query_filter=*should*${filter.key}*${encodeURI(optionName1)}*`;
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx
@@ -13,6 +13,7 @@
 
 import { Divider, Space } from 'antd';
 import { AxiosError } from 'axios';
+import { SearchIndex } from 'enums/search.enum';
 import { isEqual, isUndefined, uniqWith } from 'lodash';
 import React, { FC, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -22,7 +23,10 @@ import {
   getTagSuggestions,
   getUserSuggestions,
 } from 'rest/miscAPI';
-import { MISC_FIELDS } from '../../constants/AdvancedSearch.constants';
+import {
+  MISC_FIELDS,
+  OWNER_QUICK_FILTER_DEFAULT_OPTIONS_KEY,
+} from '../../constants/AdvancedSearch.constants';
 import {
   getAdvancedField,
   getOptionsObject,
@@ -43,19 +47,34 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
   const [options, setOptions] = useState<SearchDropdownOption[]>();
   const [isOptionsLoading, setIsOptionsLoading] = useState<boolean>(false);
 
+  const fetchDefaultOptions = async (
+    index: SearchIndex | SearchIndex[],
+    key: string
+  ) => {
+    const res = await getAdvancedFieldDefaultOptions(index, key);
+
+    const buckets = res.data.aggregations[`sterms#${key}`].buckets;
+
+    const optionsArray = buckets.map((option) => ({
+      key: option.key,
+      label: option.key,
+    }));
+
+    setOptions(uniqWith(optionsArray, isEqual));
+  };
+
   const getInitialOptions = async (key: string) => {
     setIsOptionsLoading(true);
     setOptions([]);
     try {
-      const res = await getAdvancedFieldDefaultOptions(index, key);
-      const buckets = res.data.aggregations[`sterms#${key}`].buckets;
-
-      const optionsArray = buckets.map((option) => ({
-        key: option.key,
-        label: option.label ?? option.key,
-      }));
-
-      setOptions(uniqWith(optionsArray, isEqual));
+      if (key === MISC_FIELDS[0]) {
+        await fetchDefaultOptions(
+          [SearchIndex.USER, SearchIndex.TEAM],
+          OWNER_QUICK_FILTER_DEFAULT_OPTIONS_KEY
+        );
+      } else {
+        await fetchDefaultOptions(index, key);
+      }
     } catch (error) {
       showErrorToast(error as AxiosError);
     } finally {

--- a/openmetadata-ui/src/main/resources/ui/src/constants/AdvancedSearch.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/AdvancedSearch.constants.ts
@@ -457,3 +457,5 @@ export const getQbConfigs: (searchIndex: SearchIndex) => BasicConfig = (
 };
 
 export const MISC_FIELDS = ['owner.displayName', 'tags.tagFQN'];
+
+export const OWNER_QUICK_FILTER_DEFAULT_OPTIONS_KEY = 'displayName.keyword';

--- a/openmetadata-ui/src/main/resources/ui/src/rest/miscAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/miscAPI.ts
@@ -183,7 +183,7 @@ export const getTeamsByQuery = async (params: {
 export const getTagSuggestions = (term: string) => {
   const params = {
     q: term,
-    index: `${SearchIndex.TAG},${SearchIndex.TAG}`,
+    index: `${SearchIndex.TAG},${SearchIndex.GLOSSARY}`,
   };
 
   return APIClient.get<RawSuggestResponse<SearchIndex.TAG>>(`/search/suggest`, {
@@ -249,7 +249,7 @@ export const getAdvancedFieldOptions = (
 };
 
 export const getAdvancedFieldDefaultOptions = (
-  index: SearchIndex,
+  index: SearchIndex | SearchIndex[],
   field: string
 ) => {
   const params = { index, field };


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on:

- [x] Changing the default suggestion API for owner quick filter dropdown
- [x] Fixing the issue with the tag quick filter dropdown not showing suggestions for glossary terms.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement

#
### Frontend Preview (Screenshots) :
<p align="center">

https://user-images.githubusercontent.com/51777795/215095114-a195bba3-a041-4047-859e-814c378869d7.mov

https://user-images.githubusercontent.com/51777795/215095162-611ba49a-88b4-4001-982a-96dc184264ff.mov

</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @open-metadata/ui 
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->

