### PR TITLE
chore(ui): allow parenthesis in entity name

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/cypress/e2e/Pages/Roles.spec.js
+++ b/openmetadata-ui/src/main/resources/ui/cypress/e2e/Pages/Roles.spec.js
@@ -32,7 +32,7 @@ const policies = {
 
 const errorMessageValidation = {
   ifPolicyNotSelected: 'Enter at least one policy',
-  ifNameNotEntered: 'invalid name',
+  ifNameNotEntered: 'Name size must be between 1 and 128',
   lastPolicyCannotBeRemoved: 'At least one policy is required in a role',
 };
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/AddDataQualityTest/EditTestCaseModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AddDataQualityTest/EditTestCaseModal.tsx
@@ -14,6 +14,7 @@
 import { Form, FormProps, Input } from 'antd';
 import Modal from 'antd/lib/modal/Modal';
 import { AxiosError } from 'axios';
+import { ENTITY_NAME_REGEX } from 'constants/regex.constants';
 import { compare } from 'fast-json-patch';
 import { Table } from 'generated/entity/data/table';
 import React, {
@@ -215,7 +216,16 @@ const EditTestCaseModal: React.FC<EditTestCaseModalProps> = ({
               <Input disabled />
             </Form.Item>
           )}
-          <Form.Item required label={`${t('label.name')}:`} name="name">
+          <Form.Item
+            required
+            label={`${t('label.name')}:`}
+            name="name"
+            rules={[
+              {
+                pattern: ENTITY_NAME_REGEX,
+                message: t('message.entity-name-validation'),
+              },
+            ]}>
             <Input disabled placeholder={t('message.enter-test-case-name')} />
           </Form.Item>
           <Form.Item

--- a/openmetadata-ui/src/main/resources/ui/src/components/AddDataQualityTest/components/TestCaseForm.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AddDataQualityTest/components/TestCaseForm.tsx
@@ -13,6 +13,7 @@
 
 import { Button, Form, FormProps, Input, Select, Space } from 'antd';
 import { AxiosError } from 'axios';
+import { ENTITY_NAME_REGEX } from 'constants/regex.constants';
 import { CreateTestCase } from 'generated/api/tests/createTestCase';
 import { t } from 'i18next';
 import { isEmpty } from 'lodash';
@@ -244,8 +245,8 @@ const TestCaseForm: React.FC<TestCaseFormProps> = ({
             message: `${t('label.field-required', { field: t('label.name') })}`,
           },
           {
-            pattern: /^[A-Za-z0-9_]*$/g,
-            message: t('message.special-character-not-allowed'),
+            pattern: ENTITY_NAME_REGEX,
+            message: t('message.entity-name-validation'),
           },
           {
             validator: (_, value) => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/AddIngestion/Steps/ConfigureIngestion.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AddIngestion/Steps/ConfigureIngestion.tsx
@@ -12,6 +12,7 @@
  */
 
 import { Button, Form, Space } from 'antd';
+import { ENTITY_NAME_REGEX } from 'constants/regex.constants';
 import { FieldProp, FieldTypes } from 'interface/FormUtils.interface';
 import { capitalize, isNil } from 'lodash';
 import React, { useMemo, useRef } from 'react';
@@ -243,6 +244,12 @@ const ConfigureIngestion = ({
       formItemProps: {
         initialValue: ingestionName,
       },
+      rules: [
+        {
+          pattern: ENTITY_NAME_REGEX,
+          message: t('message.entity-name-validation'),
+        },
+      ],
     },
   ];
   const includeOwnersField: FieldProp = {

--- a/openmetadata-ui/src/main/resources/ui/src/components/CreateUser/CreateUser.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/CreateUser/CreateUser.test.tsx
@@ -55,7 +55,7 @@ describe('Test CreateUser component', () => {
       container,
       /MarkdownWithPreview component/i
     );
-    const dropdown = await findByText(container, /Dropdown component/i);
+
     const teamsSelectable = await findByText(
       container,
       /TeamsSelectable component/i
@@ -64,7 +64,6 @@ describe('Test CreateUser component', () => {
     expect(email).toBeInTheDocument();
     expect(admin).toBeInTheDocument();
     expect(description).toBeInTheDocument();
-    expect(dropdown).toBeInTheDocument();
     expect(teamsSelectable).toBeInTheDocument();
     expect(cancelButton).toBeInTheDocument();
     expect(saveButton).toBeInTheDocument();

--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/EntityNameModal/EntityNameModal.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/EntityNameModal/EntityNameModal.component.tsx
@@ -11,6 +11,7 @@
  *  limitations under the License.
  */
 import { Button, Form, Input, Modal, Typography } from 'antd';
+import { ENTITY_NAME_REGEX } from 'constants/regex.constants';
 import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { EntityNameModalProps } from './EntityNameModal.interface';
@@ -76,6 +77,10 @@ const EntityNameModal: React.FC<EntityNameModalProps> = ({
               message: `${t('label.field-required', {
                 field: t('label.name'),
               })}`,
+            },
+            {
+              pattern: ENTITY_NAME_REGEX,
+              message: t('message.entity-name-validation'),
             },
           ]}>
           <Input

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/DBTConfigFormBuilder/DBTConfigFormBuilder.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/DBTConfigFormBuilder/DBTConfigFormBuilder.tsx
@@ -12,6 +12,7 @@
  */
 
 import { Button, Form, FormProps, Space } from 'antd';
+import { ENTITY_NAME_REGEX } from 'constants/regex.constants';
 import { FieldProp, FieldTypes } from 'interface/FormUtils.interface';
 import React, { FunctionComponent, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -157,6 +158,12 @@ const DBTConfigFormBuilder: FunctionComponent<DBTConfigFormProps> = ({
       formItemProps: {
         initialValue: ingestionName,
       },
+      rules: [
+        {
+          pattern: ENTITY_NAME_REGEX,
+          message: t('message.entity-name-validation'),
+        },
+      ],
     },
     {
       name: 'dbtConfigSource',

--- a/openmetadata-ui/src/main/resources/ui/src/pages/AddAlertPage/AddAlertPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/AddAlertPage/AddAlertPage.tsx
@@ -33,6 +33,7 @@ import { AxiosError } from 'axios';
 import { AsyncSelect } from 'components/AsyncSelect/AsyncSelect';
 import RichTextEditor from 'components/common/rich-text-editor/RichTextEditor';
 import { HTTP_STATUS_CODE } from 'constants/auth.constants';
+import { ENTITY_NAME_REGEX } from 'constants/regex.constants';
 import { SubscriptionType } from 'generated/events/api/createEventSubscription';
 import {
   AlertType,
@@ -501,8 +502,14 @@ const AddAlertPage = () => {
                 label={t('label.name')}
                 labelCol={{ span: 24 }}
                 name="name"
-                rules={[{ required: true }]}>
-                <Input disabled={isEditMode} />
+                rules={[
+                  { required: true },
+                  {
+                    pattern: ENTITY_NAME_REGEX,
+                    message: t('message.entity-name-validation'),
+                  },
+                ]}>
+                <Input disabled={isEditMode} placeholder={t('label.name')} />
               </Form.Item>
               <Form.Item
                 label={t('label.description')}

--- a/openmetadata-ui/src/main/resources/ui/src/pages/AddDataInsightReportAlert/AddDataInsightReportAlert.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/AddDataInsightReportAlert/AddDataInsightReportAlert.tsx
@@ -27,6 +27,7 @@ import {
   GlobalSettingOptions,
   GlobalSettingsMenuCategory,
 } from 'constants/GlobalSettings.constants';
+import { ENTITY_NAME_REGEX } from 'constants/regex.constants';
 import {
   AlertType,
   EventSubscription,
@@ -167,7 +168,13 @@ const AddDataInsightReportAlert = () => {
               label={t('label.name')}
               labelCol={{ span: 24 }}
               name="name"
-              rules={[{ required: true }]}>
+              rules={[
+                { required: true },
+                {
+                  pattern: ENTITY_NAME_REGEX,
+                  message: t('message.entity-name-validation'),
+                },
+              ]}>
               <Input data-testid="name" disabled={isEditMode} />
             </Form.Item>
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/AddPolicyPage/AddPolicyPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/AddPolicyPage/AddPolicyPage.tsx
@@ -34,7 +34,7 @@ import { useHistory } from 'react-router-dom';
 import { addPolicy } from 'rest/rolesAPIV1';
 import { getIsErrorMatch } from 'utils/CommonUtils';
 import { GlobalSettingOptions } from '../../../constants/GlobalSettings.constants';
-import { allowedNameRegEx } from '../../../constants/regex.constants';
+import { ENTITY_NAME_REGEX } from '../../../constants/regex.constants';
 import {
   CreatePolicy,
   Effect,
@@ -142,22 +142,15 @@ const AddPolicyPage = () => {
                         required: true,
                         max: 128,
                         min: 1,
-                        message: t('message.field-text-is-required', {
-                          fieldText: t('label.name'),
-                        }),
+                        message: `${t('message.entity-size-in-between', {
+                          entity: `${t('label.name')}`,
+                          max: '128',
+                          min: '1',
+                        })}`,
                       },
                       {
-                        validator: (_, value) => {
-                          if (allowedNameRegEx.test(value)) {
-                            return Promise.reject(
-                              t('message.field-text-is-invalid', {
-                                fieldText: t('label.name'),
-                              })
-                            );
-                          }
-
-                          return Promise.resolve();
-                        },
+                        pattern: ENTITY_NAME_REGEX,
+                        message: t('message.entity-name-validation'),
                       },
                     ]}>
                     <Input

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/RuleForm/RuleForm.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/RuleForm/RuleForm.tsx
@@ -25,7 +25,7 @@ import {
   validateRuleCondition,
 } from 'rest/rolesAPIV1';
 import { ALL_TYPE_RESOURCE_LIST } from 'utils/PermissionsUtils';
-import { allowedNameRegEx } from '../../../constants/regex.constants';
+import { ENTITY_NAME_REGEX } from '../../../constants/regex.constants';
 import {
   Effect,
   Operation,
@@ -208,20 +208,15 @@ const RuleForm: FC<RuleFormProps> = ({ ruleData, setRuleData }) => {
             required: true,
             max: 128,
             min: 1,
-            message: t('label.field-required', { field: t('label.rule-name') }),
+            message: `${t('message.entity-size-in-between', {
+              entity: `${t('label.name')}`,
+              max: '128',
+              min: '1',
+            })}`,
           },
           {
-            validator: (_, value) => {
-              if (allowedNameRegEx.test(value)) {
-                return Promise.reject(
-                  t('message.field-text-is-invalid', {
-                    fieldText: t('label.rule-name'),
-                  })
-                );
-              }
-
-              return Promise.resolve();
-            },
+            pattern: ENTITY_NAME_REGEX,
+            message: t('message.entity-name-validation'),
           },
         ]}>
         <Input

--- a/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/AddRolePage/AddRolePage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/AddRolePage/AddRolePage.tsx
@@ -24,7 +24,7 @@ import { useHistory } from 'react-router-dom';
 import { addRole, getPolicies } from 'rest/rolesAPIV1';
 import { getIsErrorMatch } from 'utils/CommonUtils';
 import { GlobalSettingOptions } from '../../../constants/GlobalSettings.constants';
-import { allowedNameRegEx } from '../../../constants/regex.constants';
+import { ENTITY_NAME_REGEX } from '../../../constants/regex.constants';
 import { Policy } from '../../../generated/entity/policies/policy';
 import {
   getPath,
@@ -133,20 +133,15 @@ const AddRolePage = () => {
                       required: true,
                       max: 128,
                       min: 1,
-                      message: t('label.invalid-name'),
+                      message: `${t('message.entity-size-in-between', {
+                        entity: `${t('label.name')}`,
+                        max: '128',
+                        min: '1',
+                      })}`,
                     },
                     {
-                      validator: (_, value) => {
-                        if (allowedNameRegEx.test(value)) {
-                          return Promise.reject(
-                            t('message.field-text-is-invalid', {
-                              fieldText: t('label.name'),
-                            })
-                          );
-                        }
-
-                        return Promise.resolve();
-                      },
+                      pattern: ENTITY_NAME_REGEX,
+                      message: t('message.entity-name-validation'),
                     },
                   ]}>
                   <Input

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TestSuitePage/AddTestSuiteForm.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TestSuitePage/AddTestSuiteForm.tsx
@@ -14,6 +14,7 @@
 import { Button, Form, Input, Space } from 'antd';
 import RichTextEditor from 'components/common/rich-text-editor/RichTextEditor';
 import Loader from 'components/Loader/Loader';
+import { ENTITY_NAME_REGEX } from 'constants/regex.constants';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
@@ -72,8 +73,17 @@ const AddTestSuiteForm: React.FC<AddTestSuiteFormProps> = ({ onSubmit }) => {
             required: true,
           },
           {
-            pattern: /^[A-Za-z0-9_]*$/g,
-            message: t('message.special-character-not-allowed'),
+            pattern: ENTITY_NAME_REGEX,
+            message: t('message.entity-name-validation'),
+          },
+          {
+            min: 1,
+            max: 256,
+            message: `${t('message.entity-size-in-between', {
+              entity: `${t('label.name')}`,
+              max: '256',
+              min: '1',
+            })}`,
           },
           {
             validator: (_, value) => {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/teams/AddTeamForm.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/teams/AddTeamForm.tsx
@@ -114,10 +114,7 @@ const AddTeamForm: React.FC<AddTeamFormType> = ({
             },
             {
               pattern: ENTITY_NAME_REGEX,
-              message: t('message.entity-pattern-validation', {
-                entity: `${t('label.name')}`,
-                pattern: `- _ & . '`,
-              }),
+              message: t('message.entity-name-validation'),
             },
             {
               validator: (_, value) => {


### PR DESCRIPTION
Part of #11358 
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on adding support for parenthesis in the entity name

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] Improvement


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
