### PR TITLE
fix(ui): glossary name with dot loading issue

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/cypress/e2e/Pages/Glossary.spec.js
+++ b/openmetadata-ui/src/main/resources/ui/cypress/e2e/Pages/Glossary.spec.js
@@ -266,6 +266,7 @@ const updateTags = (inTerm) => {
   const container = inTerm
     ? '[data-testid="tags-input-container"]'
     : '[data-testid="glossary-details"]';
+  cy.wait(1000);
   cy.get(container).scrollIntoView().contains('Personal').should('be.visible');
 };
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryHeader/GlossaryHeader.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryHeader/GlossaryHeader.component.tsx
@@ -121,7 +121,10 @@ const GlossaryHeader = ({
 
   const handleGlossaryImport = () =>
     history.push(
-      getGlossaryPathWithAction(selectedData.name, EntityAction.IMPORT)
+      getGlossaryPathWithAction(
+        selectedData.fullyQualifiedName ?? '',
+        EntityAction.IMPORT
+      )
     );
 
   const handleVersionClick = async () => {
@@ -181,7 +184,7 @@ const GlossaryHeader = ({
   const handleGlossaryExportClick = useCallback(async () => {
     if (selectedData) {
       showModal({
-        name: selectedData?.name,
+        name: selectedData?.fullyQualifiedName || '',
         onExport: exportGlossaryInCSVFormat,
       });
     }

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryHeader/GlossaryHeader.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryHeader/GlossaryHeader.component.tsx
@@ -56,6 +56,7 @@ import {
 } from 'utils/RouterUtils';
 import SVGIcons, { Icons } from 'utils/SvgUtils';
 import { showErrorToast } from 'utils/ToastUtils';
+import Fqn from '../../../utils/Fqn';
 
 export interface GlossaryHeaderProps {
   isVersionView?: boolean;
@@ -321,7 +322,7 @@ const GlossaryHeader = ({
       return;
     }
 
-    const arr = fqn.split(FQN_SEPARATOR_CHAR);
+    const arr = !isGlossary ? Fqn.split(fqn) : [];
     const dataFQN: Array<string> = [];
     const newData = [
       {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryV1.component.tsx
@@ -220,7 +220,9 @@ const GlossaryV1 = ({
         reviewers: formData.reviewers.map(
           (item) => item.fullyQualifiedName || ''
         ),
-        glossary: activeGlossaryTerm?.glossary?.name || selectedData.name,
+        glossary:
+          activeGlossaryTerm?.glossary?.name ||
+          (selectedData.fullyQualifiedName ?? ''),
         parent: activeGlossaryTerm?.fullyQualifiedName,
       });
       onTermModalSuccess();

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryV1.component.tsx
@@ -301,7 +301,7 @@ const GlossaryV1 = ({
   }, [id, isGlossaryActive, isVersionsView, action]);
 
   return isImportAction ? (
-    <ImportGlossary glossaryName={selectedData.name} />
+    <ImportGlossary glossaryName={selectedData.fullyQualifiedName ?? ''} />
   ) : (
     <>
       {isLoading && <Loader />}

--- a/openmetadata-ui/src/main/resources/ui/src/components/TagsInput/TagsInput.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TagsInput/TagsInput.component.tsx
@@ -10,11 +10,13 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+import { Typography } from 'antd';
 import TagsContainerV2 from 'components/Tag/TagsContainerV2/TagsContainerV2';
 import TagsViewer from 'components/Tag/TagsViewer/tags-viewer';
 import { LabelType, State, TagLabel, TagSource } from 'generated/type/tagLabel';
 import { EntityTags } from 'Models';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 type Props = {
   isVersionView?: boolean;
@@ -29,6 +31,7 @@ const TagsInput: React.FC<Props> = ({
   onTagsUpdate,
   isVersionView,
 }) => {
+  const { t } = useTranslation();
   const handleTagSelection = async (selectedTags: EntityTags[]) => {
     const updatedTags: TagLabel[] | undefined = selectedTags?.map((tag) => {
       return {
@@ -59,7 +62,14 @@ const TagsInput: React.FC<Props> = ({
   return (
     <div className="tags-input-container" data-testid="tags-input-container">
       {isVersionView ? (
-        <TagsViewer sizeCap={-1} tags={tags} type="border" />
+        <>
+          <div>
+            <Typography.Text className="right-panel-label">
+              {t('label.tag-plural')}
+            </Typography.Text>
+          </div>
+          <TagsViewer sizeCap={-1} tags={tags} type="border" />
+        </>
       ) : (
         <TagsContainerV2
           permission={editable}

--- a/openmetadata-ui/src/main/resources/ui/src/pages/AddGlossary/AddGlossaryPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/AddGlossary/AddGlossaryPage.component.tsx
@@ -71,7 +71,7 @@ const AddGlossaryPage: FunctionComponent = () => {
     setIsLoading(true);
     try {
       const res = await addGlossaries(data);
-      goToGlossary(res.name);
+      goToGlossary(res.fullyQualifiedName ?? '');
     } catch (error) {
       handleSaveFailure(
         getIsErrorMatch(error as AxiosError, ERROR_MESSAGE.alreadyExist)

--- a/openmetadata-ui/src/main/resources/ui/src/pages/Glossary/GlossaryLeftPanel/GlossaryLeftPanel.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/Glossary/GlossaryLeftPanel/GlossaryLeftPanel.component.tsx
@@ -19,7 +19,6 @@ import LeftPanelCard from 'components/common/LeftPanelCard/LeftPanelCard';
 import { usePermissionProvider } from 'components/PermissionProvider/PermissionProvider';
 import { ResourceEntity } from 'components/PermissionProvider/PermissionProvider.interface';
 import GlossaryV1Skeleton from 'components/Skeleton/GlossaryV1/GlossaryV1LeftPanelSkeleton.component';
-import { FQN_SEPARATOR_CHAR } from 'constants/char.constants';
 import { ROUTES } from 'constants/constants';
 import { Operation } from 'generated/entity/policies/policy';
 import React, { useMemo } from 'react';
@@ -43,7 +42,7 @@ const GlossaryLeftPanel = ({ glossaries }: GlossaryLeftPanelProps) => {
   );
   const selectedKey = useMemo(() => {
     if (glossaryName) {
-      return glossaryName.split(FQN_SEPARATOR_CHAR)[0];
+      return glossaryName;
     }
 
     return glossaries[0].name;
@@ -54,7 +53,7 @@ const GlossaryLeftPanel = ({ glossaries }: GlossaryLeftPanelProps) => {
       return [
         ...acc,
         {
-          key: glossary.name,
+          key: glossary.fullyQualifiedName ?? '',
           label: getEntityName(glossary),
           icon: <GlossaryIcon height={16} width={16} />,
         },

--- a/openmetadata-ui/src/main/resources/ui/src/pages/Glossary/GlossaryLeftPanel/GlossaryLeftPanel.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/Glossary/GlossaryLeftPanel/GlossaryLeftPanel.component.tsx
@@ -27,6 +27,7 @@ import { useHistory, useParams } from 'react-router-dom';
 import { getEntityName } from 'utils/EntityUtils';
 import { checkPermission } from 'utils/PermissionsUtils';
 import { getGlossaryPath } from 'utils/RouterUtils';
+import Fqn from '../../../utils/Fqn';
 import { GlossaryLeftPanelProps } from './GlossaryLeftPanel.interface';
 
 const GlossaryLeftPanel = ({ glossaries }: GlossaryLeftPanelProps) => {
@@ -42,7 +43,7 @@ const GlossaryLeftPanel = ({ glossaries }: GlossaryLeftPanelProps) => {
   );
   const selectedKey = useMemo(() => {
     if (glossaryName) {
-      return glossaryName;
+      return Fqn.split(glossaryName)[0];
     }
 
     return glossaries[0].name;

--- a/openmetadata-ui/src/main/resources/ui/src/pages/Glossary/GlossaryPage/GlossaryPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/Glossary/GlossaryPage/GlossaryPage.component.tsx
@@ -42,7 +42,6 @@ import {
 import { checkPermission } from 'utils/PermissionsUtils';
 import { getGlossaryPath, getGlossaryTermsPath } from 'utils/RouterUtils';
 import { showErrorToast, showSuccessToast } from 'utils/ToastUtils';
-import Fqn from '../../../utils/Fqn';
 import GlossaryLeftPanel from '../GlossaryLeftPanel/GlossaryLeftPanel.component';
 
 const GlossaryPage = () => {
@@ -63,12 +62,17 @@ const GlossaryPage = () => {
   const isGlossaryActive = useMemo(() => {
     setIsRightPanelLoading(true);
     setSelectedData(undefined);
-    if (glossaryFqn) {
-      return Fqn.split(glossaryFqn).length === 1;
+
+    if (glossaries.length > 0 && glossaryFqn) {
+      const item = glossaries.find(
+        (item) => (item.fullyQualifiedName ?? '') === glossaryFqn
+      );
+
+      return item !== undefined;
     }
 
     return true;
-  }, [glossaryFqn]);
+  }, [glossaries, glossaryFqn]);
 
   const createGlossaryPermission = useMemo(
     () =>
@@ -163,8 +167,9 @@ const GlossaryPage = () => {
         fetchGlossaryTermDetails();
       } else {
         setSelectedData(
-          glossaries.find((glossary) => glossary.name === glossaryFqn) ||
-            glossaries[0]
+          glossaries.find(
+            (glossary) => glossary.fullyQualifiedName === glossaryFqn
+          ) || glossaries[0]
         );
         !glossaryFqn &&
           glossaries[0].fullyQualifiedName &&

--- a/openmetadata-ui/src/main/resources/ui/src/pages/Glossary/GlossaryPage/GlossaryPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/Glossary/GlossaryPage/GlossaryPage.component.tsx
@@ -227,7 +227,14 @@ const GlossaryPage = () => {
           })
         );
         setIsLoading(true);
-        history.push(getGlossaryPath());
+        // check if the glossary available
+        const updatedGlossaries = glossaries.filter((item) => item.id !== id);
+        const glossaryPath =
+          updatedGlossaries.length > 0
+            ? getGlossaryPath(updatedGlossaries[0].fullyQualifiedName)
+            : getGlossaryPath();
+
+        history.push(glossaryPath);
         fetchGlossaryList();
       })
       .catch((err: AxiosError) => {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/Glossary/GlossaryPage/GlossaryPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/Glossary/GlossaryPage/GlossaryPage.component.tsx
@@ -42,6 +42,7 @@ import {
 import { checkPermission } from 'utils/PermissionsUtils';
 import { getGlossaryPath, getGlossaryTermsPath } from 'utils/RouterUtils';
 import { showErrorToast, showSuccessToast } from 'utils/ToastUtils';
+import Fqn from '../../../utils/Fqn';
 import GlossaryLeftPanel from '../GlossaryLeftPanel/GlossaryLeftPanel.component';
 
 const GlossaryPage = () => {
@@ -275,7 +276,7 @@ const GlossaryPage = () => {
         );
         let fqn;
         if (glossaryFqn) {
-          const fqnArr = glossaryFqn.split(FQN_SEPARATOR_CHAR);
+          const fqnArr = Fqn.split(glossaryFqn);
           fqnArr.pop();
           fqn = fqnArr.join(FQN_SEPARATOR_CHAR);
         }

--- a/openmetadata-ui/src/main/resources/ui/src/pages/Glossary/GlossaryPage/GlossaryPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/Glossary/GlossaryPage/GlossaryPage.test.tsx
@@ -24,6 +24,7 @@ import GlossaryPage from './GlossaryPage.component';
 jest.mock('react-router-dom', () => ({
   useHistory: () => ({
     push: jest.fn(),
+    replace: jest.fn(),
   }),
   useParams: jest.fn().mockReturnValue({
     glossaryName: 'GlossaryName',
@@ -73,6 +74,10 @@ jest.mock('components/Glossary/GlossaryV1.component', () => {
   ));
 });
 
+jest.mock('../../../utils/Fqn', () => ({
+  split: jest.fn(),
+}));
+
 jest.mock('../GlossaryLeftPanel/GlossaryLeftPanel.component', () => {
   return jest
     .fn()
@@ -83,6 +88,9 @@ jest.mock('../GlossaryLeftPanel/GlossaryLeftPanel.component', () => {
 jest.mock('rest/glossaryAPI', () => ({
   deleteGlossary: jest.fn().mockImplementation(() => Promise.resolve()),
   deleteGlossaryTerm: jest.fn().mockImplementation(() => Promise.resolve()),
+  getGlossaryTermByFQN: jest
+    .fn()
+    .mockImplementation(() => Promise.resolve({ data: MOCK_GLOSSARY })),
   getGlossariesList: jest
     .fn()
     .mockImplementation(() => Promise.resolve({ data: [MOCK_GLOSSARY] })),

--- a/openmetadata-ui/src/main/resources/ui/src/styles/components/entity-version-time-line.less
+++ b/openmetadata-ui/src/main/resources/ui/src/styles/components/entity-version-time-line.less
@@ -41,7 +41,7 @@
   display: block;
   width: 18px;
   height: 18px;
-  border: 3px solid #d9ceee;
+  border: 3px solid @primary-color-hover;
   background: transparent;
   border-radius: 50%;
   margin-top: 0.15rem;
@@ -73,7 +73,7 @@
   display: block;
   width: 2px;
   height: 100%;
-  background-color: #d9ceee;
+  background-color: @primary-color-hover;
   transform: translate(8px, 0);
 }
 .timeline-line.major {
@@ -83,6 +83,6 @@
   display: block;
   width: 2px;
   height: 15px;
-  background-color: #d9ceee;
+  background-color: @primary-color-hover;
   transform: translate(8px, 0);
 }

--- a/openmetadata-ui/src/main/resources/ui/src/styles/components/glossary.less
+++ b/openmetadata-ui/src/main/resources/ui/src/styles/components/glossary.less
@@ -165,5 +165,5 @@
 
 .glossary-content-container {
   height: @glossary-page-height;
-  overflow-y: scroll;
+  overflow-y: auto;
 }

--- a/openmetadata-ui/src/main/resources/ui/src/utils/GlossaryUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/GlossaryUtils.ts
@@ -122,16 +122,26 @@ export const buildTree = (data: GlossaryTerm[]): GlossaryTerm[] => {
   const nodes: Record<string, GlossaryTerm> = {};
   const tree: GlossaryTerm[] = [];
 
-  data.forEach((obj) => {
+  // Sorting children having parent first to avoid duplicates
+  const sortedData = [...data].sort((a, b) => {
+    if (a.parent && !b.parent) {
+      return 1;
+    } else if (!a.parent && b.parent) {
+      return -1;
+    } else {
+      return 0;
+    }
+  });
+
+  sortedData.forEach((obj) => {
     if (obj.fullyQualifiedName) {
       nodes[obj.fullyQualifiedName] = {
         ...obj,
         children: obj.children?.length ? [] : undefined,
       };
       const parentNode =
-        obj.parent &&
-        obj.parent.fullyQualifiedName &&
-        nodes[obj.parent.fullyQualifiedName];
+        obj.parent?.fullyQualifiedName && nodes[obj.parent.fullyQualifiedName];
+
       parentNode &&
         nodes[obj.fullyQualifiedName] &&
         parentNode.children?.push(

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TeamUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TeamUtils.ts
@@ -83,5 +83,5 @@ export const getMovedTeamData = (team: Team, parents: string[]): CreateTeam => {
     parents: parents,
     policies: getEntityValue(policies),
     users: getEntityValue(users),
-  };
+  } as CreateTeam;
 };


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes loading of glossary with name having dot in it.

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
