### PR TITLE
chore(ui): do not persist the facet filters on tab change

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/constants/constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/constants.ts
@@ -319,7 +319,8 @@ export const getExplorePath: (args: {
   tab?: string;
   search?: string;
   extraParameters?: Record<string, unknown>;
-}) => string = ({ tab, search, extraParameters }) => {
+  isPersistFilters?: boolean;
+}) => string = ({ tab, search, extraParameters, isPersistFilters = true }) => {
   const pathname = ROUTES.EXPLORE_WITH_TAB.replace(
     PLACEHOLDER_ROUTE_TAB,
     tab ?? ''
@@ -329,18 +330,33 @@ export const getExplorePath: (args: {
       ? location.search.substr(1)
       : location.search
   );
-  if (!isUndefined(search)) {
+
+  const { search: paramSearch } = paramsObject;
+
+  /**
+   * persist the filters if isPersistFilters is true
+   * otherwise only persist the search and passed extra params
+   * */
+  if (isPersistFilters) {
+    if (!isUndefined(search)) {
+      paramsObject = {
+        ...paramsObject,
+        search,
+      };
+    }
+    if (!isUndefined(extraParameters)) {
+      paramsObject = {
+        ...paramsObject,
+        ...extraParameters,
+      };
+    }
+  } else {
     paramsObject = {
-      ...paramsObject,
-      search,
+      search: isUndefined(search) ? paramSearch : search,
+      ...(!isUndefined(extraParameters) ? extraParameters : {}),
     };
   }
-  if (!isUndefined(extraParameters)) {
-    paramsObject = {
-      ...paramsObject,
-      ...extraParameters,
-    };
-  }
+
   const query = Qs.stringify(paramsObject);
 
   return `${pathname}?${query}`;

--- a/openmetadata-ui/src/main/resources/ui/src/pages/explore/ExplorePage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/explore/ExplorePage.component.tsx
@@ -102,6 +102,7 @@ const ExplorePage: FunctionComponent = () => {
       getExplorePath({
         tab: tabsInfo[nSearchIndex].path,
         extraParameters: { page: '1' },
+        isPersistFilters: false,
       })
     );
     setAdvancedSearchQueryFilter(undefined);


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on making changes in explore page not to persist the facet filters on tab change.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Frontend Preview (Screenshots) :

https://user-images.githubusercontent.com/59080942/220620845-9f819e2e-52d7-4f19-8e2a-8b8f06f73040.mov



#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
