### PR TITLE
fix: increase sleep delay for system tables

### DIFF
--- a/ingestion/tests/cli_e2e/base/test_cli_db.py
+++ b/ingestion/tests/cli_e2e/base/test_cli_db.py
@@ -225,9 +225,9 @@ class CliDBBase(TestCase):
             )
             self.delete_table_rows()
             self.update_table_row()
-            # Add 30 second delay for system
+            # Add 120 second delay for system
             # tables to register the change
-            time.sleep(30)
+            time.sleep(120)
             result = self.run_command("profile")
             sink_status, source_status = self.retrieve_statuses(result)
             self.assert_for_system_metrics(source_status, sink_status)

--- a/ingestion/tests/cli_e2e/test_cli_snowflake.py
+++ b/ingestion/tests/cli_e2e/test_cli_snowflake.py
@@ -142,9 +142,9 @@ class SnowflakeCliTest(CliCommonDB.TestSuite, SQACommonMethods):
         )
         self.delete_table_rows()
         self.update_table_row()
-        # Add 30 second delay for system
+        # Add 120 second delay for system
         # tables to register the change
-        time.sleep(30)
+        time.sleep(120)
         result = self.run_command("profile")
         sink_status, source_status = self.retrieve_statuses(result)
         self.assert_for_system_metrics(source_status, sink_status)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:
Increase delay for E2E tests for system tables to register DDL operation

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
