### PR TITLE
Added `()$#` to table entityName for oracle metadata

### DIFF
--- a/openmetadata-spec/src/main/resources/json/schema/entity/data/table.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/data/table.json
@@ -15,7 +15,7 @@
       "type": "string",
       "minLength": 1,
       "maxLength": 128,
-      "pattern": "^[\\w'\\- .\\/()$#]+$"
+      "pattern": "^[\\w'\\- .\\/()$]+$"
     },
     "profileSampleType": {
       "description": "Type of Profile Sample (percentage or rows)",
@@ -162,7 +162,7 @@
     "columnName": {
       "description": "Local name (not fully qualified name) of the column. ColumnName is `-` when the column is not named in struct dataType. For example, BigQuery supports struct with unnamed fields.",
       "type": "string",
-      "pattern": "^[\\w'\\-\" .+]+$",
+      "pattern": "^[\\w'\\-\" .+#]+$",
       "minLength": 1,
       "maxLength": 128
     },


### PR DESCRIPTION
### Describe your changes :
Oracle table metadata can contain `$` character and `#` for column names, similarly datalake table can contain `()` character. We add support for these pattern in this PR.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
