### PR TITLE
Fix: pytest CI should not skipped with changes on om-spec or om-service

### DIFF
--- a/.github/workflows/py-tests-skip.yml
+++ b/.github/workflows/py-tests-skip.yml
@@ -11,16 +11,12 @@
 
 name: py-tests
 on:
-  push:
-    branches:
-      - main
-      - '0.[0-9]+.[0-9]+'
-    paths-ignore:
-      - 'openmetadata-docs/**'
   pull_request_target:
     types: [labeled, opened, synchronize, reopened]
     paths-ignore:
       - "ingestion/**"
+      - "openmetadata-service/**"
+      - "openmetadata-spec/src/main/resources/json/schema/**"
 
 permissions:
   contents: read

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -21,6 +21,8 @@ on:
     types: [labeled, opened, synchronize, reopened]
     paths:
       - "ingestion/**"
+      - "openmetadata-service/**"
+      - "openmetadata-spec/src/main/resources/json/schema/**"
 
 permissions:
   contents: read


### PR DESCRIPTION
### Describe your changes :
pytest CI must be forced in case of changes in `openmetadata-service` or `openmetadata-spec`.

### Type of change :
- [x] Improvement

### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

### Reviewers
Ingestion: @open-metadata/ingestion
