### PR TITLE
Send encrypted automation workflow

### DIFF
--- a/ingestion/tests/integration/ometa/test_ometa_service_api.py
+++ b/ingestion/tests/integration/ometa/test_ometa_service_api.py
@@ -54,11 +54,11 @@ class OMetaServiceTest(TestCase):
             jwtToken="eyJraWQiOiJHYjM4OWEtOWY3Ni1nZGpzLWE5MmotMDI0MmJrOTQzNTYiLCJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJhZG1pbiIsImlzQm90IjpmYWxzZSwiaXNzIjoib3Blbi1tZXRhZGF0YS5vcmciLCJpYXQiOjE2NjM5Mzg0NjIsImVtYWlsIjoiYWRtaW5Ab3Blbm1ldGFkYXRhLm9yZyJ9.tS8um_5DKu7HgzGBzS1VTA5uUjKWOCU0B_j08WXBiEC0mr0zNREkqVfwFDD-d24HlNEbrqioLsBuFRiwIWKc1m_ZlVQbG7P36RUxhuv2vbSp80FKyNM-Tj93FDzq91jsyNmsQhyNv_fNr3TXfzzSPjHt8Go0FMMP66weoKMgW2PbXlhVKwEuXUHyakLLzewm9UMeQaEiRzhiTMU3UkLXcKbYEJJvfNFcLwSl9W8JCO_l0Yj3ud-qt_nQYEZwqW6u5nfdQllN133iikV4fM5QZsMCnm8Rq1mvLR0y9bmJiD7fwM1tmJ791TUWqmKaTnP49U493VanKpUAfzIiOiIbhg"
         ),
     )
-    metadata = OpenMetadata(server_config)
+    admin_metadata = OpenMetadata(server_config)
 
     # we need to use ingestion bot user for this test since the admin user won't be able to see the password fields
-    ingestion_bot: User = metadata.get_by_name(entity=User, fqn="ingestion-bot")
-    ingestion_bot_auth: AuthenticationMechanism = metadata.get_by_id(
+    ingestion_bot: User = admin_metadata.get_by_name(entity=User, fqn="ingestion-bot")
+    ingestion_bot_auth: AuthenticationMechanism = admin_metadata.get_by_id(
         entity=AuthenticationMechanism, entity_id=ingestion_bot.id
     )
     server_config.securityConfig = OpenMetadataJWTClientConfig(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/automations/WorkflowResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/automations/WorkflowResource.java
@@ -338,8 +338,12 @@ public class WorkflowResource extends EntityResource<Workflow, WorkflowRepositor
     EntityUtil.Fields fields = getFields(FIELD_OWNER);
     Workflow workflow = dao.get(uriInfo, id, fields);
     workflow.setOpenMetadataServerConnection(new OpenMetadataConnectionBuilder(openMetadataApplicationConfig).build());
-    workflow = decryptOrNullify(securityContext, workflow);
-    workflow = unmask(workflow);
+    /*
+     We will send the encrypted Workflow to the Pipeline Service Client
+     It will be fetched from the API from there, since we are
+     decrypting on GET based on user auth. The ingestion-bot will then
+     be able to pick up the right data.
+    */
     return pipelineServiceClient.runAutomationsWorkflow(workflow);
   }
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Instead of decrypting the Automation Workflow during the `trigger` call, we are sending it encrypted. Then, it's up to the client how to obtain the right information.

In our case, we're just calling a GET again by using the ingestion bot, which will receive the proper payload.

This is useful for argo, since the workflow won't have any sensitive information in the manifest

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
