### PR TITLE
Simplify Pipeline Service Client Response and prep test connection for ingestion base

### DIFF
--- a/ingestion/operators/docker/Dockerfile
+++ b/ingestion/operators/docker/Dockerfile
@@ -58,7 +58,7 @@ ENV LD_LIBRARY_PATH=/instantclient
 WORKDIR ingestion/
 
 # Required for Airflow DockerOperator, as we need to run the workflows from a `python main.py` command in the container.
-COPY ingestion/operators/docker/main.py .
+COPY ingestion/operators/docker/*.py .
 
 RUN pip install --upgrade pip
 

--- a/ingestion/operators/docker/Dockerfile-dev
+++ b/ingestion/operators/docker/Dockerfile-dev
@@ -68,7 +68,7 @@ COPY ingestion/setup.* ./
 COPY ingestion/README.md .
 
 # Required for Airflow DockerOperator, as we need to run the workflows from a `python main.py` command in the container.
-COPY ingestion/operators/docker/main.py .
+COPY ingestion/operators/docker/*.py .
 
 RUN pip install --upgrade pip
 

--- a/ingestion/operators/docker/main.py
+++ b/ingestion/operators/docker/main.py
@@ -15,13 +15,13 @@ import os
 
 import yaml
 
+from metadata.data_insight.api.workflow import DataInsightWorkflow
 from metadata.generated.schema.entity.services.ingestionPipelines.ingestionPipeline import (
     PipelineType,
 )
 from metadata.ingestion.api.workflow import Workflow
 from metadata.orm_profiler.api.workflow import ProfilerWorkflow
 from metadata.test_suite.api.workflow import TestSuiteWorkflow
-from metadata.data_insight.api.workflow import DataInsightWorkflow
 
 WORKFLOW_MAP = {
     PipelineType.metadata.value: Workflow,

--- a/ingestion/operators/docker/test_connection.py
+++ b/ingestion/operators/docker/test_connection.py
@@ -1,0 +1,62 @@
+#  Copyright 2021 Collate
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Entrypoint to test the connection to a source
+"""
+import os
+
+import yaml
+
+from metadata.generated.schema.api.services.ingestionPipelines.testServiceConnection import (
+    TestServiceConnectionRequest,
+)
+from metadata.ingestion.source.connections import get_connection, get_test_connection_fn
+from metadata.utils.secrets.secrets_manager_factory import SecretsManagerFactory
+
+
+def main():
+    """
+    Test Connection entrypoint.
+
+    The expected information is in the shape of `TestServiceConnectionRequest`, e.g.,
+    ```
+    connection:
+      config:
+        type: Mysql
+        scheme: mysql+pymysql
+        username: openmetadata_user
+        password: openmetadata_password
+        hostPort: 'localhost:3306'
+    connectionType: Database
+    ```
+    """
+
+    # DockerOperator expects an env var called config
+    test_connection_dict = yaml.safe_load(os.environ["config"])
+    test_service_connection = TestServiceConnectionRequest.parse_obj(test_connection_dict)
+
+    # we need to instantiate the secret manager in case secrets are passed
+    SecretsManagerFactory(
+        test_service_connection.secretsManagerProvider,
+        None
+    )
+    connection = get_connection(test_service_connection.connection.config)
+
+    # We won't wrap the call in a try/catch. If the connection fails, we want to
+    # raise the SourceConnectionException as it comes.
+    test_connection_fn = get_test_connection_fn(
+        test_service_connection.connection.config
+    )
+    test_connection_fn(connection)
+
+
+if __name__ == "__main__":
+    main()

--- a/ingestion/operators/docker/test_connection.py
+++ b/ingestion/operators/docker/test_connection.py
@@ -41,13 +41,12 @@ def main():
 
     # DockerOperator expects an env var called config
     test_connection_dict = yaml.safe_load(os.environ["config"])
-    test_service_connection = TestServiceConnectionRequest.parse_obj(test_connection_dict)
+    test_service_connection = TestServiceConnectionRequest.parse_obj(
+        test_connection_dict
+    )
 
     # we need to instantiate the secret manager in case secrets are passed
-    SecretsManagerFactory(
-        test_service_connection.secretsManagerProvider,
-        None
-    )
+    SecretsManagerFactory(test_service_connection.secretsManagerProvider, None)
     connection = get_connection(test_service_connection.connection.config)
 
     # We won't wrap the call in a try/catch. If the connection fails, we want to

--- a/openmetadata-service/src/main/java/org/openmetadata/service/clients/pipeline/airflow/AirflowRESTClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/clients/pipeline/airflow/AirflowRESTClient.java
@@ -230,7 +230,7 @@ public class AirflowRESTClient extends PipelineServiceClient {
   }
 
   @Override
-  public HttpResponse<String> testConnection(TestServiceConnection testServiceConnection) {
+  public Response testConnection(TestServiceConnection testServiceConnection) {
     HttpResponse<String> response;
     try {
       String statusEndPoint = "%s/%s/test_connection";
@@ -238,7 +238,7 @@ public class AirflowRESTClient extends PipelineServiceClient {
       String connectionPayload = JsonUtils.pojoToJson(testServiceConnection);
       response = post(statusUrl, connectionPayload);
       if (response.statusCode() == 200) {
-        return response;
+        return Response.status(200, response.body()).build();
       }
     } catch (Exception e) {
       throw PipelineServiceClientException.byMessage("Failed to test connection.", e.getMessage());
@@ -247,7 +247,7 @@ public class AirflowRESTClient extends PipelineServiceClient {
   }
 
   @Override
-  public HttpResponse<String> killIngestion(IngestionPipeline ingestionPipeline) {
+  public Response killIngestion(IngestionPipeline ingestionPipeline) {
     HttpResponse<String> response;
     try {
       String killEndPoint = "%s/%s/kill";
@@ -256,7 +256,7 @@ public class AirflowRESTClient extends PipelineServiceClient {
       requestPayload.put(DAG_ID, ingestionPipeline.getName());
       response = post(killUrl, requestPayload.toString());
       if (response.statusCode() == 200) {
-        return response;
+        return Response.status(200, response.body()).build();
       }
     } catch (Exception e) {
       throw PipelineServiceClientException.byMessage("Failed to kill running workflows", e.getMessage());

--- a/openmetadata-service/src/main/java/org/openmetadata/service/clients/pipeline/noop/NoopClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/clients/pipeline/noop/NoopClient.java
@@ -13,7 +13,6 @@
 
 package org.openmetadata.service.clients.pipeline.noop;
 
-import java.net.http.HttpResponse;
 import java.util.List;
 import java.util.Map;
 import javax.ws.rs.core.Response;
@@ -39,7 +38,7 @@ public class NoopClient extends PipelineServiceClient {
   }
 
   @Override
-  public HttpResponse<String> testConnection(TestServiceConnection testServiceConnection) {
+  public Response testConnection(TestServiceConnection testServiceConnection) {
     return null;
   }
 
@@ -74,7 +73,7 @@ public class NoopClient extends PipelineServiceClient {
   }
 
   @Override
-  public HttpResponse<String> killIngestion(IngestionPipeline ingestionPipeline) {
+  public Response killIngestion(IngestionPipeline ingestionPipeline) {
     throw new PipelineServiceClientException(String.format(EXCEPTION_MSG, "kill"));
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/ingestionpipelines/IngestionPipelineResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/ingestionpipelines/IngestionPipelineResource.java
@@ -26,7 +26,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
-import java.net.http.HttpResponse;
 import java.util.Map;
 import java.util.UUID;
 import javax.json.JsonPatch;
@@ -501,8 +500,7 @@ public class IngestionPipelineResource extends EntityResource<IngestionPipeline,
       throws IOException {
     IngestionPipeline ingestionPipeline = getInternal(uriInfo, securityContext, id, FIELDS, Include.NON_DELETED);
     decryptOrNullify(securityContext, ingestionPipeline);
-    HttpResponse<String> response = pipelineServiceClient.killIngestion(ingestionPipeline);
-    return Response.status(200, response.body()).build();
+    return pipelineServiceClient.killIngestion(ingestionPipeline);
   }
 
   @POST
@@ -525,8 +523,7 @@ public class IngestionPipelineResource extends EntityResource<IngestionPipeline,
     testServiceConnection =
         testServiceConnection.withSecretsManagerProvider(
             SecretsManagerFactory.getSecretsManager().getSecretsManagerProvider());
-    HttpResponse<String> response = pipelineServiceClient.testConnection(testServiceConnection);
-    return Response.status(200, response.body()).build();
+    return pipelineServiceClient.testConnection(testServiceConnection);
   }
 
   @GET

--- a/openmetadata-service/src/test/java/org/openmetadata/service/pipelineService/MockPipelineServiceClient.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/pipelineService/MockPipelineServiceClient.java
@@ -1,6 +1,5 @@
 package org.openmetadata.service.pipelineService;
 
-import java.net.http.HttpResponse;
 import java.util.List;
 import java.util.Map;
 import javax.ws.rs.core.Response;
@@ -23,7 +22,7 @@ public class MockPipelineServiceClient extends PipelineServiceClient {
   }
 
   @Override
-  public HttpResponse<String> testConnection(TestServiceConnection testServiceConnection) {
+  public Response testConnection(TestServiceConnection testServiceConnection) {
     return null;
   }
 
@@ -58,7 +57,7 @@ public class MockPipelineServiceClient extends PipelineServiceClient {
   }
 
   @Override
-  public HttpResponse<String> killIngestion(IngestionPipeline ingestionPipeline) {
+  public Response killIngestion(IngestionPipeline ingestionPipeline) {
     return null;
   }
 

--- a/openmetadata-spec/src/main/java/org/openmetadata/sdk/PipelineServiceClient.java
+++ b/openmetadata-spec/src/main/java/org/openmetadata/sdk/PipelineServiceClient.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.http.HttpResponse;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -145,7 +144,7 @@ public abstract class PipelineServiceClient {
   public abstract Response getServiceStatus();
 
   /* Test the connection to the service such as database service a pipeline depends on. */
-  public abstract HttpResponse<String> testConnection(TestServiceConnection testServiceConnection);
+  public abstract Response testConnection(TestServiceConnection testServiceConnection);
 
   /* Deploy a pipeline to the pipeline service */
   public abstract String deployPipeline(IngestionPipeline ingestionPipeline, ServiceEntityInterface service);
@@ -166,7 +165,7 @@ public abstract class PipelineServiceClient {
   public abstract Map<String, String> getLastIngestionLogs(IngestionPipeline ingestionPipeline, String after);
 
   /* Get the all last run logs of a deployed pipeline */
-  public abstract HttpResponse<String> killIngestion(IngestionPipeline ingestionPipeline);
+  public abstract Response killIngestion(IngestionPipeline ingestionPipeline);
 
   /*
   Get the Pipeline Service host IP to whitelist in source systems


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->

- Using Response instead of HttpResponse as return type for the Pipeline Service Client methods. It just makes it easier to adapt everywhere.
- Prepared the first version of the test connection entrypoint to the openmetadata/ingestion-base image

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
