### PR TITLE
Bug: TypeError when dashboards field is not present in a workspace response

### DIFF
--- a/ingestion/src/metadata/ingestion/source/dashboard/powerbi/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/powerbi/metadata.py
@@ -141,7 +141,7 @@ class PowerbiSource(DashboardServiceSource):
         """
         Get List of all dashboards
         """
-        return self.context.workspace.get("dashboards")
+        return self.context.workspace.get("dashboards", [])
 
     def get_dashboard_name(self, dashboard: dict) -> str:
         """


### PR DESCRIPTION
### Describe your changes :
When the dashboard field is not present in a workspace response during ingestion, it can cause a TypeError, which stops the whole ingestion.

### Type of change :
- [x] Bug fix

### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

### Reviewers
Ingestion: @open-metadata/ingestion
