### PR TITLE
fix: logic for number of profiled tables

### DIFF
--- a/ingestion/tests/cli_e2e/common/test_cli_db.py
+++ b/ingestion/tests/cli_e2e/common/test_cli_db.py
@@ -62,9 +62,9 @@ class CliCommonDB:
             self, source_status: SourceStatus, sink_status: SinkStatus
         ):
             self.assertTrue(len(source_status.failures) == 0)
-            self.assertTrue(len(source_status.records) >= self.expected_tables())
+            self.assertTrue(len(source_status.records) >= self.expected_profiled_tables())
             self.assertTrue(len(sink_status.failures) == 0)
-            self.assertTrue(len(sink_status.records) >= self.expected_tables())
+            self.assertTrue(len(sink_status.records) >= self.expected_profiled_tables())
             sample_data = self.retrieve_sample_data(self.fqn_created_table()).sampleData
             lineage = self.retrieve_lineage(self.fqn_created_table())
             self.assertTrue(len(sample_data.rows) == self.inserted_rows_count())
@@ -194,11 +194,20 @@ class CliCommonDB:
         @staticmethod
         def _fqn_deleted_table() -> Optional[str]:
             return None
+        
+        @staticmethod
+        def _expected_profiled_tables() -> int:
+            return None
 
         def fqn_deleted_table(self) -> str:
             if self._fqn_deleted_table() is None:
                 return self.fqn_created_table()
             return self._fqn_deleted_table()  # type: ignore
+
+        def expected_profiled_tables(self) -> int:
+            if self._expected_profiled_tables() is None:
+                return self.expected_tables()
+            return self._expected_profiled_tables()
 
         @staticmethod
         @abstractmethod

--- a/ingestion/tests/cli_e2e/common/test_cli_db.py
+++ b/ingestion/tests/cli_e2e/common/test_cli_db.py
@@ -62,7 +62,9 @@ class CliCommonDB:
             self, source_status: SourceStatus, sink_status: SinkStatus
         ):
             self.assertTrue(len(source_status.failures) == 0)
-            self.assertTrue(len(source_status.records) >= self.expected_profiled_tables())
+            self.assertTrue(
+                len(source_status.records) >= self.expected_profiled_tables()
+            )
             self.assertTrue(len(sink_status.failures) == 0)
             self.assertTrue(len(sink_status.records) >= self.expected_profiled_tables())
             sample_data = self.retrieve_sample_data(self.fqn_created_table()).sampleData
@@ -194,7 +196,7 @@ class CliCommonDB:
         @staticmethod
         def _fqn_deleted_table() -> Optional[str]:
             return None
-        
+
         @staticmethod
         def _expected_profiled_tables() -> int:
             return None

--- a/ingestion/tests/cli_e2e/test_cli_bigquery.py
+++ b/ingestion/tests/cli_e2e/test_cli_bigquery.py
@@ -64,7 +64,7 @@ class BigqueryCliTest(CliCommonDB.TestSuite, SQACommonMethods):
 
     def view_column_lineage_count(self) -> int:
         return 2
-    
+
     @staticmethod
     def _expected_profiled_tables() -> int:
         return 2

--- a/ingestion/tests/cli_e2e/test_cli_bigquery.py
+++ b/ingestion/tests/cli_e2e/test_cli_bigquery.py
@@ -64,6 +64,10 @@ class BigqueryCliTest(CliCommonDB.TestSuite, SQACommonMethods):
 
     def view_column_lineage_count(self) -> int:
         return 2
+    
+    @staticmethod
+    def _expected_profiled_tables() -> int:
+        return 2
 
     @staticmethod
     def fqn_created_table() -> str:

--- a/ingestion/tests/cli_e2e/test_cli_vertica.py
+++ b/ingestion/tests/cli_e2e/test_cli_vertica.py
@@ -62,6 +62,10 @@ class VerticaCliTest(CliCommonDB.TestSuite, SQACommonMethods):
     @staticmethod
     def expected_tables() -> int:
         return 16
+    
+    @staticmethod
+    def _expected_profiled_tables() -> int:
+        return 12
 
     def inserted_rows_count(self) -> int:
         return len(self.insert_data_queries)

--- a/ingestion/tests/cli_e2e/test_cli_vertica.py
+++ b/ingestion/tests/cli_e2e/test_cli_vertica.py
@@ -62,7 +62,7 @@ class VerticaCliTest(CliCommonDB.TestSuite, SQACommonMethods):
     @staticmethod
     def expected_tables() -> int:
         return 16
-    
+
     @staticmethod
     def _expected_profiled_tables() -> int:
         return 12


### PR DESCRIPTION
In https://github.com/open-metadata/OpenMetadata/pull/11169/files we added a filter for the profiler to be executed only against the tables in the `get_include_schema` which can have less tables than in the entire database. This PR adds the possibility to specify the number of table profile we expect.
