### PR TITLE
Fixes 12528: add custom storage connection to storageService.json 

### DIFF
--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/storageService.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/storageService.json
@@ -42,6 +42,9 @@
           "oneOf": [
             {
               "$ref": "connections/storage/s3Connection.json"
+            },
+            {
+              "$ref": "connections/storage/customStorageConnection.json"
             }
           ]
         }


### PR DESCRIPTION
Add support to using a custom storage connection

<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes issue 12528 (https://github.com/open-metadata/OpenMetadata/issues/12528)

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I have updated the serviceConnection JSON schema so that it allows defining a serviceConnection of the CustomStorageConnection type, and not just S3. This will allow building custom connectors for storages that are not S3.


### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [X ] Improvement

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

