### PR TITLE
chore(ui): change user page search variable name to `user`

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/UserListPage/UserListPageV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/UserListPage/UserListPageV1.test.tsx
@@ -153,7 +153,7 @@ describe('Test UserListPage component', () => {
 
     await waitForElement(async () => {
       const userSearchTerm = new URLSearchParams(window.location.search).get(
-        'userSearchTerm'
+        'user'
       );
 
       return userSearchTerm === 'test';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/UserListPage/UserListPageV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/UserListPage/UserListPageV1.test.tsx
@@ -18,6 +18,7 @@ import {
   render,
   screen,
   waitForDomChange,
+  waitForElement,
 } from '@testing-library/react';
 import React from 'react';
 import { searchData } from 'rest/miscAPI';
@@ -148,6 +149,14 @@ describe('Test UserListPage component', () => {
 
     await act(async () => {
       fireEvent.change(searchBox, { target: { value: 'test' } });
+    });
+
+    await waitForElement(async () => {
+      const userSearchTerm = new URLSearchParams(window.location.search).get(
+        'userSearchTerm'
+      );
+
+      return userSearchTerm === 'test';
     });
 
     expect(searchBox).toHaveValue('test');

--- a/openmetadata-ui/src/main/resources/ui/src/pages/UserListPage/UserListPageV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/UserListPage/UserListPageV1.tsx
@@ -176,7 +176,7 @@ const UserListPageV1 = () => {
   const handleSearch = (value: string) => {
     setSearchValue(value);
     setCurrentPage(INITIAL_PAGING_VALUE);
-    const params = new URLSearchParams({ search: value });
+    const params = new URLSearchParams({ userSearchTerm: value });
     // This function is called onChange in the search input with debouncing
     // Hence using history.replace instead of history.push to avoid adding multiple routes in history
     history.replace({
@@ -200,9 +200,9 @@ const UserListPageV1 = () => {
         // Converting string to URLSearchParameter
         const searchParameter = new URLSearchParams(location.search);
         // Getting the searched name
-        const searchTerm = searchParameter.get('search') || '';
-        setSearchValue(searchTerm);
-        getSearchedUsers(searchTerm, 1);
+        const userSearchTerm = searchParameter.get('userSearchTerm') || '';
+        setSearchValue(userSearchTerm);
+        getSearchedUsers(userSearchTerm, 1);
         setIsPageLoading(false);
       } else {
         fetchUsersList(tab === GlobalSettingOptions.ADMINS || undefined);

--- a/openmetadata-ui/src/main/resources/ui/src/pages/UserListPage/UserListPageV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/UserListPage/UserListPageV1.tsx
@@ -176,7 +176,7 @@ const UserListPageV1 = () => {
   const handleSearch = (value: string) => {
     setSearchValue(value);
     setCurrentPage(INITIAL_PAGING_VALUE);
-    const params = new URLSearchParams({ userSearchTerm: value });
+    const params = new URLSearchParams({ user: value });
     // This function is called onChange in the search input with debouncing
     // Hence using history.replace instead of history.push to avoid adding multiple routes in history
     history.replace({
@@ -200,7 +200,7 @@ const UserListPageV1 = () => {
         // Converting string to URLSearchParameter
         const searchParameter = new URLSearchParams(location.search);
         // Getting the searched name
-        const userSearchTerm = searchParameter.get('userSearchTerm') || '';
+        const userSearchTerm = searchParameter.get('user') || '';
         setSearchValue(userSearchTerm);
         getSearchedUsers(userSearchTerm, 1);
         setIsPageLoading(false);


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on changing the search variable for users and changed it to `userSearchTerm`, because the name was conflicting with the global search.
Closes [#10390](https://github.com/open-metadata/OpenMetadata/issues/10390)

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement


#
### Frontend Preview (Screenshots) :

https://user-images.githubusercontent.com/59080942/224322272-a105c6ff-37a5-47ac-9923-542de9484082.mov


https://user-images.githubusercontent.com/59080942/224326059-86b16385-69fd-4b69-9616-b428751f3846.mov



#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ui 
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
