### PR TITLE
Bootstrap script update

### DIFF
--- a/bootstrap/bootstrap_storage.sh
+++ b/bootstrap/bootstrap_storage.sh
@@ -10,6 +10,30 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+printUsage() {
+  cat <<-EOF
+USAGE: $0 [create|migrate|info|validate|drop|drop-create|es-drop|es-create|drop-create-all|migrate-all|repair|check-connection|rotate] [-d] [-f]
+   create           : Creates the tables. The target database should be empty
+   migrate          : Migrates the database to the latest version or creates the tables if the database is empty. Use "info" to see the current version and the pending migrations
+   info             : Shows the list of migrations applied and the pending migration waiting to be applied on the target database
+   validate         : Checks if all the migrations have been applied to the target database
+   drop             : Drops all the tables in the target database
+   drop-create      : Drops and recreates all the tables in the target database
+   es-drop          : Drops the indexes in ElasticSearch
+   es-create        : Creates the indexes in ElasticSearch
+   drop-create-all  : Drops and recreates all the tables in the database. Drops and creates all the indexes in ElasticSearch
+   migrate-all      : Migrates the database to the latest version and migrates the indexes in ElasticSearch
+   repair           : Repairs the DATABASE_CHANGE_LOG table, which is used to track all the migrations on the target database
+                      This involves removing entries for failed migrations and updating the checksum of migrations already applied on the target database
+   check-connection : Checks if a connection can be successfully obtained for the target database
+   rotate           : Rotate the Fernet Key defined in \$FERNET_KEY
+
+   Additionally, you can use:
+   -d for debug      : Enable Debugging Mode to get more info
+   -f for force      : Forces the server Migration to run, even if already run
+EOF
+}
+
 # Resolve links - $0 may be a softlink
 PRG="${0}"
 debug=false
@@ -33,7 +57,7 @@ fi
 
 opt="$1"
 shift
-# Parse options following the command
+
 while [ $# -gt 0 ]; do
   case "$1" in
     -d)
@@ -43,6 +67,9 @@ while [ $# -gt 0 ]; do
       force=true
       ;;
     *)
+      echo "Invalid option: -$1" >&2
+      echo "Only two options allowed after main argument command. Use -d for debug and -f for force. Refer:"
+      printUsage
       break
       ;;
   esac
@@ -75,29 +102,6 @@ else
   CLASSPATH=`mvn -pl openmetadata-service -q exec:exec -Dexec.executable=echo -Dexec.args="%classpath"`
 fi
 
-printUsage() {
-  cat <<-EOF
-USAGE: $0 [create|migrate|info|validate|drop|drop-create|es-drop|es-create|drop-create-all|migrate-all|repair|check-connection|rotate] [debug] [force]
-   create           : Creates the tables. The target database should be empty
-   migrate          : Migrates the database to the latest version or creates the tables if the database is empty. Use "info" to see the current version and the pending migrations
-   info             : Shows the list of migrations applied and the pending migration waiting to be applied on the target database
-   validate         : Checks if all the migrations have been applied to the target database
-   drop             : Drops all the tables in the target database
-   drop-create      : Drops and recreates all the tables in the target database
-   es-drop          : Drops the indexes in ElasticSearch
-   es-create        : Creates the indexes in ElasticSearch
-   drop-create-all  : Drops and recreates all the tables in the database. Drops and creates all the indexes in ElasticSearch
-   migrate-all      : Migrates the database to the latest version and migrates the indexes in ElasticSearch
-   repair           : Repairs the DATABASE_CHANGE_LOG table, which is used to track all the migrations on the target database. This involves removing entries for failed migrations and updating the checksum of migrations already applied on the target database
-   check-connection : Checks if a connection can be successfully obtained for the target database
-   rotate           : Rotate the Fernet Key defined in \$FERNET_KEY
-
-   Additionally, you can use:
-   -d for debug      : Enable Debugging Mode to get more info
-   -f for force      : Forces the server Migration to run, even if already run
-EOF
-}
-
 execute() {
   local command="$1"
   local debug="$2"
@@ -109,6 +113,7 @@ execute() {
   echo "The -force value is ${force} and the debug value is ${debug} and command used is ${command}"
   ${JAVA} -Dbootstrap.dir=$BOOTSTRAP_DIR  -cp ${CLASSPATH} ${TABLE_INITIALIZER_MAIN_CLASS} -c ${CONFIG_FILE_PATH} -s ${FLYWAY_SQL_ROOT_DIR} -n ${NATIVE_SQL_ROOT_DIR} --${1} -force ${force}  -${debug}
 }
+
 
 case "${opt}" in
 create | drop | migrate | info | validate | repair | check-connection | es-drop | es-create | rotate)

--- a/bootstrap/bootstrap_storage.sh
+++ b/bootstrap/bootstrap_storage.sh
@@ -115,3 +115,24 @@ rotate )
     exit 1
     ;;
 esac
