### PR TITLE
fix: Align Docker Base Image to use airflow 2.5.3

### DIFF
--- a/ingestion/Dockerfile
+++ b/ingestion/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/airflow:2.6.3-python3.9
+FROM apache/airflow:2.5.3-python3.9
 USER root
 RUN curl -sS https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 RUN curl -sS https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list

--- a/ingestion/Dockerfile.ci
+++ b/ingestion/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM apache/airflow:2.6.3-python3.9
+FROM apache/airflow:2.5.3-python3.9
 USER root
 RUN curl -sS https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 RUN curl -sS https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list


### PR DESCRIPTION
Align Docker Base Image to use airflow 2.5.3.

The reason for this change is that Helm Dependencies for Airflow which we depend on only supports airflow version uptill 2.5.
Ref - https://github.com/airflow-helm/charts/tree/main/charts/airflow#key-features

This change will better aling our quick-start methods to use same airflow version.

I've tested this change with Docker deployments as well as Kubernetes Deployments.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
