### PR TITLE
fix(ui): API errors shown for deleted tables on table details page

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DatasetDetails/DatasetDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DatasetDetails/DatasetDetails.component.tsx
@@ -787,16 +787,23 @@ const DatasetDetails: React.FC<DatasetDetailsProps> = ({
             )}
             {activeTab === 3 && (
               <div className="tab-details-container" id="sampleDataDetails">
-                <SampleDataTable tableId={tableDetails.id} />
+                <SampleDataTable
+                  isTableDeleted={tableDetails.deleted}
+                  tableId={tableDetails.id}
+                />
               </div>
             )}
             {activeTab === 4 && (
               <div className="tab-details-container">
-                <TableQueries tableId={tableDetails.id} />
+                <TableQueries
+                  isTableDeleted={tableDetails.deleted}
+                  tableId={tableDetails.id}
+                />
               </div>
             )}
             {activeTab === 5 && (
               <TableProfilerV1
+                isTableDeleted={tableDetails.deleted}
                 permissions={tablePermissions}
                 tableFqn={tableDetails.fullyQualifiedName || ''}
               />

--- a/openmetadata-ui/src/main/resources/ui/src/components/SampleDataTable/SampleDataTable.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/SampleDataTable/SampleDataTable.component.tsx
@@ -51,10 +51,14 @@ type SampleData = {
 };
 
 interface Props {
+  isTableDeleted?: boolean;
   tableId: string;
 }
 
-const SampleDataTable: FunctionComponent<Props> = ({ tableId }: Props) => {
+const SampleDataTable: FunctionComponent<Props> = ({
+  isTableDeleted,
+  tableId,
+}: Props) => {
   const tableRef = useRef<HTMLDivElement>(null);
   const location = useLocation();
   const [sampleData, setSampleData] = useState<SampleData>();
@@ -123,7 +127,11 @@ const SampleDataTable: FunctionComponent<Props> = ({ tableId }: Props) => {
 
   useEffect(() => {
     setIsLoading(true);
-    if (tableId && !location.pathname.includes(ROUTES.TOUR)) {
+    if (
+      !isTableDeleted &&
+      tableId &&
+      !location.pathname.includes(ROUTES.TOUR)
+    ) {
       fetchSampleData();
     } else {
       setIsLoading(false);

--- a/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/TableProfiler.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/TableProfiler.interface.ts
@@ -25,6 +25,7 @@ import { TestCase } from '../../generated/tests/testCase';
 import { OperationPermission } from '../PermissionProvider/PermissionProvider.interface';
 
 export interface TableProfilerProps {
+  isTableDeleted?: boolean;
   tableFqn: string;
   permissions: OperationPermission;
 }

--- a/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/TableProfilerV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TableProfiler/TableProfilerV1.tsx
@@ -70,7 +70,10 @@ import {
 } from './TableProfiler.interface';
 import './tableProfiler.less';
 
-const TableProfilerV1: FC<TableProfilerProps> = ({ permissions }) => {
+const TableProfilerV1: FC<TableProfilerProps> = ({
+  isTableDeleted,
+  permissions,
+}) => {
   const { t } = useTranslation();
   const { datasetFQN } = useParams<{ datasetFQN: string }>();
   const [table, setTable] = useState<Table>();
@@ -332,7 +335,7 @@ const TableProfilerV1: FC<TableProfilerProps> = ({ permissions }) => {
   }, [table, viewTest]);
 
   useEffect(() => {
-    if (datasetFQN) {
+    if (!isTableDeleted && datasetFQN) {
       fetchLatestProfilerData();
     }
   }, [datasetFQN]);

--- a/openmetadata-ui/src/main/resources/ui/src/components/TableQueries/TableQueries.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TableQueries/TableQueries.tsx
@@ -24,10 +24,14 @@ import Loader from '../Loader/Loader';
 import QueryCard from './QueryCard';
 
 interface TableQueriesProp {
+  isTableDeleted?: boolean;
   tableId: string;
 }
 
-const TableQueries: FC<TableQueriesProp> = ({ tableId }: TableQueriesProp) => {
+const TableQueries: FC<TableQueriesProp> = ({
+  isTableDeleted,
+  tableId,
+}: TableQueriesProp) => {
   const [tableQueries, setTableQueries] = useState<Table['tableQueries']>([]);
   const [isQueriesLoading, setIsQueriesLoading] = useState(true);
 
@@ -44,7 +48,7 @@ const TableQueries: FC<TableQueriesProp> = ({ tableId }: TableQueriesProp) => {
 
   useEffect(() => {
     setIsQueriesLoading(true);
-    if (tableId) {
+    if (tableId && !isTableDeleted) {
       fetchTableQuery();
     } else {
       setIsQueriesLoading(false);

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatasetDetailsPage/DatasetDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatasetDetailsPage/DatasetDetailsPage.component.tsx
@@ -825,7 +825,7 @@ const DatasetDetailsPage: FunctionComponent = () => {
   }, [tablePermissions]);
 
   useEffect(() => {
-    fetchTableProfileDetails();
+    !tableDetails.deleted && fetchTableProfileDetails();
   }, [tableDetails]);
 
   useEffect(() => {


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on fixing API errors shown for deleted tables on table details page

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement

#
### Frontend Preview (Screenshots) :
<p align="center">

**Before:**

https://user-images.githubusercontent.com/51777795/215103547-7deb4b82-d9df-44e4-ba7c-7ebaff8b1397.mov

**After:**

https://user-images.githubusercontent.com/51777795/215103847-18223553-c8de-49d5-a858-e6004d647d86.mov


</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
Frontend: @open-metadata/ui 
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