+
+# Parse options following the command
+while getopts "df" opt; do
+  case $opt in
+    d)
+      debug=true
+      ;;
+    f)
+      force=true
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      printUsage
+      exit 1
+      ;;
+  esac
+done
+
+# Print the parsed options
+echo "Debug: $debug"
+echo "Force: $force"

--- a/bootstrap/bootstrap_storage.sh
+++ b/bootstrap/bootstrap_storage.sh
@@ -25,6 +25,30 @@ while [ -h "${PRG}" ]; do
   fi
 done
 
+if [ $# -gt 4 ]; then
+  echo "More than one argument specified, please use only one of the below options"
+  printUsage
+  exit 1
+fi
+
+opt="$1"
+shift
+# Parse options following the command
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -d)
+      debug=true
+      ;;
+    -f)
+      force=true
+      ;;
+    *)
+      break
+      ;;
+  esac
+  shift
+done
+
 BOOTSTRAP_DIR=`dirname ${PRG}`
 CONFIG_FILE_PATH=${BOOTSTRAP_DIR}/../conf/openmetadata.yaml
 FLYWAY_SQL_ROOT_DIR="${BOOTSTRAP_DIR}/sql/migrations/flyway"
@@ -39,7 +63,7 @@ fi
 
 TABLE_INITIALIZER_MAIN_CLASS=org.openmetadata.service.util.TablesInitializer
 LIBS_DIR="${BOOTSTRAP_DIR}"/../libs/
-if  [ ${debug} ] ; then
+if  [ "${debug}" = true ] ; then
   echo $LIBS_DIR
 fi
 if [ -d "${LIBS_DIR}" ]; then
@@ -51,88 +75,60 @@ else
   CLASSPATH=`mvn -pl openmetadata-service -q exec:exec -Dexec.executable=echo -Dexec.args="%classpath"`
 fi
 
-execute() {
-  if  [ ${debug} ] ; then
-    echo "Using Configuration file: ${CONFIG_FILE_PATH}"
-  fi
-  ${JAVA} -Dbootstrap.dir=$BOOTSTRAP_DIR  -cp ${CLASSPATH} ${TABLE_INITIALIZER_MAIN_CLASS} -c ${CONFIG_FILE_PATH} -s ${FLYWAY_SQL_ROOT_DIR} -n ${NATIVE_SQL_ROOT_DIR} --${1} -force ${force}  -${debug}
-}
-
 printUsage() {
-    cat <<-EOF
+  cat <<-EOF
 USAGE: $0 [create|migrate|info|validate|drop|drop-create|es-drop|es-create|drop-create-all|migrate-all|repair|check-connection|rotate] [debug] [force]
    create           : Creates the tables. The target database should be empty
    migrate          : Migrates the database to the latest version or creates the tables if the database is empty. Use "info" to see the current version and the pending migrations
    info             : Shows the list of migrations applied and the pending migration waiting to be applied on the target database
-   validate         : Checks if the all the migrations haven been applied on the target database
+   validate         : Checks if all the migrations have been applied to the target database
    drop             : Drops all the tables in the target database
    drop-create      : Drops and recreates all the tables in the target database
    es-drop          : Drops the indexes in ElasticSearch
    es-create        : Creates the indexes in ElasticSearch
    drop-create-all  : Drops and recreates all the tables in the database. Drops and creates all the indexes in ElasticSearch
    migrate-all      : Migrates the database to the latest version and migrates the indexes in ElasticSearch
-   repair           : Repairs the DATABASE_CHANGE_LOG table which is used to track all the migrations on the target database
-                      This involves removing entries for the failed migrations and update the checksum of migrations already applied on the target database
+   repair           : Repairs the DATABASE_CHANGE_LOG table, which is used to track all the migrations on the target database. This involves removing entries for failed migrations and updating the checksum of migrations already applied on the target database
    check-connection : Checks if a connection can be successfully obtained for the target database
-   rotate           : Rotate the Fernet Key defined in $FERNET_KEY
-   Additionally you can use:
-   -d for 
-   debug            : Enable Debugging Mode to get more info
-   -f for 
-   force            : Forces the server Migration to be ran, even if already ran
+   rotate           : Rotate the Fernet Key defined in \$FERNET_KEY
 
+   Additionally, you can use:
+   -d for debug      : Enable Debugging Mode to get more info
+   -f for force      : Forces the server Migration to run, even if already run
 EOF
 }
 
