### PR TITLE
Removing the large packages clean as the github action is failing

### DIFF
--- a/.github/workflows/airflow-apis-tests-3_9.yml
+++ b/.github/workflows/airflow-apis-tests-3_9.yml
@@ -40,7 +40,7 @@ jobs:
           android: true
           dotnet: true
           haskell: true
-          large-packages: true
+          large-packages: false
           docker-images: false
           swap-storage: true
     - name: Wait for the labeler

--- a/.github/workflows/java-checkstyle.yml
+++ b/.github/workflows/java-checkstyle.yml
@@ -37,7 +37,7 @@ jobs:
             android: true
             dotnet: true
             haskell: true
-            large-packages: true
+            large-packages: false
             swap-storage: true
             docker-images: false
       - name: Wait for the labeler

--- a/.github/workflows/monitor-slack-link.yml
+++ b/.github/workflows/monitor-slack-link.yml
@@ -31,7 +31,7 @@ jobs:
           android: true
           dotnet: true
           haskell: true
-          large-packages: true
+          large-packages: false
           docker-images: true
           swap-storage: true      
     - name: Checkout

--- a/.github/workflows/publish-maven-package.yml
+++ b/.github/workflows/publish-maven-package.yml
@@ -42,7 +42,7 @@ jobs:
             android: true
             dotnet: true
             haskell: true
-            large-packages: true
+            large-packages: false
             swap-storage: true
       - uses: actions/checkout@v3
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -29,7 +29,7 @@ jobs:
             android: true
             dotnet: true
             haskell: true
-            large-packages: true
+            large-packages: false
             docker-images: true
             swap-storage: true      
       - uses: actions/checkout@v3

--- a/.github/workflows/selenium-noIngestion-tests.yml
+++ b/.github/workflows/selenium-noIngestion-tests.yml
@@ -49,7 +49,7 @@ jobs:
           android: true
           dotnet: true
           haskell: true
-          large-packages: true
+          large-packages: false
           docker-images: true
           swap-storage: true      
     - uses: actions/checkout@v3


### PR DESCRIPTION
Removing the large packages clean as the github action is failing on fetching  http://azure.archive.ubuntu.com/ubuntu which is causing the ci to fail overall

Ref: Tested here in Forked branch - https://github.com/deuex-solutions/OpenMetadata-1/actions/workflows/disk-space-test.yml