### PR TITLE
Fixes 12439: Remove braces from approx_percentile method (Trino/Presto) in profiler

### DIFF
--- a/ingestion/src/metadata/profiler/orm/functions/median.py
+++ b/ingestion/src/metadata/profiler/orm/functions/median.py
@@ -58,7 +58,7 @@ def _(elements, compiler, **kwargs):
 def _(elements, compiler, **kwargs):
     col = compiler.process(elements.clauses.clauses[0])
     percentile = elements.clauses.clauses[2].value
-    return 'approx_percentile(%s, %.2f)' % (col, percentile)
+    return "approx_percentile(%s, %.2f)" % (col, percentile)
 
 
 @compiles(MedianFn, Dialects.MSSQL)

--- a/ingestion/src/metadata/profiler/orm/functions/median.py
+++ b/ingestion/src/metadata/profiler/orm/functions/median.py
@@ -58,7 +58,7 @@ def _(elements, compiler, **kwargs):
 def _(elements, compiler, **kwargs):
     col = compiler.process(elements.clauses.clauses[0])
     percentile = elements.clauses.clauses[2].value
-    return 'approx_percentile("%s", %.2f)' % (col, percentile)
+    return 'approx_percentile(%s, %.2f)' % (col, percentile)
 
 
 @compiles(MedianFn, Dialects.MSSQL)


### PR DESCRIPTION
### Describe your changes:

Fixes https://github.com/open-metadata/OpenMetadata/issues/12439

I worked on fixing profiling for trino jobs because it fails when column profile is calculated.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.


