### PR TITLE
Relax data asset name restrictions to allow the special characters ex…

### DIFF
--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/EntityResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/EntityResourceTest.java
@@ -299,7 +299,7 @@ public abstract class EntityResourceTest<T extends EntityInterface, K extends Cr
   public static KpiTarget KPI_TARGET;
 
   public static final String C1 = "c'_+# 1";
-  public static final String C2 = "c2";
+  public static final String C2 = "c2()$";
   public static final String C3 = "\"c.3\"";
   public static List<Column> COLUMNS;
 
@@ -811,6 +811,10 @@ public abstract class EntityResourceTest<T extends EntityInterface, K extends Cr
     final K request2 = createRequest(LONG_ENTITY_NAME, "description", "displayName", null);
     assertResponse(
         () -> createEntity(request2, ADMIN_AUTH_HEADERS), BAD_REQUEST, TestUtils.getEntityNameLengthError(entityClass));
+
+    // Any entity name that has EntityLink separator must fail
+    final K request3 = createRequest("invalid::Name", "description", "displayName", null);
+    assertResponseContains(() -> createEntity(request3, ADMIN_AUTH_HEADERS), BAD_REQUEST, "name must match");
   }
 
   @Test
@@ -941,7 +945,7 @@ public abstract class EntityResourceTest<T extends EntityInterface, K extends Cr
   @Test
   @Execution(ExecutionMode.CONCURRENT)
   void post_entityWithDots_200() throws HttpResponseException {
-    if (!supportedNameCharacters.contains(" ")) { // Name does not support space
+    if (!supportedNameCharacters.contains(".")) { // Name does not support dot
       return;
     }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/bots/BotResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/bots/BotResourceTest.java
@@ -36,7 +36,7 @@ public class BotResourceTest extends EntityResourceTest<Bot, CreateBot> {
   public BotResourceTest() {
     super(Entity.BOT, Bot.class, BotList.class, "bots", "", INGESTION_BOT);
     supportsFieldsQueryParam = false;
-    supportedNameCharacters = supportedNameCharacters.replace(" ", ""); // Space not supported
+    supportedNameCharacters = "_-.";
   }
 
   @BeforeAll

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/databases/DatabaseResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/databases/DatabaseResourceTest.java
@@ -46,6 +46,7 @@ import org.openmetadata.service.util.TestUtils;
 public class DatabaseResourceTest extends EntityResourceTest<Database, CreateDatabase> {
   public DatabaseResourceTest() {
     super(Entity.DATABASE, Database.class, DatabaseList.class, "databases", DatabaseResource.FIELDS);
+    supportedNameCharacters = "_'+#- .()$" + EntityResourceTest.RANDOM_STRING_GENERATOR.generate(1);
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/databases/DatabaseSchemaResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/databases/DatabaseSchemaResourceTest.java
@@ -46,6 +46,7 @@ class DatabaseSchemaResourceTest extends EntityResourceTest<DatabaseSchema, Crea
         DatabaseSchemaList.class,
         "databaseSchemas",
         DatabaseSchemaResource.FIELDS);
+    supportedNameCharacters = "_'+#- .()$" + EntityResourceTest.RANDOM_STRING_GENERATOR.generate(1);
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/databases/TableResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/databases/TableResourceTest.java
@@ -148,7 +148,7 @@ public class TableResourceTest extends EntityResourceTest<Table, CreateTable> {
 
   public TableResourceTest() {
     super(TABLE, Table.class, TableList.class, "tables", TableResource.FIELDS);
-    supportedNameCharacters = "_'- .()$" + EntityResourceTest.RANDOM_STRING_GENERATOR.generate(1);
+    supportedNameCharacters = "_'+#- .()$" + EntityResourceTest.RANDOM_STRING_GENERATOR.generate(1);
   }
 
   public void setupDatabaseSchemas(TestInfo test) throws IOException {
@@ -1601,7 +1601,7 @@ public class TableResourceTest extends EntityResourceTest<Table, CreateTable> {
         .withDescription("new1") // Change description
         .withTags(List.of(USER_ADDRESS_TAG_LABEL)); // No change in tags
     // Column c2 description changed
-    fieldUpdated(change, build("columns", C2, "description"), "c2", "new1");
+    fieldUpdated(change, build("columns", C2, "description"), C2, "new1");
 
     columns.get(2).withTags(new ArrayList<>()).withPrecision(10).withScale(3); // Remove tag
     // Column c3 tags were removed and precision and scale were added

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/lineage/LineageResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/lineage/LineageResourceTest.java
@@ -82,7 +82,7 @@ public class LineageResourceTest extends OpenMetadataApplicationTest {
 
   @Order(1)
   @Test
-  void put_delete_lineage_withAuthorizer(TestInfo test) throws HttpResponseException {
+  void put_delete_lineage_withAuthorizer() throws HttpResponseException {
     // Random user cannot update lineage.
     UserResourceTest userResourceTest = new UserResourceTest();
     User randomUser =
@@ -436,7 +436,7 @@ public class LineageResourceTest extends OpenMetadataApplicationTest {
   public EntityLineage getLineageByName(
       String entity, String fqn, Integer upstreamDepth, Integer downStreamDepth, Map<String, String> authHeaders)
       throws HttpResponseException {
-    WebTarget target = getResource("lineage/" + entity + "/name/" + fqn);
+    WebTarget target = getResource("lineage/" + entity + "/name/").path(fqn);
     target = upstreamDepth != null ? target.queryParam("upstreamDepth", upstreamDepth) : target;
     target = downStreamDepth != null ? target.queryParam("downstreamDepth", downStreamDepth) : target;
     EntityLineage lineage = TestUtils.get(target, EntityLineage.class, authHeaders);

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/locations/LocationResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/locations/LocationResourceTest.java
@@ -50,6 +50,7 @@ public class LocationResourceTest extends EntityResourceTest<Location, CreateLoc
     super(Entity.LOCATION, Location.class, LocationList.class, "locations", LocationResource.FIELDS);
     // TODO quoted location is not allowed by the Location listPrefix APIs
     // TODO "." is not allowed
+    // supportedNameCharacters = "_'+#- .()$/" + EntityResourceTest.RANDOM_STRING_GENERATOR.generate(1);
     supportedNameCharacters = "_'-";
   }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/permissions/PermissionsResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/permissions/PermissionsResourceTest.java
@@ -378,7 +378,7 @@ class PermissionsResourceTest extends OpenMetadataApplicationTest {
   public ResourcePermission getPermissionByName(
       String resource, String name, String user, Map<String, String> authHeaders) throws HttpResponseException {
     // Get permissions for another user for a given resource type and specific resource by name
-    WebTarget target = getResource("permissions/" + resource + "/name/" + name);
+    WebTarget target = getResource("permissions/").path(resource).path("/name/").path(name);
     target = user != null ? target.queryParam("user", user) : target;
     return TestUtils.get(target, ResourcePermission.class, authHeaders);
   }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/pipelines/PipelineResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/pipelines/PipelineResourceTest.java
@@ -71,6 +71,7 @@ public class PipelineResourceTest extends EntityResourceTest<Pipeline, CreatePip
 
   public PipelineResourceTest() {
     super(Entity.PIPELINE, Pipeline.class, PipelineList.class, "pipelines", PipelineResource.FIELDS);
+    supportedNameCharacters = "_'+#- .()$" + EntityResourceTest.RANDOM_STRING_GENERATOR.generate(1);
   }
 
   @BeforeAll
@@ -555,7 +556,7 @@ public class PipelineResourceTest extends EntityResourceTest<Pipeline, CreatePip
 
   public Pipeline getPipelineByName(String fqn, String fields, Map<String, String> authHeaders)
       throws HttpResponseException {
-    WebTarget target = getResource("pipelines/name/" + fqn);
+    WebTarget target = getResource("pipelines/name/").path(fqn);
     target = fields != null ? target.queryParam("fields", fields) : target;
     return TestUtils.get(target, Pipeline.class, authHeaders);
   }
@@ -563,19 +564,19 @@ public class PipelineResourceTest extends EntityResourceTest<Pipeline, CreatePip
   // Prepare Pipeline status endpoint for PUT
   public Pipeline putPipelineStatusData(String fqn, PipelineStatus data, Map<String, String> authHeaders)
       throws HttpResponseException {
-    WebTarget target = getResource("pipelines/" + fqn + "/status");
+    WebTarget target = getResource("pipelines/").path(fqn).path("/status");
     return TestUtils.put(target, data, Pipeline.class, OK, authHeaders);
   }
 
   public Pipeline deletePipelineStatus(String fqn, Long timestamp, Map<String, String> authHeaders)
       throws HttpResponseException {
-    WebTarget target = getResource("pipelines/" + fqn + "/status/" + timestamp);
+    WebTarget target = getResource("pipelines/").path(fqn).path("/status/").path(String.valueOf(timestamp));
     return TestUtils.delete(target, Pipeline.class, authHeaders);
   }
 
   public ResultList<PipelineStatus> getPipelineStatues(
       String fqn, Long startTs, Long endTs, Map<String, String> authHeaders) throws HttpResponseException {
-    WebTarget target = getResource("pipelines/" + fqn + "/status");
+    WebTarget target = getResource("pipelines/").path(fqn).path("/status");
     target = target.queryParam("startTs", startTs).queryParam("endTs", endTs);
     return TestUtils.get(target, PipelineResource.PipelineStatusList.class, authHeaders);
   }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/usage/UsageResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/usage/UsageResourceTest.java
@@ -312,27 +312,21 @@ class UsageResourceTest extends OpenMetadataApplicationTest {
     checkUsage(usage.getDate(), entity, id, usage.getCount(), weeklyCount, monthlyCount, authHeaders);
   }
 
-  public void reportUsageByName(String entity, String name, DailyCount usage, Map<String, String> authHeaders)
-      throws HttpResponseException {
-    WebTarget target = getResource("usage/" + entity + "/name/" + name);
-    TestUtils.post(target, usage, authHeaders);
-  }
-
   public void reportUsageByNamePut(String entity, String name, DailyCount usage, Map<String, String> authHeaders)
       throws HttpResponseException {
-    WebTarget target = getResource("usage/" + entity + "/name/" + name);
+    WebTarget target = getResource("usage/").path(entity).path("/name/").path(name);
     TestUtils.put(target, usage, Response.Status.CREATED, authHeaders);
   }
 
   public void reportUsage(String entity, UUID id, DailyCount usage, Map<String, String> authHeaders)
       throws HttpResponseException {
-    WebTarget target = getResource("usage/" + entity + "/" + id);
+    WebTarget target = getResource("usage/").path(entity).path("/").path(id.toString());
     TestUtils.post(target, usage, authHeaders);
   }
 
   public void reportUsagePut(String entity, UUID id, DailyCount usage, Map<String, String> authHeaders)
       throws HttpResponseException {
-    WebTarget target = getResource("usage/" + entity + "/" + id);
+    WebTarget target = getResource("usage/").path(entity).path("/").path(id.toString());
     TestUtils.put(target, usage, Response.Status.CREATED, authHeaders);
   }
 
@@ -352,7 +346,7 @@ class UsageResourceTest extends OpenMetadataApplicationTest {
   public EntityUsage getUsageByName(
       String entity, String fqn, String date, Integer days, Map<String, String> authHeaders)
       throws HttpResponseException {
-    return getUsage(getResource("usage/" + entity + "/name/" + fqn), date, days, authHeaders);
+    return getUsage(getResource("usage/" + entity + "/name/").path(fqn), date, days, authHeaders);
   }
 
   public EntityUsage getUsage(String entity, UUID id, String date, Integer days, Map<String, String> authHeaders)

--- a/openmetadata-spec/src/main/resources/json/schema/api/data/createDatabase.json
+++ b/openmetadata-spec/src/main/resources/json/schema/api/data/createDatabase.json
@@ -10,7 +10,7 @@
   "properties": {
     "name": {
       "description": "Name that identifies this database instance uniquely.",
-      "$ref": "../../type/basic.json#/definitions/entityName"
+      "$ref": "../../entity/data/database.json#/definitions/entityName"
     },
     "displayName": {
       "description": "Display Name that identifies this database.",

--- a/openmetadata-spec/src/main/resources/json/schema/api/data/createDatabaseSchema.json
+++ b/openmetadata-spec/src/main/resources/json/schema/api/data/createDatabaseSchema.json
@@ -10,7 +10,7 @@
   "properties": {
     "name": {
       "description": "Name that identifies this database schema instance uniquely.",
-      "$ref": "../../type/basic.json#/definitions/entityName"
+      "$ref": "../../entity/data/databaseSchema.json#/definitions/entityName"
     },
     "displayName": {
       "description": "Display Name that identifies this database schema.",

--- a/openmetadata-spec/src/main/resources/json/schema/api/data/createPipeline.json
+++ b/openmetadata-spec/src/main/resources/json/schema/api/data/createPipeline.json
@@ -10,7 +10,7 @@
   "properties": {
     "name": {
       "description": "Name that identifies this pipeline instance uniquely.",
-      "$ref": "../../type/basic.json#/definitions/entityName"
+      "$ref": "../../entity/data/pipeline.json#/definitions/entityName"
     },
     "displayName": {
       "description": "Display Name that identifies this Pipeline. It could be title or label from the source services.",

--- a/openmetadata-spec/src/main/resources/json/schema/entity/classification/tag.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/classification/tag.json
@@ -11,7 +11,8 @@
       "description": "Name of the tag.",
       "type": "string",
       "minLength": 2,
-      "maxLength": 64
+      "maxLength": 64,
+      "pattern": "^(?U)[\\w'\\- .&]+$"
     }
   },
   "properties": {

--- a/openmetadata-spec/src/main/resources/json/schema/entity/data/database.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/data/database.json
@@ -6,6 +6,15 @@
   "type": "object",
   "javaType": "org.openmetadata.schema.entity.data.Database",
   "javaInterfaces": ["org.openmetadata.schema.EntityInterface"],
+  "definitions": {
+    "entityName": {
+      "description": "Name of a table. Expected to be unique within a database.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^((?!::).)*$"
+    }
+  },
   "properties": {
     "id": {
       "description": "Unique identifier that identifies this database instance.",
@@ -13,7 +22,7 @@
     },
     "name": {
       "description": "Name that identifies the database.",
-      "$ref": "../../type/basic.json#/definitions/entityName"
+      "$ref": "#/definitions/entityName"
     },
     "fullyQualifiedName": {
       "description": "Name that uniquely identifies a database in the format 'ServiceName.DatabaseName'.",

--- a/openmetadata-spec/src/main/resources/json/schema/entity/data/databaseSchema.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/data/databaseSchema.json
@@ -6,6 +6,15 @@
   "type": "object",
   "javaType": "org.openmetadata.schema.entity.data.DatabaseSchema",
   "javaInterfaces": ["org.openmetadata.schema.EntityInterface"],
+  "definitions": {
+    "entityName": {
+      "description": "Name of a table. Expected to be unique within a database.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^((?!::).)*$"
+    }
+  },
   "properties": {
     "id": {
       "description": "Unique identifier that identifies this schema instance.",
@@ -13,7 +22,7 @@
     },
     "name": {
       "description": "Name that identifies the schema.",
-      "$ref": "../../type/basic.json#/definitions/entityName"
+      "$ref": "#/definitions/entityName"
     },
     "fullyQualifiedName": {
       "description": "Name that uniquely identifies a schema in the format 'ServiceName.DatabaseName.SchemaName'.",

--- a/openmetadata-spec/src/main/resources/json/schema/entity/data/location.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/data/location.json
@@ -12,7 +12,7 @@
       "type": "string",
       "minLength": 1,
       "maxLength": 128,
-      "pattern": "^(?U)[\\w'\\-./]+$"
+      "pattern": "^((?!::).)*$"
     },
     "locationType": {
       "javaType": "org.openmetadata.schema.type.LocationType",

--- a/openmetadata-spec/src/main/resources/json/schema/entity/data/pipeline.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/data/pipeline.json
@@ -8,6 +8,13 @@
   "javaType": "org.openmetadata.schema.entity.data.Pipeline",
   "javaInterfaces": ["org.openmetadata.schema.EntityInterface"],
   "definitions": {
+    "entityName": {
+      "description": "Name of a table. Expected to be unique within a database.",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^((?!::).)*$"
+    },
     "statusType": {
       "javaType": "org.openmetadata.schema.type.StatusType",
       "description": "Enum defining the possible Status.",
@@ -146,7 +153,7 @@
     },
     "name": {
       "description": "Name that identifies this pipeline instance uniquely.",
-      "$ref": "../../type/basic.json#/definitions/entityName"
+      "$ref": "#/definitions/entityName"
     },
     "displayName": {
       "description": "Display Name that identifies this Pipeline. It could be title or label from the source services.",

--- a/openmetadata-spec/src/main/resources/json/schema/entity/data/table.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/data/table.json
@@ -15,7 +15,7 @@
       "type": "string",
       "minLength": 1,
       "maxLength": 128,
-      "pattern": "^(?U)[\\w'\\- ./()$]+$"
+      "pattern": "^((?!::).)*$"
     },
     "profileSampleType": {
       "description": "Type of Profile Sample (percentage or rows)",
@@ -166,9 +166,9 @@
     "columnName": {
       "description": "Local name (not fully qualified name) of the column. ColumnName is `-` when the column is not named in struct dataType. For example, BigQuery supports struct with unnamed fields.",
       "type": "string",
-      "pattern": "^(?U)[\\w'\\-\" .+#]+$",
       "minLength": 1,
-      "maxLength": 128
+      "maxLength": 128,
+      "pattern": "^((?!::).)*$"
     },
     "tablePartition": {
       "type": "object",

--- a/openmetadata-spec/src/main/resources/json/schema/entity/teams/user.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/teams/user.json
@@ -12,7 +12,7 @@
       "type": "string",
       "minLength": 1,
       "maxLength": 64,
-      "pattern": "(?U)([\\w\\-.]|[^@])+$"
+      "pattern": "^(?U)[\\w\\-.]+$"
     },
     "authenticationMechanism": {
       "type": "object",


### PR DESCRIPTION
…cept "::"


### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Many databases allow special characters in the object names. With this change, the name restriction is relaxed except names containing "::" which is used as EntityLink separator.

For the entities that are created within OpenMetadata such as Glossary, Tags, TestCase etc. the name restrictions to allow only selected special characters still apply.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