-if [ $# -gt 4 ]
-then
-    echo "More than one argument specified, please use only one of the below options"
-    printUsage
-    exit 1
-fi
+execute() {
+  local command="$1"
+  local debug="$2"
+  local force="$3"
 
-opt="$1"
-shift
+  if [ "${debug}" = true ]; then
+    echo "Using Configuration file: ${CONFIG_FILE_PATH}"
+  fi
+  echo "The -force value is ${force} and the debug value is ${debug} and command used is ${command}"
+  ${JAVA} -Dbootstrap.dir=$BOOTSTRAP_DIR  -cp ${CLASSPATH} ${TABLE_INITIALIZER_MAIN_CLASS} -c ${CONFIG_FILE_PATH} -s ${FLYWAY_SQL_ROOT_DIR} -n ${NATIVE_SQL_ROOT_DIR} --${1} -force ${force}  -${debug}
+}
 
 case "${opt}" in
 create | drop | migrate | info | validate | repair | check-connection | es-drop | es-create | rotate)
-    execute "${opt}"
+    execute "${opt}" "${debug}" "${force}"
     ;;
 drop-create )
-    execute "drop" && execute "create"
+    execute "drop" "${debug}" "${force}" && execute "create" "${debug}" "${force}"
     ;;
 drop-create-all )
-    execute "drop" && execute "create" && execute "es-drop" && execute "es-create"
+    execute "drop" "${debug}" "${force}" && execute "create" "${debug}" "${force}" && execute "es-drop" "${debug}" "${force}" && execute "es-create" "${debug}" "${force}"
     ;;
 migrate-all )
-    execute "repair" && execute "migrate" && execute "es-migrate"
+    execute "repair" "${debug}" "${force}" && execute "migrate" "${debug}" "${force}" && execute "es-migrate" "${debug}" "${force}"
     ;;
 rotate )
-    execute "rotate"
+    execute "rotate" "${debug}" "${force}"
     ;;
 *)
+    echo "Invalid command: ${opt}"
     printUsage
     exit 1
     ;;
 esac
-
-# Parse options following the command
-while getopts "df" opt; do
-  case $opt in
-    d)
-      debug=true
-      ;;
-    f)
-      force=true
-      ;;
-    \?)
-      echo "Invalid option: -$OPTARG" >&2
-      printUsage
-      exit 1
-      ;;
-  esac
-done
-
-# Print the parsed options
-echo "Debug: $debug"
-echo "Force: $force"

--- a/bootstrap/bootstrap_storage.sh
+++ b/bootstrap/bootstrap_storage.sh
@@ -12,14 +12,8 @@
 
 # Resolve links - $0 may be a softlink
 PRG="${0}"
-debug="$2"
+debug=false
 force=false
-
-if [ -z "$3" ]; then
-  force=false
-else
-  force=true
-fi
 
 while [ -h "${PRG}" ]; do
   ls=`ls -ld "${PRG}"`
@@ -81,12 +75,16 @@ USAGE: $0 [create|migrate|info|validate|drop|drop-create|es-drop|es-create|drop-
                       This involves removing entries for the failed migrations and update the checksum of migrations already applied on the target database
    check-connection : Checks if a connection can be successfully obtained for the target database
    rotate           : Rotate the Fernet Key defined in $FERNET_KEY
+   Additionally you can use:
+   -d for 
    debug            : Enable Debugging Mode to get more info
+   -f for 
    force            : Forces the server Migration to be ran, even if already ran
+
 EOF
 }
 
-if [ $# -gt 3 ]
+if [ $# -gt 4 ]
 then
     echo "More than one argument specified, please use only one of the below options"
     printUsage
@@ -94,6 +92,7 @@ then
 fi
 
 opt="$1"
+shift
 
 case "${opt}" in
 create | drop | migrate | info | validate | repair | check-connection | es-drop | es-create | rotate)

--- a/bootstrap/bootstrap_storage.sh
+++ b/bootstrap/bootstrap_storage.sh
@@ -103,14 +103,10 @@ else
 fi
 
 execute() {
-  local command="$1"
-  local debug="$2"
-  local force="$3"
-
   if [ "${debug}" = true ]; then
     echo "Using Configuration file: ${CONFIG_FILE_PATH}"
   fi
-  echo "The -force value is ${force} and the debug value is ${debug} and command used is ${command}"
+  echo "The -force value is ${force} and the debug value is ${debug} and command used is ${opt}"
   ${JAVA} -Dbootstrap.dir=$BOOTSTRAP_DIR  -cp ${CLASSPATH} ${TABLE_INITIALIZER_MAIN_CLASS} -c ${CONFIG_FILE_PATH} -s ${FLYWAY_SQL_ROOT_DIR} -n ${NATIVE_SQL_ROOT_DIR} --${1} -force ${force}  -${debug}
 }
 


### PR DESCRIPTION
Updating bootstrap script to include force and debug as getopts.

The script now can be run as:
`bootstrap.sh create` or 
`bootstrap.sh create -d` or 
`bootstrap.sh create -f -d` or
`bootstrap.sh create -d -f`

-d and -f are set to use debug and force, which are optional and by default are false.