### PR TITLE
fix: declaring self.data after calling self.token

### DIFF
--- a/ingestion/src/metadata/ingestion/source/pipeline/nifi/client.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/nifi/client.py
@@ -52,12 +52,12 @@ class NifiClient:
         self.password = password
 
         if all(setting for setting in [self.username, self.password]):
+            self.data = f"username={self.username}&password={self.password}"
             self.verify = verify
             self.headers = {
                 "Authorization": f"Bearer {self.token}",
                 **self.content_headers,
             }
-            self.data = f"username={self.username}&password={self.password}"
             self.client_cert = None
         else:
             self.data = None


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the ..... because ...

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
