### PR TITLE
chore(ui): add internal form item props support in form utils

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/AddService/Steps/ConfigureService.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AddService/Steps/ConfigureService.tsx
@@ -56,10 +56,6 @@ const ConfigureService = ({
         'data-testid': 'description',
         initialValue: '',
       },
-      formItemProps: {
-        trigger: 'onTextChange',
-        valuePropName: 'initialValue',
-      },
     },
   ];
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/CustomEntityDetail/AddCustomProperty/AddCustomProperty.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/CustomEntityDetail/AddCustomProperty/AddCustomProperty.tsx
@@ -198,10 +198,6 @@ const AddCustomProperty = () => {
         'data-testid': 'description',
         initialValue: '',
       },
-      formItemProps: {
-        trigger: 'onTextChange',
-        valuePropName: 'initialValue',
-      },
     },
   ];
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TagsPage/TagsForm.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TagsPage/TagsForm.tsx
@@ -78,10 +78,6 @@ const TagsForm = ({
         'data-testid': 'description',
         initialValue: '',
       },
-      formItemProps: {
-        trigger: 'onTextChange',
-        valuePropName: 'initialValue',
-      },
     },
     ...(showMutuallyExclusive
       ? ([

--- a/openmetadata-ui/src/main/resources/ui/src/utils/formUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/formUtils.tsx
@@ -75,6 +75,7 @@ export const getField = (field: FieldProp) => {
     formItemLayout = 'vertical',
   } = field;
 
+  let internalFormItemProps: FormItemProps = {};
   let fieldElement: ReactNode = null;
   let fieldRules = [...rules];
   if (required) {
@@ -137,6 +138,11 @@ export const getField = (field: FieldProp) => {
       fieldElement = (
         <RichTextEditor {...(props as unknown as RichTextEditorProp)} />
       );
+      internalFormItemProps = {
+        ...internalFormItemProps,
+        trigger: 'onTextChange',
+        valuePropName: 'initialValue',
+      };
 
       break;
     default:
@@ -155,6 +161,7 @@ export const getField = (field: FieldProp) => {
         label={label}
         name={name}
         rules={fieldRules}
+        {...internalFormItemProps}
         {...formItemProps}>
         {fieldElement}
       </Form.Item>


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:



<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on adding support for internal form item props in form utils.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] Improvement


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
