### PR TITLE
fix: Make column name a selection box only for tableRowInsertedCountToBeBetween test

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/AddDataQualityTest/components/ParameterForm.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AddDataQualityTest/components/ParameterForm.test.tsx
@@ -14,6 +14,7 @@
 import { act, render, screen } from '@testing-library/react';
 import { TestDefinition } from 'generated/tests/testDefinition';
 import {
+  MOCK_TABLE_COLUMN_NAME_TO_EXIST,
   MOCK_TABLE_ROW_INSERTED_COUNT_TO_BE_BETWEEN,
   MOCK_TABLE_WITH_DATE_TIME_COLUMNS,
 } from 'mocks/TestSuite.mock';
@@ -32,7 +33,7 @@ describe('ParameterForm component test', () => {
         />
       );
     });
-
+    // test definition should be "tableRowInsertedCountToBeBetween"
     const selectBox = await screen.findByRole('combobox');
     const parameters = await screen.findAllByTestId('parameter');
 
@@ -59,6 +60,25 @@ describe('ParameterForm component test', () => {
     expect(selectBox).not.toBeInTheDocument();
     expect(parameters).toHaveLength(
       MOCK_TABLE_ROW_INSERTED_COUNT_TO_BE_BETWEEN.parameterDefinition.length
+    );
+  });
+
+  it('Select box should not render if "columnName" field is present but test definition is not "tableRowInsertedCountToBeBetween"', async () => {
+    await act(async () => {
+      render(
+        <ParameterForm
+          definition={MOCK_TABLE_COLUMN_NAME_TO_EXIST as TestDefinition}
+          table={MOCK_TABLE_WITH_DATE_TIME_COLUMNS}
+        />
+      );
+    });
+
+    const selectBox = screen.queryByRole('combobox');
+    const parameters = await screen.findAllByTestId('parameter');
+
+    expect(selectBox).not.toBeInTheDocument();
+    expect(parameters).toHaveLength(
+      MOCK_TABLE_COLUMN_NAME_TO_EXIST.parameterDefinition.length
     );
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/AddDataQualityTest/components/ParameterForm.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AddDataQualityTest/components/ParameterForm.tsx
@@ -39,7 +39,11 @@ const ParameterForm: React.FC<ParameterFormProps> = ({ definition, table }) => {
     );
     switch (data.dataType) {
       case TestDataType.String:
-        if (data.name === 'columnName' && !isUndefined(table)) {
+        if (
+          !isUndefined(table) &&
+          definition.name === 'tableRowInsertedCountToBeBetween' &&
+          data.name === 'columnName'
+        ) {
           const partitionColumnOptions = table.columns.reduce(
             (result, column) => {
               if (SUPPORTED_PARTITION_TYPE.includes(column.dataType)) {

--- a/openmetadata-ui/src/main/resources/ui/src/mocks/TestSuite.mock.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/mocks/TestSuite.mock.ts
@@ -738,3 +738,29 @@ export const MOCK_TABLE_ROW_INSERTED_COUNT_TO_BE_BETWEEN = {
   href: 'http://sandbox-beta.open-metadata.org/api/v1/testDefinition/756c7770-0af3-49a9-9905-75a2886e5eec',
   deleted: false,
 };
+
+export const MOCK_TABLE_COLUMN_NAME_TO_EXIST = {
+  id: '6d4e4673-fd7f-4b37-811e-7645c3c17e93',
+  name: 'tableColumnNameToExist',
+  displayName: 'Table Column Name To Exist',
+  fullyQualifiedName: 'tableColumnNameToExist',
+  description:
+    'This test defines the test TableColumnNameToExist. Test the table columns exists in the table.',
+  entityType: 'TABLE',
+  testPlatforms: ['OpenMetadata'],
+  supportedDataTypes: [],
+  parameterDefinition: [
+    {
+      name: 'columnName',
+      displayName: 'Column Name',
+      dataType: 'STRING',
+      description: 'Expected column of the table to exist',
+      required: true,
+    },
+  ],
+  version: 0.1,
+  updatedAt: 1672236872076,
+  updatedBy: 'admin',
+  href: 'http://sandbox-beta.open-metadata.org/api/v1/testDefinition/6d4e4673-fd7f-4b37-811e-7645c3c17e93',
+  deleted: false,
+};


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Make column name a selection box only for tableRowInsertedCountToBeBetween test

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement


#
### Frontend Preview (Screenshots) :
<img width="1624" alt="image" src="https://user-images.githubusercontent.com/71748675/224482891-dda16187-d9e0-4eb2-bd1f-0ee5187790b5.png">

<img width="1624" alt="image" src="https://user-images.githubusercontent.com/71748675/224482906-71802416-b367-4a1b-8dc9-7120a41fad4f.png">

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
