### PR TITLE
Fix search by email index keyword

### DIFF
--- a/ingestion/src/metadata/ingestion/ometa/mixins/user_mixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/user_mixin.py
@@ -35,7 +35,7 @@ class OMetaUserMixin:
     client: REST
 
     email_search = (
-        "/search/query?q=email:{email}&from={from_}&size={size}&index="
+        "/search/query?q=email.keyword:{email}&from={from_}&size={size}&index="
         + ES_INDEX_MAP[User.__name__]
     )
 
@@ -44,7 +44,7 @@ class OMetaUserMixin:
         self,
         email: Optional[str],
         from_count: int = 0,
-        size: int = 10,
+        size: int = 1,
         fields: Optional[list] = None,
     ) -> Optional[User]:
         """

--- a/ingestion/src/metadata/ingestion/sink/elasticsearch_mapping/user_search_index_mapping.py
+++ b/ingestion/src/metadata/ingestion/sink/elasticsearch_mapping/user_search_index_mapping.py
@@ -56,7 +56,13 @@ USER_ELASTICSEARCH_INDEX_MAPPING = textwrap.dedent(
         "type": "text"
       },
       "email": {
-        "type": "text"
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
       },
       "isAdmin": {
         "type": "text"

--- a/ingestion/tests/integration/ometa/test_ometa_user_api.py
+++ b/ingestion/tests/integration/ometa/test_ometa_user_api.py
@@ -78,6 +78,10 @@ class OMetaUserTest(TestCase):
             data=CreateUserRequest(name="Levy", email="user2.1234@getcollate.io"),
         )
 
+        cls.user_3: User = cls.metadata.create_or_update(
+            data=CreateUserRequest(name="Lima", email="random.lima@getcollate.io"),
+        )
+
         # Leave some time for indexes to get updated, otherwise this happens too fast
         cls.check_es_index()
 
@@ -110,6 +114,13 @@ class OMetaUserTest(TestCase):
         # Non existing email returns None
         self.assertIsNone(
             self.metadata.get_user_by_email(email="idonotexist@random.com")
+        )
+
+        # Non existing email returns, even if they have the same domain
+        # To get this fixed, we had to update the `email` field in the
+        # index as a `keyword` and search by `email.keyword` in ES.
+        self.assertIsNone(
+            self.metadata.get_user_by_email(email="idonotexist@getcollate.io")
         )
 
         # I can get User 1, who has the name equal to its email

--- a/openmetadata-service/src/main/resources/elasticsearch/en/user_index_mapping.json
+++ b/openmetadata-service/src/main/resources/elasticsearch/en/user_index_mapping.json
@@ -39,7 +39,13 @@
         "type": "text"
       },
       "email": {
-        "type": "text"
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
       },
       "isAdmin": {
         "type": "boolean"


### PR DESCRIPTION
### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->

The old index and search query properly returned `None` if an email with an unknown domain was sent, e.g., searching by `user@random.com`. However, there were errors if we searched an unexisting email from an existent domain, e.g., `not-a-real-user@known-domain.com`.

This PR adds the email as a keyword and updates the search query to properly flag these cases and avoid false positives in the hits.

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
