### PR TITLE
datatype mapped for mysql,mariadb, mssql and azuresql

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/azuresql/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/azuresql/metadata.py
@@ -10,6 +10,10 @@
 #  limitations under the License.
 """Azure SQL source module"""
 
+from sqlalchemy.dialects.mssql.base import ischema_names
+from sqlalchemy.dialects.mssql.pyodbc import MSDialect_pyodbc
+from sqlalchemy.sql.sqltypes import String
+
 from metadata.generated.schema.entity.services.connections.database.azureSQLConnection import (
     AzureSQLConnection,
 )
@@ -21,6 +25,134 @@ from metadata.generated.schema.metadataIngestion.workflow import (
 )
 from metadata.ingestion.api.source import InvalidSourceException
 from metadata.ingestion.source.database.common_db_source import CommonDbSourceService
+
+
+class NCHAR(String):
+    """The SQL NCHAR type."""
+
+    __visit_name__ = "NCHAR"
+
+
+class NVARCHAR(String):
+    """The SQL NVARCHAR type."""
+
+    __visit_name__ = "NVARCHAR"
+
+
+class NTEXT(String):
+    """The SQL NTEXT type."""
+
+    __visit_name__ = "NTEXT"
+
+
+class BINARY(String):
+    """The SQL BINARY type."""
+
+    __visit_name__ = "BINARY"
+
+
+class IMAGE(String):
+    """The SQL IMAGE type."""
+
+    __visit_name__ = "IMAGE"
+
+
+class BIT(String):
+    """The SQL BIT type."""
+
+    __visit_name__ = "BIT"
+
+
+class SMALLMONEY(String):
+    """The SQL SMALLMONEY type."""
+
+    __visit_name__ = "SMALLMONEY"
+
+
+class MONEY(String):
+    """The SQL MONEY type."""
+
+    __visit_name__ = "MONEY"
+
+
+class REAL(String):
+    """The SQL REAL type."""
+
+    __visit_name__ = "REAL"
+
+
+class SMALLDATETIME(String):
+    """The SQL SMALLDATETIME type."""
+
+    __visit_name__ = "SMALLDATETIME"
+
+
+class DATETIME2(String):
+    """The SQL DATETIME2 type."""
+
+    __visit_name__ = "DATETIME2"
+
+
+class DATETIMEOFFSET(String):
+    """The SQL DATETIMEOFFSET type."""
+
+    __visit_name__ = "DATETIMEOFFSET"
+
+
+class SQL_VARIANT(String):
+    """The SQL SQL_VARIANT type."""
+
+    __visit_name__ = "SQL_VARIANT"
+
+
+class UNIQUEIDENTIFIER(String):
+    """The SQL UNIQUEIDENTIFIER type."""
+
+    __visit_name__ = "UNIQUEIDENTIFIER"
+
+
+class XML(String):
+    """The SQL XML type."""
+
+    __visit_name__ = "XML"
+
+
+class GEOGRAPHY(String):
+    """The SQL GEOGRAPHY type."""
+
+    __visit_name__ = "GEOGRAPHY"
+
+
+class GEOMETRY(String):
+    """The SQL GEOMETRY type."""
+
+    __visit_name__ = "GEOMETRY"
+
+
+ischema_names.update(
+    {
+        "nvarchar": NVARCHAR,
+        "nchar": NCHAR,
+        "ntext": NTEXT,
+        "bit": BIT,
+        "image": IMAGE,
+        "binary": BINARY,
+        "smallmoney": SMALLMONEY,
+        "money": MONEY,
+        "real": REAL,
+        "smalldatetime": SMALLDATETIME,
+        "datetime2": DATETIME2,
+        "datetimeoffset": DATETIMEOFFSET,
+        "sql_variant": SQL_VARIANT,
+        "uniqueidentifier": UNIQUEIDENTIFIER,
+        "xml": XML,
+        "geography": GEOGRAPHY,
+        "geometry": GEOMETRY,
+    }
+)
+
+
+MSDialect_pyodbc.ischema_names = ischema_names
 
 
 class AzuresqlSource(CommonDbSourceService):

--- a/ingestion/src/metadata/ingestion/source/database/column_type_parser.py
+++ b/ingestion/src/metadata/ingestion/source/database/column_type_parser.py
@@ -194,6 +194,12 @@ class ColumnTypeParser:
         "POLYGON": "POLYGON",
         "AggregateFunction()": "AGGREGATEFUNCTION",
         "BYTEA": "BYTEA",
