### PR TITLE
Upgrade: airflow base image from 2.5.3 to 2.6.3

### DIFF
--- a/ingestion/Dockerfile
+++ b/ingestion/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/airflow:2.5.3-python3.9
+FROM apache/airflow:2.6.3-python3.9
 USER root
 RUN curl -sS https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 RUN curl -sS https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list

--- a/ingestion/Dockerfile.ci
+++ b/ingestion/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM apache/airflow:2.5.3-python3.9
+FROM apache/airflow:2.6.3-python3.9
 USER root
 RUN curl -sS https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 RUN curl -sS https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list


### PR DESCRIPTION

Upgrading the airflow base image from 2.5.3 to 2.6.3


