### PR TITLE
fix: Use endpointURL and region in s3_fs

### DIFF
--- a/ingestion/src/metadata/utils/s3_utils.py
+++ b/ingestion/src/metadata/utils/s3_utils.py
@@ -87,12 +87,21 @@ def read_parquet_from_s3(client: Any, key: str, bucket_name: str):
     """
     Read the parquet file from the s3 bucket and return a dataframe
     """
-    s3_fs = s3fs.S3FileSystem()
+    client_kwargs = {}
+    if client.endPointURL:
+        client_kwargs["endpoint_url"] = client.endPointURL
+
+    if client.awsRegion:
+        client_kwargs["region_name"] = client.awsRegion
+
+    s3_fs = s3fs.S3FileSystem(client_kwargs=client_kwargs)
+
     if client.awsAccessKeyId and client.awsSecretAccessKey:
         s3_fs = s3fs.S3FileSystem(
             key=client.awsAccessKeyId,
             secret=client.awsSecretAccessKey.get_secret_value(),
             token=client.awsSessionToken,
+            client_kwargs=client_kwargs,
         )
     bucket_uri = f"s3://{bucket_name}/{key}"
     dataset = pq.ParquetDataset(bucket_uri, filesystem=s3_fs)


### PR DESCRIPTION
### Describe your changes :
Added endpointURL and region_name in s3_utils.py because this was missing in S3FileSystem
and crashed the ingress (because it called the wrong S3 - storage).

This fixes https://github.com/open-metadata/OpenMetadata/issues/10279

#
### Type of change :
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] All new and existing tests passed.
