### PR TITLE
[WIP] - Remove SecretsManagerCredentials from IngestionPipeline

### DIFF
--- a/bootstrap/sql/com.mysql.cj.jdbc.Driver/v009__create_db_connection_info.sql
+++ b/bootstrap/sql/com.mysql.cj.jdbc.Driver/v009__create_db_connection_info.sql
@@ -119,6 +119,11 @@ WHERE name = 'OpenMetadata' AND JSON_EXTRACT(json, '$.connection.config.authProv
 
 ALTER TABLE user_tokens MODIFY COLUMN expiryDate BIGINT UNSIGNED GENERATED ALWAYS AS (json ->> '$.expiryDate');
 
+-- we are not using the secretsManagerCredentials
+UPDATE metadata_service_entity
+SET json = JSON_REMOVE(json, '$.openMetadataServerConnection.secretsManagerCredentials')
+where name = 'OpenMetadata';
+
 DELETE FROM alert_entity;
 drop table alert_action_def;
 

--- a/bootstrap/sql/org.postgresql.Driver/v009__create_db_connection_info.sql
+++ b/bootstrap/sql/org.postgresql.Driver/v009__create_db_connection_info.sql
@@ -122,6 +122,11 @@ WHERE name = 'OpenMetadata'
 
 ALTER TABLE user_tokens ALTER COLUMN expiryDate DROP NOT NULL;
 
+-- we are not using the secretsManagerCredentials
+UPDATE metadata_service_entity
+SET json = json::jsonb #- '{openMetadataServerConnection.secretsManagerCredentials}'
+where name = 'OpenMetadata';
+
 DELETE FROM alert_entity;
 drop table alert_action_def;
 

--- a/ingestion/src/metadata/clients/aws_client.py
+++ b/ingestion/src/metadata/clients/aws_client.py
@@ -98,12 +98,18 @@ class AWSClient:
 
     @staticmethod
     def _get_session(
-        aws_access_key_id,
-        aws_secret_access_key,
-        aws_session_token,
-        aws_region,
+        aws_access_key_id: Optional[str],
+        aws_secret_access_key: Optional[CustomSecretStr],
+        aws_session_token: Optional[str],
+        aws_region: str,
         profile=None,
     ) -> Session:
+        """
+        The only requred param for boto3 is the region.
+
+        The rest of credentials will have fallback strategies based on
+        https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials
+        """
         return Session(
             aws_access_key_id=aws_access_key_id,
             aws_secret_access_key=aws_secret_access_key.get_secret_value()

--- a/openmetadata-clients/openmetadata-java-client/pom.xml
+++ b/openmetadata-clients/openmetadata-java-client/pom.xml
@@ -95,14 +95,10 @@
         </dependency>
         <!-- TEST -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <version>5.9.2</version>
+            <scope>test</scope>
         </dependency>
 
         <!--avoid security issue https://security.snyk.io/vuln/SNYK-JAVA-ORGMOZILLA-1314295-->

--- a/openmetadata-clients/openmetadata-java-client/pom.xml
+++ b/openmetadata-clients/openmetadata-java-client/pom.xml
@@ -99,6 +99,11 @@
             <artifactId>junit</artifactId>
             <version>4.13.2</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.2</version>
+        </dependency>
 
         <!--avoid security issue https://security.snyk.io/vuln/SNYK-JAVA-ORGMOZILLA-1314295-->
         <dependency>

--- a/openmetadata-service/src/main/java/org/openmetadata/service/secrets/converter/OpenMetadataConnectionClassConverter.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/secrets/converter/OpenMetadataConnectionClassConverter.java
@@ -20,7 +20,6 @@ import org.openmetadata.schema.security.client.CustomOIDCSSOClientConfig;
 import org.openmetadata.schema.security.client.GoogleSSOClientConfig;
 import org.openmetadata.schema.security.client.OktaSSOClientConfig;
 import org.openmetadata.schema.security.client.OpenMetadataJWTClientConfig;
-import org.openmetadata.schema.security.credentials.AWSCredentials;
 import org.openmetadata.schema.services.connections.metadata.OpenMetadataConnection;
 import org.openmetadata.service.util.JsonUtils;
 
@@ -36,8 +35,6 @@ public class OpenMetadataConnectionClassConverter extends ClassConverter {
           AzureSSOClientConfig.class,
           CustomOIDCSSOClientConfig.class);
 
-  private static final List<Class<?>> SECRET_MANAGER_CREDENTIALS_CLASSES = List.of(AWSCredentials.class);
-
   public OpenMetadataConnectionClassConverter() {
     super(OpenMetadataConnection.class);
   }
@@ -49,8 +46,6 @@ public class OpenMetadataConnectionClassConverter extends ClassConverter {
 
     tryToConvertOrFail(openMetadataConnection.getSecurityConfig(), SECURITY_CONFIG_CLASSES)
         .ifPresent(openMetadataConnection::setSecurityConfig);
-    tryToConvertOrFail(openMetadataConnection.getSecretsManagerCredentials(), SECRET_MANAGER_CREDENTIALS_CLASSES)
-        .ifPresent(openMetadataConnection::setSecretsManagerCredentials);
 
     return openMetadataConnection;
   }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/secrets/ExternalSecretsManagerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/secrets/ExternalSecretsManagerTest.java
@@ -206,7 +206,6 @@ public abstract class ExternalSecretsManagerTest {
             .withName("my-workflow")
             .withOpenMetadataServerConnection(
                 new OpenMetadataConnection()
-                    .withSecretsManagerCredentials(new AWSCredentials().withAwsSecretAccessKey("aws-secret"))
                     .withSecurityConfig(new GoogleSSOClientConfig().withSecretKey("google-secret")))
             .withRequest(
                 new TestServiceConnectionRequest()
@@ -234,11 +233,6 @@ public abstract class ExternalSecretsManagerTest {
       GoogleSSOClientConfig googleSSOClientConfig =
           ((GoogleSSOClientConfig) (actualWorkflow.getOpenMetadataServerConnection()).getSecurityConfig());
       googleSSOClientConfig.setSecretKey(Fernet.getInstance().decrypt(googleSSOClientConfig.getSecretKey()));
-      ((AWSCredentials) (expectedWorkflow.getOpenMetadataServerConnection()).getSecretsManagerCredentials())
-          .setAwsSecretAccessKey("secret:/openmetadata/serverconnection/secretsmanagercredentials/awssecretaccesskey");
-      AWSCredentials awsCredentials =
-          ((AWSCredentials) (actualWorkflow.getOpenMetadataServerConnection()).getSecretsManagerCredentials());
-      awsCredentials.setAwsSecretAccessKey(Fernet.getInstance().decrypt(awsCredentials.getAwsSecretAccessKey()));
     }
 
     assertEquals(expectedWorkflow, actualWorkflow);

--- a/openmetadata-service/src/test/java/org/openmetadata/service/secrets/masker/TestEntityMasker.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/secrets/masker/TestEntityMasker.java
@@ -20,7 +20,6 @@ import org.openmetadata.schema.metadataIngestion.SourceConfig;
 import org.openmetadata.schema.metadataIngestion.dbtconfig.DbtGCSConfig;
 import org.openmetadata.schema.security.SecurityConfiguration;
 import org.openmetadata.schema.security.client.GoogleSSOClientConfig;
-import org.openmetadata.schema.security.credentials.AWSCredentials;
 import org.openmetadata.schema.security.credentials.GCSCredentials;
 import org.openmetadata.schema.security.credentials.GCSValues;
 import org.openmetadata.schema.services.connections.dashboard.SupersetConnection;
@@ -247,8 +246,7 @@ abstract class TestEntityMasker {
   }
 
   private OpenMetadataConnection buildOpenMetadataConnection() {
-    return new OpenMetadataConnection()
-        .withSecurityConfig(buildGoogleSSOClientConfig());
+    return new OpenMetadataConnection().withSecurityConfig(buildGoogleSSOClientConfig());
   }
 
   private GoogleSSOClientConfig buildGoogleSSOClientConfig() {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/secrets/masker/TestEntityMasker.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/secrets/masker/TestEntityMasker.java
@@ -105,10 +105,6 @@ abstract class TestEntityMasker {
                 .getDbtSecurityConfig()),
         getMaskedPassword());
     assertEquals(
-        ((AWSCredentials) dbtPipeline.getOpenMetadataServerConnection().getSecretsManagerCredentials())
-            .getAwsSecretAccessKey(),
-        getMaskedPassword());
-    assertEquals(
         ((GoogleSSOClientConfig) dbtPipeline.getOpenMetadataServerConnection().getSecurityConfig()).getSecretKey(),
         getMaskedPassword());
     EntityMaskerFactory.createEntityMasker(config).unmaskIngestionPipeline(dbtPipeline, originalDbtPipeline);
@@ -116,10 +112,6 @@ abstract class TestEntityMasker {
         getPrivateKeyFromGcsConfig(
             ((DbtGCSConfig) ((DbtPipeline) dbtPipeline.getSourceConfig().getConfig()).getDbtConfigSource())
                 .getDbtSecurityConfig()),
-        PASSWORD);
-    assertEquals(
-        ((AWSCredentials) dbtPipeline.getOpenMetadataServerConnection().getSecretsManagerCredentials())
-            .getAwsSecretAccessKey(),
         PASSWORD);
     assertEquals(
         ((GoogleSSOClientConfig) dbtPipeline.getOpenMetadataServerConnection().getSecurityConfig()).getSecretKey(),
@@ -193,10 +185,6 @@ abstract class TestEntityMasker {
             .getPassword(),
         getMaskedPassword());
     assertEquals(
-        ((AWSCredentials) masked.getOpenMetadataServerConnection().getSecretsManagerCredentials())
-            .getAwsSecretAccessKey(),
-        getMaskedPassword());
-    assertEquals(
         ((GoogleSSOClientConfig) masked.getOpenMetadataServerConnection().getSecurityConfig()).getSecretKey(),
         getMaskedPassword());
     Workflow unmasked = EntityMaskerFactory.createEntityMasker(config).unmaskWorkflow(masked, workflow);
@@ -205,10 +193,6 @@ abstract class TestEntityMasker {
                 ((DatabaseConnection) ((TestServiceConnectionRequest) unmasked.getRequest()).getConnection())
                     .getConfig())
             .getPassword(),
-        PASSWORD);
-    assertEquals(
-        ((AWSCredentials) unmasked.getOpenMetadataServerConnection().getSecretsManagerCredentials())
-            .getAwsSecretAccessKey(),
         PASSWORD);
     assertEquals(
         ((GoogleSSOClientConfig) unmasked.getOpenMetadataServerConnection().getSecurityConfig()).getSecretKey(),
@@ -264,7 +248,6 @@ abstract class TestEntityMasker {
 
   private OpenMetadataConnection buildOpenMetadataConnection() {
     return new OpenMetadataConnection()
-        .withSecretsManagerCredentials(new AWSCredentials().withAwsSecretAccessKey(PASSWORD))
         .withSecurityConfig(buildGoogleSSOClientConfig());
   }
 

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/metadata/openMetadataConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/metadata/openMetadataConnection.json
@@ -85,14 +85,6 @@
       "$ref": "./../../../../security/secrets/secretsManagerProvider.json",
       "default": "noop"
     },
-    "secretsManagerCredentials": {
-      "description": "OpenMetadata Secrets Manager Client credentials",
-      "oneOf": [
-        {
-          "$ref": "../../../../security/credentials/awsCredentials.json"
-        }
-      ]
-    },
     "apiVersion": {
       "description": "OpenMetadata server API version to use.",
       "type": "string",


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

The `secretsManagerCredentials` property in the ingestion pipeline was not being used anywhere (not being set at any point in time in the backend) and it was misleading.

We are now removing it, and updating the migration scripts just in case. As we already removed the full OM connection from the Ingestion Pipeline Entity table, we are only updating the OM service.

---

UPDATE: Ok so this is a bit trickier than anticipated, but we need to make our intent clear on how we are defining the classes.

Current approach:
1. The OM connection class has a `secretsManagerCredentials` that we build on the fly, and then pass it to the `ometa_api` object.
2. This is confusing in two ways:
    1. We share this object with server <> client and it is actually only needed in the client
    2. We make it seem that is the server the one passing the keys to the client to connect to the SM

Preferred approach:
1. The OM connection class does not have the property `secretsManagerCredentials`. This is something that relies completely on the client side
2. The `SecretManagerFactory` accepts the Secret Manager Provider + a registry of functions (this is an abstract class we'll need to define).
3. Basically, depending on the environment, we'll load SM creds in a way or another (e.g., from `airflow.cfg`, env vars, reading a file,...). The Function Registry should be selected by the client, depending on the environment, and allow the factory to know how to read the creds.



<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->


<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
