### PR TITLE
chore(ui): removed error toasts for API failures in summary panels

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityInfoDrawer/EntityInfoDrawer.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityInfoDrawer/EntityInfoDrawer.component.tsx
@@ -31,7 +31,6 @@ import { SearchIndex } from 'generated/entity/data/searchIndex';
 import { StoredProcedure } from 'generated/entity/data/storedProcedure';
 import { EntityDetailUnion } from 'Models';
 import React, { useEffect, useMemo, useState } from 'react';
-import { useTranslation } from 'react-i18next';
 import { getDashboardByFqn } from 'rest/dashboardAPI';
 import { getDataModelsByName } from 'rest/dataModelsAPI';
 import { getMlModelByFQN } from 'rest/mlModelAPI';
@@ -53,7 +52,6 @@ import {
 } from '../../../utils/EntityUtils';
 import { getEncodedFqn } from '../../../utils/StringsUtils';
 import { getEntityIcon } from '../../../utils/TableUtils';
-import { showErrorToast } from '../../../utils/ToastUtils';
 import { SelectedNode } from '../EntityLineage/EntityLineage.interface';
 import { LineageDrawerProps } from './EntityInfoDrawer.interface';
 import './EntityInfoDrawer.style.less';
@@ -64,7 +62,6 @@ const EntityInfoDrawer = ({
   selectedNode,
   isMainNode = false,
 }: LineageDrawerProps) => {
-  const { t } = useTranslation();
   const [entityDetail, setEntityDetail] = useState<EntityDetailUnion>(
     {} as EntityDetailUnion
   );
@@ -153,12 +150,6 @@ const EntityInfoDrawer = ({
           break;
       }
       setEntityDetail(response);
-    } catch (error) {
-      showErrorToast(
-        t('server.error-selected-node-name-details', {
-          selectedNodeName: selectedNode.name,
-        })
-      );
     } finally {
       setIsLoading(false);
     }

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/DashboardSummary/DashboardSummary.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/DashboardSummary/DashboardSummary.component.tsx
@@ -12,7 +12,6 @@
  */
 
 import { Col, Divider, Row, Typography } from 'antd';
-import { AxiosError } from 'axios';
 import SummaryTagsDescription from 'components/common/SummaryTagsDescription/SummaryTagsDescription.component';
 import SummaryPanelSkeleton from 'components/Skeleton/SummaryPanelSkeleton/SummaryPanelSkeleton.component';
 import { ExplorePageTabs } from 'enums/Explore.enum';
@@ -28,7 +27,6 @@ import { SummaryEntityType } from '../../../../enums/EntitySummary.enum';
 import { Dashboard } from '../../../../generated/entity/data/dashboard';
 import { fetchCharts } from '../../../../utils/DashboardDetailsUtils';
 import { getFormattedEntityData } from '../../../../utils/EntitySummaryPanelUtils';
-import { showErrorToast } from '../../../../utils/ToastUtils';
 import CommonEntitySummaryInfo from '../CommonEntitySummaryInfo/CommonEntitySummaryInfo';
 import SummaryList from '../SummaryList/SummaryList.component';
 import { BasicEntityInfo } from '../SummaryList/SummaryList.interface';
@@ -60,12 +58,7 @@ function DashboardSummary({
 
       setCharts(updatedCharts);
     } catch (err) {
-      showErrorToast(
-        err as AxiosError,
-        t('server.entity-fetch-error', {
-          entity: t('label.dashboard-detail-plural-lowercase'),
-        })
-      );
+      // Error
     }
   };
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/GlossaryTermSummary/GlossaryTermSummary.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/GlossaryTermSummary/GlossaryTermSummary.component.tsx
@@ -12,7 +12,6 @@
  */
 
 import { Col, Divider, Row, Space, Typography } from 'antd';
-import { AxiosError } from 'axios';
 import { OwnerLabel } from 'components/common/OwnerLabel/OwnerLabel.component';
 import SummaryPanelSkeleton from 'components/Skeleton/SummaryPanelSkeleton/SummaryPanelSkeleton.component';
 import TagButton from 'components/TagButton/TagButton.component';
@@ -22,7 +21,6 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getGlossaryTermByFQN } from 'rest/glossaryAPI';
 import { getFormattedEntityData } from 'utils/EntitySummaryPanelUtils';
-import { showErrorToast } from 'utils/ToastUtils';
 import SummaryList from '../SummaryList/SummaryList.component';
 import { BasicEntityInfo } from '../SummaryList/SummaryList.interface';
 import { GlossaryTermSummaryProps } from './GlossaryTermSummary.interface';
