### PR TITLE
Fixes #10907 Parent glossary term should not be allowed moved under i…

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/exception/CatalogExceptionMessage.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/exception/CatalogExceptionMessage.java
@@ -202,4 +202,8 @@ public final class CatalogExceptionMessage {
   public static String userAlreadyBot(String userName, String botName) {
     return String.format("Bot user [%s] is already used by [%s] bot", userName, botName);
   }
+
+  public static String invalidGlossaryTermMove(String term, String newParent) {
+    return String.format("Can't move Glossary term %s to its child Glossary term %s", term, newParent);
+  }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
@@ -20,6 +20,7 @@ import static org.openmetadata.common.utils.CommonUtil.listOrEmpty;
 import static org.openmetadata.schema.type.Include.ALL;
 import static org.openmetadata.service.Entity.GLOSSARY;
 import static org.openmetadata.service.Entity.GLOSSARY_TERM;
+import static org.openmetadata.service.exception.CatalogExceptionMessage.invalidGlossaryTermMove;
 import static org.openmetadata.service.util.EntityUtil.entityReferenceMatch;
 import static org.openmetadata.service.util.EntityUtil.getId;
 import static org.openmetadata.service.util.EntityUtil.stringMatch;
@@ -254,6 +255,7 @@ public class GlossaryTermRepository extends EntityRepository<GlossaryTerm> {
 
     @Override
     public void entitySpecificUpdate() throws IOException {
+      validateParent();
       updateStatus(original, updated);
       updateSynonyms(original, updated);
       updateReferences(original, updated);
@@ -360,6 +362,15 @@ public class GlossaryTermRepository extends EntityRepository<GlossaryTerm> {
       if (parentChanged) {
         updateParentRelationship(original, updated);
         recordChange("parent", original.getParent(), updated.getParent(), true, entityReferenceMatch);
+      }
+    }
+
+    private void validateParent() {
+      String fqn = original.getFullyQualifiedName();
+      String newParentFqn = updated.getParent() == null ? null : updated.getParent().getFullyQualifiedName();
+      // A glossary term can't be moved under its child
+      if (newParentFqn != null && FullyQualifiedName.isParent(newParentFqn, fqn)) {
+        throw new IllegalArgumentException(invalidGlossaryTermMove(fqn, newParentFqn));
       }
     }
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/MlModelRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/MlModelRepository.java
@@ -129,7 +129,6 @@ public class MlModelRepository extends EntityRepository<MlModel> {
   @Override
   public void prepare(MlModel mlModel) throws IOException {
     populateService(mlModel);
-    setFullyQualifiedName(mlModel);
     if (!nullOrEmpty(mlModel.getMlFeatures())) {
       validateReferences(mlModel.getMlFeatures());
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/tags/TagResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/tags/TagResource.java
@@ -498,12 +498,8 @@ public class TagResource extends EntityResource<Tag, TagRepository> {
 
   private Tag getTag(CreateTag create, String updateBy) throws IOException {
     String parentFQN = create.getParent() != null ? create.getParent() : create.getClassification();
-    EntityReference classification =
-        new EntityReference().withFullyQualifiedName(create.getClassification()).withType(CLASSIFICATION);
-    EntityReference parent =
-        create.getParent() == null
-            ? null
-            : new EntityReference().withFullyQualifiedName(create.getParent()).withType(TAG);
+    EntityReference classification = getEntityReference(CLASSIFICATION, create.getClassification());
+    EntityReference parent = create.getParent() == null ? null : getEntityReference(TAG, create.getParent());
     return copy(new Tag(), create, updateBy)
         .withFullyQualifiedName(FullyQualifiedName.add(parentFQN, create.getName()))
         .withParent(parent)

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/FullyQualifiedName.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/FullyQualifiedName.java
@@ -98,6 +98,11 @@ public class FullyQualifiedName {
     return split[0];
   }
 
+  public static boolean isParent(String childFqn, String parentFqn) {
+    // Returns true if the childFqn is indeed the child of parentFqn
+    return childFqn.startsWith(parentFqn) && childFqn.length() > parentFqn.length();
+  }
+
   private static class SplitListener extends FqnBaseListener {
     final List<String> list = new ArrayList<>();
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/glossary/GlossaryResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/glossary/GlossaryResourceTest.java
@@ -314,7 +314,16 @@ public class GlossaryResourceTest extends EntityResourceTest<Glossary, CreateGlo
         copyGlossaryTerm(updatedTerm, termToMove);
       }
     }
+
+    // Move a parent term g1.t1 to its child g1.t1.t11 should be disallowed
+    assertResponse(
+        () -> glossaryTermResourceTest.moveGlossaryTerm(g.getEntityReference(), t11.getEntityReference(), t1),
+        Status.BAD_REQUEST,
+        CatalogExceptionMessage.invalidGlossaryTermMove(t1.getFullyQualifiedName(), t11.getFullyQualifiedName()));
   }
+
+  @Test
+  void patch_moveGlossaryTermParentToChild() {}
 
   @Test
   void testCsvDocumentation() throws HttpResponseException {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/FullyQualifiedNameTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/FullyQualifiedNameTest.java
@@ -1,8 +1,10 @@
 package org.openmetadata.service.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
@@ -95,5 +97,14 @@ class FullyQualifiedNameTest {
     assertEquals("a", FullyQualifiedName.getRoot("a.b.c"));
     assertEquals("a", FullyQualifiedName.getRoot("a.b"));
     assertNull(FullyQualifiedName.getRoot("a"));
+  }
+
+  @Test
+  void test_isParent() {
+    assertTrue(FullyQualifiedName.isParent("a.b.c", "a.b"));
+    assertTrue(FullyQualifiedName.isParent("a.b.c", "a"));
+    assertFalse(FullyQualifiedName.isParent("a", "a.b.c"));
+    assertFalse(FullyQualifiedName.isParent("a.b", "a.b.c"));
+    assertFalse(FullyQualifiedName.isParent("a.b.c", "a.b.c"));
   }
 }


### PR DESCRIPTION
…ts child term

<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #10907 

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
