### PR TITLE
Fix Missing Config on Error Page Response in #UI

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/OpenMetadataApplication.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/OpenMetadataApplication.java
@@ -58,7 +58,6 @@ import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jetty.http.pathmap.ServletPathSpec;
-import org.eclipse.jetty.servlet.ErrorPageErrorHandler;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.websocket.server.NativeWebSocketServletContainerInitializer;
@@ -82,6 +81,7 @@ import org.openmetadata.service.events.scheduled.ReportsHandler;
 import org.openmetadata.service.exception.CatalogGenericExceptionMapper;
 import org.openmetadata.service.exception.ConstraintViolationExceptionMapper;
 import org.openmetadata.service.exception.JsonMappingExceptionMapper;
+import org.openmetadata.service.exception.OMErrorPageHandler;
 import org.openmetadata.service.extension.OpenMetadataExtension;
 import org.openmetadata.service.fernet.Fernet;
 import org.openmetadata.service.jdbi3.CollectionDAO;
@@ -437,7 +437,7 @@ public class OpenMetadataApplication extends Application<OpenMetadataApplication
     CollectionRegistry.initialize(extensionResources);
     CollectionRegistry.getInstance().registerResources(jdbi, environment, config, authorizer, authenticatorHandler);
     environment.jersey().register(new JsonPatchProvider());
-    ErrorPageErrorHandler eph = new ErrorPageErrorHandler();
+    OMErrorPageHandler eph = new OMErrorPageHandler(config.getWebConfiguration());
     eph.addErrorPage(Response.Status.NOT_FOUND.getStatusCode(), "/");
     environment.getApplicationContext().setErrorHandler(eph);
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/exception/OMErrorPageHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/exception/OMErrorPageHandler.java
@@ -1,0 +1,79 @@
+package org.openmetadata.service.exception;
+
+import io.dropwizard.web.conf.WebConfiguration;
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.server.Dispatcher;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.servlet.ErrorPageErrorHandler;
+
+@Slf4j
+public class OMErrorPageHandler extends ErrorPageErrorHandler {
+  private final WebConfiguration webConfiguration;
+
+  public OMErrorPageHandler(WebConfiguration webConfiguration) {
+    this.webConfiguration = webConfiguration;
+  }
+
+  @Override
+  public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response)
+      throws IOException, ServletException {
+    this.doError(target, baseRequest, request, response);
+  }
+
+  @Override
+  public void doError(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response)
+      throws IOException {
+    String cacheControl = this.getCacheControl();
+    if (cacheControl != null) {
+      response.setHeader(HttpHeader.CACHE_CONTROL.asString(), cacheControl);
+    }
+
+    // Attach Response Header from OM
+
+    // Hsts
+    webConfiguration.getHstsHeaderFactory().build().forEach(response::setHeader);
+
+    // Frame Options
+    webConfiguration.getFrameOptionsHeaderFactory().build().forEach(response::setHeader);
+
+    // Content Option
+    webConfiguration.getContentTypeOptionsHeaderFactory().build().forEach(response::setHeader);
+
+    // Xss Protections
+    webConfiguration.getXssProtectionHeaderFactory().build().forEach(response::setHeader);
+
+    String errorPage = ((ErrorPageMapper) this).getErrorPage(request);
+    ContextHandler.Context context = baseRequest.getErrorContext();
+    Dispatcher errorDispatcher =
+        errorPage != null && context != null ? (Dispatcher) context.getRequestDispatcher(errorPage) : null;
+
+    try {
+      if (errorDispatcher != null) {
+        try {
+          errorDispatcher.error(request, response);
+          return;
+        } catch (ServletException ex) {
+          LOG.debug("Error in OMErrorPageHandler", ex);
+          if (response.isCommitted()) {
+            return;
+          }
+        }
+      }
+
+      String message = (String) request.getAttribute("javax.servlet.error.message");
+      if (message == null) {
+        message = baseRequest.getResponse().getReason();
+      }
+
+      this.generateAcceptableResponse(baseRequest, request, response, response.getStatus(), message);
+    } finally {
+      baseRequest.setHandled(true);
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes missing security header in response in case of Error Page (404)
Currently the server APIs have the correct response headers from the web configuration , but to serve index.html , whenever we hit 404 that response doesn't seem to contain those header , this Pr takes care of that

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
