### PR TITLE
fix(ui): supported unit test for stored database schema page

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaPage/DatabaseSchemaPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaPage/DatabaseSchemaPage.component.tsx
@@ -51,14 +51,16 @@ import React, {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory, useParams } from 'react-router-dom';
-import { ListDataModelParams } from 'rest/dashboardAPI';
 import {
   getDatabaseSchemaDetailsByFQN,
   patchDatabaseSchemaDetails,
   restoreDatabaseSchema,
 } from 'rest/databaseAPI';
 import { getFeedCount, postThread } from 'rest/feedsAPI';
-import { getStoredProceduresList } from 'rest/storedProceduresAPI';
+import {
+  getStoredProceduresList,
+  ListStoredProcedureParams,
+} from 'rest/storedProceduresAPI';
 import { getTableList, TableListParams } from 'rest/tableAPI';
 import { getEntityMissingError } from 'utils/CommonUtils';
 import { getDatabaseSchemaVersionPath } from 'utils/RouterUtils';
@@ -218,7 +220,7 @@ const DatabaseSchemaPage: FunctionComponent = () => {
   }, [databaseSchemaFQN]);
 
   const fetchStoreProcedureDetails = useCallback(
-    async (params?: ListDataModelParams) => {
+    async (params?: ListStoredProcedureParams) => {
       try {
         setStoredProcedure((prev) => ({ ...prev, isLoading: true }));
         const { data, paging } = await getStoredProceduresList({

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaPage/DatabaseSchemaPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaPage/DatabaseSchemaPage.test.tsx
@@ -11,22 +11,125 @@
  *  limitations under the License.
  */
 
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { usePermissionProvider } from 'components/PermissionProvider/PermissionProvider';
 import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
 import { getDatabaseSchemaDetailsByFQN } from 'rest/databaseAPI';
+import { getStoredProceduresList } from 'rest/storedProceduresAPI';
+import { DEFAULT_ENTITY_PERMISSION } from 'utils/PermissionsUtils';
 import DatabaseSchemaPageComponent from './DatabaseSchemaPage.component';
 import {
-  mockEntityPermissions,
-  mockGetAllFeedsData,
   mockGetDatabaseSchemaDetailsByFQNData,
   mockGetFeedCountData,
   mockPatchDatabaseSchemaDetailsData,
-  mockPostFeedByIdData,
   mockPostThreadData,
-  mockSearchQueryData,
 } from './mocks/DatabaseSchemaPage.mock';
+
+const mockEntityPermissionByFqn = jest
+  .fn()
+  .mockImplementation(() => DEFAULT_ENTITY_PERMISSION);
+
+jest.mock('components/PermissionProvider/PermissionProvider', () => ({
+  usePermissionProvider: jest.fn().mockImplementation(() => ({
+    getEntityPermissionByFqn: mockEntityPermissionByFqn,
+  })),
+}));
+
+jest.mock(
+  'components/ActivityFeed/ActivityFeedProvider/ActivityFeedProvider',
+  () => ({
+    useActivityFeedProvider: jest.fn().mockImplementation(() => ({
+      postFeed: jest.fn(),
+      deleteFeed: jest.fn(),
+      updateFeed: jest.fn(),
+    })),
+    __esModule: true,
+    default: 'ActivityFeedProvider',
+  })
+);
+
+jest.mock(
+  'components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.component',
+  () => ({
+    ActivityFeedTab: jest
+      .fn()
+      .mockImplementation(() => <>testActivityFeedTab</>),
+  })
+);
+
+jest.mock(
+  'components/ActivityFeed/ActivityThreadPanel/ActivityThreadPanel',
+  () => {
+    return jest.fn().mockImplementation(() => <p>testActivityThreadPanel</p>);
+  }
+);
+
+jest.mock(
+  'components/DataAssets/DataAssetsHeader/DataAssetsHeader.component',
+  () => ({
+    DataAssetsHeader: jest
+      .fn()
+      .mockImplementation(() => <p>testDataAssetsHeader</p>),
+  })
+);
+
+jest.mock('components/TabsLabel/TabsLabel.component', () =>
+  jest.fn().mockImplementation(({ name }) => <div>{name}</div>)
+);
+
+jest.mock('components/Tag/TagsContainerV2/TagsContainerV2', () => {
+  return jest.fn().mockImplementation(() => <p>testTagsContainerV2</p>);
+});
+
+jest.mock('./SchemaTablesTab', () => {
+  return jest.fn().mockReturnValue(<p>testSchemaTablesTab</p>);
+});
+
+jest.mock('pages/StoredProcedure/StoredProcedureTab', () => {
+  return jest.fn().mockImplementation(() => <div>testStoredProcedureTab</div>);
+});
+
+jest.mock('components/containers/PageLayoutV1', () => {
+  return jest.fn().mockImplementation(({ children }) => <p>{children}</p>);
+});
+
+jest.mock('utils/StringsUtils', () => ({
+  getDecodedFqn: jest.fn().mockImplementation((fqn) => fqn),
+}));
+
+jest.mock('rest/storedProceduresAPI', () => ({
+  getStoredProceduresList: jest
+    .fn()
+    .mockImplementation(() =>
+      Promise.resolve({ data: [], paging: { total: 2 } })
+    ),
+}));
+
+jest.mock('rest/tableAPI', () => ({
+  getTableList: jest
+    .fn()
+    .mockImplementation(() =>
+      Promise.resolve({ data: [], paging: { total: 0 } })
+    ),
+}));
+
+jest.mock('utils/CommonUtils', () => ({
+  getEntityMissingError: jest.fn().mockImplementation((error) => error),
+}));
+
+jest.mock('utils/RouterUtils', () => ({
+  getDatabaseSchemaVersionPath: jest.fn().mockImplementation((path) => path),
+}));
+
+jest.mock('../../utils/EntityUtils', () => ({
+  getEntityFeedLink: jest.fn(),
+  getEntityName: jest.fn().mockImplementation((obj) => obj.name),
+}));
+
+jest.mock('../../utils/TableUtils', () => ({
+  getTierTags: jest.fn(),
+  getTagsWithoutTier: jest.fn(),
+}));
 
 jest.mock('../../utils/ToastUtils', () => ({
   showErrorToast: jest
@@ -35,79 +138,23 @@ jest.mock('../../utils/ToastUtils', () => ({
 }));
 
 jest.mock('components/Loader/Loader', () =>
-  jest.fn().mockImplementation(() => <div>Loader</div>)
+  jest.fn().mockImplementation(() => <div>testLoader</div>)
 );
-
-jest.mock('components/common/rich-text-editor/RichTextEditorPreviewer', () =>
-  jest.fn().mockImplementation(() => <div>RichTextEditorPreviewer</div>)
-);
-
-jest.mock('components/common/next-previous/NextPrevious', () =>
-  jest.fn().mockImplementation(() => <div>NextPrevious</div>)
-);
-
-jest.mock('components/FeedEditor/FeedEditor', () => {
-  return jest.fn().mockReturnValue(<p>ActivityFeedEditor</p>);
-});
 
 jest.mock('components/common/error-with-placeholder/ErrorPlaceHolder', () =>
-  jest
-    .fn()
-    .mockImplementation(({ children }) => (
-      <div data-testid="error-placeHolder">{children}</div>
-    ))
-);
-
-jest.mock('components/common/description/Description', () =>
-  jest
-    .fn()
-    .mockImplementation(
-      ({ onThreadLinkSelect, onDescriptionEdit, onDescriptionUpdate }) => (
-        <div
-          onClick={() => {
-            onThreadLinkSelect('threadLink');
-            onDescriptionEdit();
-            onDescriptionUpdate('Updated Description');
-          }}>
-          Description
-        </div>
-      )
-    )
-);
-
-jest.mock(
-  'components/ActivityFeed/ActivityThreadPanel/ActivityThreadPanel',
-  () => jest.fn().mockImplementation(() => <div>ActivityThreadPanel</div>)
+  jest.fn().mockImplementation(() => <p>ErrorPlaceHolder</p>)
 );
 
 jest.mock('components/PermissionProvider/PermissionProvider', () => ({
   usePermissionProvider: jest.fn().mockImplementation(() => ({
-    getEntityPermissionByFqn: jest
-      .fn()
-      .mockImplementation(() => Promise.resolve(mockEntityPermissions)),
+    getEntityPermissionByFqn: mockEntityPermissionByFqn,
   })),
 }));
 
-jest.mock('rest/searchAPI', () => ({
-  searchQuery: jest
-    .fn()
-    .mockImplementation(() => Promise.resolve(mockSearchQueryData)),
-}));
-
-jest.mock('components/MyData/LeftSidebar/LeftSidebar.component', () =>
-  jest.fn().mockReturnValue(<p>Sidebar</p>)
-);
-
 jest.mock('rest/feedsAPI', () => ({
-  getAllFeeds: jest
-    .fn()
-    .mockImplementation(() => Promise.resolve(mockGetAllFeedsData)),
   getFeedCount: jest
     .fn()
     .mockImplementation(() => Promise.resolve(mockGetFeedCountData)),
-  postFeedById: jest
-    .fn()
-    .mockImplementation(() => Promise.resolve(mockPostFeedByIdData)),
   postThread: jest
     .fn()
     .mockImplementation(() => Promise.resolve(mockPostThreadData)),
@@ -124,6 +171,11 @@ jest.mock('rest/databaseAPI', () => ({
     .mockImplementation(() =>
       Promise.resolve(mockPatchDatabaseSchemaDetailsData)
     ),
+  restoreDatabaseSchema: jest
+    .fn()
+    .mockImplementation(() =>
+      Promise.resolve(mockPatchDatabaseSchemaDetailsData)
+    ),
 }));
 
 jest.mock('../../AppState', () => ({
@@ -136,11 +188,6 @@ const mockParams = {
 };
 
 jest.mock('react-router-dom', () => ({
-  Link: jest
-    .fn()
-    .mockImplementation(({ children }) => (
-      <div data-testid="link">{children}</div>
-    )),
   useHistory: jest.fn().mockImplementation(() => ({
     history: {
       push: jest.fn(),
@@ -149,129 +196,113 @@ jest.mock('react-router-dom', () => ({
   useParams: jest.fn().mockImplementation(() => mockParams),
 }));
 
-jest.mock('components/containers/PageLayoutV1', () => {
-  return jest.fn().mockImplementation(({ children }) => children);
-});
+describe('Tests for DatabaseSchemaPage', () => {
+  it('DatabaseSchemaPage should fetch permissions', () => {
+    render(<DatabaseSchemaPageComponent />);
 
-describe.skip('Tests for DatabaseSchemaPage', () => {
-  it('Page should render properly for "Tables" tab', async () => {
-    act(() => {
-      render(<DatabaseSchemaPageComponent />, {
-        wrapper: MemoryRouter,
-      });
-    });
-
-    const entityPageInfo = await screen.findByTestId('entityPageInfo');
-    const tabsPane = await screen.findByTestId('tabs');
-    const richTextEditorPreviewer = await screen.findAllByText(
-      'RichTextEditorPreviewer'
+    expect(mockEntityPermissionByFqn).toHaveBeenCalledWith(
+      'databaseSchema',
+      mockParams.databaseSchemaFQN
     );
-    const description = await screen.findByText('Description');
-    const nextPrevious = await screen.findByText('NextPrevious');
-    const databaseSchemaTable = await screen.findByTestId(
-      'databaseSchema-tables'
-    );
-
-    expect(entityPageInfo).toBeInTheDocument();
-    expect(tabsPane).toBeInTheDocument();
-    expect(richTextEditorPreviewer).toHaveLength(10);
-    expect(description).toBeInTheDocument();
-    expect(nextPrevious).toBeInTheDocument();
-    expect(databaseSchemaTable).toBeInTheDocument();
   });
 
-  it('Loader should be visible if the permissions are being fetched', async () => {
-    await act(async () => {
-      render(<DatabaseSchemaPageComponent />, {
-        wrapper: MemoryRouter,
-      });
+  it('DatabaseSchemaPage should not fetch details if permission is there', () => {
+    render(<DatabaseSchemaPageComponent />);
 
-      const loader = screen.getByText('Loader');
-      const errorPlaceHolder = screen.queryByText('error-placeHolder');
-
-      expect(loader).toBeInTheDocument();
-      expect(errorPlaceHolder).toBeNull();
-    });
-
-    const entityPageInfo = await screen.findByTestId('entityPageInfo');
-    const tabsPane = await screen.findByTestId('tabs');
-
-    expect(entityPageInfo).toBeInTheDocument();
-    expect(tabsPane).toBeInTheDocument();
+    expect(getDatabaseSchemaDetailsByFQN).not.toHaveBeenCalled();
+    expect(getStoredProceduresList).not.toHaveBeenCalled();
   });
 
-  it('Activity Feed List should render properly for "Activity Feeds" tab', async () => {
-    mockParams.tab = 'activity_feed';
-
-    await act(async () => {
-      render(<DatabaseSchemaPageComponent />, {
-        wrapper: MemoryRouter,
-      });
-    });
-
-    const activityFeedList = await screen.findByTestId('ActivityFeedList');
-
-    expect(activityFeedList).toBeInTheDocument();
-  });
-
-  it('ActivityThreadPanel should render properly after clicked on thread panel button', async () => {
-    mockParams.tab = 'table';
-    await act(async () => {
-      render(<DatabaseSchemaPageComponent />, {
-        wrapper: MemoryRouter,
-      });
-    });
-
-    const description = await screen.findByText('Description');
-
-    expect(description).toBeInTheDocument();
-
-    act(() => {
-      fireEvent.click(description);
-    });
-
-    const activityThreadPanel = await screen.findByText('ActivityThreadPanel');
-
-    expect(activityThreadPanel).toBeInTheDocument();
-  });
-
-  it('ErrorPlaceholder should be displayed in case error occurs while fetching database schema details', async () => {
-    (getDatabaseSchemaDetailsByFQN as jest.Mock).mockImplementationOnce(() =>
-      Promise.reject('An error occurred')
-    );
-
-    await act(async () => {
-      render(<DatabaseSchemaPageComponent />, {
-        wrapper: MemoryRouter,
-      });
-    });
-
-    const errorPlaceHolder = await screen.findByTestId('error-placeHolder');
-    const errorMessage = await screen.findByTestId('error-message');
-
-    expect(errorPlaceHolder).toBeInTheDocument();
-    expect(errorMessage).toHaveTextContent('An error occurred');
-  });
-
-  it('ErrorPlaceholder should be shown in case of not viewing permissions', async () => {
+  it('DatabaseSchemaPage should render permission placeholder if not have required permission', async () => {
     (usePermissionProvider as jest.Mock).mockImplementationOnce(() => ({
-      getEntityPermissionByFqn: jest.fn().mockImplementation(() =>
-        Promise.resolve({
-          ...mockEntityPermissions,
-          ViewAll: false,
-          ViewBasic: false,
-        })
-      ),
+      getEntityPermissionByFqn: jest.fn().mockImplementationOnce(() => ({
+        ViewBasic: false,
+      })),
     }));
 
     await act(async () => {
-      render(<DatabaseSchemaPageComponent />, {
-        wrapper: MemoryRouter,
-      });
+      render(<DatabaseSchemaPageComponent />);
     });
 
-    const errorPlaceHolder = await screen.findByTestId('error-placeHolder');
+    expect(await screen.findByText('ErrorPlaceHolder')).toBeInTheDocument();
+  });
 
-    expect(errorPlaceHolder).toBeInTheDocument();
+  it('DatabaseSchemaPage should fetch details with basic fields', async () => {
+    (usePermissionProvider as jest.Mock).mockImplementationOnce(() => ({
+      getEntityPermissionByFqn: jest.fn().mockImplementationOnce(() => ({
+        ViewBasic: true,
+      })),
+    }));
+
+    await act(async () => {
+      render(<DatabaseSchemaPageComponent />);
+    });
+
+    expect(getDatabaseSchemaDetailsByFQN).toHaveBeenCalledWith(
+      mockParams.databaseSchemaFQN,
+      ['owner', 'usageSummary', 'tags'],
+      'include=all'
+    );
+  });
+
+  it('DatabaseSchemaPage should fetch storedProcedure with basic fields', async () => {
+    (usePermissionProvider as jest.Mock).mockImplementationOnce(() => ({
+      getEntityPermissionByFqn: jest.fn().mockImplementationOnce(() => ({
+        ViewBasic: true,
+      })),
+    }));
+
+    await act(async () => {
+      render(<DatabaseSchemaPageComponent />);
+    });
+
+    expect(getStoredProceduresList).toHaveBeenCalledWith({
+      databaseSchema: mockParams.databaseSchemaFQN,
+      fields: 'owner,tags,followers',
+      include: 'non-deleted',
+      limit: 0,
+    });
+  });
+
+  it('DatabaseSchemaPage should render page for ViewBasic permissions', async () => {
+    (usePermissionProvider as jest.Mock).mockImplementationOnce(() => ({
+      getEntityPermissionByFqn: jest.fn().mockImplementationOnce(() => ({
+        ViewBasic: true,
+      })),
+    }));
+
+    await act(async () => {
+      render(<DatabaseSchemaPageComponent />);
+    });
+
+    expect(getDatabaseSchemaDetailsByFQN).toHaveBeenCalledWith(
+      mockParams.databaseSchemaFQN,
+      ['owner', 'usageSummary', 'tags'],
+      'include=all'
+    );
+
+    expect(await screen.findByText('testDataAssetsHeader')).toBeInTheDocument();
+    expect(await screen.findByTestId('tabs')).toBeInTheDocument();
+    expect(await screen.findByText('testSchemaTablesTab')).toBeInTheDocument();
+  });
+
+  it('DatabaseSchemaPage should render tables by default', async () => {
+    (usePermissionProvider as jest.Mock).mockImplementationOnce(() => ({
+      getEntityPermissionByFqn: jest.fn().mockImplementationOnce(() => ({
+        ViewBasic: true,
+      })),
+    }));
+
+    await act(async () => {
+      render(<DatabaseSchemaPageComponent />);
+    });
+
+    expect(getDatabaseSchemaDetailsByFQN).toHaveBeenCalledWith(
+      mockParams.databaseSchemaFQN,
+      ['owner', 'usageSummary', 'tags'],
+      'include=all'
+    );
+
+    expect(await screen.findByText('testSchemaTablesTab')).toBeInTheDocument();
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaPage/mocks/DatabaseSchemaPage.mock.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaPage/mocks/DatabaseSchemaPage.mock.ts
@@ -254,3 +254,109 @@ export const mockEntityPermissions = {
   EditDisplayName: true,
   EditCustomFields: true,
 };
+
+export const mockStoredProcedure = {
+  data: [
+    {
+      id: '5c225b39-0a20-4157-8085-5b22d0beea95',
+      name: 'update_dim_address_table',
+      fullyQualifiedName:
+        'sample_data.ecommerce_db.shopify.update_dim_address_table',
+      description: 'This stored procedure updates dim_address table',
+      storedProcedureCode: {
+        code: 'CREATE OR REPLACE PROCEDURE output_message(message VARCHAR)\nRETURNS VARCHAR NOT NULL\nLANGUAGE SQL\nAS\n$$\nBEGIN\n  RETURN message;\nEND;\n$$\n;',
+      },
+      version: 0.1,
+      updatedAt: 1694001765000,
+      updatedBy: 'admin',
+      href: 'http://localhost:8585/api/v1/storedProcedures/5c225b39-0a20-4157-8085-5b22d0beea95',
+      databaseSchema: {
+        id: '6745cd0c-e9d7-423e-80cc-accc3629811c',
+        type: 'databaseSchema',
+        name: 'shopify',
+        fullyQualifiedName: 'sample_data.ecommerce_db.shopify',
+        description:
+          'This **mock** database contains schema related to shopify sales and orders with related dimension tables.',
+        deleted: false,
+        href: 'http://localhost:8585/api/v1/databaseSchemas/6745cd0c-e9d7-423e-80cc-accc3629811c',
+      },
+      database: {
+        id: 'a5f8e3b5-a23d-4d3c-9fca-ce7449493c5b',
+        type: 'database',
+        name: 'ecommerce_db',
+        fullyQualifiedName: 'sample_data.ecommerce_db',
+        description:
+          'This **mock** database contains schemas related to shopify sales and orders with related dimension tables.',
+        deleted: false,
+        href: 'http://localhost:8585/api/v1/databases/a5f8e3b5-a23d-4d3c-9fca-ce7449493c5b',
+      },
+      service: {
+        id: '7ac73a36-67f0-451e-a042-e91fb24ee6f1',
+        type: 'databaseService',
+        name: 'sample_data',
+        fullyQualifiedName: 'sample_data',
+        deleted: false,
+        href: 'http://localhost:8585/api/v1/services/databaseServices/7ac73a36-67f0-451e-a042-e91fb24ee6f1',
+      },
+      serviceType: 'CustomDatabase',
+      deleted: false,
+      followers: [],
+      tags: [],
+    },
+    {
+      id: '4651cccf-6c8a-49fc-804f-41a81bf6898b',
+      name: 'update_orders_table',
+      fullyQualifiedName:
+        'sample_data.ecommerce_db.shopify.update_orders_table',
+      description:
+        'This stored procedure is written java script to update the orders table',
+      storedProcedureCode: {
+        code: `create or replace procedure read_result_set()\n  returns float not null\n  language javascript\n 
+         as     \n  $$  \n    var my_sql_command = "select * from table1";\n    var statement1 = snowflake.
+         createStatement( {sqlText: my_sql_command} );\n    var result_set1 = statement1.execute();\n    // Loop
+          through the results, processing one row at a time... \n    while (result_set1.next())  {\n     
+              var column1 = result_set1.getColumnValue(1);\n       var column2 = result_set1.getColumnValue(2);\n  
+                   // Do something with the retrieved values...\n       }\n  return 0.0; // Replace with something more useful.\n  $$\n  ;`,
+      },
+      version: 0.1,
+      updatedAt: 1694001765116,
+      updatedBy: 'admin',
+      href: 'http://localhost:8585/api/v1/storedProcedures/4651cccf-6c8a-49fc-804f-41a81bf6898b',
+      databaseSchema: {
+        id: '6745cd0c-e9d7-423e-80cc-accc3629811c',
+        type: 'databaseSchema',
+        name: 'shopify',
+        fullyQualifiedName: 'sample_data.ecommerce_db.shopify',
+        description:
+          'This **mock** database contains schema related to shopify sales and orders with related dimension tables.',
+        deleted: false,
+        href: 'http://localhost:8585/api/v1/databaseSchemas/6745cd0c-e9d7-423e-80cc-accc3629811c',
+      },
+      database: {
+        id: 'a5f8e3b5-a23d-4d3c-9fca-ce7449493c5b',
+        type: 'database',
+        name: 'ecommerce_db',
+        fullyQualifiedName: 'sample_data.ecommerce_db',
+        description:
+          'This **mock** database contains schemas related to shopify sales and orders with related dimension tables.',
+        deleted: false,
+        href: 'http://localhost:8585/api/v1/databases/a5f8e3b5-a23d-4d3c-9fca-ce7449493c5b',
+      },
+      service: {
+        id: '7ac73a36-67f0-451e-a042-e91fb24ee6f1',
+        type: 'databaseService',
+        name: 'sample_data',
+        fullyQualifiedName: 'sample_data',
+        deleted: false,
+        href: 'http://localhost:8585/api/v1/services/databaseServices/7ac73a36-67f0-451e-a042-e91fb24ee6f1',
+      },
+      serviceType: 'CustomDatabase',
+      deleted: false,
+      followers: [],
+      tags: [],
+    },
+  ],
+  paging: {
+    total: 2,
+  },
+};

--- a/openmetadata-ui/src/main/resources/ui/src/rest/storedProceduresAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/storedProceduresAPI.ts
@@ -21,7 +21,7 @@ import { ServicePageData } from 'pages/ServiceDetailsPage/ServiceDetailsPage';
 import { getURLWithQueryFields } from 'utils/APIUtils';
 import APIClient from './index';
 
-interface ListStoredProcedureParams {
+export interface ListStoredProcedureParams {
   databaseSchema?: string;
   fields?: string;
   after?: string;


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #13102

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

- I worked on supporting unit tests for database schema

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
