### PR TITLE
fix: Table list view within service shows `name` instead of `displayName` #10136

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaPage/DatabaseSchemaPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaPage/DatabaseSchemaPage.component.tsx
@@ -583,14 +583,14 @@ const DatabaseSchemaPage: FunctionComponent = () => {
         }),
         dataIndex: 'name',
         key: 'name',
-        render: (text: string, record: Table) => {
+        render: (_, record: Table) => {
           return (
             <Link
               to={getEntityLink(
                 EntityType.TABLE,
                 record.fullyQualifiedName as string
               )}>
-              {text}
+              {getEntityName(record)}
             </Link>
           );
         },


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Closes #10136 

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement


#
### Frontend Preview (Screenshots) :
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/71748675/217459551-00f15cdc-c2a5-4ba4-a708-bc07250f3d46.png">


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
