### PR TITLE
Support '%' in glossary and glossaryTerm name

### DIFF
--- a/openmetadata-spec/src/main/resources/json/schema/api/data/createGlossary.json
+++ b/openmetadata-spec/src/main/resources/json/schema/api/data/createGlossary.json
@@ -10,7 +10,10 @@
   "properties": {
     "name": {
       "description": "Name that identifies this glossary.",
-      "$ref": "../../type/basic.json#/definitions/entityName"
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^(?U)[\\w'\\- .&()%]+$"
     },
     "displayName": {
       "description": "Display Name that identifies this glossary.",

--- a/openmetadata-spec/src/main/resources/json/schema/api/data/createGlossaryTerm.json
+++ b/openmetadata-spec/src/main/resources/json/schema/api/data/createGlossaryTerm.json
@@ -18,7 +18,10 @@
     },
     "name": {
       "description": "Preferred name for the glossary term.",
-      "$ref": "../../type/basic.json#/definitions/entityName"
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "pattern": "^(?U)[\\w'\\- .&()%]+$"
     },
     "displayName": {
       "description": "Display Name that identifies this glossary term.",

--- a/openmetadata-spec/src/main/resources/json/schema/type/basic.json
+++ b/openmetadata-spec/src/main/resources/json/schema/type/basic.json
@@ -100,7 +100,7 @@
       "type": "string",
       "minLength": 1,
       "maxLength": 128,
-      "pattern": "^(?U)[\\w'\\- .&()]+$"
+      "pattern": "^(?U)[\\w'\\- .&()%]+$"
     },
     "fullyQualifiedEntityName": {
       "description": "A unique name that identifies an entity. Example for table 'DatabaseService:Database:Table'.",

--- a/openmetadata-spec/src/main/resources/json/schema/type/basic.json
+++ b/openmetadata-spec/src/main/resources/json/schema/type/basic.json
@@ -100,7 +100,7 @@
       "type": "string",
       "minLength": 1,
       "maxLength": 128,
-      "pattern": "^(?U)[\\w'\\- .&()%]+$"
+      "pattern": "^(?U)[\\w'\\- .&()]+$"
     },
     "fullyQualifiedEntityName": {
       "description": "A unique name that identifies an entity. Example for table 'DatabaseService:Database:Table'.",


### PR DESCRIPTION
Fixes #12380

I worked on ... because ... added support '%' in glossary and glossary term name.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x ] Bug fix
- [x ] Improvement

