### PR TITLE
Fix #12610: adminUsers lookup should be quoted, do not allow bot users s to be promoted to admin user via adminUsers config

### DIFF
--- a/conf/openmetadata.yaml
+++ b/conf/openmetadata.yaml
@@ -134,7 +134,7 @@ migrationConfiguration:
 authorizerConfiguration:
   className: ${AUTHORIZER_CLASS_NAME:-org.openmetadata.service.security.DefaultAuthorizer}
   containerRequestFilter: ${AUTHORIZER_REQUEST_FILTER:-org.openmetadata.service.security.JwtFilter}
-  adminPrincipals: ${AUTHORIZER_ADMIN_PRINCIPALS:-[admin,harsha.ch,ingestion-bot]}
+  adminPrincipals: ${AUTHORIZER_ADMIN_PRINCIPALS:-[admin]}
   allowedEmailRegistrationDomains: ${AUTHORIZER_ALLOWED_REGISTRATION_DOMAIN:-["all"]}
   principalDomain: ${AUTHORIZER_PRINCIPAL_DOMAIN:-"openmetadata.org"}
   enforcePrincipalDomain: ${AUTHORIZER_ENFORCE_PRINCIPAL_DOMAIN:-false}

--- a/conf/openmetadata.yaml
+++ b/conf/openmetadata.yaml
@@ -134,7 +134,7 @@ migrationConfiguration:
 authorizerConfiguration:
   className: ${AUTHORIZER_CLASS_NAME:-org.openmetadata.service.security.DefaultAuthorizer}
   containerRequestFilter: ${AUTHORIZER_REQUEST_FILTER:-org.openmetadata.service.security.JwtFilter}
-  adminPrincipals: ${AUTHORIZER_ADMIN_PRINCIPALS:-[admin]}
+  adminPrincipals: ${AUTHORIZER_ADMIN_PRINCIPALS:-[admin,harsha.ch,ingestion-bot]}
   allowedEmailRegistrationDomains: ${AUTHORIZER_ALLOWED_REGISTRATION_DOMAIN:-["all"]}
   principalDomain: ${AUTHORIZER_PRINCIPAL_DOMAIN:-"openmetadata.org"}
   enforcePrincipalDomain: ${AUTHORIZER_ENFORCE_PRINCIPAL_DOMAIN:-false}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/UserUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/UserUtil.java
@@ -26,7 +26,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
-import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.api.configuration.pipelineServiceClient.PipelineServiceClientConfiguration;
 import org.openmetadata.schema.auth.BasicAuthMechanism;
 import org.openmetadata.schema.auth.JWTAuthMechanism;
