### PR TITLE
Fix#11311: Add IBM dependency for i Series in DB2 connector

### DIFF
--- a/ingestion/setup.py
+++ b/ingestion/setup.py
@@ -139,7 +139,7 @@ plugins: Dict[str, Set[str]] = {
         VERSIONS["google-cloud-storage"],
         "dbt-artifacts-parser",
     },
-    "db2": {"ibm-db-sa~=0.3"},
+    "db2": {"ibm-db-sa~=0.3", "sqlalchemy-ibmi==0.9.2"},
     "databricks": {"sqlalchemy-databricks~=0.1"},
     "datalake-azure": {
         "azure-storage-blob~=12.14",

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/db2Connection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/db2Connection.json
@@ -15,7 +15,7 @@
     "db2Scheme": {
       "description": "SQLAlchemy driver scheme options.",
       "type": "string",
-      "enum": ["db2+ibm_db"],
+      "enum": ["db2+ibm_db", "ibmi"],
       "default": "db2+ibm_db"
     }
   },


### PR DESCRIPTION
### Describe your changes:

Added IBM dependency for i Series in DB2 connector along with the required db2 schema.

### Type of change:
- [x] Improvement

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.