### PR TITLE
fix: move testSuite summary state update to preDelete

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
@@ -405,7 +405,7 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
   }
 
   @Override
-  protected void postDelete(TestCase entity) {
+  protected void preDelete(TestCase entity, String deletedBy) {
     // delete test case from test suite summary when test case is deleted
     // from an executable test suite
     List<TestSuite> testSuites = getTestSuites(entity);


### PR DESCRIPTION
- move update testSuite summary on test case deletion from postDelete to preDelete. In postDelete the relationship does not exists anymore (the test case has been deleted) - hence causing the testSummary to not be updated.