### PR TITLE
Fix: error getting 'certificatePath' from SSLConfig object

### DIFF
--- a/ingestion/src/metadata/utils/ssl_registry.py
+++ b/ingestion/src/metadata/utils/ssl_registry.py
@@ -42,7 +42,7 @@ def ignore_ssl_init(_: Optional[ValidateSSLClientConfig]) -> bool:
 
 @ssl_verification_registry.add(VerifySSL.validate.value)
 def validate_ssl_init(ssl_config: Optional[ValidateSSLClientConfig]) -> str:
-    return ssl_config.certificatePath
+    return ssl_config.__root__.certificatePath
 
 
 def get_verify_ssl_fn(verify_ssl: VerifySSL) -> Callable:


### PR DESCRIPTION
### Describe your changes :
When configuring SSL for ingesting, an error on missing 'certificatePath' from SSLConfig object was raised.

### Type of change :
- [x] Bug fix

### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

### Reviewers
Ingestion: @open-metadata/ingestion
