### PR TITLE
fixes #11361 catch generic SQAlchemy error for non supported regex_match

### DIFF
--- a/ingestion/src/metadata/data_quality/validations/column/sqlalchemy/columnValuesToMatchRegex.py
+++ b/ingestion/src/metadata/data_quality/validations/column/sqlalchemy/columnValuesToMatchRegex.py
@@ -16,7 +16,7 @@ Validator for column values to match regex test case
 from typing import Optional
 
 from sqlalchemy import Column, inspect
-from sqlalchemy.exc import CompileError
+from sqlalchemy.exc import CompileError, SQLAlchemyError
 
 from metadata.data_quality.validations.column.base.columnValuesToMatchRegex import (
     BaseColumnValuesToMatchRegexValidator,
@@ -55,7 +55,7 @@ class ColumnValuesToMatchRegexValidator(
         """
         try:
             return self.run_query_results(self.runner, metric, column, **kwargs)
-        except CompileError as err:
+        except (CompileError, SQLAlchemyError) as err:
             logger.warning(
                 f"Could not use `REGEXP` due to - {err}. Falling back to `LIKE`"
             )

--- a/ingestion/src/metadata/data_quality/validations/column/sqlalchemy/columnValuesToNotMatchRegex.py
+++ b/ingestion/src/metadata/data_quality/validations/column/sqlalchemy/columnValuesToNotMatchRegex.py
@@ -16,7 +16,7 @@ Validator for column values to not match regex test case
 from typing import Optional
 
 from sqlalchemy import Column, inspect
-from sqlalchemy.exc import CompileError
+from sqlalchemy.exc import CompileError, SQLAlchemyError
 
 from metadata.data_quality.validations.column.base.columnValuesToNotMatchRegex import (
     BaseColumnValuesToNotMatchRegexValidator,
@@ -55,7 +55,7 @@ class ColumnValuesToNotMatchRegexValidator(
         """
         try:
             return self.run_query_results(self.runner, metric, column, **kwargs)
-        except CompileError as err:
+        except (CompileError, SQLAlchemyError) as err:
             logger.warning(
                 f"Could not use `REGEXP` due to - {err}. Falling back to `LIKE`"
             )


### PR DESCRIPTION
### Describe your changes:
**Context**
When running the regex type of tests, we have a try/catch logic to fall back to `LIKE` for dialect that have not implemented the `regex` method. The initial logic only catches compilation error. From community feedback, certain dialects appear to throw a generics `SQAlchemyError`.

**PR**
- Add logic to catch generic SQA error and fall back to `LIKE`


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

