### PR TITLE
Fix Snowflake Test Connection when no database passed

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/snowflake/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/connection.py
@@ -12,13 +12,15 @@
 """
 Source connection handler
 """
-from typing import Optional
+from functools import partial
+from typing import Any, Optional
 from urllib.parse import quote_plus
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
-from pydantic import SecretStr
+from pydantic import BaseModel, SecretStr
 from sqlalchemy.engine import Engine
+from sqlalchemy.inspection import inspect
 
 from metadata.generated.schema.entity.automations.workflow import (
     Workflow as AutomationWorkflow,
@@ -32,7 +34,11 @@ from metadata.ingestion.connections.builders import (
     get_connection_options_dict,
     init_empty_connection_arguments,
 )
-from metadata.ingestion.connections.test_connections import test_connection_db_common
+from metadata.ingestion.connections.test_connections import (
+    test_connection_engine_step,
+    test_connection_steps,
+    test_query,
+)
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.database.snowflake.queries import (
     SNOWFLAKE_GET_DATABASES,
@@ -42,6 +48,12 @@ from metadata.ingestion.source.database.snowflake.queries import (
 from metadata.utils.logger import ingestion_logger
 
 logger = ingestion_logger()
+
+
+class SnowflakeEngineWrapper(BaseModel):
+    service_connection: SnowflakeConnection
+    engine: Any
+    is_use_executed: bool = False
 
 
 def get_connection_url(connection: SnowflakeConnection) -> str:
@@ -132,16 +144,50 @@ def test_connection(
     Test connection. This can be executed either as part
     of a metadata workflow or during an Automation Workflow
     """
-
-    queries = {
-        "GetQueries": SNOWFLAKE_TEST_GET_QUERIES,
-        "GetDatabases": SNOWFLAKE_GET_DATABASES,
-        "GetTags": SNOWFLAKE_TEST_FETCH_TAG,
-    }
-    test_connection_db_common(
-        metadata=metadata,
-        engine=engine,
-        service_connection=service_connection,
-        automation_workflow=automation_workflow,
-        queries=queries,
+    engine_wrapper = SnowflakeEngineWrapper(
+        service_connection=service_connection, engine=engine, is_use_executed=False
     )
+    test_fn = {
+        "CheckAccess": partial(test_connection_engine_step, engine),
+        "GetDatabases": partial(
+            test_query, statement=SNOWFLAKE_GET_DATABASES, engine=engine
+        ),
+        "GetSchemas": partial(
+            execute_inspector_func, engine_wrapper, "get_schema_names"
+        ),
+        "GetTables": partial(execute_inspector_func, engine_wrapper, "get_table_names"),
+        "GetViews": partial(execute_inspector_func, engine_wrapper, "get_view_names"),
+        "GetQueries": partial(
+            test_query, statement=SNOWFLAKE_TEST_GET_QUERIES, engine=engine
+        ),
+        "GetTags": partial(
+            test_query, statement=SNOWFLAKE_TEST_FETCH_TAG, engine=engine
+        ),
+    }
+
+    test_connection_steps(
+        metadata=metadata,
+        test_fn=test_fn,
+        service_fqn=service_connection.type.value,
+        automation_workflow=automation_workflow,
+    )
+
+
+def execute_inspector_func(engine_wrapper: SnowflakeEngineWrapper, func_name: str):
+    """
+    Method to test connection via inspector functions,
+    this function creates the inspector object and fetches
+    the function with name `func_name` and executes it
+    """
+    if (
+        not engine_wrapper.service_connection.database
+        and not engine_wrapper.is_use_executed
+    ):
+        databases = engine_wrapper.engine.execute(SNOWFLAKE_GET_DATABASES)
+        for database in databases:
+            engine_wrapper.engine.execute(f"USE DATABASE {database.name}")
+            engine_wrapper.is_use_executed = True
+            break
+    inspector = inspect(engine_wrapper.engine)
+    inspector_fn = getattr(inspector, func_name)
+    inspector_fn()


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fix Snowflake Test Connection when no database passed

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
