### PR TITLE
Move common functionality to EntityRepository store method

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/AlertActionRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/AlertActionRepository.java
@@ -5,7 +5,6 @@ import static org.openmetadata.service.Entity.ALERT_ACTION;
 import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.entity.alerts.AlertAction;
-import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.service.alerts.AlertsPublisherManager;
 import org.openmetadata.service.resources.dqtests.TestDefinitionResource;
 import org.openmetadata.service.util.EntityUtil;
@@ -40,13 +39,7 @@ public class AlertActionRepository extends EntityRepository<AlertAction> {
 
   @Override
   public void storeEntity(AlertAction entity, boolean update) throws IOException {
-    EntityReference owner = entity.getOwner();
-    // Don't store owner, database, href and tags as JSON. Build it on the fly based on relationships
-    entity.withOwner(null).withHref(null);
     store(entity, update);
-
-    // Restore the relationships
-    entity.withOwner(owner);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/AlertRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/AlertRepository.java
@@ -80,13 +80,7 @@ public class AlertRepository extends EntityRepository<Alert> {
 
   @Override
   public void storeEntity(Alert entity, boolean update) throws IOException {
-    EntityReference owner = entity.getOwner();
-    // Don't store owner, database, href and tags as JSON. Build it on the fly based on relationships
-    entity.withOwner(null).withHref(null);
     store(entity, update);
-
-    // Restore the relationships
-    entity.withOwner(owner);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ChartRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ChartRepository.java
@@ -17,7 +17,6 @@ import static org.openmetadata.service.Entity.FIELD_FOLLOWERS;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
-import java.util.List;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.entity.data.Chart;
@@ -25,7 +24,6 @@ import org.openmetadata.schema.entity.services.DashboardService;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.Relationship;
-import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.resources.charts.ChartResource;
 import org.openmetadata.service.util.EntityUtil.Fields;
@@ -61,18 +59,11 @@ public class ChartRepository extends EntityRepository<Chart> {
 
   @Override
   public void storeEntity(Chart chart, boolean update) throws JsonProcessingException {
-    // Relationships and fields such as href are derived and not stored as part of json
-    EntityReference owner = chart.getOwner();
-    List<TagLabel> tags = chart.getTags();
+    // Relationships and fields such as tags are not stored as part of json
     EntityReference service = chart.getService();
-
-    // Don't store owner, database, href and tags as JSON. Build it on the fly based on relationships
-    chart.withOwner(null).withService(null).withHref(null).withTags(null);
-
+    chart.withService(null);
     store(chart, update);
-
-    // Restore the relationships
-    chart.withOwner(owner).withService(service).withTags(tags);
+    chart.withService(service);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DashboardRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DashboardRepository.java
@@ -27,7 +27,6 @@ import org.openmetadata.schema.entity.services.DashboardService;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.Relationship;
-import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.CollectionDAO.EntityRelationshipRecord;
 import org.openmetadata.service.resources.dashboards.DashboardResource;
@@ -98,18 +97,11 @@ public class DashboardRepository extends EntityRepository<Dashboard> {
 
   @Override
   public void storeEntity(Dashboard dashboard, boolean update) throws JsonProcessingException {
-    // Relationships and fields such as href are derived and not stored as part of json
-    EntityReference owner = dashboard.getOwner();
-    List<TagLabel> tags = dashboard.getTags();
+    // Relationships and fields such as service are not stored as part of json
     EntityReference service = dashboard.getService();
-
-    // Don't store owner, database, href and tags as JSON. Build it on the fly based on relationships
-    dashboard.withOwner(null).withHref(null).withTags(null).withService(null);
-
+    dashboard.withService(null);
     store(dashboard, update);
-
-    // Restore the relationships
-    dashboard.withOwner(owner).withTags(tags).withService(service);
+    dashboard.withService(service);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataInsightChartRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataInsightChartRepository.java
@@ -19,7 +19,6 @@ import org.elasticsearch.search.aggregations.metrics.SumAggregationBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.openmetadata.schema.dataInsight.DataInsightChart;
 import org.openmetadata.schema.dataInsight.DataInsightChartResult;
-import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.service.util.EntityUtil;
 
 public class DataInsightChartRepository extends EntityRepository<DataInsightChart> {
@@ -97,12 +96,7 @@ public class DataInsightChartRepository extends EntityRepository<DataInsightChar
 
   @Override
   public void storeEntity(DataInsightChart entity, boolean update) throws IOException {
-    EntityReference owner = entity.getOwner();
-    // Don't store owner, database, href and tags as JSON. Build it on the fly based on relationships
-    entity.withOwner(null).withHref(null);
     store(entity, update);
-    // Restore the relationships
-    entity.withOwner(owner);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DatabaseRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DatabaseRepository.java
@@ -24,7 +24,6 @@ import org.openmetadata.schema.entity.services.DatabaseService;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.Relationship;
-import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.CollectionDAO.EntityRelationshipRecord;
 import org.openmetadata.service.resources.databases.DatabaseResource;
@@ -64,17 +63,11 @@ public class DatabaseRepository extends EntityRepository<Database> {
 
   @Override
   public void storeEntity(Database database, boolean update) throws IOException {
-    // Relationships and fields such as href are derived and not stored as part of json
-    EntityReference owner = database.getOwner();
+    // Relationships and fields such as service are not stored as part of json
     EntityReference service = database.getService();
-    List<TagLabel> tags = database.getTags();
-    // Don't store owner, database, href and tags as JSON. Build it on the fly based on relationships
-    database.withOwner(null).withService(null).withHref(null).withTags(null);
-
+    database.withService(null);
     store(database, update);
-
-    // Restore the relationships
-    database.withOwner(owner).withService(service).withTags(tags);
+    database.withService(service);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DatabaseSchemaRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DatabaseSchemaRepository.java
@@ -59,16 +59,13 @@ public class DatabaseSchemaRepository extends EntityRepository<DatabaseSchema> {
 
   @Override
   public void storeEntity(DatabaseSchema schema, boolean update) throws IOException {
-    // Relationships and fields such as href are derived and not stored as part of json
-    EntityReference owner = schema.getOwner();
+    // Relationships and fields such as service are derived and not stored as part of json
     EntityReference service = schema.getService();
-
-    // Don't store owner, database, href and tags as JSON. Build it on the fly based on relationships
-    schema.withOwner(null).withService(null).withHref(null);
+    schema.withService(null);
 
     store(schema, update);
     // Restore the relationships
-    schema.withOwner(owner).withService(service);
+    schema.withService(service);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -741,6 +741,13 @@ public abstract class EntityRepository<T extends EntityInterface> {
   }
 
   protected void store(T entity, boolean update) throws JsonProcessingException {
+    // Don't store owner, database, href and tags as JSON. Build it on the fly based on relationships
+    entity.withHref(null);
+    EntityReference owner = entity.getOwner();
+    entity.setOwner(null);
+    List<TagLabel> tags = entity.getTags();
+    entity.setTags(null);
+
     if (update) {
       dao.update(entity.getId(), JsonUtils.pojoToJson(entity));
       LOG.info("Updated {}:{}:{}", entityType, entity.getId(), entity.getFullyQualifiedName());
@@ -748,6 +755,10 @@ public abstract class EntityRepository<T extends EntityInterface> {
       dao.insert(entity);
       LOG.info("Created {}:{}:{}", entityType, entity.getId(), entity.getFullyQualifiedName());
     }
+
+    // Restore the relationships
+    entity.setOwner(owner);
+    entity.setTags(tags);
   }
 
   public void validateExtension(T entity) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryRepository.java
@@ -43,7 +43,6 @@ import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.ProviderType;
 import org.openmetadata.schema.type.Relationship;
-import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.schema.type.TagLabel.TagSource;
 import org.openmetadata.schema.type.csv.CsvDocumentation;
 import org.openmetadata.schema.type.csv.CsvHeader;
@@ -86,18 +85,11 @@ public class GlossaryRepository extends EntityRepository<Glossary> {
 
   @Override
   public void storeEntity(Glossary glossary, boolean update) throws IOException {
-    // Relationships and fields such as href are derived and not stored as part of json
-    EntityReference owner = glossary.getOwner();
-    List<TagLabel> tags = glossary.getTags();
+    // Relationships and fields such as reviewers are derived and not stored as part of json
     List<EntityReference> reviewers = glossary.getReviewers();
-
-    // Don't store owner, href and tags as JSON. Build it on the fly based on relationships
-    glossary.withOwner(null).withHref(null).withTags(null);
-
+    glossary.withReviewers(null);
     store(glossary, update);
-
-    // Restore the relationships
-    glossary.withOwner(owner).withTags(tags).withReviewers(reviewers);
+    glossary.withReviewers(reviewers);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
@@ -137,34 +137,17 @@ public class GlossaryTermRepository extends EntityRepository<GlossaryTerm> {
 
   @Override
   public void storeEntity(GlossaryTerm entity, boolean update) throws IOException {
-    // Relationships and fields such as href are derived and not stored as part of json
-    List<TagLabel> tags = entity.getTags();
+    // Relationships and fields such as parentTerm are derived and not stored as part of json
     EntityReference glossary = entity.getGlossary();
     EntityReference parentTerm = entity.getParent();
     List<EntityReference> relatedTerms = entity.getRelatedTerms();
     List<EntityReference> reviewers = entity.getReviewers();
-    EntityReference owner = entity.getOwner();
 
-    // Don't store owner, dashboard, href and tags as JSON. Build it on the fly based on relationships
-    entity
-        .withGlossary(null)
-        .withParent(null)
-        .withRelatedTerms(relatedTerms)
-        .withReviewers(null)
-        .withOwner(null)
-        .withHref(null)
-        .withTags(null);
-
+    entity.withGlossary(null).withParent(null).withRelatedTerms(relatedTerms).withReviewers(null);
     store(entity, update);
 
     // Restore the relationships
-    entity
-        .withGlossary(glossary)
-        .withParent(parentTerm)
-        .withRelatedTerms(relatedTerms)
-        .withReviewers(reviewers)
-        .withOwner(owner)
-        .withTags(tags);
+    entity.withGlossary(glossary).withParent(parentTerm).withRelatedTerms(relatedTerms).withReviewers(reviewers);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java
@@ -82,8 +82,7 @@ public class IngestionPipelineRepository extends EntityRepository<IngestionPipel
 
   @Override
   public void storeEntity(IngestionPipeline ingestionPipeline, boolean update) throws IOException {
-    // Relationships and fields such as href are derived and not stored as part of json
-    EntityReference owner = ingestionPipeline.getOwner();
+    // Relationships and fields such as service are derived and not stored as part of json
     EntityReference service = ingestionPipeline.getService();
     OpenMetadataConnection openmetadataConnection = ingestionPipeline.getOpenMetadataServerConnection();
 
@@ -96,14 +95,9 @@ public class IngestionPipelineRepository extends EntityRepository<IngestionPipel
           secretsManager.encryptOrDecryptOpenMetadataConnection(openmetadataConnection, true, true);
     }
 
-    // Don't store owner. Build it on the fly based on relationships
-    // We don't want to store the OM connection.
-    ingestionPipeline.withOwner(null).withService(null).withHref(null).withOpenMetadataServerConnection(null);
-
+    ingestionPipeline.withService(null).withOpenMetadataServerConnection(null);
     store(ingestionPipeline, update);
-
-    // Restore the relationships
-    ingestionPipeline.withOwner(owner).withService(service).withOpenMetadataServerConnection(openmetadataConnection);
+    ingestionPipeline.withService(service).withOpenMetadataServerConnection(openmetadataConnection);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/KpiRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/KpiRepository.java
@@ -82,16 +82,11 @@ public class KpiRepository extends EntityRepository<Kpi> {
 
   @Override
   public void storeEntity(Kpi kpi, boolean update) throws IOException {
-    EntityReference owner = kpi.getOwner();
     EntityReference dataInsightChart = kpi.getDataInsightChart();
     KpiResult kpiResults = kpi.getKpiResult();
-
-    // Don't store owner, database, href and tags as JSON. Build it on the fly based on relationships
-    kpi.withOwner(null).withHref(null).withDataInsightChart(null).withKpiResult(null);
+    kpi.withDataInsightChart(null).withKpiResult(null);
     store(kpi, update);
-
-    // Restore the relationships
-    kpi.withOwner(owner).withDataInsightChart(dataInsightChart).withKpiResult(kpiResults);
+    kpi.withDataInsightChart(dataInsightChart).withKpiResult(kpiResults);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/LocationRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/LocationRepository.java
@@ -25,7 +25,6 @@ import org.openmetadata.schema.entity.data.Location;
 import org.openmetadata.schema.entity.services.StorageService;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.Relationship;
-import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.CatalogExceptionMessage;
 import org.openmetadata.service.resources.locations.LocationResource;
@@ -164,18 +163,11 @@ public class LocationRepository extends EntityRepository<Location> {
 
   @Override
   public void storeEntity(Location location, boolean update) throws IOException {
-    // Relationships and fields such as href are derived and not stored as part of json
-    EntityReference owner = location.getOwner();
+    // Relationships and fields such as service are derived and not stored as part of json
     EntityReference service = location.getService();
-    List<TagLabel> tags = location.getTags();
-
-    // Don't store owner, href and tags as JSON. Build it on the fly based on relationships
-    location.withOwner(null).withService(null).withHref(null).withTags(null);
-
+    location.withService(null);
     store(location, update);
-
-    // Restore the relationships
-    location.withOwner(owner).withService(service).withTags(tags);
+    location.withService(service);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/MetricsRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/MetricsRepository.java
@@ -16,11 +16,9 @@ package org.openmetadata.service.jdbi3;
 import static org.openmetadata.service.Entity.DASHBOARD_SERVICE;
 
 import java.io.IOException;
-import java.util.List;
 import org.openmetadata.schema.entity.data.Metrics;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.Relationship;
-import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.CatalogExceptionMessage;
 import org.openmetadata.service.resources.metrics.MetricsResource;
@@ -61,18 +59,11 @@ public class MetricsRepository extends EntityRepository<Metrics> {
 
   @Override
   public void storeEntity(Metrics metrics, boolean update) throws IOException {
-    // Relationships and fields such as href are derived and not stored as part of json
-    EntityReference owner = metrics.getOwner();
-    List<TagLabel> tags = metrics.getTags();
+    // Relationships and fields such as service are derived and not stored as part of json
     EntityReference service = metrics.getService();
-
-    // Don't store owner, database, href and tags as JSON. Build it on the fly based on relationships
-    metrics.withOwner(null).withService(null).withHref(null).withTags(null);
-
+    metrics.withService(null);
     store(metrics, update);
-
-    // Restore the relationships
-    metrics.withOwner(owner).withService(service).withTags(tags);
+    metrics.withService(service);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/MlModelRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/MlModelRepository.java
@@ -34,7 +34,6 @@ import org.openmetadata.schema.type.MlFeature;
 import org.openmetadata.schema.type.MlFeatureSource;
 import org.openmetadata.schema.type.MlHyperParameter;
 import org.openmetadata.schema.type.Relationship;
-import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.resources.mlmodels.MlModelResource;
 import org.openmetadata.service.util.EntityUtil;
@@ -140,19 +139,12 @@ public class MlModelRepository extends EntityRepository<MlModel> {
 
   @Override
   public void storeEntity(MlModel mlModel, boolean update) throws IOException {
-    // Relationships and fields such as href are derived and not stored as part of json
-    EntityReference owner = mlModel.getOwner();
-    List<TagLabel> tags = mlModel.getTags();
+    // Relationships and fields such as service are derived and not stored as part of json
     EntityReference dashboard = mlModel.getDashboard();
     EntityReference service = mlModel.getService();
-
-    // Don't store owner, dashboard, href and tags as JSON. Build it on the fly based on relationships
-    mlModel.withService(null).withOwner(null).withDashboard(null).withHref(null).withTags(null);
-
+    mlModel.withService(null).withDashboard(null);
     store(mlModel, update);
-
-    // Restore the relationships
-    mlModel.withService(service).withOwner(owner).withDashboard(dashboard).withTags(tags);
+    mlModel.withService(service).withDashboard(dashboard);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/PipelineRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/PipelineRepository.java
@@ -31,7 +31,6 @@ import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.Relationship;
 import org.openmetadata.schema.type.Status;
-import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.schema.type.Task;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.EntityNotFoundException;
@@ -176,21 +175,15 @@ public class PipelineRepository extends EntityRepository<Pipeline> {
 
   @Override
   public void storeEntity(Pipeline pipeline, boolean update) throws IOException {
-    // Relationships and fields such as href are derived and not stored as part of json
-    EntityReference owner = pipeline.getOwner();
-    List<TagLabel> tags = pipeline.getTags();
+    // Relationships and fields such as service are derived and not stored as part of json
     EntityReference service = pipeline.getService();
-
-    // Don't store owner, database, href and tags as JSON. Build it on the fly based on relationships
-    pipeline.withOwner(null).withService(null).withHref(null).withTags(null);
+    pipeline.withService(null);
 
     // Don't store column tags as JSON but build it on the fly based on relationships
     List<Task> taskWithTags = pipeline.getTasks();
     pipeline.setTasks(cloneWithoutTags(taskWithTags));
     store(pipeline, update);
-
-    // Restore the relationships
-    pipeline.withOwner(owner).withService(service).withTags(tags).withTasks(taskWithTags);
+    pipeline.withService(service).withTasks(taskWithTags);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/PolicyRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/PolicyRepository.java
@@ -30,7 +30,6 @@ import static org.openmetadata.service.util.EntityUtil.ruleMatch;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -115,18 +114,11 @@ public class PolicyRepository extends EntityRepository<Policy> {
 
   @Override
   public void storeEntity(Policy policy, boolean update) throws IOException {
-    // Relationships and fields such as href are derived and not stored as part of json
-    EntityReference owner = policy.getOwner();
+    // Relationships and fields such as location are derived and not stored as part of json
     EntityReference location = policy.getLocation();
-    URI href = policy.getHref();
-
-    // Don't store owner, location and href as JSON. Build it on the fly based on relationships
-    policy.withOwner(null).withLocation(null).withHref(null);
-
+    policy.withLocation(null);
     store(policy, update);
-
-    // Restore the relationships
-    policy.withOwner(owner).withLocation(location).withHref(href);
+    policy.withLocation(location);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ReportRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ReportRepository.java
@@ -45,7 +45,6 @@ public class ReportRepository extends EntityRepository<Report> {
 
   @Override
   public void storeEntity(Report report, boolean update) throws IOException {
-    report.setHref(null);
     store(report, update);
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/RoleRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/RoleRepository.java
@@ -90,11 +90,11 @@ public class RoleRepository extends EntityRepository<Role> {
   @Override
   @Transaction
   public void storeEntity(Role role, boolean update) throws IOException {
-    // Don't store policy and href as JSON. Build it on the fly based on relationships
+    // Don't store policy. Build it on the fly based on relationships
     List<EntityReference> policies = role.getPolicies();
-    role.withPolicies(null).withHref(null);
+    role.withPolicies(null);
     store(role, update);
-    role.withPolicies(policies); // Restore policies
+    role.withPolicies(policies);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ServiceEntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ServiceEntityRepository.java
@@ -15,15 +15,12 @@ package org.openmetadata.service.jdbi3;
 import static org.openmetadata.service.util.EntityUtil.objectMatch;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.UUID;
 import lombok.Getter;
 import org.openmetadata.schema.ServiceConnectionEntityInterface;
 import org.openmetadata.schema.ServiceEntityInterface;
 import org.openmetadata.schema.entity.services.ServiceType;
 import org.openmetadata.schema.entity.services.connections.TestConnectionResult;
-import org.openmetadata.schema.type.EntityReference;
-import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.service.secrets.SecretsManager;
 import org.openmetadata.service.secrets.SecretsManagerFactory;
 import org.openmetadata.service.util.EntityUtil;
@@ -85,14 +82,7 @@ public abstract class ServiceEntityRepository<
 
   @Override
   public void storeEntity(T service, boolean update) throws IOException {
-    // Relationships and fields such as href are derived and not stored as part of json
-    EntityReference owner = service.getOwner();
-    List<TagLabel> tags = service.getTags();
-    // Don't store owner, service, href and tags as JSON. Build it on the fly based on relationships
-    service.withOwner(null).withHref(null).setTags(null);
     store(service, update);
-    // Restore the relationships
-    service.withOwner(owner).setTags(tags);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/StorageServiceRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/StorageServiceRepository.java
@@ -17,7 +17,6 @@ import static org.openmetadata.service.util.EntityUtil.Fields;
 
 import java.io.IOException;
 import org.openmetadata.schema.entity.services.StorageService;
-import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.resources.services.storage.StorageServiceResource;
 
@@ -47,16 +46,7 @@ public class StorageServiceRepository extends EntityRepository<StorageService> {
 
   @Override
   public void storeEntity(StorageService service, boolean update) throws IOException {
-    // Relationships and fields such as href are derived and not stored as part of json
-    EntityReference owner = service.getOwner();
-
-    // Don't store owner, database, href and tags as JSON. Build it on the fly based on relationships
-    service.withOwner(null).withHref(null);
-
     store(service, update);
-
-    // Restore the relationships
-    service.withOwner(owner);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
@@ -65,7 +65,6 @@ import org.openmetadata.schema.type.TableData;
 import org.openmetadata.schema.type.TableJoins;
 import org.openmetadata.schema.type.TableProfile;
 import org.openmetadata.schema.type.TableProfilerConfig;
-import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.CatalogExceptionMessage;
 import org.openmetadata.service.exception.EntityNotFoundException;
@@ -623,13 +622,9 @@ public class TableRepository extends EntityRepository<Table> {
 
   @Override
   public void storeEntity(Table table, boolean update) throws IOException {
-    // Relationships and fields such as href are derived and not stored as part of json
-    EntityReference owner = table.getOwner();
-    List<TagLabel> tags = table.getTags();
+    // Relationships and fields such as service are derived and not stored as part of json
     EntityReference service = table.getService();
-
-    // Don't store owner, database, href and tags as JSON. Build it on the fly based on relationships
-    table.withOwner(null).withHref(null).withTags(null).withService(null);
+    table.withService(null);
 
     // Don't store column tags as JSON but build it on the fly based on relationships
     List<Column> columnWithTags = table.getColumns();
@@ -639,7 +634,7 @@ public class TableRepository extends EntityRepository<Table> {
     store(table, update);
 
     // Restore the relationships
-    table.withOwner(owner).withTags(tags).withColumns(columnWithTags).withService(service);
+    table.withColumns(columnWithTags).withService(service);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TeamRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TeamRepository.java
@@ -123,7 +123,6 @@ public class TeamRepository extends EntityRepository<Team> {
   @Override
   public void storeEntity(Team team, boolean update) throws IOException {
     // Relationships and fields such as href are derived and not stored as part of json
-    EntityReference owner = team.getOwner();
     List<EntityReference> users = team.getUsers();
     List<EntityReference> defaultRoles = team.getDefaultRoles();
     List<EntityReference> parents = team.getParents();
@@ -131,14 +130,13 @@ public class TeamRepository extends EntityRepository<Team> {
     List<EntityReference> policies = team.getPolicies();
 
     // Don't store users, defaultRoles, href as JSON. Build it on the fly based on relationships
-    team.withUsers(null).withDefaultRoles(null).withHref(null).withOwner(null).withInheritedRoles(null);
+    team.withUsers(null).withDefaultRoles(null).withInheritedRoles(null);
 
     store(team, update);
 
     // Restore the relationships
     team.withUsers(users)
         .withDefaultRoles(defaultRoles)
-        .withOwner(owner)
         .withParents(parents)
         .withChildren(children)
         .withPolicies(policies);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
@@ -105,16 +105,15 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
 
   @Override
   public void storeEntity(TestCase test, boolean update) throws IOException {
-    EntityReference owner = test.getOwner();
     EntityReference testSuite = test.getTestSuite();
     EntityReference testDefinition = test.getTestDefinition();
 
     // Don't store owner, database, href and tags as JSON. Build it on the fly based on relationships
-    test.withOwner(null).withHref(null).withTestSuite(null).withTestDefinition(null);
+    test.withTestSuite(null).withTestDefinition(null);
     store(test, update);
 
     // Restore the relationships
-    test.withOwner(owner).withTestSuite(testSuite).withTestDefinition(testDefinition);
+    test.withTestSuite(testSuite).withTestDefinition(testDefinition);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestDefinitionRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestDefinitionRepository.java
@@ -5,7 +5,6 @@ import static org.openmetadata.service.Entity.TEST_DEFINITION;
 import java.io.IOException;
 import org.openmetadata.common.utils.CommonUtil;
 import org.openmetadata.schema.tests.TestDefinition;
-import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.resources.dqtests.TestDefinitionResource;
 import org.openmetadata.service.util.EntityUtil;
@@ -40,13 +39,7 @@ public class TestDefinitionRepository extends EntityRepository<TestDefinition> {
 
   @Override
   public void storeEntity(TestDefinition entity, boolean update) throws IOException {
-    EntityReference owner = entity.getOwner();
-    // Don't store owner, database, href and tags as JSON. Build it on the fly based on relationships
-    entity.withOwner(null).withHref(null);
     store(entity, update);
-
-    // Restore the relationships
-    entity.withOwner(owner);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestSuiteRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestSuiteRepository.java
@@ -54,13 +54,7 @@ public class TestSuiteRepository extends EntityRepository<TestSuite> {
 
   @Override
   public void storeEntity(TestSuite entity, boolean update) throws IOException {
-    EntityReference owner = entity.getOwner();
-    // Don't store owner, database, href and tags as JSON. Build it on the fly based on relationships
-    entity.withOwner(null).withHref(null);
     store(entity, update);
-
-    // Restore the relationships
-    entity.withOwner(owner);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TopicRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TopicRepository.java
@@ -36,7 +36,6 @@ import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.Field;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.Relationship;
-import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.schema.type.topic.CleanupPolicy;
 import org.openmetadata.schema.type.topic.TopicSampleData;
 import org.openmetadata.service.Entity;
@@ -83,15 +82,11 @@ public class TopicRepository extends EntityRepository<Topic> {
 
   @Override
   public void storeEntity(Topic topic, boolean update) throws IOException {
-    // Relationships and fields such as href are derived and not stored as part of json
-    EntityReference owner = topic.getOwner();
-    List<TagLabel> tags = topic.getTags();
+    // Relationships and fields such as service are derived and not stored as part of json
     EntityReference service = topic.getService();
+    topic.withService(null);
 
-    // Don't store owner, database, href and tags as JSON. Build it on the fly based on relationships
-    topic.withOwner(null).withService(null).withHref(null).withTags(null);
-
-    // Don't store feild tags as JSON but build it on the fly based on relationships
+    // Don't store fields tags as JSON but build it on the fly based on relationships
     List<Field> fieldsWithTags = null;
     if (topic.getMessageSchema() != null) {
       fieldsWithTags = topic.getMessageSchema().getSchemaFields();
@@ -105,7 +100,7 @@ public class TopicRepository extends EntityRepository<Topic> {
     if (fieldsWithTags != null) {
       topic.getMessageSchema().withSchemaFields(fieldsWithTags);
     }
-    topic.withOwner(owner).withService(service).withTags(tags);
+    topic.withService(service);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TypeRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TypeRepository.java
@@ -23,7 +23,6 @@ import static org.openmetadata.service.util.EntityUtil.getCustomField;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -65,11 +64,10 @@ public class TypeRepository extends EntityRepository<Type> {
 
   @Override
   public void storeEntity(Type type, boolean update) throws IOException {
-    URI href = type.getHref();
     List<CustomProperty> customProperties = type.getCustomProperties();
-    type.withHref(null).withCustomProperties(null);
+    type.withCustomProperties(null);
     store(type, update);
-    type.withHref(href).withCustomProperties(customProperties);
+    type.withCustomProperties(customProperties);
     updateTypeMap(type);
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/UserRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/UserRepository.java
@@ -113,7 +113,7 @@ public class UserRepository extends EntityRepository<User> {
     List<EntityReference> teams = user.getTeams();
 
     // Don't store roles, teams and href as JSON. Build it on the fly based on relationships
-    user.withRoles(null).withTeams(null).withHref(null).withInheritedRoles(null);
+    user.withRoles(null).withTeams(null).withInheritedRoles(null);
 
     SecretsManager secretsManager = SecretsManagerFactory.getSecretsManager();
     if (secretsManager != null && Boolean.TRUE.equals(user.getIsBot())) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/WebAnalyticEventRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/WebAnalyticEventRepository.java
@@ -10,7 +10,6 @@ import org.jdbi.v3.sqlobject.transaction.Transaction;
 import org.openmetadata.schema.analytics.WebAnalyticEvent;
 import org.openmetadata.schema.analytics.WebAnalyticEventData;
 import org.openmetadata.schema.analytics.type.WebAnalyticEventType;
-import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.service.util.EntityUtil;
 import org.openmetadata.service.util.JsonUtils;
 import org.openmetadata.service.util.ResultList;
@@ -44,12 +43,7 @@ public class WebAnalyticEventRepository extends EntityRepository<WebAnalyticEven
 
   @Override
   public void storeEntity(WebAnalyticEvent entity, boolean update) throws IOException {
-    EntityReference owner = entity.getOwner();
-
-    entity.withOwner(null).withHref(null);
     store(entity, update);
-
-    entity.withOwner(owner);
   }
 
   @Override


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
Setting the fields `owner`, `tags`, `href` before writing entity JSON to the backend database and restoring them after the write can be moved to `EntityRepository.store()` method instead of doing it in every class the implements the `storeEntity` method.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement
#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

