### PR TITLE
Remove profiler support for dynamodb

### DIFF
--- a/ingestion/tests/unit/topology/metadata/test_amundsen.py
+++ b/ingestion/tests/unit/topology/metadata/test_amundsen.py
@@ -149,7 +149,6 @@ EXPECTED_SERVICE = [
                 awsConfig=AWSCredentials(awsRegion="aws_region"),
                 connectionArguments=None,
                 supportsMetadataExtraction=True,
-                supportsProfiler=True,
             )
         ),
         pipelines=None,

--- a/openmetadata-docs/content/connectors/database/dynamodb/airflow.md
+++ b/openmetadata-docs/content/connectors/database/dynamodb/airflow.md
@@ -7,10 +7,10 @@ slug: /connectors/database/dynamodb/airflow
 
 In this section, we provide guides and references to use the DynamoDB connector.
 
-Configure and schedule DynamoDB metadata and profiler workflows from the OpenMetadata UI:
+Configure and schedule DynamoDB metadata workflows from the OpenMetadata UI:
 - [Requirements](#requirements)
 - [Metadata Ingestion](#metadata-ingestion)
-- [dbt Integration](#dbt-integration)
+
 
 ## Requirements
 
@@ -341,7 +341,3 @@ with DAG(
 
 Note that from connector to connector, this recipe will always be the same.
 By updating the YAML configuration, you will be able to extract metadata from different sources.
-
-## dbt Integration
-
-You can learn more about how to ingest dbt models' definitions and their lineage [here](/connectors/ingestion/workflows/dbt).

--- a/openmetadata-docs/content/connectors/database/dynamodb/cli.md
+++ b/openmetadata-docs/content/connectors/database/dynamodb/cli.md
@@ -7,10 +7,9 @@ slug: /connectors/database/dynamodb/cli
 
 In this section, we provide guides and references to use the DynamoDB connector.
 
-Configure and schedule DynamoDB metadata and profiler workflows from the OpenMetadata UI:
+Configure and schedule DynamoDB metadata workflows from the OpenMetadata UI:
 - [Requirements](#requirements)
 - [Metadata Ingestion](#metadata-ingestion)
-- [dbt Integration](#dbt-integration)
 
 ## Requirements
 
@@ -294,7 +293,3 @@ metadata ingest -c <path-to-yaml>
 
 Note that from connector to connector, this recipe will always be the same. By updating the YAML configuration,
 you will be able to extract metadata from different sources.
-
-## dbt Integration
-
-You can learn more about how to ingest dbt models' definitions and their lineage [here](https://docs.open-metadata.org/connectors/ingestion/workflows/dbt).

--- a/openmetadata-docs/content/connectors/database/dynamodb/index.md
+++ b/openmetadata-docs/content/connectors/database/dynamodb/index.md
@@ -7,10 +7,9 @@ slug: /connectors/database/dynamodb
 
 In this section, we provide guides and references to use the DynamoDB connector.
 
-Configure and schedule DynamoDB metadata and profiler workflows from the OpenMetadata UI:
+Configure and schedule DynamoDB metadata workflows from the OpenMetadata UI:
 - [Requirements](#requirements)
 - [Metadata Ingestion](#metadata-ingestion)
-- [dbt Integration](#dbt-integration)
 
 If you don't want to use the OpenMetadata Ingestion container to configure the workflows via the UI, then you can check
 the following docs to connect using Airflow SDK or with the CLI.
@@ -47,8 +46,7 @@ custom Airflow plugins to handle the workflow deployment.
 
 The first step is ingesting the metadata from your sources. Under
 Settings, you will find a Services link an external source system to
-OpenMetadata. Once a service is created, it can be used to configure
-metadata, usage, and profiler workflows.
+OpenMetadata.
 
 To visit the Services page, select Services from the Settings menu.
 
@@ -217,12 +215,3 @@ caption="Edit and Deploy the Ingestion Pipeline"
 />
 
 From the Connection tab, you can also Edit the Service if needed.
-
-## dbt Integration
-
-<Tile
-icon="mediation"
-title="dbt Integration"
-text="Learn more about how to ingest dbt models' definitions and their lineage."
-link="/connectors/ingestion/workflows/dbt"
-/>

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/dynamoDBConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/dynamoDBConnection.json
@@ -40,10 +40,6 @@
     "supportsMetadataExtraction": {
       "title": "Supports Metadata Extraction",
       "$ref": "../connectionBasicType.json#/definitions/supportsMetadataExtraction"
-    },
-    "supportsProfiler": {
-      "title": "Supports Profiler",
-      "$ref": "../connectionBasicType.json#/definitions/supportsProfiler"
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
### Describe your changes :
DynamoDB being a NoSQL database it currently does not support the implementation of the profiler, neither can it support dbt ingestion.

This PR cleans up both of this element. We opened an [issue](https://github.com/open-metadata/OpenMetadata/issues/10013) to add profiler support to NoSQL db.
 
#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
