### PR TITLE
Fix: remove avro-python3 deprecated dependency

### DIFF
--- a/ingestion/setup.py
+++ b/ingestion/setup.py
@@ -29,7 +29,7 @@ def get_long_description():
 # Add here versions required for multiple plugins
 VERSIONS = {
     "airflow": "apache-airflow==2.3.3",
-    "avro-python3": "avro-python3~=1.10",
+    "avro": "avro~=1.11",
     "boto3": "boto3>=1.20,<2.0",  # No need to add botocore separately. It's a dep from boto3
     "geoalchemy2": "GeoAlchemy2~=0.12",
     "google-cloud-storage": "google-cloud-storage==1.43.0",
@@ -52,8 +52,7 @@ COMMONS = {
         "pyhive~=0.6",
     },
     "kafka": {
-        "avro~=1.11",
-        VERSIONS["avro-python3"],
+        VERSIONS["avro"],
         "confluent_kafka==1.8.2",
         "fastavro>=1.2.0",
         # Due to https://github.com/grpc/grpc/issues/30843#issuecomment-1303816925
@@ -78,7 +77,7 @@ pii_requirements = {
 
 base_requirements = {
     "antlr4-python3-runtime==4.9.2",
-    VERSIONS["avro-python3"],  # Used in sample data
+    VERSIONS["avro"],  # Used in sample data
     VERSIONS["boto3"],  # Required in base for the secrets manager
     "cached-property==1.5.2",
     "chardet==4.0.0",

--- a/ingestion/tests/unit/topology/database/test_datalake.py
+++ b/ingestion/tests/unit/topology/database/test_datalake.py
@@ -332,7 +332,7 @@ class DatalakeUnitTest(TestCase):
         assert actual_df_1.compare(exp_df_list).empty
         assert actual_df_2.compare(exp_df_obj).empty
 
-    def x_test_avro_file_parse(self):  # disabling this test as failing with CI
+    def test_avro_file_parse(self):  # disabling this test as failing with CI
         columns = read_from_avro(AVRO_SCHEMA_FILE)
         Column.__eq__ = custom_column_compare
 


### PR DESCRIPTION
### Describe your changes :
Remove `avro-python3` deprecated dependency

### Type of change :
- [x] Improvement


### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

### Reviewers
Ingestion: @open-metadata/ingestion
