### PR TITLE
ISSUE-11068: Add IAM authentication for MySQL ingestion

### DIFF
--- a/ingestion/src/metadata/clients/aws_client.py
+++ b/ingestion/src/metadata/clients/aws_client.py
@@ -34,6 +34,7 @@ class AWSServices(Enum):
     KINESIS = "kinesis"
     QUICKSIGHT = "quicksight"
     ATHENA = "athena"
+    RDS = "rds"
 
 
 class AWSAssumeRoleException(Exception):
@@ -181,3 +182,6 @@ class AWSClient:
 
     def get_athena_client(self):
         return self.get_client(AWSServices.ATHENA.value)
+
+    def get_rds_client(self):
+        return self.get_client(AWSServices.RDS.value)

--- a/ingestion/src/metadata/ingestion/source/database/mysql/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/mysql/connection.py
@@ -57,7 +57,11 @@ def get_connection(connection: MysqlConnection) -> Engine:
     if connection.iamAuth:
         client = AWSClient(connection.awsConfig).get_rds_client()
         host, port = connection.hostPort.split(':')
-        token = client.generate_db_auth_token(host, port, connection.username)
+        token = client.generate_db_auth_token(
+            DBHostname=host,
+            Port=port,
+            DBUsername=connection.username
+        )
         connection.password=SecretStr(token)
 
     return create_generic_db_connection(

--- a/openmetadata-docs/content/connectors/database/mysql/index.md
+++ b/openmetadata-docs/content/connectors/database/mysql/index.md
@@ -151,7 +151,9 @@ the changes.
 
 - **Username**: Specify the User to connect to MySQL. It should have enough privileges to read all the metadata.
 - **Password**: Password to connect to MySQL.
+- **IAM Authentication (Optional)**: For cloud providers supporting IAM authentication, this feature will request a temporary set of credentials before connecting to the database. Enabling this field will override the `Password` authentication method.
 - **Host and Port**: Enter the fully qualified hostname and port number for your MySQL deployment in the Host and Port field.
+- **AWS Credentials**: Only needed for IAM Authentication to retrieve temporary credentials.
 - **Connection Options (Optional)**: Enter the details for any additional connection options that can be sent to MySQL during the connection. These details must be added as Key-Value pairs.
 - **Connection Arguments (Optional)**: Enter the details for any additional connection arguments such as security or protocol configs that can be sent to MySQL during the connection. These details must be added as Key-Value pairs. 
   - In case you are using Single-Sign-On (SSO) for authentication, add the `authenticator` details in the Connection Arguments as a Key-Value pair as follows: `"authenticator" : "sso_login_url"`

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/mysqlConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/mysqlConnection.json
@@ -43,6 +43,12 @@
       "type": "string",
       "format": "password"
     },
+    "iamAuth": {
+      "title": "IAM Authentication",
+      "description": "Use IAM Authentication to retrieve temporary credentials to connect to MySQL.",
+      "type": "boolean",
+      "default": false
+    },
     "hostPort": {
       "title": "Host and Port",
       "description": "Host and port of the MySQL service.",
@@ -76,6 +82,10 @@
     "connectionOptions": {
       "title": "Connection Options",
       "$ref": "../connectionBasicType.json#/definitions/connectionOptions"
+    },
+    "awsConfig": {
+      "title": "AWS Credentials Configuration",
+      "$ref": "../../../../security/credentials/awsCredentials.json"
     },
     "connectionArguments": {
       "title": "Connection Arguments",

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Mysql/fields/awsAccessKeyId.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Mysql/fields/awsAccessKeyId.md
@@ -1,0 +1,11 @@
+When you interact with AWS, you specify your AWS security credentials to verify who you are and whether you have 
+permission to access the resources that you are requesting. AWS uses the security credentials to authenticate and
+authorize your requests ([docs](https://docs.aws.amazon.com/IAM/latest/UserGuide/security-creds.html)).
+
+Access keys consist of two parts: 
+1. An access key ID (for example, `AKIAIOSFODNN7EXAMPLE`),
+2. And a secret access key (for example, `wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY`).
+
+You must use both the access key ID and secret access key together to authenticate your requests.
+
+You can find further information on how to manage your access keys [here](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html)

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Mysql/fields/awsConfig.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Mysql/fields/awsConfig.md
@@ -1,0 +1,2 @@
+AWS credentials configs.
+<!-- awsConfig to be updated -->

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Mysql/fields/awsRegion.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Mysql/fields/awsRegion.md
@@ -1,0 +1,7 @@
+Each AWS Region is a separate geographic area in which AWS clusters data centers ([docs](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html)).
+
+As AWS can have instances in multiple regions, we need to know the region the service you want reach belongs to.
+
+Note that the AWS Region is the only required parameter when configuring a connection. When connecting to the
+services programmatically, there are different ways in which we can extract and use the rest of AWS configurations.
+You can find further information about configuring your credentials [here](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials).

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Mysql/fields/awsSecretAccessKey.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Mysql/fields/awsSecretAccessKey.md
@@ -1,0 +1,11 @@
+When you interact with AWS, you specify your AWS security credentials to verify who you are and whether you have 
+permission to access the resources that you are requesting. AWS uses the security credentials to authenticate and
+authorize your requests ([docs](https://docs.aws.amazon.com/IAM/latest/UserGuide/security-creds.html)).
+
+Access keys consist of two parts: 
+1. An access key ID (for example, `AKIAIOSFODNN7EXAMPLE`),
+2. And a secret access key (for example, `wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY`).
+
+You must use both the access key ID and secret access key together to authenticate your requests.
+
+You can find further information on how to manage your access keys [here](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html)

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Mysql/fields/awsSessionToken.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Mysql/fields/awsSessionToken.md
@@ -1,0 +1,4 @@
+If you are using temporary credentials to access your services, you will need to inform the AWS Access Key ID
+and AWS Secrets Access Key. Also, these will include an AWS Session Token.
+
+You can find more information on [Using temporary credentials with AWS resources](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html).

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Mysql/fields/iamAuth.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Mysql/fields/iamAuth.md
@@ -1,0 +1,4 @@
+Use IAM Authentication to retrieve temporary credentials to connect to MySQL.
+
+Only supported for AWS.
+Requires a valid authentication profile and `SSL CA`.


### PR DESCRIPTION
### Describe your changes:

Fixes [ISSUE-11068](https://github.com/open-metadata/OpenMetadata/issues/11068)

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on MySQL IAM Authentication because users need to ingest from databases at scale without having to manage static credentials.

#
### Type of change:
- [ ] Improvement
- [x] New feature
- [ ] Documentation

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

- [x] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [x] I have updated the documentation.
- [ ] I have added tests around the new logic.

