### PR TITLE
cypress: rename advanceSearch spec to SearchFlow

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/cypress.config.ts
+++ b/openmetadata-ui/src/main/resources/ui/cypress.config.ts
@@ -31,11 +31,8 @@ export default defineConfig({
     },
     baseUrl: 'http://localhost:8585',
     specPattern: [
-      'cypress/e2e/AddNewService/*.{js,jsx,ts,tsx}',
-      'cypress/e2e/Features/*.{js,jsx,ts,tsx}',
-      'cypress/e2e/Pages/*.{js,jsx,ts,tsx}',
-      'cypress/e2e/Flow/*.{js,jsx,ts,tsx}',
       'cypress/e2e/**/*.{js,jsx,ts,tsx}',
+      'cypress/e2e/Flow/SearchFlow.spec.js',
     ],
   },
 });

--- a/openmetadata-ui/src/main/resources/ui/cypress.config.ts
+++ b/openmetadata-ui/src/main/resources/ui/cypress.config.ts
@@ -31,8 +31,11 @@ export default defineConfig({
     },
     baseUrl: 'http://localhost:8585',
     specPattern: [
+      'cypress/e2e/AddNewService/*.{js,jsx,ts,tsx}',
+      'cypress/e2e/Features/*.{js,jsx,ts,tsx}',
+      'cypress/e2e/Pages/*.{js,jsx,ts,tsx}',
+      'cypress/e2e/Flow/*.{js,jsx,ts,tsx}',
       'cypress/e2e/**/*.{js,jsx,ts,tsx}',
-      'cypress/e2e/Flow/SearchFlow.spec.js',
     ],
   },
 });

--- a/openmetadata-ui/src/main/resources/ui/cypress.config.ts
+++ b/openmetadata-ui/src/main/resources/ui/cypress.config.ts
@@ -30,6 +30,9 @@ export default defineConfig({
       return plugins(on, config);
     },
     baseUrl: 'http://localhost:8585',
-    specPattern: 'cypress/e2e/**/*.{js,jsx,ts,tsx}',
+    specPattern: [
+      'cypress/e2e/**/*.{js,jsx,ts,tsx}',
+      'cypress/e2e/Flow/SearchFlow.spec.js',
+    ],
   },
 });

--- a/openmetadata-ui/src/main/resources/ui/cypress.config.ts
+++ b/openmetadata-ui/src/main/resources/ui/cypress.config.ts
@@ -30,9 +30,6 @@ export default defineConfig({
       return plugins(on, config);
     },
     baseUrl: 'http://localhost:8585',
-    specPattern: [
-      'cypress/e2e/**/*.{js,jsx,ts,tsx}',
-      'cypress/e2e/Flow/SearchFlow.spec.js',
-    ],
+    specPattern: 'cypress/e2e/**/*.{js,jsx,ts,tsx}',
   },
 });

--- a/openmetadata-ui/src/main/resources/ui/cypress/e2e/Flow/SearchFlow.spec.js
+++ b/openmetadata-ui/src/main/resources/ui/cypress/e2e/Flow/SearchFlow.spec.js
@@ -10,6 +10,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+
+// The spec is related to advance search feature
+
 import {
   addOwner,
   addTag,

--- a/openmetadata-ui/src/main/resources/ui/cypress/e2e/Flow/SearchFlow.spec.js
+++ b/openmetadata-ui/src/main/resources/ui/cypress/e2e/Flow/SearchFlow.spec.js
@@ -40,7 +40,7 @@ import { MYSQL } from '../../constants/service.constants';
 
 const service_name = MYSQL.serviceName;
 
-describe('Advance search should work properly for all fields', () => {
+describe('pre-requests for test case', () => {
   beforeEach(() => {
     cy.login();
   });
@@ -93,6 +93,12 @@ describe('Advance search should work properly for all fields', () => {
       service_name
     );
   });
+});
+
+describe('Single filed search', () => {
+  beforeEach(() => {
+    cy.login();
+  });
 
   Object.values(FIELDS).forEach((field) => {
     it(`Verify advance search results for ${field.name} field and all condition`, () => {
@@ -123,7 +129,7 @@ describe('Advance search should work properly for all fields', () => {
   });
 });
 
-describe('Advance search should work properly for Add Group functionality', () => {
+describe('Group search', () => {
   beforeEach(() => {
     cy.login();
   });
@@ -201,7 +207,7 @@ describe('Advance search should work properly for Add Group functionality', () =
   });
 });
 
-describe('Advance search should work properly for Add Rule functionality', () => {
+describe('Search with additional rule', () => {
   beforeEach(() => {
     cy.login();
   });


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
As advance search is always running 1st in cypress and it takes a good amount of time and occupies 1 full machine, so renaming the spec to change the order of the test

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
