### PR TITLE
Fixes issue #10082 -- Unsupported field types for bigquery

### DIFF
--- a/ingestion/src/metadata/orm_profiler/orm/functions/datetime.py
+++ b/ingestion/src/metadata/orm_profiler/orm/functions/datetime.py
@@ -122,18 +122,19 @@ def _(elements, compiler, **kwargs):
 
 
 @compiles(DatetimeAddFn, Dialects.BigQuery)
-def _(elements, compiler, **kwargs):
+def _(elements, compiler, **kwargs):  # pylint: disable=unused-argument
     """generic date and datetime function"""
     interval = elements.clauses.clauses[0].value
     interval_unit = elements.clauses.clauses[1].text
 
     # bigquery does not support month or year interval for timestamp
     # we'll do an approximation to get the interval in days.
-    if interval_unit.lower() in {"month","year"}:
+    if interval_unit.lower() in {"month", "year"}:
         raise ValueError(
             "Bigquery does not support `month` or `year` interval for table partitioned on timestamp",
             "field types. You can set the `interval_unit to day directly from OpenMetadata UI`."
-            "Visit https://docs.open-metadata.org/connectors/ingestion/workflows/profiler#4-updating-profiler-setting-at-the-table-level for more details."
+            # pylint: disable=line-too-long
+            "Visit https://docs.open-metadata.org/connectors/ingestion/workflows/profiler#4-updating-profiler-setting-at-the-table-level for more details.",
         )
 
     return f"CAST(CURRENT_TIMESTAMP - interval {interval} {interval_unit} AS TIMESTAMP)"
@@ -173,7 +174,9 @@ def _(elements, compiler, **kwargs):
     interval, interval_unit = [
         compiler.process(element, **kwargs) for element in elements.clauses
     ]
-    return f"DATEADD({interval_unit}, -{interval}, {func.current_timestamp()}::timestamp)"
+    return (
+        f"DATEADD({interval_unit}, -{interval}, {func.current_timestamp()}::timestamp)"
+    )
 
 
 @compiles(DatetimeAddFn, Dialects.SQLite)

--- a/openmetadata-docs/content/connectors/ingestion/workflows/profiler/index.md
+++ b/openmetadata-docs/content/connectors/ingestion/workflows/profiler/index.md
@@ -102,6 +102,8 @@ Use a query to sample data for the profiler. This will overwrite any profle samp
 **Enable Column Profile**
 This setting allows user to exclude or include specific columns and metrics from the profiler.
 
+*Note: for Google BigQuery tables partitioned on timestamp/datetime column type, month and year interval are not supported. You will need to set the `Interval Unit` to `DAY` or `HOUR`.*
+
 **Enable Partition**
 If your table includes a timestamp, date or datetime column type you can enable partitionning. If enabled, the profiler will fetch the last `<interval>` `<interval unit>` of data to profile the table. Note that if "profile sample" is set, this configuration will be used against the partitioned data and not the whole table.
 - `Column Name`: this is the name of the column that will be used as the partition field


### PR DESCRIPTION
### Describe your changes :
Bigquery timestamp fields do not support INTERVAL with MONTH and YEAR unit. We decided to raise an exception pointing to the documentation on setting partition for the user (vs doing some approximation).

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.
