### PR TITLE
fix: release connection from engine pool

### DIFF
--- a/ingestion/src/metadata/profiler/api/workflow.py
+++ b/ingestion/src/metadata/profiler/api/workflow.py
@@ -274,6 +274,7 @@ class ProfilerWorkflow(WorkflowStatusMixin):
                 self.source_config.generateSampleData,
                 self.source_config.processPiiSensitive,
             )
+            profiler_runner.close()
         except Exception as exc:
             name = entity.fullyQualifiedName.__root__
             error = f"Unexpected exception processing entity [{name}]: {exc}"

--- a/ingestion/src/metadata/profiler/api/workflow.py
+++ b/ingestion/src/metadata/profiler/api/workflow.py
@@ -266,32 +266,27 @@ class ProfilerWorkflow(WorkflowStatusMixin):
         """
         Main logic for the profiler workflow
         """
+        profiler_runner: Profiler = profiler_source.get_profiler_runner(
+            entity, self.profiler_config
+        )
+
         try:
-            profiler_runner: Profiler = profiler_source.get_profiler_runner(
-                entity, self.profiler_config
-            )
             profile: ProfilerResponse = profiler_runner.process(
                 self.source_config.generateSampleData,
                 self.source_config.processPiiSensitive,
             )
-            profiler_runner.close()
         except Exception as exc:
             name = entity.fullyQualifiedName.__root__
             error = f"Unexpected exception processing entity [{name}]: {exc}"
             logger.debug(traceback.format_exc())
             logger.error(error)
             self.source_status.failed(name, error, traceback.format_exc())
-            try:
-                # if we fail to instantiate a profiler_interface, we won't have a profiler_interface variable
-                # we'll also catch scenarios where we don't have an interface set
-                self.source_status.fail_all(
-                    profiler_source.interface.processor_status.failures
-                )
-                self.source_status.records.extend(
-                    profiler_source.interface.processor_status.records
-                )
-            except (UnboundLocalError, AttributeError):
-                pass
+            self.source_status.fail_all(
+                profiler_source.interface.processor_status.failures
+            )
+            self.source_status.records.extend(
+                profiler_source.interface.processor_status.records
+            )
         else:
             # at this point we know we have an interface variable since we the `try` block above didn't raise
             self.source_status.fail_all(profiler_source.interface.processor_status.failures)  # type: ignore
@@ -299,6 +294,8 @@ class ProfilerWorkflow(WorkflowStatusMixin):
                 profiler_source.interface.processor_status.records  # type: ignore
             )
             return profile
+        finally:
+            profiler_runner.close()
 
         return None
 

--- a/ingestion/src/metadata/profiler/interface/profiler_protocol.py
+++ b/ingestion/src/metadata/profiler/interface/profiler_protocol.py
@@ -230,3 +230,8 @@ class ProfilerProtocol(ABC):
     def fetch_sample_data(self, table) -> TableData:
         """run profiler metrics"""
         raise NotImplementedError
+
+    @abstractmethod
+    def close(self):
+        """Clean up profiler interface"""
+        raise NotImplementedError

--- a/ingestion/src/metadata/profiler/processor/core.py
+++ b/ingestion/src/metadata/profiler/processor/core.py
@@ -596,3 +596,7 @@ class Profiler(Generic[TMetric]):
     @property
     def column_results(self):
         return self._column_results
+
+    def close(self):
+        """clean up profiler after processing"""
+        self.profiler_interface.close()


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:
Implement logic to release connection from QueuePool on the profiler side.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.


- [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
