### PR TITLE
fix(testSuite): removed relationship update with testCase on testSuite update

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestSuiteRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestSuiteRepository.java
@@ -81,8 +81,7 @@ public class TestSuiteRepository extends EntityRepository<TestSuite> {
     public void entitySpecificUpdate() throws IOException {
       List<EntityReference> origTests = listOrEmpty(original.getTests());
       List<EntityReference> updatedTests = listOrEmpty(updated.getTests());
-      updateToRelationships(
-          "tests", TEST_SUITE, original.getId(), Relationship.CONTAINS, TEST_CASE, origTests, updatedTests, false);
+      recordChange("tests", origTests, updatedTests);
     }
   }
 }


### PR DESCRIPTION
### Describe your changes :
With the current logic, when updating test suites, if a test suite is updated via the API without explicitly passing the existing test cases linked to that test suite then all the relationship between the test suite and the test case are deleted.

From a user point of view it seems more confortable to reason in terms of testCase -> testSuite relationship where test cases are added and remove from the perspective of the test case (vs a bi-directional relationship) - i.e. test cases are deleted from test suite through a test case deletion request (vs a test suite update). 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>