### PR TITLE
Handle object store tags & Create abstract EntityUpdaterWithColumn

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ContainerRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ContainerRepository.java
@@ -7,7 +7,6 @@ import static org.openmetadata.service.Entity.FIELD_FOLLOWERS;
 import static org.openmetadata.service.Entity.FIELD_TAGS;
 import static org.openmetadata.service.Entity.OBJECT_STORE_SERVICE;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.Collections;
@@ -178,7 +177,7 @@ public class ContainerRepository extends EntityRepository<Container> {
   }
 
   /** Handles entity updated from PUT and POST operations */
-  public class ContainerUpdater extends EntityUpdater {
+  public class ContainerUpdater extends EntityUpdaterWithColumns {
     public ContainerUpdater(Container original, Container updated, Operation operation) {
       super(original, updated, operation);
     }
@@ -188,7 +187,16 @@ public class ContainerRepository extends EntityRepository<Container> {
       updateDataModel(original, updated);
     }
 
-    private void updateDataModel(Container original, Container updated) throws JsonProcessingException {
+    private void updateDataModel(Container original, Container updated) throws IOException {
+
+      if (original.getDataModel() != null && updated.getDataModel() != null) {
+        updateColumns(
+            "dataModel",
+            original.getDataModel().getColumns(),
+            updated.getDataModel().getColumns(),
+            EntityUtil.columnMatch);
+      }
+
       recordChange("dataModel", original.getDataModel(), updated.getDataModel(), true);
     }
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ContainerRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ContainerRepository.java
@@ -189,15 +189,21 @@ public class ContainerRepository extends EntityRepository<Container> {
 
     private void updateDataModel(Container original, Container updated) throws IOException {
 
+      if (original.getDataModel() == null || updated.getDataModel() == null) {
+        recordChange("dataModel", original.getDataModel(), updated.getDataModel(), true);
+      }
+
       if (original.getDataModel() != null && updated.getDataModel() != null) {
         updateColumns(
-            "dataModel",
+            "dataModel.columns",
             original.getDataModel().getColumns(),
             updated.getDataModel().getColumns(),
             EntityUtil.columnMatch);
+        recordChange(
+            "dataModel.partition",
+            original.getDataModel().getIsPartitioned(),
+            updated.getDataModel().getIsPartitioned());
       }
-
-      recordChange("dataModel", original.getDataModel(), updated.getDataModel(), true);
     }
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ContainerRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ContainerRepository.java
@@ -173,11 +173,11 @@ public class ContainerRepository extends EntityRepository<Container> {
 
   @Override
   public EntityUpdater getUpdater(Container original, Container updated, Operation operation) {
-    return new ContainerRepository.ContainerUpdater(original, updated, operation);
+    return new ContainerUpdater(original, updated, operation);
   }
 
   /** Handles entity updated from PUT and POST operations */
-  public class ContainerUpdater extends EntityUpdaterWithColumns {
+  public class ContainerUpdater extends ColumnEntityUpdater {
     public ContainerUpdater(Container original, Container updated, Operation operation) {
       super(original, updated, operation);
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -95,7 +95,6 @@ import org.openmetadata.service.exception.UnhandledServerException;
 import org.openmetadata.service.jdbi3.CollectionDAO.EntityRelationshipRecord;
 import org.openmetadata.service.jdbi3.CollectionDAO.EntityVersionPair;
 import org.openmetadata.service.jdbi3.CollectionDAO.ExtensionRecord;
-import org.openmetadata.service.jdbi3.TableRepository.TableUpdater;
 import org.openmetadata.service.resources.tags.TagLabelCache;
 import org.openmetadata.service.security.policyevaluator.SubjectCache;
 import org.openmetadata.service.util.EntityUtil;
@@ -1209,7 +1208,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
    * Common entity attributes such as description, displayName, owner, tags are handled by this class. Override {@code
    * entitySpecificUpdate()} to add additional entity specific fields to be updated.
    *
-   * @see TableUpdater#entitySpecificUpdate() for example.
+   * @see TableRepository.TableUpdater#entitySpecificUpdate() for example.
    */
   public class EntityUpdater {
     protected final T original;
@@ -1599,9 +1598,9 @@ public abstract class EntityRepository<T extends EntityInterface> {
   }
 
   /** Handle column-specific updates for entities such as Tables, Containers' dataModel or Dashboard Model Entities. */
-  abstract class EntityUpdaterWithColumns extends EntityUpdater {
+  abstract class ColumnEntityUpdater extends EntityUpdater {
 
-    public EntityUpdaterWithColumns(T original, T updated, Operation operation) {
+    public ColumnEntityUpdater(T original, T updated, Operation operation) {
       super(original, updated, operation);
     }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -32,6 +32,7 @@ import static org.openmetadata.service.util.EntityUtil.compareTagLabel;
 import static org.openmetadata.service.util.EntityUtil.entityReferenceMatch;
 import static org.openmetadata.service.util.EntityUtil.fieldAdded;
 import static org.openmetadata.service.util.EntityUtil.fieldDeleted;
+import static org.openmetadata.service.util.EntityUtil.getColumnField;
 import static org.openmetadata.service.util.EntityUtil.getExtensionField;
 import static org.openmetadata.service.util.EntityUtil.nextMajorVersion;
 import static org.openmetadata.service.util.EntityUtil.nextVersion;
@@ -56,6 +57,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.BiPredicate;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import javax.json.JsonPatch;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
@@ -72,6 +75,7 @@ import org.openmetadata.schema.entity.teams.Team;
 import org.openmetadata.schema.entity.teams.User;
 import org.openmetadata.schema.type.ChangeDescription;
 import org.openmetadata.schema.type.ChangeEvent;
+import org.openmetadata.schema.type.Column;
 import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.EventType;
@@ -1591,6 +1595,134 @@ public abstract class EntityRepository<T extends EntityInterface> {
 
     public final boolean updatedByBot() {
       return Boolean.TRUE.equals(updatingUser.getIsBot());
+    }
+  }
+
+  /** Handle column-specific updates for entities such as Tables, Containers' dataModel or Dashboard Model Entities. */
+  abstract class EntityUpdaterWithColumns extends EntityUpdater {
+
+    public EntityUpdaterWithColumns(T original, T updated, Operation operation) {
+      super(original, updated, operation);
+    }
+
+    public void updateColumns(
+        String fieldName,
+        List<Column> origColumns,
+        List<Column> updatedColumns,
+        BiPredicate<Column, Column> columnMatch)
+        throws IOException {
+      List<Column> deletedColumns = new ArrayList<>();
+      List<Column> addedColumns = new ArrayList<>();
+      recordListChange(fieldName, origColumns, updatedColumns, addedColumns, deletedColumns, columnMatch);
+      // carry forward tags and description if deletedColumns matches added column
+      Map<String, Column> addedColumnMap =
+          addedColumns.stream().collect(Collectors.toMap(Column::getName, Function.identity()));
+
+      for (Column deleted : deletedColumns) {
+        if (addedColumnMap.containsKey(deleted.getName())) {
+          Column addedColumn = addedColumnMap.get(deleted.getName());
+          if (nullOrEmpty(addedColumn.getDescription())) {
+            addedColumn.setDescription(deleted.getDescription());
+          }
+          if (nullOrEmpty(addedColumn.getTags()) && nullOrEmpty(deleted.getTags())) {
+            addedColumn.setTags(deleted.getTags());
+          }
+        }
+      }
+
+      // Delete tags related to deleted columns
+      deletedColumns.forEach(
+          deleted -> daoCollection.tagUsageDAO().deleteTagsByTarget(deleted.getFullyQualifiedName()));
+
+      // Add tags related to newly added columns
+      for (Column added : addedColumns) {
+        applyTags(added.getTags(), added.getFullyQualifiedName());
+      }
+
+      // Carry forward the user generated metadata from existing columns to new columns
+      for (Column updated : updatedColumns) {
+        // Find stored column matching name, data type and ordinal position
+        Column stored = origColumns.stream().filter(c -> columnMatch.test(c, updated)).findAny().orElse(null);
+        if (stored == null) { // New column added
+          continue;
+        }
+
+        updateColumnDescription(stored, updated);
+        updateColumnDisplayName(stored, updated);
+        updateColumnDataLength(stored, updated);
+        updateColumnPrecision(stored, updated);
+        updateColumnScale(stored, updated);
+        updateTags(
+            stored.getFullyQualifiedName(),
+            EntityUtil.getFieldName(fieldName, updated.getName(), FIELD_TAGS),
+            stored.getTags(),
+            updated.getTags());
+        updateColumnConstraint(stored, updated);
+
+        if (updated.getChildren() != null && stored.getChildren() != null) {
+          String childrenFieldName = EntityUtil.getFieldName(fieldName, updated.getName());
+          updateColumns(childrenFieldName, stored.getChildren(), updated.getChildren(), columnMatch);
+        }
+      }
+
+      majorVersionChange = majorVersionChange || !deletedColumns.isEmpty();
+    }
+
+    private void updateColumnDescription(Column origColumn, Column updatedColumn) throws JsonProcessingException {
+      if (operation.isPut() && !nullOrEmpty(origColumn.getDescription()) && updatedByBot()) {
+        // Revert the non-empty task description if being updated by a bot
+        updatedColumn.setDescription(origColumn.getDescription());
+        return;
+      }
+      String columnField = getColumnField(original, origColumn, FIELD_DESCRIPTION);
+      recordChange(columnField, origColumn.getDescription(), updatedColumn.getDescription());
+    }
+
+    private void updateColumnDisplayName(Column origColumn, Column updatedColumn) throws JsonProcessingException {
+      if (operation.isPut() && !nullOrEmpty(origColumn.getDescription()) && updatedByBot()) {
+        // Revert the non-empty task description if being updated by a bot
+        updatedColumn.setDisplayName(origColumn.getDisplayName());
+        return;
+      }
+      String columnField = getColumnField(original, origColumn, FIELD_DISPLAY_NAME);
+      recordChange(columnField, origColumn.getDisplayName(), updatedColumn.getDisplayName());
+    }
+
+    private void updateColumnConstraint(Column origColumn, Column updatedColumn) throws JsonProcessingException {
+      String columnField = getColumnField(original, origColumn, "constraint");
+      recordChange(columnField, origColumn.getConstraint(), updatedColumn.getConstraint());
+    }
+
+    protected void updateColumnDataLength(Column origColumn, Column updatedColumn) throws JsonProcessingException {
+      String columnField = getColumnField(original, origColumn, "dataLength");
+      boolean updated = recordChange(columnField, origColumn.getDataLength(), updatedColumn.getDataLength());
+      if (updated
+          && (origColumn.getDataLength() == null || updatedColumn.getDataLength() < origColumn.getDataLength())) {
+        // The data length of a column was reduced or added. Treat it as backward-incompatible change
+        majorVersionChange = true;
+      }
+    }
+
+    private void updateColumnPrecision(Column origColumn, Column updatedColumn) throws JsonProcessingException {
+      String columnField = getColumnField(original, origColumn, "precision");
+      boolean updated = recordChange(columnField, origColumn.getPrecision(), updatedColumn.getPrecision());
+      if (origColumn.getPrecision() != null
+          && updated
+          && updatedColumn.getPrecision() < origColumn.getPrecision()) { // Previously precision was set
+        // The precision was reduced. Treat it as backward-incompatible change
+        majorVersionChange = true;
+      }
+    }
+
+    private void updateColumnScale(Column origColumn, Column updatedColumn) throws JsonProcessingException {
+      String columnField = getColumnField(original, origColumn, "scale");
+      boolean updated = recordChange(columnField, origColumn.getScale(), updatedColumn.getScale());
+      if (origColumn.getScale() != null
+          && updated
+          && updatedColumn.getScale() < origColumn.getScale()) { // Previously scale was set
+        // The scale was reduced. Treat it as backward-incompatible change
+        majorVersionChange = true;
+      }
     }
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
@@ -19,14 +19,11 @@ import static org.openmetadata.common.utils.CommonUtil.listOrEmpty;
 import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 import static org.openmetadata.schema.type.Include.ALL;
 import static org.openmetadata.service.Entity.DATABASE_SCHEMA;
-import static org.openmetadata.service.Entity.FIELD_DESCRIPTION;
-import static org.openmetadata.service.Entity.FIELD_DISPLAY_NAME;
 import static org.openmetadata.service.Entity.FIELD_FOLLOWERS;
 import static org.openmetadata.service.Entity.FIELD_OWNER;
 import static org.openmetadata.service.Entity.FIELD_TAGS;
 import static org.openmetadata.service.Entity.LOCATION;
 import static org.openmetadata.service.Entity.TABLE;
-import static org.openmetadata.service.util.EntityUtil.getColumnField;
 import static org.openmetadata.service.util.LambdaExceptionUtil.ignoringComparator;
 import static org.openmetadata.service.util.LambdaExceptionUtil.rethrowFunction;
 
@@ -45,8 +42,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.function.BiPredicate;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -1044,7 +1039,7 @@ public class TableRepository extends EntityRepository<Table> {
   }
 
   /** Handles entity updated from PUT and POST operation. */
-  public class TableUpdater extends EntityUpdater {
+  public class TableUpdater extends EntityUpdaterWithColumns {
     public TableUpdater(Table original, Table updated, Operation operation) {
       super(original, updated, operation);
     }
@@ -1073,126 +1068,6 @@ public class TableRepository extends EntityRepository<Table> {
       List<TableConstraint> deleted = new ArrayList<>();
       recordListChange(
           "tableConstraints", origConstraints, updatedConstraints, added, deleted, EntityUtil.tableConstraintMatch);
-    }
-
-    private void updateColumns(
-        String fieldName,
-        List<Column> origColumns,
-        List<Column> updatedColumns,
-        BiPredicate<Column, Column> columnMatch)
-        throws IOException {
-      List<Column> deletedColumns = new ArrayList<>();
-      List<Column> addedColumns = new ArrayList<>();
-      recordListChange(fieldName, origColumns, updatedColumns, addedColumns, deletedColumns, columnMatch);
-      // carry forward tags and description if deletedColumns matches added column
-      Map<String, Column> addedColumnMap =
-          addedColumns.stream().collect(Collectors.toMap(Column::getName, Function.identity()));
-
-      for (Column deleted : deletedColumns) {
-        if (addedColumnMap.containsKey(deleted.getName())) {
-          Column addedColumn = addedColumnMap.get(deleted.getName());
-          if (nullOrEmpty(addedColumn.getDescription())) {
-            addedColumn.setDescription(deleted.getDescription());
-          }
-          if (nullOrEmpty(addedColumn.getTags()) && nullOrEmpty(deleted.getTags())) {
-            addedColumn.setTags(deleted.getTags());
-          }
-        }
-      }
-
-      // Delete tags related to deleted columns
-      deletedColumns.forEach(
-          deleted -> daoCollection.tagUsageDAO().deleteTagsByTarget(deleted.getFullyQualifiedName()));
-
-      // Add tags related to newly added columns
-      for (Column added : addedColumns) {
-        applyTags(added.getTags(), added.getFullyQualifiedName());
-      }
-
-      // Carry forward the user generated metadata from existing columns to new columns
-      for (Column updated : updatedColumns) {
-        // Find stored column matching name, data type and ordinal position
-        Column stored = origColumns.stream().filter(c -> columnMatch.test(c, updated)).findAny().orElse(null);
-        if (stored == null) { // New column added
-          continue;
-        }
-
-        updateColumnDescription(stored, updated);
-        updateColumnDisplayName(stored, updated);
-        updateColumnDataLength(stored, updated);
-        updateColumnPrecision(stored, updated);
-        updateColumnScale(stored, updated);
-        updateTags(
-            stored.getFullyQualifiedName(),
-            EntityUtil.getFieldName(fieldName, updated.getName(), FIELD_TAGS),
-            stored.getTags(),
-            updated.getTags());
-        updateColumnConstraint(stored, updated);
-
-        if (updated.getChildren() != null && stored.getChildren() != null) {
-          String childrenFieldName = EntityUtil.getFieldName(fieldName, updated.getName());
-          updateColumns(childrenFieldName, stored.getChildren(), updated.getChildren(), columnMatch);
-        }
-      }
-
-      majorVersionChange = majorVersionChange || !deletedColumns.isEmpty();
-    }
-
-    private void updateColumnDescription(Column origColumn, Column updatedColumn) throws JsonProcessingException {
-      if (operation.isPut() && !nullOrEmpty(origColumn.getDescription()) && updatedByBot()) {
-        // Revert the non-empty task description if being updated by a bot
-        updatedColumn.setDescription(origColumn.getDescription());
-        return;
-      }
-      String columnField = getColumnField(original, origColumn, FIELD_DESCRIPTION);
-      recordChange(columnField, origColumn.getDescription(), updatedColumn.getDescription());
-    }
-
-    private void updateColumnDisplayName(Column origColumn, Column updatedColumn) throws JsonProcessingException {
-      if (operation.isPut() && !nullOrEmpty(origColumn.getDescription()) && updatedByBot()) {
-        // Revert the non-empty task description if being updated by a bot
-        updatedColumn.setDisplayName(origColumn.getDisplayName());
-        return;
-      }
-      String columnField = getColumnField(original, origColumn, FIELD_DISPLAY_NAME);
-      recordChange(columnField, origColumn.getDisplayName(), updatedColumn.getDisplayName());
-    }
-
-    private void updateColumnConstraint(Column origColumn, Column updatedColumn) throws JsonProcessingException {
-      String columnField = getColumnField(original, origColumn, "constraint");
-      recordChange(columnField, origColumn.getConstraint(), updatedColumn.getConstraint());
-    }
-
-    protected void updateColumnDataLength(Column origColumn, Column updatedColumn) throws JsonProcessingException {
-      String columnField = getColumnField(original, origColumn, "dataLength");
-      boolean updated = recordChange(columnField, origColumn.getDataLength(), updatedColumn.getDataLength());
-      if (updated
-          && (origColumn.getDataLength() == null || updatedColumn.getDataLength() < origColumn.getDataLength())) {
-        // The data length of a column was reduced or added. Treat it as backward-incompatible change
-        majorVersionChange = true;
-      }
-    }
-
-    private void updateColumnPrecision(Column origColumn, Column updatedColumn) throws JsonProcessingException {
-      String columnField = getColumnField(original, origColumn, "precision");
-      boolean updated = recordChange(columnField, origColumn.getPrecision(), updatedColumn.getPrecision());
-      if (origColumn.getPrecision() != null
-          && updated
-          && updatedColumn.getPrecision() < origColumn.getPrecision()) { // Previously precision was set
-        // The precision was reduced. Treat it as backward-incompatible change
-        majorVersionChange = true;
-      }
-    }
-
-    private void updateColumnScale(Column origColumn, Column updatedColumn) throws JsonProcessingException {
-      String columnField = getColumnField(original, origColumn, "scale");
-      boolean updated = recordChange(columnField, origColumn.getScale(), updatedColumn.getScale());
-      if (origColumn.getScale() != null
-          && updated
-          && updatedColumn.getScale() < origColumn.getScale()) { // Previously scale was set
-        // The scale was reduced. Treat it as backward-incompatible change
-        majorVersionChange = true;
-      }
     }
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
@@ -1039,7 +1039,7 @@ public class TableRepository extends EntityRepository<Table> {
   }
 
   /** Handles entity updated from PUT and POST operation. */
-  public class TableUpdater extends EntityUpdaterWithColumns {
+  public class TableUpdater extends ColumnEntityUpdater {
     public TableUpdater(Table original, Table updated, Operation operation) {
       super(original, updated, operation);
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/EntityUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/EntityUtil.java
@@ -328,10 +328,11 @@ public final class EntityUtil {
   }
 
   /** Return column field name of format "columns".columnName.columnFieldName */
-  public static String getColumnField(Table table, Column column, String columnField) {
+  public static <T extends EntityInterface> String getColumnField(
+      T entityWithColumns, Column column, String columnField) {
     // Remove table FQN from column FQN to get the local name
     String localColumnName =
-        EntityUtil.getLocalColumnName(table.getFullyQualifiedName(), column.getFullyQualifiedName());
+        EntityUtil.getLocalColumnName(entityWithColumns.getFullyQualifiedName(), column.getFullyQualifiedName());
     return columnField == null
         ? FullyQualifiedName.build("columns", localColumnName)
         : FullyQualifiedName.build("columns", localColumnName, columnField);

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/objectstores/ContainerResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/objectstores/ContainerResourceTest.java
@@ -12,6 +12,7 @@ import static org.openmetadata.service.resources.databases.TableResourceTest.get
 import static org.openmetadata.service.util.EntityUtil.fieldAdded;
 import static org.openmetadata.service.util.EntityUtil.fieldUpdated;
 import static org.openmetadata.service.util.TestUtils.ADMIN_AUTH_HEADERS;
+import static org.openmetadata.service.util.TestUtils.UpdateType.MAJOR_UPDATE;
 import static org.openmetadata.service.util.TestUtils.UpdateType.MINOR_UPDATE;
 import static org.openmetadata.service.util.TestUtils.UpdateType.NO_CHANGE;
 import static org.openmetadata.service.util.TestUtils.assertListNotNull;
@@ -154,10 +155,11 @@ public class ContainerResourceTest extends EntityResourceTest<Container, CreateC
     Container container = createAndCheckEntity(request, ADMIN_AUTH_HEADERS);
     ChangeDescription change = getChangeDescription(container.getVersion());
 
+    // We are removing the columns here. This is a major change
     ContainerDataModel newDataModel =
         new ContainerDataModel().withIsPartitioned(false).withColumns(Collections.emptyList());
     fieldUpdated(change, "dataModel", PARTITIONED_DATA_MODEL, newDataModel);
-    updateAndCheckEntity(request.withDataModel(newDataModel), OK, ADMIN_AUTH_HEADERS, MINOR_UPDATE, change);
+    updateAndCheckEntity(request.withDataModel(newDataModel), OK, ADMIN_AUTH_HEADERS, MAJOR_UPDATE, change);
   }
 
   @Test


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->

Containers can have `dataModel` as a property. The columns in the data model can have tags, which werent' properly handled by the PATCH operations as the updater was missing all the logic.

As we'll have columns in tables, datamodels and the incoming Data Model Entity for dashboards, we have externalized the columns updater logic so that it can be reused everywhere.


#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
