### PR TITLE
Fixes 13015 : [Docs] Add SSAL_SSL config info for Confluent kafka with SSL encryption

### DIFF
--- a/openmetadata-docs/content/v1.2.0-SNAPSHOT/connectors/messaging/kafka/index.md
+++ b/openmetadata-docs/content/v1.2.0-SNAPSHOT/connectors/messaging/kafka/index.md
@@ -43,7 +43,8 @@ The ingestion of the Kafka topics' schema is done separately by configuring the 
 - **SASL Password**: SASL password for use with the PLAIN and SASL-SCRAM mechanisms.
 - **SASL Mechanism**: SASL mechanism to use for authentication.
 - **Basic Auth User Info**: Schema Registry Client HTTP credentials in the form of `username:password`. By default, user info is extracted from the URL if present.
-- **Consumer Config**: The accepted additional values for the consumer configuration can be found in the following [link](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md).
+- **Consumer Config**: The accepted additional values for the consumer configuration can be found in the following [link](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md).  
+If you are using Confluent kafka and SSL encryption is enabled you need to add `security.protocol` as key and `SASL_SSL` as value under Consumer Config
 - **Schema Registry Config**: The accepted additional values for the Schema Registry configuration can be found in the following [link](https://docs.confluent.io/5.5.1/clients/confluent-kafka-python/index.html#confluent_kafka.schema_registry.SchemaRegistryClient).
 
 {% note %}

--- a/openmetadata-docs/content/v1.2.0-SNAPSHOT/connectors/messaging/kafka/troubleshooting.md
+++ b/openmetadata-docs/content/v1.2.0-SNAPSHOT/connectors/messaging/kafka/troubleshooting.md
@@ -33,3 +33,7 @@ like this:
       schemaRegistryConfig:
         "basic.auth.user.info": "username:password"
 ```
+
+## Connecting to Confluent Cloud Kafka
+
+If you are using Confluent kafka and SSL encryption is enabled you need to add `security.protocol` as key and `SASL_SSL` as value under Consumer Config


### PR DESCRIPTION

Fixes [13015](https://github.com/open-metadata/OpenMetadata/issues/13015)

If you are using Confluent kafka and SSL encryption is enabled you need to add `security.protocol` as key and `SASL_SSL` as value under Consumer Config.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement 
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [x] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [x] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [x] I have added the tag `Backward-Incompatible-Change`.
-->
