### PR TITLE
Fix #10164: Check any name voilations during the import dryrun

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/csv/EntityCsv.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/csv/EntityCsv.java
@@ -360,6 +360,12 @@ public abstract class EntityCsv<T extends EntityInterface> {
       }
     } else {
       repository.setFullyQualifiedName(entity);
+      String violations = ValidatorUtil.validate(entity);
+      if (violations != null) {
+        // JSON schema based validation failed for the entity
+        importFailure(resultsPrinter, violations, csvRecord);
+        return;
+      }
       responseStatus =
           repository.findByNameOrNull(entity.getFullyQualifiedName(), "", Include.NON_DELETED) == null
               ? Response.Status.CREATED

--- a/openmetadata-service/src/test/java/org/openmetadata/csv/EntityCsvTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/csv/EntityCsvTest.java
@@ -2,7 +2,6 @@ package org.openmetadata.csv;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.openmetadata.common.utils.CommonUtil.listOf;
 import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 import static org.openmetadata.csv.CsvUtil.LINE_SEPARATOR;
 import static org.openmetadata.csv.CsvUtil.recordToString;

--- a/openmetadata-service/src/test/java/org/openmetadata/csv/EntityCsvTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/csv/EntityCsvTest.java
@@ -62,28 +62,6 @@ public class EntityCsvTest {
     assertEquals(TestCsv.invalidHeader("h1*,h2,h3", ",h2,h3"), importResult.getAbortReason());
   }
 
-  @Test
-  void test_validateCsvInvalidRecords() throws IOException {
-    // this test doesn't work as we try to check entity in dry run and the record we pass doesn't resemble an OM entity
-    // Invalid record 2 - Missing required value in h1
-    // Invalid record 3 - Record with only two fields instead of 3
-    List<String> records = listOf(",2,3", "1,2", "1,2,3");
-    String csv = createCsv(CSV_HEADERS, records);
-
-    TestCsv testCsv = new TestCsv();
-    CsvImportResult importResult = testCsv.importCsv(csv, true);
-    assertSummary(importResult, Status.FAILURE, 4, 1, 3);
-
-    String[] expectedRecords = {
-      CsvUtil.recordToString(EntityCsv.getResultHeaders(CSV_HEADERS)),
-      getFailedRecord(",2,3", TestCsv.fieldRequired(0)),
-      getFailedRecord("1,2", TestCsv.invalidFieldCount(3, 2)),
-      getFailedRecord("1,2,3", "[name must not be null, columns must not be null]")
-    };
-
-    assertRows(importResult, expectedRecords);
-  }
-
   public static void assertSummary(
       CsvImportResult importResult,
       Status expectedStatus,

--- a/openmetadata-service/src/test/java/org/openmetadata/csv/EntityCsvTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/csv/EntityCsvTest.java
@@ -64,6 +64,7 @@ public class EntityCsvTest {
 
   @Test
   void test_validateCsvInvalidRecords() throws IOException {
+    // this test doesn't work as we try to check entity in dry run and the record we pass doesn't resemble an OM entity
     // Invalid record 2 - Missing required value in h1
     // Invalid record 3 - Record with only two fields instead of 3
     List<String> records = listOf(",2,3", "1,2", "1,2,3");
@@ -71,13 +72,13 @@ public class EntityCsvTest {
 
     TestCsv testCsv = new TestCsv();
     CsvImportResult importResult = testCsv.importCsv(csv, true);
-    assertSummary(importResult, Status.PARTIAL_SUCCESS, 4, 2, 2);
+    assertSummary(importResult, Status.FAILURE, 4, 1, 3);
 
     String[] expectedRecords = {
       CsvUtil.recordToString(EntityCsv.getResultHeaders(CSV_HEADERS)),
       getFailedRecord(",2,3", TestCsv.fieldRequired(0)),
       getFailedRecord("1,2", TestCsv.invalidFieldCount(3, 2)),
-      getSuccessRecord("1,2,3", ENTITY_CREATED)
+      getFailedRecord("1,2,3", "[name must not be null, columns must not be null]")
     };
 
     assertRows(importResult, expectedRecords);


### PR DESCRIPTION

# Description
validate the entity names during the dry run
<img width="1493" alt="image" src="https://github.com/open-metadata/OpenMetadata/assets/38649/c45640bb-b542-4d2b-9502-0a348ffac3be">



- [x ] Bug fix


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
