### PR TITLE
Fixes #10911 - Improve Data Insight Logging

### DIFF
--- a/ingestion/src/metadata/data_insight/processor/web_analytic_report_data_processor.py
+++ b/ingestion/src/metadata/data_insight/processor/web_analytic_report_data_processor.py
@@ -195,6 +195,8 @@ class WebAnalyticEntityViewReportDataProcessor(DataProcessor):
             else:
                 refined_data[split_url[1]]["views"] += 1
 
+            self.processor_status.scanned(ENTITIES[entity_type].__name__)
+
     def refine(self):
         """Aggregates data. It will return a dictionary of the following shape
 
@@ -324,6 +326,8 @@ class WebAnalyticUserActivityReportDataProcessor(DataProcessor):
 
                 if timestamp > user_data["lastSession"]:
                     user_data["lastSession"] = timestamp
+
+            self.processor_status.scanned(user_id)
 
     def fetch_data(self) -> Iterable[WebAnalyticEventData]:
         if CACHED_EVENTS:

--- a/ingestion/src/metadata/data_insight/sink/metadata_rest.py
+++ b/ingestion/src/metadata/data_insight/sink/metadata_rest.py
@@ -66,8 +66,8 @@ class MetadataRestSink(Sink[Entity]):
         try:
             if isinstance(record, ReportData):
                 self.metadata.add_data_insight_report_data(record)
-                logger.info(
-                    "Successfully ingested data insight for"
+                logger.debug(
+                    "Successfully ingested data insight for "
                     f"{record.data.__class__.__name__ if record.data else 'Unknown'}"
                 )
                 self.status.records_written(
@@ -75,7 +75,7 @@ class MetadataRestSink(Sink[Entity]):
                 )
             if isinstance(record, KpiResult):
                 self.metadata.add_kpi_result(fqn=record.kpiFqn.__root__, record=record)
-                logger.info(f"Successfully ingested KPI for {record.kpiFqn}")
+                logger.debug(f"Successfully ingested KPI for {record.kpiFqn}")
                 self.status.records_written(f"Data Insight: {record.kpiFqn}")
 
         except APIError as err:

--- a/ingestion/src/metadata/ingestion/sink/elasticsearch.py
+++ b/ingestion/src/metadata/ingestion/sink/elasticsearch.py
@@ -341,7 +341,11 @@ class ElasticsearchSink(Sink[Entity]):
 
         try:
             self._write_record(record)
-            self.status.records_written(record.name.__root__)
+            self.status.records_written(
+                record.name.__root__
+                if hasattr(record, "name")
+                else type(record).__name__
+            )
 
         except Exception as exc:
             logger.debug(traceback.format_exc())

--- a/ingestion/src/metadata/utils/workflow_output_handler.py
+++ b/ingestion/src/metadata/utils/workflow_output_handler.py
@@ -278,18 +278,18 @@ def print_data_insight_status(workflow) -> None:
     print_workflow_summary(
         workflow,
         processor=True,
-        processor_status=workflow.data_processor.get_status(),
+        processor_status=workflow.status,
     )
 
-    if workflow.data_processor.get_status().source_start_time:
+    if workflow.source.get_status().source_start_time:
         log_ansi_encoded_string(
-            message=f"Workflow finished in time {pretty_print_time_duration(time.time()-workflow.data_processor.get_status().source_start_time)} ",  # pylint: disable=line-too-long
+            message=f"Workflow finished in time {pretty_print_time_duration(time.time()-workflow.source.get_status().source_start_time)} ",  # pylint: disable=line-too-long
         )
 
     if workflow.result_status() == 1:
         log_ansi_encoded_string(message=WORKFLOW_FAILURE_MESSAGE)
     elif (
-        workflow.data_processor.get_status().warnings
+        workflow.source.get_status().warnings
         or workflow.status.warnings
         or (hasattr(workflow, "sink") and workflow.sink.get_status().warnings)
     ):


### PR DESCRIPTION
### Describe your changes:

Fixes #10911 
- Improve logging output for data insight workflow

**Success**
```logs
[2023-04-04 10:55:09] INFO     {metadata.DataInsight:workflow:298} - Starting data processor execution
[2023-04-04 10:55:09] INFO     {metadata.DataInsight:workflow:216} - Processing data for report type ReportDataType.EntityReportData
[2023-04-04 10:55:14] INFO     {metadata.DataInsight:workflow_reporter:29} - Source: Processed 412 records, filtered 0 records, found 0 errors
[2023-04-04 10:55:14] INFO     {metadata.DataInsight:workflow_reporter:36} - Sink: Processed 0 records, found 0 errors
[2023-04-04 10:55:19] INFO     {metadata.DataInsight:workflow_reporter:29} - Source: Processed 1112 records, filtered 0 records, found 0 errors
[2023-04-04 10:55:19] INFO     {metadata.DataInsight:workflow_reporter:36} - Sink: Processed 0 records, found 0 errors
[2023-04-04 10:55:24] INFO     {metadata.DataInsight:workflow_reporter:29} - Source: Processed 1912 records, filtered 0 records, found 0 errors
[2023-04-04 10:55:24] INFO     {metadata.DataInsight:workflow_reporter:36} - Sink: Processed 0 records, found 0 errors
[2023-04-04 10:55:29] INFO     {metadata.DataInsight:workflow_reporter:29} - Source: Processed 2712 records, filtered 0 records, found 0 errors
[2023-04-04 10:55:29] INFO     {metadata.DataInsight:workflow_reporter:36} - Sink: Processed 0 records, found 0 errors
[2023-04-04 10:55:34] INFO     {metadata.DataInsight:workflow_reporter:29} - Source: Processed 3512 records, filtered 0 records, found 0 errors
[2023-04-04 10:55:34] INFO     {metadata.DataInsight:workflow_reporter:36} - Sink: Processed 0 records, found 0 errors
[2023-04-04 10:55:39] INFO     {metadata.DataInsight:workflow_reporter:29} - Source: Processed 4312 records, filtered 0 records, found 0 errors
[2023-04-04 10:55:39] INFO     {metadata.DataInsight:workflow_reporter:36} - Sink: Processed 0 records, found 0 errors
[2023-04-04 10:55:59] INFO     {metadata.DataInsight:workflow_reporter:29} - Source: Processed 4400 records, filtered 0 records, found 0 errors
[2023-04-04 10:56:16] INFO     {metadata.DataInsight:workflow_reporter:36} - Sink: Processed 1 records, found 0 errors
[2023-04-04 10:56:27] INFO     {metadata.DataInsight:workflow_reporter:29} - Source: Processed 4400 records, filtered 0 records, found 0 errors
[2023-04-04 10:56:31] INFO     {metadata.DataInsight:workflow_reporter:36} - Sink: Processed 2 records, found 0 errors
[2023-04-04 10:56:35] INFO     {metadata.DataInsight:workflow_reporter:29} - Source: Processed 4400 records, filtered 0 records, found 0 errors
[2023-04-04 10:56:37] INFO     {metadata.DataInsight:workflow_reporter:36} - Sink: Processed 3 records, found 0 errors
[2023-04-04 10:56:39] INFO     {metadata.DataInsight:workflow:216} - Processing data for report type ReportDataType.WebAnalyticUserActivityReportData
[2023-04-04 10:56:40] INFO     {metadata.DataInsight:workflow_reporter:29} - Source: Processed 4400 records, filtered 0 records, found 0 errors
[2023-04-04 10:56:42] INFO     {metadata.DataInsight:workflow_reporter:36} - Sink: Processed 3 records, found 0 errors
[2023-04-04 10:56:45] INFO     {metadata.DataInsight:workflow:216} - Processing data for report type ReportDataType.WebAnalyticEntityViewReportData
[2023-04-04 10:56:45] INFO     {metadata.DataInsight:workflow_reporter:29} - Source: Processed 0 records, filtered 0 records, found 0 errors
[2023-04-04 10:56:49] INFO     {metadata.DataInsight:workflow_reporter:36} - Sink: Processed 3 records, found 0 errors
[2023-04-04 10:56:52] INFO     {metadata.DataInsight:workflow:300} - Data processor finished running
[2023-04-04 10:56:52] INFO     {metadata.DataInsight:workflow:302} - Sleeping for 1 second. Waiting for ES data to be indexed.
[2023-04-04 10:56:52] INFO     {metadata.DataInsight:workflow_reporter:29} - Source: Processed 0 records, filtered 0 records, found 0 errors
[2023-04-04 10:56:52] INFO     {metadata.DataInsight:workflow_reporter:36} - Sink: Processed 3 records, found 0 errors
[2023-04-04 10:56:53] INFO     {metadata.DataInsight:workflow:304} - Starting KPI runner
[2023-04-04 10:56:53] INFO     {metadata.DataInsight:workflow:306} - KPI runner finished running
[2023-04-04 10:56:53] INFO     {metadata.DataInsight:workflow:308} - Deleting Web Analytic Events older than 7
[2023-04-04 10:56:53] INFO     {metadata.Utils:logger:174} - Workflow Summary:
[2023-04-04 10:56:53] INFO     {metadata.Utils:logger:174} - Total processed records: 4403
[2023-04-04 10:56:53] INFO     {metadata.Utils:logger:174} - Total warnings: 0
[2023-04-04 10:56:53] INFO     {metadata.Utils:logger:174} - Total filtered: 0
[2023-04-04 10:56:53] INFO     {metadata.Utils:logger:174} - Total errors: 0
[2023-04-04 10:56:53] INFO     {metadata.Utils:logger:174} - Success %: 100.0
[2023-04-04 10:56:53] INFO     {metadata.Utils:logger:174} - Workflow finished in time 1.0m 44.5s 
[2023-04-04 10:56:53] INFO     {metadata.Utils:logger:174} - Workflow finished successfully
[2023-04-04 10:56:53] INFO     {metadata.Utils:logger:174} - Workflow finished successfully
```

**Failure** 
```logs
[2023-04-04 10:51:14] INFO     {metadata.DataInsight:workflow:298} - Starting data processor execution
[2023-04-04 10:51:14] INFO     {metadata.DataInsight:workflow:216} - Processing data for report type ReportDataType.EntityReportData
[2023-04-04 10:51:19] INFO     {metadata.DataInsight:workflow_reporter:29} - Source: Processed 0 records, filtered 0 records, found 412 errors
[2023-04-04 10:51:19] INFO     {metadata.DataInsight:workflow_reporter:36} - Sink: Processed 0 records, found 0 errors
[2023-04-04 10:51:24] INFO     {metadata.DataInsight:workflow_reporter:29} - Source: Processed 0 records, filtered 0 records, found 1212 errors
[2023-04-04 10:51:24] INFO     {metadata.DataInsight:workflow_reporter:36} - Sink: Processed 0 records, found 0 errors
[2023-04-04 10:51:29] INFO     {metadata.DataInsight:workflow_reporter:29} - Source: Processed 0 records, filtered 0 records, found 2012 errors
[2023-04-04 10:51:29] INFO     {metadata.DataInsight:workflow_reporter:36} - Sink: Processed 0 records, found 0 errors
[2023-04-04 10:51:34] INFO     {metadata.DataInsight:workflow_reporter:29} - Source: Processed 0 records, filtered 0 records, found 2912 errors
[2023-04-04 10:51:34] INFO     {metadata.DataInsight:workflow_reporter:36} - Sink: Processed 0 records, found 0 errors
[2023-04-04 10:51:39] INFO     {metadata.DataInsight:workflow_reporter:29} - Source: Processed 0 records, filtered 0 records, found 3712 errors
[2023-04-04 10:51:39] INFO     {metadata.DataInsight:workflow_reporter:36} - Sink: Processed 0 records, found 0 errors
[2023-04-04 10:51:43] INFO     {metadata.DataInsight:workflow:216} - Processing data for report type ReportDataType.WebAnalyticUserActivityReportData
[2023-04-04 10:51:43] INFO     {metadata.DataInsight:workflow:216} - Processing data for report type ReportDataType.WebAnalyticEntityViewReportData
[2023-04-04 10:51:43] INFO     {metadata.DataInsight:workflow:300} - Data processor finished running
[2023-04-04 10:51:43] INFO     {metadata.DataInsight:workflow:302} - Sleeping for 1 second. Waiting for ES data to be indexed.
[2023-04-04 10:51:44] INFO     {metadata.DataInsight:workflow_reporter:29} - Source: Processed 0 records, filtered 0 records, found 0 errors
[2023-04-04 10:51:44] INFO     {metadata.DataInsight:workflow_reporter:36} - Sink: Processed 0 records, found 0 errors
[2023-04-04 10:51:44] INFO     {metadata.DataInsight:workflow:304} - Starting KPI runner
[2023-04-04 10:51:44] INFO     {metadata.DataInsight:workflow:306} - KPI runner finished running
[2023-04-04 10:51:44] INFO     {metadata.DataInsight:workflow:308} - Deleting Web Analytic Events older than 7
[2023-04-04 10:51:44] INFO     {metadata.Utils:logger:174} - Showing only the first 100 failures:
[2023-04-04 10:51:44] INFO     {metadata.Utils:logger:174} - 
+-----------+------------------------------+-----------------------+---------------+
| From      | Entity Name                  | Message               | Stack Trace   |
+===========+==============================+=======================+===============+
| Processor | default                      | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | dev                          | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | openmetadata_db              | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | catalog_history              | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | dbt_analysis                 | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | dbt_jaffle                   | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | dbt_test                     | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | exclude_me                   | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | information_schema           | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | public                       | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | sample_data                  | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | test                         | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | automations_workflow         | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | bot_entity                   | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | change_event                 | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | chart_entity                 | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | classification               | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | dashboard_data_model_entity  | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | dashboard_entity             | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | dashboard_service_entity     | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | data_insight_chart           | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | DATABASE_CHANGE_LOG          | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | database_entity              | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | database_schema_entity       | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | dbservice_entity             | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | entity_extension             | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | entity_extension_time_series | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | entity_relationship          | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | entity_usage                 | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | event_subscription_entity    | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | field_relationship           | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | glossary_entity              | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | glossary_term_entity         | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | ingestion_pipeline_entity    | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | kpi_entity                   | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | location_entity              | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | messaging_service_entity     | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | metadata_service_entity      | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | metric_entity                | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | ml_model_entity              | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | mlmodel_service_entity       | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | objectstore_container_entity | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | objectstore_service_entity   | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | openmetadata_settings        | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | pipeline_entity              | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | pipeline_service_entity      | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | policy_entity                | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | query_entity                 | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | report_entity                | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | role_entity                  | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | storage_service_entity       | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | table_entity                 | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | tag                          | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | tag_usage                    | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | task_sequence                | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | team_entity                  | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | test_case                    | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | test_connection_definition   | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | test_definition              | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | test_suite                   | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | thread_entity                | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | topic_entity                 | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | type_entity                  | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | user_entity                  | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | user_tokens                  | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | web_analytic_event           | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | customers                    | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | customers1                   | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | customers10                  | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | customers100                 | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | customers11                  | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | customers12                  | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | customers13                  | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | customers14                  | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | customers15                  | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | customers16                  | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | customers17                  | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | customers18                  | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | customers19                  | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | customers2                   | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | customers20                  | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | customers21                  | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | customers22                  | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | customers23                  | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | customers24                  | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | customers25                  | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | customers26                  | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | customers27                  | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | customers28                  | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | customers29                  | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | customers3                   | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
| Processor | customers30                  | error retrieving team |               |
+-----------+------------------------------+-----------------------+---------------+
```

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [x] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
