### PR TITLE
Fix year of latest release in releases documentation page

### DIFF
--- a/openmetadata-docs/content/overview/releases/index.md
+++ b/openmetadata-docs/content/overview/releases/index.md
@@ -12,7 +12,7 @@ version. To see what's coming in next releases, please check our [Roadmap](/over
 
 </Note>
 
-# [0.13.2 Release](https://github.com/open-metadata/OpenMetadata/releases/tag/0.13.2-release) - Latest - Jan 30th 2022 🎉
+# [0.13.2 Release](https://github.com/open-metadata/OpenMetadata/releases/tag/0.13.2-release) - Latest - Jan 30th 2023 🎉
 
 ## Improved SQL Lineage
 - We have collaborated with the [sqllineage](https://github.com/reata/sqllineage) and [sqlfluff](https://www.sqlfluff.com/) communities


### PR DESCRIPTION
### Describe your changes :
Due to a typo in the year on the [releases page](https://docs.open-metadata.org/overview/releases) it looks like the latest release is more than 1 year ago...

#
### Type of change :
- [X] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.