### PR TITLE
UI : Fix the add button styling for non admin button

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/Glossary/GlossaryLeftPanel/GlossaryLeftPanel.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/Glossary/GlossaryLeftPanel/GlossaryLeftPanel.component.tsx
@@ -113,10 +113,11 @@ const GlossaryLeftPanel = ({ glossaries }: GlossaryLeftPanelProps) => {
                   : t('message.no-permission-for-action')
               }>
               <Button
-                className="w-full flex-center gap-2 text-primary"
+                block
+                className="text-primary"
                 data-testid="add-glossary"
                 disabled={!createGlossaryPermission}
-                icon={<PlusIcon />}
+                icon={<PlusIcon className="anticon" />}
                 onClick={handleAddGlossaryClick}>
                 {t('label.add-glossary')}
               </Button>

--- a/openmetadata-ui/src/main/resources/ui/src/styles/components/button.less
+++ b/openmetadata-ui/src/main/resources/ui/src/styles/components/button.less
@@ -15,7 +15,8 @@
 button {
   &:disabled {
     cursor: not-allowed;
-    img {
+    img,
+    svg {
       opacity: 0.5;
     }
   }


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
- Fix the add button styling for non admin button

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
<img width="548" alt="image" src="https://user-images.githubusercontent.com/66266464/215404606-785a8fe7-c05e-4d0e-9728-f68877b97ea0.png">
<img width="548" alt="image" src="https://user-images.githubusercontent.com/66266464/215405171-8084e91a-dfe4-4bde-8b30-8e83f068336b.png">


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
