### PR TITLE
chore(ui): add check for notification is present or not in the browser

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/nav-bar/NavBar.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/nav-bar/NavBar.tsx
@@ -183,7 +183,6 @@ const NavBar = ({
         });
         path = prepareFeedLink(entityType as string, entityFQN as string);
     }
-
     const notification = new Notification('Notification From OpenMetadata', {
       body: body,
       icon: Logo,

--- a/openmetadata-ui/src/main/resources/ui/src/components/nav-bar/NavBar.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/nav-bar/NavBar.tsx
@@ -183,20 +183,26 @@ const NavBar = ({
         });
         path = prepareFeedLink(entityType as string, entityFQN as string);
     }
-    const notification = new Notification('Notification From OpenMetadata', {
-      body: body,
-      icon: Logo,
-    });
-    notification.onclick = () => {
-      const isChrome = window.navigator.userAgent.indexOf('Chrome');
-      // Applying logic to open a new window onclick of browser notification from chrome
-      // As it does not open the concerned tab by default.
-      if (isChrome > -1) {
-        window.open(path);
-      } else {
-        history.push(path);
-      }
-    };
+
+    if ('Notification' in window) {
+      const notification = new Notification('Notification From OpenMetadata', {
+        body: body,
+        icon: Logo,
+      });
+      notification.onclick = () => {
+        const isChrome = window.navigator.userAgent.indexOf('Chrome');
+        // Applying logic to open a new window onclick of browser notification from chrome
+        // As it does not open the concerned tab by default.
+        if (isChrome > -1) {
+          window.open(path);
+        } else {
+          history.push(path);
+        }
+      };
+    } else {
+      // Handle the case when the Notification API is not supported
+      console.error('Notifications are not supported in this browser.');
+    }
   };
 
   const governanceMenu = [

--- a/openmetadata-ui/src/main/resources/ui/src/components/nav-bar/NavBar.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/nav-bar/NavBar.tsx
@@ -184,25 +184,20 @@ const NavBar = ({
         path = prepareFeedLink(entityType as string, entityFQN as string);
     }
 
-    if ('Notification' in window) {
-      const notification = new Notification('Notification From OpenMetadata', {
-        body: body,
-        icon: Logo,
-      });
-      notification.onclick = () => {
-        const isChrome = window.navigator.userAgent.indexOf('Chrome');
-        // Applying logic to open a new window onclick of browser notification from chrome
-        // As it does not open the concerned tab by default.
-        if (isChrome > -1) {
-          window.open(path);
-        } else {
-          history.push(path);
-        }
-      };
-    } else {
-      // Handle the case when the Notification API is not supported
-      console.error('Notifications are not supported in this browser.');
-    }
+    const notification = new Notification('Notification From OpenMetadata', {
+      body: body,
+      icon: Logo,
+    });
+    notification.onclick = () => {
+      const isChrome = window.navigator.userAgent.indexOf('Chrome');
+      // Applying logic to open a new window onclick of browser notification from chrome
+      // As it does not open the concerned tab by default.
+      if (isChrome > -1) {
+        window.open(path);
+      } else {
+        history.push(path);
+      }
+    };
   };
 
   const governanceMenu = [

--- a/openmetadata-ui/src/main/resources/ui/src/utils/BrowserNotificationUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/BrowserNotificationUtils.test.ts
@@ -1,0 +1,87 @@
+/*
+ *  Copyright 2023 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import {
+  hasNotificationPermission,
+  shouldRequestPermission,
+} from './BrowserNotificationUtils';
+
+// Mock the Notification object
+Object.defineProperty(window, 'Notification', {
+  value: {
+    permission: 'default',
+    requestPermission: jest.fn(),
+  },
+  writable: true,
+});
+
+describe('BrowserNotificationUtils', () => {
+  describe('shouldRequestPermission', () => {
+    it('should return false if Notification API is not available', () => {
+      jest
+        .spyOn(global, 'window', 'get')
+        .mockReturnValueOnce({} as Window & typeof globalThis);
+
+      const result = shouldRequestPermission();
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false if permission is already granted or denied', () => {
+      Object.defineProperty(Notification, 'permission', {
+        get: () => 'granted',
+      });
+
+      const result1 = shouldRequestPermission();
+
+      expect(result1).toBe(false);
+
+      Object.defineProperty(Notification, 'permission', {
+        get: () => 'denied',
+      });
+
+      const result2 = shouldRequestPermission();
+
+      expect(result2).toBe(false);
+    });
+  });
+
+  describe('hasNotificationPermission', () => {
+    it('should return false if Notification API is not available', () => {
+      jest
+        .spyOn(global, 'window', 'get')
+        .mockReturnValueOnce({} as Window & typeof globalThis);
+
+      const result = hasNotificationPermission();
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false if permission is not granted', () => {
+      Object.defineProperty(Notification, 'permission', {
+        get: () => 'default',
+      });
+
+      const result1 = hasNotificationPermission();
+
+      expect(result1).toBe(false);
+
+      Object.defineProperty(Notification, 'permission', {
+        get: () => 'denied',
+      });
+
+      const result2 = hasNotificationPermission();
+
+      expect(result2).toBe(false);
+    });
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/BrowserNotificationUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/BrowserNotificationUtils.ts
@@ -11,11 +11,11 @@
  *  limitations under the License.
  */
 
-export const isNotificationAPIAvailable = () => 'Notification' in window;
+export const isNotificationAPIAvailable = 'Notification' in window;
 
 export const shouldRequestPermission = () =>
-  isNotificationAPIAvailable() &&
+  isNotificationAPIAvailable &&
   !['granted', 'denied'].includes(Notification.permission);
 
 export const hasNotificationPermission = () =>
-  isNotificationAPIAvailable() && Notification.permission === 'granted';
+  isNotificationAPIAvailable && Notification.permission === 'granted';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/BrowserNotificationUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/BrowserNotificationUtils.ts
@@ -11,8 +11,11 @@
  *  limitations under the License.
  */
 
+export const isNotificationAPIAvailable = () => 'Notification' in window;
+
 export const shouldRequestPermission = () =>
+  isNotificationAPIAvailable() &&
   !['granted', 'denied'].includes(Notification.permission);
 
 export const hasNotificationPermission = () =>
-  Notification.permission === 'granted';
+  isNotificationAPIAvailable() && Notification.permission === 'granted';


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on adding a check for whether a notification is present in the window because some browser does not support the notification API.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Frontend Preview (Screenshots) :
I have tested on a simulator and the alert shown is only for testing purposes.

https://user-images.githubusercontent.com/59080942/220907380-c42d4e08-ef1d-417d-8dfb-cd20136f17d3.mov



#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
