### PR TITLE
chore(ui): remove refresh token on logout

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/PermissionProvider/PermissionProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/PermissionProvider/PermissionProvider.tsx
@@ -12,7 +12,7 @@
  */
 
 import { CookieStorage } from 'cookie-storage';
-import { isEmpty, isUndefined } from 'lodash';
+import { isEmpty } from 'lodash';
 import { observer } from 'mobx-react';
 import React, {
   createContext,
@@ -177,14 +177,10 @@ const PermissionProvider: FC<PermissionProviderProps> = ({ children }) => {
     /**
      * Only fetch permissions if current user is present
      */
-    if (
-      isProtectedRoute(location.pathname) &&
-      !isUndefined(currentUser) &&
-      !isEmpty(currentUser)
-    ) {
+    if (isProtectedRoute(location.pathname) && !isEmpty(currentUser)) {
       fetchLoggedInUserPermissions();
     }
-    if (isUndefined(currentUser) || isEmpty(currentUser)) {
+    if (isEmpty(currentUser)) {
       resetPermissions();
     }
   }, [currentUser]);

--- a/openmetadata-ui/src/main/resources/ui/src/components/authentication/auth-provider/AuthProvider.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/authentication/auth-provider/AuthProvider.test.tsx
@@ -18,8 +18,22 @@ import {
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import AppState from 'AppState';
+import { refreshTokenKey } from 'constants/constants';
 import React from 'react';
 import AuthProvider, { useAuthContext } from './AuthProvider';
+
+const localStorageMock = (() => {
+  return {
+    getItem: jest.fn(),
+    setItem: jest.fn(),
+    removeItem: jest.fn(),
+    clear: jest.fn(),
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+});
 
 jest.mock('react-router-dom', () => ({
   useHistory: jest.fn().mockReturnValue({ push: jest.fn(), listen: jest.fn() }),
@@ -69,5 +83,35 @@ describe('Test auth provider', () => {
 
     expect(mockUpdateUserDetails).toHaveBeenCalled();
     expect(mockUpdateUserDetails).toHaveBeenCalledWith({});
+  });
+
+  it('Logout handler should remove the refresh token', async () => {
+    const ConsumerComponent = () => {
+      const { onLogoutHandler } = useAuthContext();
+
+      return (
+        <button data-testid="logout-button" onClick={onLogoutHandler}>
+          Logout
+        </button>
+      );
+    };
+
+    render(
+      <AuthProvider childComponentType={ConsumerComponent}>
+        <ConsumerComponent />
+      </AuthProvider>
+    );
+
+    await waitForElementToBeRemoved(() => screen.getByTestId('loader'));
+
+    const logoutButton = screen.getByTestId('logout-button');
+
+    expect(logoutButton).toBeInTheDocument();
+
+    await act(async () => {
+      userEvent.click(logoutButton);
+    });
+
+    expect(localStorageMock.removeItem).toHaveBeenCalledWith(refreshTokenKey);
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/authentication/auth-provider/AuthProvider.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/authentication/auth-provider/AuthProvider.test.tsx
@@ -22,14 +22,12 @@ import { refreshTokenKey } from 'constants/constants';
 import React from 'react';
 import AuthProvider, { useAuthContext } from './AuthProvider';
 
-const localStorageMock = (() => {
-  return {
-    getItem: jest.fn(),
-    setItem: jest.fn(),
-    removeItem: jest.fn(),
-    clear: jest.fn(),
-  };
-})();
+const localStorageMock = {
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+  clear: jest.fn(),
+};
 
 Object.defineProperty(window, 'localStorage', {
   value: localStorageMock,

--- a/openmetadata-ui/src/main/resources/ui/src/components/authentication/auth-provider/AuthProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/authentication/auth-provider/AuthProvider.tsx
@@ -138,6 +138,10 @@ export const AuthProvider = ({
 
     // remove analytics session on logout
     removeSession();
+
+    // remove the refresh token on logout
+    localState.removeRefreshToken();
+
     setLoading(false);
   }, [timeoutId, appState]);
 

--- a/openmetadata-ui/src/main/resources/ui/src/utils/LocalStorageUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/LocalStorageUtils.ts
@@ -30,6 +30,8 @@ const localState = {
   },
 
   removeOidcToken: () => localStorage.removeItem(oidcTokenKey),
+
+  removeRefreshToken: () => localStorage.removeItem(refreshTokenKey),
 };
 
 export default localState;


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on logic to remove refresh token on logout

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] Improvement


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

- [x] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.


<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
