### PR TITLE
Fix: Tableau DataModel optional dataType

### DIFF
--- a/ingestion/src/metadata/ingestion/source/dashboard/tableau/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/tableau/metadata.py
@@ -435,7 +435,7 @@ class TableauSource(DashboardServiceSource):
         for column in sheet.datasourceFields:
             parsed_string = {
                 "dataTypeDisplay": column.remoteField.dataType.value
-                if column.remoteField
+                if column.remoteField and column.remoteField.dataType
                 else DataType.UNKNOWN.value,
                 "dataType": ColumnTypeParser.get_column_type(
                     column.remoteField.dataType if column.remoteField else None

--- a/ingestion/src/metadata/ingestion/source/dashboard/tableau/models.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/tableau/models.py
@@ -160,7 +160,7 @@ class CalculatedField(TableauBaseModel):
     https://help.tableau.com/current/api/metadata_api/en-us/reference/calculatedfield.doc.html
     """
 
-    dataType: FieldDataType
+    dataType: Optional[FieldDataType]
 
 
 class ColumnField(TableauBaseModel):
@@ -169,7 +169,7 @@ class ColumnField(TableauBaseModel):
     https://help.tableau.com/current/api/metadata_api/en-us/reference/columnfield.doc.html
     """
 
-    dataType: FieldDataType
+    dataType: Optional[FieldDataType]
 
 
 class DatasourceField(TableauBaseModel):


### PR DESCRIPTION
### Describe your changes:

The `dataType` field when querying the Tableau API to extract the Data Models is optional.

### Type of change:
- [x] Bug fix

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.