### PR TITLE
Added enum for ssl and auth in redshift, postgres and hive

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/hive/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/connection.py
@@ -44,7 +44,7 @@ def get_connection_url(connection: HiveConnection) -> str:
     if (
         connection.username
         and connection.auth
-        and connection.auth in ("LDAP", "CUSTOM")
+        and connection.auth.value in ("LDAP", "CUSTOM")
     ):
         url += quote_plus(connection.username)
         if not connection.password:
@@ -80,7 +80,7 @@ def get_connection(connection: HiveConnection) -> Engine:
     if connection.auth:
         if not connection.connectionArguments:
             connection.connectionArguments = init_empty_connection_arguments()
-        connection.connectionArguments.__root__["auth"] = connection.auth
+        connection.connectionArguments.__root__["auth"] = connection.auth.value
 
     if connection.kerberosServiceName:
         if not connection.connectionArguments:

--- a/ingestion/src/metadata/ingestion/source/database/postgres/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/postgres/connection.py
@@ -22,6 +22,7 @@ from metadata.generated.schema.entity.automations.workflow import (
 )
 from metadata.generated.schema.entity.services.connections.database.postgresConnection import (
     PostgresConnection,
+    SslMode,
 )
 from metadata.ingestion.connections.builders import (
     create_generic_db_connection,
@@ -45,7 +46,11 @@ def get_connection(connection: PostgresConnection) -> Engine:
     if connection.sslMode:
         if not connection.connectionArguments:
             connection.connectionArguments = init_empty_connection_arguments()
-        connection.connectionArguments.__root__["sslmode"] = connection.sslMode
+        connection.connectionArguments.__root__["sslmode"] = connection.sslMode.value
+        if connection.sslMode in (SslMode.verify_ca, SslMode.verify_full):
+            connection.connectionArguments.__root__[
+                "sslrootcert"
+            ] = connection.sslConfig.__root__.certificatePath
     return create_generic_db_connection(
         connection=connection,
         get_connection_url_fn=get_connection_url_common,

--- a/ingestion/src/metadata/ingestion/source/database/redshift/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/redshift/connection.py
@@ -21,6 +21,7 @@ from metadata.generated.schema.entity.automations.workflow import (
 )
 from metadata.generated.schema.entity.services.connections.database.redshiftConnection import (
     RedshiftConnection,
+    SslMode,
 )
 from metadata.ingestion.connections.builders import (
     create_generic_db_connection,
@@ -44,7 +45,11 @@ def get_connection(connection: RedshiftConnection) -> Engine:
     if connection.sslMode:
         if not connection.connectionArguments:
             connection.connectionArguments = init_empty_connection_arguments()
-        connection.connectionArguments.__root__["sslmode"] = connection.sslMode
+        connection.connectionArguments.__root__["sslmode"] = connection.sslMode.value
+        if connection.sslMode in (SslMode.verify_ca, SslMode.verify_full):
+            connection.connectionArguments.__root__[
+                "sslrootcert"
+            ] = connection.sslConfig.__root__.certificatePath
     return create_generic_db_connection(
         connection=connection,
         get_connection_url_fn=get_connection_url_common,

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/hiveConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/hiveConnection.json
@@ -50,8 +50,10 @@
     },
     "auth": {
       "title": "Authentication Mode",
-      "description": "Authentication mode to connect to hive, E.g, LDAP, CUSTOM etc",
-      "type": "string"
+      "description": "Authentication mode to connect to hive.",
+      "type": "string",
+      "enum": ["NONE", "LDAP", "KERBEROS", "CUSTOM", "NOSASL", "BASIC"],
+      "default": "NONE"
     },
     "kerberosServiceName": {
       "title": "Kerberos Service Name",

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/postgresConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/postgresConnection.json
@@ -55,8 +55,12 @@
     },
     "sslMode": {
       "title": "SSL Mode",
-      "description": "SSL Mode to connect to postgres database. E.g, prefer, verify-ca etc.",
-      "type": "string"
+      "description": "SSL Mode to connect to postgres database.",
+      "enum": ["disable", "allow", "prefer", "require", "verify-ca", "verify-full"],
+      "default": "disable"
+    },
+    "sslConfig": {
+      "$ref": "../../../../security/ssl/verifySSLConfig.json#/definitions/sslConfig"
     },
     "classificationName": {
       "title": "Classification Name",

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/redshiftConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/redshiftConnection.json
@@ -61,8 +61,12 @@
     },
     "sslMode": {
       "title": "SSL Mode",
-      "description": "SSL Mode to connect to postgres database. E.g, prefer, verify-ca etc.",
-      "type": "string"
+      "description": "SSL Mode to connect to redshift database.",
+      "enum": ["disable", "allow", "prefer", "require", "verify-ca", "verify-full"],
+      "default": "disable"
+    },
+    "sslConfig": {
+      "$ref": "../../../../security/ssl/verifySSLConfig.json#/definitions/sslConfig"
     },
     "connectionOptions": {
       "title": "Connection Options",

--- a/openmetadata-spec/src/main/resources/json/schema/security/ssl/validateSSLClientConfig.json
+++ b/openmetadata-spec/src/main/resources/json/schema/security/ssl/validateSSLClientConfig.json
@@ -7,7 +7,7 @@
   "javaType": "org.openmetadata.schema.security.ssl.ValidateSSLClientConfig",
   "properties": {
     "certificatePath": {
-      "description": "CA certificate path. E.g., /path/to/public.cert. Will be used if Verify SSL is set to `validate`.",
+      "description": "CA certificate path. E.g., /path/to/public.cert. Will be used if Verify SSL is set to `validate` or `verify`.",
       "type": "string"
     }
   },


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Added enums and fields for:

- Redshift SSL
- Postgres SSL
- Hive Auth

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