+        "YEAR": "YEAR",
+        "LONGTEXT": "LONGTEXT",
+        "TINYTEXT": "TINYTEXT",
+        "MEDIUMINT": "MEDIUMINT",
+        "TINYBLOB": "TINYBLOB",
+        "BIT": "BIT",
     }
 
     _COMPLEX_TYPE = re.compile("^(struct|map|array|uniontype)")

--- a/ingestion/src/metadata/ingestion/source/database/mariadb/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/mariadb/metadata.py
@@ -11,6 +11,10 @@
 """
 MariaDB source module
 """
+from sqlalchemy.dialects.mysql.base import ischema_names
+from sqlalchemy.dialects.mysql.mariadb import MariaDBDialect
+from sqlalchemy.sql.sqltypes import String
+
 from metadata.generated.schema.entity.services.connections.database.mariaDBConnection import (
     MariaDBConnection,
 )
@@ -22,6 +26,57 @@ from metadata.generated.schema.metadataIngestion.workflow import (
 )
 from metadata.ingestion.api.source import InvalidSourceException
 from metadata.ingestion.source.database.common_db_source import CommonDbSourceService
+
+
+class YEAR(String):
+    """The SQL GEOMETRY type."""
+
+    __visit_name__ = "GEOMETRY"
+
+
+class LONGTEXT(String):
+    """The SQL LONGTEXT type."""
+
+    __visit_name__ = "LONGTEXT"
+
+
+class TINYTEXT(String):
+    """The SQL TINYTEXT type."""
+
+    __visit_name__ = "TINYTEXT"
+
+
+class BOOL(String):
+    """The SQL BOOL type."""
+
+    __visit_name__ = "BOOL"
+
+
+class MEDIUMINT(String):
+    """The SQL MEDIUMINT type."""
+
+    __visit_name__ = "MEDIUMINT"
+
+
+class TINYBLOB(String):
+    """The SQL TINYBLOB type."""
+
+    __visit_name__ = "TINYBLOB"
+
+
+ischema_names.update(
+    {
+        "year": YEAR,
+        "longtext": LONGTEXT,
+        "tinytext": TINYTEXT,
+        "BOOL": BOOL,
+        "MEDIUMINT": MEDIUMINT,
+        "TINYBLOB": TINYBLOB,
+    }
+)
+
+
+MariaDBDialect.ischema_names = ischema_names
 
 
 class MariadbSource(CommonDbSourceService):

--- a/ingestion/src/metadata/ingestion/source/database/mssql/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/mssql/metadata.py
@@ -27,9 +27,11 @@ from sqlalchemy.dialects.mssql.base import (
     MSText,
     MSVarBinary,
     _db_plus_owner,
+    ischema_names,
 )
 from sqlalchemy.engine import reflection
 from sqlalchemy.sql import func
+from sqlalchemy.sql.sqltypes import String
 from sqlalchemy.types import NVARCHAR
 from sqlalchemy.util import compat
 
@@ -61,6 +63,120 @@ from metadata.utils.sqlalchemy_utils import (
 )
 
 logger = ingestion_logger()
