### PR TITLE
fix: use entityLink FQN vs entityFQN when checking against entity FQN…

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertsRuleEvaluator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertsRuleEvaluator.java
@@ -29,6 +29,7 @@ import org.openmetadata.schema.type.FieldChange;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.formatter.util.FormatterUtil;
+import org.openmetadata.service.resources.feeds.MessageParser;
 import org.openmetadata.service.util.JsonUtils;
 
 @Slf4j
@@ -102,7 +103,8 @@ public class AlertsRuleEvaluator {
     }
     EntityInterface entity = getEntity(changeEvent);
     for (String name : entityNames) {
-      if (changeEvent.getEntityType().equals(TEST_CASE) && ((TestCase) entity).getEntityFQN().equals(name)) {
+      if (changeEvent.getEntityType().equals(TEST_CASE)
+          && (MessageParser.EntityLink.parse(((TestCase) entity).getEntityLink()).getEntityFQN().equals(name))) {
         return true;
       }
       if (entity.getFullyQualifiedName().equals(name)) {


### PR DESCRIPTION
### Describe your changes:

Fixes <issue-number>
`entityFQN` will include column name for column test which will evaluate to false when comparing against the FQN to match. Use the entity link and parse the FQN (which will be the table FQN) to compare against the FQN name