@@ -38,7 +36,7 @@ function GlossaryTermSummary({
     if (selectedData?.children) {
       return getFormattedEntityData(
         SummaryEntityType.COLUMN,
-        (selectedData as GlossaryTerm).children
+        selectedData.children
       );
     } else {
       return [];
@@ -46,14 +44,11 @@ function GlossaryTermSummary({
   }, [selectedData]);
 
   const reviewers = useMemo(
-    () => (entityDetails as GlossaryTerm).reviewers || [],
+    () => entityDetails.reviewers ?? [],
     [selectedData]
   );
 
-  const synonyms = useMemo(
-    () => (entityDetails as GlossaryTerm).synonyms || [],
-    [selectedData]
-  );
+  const synonyms = useMemo(() => entityDetails.synonyms ?? [], [selectedData]);
 
   const fetchGlossaryTermDetails = useCallback(async () => {
     try {
@@ -63,7 +58,7 @@ function GlossaryTermSummary({
       );
       setSelectedData(response);
     } catch (error) {
-      showErrorToast(error as AxiosError);
+      // Error
     }
   }, [entityDetails.fullyQualifiedName, setSelectedData]);
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/TableSummary/TableSummary.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/TableSummary/TableSummary.component.tsx
@@ -12,7 +12,6 @@
  */
 
 import { Col, Divider, Row, Typography } from 'antd';
-import { AxiosError } from 'axios';
 import SummaryTagsDescription from 'components/common/SummaryTagsDescription/SummaryTagsDescription.component';
 import { usePermissionProvider } from 'components/PermissionProvider/PermissionProvider';
 import {
@@ -21,7 +20,6 @@ import {
 } from 'components/PermissionProvider/PermissionProvider.interface';
 import SummaryPanelSkeleton from 'components/Skeleton/SummaryPanelSkeleton/SummaryPanelSkeleton.component';
 import { mockTablePermission } from 'constants/mockTourData.constants';
-import { ClientErrors } from 'enums/axios.enum';
 import { ExplorePageTabs } from 'enums/Explore.enum';
 import { isEmpty, isUndefined } from 'lodash';
 import {
@@ -47,7 +45,6 @@ import { SummaryEntityType } from '../../../../enums/EntitySummary.enum';
 import { Table, TestSummary } from '../../../../generated/entity/data/table';
 import { formTwoDigitNmber as formTwoDigitNumber } from '../../../../utils/CommonUtils';
 import { getFormattedEntityData } from '../../../../utils/EntitySummaryPanelUtils';
-import { showErrorToast } from '../../../../utils/ToastUtils';
 import CommonEntitySummaryInfo from '../CommonEntitySummaryInfo/CommonEntitySummaryInfo';
 import SummaryList from '../SummaryList/SummaryList.component';
 import { BasicEntityInfo } from '../SummaryList/SummaryList.interface';
@@ -88,7 +85,7 @@ function TableSummary({
         setTestSuiteSummary(res?.testSuite?.summary);
       }
     } catch (error) {
-      showErrorToast(error as AxiosError);
+      // Error
     }
   };
 
@@ -108,15 +105,7 @@ function TableSummary({
         }
       });
     } catch (error) {
-      const axiosError = error as AxiosError;
-      if (axiosError.response?.status !== ClientErrors.FORBIDDEN) {
-        showErrorToast(
-          t('server.entity-details-fetch-error', {
-            entityType: t('label.table-lowercase'),
-            entityName: entityDetails.name,
-          })
-        );
-      }
+      // Error
     }
   }, [entityDetails]);
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/TagsSummary/TagsSummary.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/TagsSummary/TagsSummary.component.tsx
@@ -12,7 +12,6 @@
  */
 
 import { Col, Row, Typography } from 'antd';
-import { AxiosError } from 'axios';
 import TableDataCardV2 from 'components/common/table-data-card-v2/TableDataCardV2';
 import { EntityUnion } from 'components/Explore/explore.interface';
 import { SourceType } from 'components/searched-data/SearchedData.interface';
@@ -21,7 +20,6 @@ import { SearchIndex } from 'enums/search.enum';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { searchData } from 'rest/miscAPI';
-import { showErrorToast } from 'utils/ToastUtils';
 import { TagsSummaryProps } from './TagsSummary.interface';
 
 function TagsSummary({ entityDetails, isLoading }: TagsSummaryProps) {
@@ -45,7 +43,7 @@ function TagsSummary({ entityDetails, isLoading }: TagsSummaryProps) {
       const sources = res.data.hits.hits.map((hit) => hit._source);
       setSelectedData(sources);
     } catch (error) {
-      showErrorToast(error as AxiosError);
+      // Error
     }
   }, [entityDetails.fullyQualifiedName, setSelectedData]);
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/TopicSummary/TopicSummary.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/TopicSummary/TopicSummary.component.tsx
@@ -12,11 +12,9 @@
  */
 
 import { Col, Divider, Row, Typography } from 'antd';
