### PR TITLE
[Docs] - host.docker.internal docs & postgres ingestAllDatabases belo…

### DIFF
--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/postgresConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/postgresConnection.json
@@ -63,6 +63,12 @@
       "description": "Database of the data source. This is optional parameter, if you would like to restrict the metadata reading to a single database. When left blank, OpenMetadata Ingestion attempts to scan all the databases.",
       "type": "string"
     },
+    "ingestAllDatabases": {
+      "title": "Ingest All Databases",
+      "description": "Ingest data from all databases in Postgres. You can use databaseFilterPattern on top of this.",
+      "type": "boolean",
+      "default": false
+    },
     "sslMode": {
       "title": "SSL Mode",
       "description": "SSL Mode to connect to postgres database.",
@@ -84,12 +90,6 @@
       "description": "Custom OpenMetadata Classification name for Postgres policy tags.",
       "type": "string",
       "default": "PostgresPolicyTags"
-    },
-    "ingestAllDatabases": {
-      "title": "Ingest All Databases",
-      "description": "Ingest data from all databases in Postgres. You can use databaseFilterPattern on top of this.",
-      "type": "boolean",
-      "default": false
     },
     "connectionOptions": {
       "title": "Connection Options",

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/AzureSQL.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/AzureSQL.md
@@ -43,7 +43,7 @@ $$section
 
 This parameter specifies the host and port of the AzureSQL instance. This should be specified as a string in the format `hostname:port`. For example, you might set the hostPort parameter to `azure-sql-service-name.database.windows.net:1433`.
 
-If your database service and Open Metadata are both running via docker locally, use `host.docker.internal:3000` as the value.
+If you are running the OpenMetadata ingestion in a docker and your services are hosted on the `localhost`, then use `host.docker.internal:3000` as the value.
 $$
 
 $$section

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Clickhouse.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Clickhouse.md
@@ -58,7 +58,7 @@ $$section
 
 This parameter specifies the host and port of the ClickHouse instance. This should be specified as a string in the format `hostname:port`. For example, you might set the hostPort parameter to `localhost:3000`.
 
-If your database service and Open Metadata are both running via docker locally, use `host.docker.internal:3000` as the value.
+If you are running the OpenMetadata ingestion in a docker and your services are hosted on the `localhost`, then use `host.docker.internal:3000` as the value.
 $$
 
 $$section

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Databricks.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Databricks.md
@@ -29,7 +29,7 @@ $$section
 ### Host Port $(id="hostPort")
 This parameter specifies the host and port of the Databricks instance. This should be specified as a string in the format `hostname:port`. For example, you might set the hostPort parameter to `adb-xyz.azuredatabricks.net:443`.
 
-If your database service and Open Metadata are both running via docker locally, use `host.docker.internal:3000` as the value.
+If you are running the OpenMetadata ingestion in a docker and your services are hosted on the `localhost`, then use `host.docker.internal:3000` as the value.
 $$
 
 $$section

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Db2.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Db2.md
@@ -58,7 +58,7 @@ $$section
 
 This parameter specifies the host and port of the Db2 instance. This should be specified as a string in the format `hostname:port`. For example, you might set the hostPort parameter to `localhost:8000`.
 
-If your database service and Open Metadata are both running via docker locally, use `host.docker.internal:8000` as the value.
+If you are running the OpenMetadata ingestion in a docker and your services are hosted on the `localhost`, then use `host.docker.internal:8000` as the value.
 $$
 
 $$section

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Druid.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Druid.md
@@ -31,7 +31,7 @@ $$section
 
 This parameter specifies the host and port of the Druid instance. This should be specified as a string in the format `hostname:port`. For example, you might set the hostPort parameter to `localhost:8000`.
 
-If your database service and Open Metadata are both running via docker locally, use `host.docker.internal:8000` as the value.
+If you are running the OpenMetadata ingestion in a docker and your services are hosted on the `localhost`, then use `host.docker.internal:8000` as the value.
 $$
 
 $$section

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Hive.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Hive.md
@@ -24,7 +24,7 @@ Password to connect to Hive.
 
 This parameter specifies the host and port of the Hive instance. This should be specified as a string in the format `hostname:port`. For example, you might set the hostPort parameter to `myhivehost:10000`.
 
-If your database service and Open Metadata are both running via docker locally, use `host.docker.internal:10000` as the value.
+If you are running the OpenMetadata ingestion in a docker and your services are hosted on the `localhost`, then use `host.docker.internal:10000` as the value.
 
 ### Auth
 The auth parameter specifies the authentication method to use when connecting to the Hive server. Possible values are `LDAP`, `NONE`, `CUSTOM`, or `KERBEROS`. If you are using Kerberos authentication, you should set auth to `KERBEROS`. If you are using custom authentication, you should set auth to `CUSTOM` and provide additional options in the `authOptions` parameter.
@@ -146,7 +146,7 @@ Find more information about [Source Identity](https://docs.aws.amazon.com/STS/la
 
 This parameter specifies the host and port of the Postgres instance. This should be specified as a string in the format `hostname:port`. For example, you might set the hostPort parameter to `localhost:5432`.
 
-If your database service and Open Metadata are both running via docker locally, use `host.docker.internal:5432` as the value.
+If you are running the OpenMetadata ingestion in a docker and your services are hosted on the `localhost`, then use `host.docker.internal:5432` as the value.
 
 ### Database
 
@@ -275,7 +275,7 @@ Find more information about [Source Identity](https://docs.aws.amazon.com/STS/la
 
 This parameter specifies the host and port of the MySQL instance. This should be specified as a string in the format `hostname:port`. For example, you might set the hostPort parameter to `localhost:3306`.
 
-If your database service and Open Metadata are both running via docker locally, use `host.docker.internal:3306` as the value.
+If you are running the OpenMetadata ingestion in a docker and your services are hosted on the `localhost`, then use `host.docker.internal:3306` as the value.
 
 ### Database Name $(id="databaseName")
 In OpenMetadata, the Database Service hierarchy works as follows:

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Impala.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Impala.md
@@ -32,7 +32,7 @@ $$section
 
 This parameter specifies the host and port of the Impala instance. This should be specified as a string in the format `hostname:port`. For example, you might set the hostPort parameter to `myimpalahost:21050`.
 
-If your database service and Open Metadata are both running via docker locally, use `host.docker.internal:21050` as the value.
+If you are running the OpenMetadata ingestion in a docker and your services are hosted on the `localhost`, then use `host.docker.internal:21050` as the value.
 $$
 
 $$section

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/MariaDB.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/MariaDB.md
@@ -47,7 +47,7 @@ $$section
 
 This parameter specifies the host and port of the MariaDB instance. This should be specified as a string in the format `hostname:port`. For example, you might set the hostPort parameter to `localhost:3306`.
 
-If your database service and Open Metadata are both running via docker locally, use `host.docker.internal:3306` as the value.
+If you are running the OpenMetadata ingestion in a docker and your services are hosted on the `localhost`, then use `host.docker.internal:3306` as the value.
 $$
 
 $$section

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/MongoDB.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/MongoDB.md
@@ -35,7 +35,7 @@ $$section
 
 This parameter specifies the host and port of the MongoDB instance. This should be specified as a string in the format `hostname:port`. For example, you might set the hostPort parameter to `localhost:27017`.
 
-If your database service and Open Metadata are both running via docker locally, use `host.docker.internal:27017` as the value.
+If you are running the OpenMetadata ingestion in a docker and your services are hosted on the `localhost`, then use `host.docker.internal:27017` as the value.
 $$
 
 $$section

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Mssql.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Mssql.md
@@ -78,7 +78,7 @@ $$section
 
 This parameter specifies the host and port of the MSSQL instance. This should be specified as a string in the format `hostname:port`. For example, you might set the hostPort parameter to `localhost:1433`.
 
-If your database service and Open Metadata are both running via docker locally, use `host.docker.internal:1433` as the value.
+If you are running the OpenMetadata ingestion in a docker and your services are hosted on the `localhost`, then use `host.docker.internal:1433` as the value.
 $$
 
 $$section

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Mysql.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Mysql.md
@@ -155,7 +155,7 @@ $$section
 
 This parameter specifies the host and port of the MySQL instance. This should be specified as a string in the format `hostname:port`. For example, you might set the hostPort parameter to `localhost:3306`.
 
-If your database service and Open Metadata are both running via docker locally, use `host.docker.internal:3306` as the value.
+If you are running the OpenMetadata ingestion in a docker and your services are hosted on the `localhost`, then use `host.docker.internal:3306` as the value.
 $$
 
 $$section

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Oracle.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Oracle.md
@@ -63,7 +63,7 @@ $$section
 
 This parameter specifies the host and port of the Oracle instance. This should be specified as a string in the format `hostname:port`. For example, you might set the hostPort parameter to `localhost:1521`.
 
-If your database service and Open Metadata are both running via docker locally, use `host.docker.internal:1521` as the value.
+If you are running the OpenMetadata ingestion in a docker and your services are hosted on the `localhost`, then use `host.docker.internal:1521` as the value.
 $$
 
 $$section

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/PinotDB.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/PinotDB.md
@@ -31,7 +31,7 @@ $$section
 
 This parameter specifies the host and port of the PinotDB instance. This should be specified as a string in the format `hostname:port`. For example, you might set the hostPort parameter to `localhost:8099`.
 
-If your database service and Open Metadata are both running via docker locally, use `host.docker.internal:8099` as the value.
+If you are running the OpenMetadata ingestion in a docker and your services are hosted on the `localhost`, then use `host.docker.internal:8099` as the value.
 $$
 
 $$section

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Postgres.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Postgres.md
@@ -156,7 +156,7 @@ $$section
 
 This parameter specifies the host and port of the Postgres instance. This should be specified as a string in the format `hostname:port`. For example, you might set the hostPort parameter to `localhost:5432`.
 
-If your database service and Open Metadata are both running via docker locally, use `host.docker.internal:5432` as the value.
+If you are running the OpenMetadata ingestion in a docker and your services are hosted on the `localhost`, then use `host.docker.internal:5432` as the value.
 $$
 
 $$section

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Presto.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Presto.md
@@ -34,7 +34,7 @@ $$section
 
 This parameter specifies the host and port of the Presto instance. This should be specified as a string in the format `hostname:port`. For example, you might set the hostPort parameter to `localhost:8080`.
 
-If your database service and Open Metadata are both running via docker locally, use `host.docker.internal:8080` as the value.
+If you are running the OpenMetadata ingestion in a docker and your services are hosted on the `localhost`, then use `host.docker.internal:8080` as the value.
 $$
 
 $$section

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Redshift.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Redshift.md
@@ -45,7 +45,7 @@ $$section
 ### Host Port $(id="hostPort")
 This parameter specifies the host and port of the Redshift instance. This should be specified as a string in the format `hostname:port`. For example, you might set the hostPort parameter to `localhost:5439`.
 
-If your database service and Open Metadata are both running via docker locally, use `host.docker.internal:5439` as the value.
+If you are running the OpenMetadata ingestion in a docker and your services are hosted on the `localhost`, then use `host.docker.internal:5439` as the value.
 $$
 
 $$section

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/SQLite.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/SQLite.md
@@ -30,7 +30,7 @@ $$section
 ### Host Port $(id="hostPort")
 This parameter specifies the host and port of the SQLite instance. This should be specified as a string in the format `hostname:port`. For example, you might set the hostPort parameter to `localhost:3306`.
 
-If your database service and Open Metadata are both running via docker locally, use `host.docker.internal:3306` as the value.
+If you are running the OpenMetadata ingestion in a docker and your services are hosted on the `localhost`, then use `host.docker.internal:3306` as the value.
 
 Keep it blank for in-memory databases.
 $$

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/SapHana.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/SapHana.md
@@ -47,7 +47,7 @@ $$section
 
 This parameter specifies the host and port of the SAP Hana instance. This should be specified as a string in the format `hostname:port`. For example, you might set the hostPort parameter to `localhost:39041`.
 
-If your database service and Open Metadata are both running via docker locally, use `host.docker.internal:39041` as the value.
+If you are running the OpenMetadata ingestion in a docker and your services are hosted on the `localhost`, then use `host.docker.internal:39041` as the value.
 $$
 
 $$section

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/SingleStore.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/SingleStore.md
@@ -45,7 +45,7 @@ $$section
 ### Host Port $(id="hostPort")
 This parameter specifies the host and port of the SingleStore instance. This should be specified as a string in the format `hostname:port`. For example, you might set the hostPort parameter to `localhost:3306`.
 
-If your database service and Open Metadata are both running via docker locally, use `host.docker.internal:3306` as the value.
+If you are running the OpenMetadata ingestion in a docker and your services are hosted on the `localhost`, then use `host.docker.internal:3306` as the value.
 $$
 
 $$section

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Trino.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Trino.md
@@ -38,7 +38,7 @@ $$section
 ### Host Port $(id="hostPort")
 This parameter specifies the host and port of the Trino instance. This should be specified as a string in the format `hostname:port`. For example, you might set the hostPort parameter to `localhost:8080`.
 
-If your database service and Open Metadata are both running via docker locally, use `host.docker.internal:8080` as the value.
+If you are running the OpenMetadata ingestion in a docker and your services are hosted on the `localhost`, then use `host.docker.internal:8080` as the value.
 $$
 
 $$section

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Vertica.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Vertica.md
@@ -72,8 +72,7 @@ $$section
 
 This parameter specifies the host and port of the Vertica instance. This should be specified as a string in the format `hostname:port`. For example, you might set the hostPort parameter to `localhost:5433`.
 
-If your database service and Open Metadata are both running via docker locally, use `host.docker.internal:5433` as the value.
-
+If you are running the OpenMetadata ingestion in a docker and your services are hosted on the `localhost`, then use `host.docker.internal:5433` as the value.
 $$
 
 $$section


### PR DESCRIPTION
…w db input

<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
