### PR TITLE
Fix: Update when GH actions are triggered

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -23,6 +23,9 @@ on:
       - "openmetadata-dist/**"
       - "openmetadata-clients/**"
       - "common/**"
+      - "pom.xml"
+      - "yarn.lock"
+      - "Makefile"
   pull_request_target:
     types: [labeled, opened, synchronize, reopened]
     paths:
@@ -32,6 +35,9 @@ on:
       - "openmetadata-dist/**"
       - "openmetadata-clients/**"
       - "common/**"
+      - "pom.xml"
+      - "yarn.lock"
+      - "Makefile"
 
 permissions:
   contents: read

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -23,6 +23,8 @@ on:
       - "ingestion/**"
       - "openmetadata-service/**"
       - "openmetadata-spec/src/main/resources/json/schema/**"
+      - "pom.xml"
+      - "Makefile"
 
 permissions:
   contents: read


### PR DESCRIPTION
### Describe your changes:
GitHub actions are not being triggered when the following files are updated:
- Makefile
- pom.xml
- yarn.lock

This PR can only be tested manually and comments in the code are not required.

### Type of change:
- [x] Improvement

### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