@@ -72,14 +71,15 @@ public final class UserUtil {
       fieldList.add("authenticationMechanism");
 
       // Fetch Original User, is available
-      User originalUser = userRepository.getByName(null, EntityInterfaceUtil.quoteName(username), new Fields(fieldList));
+      User originalUser =
+          userRepository.getByName(null, EntityInterfaceUtil.quoteName(username), new Fields(fieldList));
       if (!originalUser.getIsBot() && !originalUser.getIsAdmin()) {
         updatedUser = originalUser;
 
         // Update Auth Mechanism if not present, and send mail to the user
         if (authProvider.equals(AuthProvider.BASIC)) {
           if (originalUser.getAuthenticationMechanism() == null
-                  || originalUser.getAuthenticationMechanism().equals(new AuthenticationMechanism())) {
+              || originalUser.getAuthenticationMechanism().equals(new AuthenticationMechanism())) {
             updateUserWithHashedPwd(updatedUser, getPassword());
             EmailUtil.sendInviteMailToAdmin(updatedUser, ADMIN_USER_NAME);
           }
@@ -93,7 +93,10 @@ public final class UserUtil {
         // user email
         updatedUser.setEmail(String.format("%s@%s", username, domain));
       } else {
-        LOG.error(String.format("You configured bot user %s in initialAdmins config. Bot user cannot be promoted to be an admin.", originalUser.getName()));
+        LOG.error(
+            String.format(
+                "You configured bot user %s in initialAdmins config. Bot user cannot be promoted to be an admin.",
+                originalUser.getName()));
       }
     } catch (EntityNotFoundException e) {
       updatedUser = user(username, domain, username).withIsAdmin(isAdmin).withIsEmailVerified(true);
@@ -108,7 +111,6 @@ public final class UserUtil {
     if (updatedUser != null) {
       addOrUpdateUser(updatedUser);
     }
-
   }
 
   private static String getPassword() {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/UserUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/UserUtil.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.api.configuration.pipelineServiceClient.PipelineServiceClientConfiguration;
 import org.openmetadata.schema.auth.BasicAuthMechanism;
 import org.openmetadata.schema.auth.JWTAuthMechanism;
@@ -35,6 +36,7 @@ import org.openmetadata.schema.entity.teams.User;
 import org.openmetadata.schema.security.client.OpenMetadataJWTClientConfig;
 import org.openmetadata.schema.services.connections.metadata.AuthProvider;
 import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.utils.EntityInterfaceUtil;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
 import org.openmetadata.service.exception.EntityNotFoundException;
@@ -63,32 +65,36 @@ public final class UserUtil {
   private static void createOrUpdateUser(AuthProvider authProvider, String username, String domain, Boolean isAdmin)
       throws IOException {
     UserRepository userRepository = (UserRepository) Entity.getEntityRepository(Entity.USER);
-    User updatedUser;
+    User updatedUser = null;
     try {
       // Create Required Fields List
       Set<String> fieldList = new HashSet<>(userRepository.getPatchFields().getFieldList());
       fieldList.add("authenticationMechanism");
 
       // Fetch Original User, is available
-      User originalUser = userRepository.getByName(null, username, new Fields(fieldList));
-      updatedUser = originalUser;
+      User originalUser = userRepository.getByName(null, EntityInterfaceUtil.quoteName(username), new Fields(fieldList));
+      if (!originalUser.getIsBot() && !originalUser.getIsAdmin()) {
+        updatedUser = originalUser;
 
-      // Update Auth Mechanism if not present, and send mail to the user
-      if (authProvider.equals(AuthProvider.BASIC)) {
-        if (originalUser.getAuthenticationMechanism() == null
-            || originalUser.getAuthenticationMechanism().equals(new AuthenticationMechanism())) {
-          updateUserWithHashedPwd(updatedUser, getPassword());
-          EmailUtil.sendInviteMailToAdmin(updatedUser, ADMIN_USER_NAME);
+        // Update Auth Mechanism if not present, and send mail to the user
+        if (authProvider.equals(AuthProvider.BASIC)) {
+          if (originalUser.getAuthenticationMechanism() == null
+                  || originalUser.getAuthenticationMechanism().equals(new AuthenticationMechanism())) {
+            updateUserWithHashedPwd(updatedUser, getPassword());
+            EmailUtil.sendInviteMailToAdmin(updatedUser, ADMIN_USER_NAME);
+          }
+        } else {
+          updatedUser.setAuthenticationMechanism(new AuthenticationMechanism());
         }
+
+        // Update the specific fields isAdmin
+        updatedUser.setIsAdmin(isAdmin);
+
+        // user email
+        updatedUser.setEmail(String.format("%s@%s", username, domain));
       } else {
-        updatedUser.setAuthenticationMechanism(new AuthenticationMechanism());
+        LOG.error(String.format("You configured bot user %s in initialAdmins config. Bot user cannot be promoted to be an admin.", originalUser.getName()));
       }
-
-      // Update the specific fields isAdmin
-      updatedUser.setIsAdmin(isAdmin);
-
-      // user email
-      updatedUser.setEmail(String.format("%s@%s", username, domain));
     } catch (EntityNotFoundException e) {
       updatedUser = user(username, domain, username).withIsAdmin(isAdmin).withIsEmailVerified(true);
       // Update Auth Mechanism if not present, and send mail to the user
@@ -99,7 +105,10 @@ public final class UserUtil {
     }
 
     // Update the user
-    addOrUpdateUser(updatedUser);
+    if (updatedUser != null) {
+      addOrUpdateUser(updatedUser);
+    }
+
   }
 
   private static String getPassword() {


### PR DESCRIPTION
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
