### PR TITLE
Fix Vertica column fetch query

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/vertica/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/vertica/metadata.py
@@ -145,16 +145,12 @@ def _get_column_info(  # pylint: disable=too-many-locals,too-many-branches,too-m
         args = ()
     elif attype in ("timestamptz", "timetz"):
         kwargs["timezone"] = True
-        if charlen:
-            kwargs["precision"] = int(charlen)
         args = ()
     elif attype in (
         "timestamp",
         "time",
     ):
         kwargs["timezone"] = False
-        if charlen:
-            kwargs["precision"] = int(charlen)
         args = ()
     elif attype.startswith("interval"):
         field_match = re.match(r"interval (.+)", attype, re.I)

--- a/ingestion/src/metadata/ingestion/source/database/vertica/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/vertica/queries.py
@@ -35,7 +35,8 @@ VERTICA_GET_COLUMNS = textwrap.dedent(
         FROM v_catalog.columns col
         LEFT JOIN v_catalog.comments com
           ON com.object_type = 'COLUMN'
-         AND com.object_name LIKE CONCAT(CONCAT(col.table_name, '_%.'), col.column_name)
+          AND com.object_id = col.table_id
+          AND com.child_object = col.column_name
         WHERE lower(table_name) = '{table}'
         AND {schema_condition}
         UNION ALL


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

To fetch the vertica comments we have applied a join between `v_catalog.columns` and  `v_catalog.comments` table based on the condition `com.object_name LIKE CONCAT(CONCAT(col.table_name, '_%.'), col.column_name)`

since there is a wildcard it will fetch the comment for a table with similar names for example `table_a.col` and `table_a_new.col` will be considered the columns of the same table, hence this logic is flawed, I've changed it to compare with the object/table id and column name

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->


<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
