### PR TITLE
Updating the large package removals for cypress

### DIFF
--- a/.github/workflows/cypress-integration-tests-mysql.yml
+++ b/.github/workflows/cypress-integration-tests-mysql.yml
@@ -49,7 +49,7 @@ jobs:
             android: true
             dotnet: true
             haskell: true
-            large-packages: true
+            large-packages: false
             swap-storage: true
             docker-images: false
       - name: Wait for the labeler

--- a/.github/workflows/cypress-integration-tests-postgresql.yml
+++ b/.github/workflows/cypress-integration-tests-postgresql.yml
@@ -49,7 +49,7 @@ jobs:
             android: true
             dotnet: true
             haskell: true
-            large-packages: true
+            large-packages: false
             swap-storage: true
             docker-images: false
       - name: Wait for the labeler


### PR DESCRIPTION
The following action removes these packages - " azure-cli google-cloud-sdk google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri"
which are needed in cypress test, making it false so that packages can be found on runner.

In reference to : https://github.com/open-metadata/OpenMetadata/actions/runs/5693882152/job/15433925744?pr=12646