### PR TITLE
Fix(UI) : Make generated fields required in filters and destination

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
@@ -547,6 +547,7 @@
     "please-enter-value": "Please enter {{name}} value",
     "please-password-type-first": "Please type password first",
     "please-select": "Please Select",
+    "please-select-entity": "Please Select a {{entity}}",
     "plus-symbol": "+",
     "policy": "Policy",
     "policy-lowercase": "policy",

--- a/openmetadata-ui/src/main/resources/ui/src/pages/AddAlertPage/AddAlertPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/AddAlertPage/AddAlertPage.tsx
@@ -647,7 +647,20 @@ const AddAlertPage = () => {
                                 )}
                                 <div className="d-flex gap-1">
                                   <div className="flex-1">
-                                    <Form.Item key={key} name={[name, 'name']}>
+                                    <Form.Item
+                                      key={key}
+                                      name={[name, 'name']}
+                                      rules={[
+                                        {
+                                          required: true,
+                                          message: t(
+                                            'label.please-select-entity',
+                                            {
+                                              entity: t('label.condition'),
+                                            }
+                                          ),
+                                        },
+                                      ]}>
                                       <Select
                                         options={functions}
                                         placeholder={t('label.select-field', {
@@ -742,9 +755,19 @@ const AddAlertPage = () => {
                                 <div className="d-flex" style={{ gap: '10px' }}>
                                   <div className="flex-1">
                                     <Form.Item
-                                      required
                                       key={key}
-                                      name={[name, 'alertActionType']}>
+                                      name={[name, 'alertActionType']}
+                                      rules={[
+                                        {
+                                          required: true,
+                                          message: t(
+                                            'label.please-select-entity',
+                                            {
+                                              entity: t('label.source'),
+                                            }
+                                          ),
+                                        },
+                                      ]}>
                                       <Select
                                         data-testid="alert-action-type"
                                         disabled={


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
- Issue : -  Empty object is sent if added fields are empty in filters and destination
- Make generated fields required in filters and destination

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Frontend Preview (Screenshots) :
Issue : 
<img width="1440" alt="image (7)" src="https://user-images.githubusercontent.com/66266464/221784252-e8e26221-983b-426e-917e-71903a1f7e0d.png">


Resolved : 
<img width="790" alt="image" src="https://user-images.githubusercontent.com/66266464/221784053-21e16a69-2f1d-4558-b31a-d290e1d80bca.png">


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
