### PR TITLE
Bug: Change password of a user without auth mechanism set

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/auth/BasicAuthenticator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/auth/BasicAuthenticator.java
@@ -439,6 +439,11 @@ public class BasicAuthenticator implements AuthenticatorHandler {
   }
 
   public void validatePassword(User storedUser, String reqPassword) throws TemplateException, IOException {
+    // when basic auth is enabled and the user is created through the API without password, the stored auth mechanism
+    // for the user is null
+    if (storedUser.getAuthenticationMechanism() == null) {
+      throw new AuthenticationException(INVALID_USERNAME_PASSWORD);
+    }
     @SuppressWarnings("unchecked")
     LinkedHashMap<String, String> storedData =
         (LinkedHashMap<String, String>) storedUser.getAuthenticationMechanism().getConfig();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/auth/BasicAuthenticator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/auth/BasicAuthenticator.java
@@ -248,6 +248,14 @@ public class BasicAuthenticator implements AuthenticatorHandler {
 
     // Fetch user
     User storedUser = userRepository.getByName(uriInfo, userName, userRepository.getFieldsWithUserAuth("*"));
+
+    // when basic auth is enabled and the user is created through the API without password, the stored auth mechanism
+    // for the user is null
+    if (storedUser.getAuthenticationMechanism() == null) {
+      storedUser.setAuthenticationMechanism(
+          new AuthenticationMechanism().withAuthType(BASIC).withConfig(new BasicAuthMechanism().withPassword("")));
+    }
+
     BasicAuthMechanism storedBasicAuthMechanism =
         JsonUtils.convertValue(storedUser.getAuthenticationMechanism().getConfig(), BasicAuthMechanism.class);
 


### PR DESCRIPTION
### Describe your changes :
When basic auth is enabled and the user is created through the API without a password, the stored auth mechanism is null. This can cause a null pointer exception when changing the user password for the first time.

### Type of change :
- [x] Bug fix

### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

### Reviewers
Ingestion: @open-metadata/ingestion
