### PR TITLE
fix service name typo in docs

### DIFF
--- a/openmetadata-docs/content/connectors/pipeline/airflow/index.md
+++ b/openmetadata-docs/content/connectors/pipeline/airflow/index.md
@@ -72,7 +72,7 @@ caption="Add a new Service from the Services page"
 
 ### 3. Select the Service Type
 
-Select Airbyte as the service type and click Next.
+Select Airflow as the service type and click Next.
 
 <div className="w-100 flex justify-center">
 <Image


### PR DESCRIPTION
### Describe your changes :
Fixed a service name typo that was using `Airbyte` instead of the correct name `Airflow`

#
### Type of change :
- [x] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
not sure who reviews documentation, couldn't find anything specific on the contributing doc
