### PR TITLE
Fix #10273: Parse nested json for datalake

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/datalake/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/datalake/metadata.py
@@ -13,7 +13,7 @@
 DataLake connector to fetch metadata from a files stored s3, gcs and Hdfs
 """
 import traceback
-from typing import Iterable, Optional, Tuple
+from typing import Iterable, List, Optional, Tuple
 
 from metadata.generated.schema.api.data.createDatabase import CreateDatabaseRequest
 from metadata.generated.schema.api.data.createDatabaseSchema import (
@@ -55,6 +55,7 @@ from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.connections import get_connection
 from metadata.ingestion.source.database.database_service import DatabaseServiceSource
 from metadata.ingestion.source.database.datalake.models import DatalakeColumnWrapper
+from metadata.ingestion.source.database.datalake.utils import COMPLEX_COLUMN_SEPARATOR
 from metadata.utils import fqn
 from metadata.utils.constants import DEFAULT_DATABASE
 from metadata.utils.filters import filter_by_schema, filter_by_table
@@ -566,35 +567,129 @@ class DatalakeSource(DatabaseServiceSource):
         return None
 
     @staticmethod
+    def _parse_complex_column(
+        data_frame,
+        column,
+        final_column_list: List[Column],
+        complex_col_dict: dict,
+        processed_complex_columns: set,
+    ) -> None:
+        """
+        This class parses the complex columns
+
+        for example consider this data:
+            {
+                "level1": {
+                    "level2":{
+                        "level3": 1
+                    }
+                }
+            }
+
+        pandas would name this column as: _##level1_##level2_##level3
+        (_## being the custom separator)
+
+        this function would parse this column name and prepare a Column object like
+        Column(
+            name="level1",
+            dataType="RECORD",
+            children=[
+                Column(
+                    name="level2",
+                    dataType="RECORD",
+                    children=[
+                        Column(
+                            name="level3",
+                            dataType="INT",
+                        )
+                    ]
+                )
+            ]
+        )
+        """
+        try:
+            column_name = str(column).strip(COMPLEX_COLUMN_SEPARATOR)
+            col_hierarchy = tuple(column_name.split(COMPLEX_COLUMN_SEPARATOR))
+            parent_col: Optional[Column] = None
+            root_col: Optional[Column] = None
+            for i, col_name in enumerate(col_hierarchy[:-1]):
+                if complex_col_dict.get(col_hierarchy[: i + 1]):
+                    parent_col = complex_col_dict.get(col_hierarchy[: i + 1])
+                else:
+                    intermediate_column = Column(
+                        name=col_name[:64],
+                        dataType=DataType.RECORD.value,
+                        children=[],
+                        dataTypeDisplay=DataType.RECORD.value,
+                    )
+                    if parent_col:
+                        parent_col.children.append(intermediate_column)
+                        root_col = parent_col
+                    parent_col = intermediate_column
+                    complex_col_dict[col_hierarchy[: i + 1]] = parent_col
+
+            # use String by default
+            data_type = DataType.STRING.value
+            if hasattr(data_frame[column], "dtypes"):
+                data_type = DATALAKE_DATA_TYPES.get(
+                    data_frame[column].dtypes.name, DataType.STRING.value
+                )
+            leaf_column = Column(
+                name=col_hierarchy[-1],
+                dataType=data_type,
+                dataTypeDisplay=data_type,
+            )
+            parent_col.children.append(leaf_column)
+
+            if col_hierarchy[0] not in processed_complex_columns and root_col:
+                processed_complex_columns.add(col_hierarchy[0])
+                final_column_list.append(root_col)
+        except Exception as exc:
+            logger.debug(traceback.format_exc())
+            logger.warning(f"Unexpected exception parsing column [{column}]: {exc}")
+
+    @staticmethod
     def get_columns(data_frame):
         """
         method to process column details
         """
         cols = []
+        complex_col_dict = {}
+        processed_complex_columns = set()
         if hasattr(data_frame, "columns"):
             df_columns = list(data_frame.columns)
             for column in df_columns:
-                # use String by default
-                data_type = DataType.STRING.value
-                try:
-                    if hasattr(data_frame[column], "dtypes"):
-                        data_type = DATALAKE_DATA_TYPES.get(
-                            data_frame[column].dtypes.name, DataType.STRING.value
-                        )
 
-                    parsed_string = {
-                        "dataTypeDisplay": data_type,
-                        "dataType": data_type,
-                        "name": column[:64],
-                    }
-                    parsed_string["dataLength"] = parsed_string.get("dataLength", 1)
-                    cols.append(Column(**parsed_string))
-                except Exception as exc:
-                    logger.debug(traceback.format_exc())
-                    logger.warning(
-                        f"Unexpected exception parsing column [{column}]: {exc}"
+                if COMPLEX_COLUMN_SEPARATOR in column:
+                    DatalakeSource._parse_complex_column(
+                        data_frame,
+                        column,
+                        cols,
+                        complex_col_dict,
+                        processed_complex_columns,
                     )
+                else:
+                    # use String by default
+                    data_type = DataType.STRING.value
+                    try:
+                        if hasattr(data_frame[column], "dtypes"):
+                            data_type = DATALAKE_DATA_TYPES.get(
+                                data_frame[column].dtypes.name, DataType.STRING.value
+                            )
 
+                        parsed_string = {
+                            "dataTypeDisplay": data_type,
+                            "dataType": data_type,
+                            "name": column[:64],
+                        }
+                        parsed_string["dataLength"] = parsed_string.get("dataLength", 1)
+                        cols.append(Column(**parsed_string))
+                    except Exception as exc:
+                        logger.debug(traceback.format_exc())
+                        logger.warning(
+                            f"Unexpected exception parsing column [{column}]: {exc}"
+                        )
+        complex_col_dict.clear()
         return cols
 
     def yield_view_lineage(self) -> Optional[Iterable[AddLineageRequest]]:

--- a/ingestion/src/metadata/ingestion/source/database/datalake/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/datalake/metadata.py
@@ -608,13 +608,14 @@ class DatalakeSource(DatabaseServiceSource):
         )
         """
         try:
+            # pylint: disable=bad-str-strip-call
             column_name = str(column).strip(COMPLEX_COLUMN_SEPARATOR)
             col_hierarchy = tuple(column_name.split(COMPLEX_COLUMN_SEPARATOR))
             parent_col: Optional[Column] = None
             root_col: Optional[Column] = None
-            for i, col_name in enumerate(col_hierarchy[:-1]):
-                if complex_col_dict.get(col_hierarchy[: i + 1]):
-                    parent_col = complex_col_dict.get(col_hierarchy[: i + 1])
+            for index, col_name in enumerate(col_hierarchy[:-1]):
+                if complex_col_dict.get(col_hierarchy[: index + 1]):
+                    parent_col = complex_col_dict.get(col_hierarchy[: index + 1])
                 else:
                     intermediate_column = Column(
                         name=col_name[:64],
@@ -626,7 +627,7 @@ class DatalakeSource(DatabaseServiceSource):
                         parent_col.children.append(intermediate_column)
                         root_col = parent_col
                     parent_col = intermediate_column
-                    complex_col_dict[col_hierarchy[: i + 1]] = parent_col
+                    complex_col_dict[col_hierarchy[: index + 1]] = parent_col
 
             # use String by default
             data_type = DataType.STRING.value

--- a/ingestion/src/metadata/ingestion/source/database/datalake/utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/datalake/utils.py
@@ -106,14 +106,5 @@ def read_from_json(
         ]
 
     if isinstance(data, list):
-        df = pd.json_normalize(data[:sample_size], sep=COMPLEX_COLUMN_SEPARATOR)
-        print(df.columns)
         return [pd.json_normalize(data[:sample_size], sep=COMPLEX_COLUMN_SEPARATOR)]
-    df = pd.json_normalize(data, sep=COMPLEX_COLUMN_SEPARATOR)
-    print(df.columns)
     return [pd.json_normalize(data, sep=COMPLEX_COLUMN_SEPARATOR)]
-    # if isinstance(data, list):
-    #     return [pd.DataFrame.from_dict(data[:sample_size])]
-    # return [
-    #     pd.DataFrame.from_dict({key: pd.Series(value) for key, value in data.items()})
-    # ]

--- a/ingestion/src/metadata/ingestion/source/database/datalake/utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/datalake/utils.py
@@ -46,6 +46,9 @@ PD_AVRO_FIELD_MAP = {
 AVRO_SCHEMA = "avro.schema"
 
 
+COMPLEX_COLUMN_SEPARATOR = "_##"
+
+
 def read_from_avro(
     avro_text: bytes,
 ) -> Union[DatalakeColumnWrapper, List[pd.DataFrame]]:
@@ -103,7 +106,14 @@ def read_from_json(
         ]
 
     if isinstance(data, list):
-        return [pd.DataFrame.from_dict(data[:sample_size])]
-    return [
-        pd.DataFrame.from_dict({key: pd.Series(value) for key, value in data.items()})
-    ]
+        df = pd.json_normalize(data[:sample_size], sep=COMPLEX_COLUMN_SEPARATOR)
+        print(df.columns)
+        return [pd.json_normalize(data[:sample_size], sep=COMPLEX_COLUMN_SEPARATOR)]
+    df = pd.json_normalize(data, sep=COMPLEX_COLUMN_SEPARATOR)
+    print(df.columns)
+    return [pd.json_normalize(data, sep=COMPLEX_COLUMN_SEPARATOR)]
+    # if isinstance(data, list):
+    #     return [pd.DataFrame.from_dict(data[:sample_size])]
+    # return [
+    #     pd.DataFrame.from_dict({key: pd.Series(value) for key, value in data.items()})
+    # ]

--- a/ingestion/tests/unit/topology/database/test_datalake.py
+++ b/ingestion/tests/unit/topology/database/test_datalake.py
@@ -14,6 +14,7 @@
 Unit tests for datalake source
 """
 
+from copy import deepcopy
 from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import patch
@@ -123,6 +124,115 @@ EXAMPLE_JSON_TEST_1 = """
 EXAMPLE_JSON_TEST_2 = """
 {"name":"John","age":16,"sex":"M"}
 """
+
+EXAMPLE_JSON_TEST_3 = """
+{
+    "name":"John",
+    "age":16,
+    "sex":"M",
+    "address":{
+        "city":"Mumbai",
+        "state":"Maharashtra",
+        "country":"India",
+        "coordinates":{
+            "lat":123,
+            "lon":123
+        }
+    }
+}
+"""
+
+EXAMPLE_JSON_TEST_4 = """
+[
+    {"name":"John","age":16,"sex":"M"},
+    {
+        "name":"John",
+        "age":16,
+        "sex":"M",
+        "address":{
+            "city":"Mumbai",
+            "state":"Maharashtra",
+            "country":"India",
+            "coordinates":{
+                "lat":123,
+                "lon":123
+            }
+        }
+    }
+]
+"""
+
+EXAMPLE_JSON_COL_3 = [
+    Column(
+        name="name",
+        dataType="STRING",
+        dataTypeDisplay="STRING",
+    ),
+    Column(
+        name="age",
+        dataType="INT",
+        dataTypeDisplay="INT",
+    ),
+    Column(
+        name="sex",
+        dataType="STRING",
+        dataTypeDisplay="STRING",
+    ),
+    Column(
+        name="address",
+        dataType="RECORD",
+        dataTypeDisplay="RECORD",
+        children=[
+            Column(
+                name="city",
+                dataType="STRING",
+                dataTypeDisplay="STRING",
+            ),
+            Column(
+                name="state",
+                dataType="STRING",
+                dataTypeDisplay="STRING",
+            ),
+            Column(
+                name="country",
+                dataType="STRING",
+                dataTypeDisplay="STRING",
+            ),
+            Column(
+                name="coordinates",
+                dataType="RECORD",
+                dataTypeDisplay="RECORD",
+                children=[
+                    Column(
+                        name="lat",
+                        dataType="INT",
+                        dataTypeDisplay="INT",
+                    ),
+                    Column(
+                        name="lon",
+                        dataType="INT",
+                        dataTypeDisplay="INT",
+                    ),
+                ],
+            ),
+        ],
+    ),
+]
+
+
+EXAMPLE_JSON_COL_4 = deepcopy(EXAMPLE_JSON_COL_3)
+EXAMPLE_JSON_COL_4[3].children[3].children = [
+    Column(
+        name="lat",
+        dataType="FLOAT",
+        dataTypeDisplay="FLOAT",
+    ),
+    Column(
+        name="lon",
+        dataType="FLOAT",
+        dataTypeDisplay="FLOAT",
+    ),
+]
 
 EXPECTED_AVRO_COL_1 = [
     Column(
@@ -314,15 +424,13 @@ class DatalakeUnitTest(TestCase):
 
         sample_dict = {"name": "John", "age": 16, "sex": "M"}
 
-        exp_df_list = pd.DataFrame.from_dict(
+        exp_df_list = pd.json_normalize(
             [
                 {"name": "John", "age": 16, "sex": "M"},
                 {"name": "Milan", "age": 19, "sex": "M"},
             ]
         )
-        exp_df_obj = pd.DataFrame.from_dict(
-            {key: pd.Series(value) for key, value in sample_dict.items()}
-        )
+        exp_df_obj = pd.json_normalize(sample_dict)
 
         actual_df_1 = read_from_json(key="file.json", json_text=EXAMPLE_JSON_TEST_1)[0]
         actual_df_2 = read_from_json(key="file.json", json_text=EXAMPLE_JSON_TEST_2)[0]
@@ -330,7 +438,15 @@ class DatalakeUnitTest(TestCase):
         assert actual_df_1.compare(exp_df_list).empty
         assert actual_df_2.compare(exp_df_obj).empty
 
-    def test_avro_file_parse(self):  # disabling this test as failing with CI
+        actual_df_3 = read_from_json(key="file.json", json_text=EXAMPLE_JSON_TEST_3)[0]
+        actual_cols_3 = DatalakeSource.get_columns(actual_df_3)
+        self.assertEqual(actual_cols_3, EXAMPLE_JSON_COL_3)
+
+        actual_df_4 = read_from_json(key="file.json", json_text=EXAMPLE_JSON_TEST_4)[0]
+        actual_cols_4 = DatalakeSource.get_columns(actual_df_4)
+        self.assertEqual(actual_cols_4, EXAMPLE_JSON_COL_4)
+
+    def test_avro_file_parse(self):
         columns = read_from_avro(AVRO_SCHEMA_FILE)
         Column.__eq__ = custom_column_compare
 

--- a/ingestion/tests/unit/topology/database/test_datalake.py
+++ b/ingestion/tests/unit/topology/database/test_datalake.py
@@ -420,6 +420,9 @@ class DatalakeUnitTest(TestCase):
         assert list(self.datalake_source.fetch_gcs_bucket_names()) == EXPECTED_SCHEMA
 
     def test_json_file_parse(self):
+        """
+        Test json data files
+        """
         import pandas as pd  # pylint: disable=import-outside-toplevel
 
         sample_dict = {"name": "John", "age": 16, "sex": "M"}


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fix #10273: Parse nested json for dataleke

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

as of now we parse only top level the json keys

```
{
    "level1": {
        "level2":{
            "level3": 1
        }
    }
}
```

for example if my data looks like above we only will consider the `level1` as of current implementation 

this pr will improve the parsing logic and will append the children in case of nested records

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

- [x] I have added tests around the new logic.

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