+
+
+class NCHAR(String):
+    """The SQL NCHAR type."""
+
+    __visit_name__ = "NCHAR"
+
+
+class NVARCHAR(String):
+    """The SQL NVARCHAR type."""
+
+    __visit_name__ = "NVARCHAR"
+
+
+class NTEXT(String):
+    """The SQL NTEXT type."""
+
+    __visit_name__ = "NTEXT"
+
+
+class BINARY(String):
+    """The SQL BINARY type."""
+
+    __visit_name__ = "BINARY"
+
+
+class IMAGE(String):
+    """The SQL IMAGE type."""
+
+    __visit_name__ = "IMAGE"
+
+
+class BIT(String):
+    """The SQL BIT type."""
+
+    __visit_name__ = "BIT"
+
+
+class SMALLMONEY(String):
+    """The SQL SMALLMONEY type."""
+
+    __visit_name__ = "SMALLMONEY"
+
+
+class MONEY(String):
+    """The SQL MONEY type."""
+
+    __visit_name__ = "MONEY"
+
+
+class REAL(String):
+    """The SQL REAL type."""
+
+    __visit_name__ = "REAL"
+
+
+class SMALLDATETIME(String):
+    """The SQL SMALLDATETIME type."""
+
+    __visit_name__ = "SMALLDATETIME"
+
+
+class DATETIME2(String):
+    """The SQL DATETIME2 type."""
+
+    __visit_name__ = "DATETIME2"
+
+
+class DATETIMEOFFSET(String):
+    """The SQL DATETIMEOFFSET type."""
+
+    __visit_name__ = "DATETIMEOFFSET"
+
+
+class SQL_VARIANT(String):
+    """The SQL SQL_VARIANT type."""
+
+    __visit_name__ = "SQL_VARIANT"
+
+
+class UNIQUEIDENTIFIER(String):
+    """The SQL UNIQUEIDENTIFIER type."""
+
+    __visit_name__ = "UNIQUEIDENTIFIER"
+
+
+class XML(String):
+    """The SQL XML type."""
+
+    __visit_name__ = "XML"
+
+
+ischema_names.update(
+    {
+        "nvarchar": NVARCHAR,
+        "nchar": NCHAR,
+        "ntext": NTEXT,
+        "bit": BIT,
+        "image": IMAGE,
+        "binary": BINARY,
+        "smallmoney": SMALLMONEY,
+        "money": MONEY,
+        "real": REAL,
+        "smalldatetime": SMALLDATETIME,
+        "datetime2": DATETIME2,
+        "datetimeoffset": DATETIMEOFFSET,
+        "sql_variant": SQL_VARIANT,
+        "uniqueidentifier": UNIQUEIDENTIFIER,
+        "xml": XML,
+    }
+)
+
+
+MSDialect.ischema_names = ischema_names
 
 
 @reflection.cache

--- a/ingestion/src/metadata/ingestion/source/database/mysql/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/mysql/metadata.py
@@ -9,6 +9,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """Mysql source module"""
+from sqlalchemy.dialects.mysql.base import MySQLDialect, ischema_names
+from sqlalchemy.sql.sqltypes import String
+
 from metadata.generated.schema.entity.services.connections.database.mysqlConnection import (
     MysqlConnection,
 )
@@ -20,6 +23,57 @@ from metadata.generated.schema.metadataIngestion.workflow import (
 )
 from metadata.ingestion.api.source import InvalidSourceException
 from metadata.ingestion.source.database.common_db_source import CommonDbSourceService
+
+
+class YEAR(String):
+    """The SQL GEOMETRY type."""
+
+    __visit_name__ = "GEOMETRY"
+
+
+class LONGTEXT(String):
+    """The SQL LONGTEXT type."""
+
+    __visit_name__ = "LONGTEXT"
+
+
+class TINYTEXT(String):
+    """The SQL TINYTEXT type."""
+
+    __visit_name__ = "TINYTEXT"
+
+
+class BOOL(String):
+    """The SQL BOOL type."""
+
+    __visit_name__ = "BOOL"
+
+
+class MEDIUMINT(String):
+    """The SQL MEDIUMINT type."""
+
+    __visit_name__ = "MEDIUMINT"
+
+
+class TINYBLOB(String):
+    """The SQL TINYBLOB type."""
+
+    __visit_name__ = "TINYBLOB"
+
+
+ischema_names.update(
+    {
+        "year": YEAR,
+        "longtext": LONGTEXT,
+        "tinytext": TINYTEXT,
+        "BOOL": BOOL,
+        "MEDIUMINT": MEDIUMINT,
+        "TINYBLOB": TINYBLOB,
+    }
+)
+
+
+MySQLDialect.ischema_names = ischema_names
 
 
 class MysqlSource(CommonDbSourceService):

--- a/openmetadata-spec/src/main/resources/json/schema/entity/data/table.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/data/table.json
@@ -123,7 +123,27 @@
         "ERROR",
         "FIXED",
         "RECORD",
-        "NULL"
+        "NULL",
+        "YEAR",
+        "LONGTEXT",
+        "TINYTEXT",
+        "BOOL",
+        "MEDIUMINT",
+        "TINYBLOB",
+        "NCHAR",
+        "NVARCHAR",
+        "NTEXT",
+        "IMAGE",
+        "BIT",
+        "SMALLMONEY",
+        "MONEY",
+        "REAL",
+        "SMALLDATETIME",
+        "DATETIME2",
+        "DATETIMEOFFSET",
+        "SQL_VARIANT",
+        "UNIQUEIDENTIFIER",
+        "XML"
       ]
     },
     "constraint": {


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the mapping all possible datatypes for mysql, mariadb, mssql and azuresql to openmetadata.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] All new and existing tests passed.

#
### Reviewers
@open-metadata/ingestion
