### PR TITLE
Issue 10975 - fix workflow break at none

### DIFF
--- a/ingestion/src/metadata/data_quality/validations/table/base/tableRowInsertedCountToBeBetween.py
+++ b/ingestion/src/metadata/data_quality/validations/table/base/tableRowInsertedCountToBeBetween.py
@@ -64,7 +64,7 @@ class BaseTableRowInsertedCountToBeBetweenValidator(BaseTestValidator):
             res = self._run_results(column_name, range_type, range_interval)
 
         except Exception as exc:
-            msg = f"Error computing {self.test_case.name} for {self.runner.table.__tablename__}: {exc}"  # type: ignore
+            msg = f"Error computing {self.test_case.name}: {exc}"  # type: ignore
             logger.debug(traceback.format_exc())
             logger.warning(msg)
             return self.get_test_case_result_object(

--- a/ingestion/src/metadata/ingestion/connections/test_connections.py
+++ b/ingestion/src/metadata/ingestion/connections/test_connections.py
@@ -74,8 +74,8 @@ class TestConnectionStep(BaseModel):
 
     function: Callable
     name: str
-    error_message: str
-    description: Optional[str] = None
+    error_message: Optional[str]
+    description: Optional[str]
     mandatory: bool = True
     short_circuit: bool = False
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #10975

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on this issue as it was breaking the workflow as part of an edge case.


<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