-import { AxiosError } from 'axios';
 import SummaryTagsDescription from 'components/common/SummaryTagsDescription/SummaryTagsDescription.component';
 import SummaryPanelSkeleton from 'components/Skeleton/SummaryPanelSkeleton/SummaryPanelSkeleton.component';
 import { getTeamAndUserDetailsPath } from 'constants/constants';
-import { ClientErrors } from 'enums/axios.enum';
 import { isArray, isEmpty } from 'lodash';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -26,7 +24,6 @@ import {
   DRAWER_NAVIGATION_OPTIONS,
   getOwnerNameWithProfilePic,
 } from 'utils/EntityUtils';
-import { showErrorToast } from 'utils/ToastUtils';
 import { SummaryEntityType } from '../../../../enums/EntitySummary.enum';
 import { TagLabel, Topic } from '../../../../generated/entity/data/topic';
 import { getFormattedEntityData } from '../../../../utils/EntitySummaryPanelUtils';
@@ -73,12 +70,12 @@ function TopicSummary({
 
     return {
       value:
-        getOwnerNameWithProfilePic(owner) ||
+        getOwnerNameWithProfilePic(owner) ??
         t('label.no-entity', {
           entity: t('label.owner'),
         }),
-      url: getTeamAndUserDetailsPath(owner?.name || ''),
-      isLink: owner?.name ? true : false,
+      url: getTeamAndUserDetailsPath(owner?.name ?? ''),
+      isLink: !isEmpty(owner?.name),
     };
   }, [entityDetails, topicDetails]);
 
@@ -93,15 +90,7 @@ function TopicSummary({
 
       setTopicDetails({ ...entityDetails, partitions, messageSchema });
     } catch (error) {
-      const axiosError = error as AxiosError;
-      if (axiosError.response?.status !== ClientErrors.FORBIDDEN) {
-        showErrorToast(
-          t('server.entity-details-fetch-error', {
-            entityType: t('label.topic-lowercase'),
-            entityName: entityDetails.name,
-          })
-        );
-      }
+      // Error
     }
   }, [entityDetails]);
 

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityUtils.tsx
@@ -586,22 +586,19 @@ const getDataModelOverview = (dataModelDetails: DashboardDataModel) => {
     dataModelType,
     fullyQualifiedName,
   } = dataModelDetails;
-  const tier = getTierFromTableTags(tags || []);
+  const tier = getTierFromTableTags(tags ?? []);
 
   const overview = [
     {
       name: i18next.t('label.owner'),
       value:
-        getOwnerNameWithProfilePic(owner) ||
+        getOwnerNameWithProfilePic(owner) ??
         i18next.t('label.no-entity', {
           entity: i18next.t('label.owner'),
         }),
       url: getOwnerValue(owner as EntityReference),
-      isLink: owner?.name ? true : false,
-      visible: [
-        DRAWER_NAVIGATION_OPTIONS.lineage,
-        DRAWER_NAVIGATION_OPTIONS.explore,
-      ],
+      isLink: !isEmpty(owner?.name),
+      visible: [DRAWER_NAVIGATION_OPTIONS.lineage],
     },
     {
       name: `${i18next.t('label.data-model')} ${i18next.t(
@@ -666,22 +663,19 @@ const getStoredProcedureOverview = (
     FQN_SEPARATOR_CHAR
   ).split(FQN_SEPARATOR_CHAR);
 
-  const tier = getTierFromTableTags(tags || []);
+  const tier = getTierFromTableTags(tags ?? []);
 
   const overview = [
     {
       name: i18next.t('label.owner'),
       value:
-        getOwnerNameWithProfilePic(owner) ||
+        getOwnerNameWithProfilePic(owner) ??
         i18next.t('label.no-entity', {
           entity: i18next.t('label.owner'),
         }),
       url: getOwnerValue(owner as EntityReference),
-      isLink: owner?.name ? true : false,
-      visible: [
-        DRAWER_NAVIGATION_OPTIONS.lineage,
-        DRAWER_NAVIGATION_OPTIONS.explore,
-      ],
+      isLink: !isEmpty(owner?.name),
+      visible: [DRAWER_NAVIGATION_OPTIONS.lineage],
     },
     {
       name: i18next.t('label.service'),


### PR DESCRIPTION
I worked on removing the error toasts for API failures in the summary panels

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
