### PR TITLE
[fixed] profiler would not fetch serviceConnection from OpenMetadata

### DIFF
--- a/ingestion/src/metadata/orm_profiler/api/workflow.py
+++ b/ingestion/src/metadata/orm_profiler/api/workflow.py
@@ -113,8 +113,8 @@ class ProfilerWorkflow(WorkflowStatusMixin):
             self.config.processor.dict().get("config")
         )
         self.metadata = OpenMetadata(self.metadata_config)
-        self.test_connection()
         self._retrieve_service_connection_if_needed()
+        self.test_connection()
         self.set_ingestion_pipeline_status(state=PipelineState.running)
         # Init and type the source config
         self.source_config: DatabaseServiceProfilerPipeline = cast(
@@ -564,7 +564,7 @@ class ProfilerWorkflow(WorkflowStatusMixin):
         service_type: ServiceType = get_service_type_from_source_type(
             self.config.source.type
         )
-        if self.config.source.serviceConnection:
+        if not self.config.source.serviceConnection:
             service_name = self.config.source.serviceName
             try:
                 service: ServiceWithConnectionType = cast(


### PR DESCRIPTION
... even when `serviceConnection` was omitted from workflow YAML.

### Describe your changes :

The profiler workflow tested the `serviceConnection` before attempting to retrieve `serviceConnection` details from OMD server. This meant that you could not store `serviceConnection` credentials for profiling on OMD server; you had to put them inline in the workflow YAML.

The profiler workflow's `_retrieve_service_connection_if_needed` function was missing a negation: It would only try to retrieve `serviceConnection` details from OMD server _if they were already defined in the workflow_. This was opposite the behavior described in the docstring, and meant that even if the first issue above were fixed, you still couldn't retrieve profiling `serviceConnection` details from OMD server.

**NOTE:** I have patched my `workflow.py` in my local OpenMetadata installation, and I am able to run profiling with 
1. JWT Token in YAML
2. no `serviceConnection` in YAML
3. database service connection details stored in OpenMetadata server

#
### Type of change :
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
(n/a)

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] All new and existing tests passed.

#
### Reviewers
