### PR TITLE
Fix #12014: Register OpenMetadata as a service when the server starts.

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/ServiceEntityResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/ServiceEntityResource.java
@@ -53,9 +53,11 @@ public abstract class ServiceEntityResource<
   }
 
   protected T decryptOrNullify(SecurityContext securityContext, T service) {
-    service
-        .getConnection()
-        .setConfig(retrieveServiceConnectionConfig(service, authorizer.shouldMaskPasswords(securityContext)));
+    if (service.getConnection() != null) {
+      service
+          .getConnection()
+          .setConfig(retrieveServiceConnectionConfig(service, authorizer.shouldMaskPasswords(securityContext)));
+    }
     return service;
   }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/services/MetadataServiceResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/services/MetadataServiceResourceTest.java
@@ -38,6 +38,8 @@ import org.openmetadata.service.util.TestUtils;
 
 @Slf4j
 public class MetadataServiceResourceTest extends EntityResourceTest<MetadataService, CreateMetadataService> {
+  public static final String DEFAULT_OPENMETADATA_SERVICE_NAME = "OpenMetadata";
+
   public MetadataServiceResourceTest() {
     super(
         Entity.METADATA_SERVICE,
@@ -67,6 +69,12 @@ public class MetadataServiceResourceTest extends EntityResourceTest<MetadataServ
 
     metadataService = metadataServiceResourceTest.createEntity(createMetadata, ADMIN_AUTH_HEADERS);
     ATLAS_SERVICE_REFERENCE = metadataService.getEntityReference();
+  }
+
+  @Test
+  void defaultOpenMetadataServiceMustExist(TestInfo test) throws HttpResponseException {
+    MetadataService service = getEntityByName(DEFAULT_OPENMETADATA_SERVICE_NAME, ADMIN_AUTH_HEADERS);
+    assertEquals(service.getName(), DEFAULT_OPENMETADATA_SERVICE_NAME);
   }
 
   @Test


### PR DESCRIPTION
The previous code missed adding auto-generated UUID.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
