### PR TITLE
Fix: bump 'openmetadata-sqllineage' version to 1.0.4

### DIFF
--- a/ingestion/setup.py
+++ b/ingestion/setup.py
@@ -103,7 +103,7 @@ base_requirements = {
     "requests-aws4auth~=1.1",  # Only depends on requests as external package. Leaving as base.
     "setuptools~=65.6.3",
     "sqlalchemy>=1.4.0,<2",
-    "openmetadata-sqllineage>=1.0.3",
+    "openmetadata-sqllineage>=1.0.4",
     "tabulate==0.9.0",
     "typing-compat~=0.1.0",  # compatibility requirements for 3.7
     "typing-inspect",


### PR DESCRIPTION
### Describe your changes:

Bump `openmetadata-sqllineage` version to 1.0.4.

### Type of change:
- [x] Improvement

### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.