### PR TITLE
fix: add rollback logic to custom sql query to exit out of transaction

### DIFF
--- a/ingestion/src/metadata/data_quality/validations/table/sqlalchemy/tableCustomSQLQuery.py
+++ b/ingestion/src/metadata/data_quality/validations/table/sqlalchemy/tableCustomSQLQuery.py
@@ -28,6 +28,10 @@ class TableCustomSQLQueryValidator(BaseTableCustomSQLQueryValidator, SQAValidato
 
     def _run_results(self, sql_expression):
         """compute result of the test case"""
-        return self.runner._session.execute(  # pylint: disable=protected-access
-            text(sql_expression)
-        ).all()
+        try:
+            return self.runner._session.execute(  # pylint: disable=protected-access
+                text(sql_expression)
+            ).all()
+        except Exception as exc:
+            self.runner._session.rollback()  # pylint: disable=protected-access
+            raise exc


### PR DESCRIPTION
add rollback logic to custom sql query to exit out of transaction

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
