### PR TITLE
UI : Increase tag input size and added tooltip on options

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/EntityTable/EntityTable.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/EntityTable/EntityTable.component.tsx
@@ -544,6 +544,7 @@ const EntityTable = ({
                 }
               }}>
               <TagsContainer
+                className="w-min-15 "
                 editable={editColumnTag?.index === index}
                 isLoading={isTagLoading && editColumnTag?.index === index}
                 selectedTags={tags || []}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsContainer/tags-container.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsContainer/tags-container.tsx
@@ -12,7 +12,7 @@
  */
 
 import { CheckOutlined, CloseOutlined } from '@ant-design/icons';
-import { Button, Select, Space } from 'antd';
+import { Button, Select, Space, Tooltip } from 'antd';
 import classNames from 'classnames';
 import Tags from 'components/Tag/Tags/tags';
 import { isEmpty } from 'lodash';
@@ -154,9 +154,19 @@ const TagsContainer: FunctionComponent<TagsContainerProps> = ({
             data-testid="tag-selector"
             defaultValue={selectedTagsInternal}
             mode="multiple"
-            options={tagOptions}
-            onChange={handleTagSelection}
-          />
+            onChange={handleTagSelection}>
+            {tagOptions.map(({ label, value }) => (
+              <Select.Option key={label} value={value}>
+                <Tooltip
+                  destroyTooltipOnHide
+                  placement="topLeft"
+                  title={label}
+                  trigger="hover">
+                  {label}
+                </Tooltip>
+              </Select.Option>
+            ))}
+          </Select>
         ) : (
           children
         )}

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/entityPageInfo/EntityPageInfo.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/entityPageInfo/EntityPageInfo.tsx
@@ -22,6 +22,7 @@ import { EntityTags, ExtraInfo, TagOption } from 'Models';
 import React, { Fragment, useCallback, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { getActiveAnnouncement } from 'rest/feedsAPI';
+import { ReactComponent as IconEdit } from '../../../assets/svg/ic-edit.svg';
 import { FQN_SEPARATOR_CHAR } from '../../../constants/char.constants';
 import { FOLLOWERS_VIEW_CAP } from '../../../constants/constants';
 import { EntityType } from '../../../enums/entity.enum';
@@ -533,6 +534,7 @@ const EntityPageInfo = ({
                     setIsEditable(true);
                   }}>
                   <TagsContainer
+                    className="w-min-20"
                     dropDownHorzPosRight={false}
                     editable={isEditable}
                     isLoading={isTagLoading}
@@ -547,17 +549,16 @@ const EntityPageInfo = ({
                       handleTagSelection(tags);
                     }}>
                     {tags.length || tier ? (
-                      <button
-                        className="tw-w-7 tw-h-7 tw-flex-none focus:tw-outline-none"
-                        data-testid="edit-button">
-                        <SVGIcons
-                          alt="edit"
-                          className="tw--mt-3 "
-                          icon="icon-edit"
-                          title={t('label.edit')}
-                          width="16px"
+                      <Button
+                        className="w-7 h-7 p-0 d-flex justify-center"
+                        data-testid="edit-button"
+                        type="text">
+                        <IconEdit
+                          height={16}
+                          name={t('label.edit')}
+                          width={16}
                         />
-                      </button>
+                      </Button>
                     ) : (
                       <span>
                         <Tags

--- a/openmetadata-ui/src/main/resources/ui/src/styles/components/size.less
+++ b/openmetadata-ui/src/main/resources/ui/src/styles/components/size.less
@@ -123,6 +123,12 @@
 .w-min-10 {
   min-width: 10rem;
 }
+.w-min-15 {
+  min-width: 15rem;
+}
+.w-min-20 {
+  min-width: 20rem;
+}
 
 //Height
 .h-3 {


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
- Issue : https://github.com/open-metadata/OpenMetadata/issues/9819#issuecomment-1411180469
- Increase tag input size and added a tooltip on options


#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement


#
### Frontend Preview (Screenshots) :
<img width="718" alt="image" src="https://user-images.githubusercontent.com/66266464/222450830-17959c34-a83e-4ab2-9262-8b540da6ed32.png">
<img width="718" alt="image" src="https://user-images.githubusercontent.com/66266464/222450880-5d16db7a-71da-49a8-82f1-a69909e648bd.png">
<img width="377" alt="image" src="https://user-images.githubusercontent.com/66266464/222450969-80b8631a-9a3a-4030-9014-6246abaf43d6.png">


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
