### PR TITLE
fix: alerting for entiyFQN filter and testResult filter for test cases

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertsRuleEvaluator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertsRuleEvaluator.java
@@ -10,6 +10,7 @@ import static org.openmetadata.service.Entity.TEST_CASE;
 import static org.openmetadata.service.Entity.USER;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
@@ -19,6 +20,7 @@ import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineStatus
 import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineStatusType;
 import org.openmetadata.schema.entity.teams.Team;
 import org.openmetadata.schema.entity.teams.User;
+import org.openmetadata.schema.tests.TestCase;
 import org.openmetadata.schema.tests.type.TestCaseResult;
 import org.openmetadata.schema.tests.type.TestCaseStatus;
 import org.openmetadata.schema.type.ChangeEvent;
@@ -100,6 +102,9 @@ public class AlertsRuleEvaluator {
     }
     EntityInterface entity = getEntity(changeEvent);
     for (String name : entityNames) {
+      if (changeEvent.getEntityType().equals(TEST_CASE) && ((TestCase) entity).getEntityFQN().equals(name)) {
+        return true;
+      }
       if (entity.getFullyQualifiedName().equals(name)) {
         return true;
       }
@@ -159,7 +164,12 @@ public class AlertsRuleEvaluator {
       // in case the entity is not test case return since the filter doesn't apply
       return true;
     }
-    for (FieldChange fieldChange : changeEvent.getChangeDescription().getFieldsUpdated()) {
+
+    // we need to handle both fields updated and fields added
+    List<FieldChange> fieldChanges = changeEvent.getChangeDescription().getFieldsUpdated();
+    fieldChanges.addAll(changeEvent.getChangeDescription().getFieldsAdded());
+
+    for (FieldChange fieldChange : fieldChanges) {
       if (fieldChange.getName().equals("testCaseResult") && fieldChange.getNewValue() != null) {
         TestCaseResult testCaseResult = (TestCaseResult) fieldChange.getNewValue();
         TestCaseStatus status = testCaseResult.getTestCaseStatus();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertsRuleEvaluator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertsRuleEvaluator.java
@@ -167,7 +167,9 @@ public class AlertsRuleEvaluator {
 
     // we need to handle both fields updated and fields added
     List<FieldChange> fieldChanges = changeEvent.getChangeDescription().getFieldsUpdated();
-    fieldChanges.addAll(changeEvent.getChangeDescription().getFieldsAdded());
+    if (!changeEvent.getChangeDescription().getFieldsAdded().isEmpty()) {
+      fieldChanges.addAll(changeEvent.getChangeDescription().getFieldsAdded());
+    }
 
     for (FieldChange fieldChange : fieldChanges) {
       if (fieldChange.getName().equals("testCaseResult") && fieldChange.getNewValue() != null) {


### PR DESCRIPTION
### Describe your changes:
- add logic to check for field updated and field added when evaluating the test result
- add logic to handle entiyFQN filtering for test cases (i.e. this will be the entity against which the test cases are running)

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
