### PR TITLE
Fix#10177: Check if user is bot before update or create a bot user

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java
@@ -1138,7 +1138,9 @@ public class UserResource extends EntityResource<User, UserRepository> {
     String botName = create.getBotName();
     EntityInterface bot = retrieveBot(botName);
     // check if the bot user exists
-    if (!botHasRelationshipWithUser(bot, original)
+    if (original != null && (original.getIsBot() == null || Boolean.FALSE.equals(original.getIsBot()))) {
+      throw new IllegalArgumentException(String.format("User [%s] already exists.", original.getName()));
+    } else if (!botHasRelationshipWithUser(bot, original)
         && original != null
         && userHasRelationshipWithAnyBot(original, bot)) {
       // throw an exception if user already has a relationship with a bot


### PR DESCRIPTION
### Describe your changes :
We were not checking if the user was a bot when updating or creating a bot user.

fixes #10177

### Type of change :
- [x] Bug fix

### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

### Reviewers
Backend: @open-metadata/backend
