### PR TITLE
Bug: fix flaky timeout test

### DIFF
--- a/ingestion/src/metadata/utils/timeout.py
+++ b/ingestion/src/metadata/utils/timeout.py
@@ -18,7 +18,6 @@ import inspect
 import os
 import platform
 import signal
-import traceback
 from typing import Callable
 
 from metadata.utils.constants import TEN_MIN
@@ -31,7 +30,6 @@ def _handle_timeout(signum, frame):
     """
     Handler for signal timeout
     """
-    logger.debug(traceback.print_stack(frame))
     raise TimeoutError(f"[SIGNUM {signum}] {os.strerror(errno.ETIME)}")
 
 

--- a/ingestion/tests/unit/test_sql_lineage.py
+++ b/ingestion/tests/unit/test_sql_lineage.py
@@ -164,13 +164,15 @@ class SqlLineageTest(TestCase):
         # When
         with self.assertLogs(Loggers.INGESTION.value, level="DEBUG") as logger:
             LineageParser(
-                query.format(values="\n".join(values)), dialect=Dialect.SNOWFLAKE
+                query.format(values="\n".join(values)),
+                dialect=Dialect.SNOWFLAKE,
+                timeout_seconds=1,
             )
             # Then
             self.assertTrue(
                 any(
-                    "Parser has been running for more than 10 seconds." in log
+                    "Parser has been running for more than 1 seconds." in log
                     for log in logger.output
                 ),
-                "Parser finished before the 10 expected seconds!",
+                "Parser finished before the 1 expected seconds!",
             )


### PR DESCRIPTION
### Describe your changes :
Fix flaky test where testing timeout was not working as expected. Removed unnecessary debug print inside the timeout decorator.

### Type of change :
- [x] Bug fix

### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

### Reviewers
Ingestion: @open-metadata/ingestion