### PR TITLE
Revert "fix: Align Docker Base Image to use airflow 2.5.3"

### DIFF
--- a/ingestion/Dockerfile
+++ b/ingestion/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/airflow:2.5.3-python3.9
+FROM apache/airflow:2.6.3-python3.9
 USER root
 RUN curl -sS https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 RUN curl -sS https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list

--- a/ingestion/Dockerfile.ci
+++ b/ingestion/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM apache/airflow:2.5.3-python3.9
+FROM apache/airflow:2.6.3-python3.9
 USER root
 RUN curl -sS https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 RUN curl -sS https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list


### PR DESCRIPTION
Reverts open-metadata/OpenMetadata#12737

The reason for downgrading the airflow base image was that the helm chart did not support airflow 2.6.x. Since then the dependency has been updated as part of https://github.com/open-metadata/openmetadata-helm-charts/pull/168 and airflow 2.6.3 is used. The database upgrade now fails because the new revision ID is not known in the old airflow version resulting in the following error: `alembic.script.revision.ResolutionError: No such revision or branch 'c804e5c76e3e'`. See https://airflow.apache.org/docs/apache-airflow/stable/migrations-ref.html