### PR TITLE
Separate initialization of Repository and Resources

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/Entity.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/Entity.java
@@ -287,8 +287,14 @@ public final class Entity {
 
   public static void registerResourcePermissions(String entity, List<MetadataOperation> entitySpecificOperations) {
     // Set up entity operations for permissions
-    Class<? extends EntityInterface> clazz = getEntityClassFromType(entity);
+    Class<?> clazz = getEntityClassFromType(entity);
     ResourceRegistry.addResource(entity, entitySpecificOperations, getEntityFields(clazz));
+  }
+
+  public static void registerTimeSeriesResourcePermissions(String entity) {
+    // Set up entity operations for permissions
+    Class<?> clazz = getEntityTimeSeriesClassFromType(entity);
+    ResourceRegistry.addResource(entity, null, getEntityFields(clazz));
   }
 
   public static List<String> getEntityList() {
@@ -439,6 +445,10 @@ public final class Entity {
 
   public static Class<? extends EntityInterface> getEntityClassFromType(String entityType) {
     return EntityInterface.ENTITY_TYPE_TO_CLASS_MAP.get(entityType.toLowerCase(Locale.ROOT));
+  }
+
+  public static Class<? extends EntityTimeSeriesInterface> getEntityTimeSeriesClassFromType(String entityType) {
+    return EntityTimeSeriesInterface.ENTITY_TYPE_TO_CLASS_MAP.get(entityType.toLowerCase(Locale.ROOT));
   }
 
   /**

--- a/openmetadata-service/src/main/java/org/openmetadata/service/Entity.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/Entity.java
@@ -62,6 +62,7 @@ import org.reflections.Reflections;
 @Slf4j
 public final class Entity {
   private static volatile boolean initializedRepositories = false;
+  @Getter private static volatile CollectionDAO collectionDAO;
   public static final String SEPARATOR = "."; // Fully qualified name separator
 
   // Canonical entity name to corresponding EntityRepository map
@@ -238,6 +239,7 @@ public final class Entity {
 
   public static void initializeRepositories(CollectionDAO collectionDAO) {
     if (!initializedRepositories) {
+      Entity.collectionDAO = collectionDAO;
       tokenRepository = new TokenRepository(collectionDAO);
       // Check Collection DAO
       Objects.requireNonNull(collectionDAO, "CollectionDAO must not be null");

--- a/openmetadata-service/src/main/java/org/openmetadata/service/Entity.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/Entity.java
@@ -17,6 +17,7 @@ import static org.openmetadata.common.utils.CommonUtil.listOf;
 import static org.openmetadata.common.utils.CommonUtil.listOrEmpty;
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.lang.reflect.Modifier;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -27,6 +28,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import javax.ws.rs.core.UriInfo;
@@ -44,32 +46,35 @@ import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.service.exception.CatalogExceptionMessage;
 import org.openmetadata.service.exception.EntityNotFoundException;
 import org.openmetadata.service.jdbi3.ChangeEventRepository;
+import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.EntityRepository;
 import org.openmetadata.service.jdbi3.EntityTimeSeriesRepository;
 import org.openmetadata.service.jdbi3.FeedRepository;
 import org.openmetadata.service.jdbi3.LineageRepository;
+import org.openmetadata.service.jdbi3.Repository;
 import org.openmetadata.service.jdbi3.SystemRepository;
 import org.openmetadata.service.jdbi3.TokenRepository;
 import org.openmetadata.service.jdbi3.UsageRepository;
 import org.openmetadata.service.resources.feeds.MessageParser.EntityLink;
 import org.openmetadata.service.util.EntityUtil.Fields;
+import org.reflections.Reflections;
 
 @Slf4j
 public final class Entity {
-  // Fully qualified name separator
-  public static final String SEPARATOR = ".";
+  private static volatile boolean initializedRepositories = false;
+  public static final String SEPARATOR = "."; // Fully qualified name separator
 
   // Canonical entity name to corresponding EntityRepository map
   private static final Map<String, EntityRepository<? extends EntityInterface>> ENTITY_REPOSITORY_MAP = new HashMap<>();
   private static final Map<String, EntityTimeSeriesRepository<? extends EntityTimeSeriesInterface>>
       ENTITY_TS_REPOSITORY_MAP = new HashMap<>();
 
+  @Getter @Setter private static TokenRepository tokenRepository;
   @Getter @Setter private static FeedRepository feedRepository;
   @Getter @Setter private static LineageRepository lineageRepository;
   @Getter @Setter private static UsageRepository usageRepository;
   @Getter @Setter private static SystemRepository systemRepository;
   @Getter @Setter private static ChangeEventRepository changeEventRepository;
-  @Getter @Setter private static TokenRepository tokenRepository;
 
   // List of all the entities
   private static final List<String> ENTITY_LIST = new ArrayList<>();
@@ -231,6 +236,31 @@ public final class Entity {
 
   private Entity() {}
 
+  public static void initializeRepositories(CollectionDAO collectionDAO) {
+    if (!initializedRepositories) {
+      tokenRepository = new TokenRepository(collectionDAO);
+      // Check Collection DAO
+      Objects.requireNonNull(collectionDAO, "CollectionDAO must not be null");
+      Set<Class<?>> repositories = getRepositories();
+      for (Class<?> clz : repositories) {
+        if (Modifier.isAbstract(clz.getModifiers())) {
+          continue; // Don't instantiate abstract classes
+        }
+        try {
+          clz.getDeclaredConstructor(CollectionDAO.class).newInstance(collectionDAO);
+        } catch (Exception e) {
+          LOG.warn("Exception encountered", e);
+        }
+      }
+      initializedRepositories = true;
+    }
+  }
+
+  public static void cleanup() {
+    initializedRepositories = false;
+    ENTITY_REPOSITORY_MAP.clear();
+  }
+
   public static <T extends EntityInterface> void registerEntity(
       Class<T> clazz, String entity, EntityRepository<T> entityRepository) {
     ENTITY_REPOSITORY_MAP.put(entity, entityRepository);
@@ -253,8 +283,7 @@ public final class Entity {
     LOG.info("Registering entity time series {} {}", clazz, entity);
   }
 
-  public static <T extends EntityTimeSeriesInterface> void registerResourcePermissions(
-      String entity, List<MetadataOperation> entitySpecificOperations) {
+  public static void registerResourcePermissions(String entity, List<MetadataOperation> entitySpecificOperations) {
     // Set up entity operations for permissions
     Class<? extends EntityInterface> clazz = getEntityClassFromType(entity);
     ResourceRegistry.addResource(entity, entitySpecificOperations, getEntityFields(clazz));
@@ -465,5 +494,12 @@ public final class Entity {
         }
       }
     }
+  }
+
+  /** Compile a list of REST collections based on Resource classes marked with {@code Repository} annotation */
+  private static Set<Class<?>> getRepositories() {
+    // Get classes marked with @Repository annotation
+    Reflections reflections = new Reflections("org.openmetadata.service.jdbi3");
+    return reflections.getTypesAnnotatedWith(Repository.class);
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/OpenMetadataApplication.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/OpenMetadataApplication.java
@@ -52,6 +52,7 @@ import javax.servlet.ServletRegistration;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.core.Response;
+import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -130,6 +131,7 @@ import org.quartz.SchedulerException;
 public class OpenMetadataApplication extends Application<OpenMetadataApplicationConfig> {
   private Authorizer authorizer;
   private AuthenticatorHandler authenticatorHandler;
+  @Getter private static CollectionDAO collectionDAO;
 
   @Override
   public void run(OpenMetadataApplicationConfig catalogConfig, Environment environment)
@@ -144,7 +146,7 @@ public class OpenMetadataApplication extends Application<OpenMetadataApplication
     ChangeEventConfig.initialize(catalogConfig);
     final Jdbi jdbi = createAndSetupJDBI(environment, catalogConfig.getDataSourceFactory());
     JdbiUnitOfWorkProvider jdbiUnitOfWorkProvider = JdbiUnitOfWorkProvider.withDefault(jdbi);
-    CollectionDAO daoObject = (CollectionDAO) getWrappedInstanceForDaoClass(CollectionDAO.class);
+    collectionDAO = (CollectionDAO) getWrappedInstanceForDaoClass(CollectionDAO.class);
     JdbiTransactionManager.initialize(jdbiUnitOfWorkProvider.getHandleManager());
     environment.jersey().register(new JdbiUnitOfWorkApplicationEventListener(new HashSet<>()));
 
@@ -152,7 +154,7 @@ public class OpenMetadataApplication extends Application<OpenMetadataApplication
     Fernet.getInstance().setFernetKey(catalogConfig);
 
     // Init Settings Cache
-    SettingsCache.initialize(daoObject, catalogConfig);
+    SettingsCache.initialize(catalogConfig);
 
     // init Secret Manager
     final SecretsManager secretsManager =
@@ -196,23 +198,23 @@ public class OpenMetadataApplication extends Application<OpenMetadataApplication
     // start event hub before registering publishers
     EventPubSub.start();
 
-    registerResources(catalogConfig, environment, jdbi, jdbiUnitOfWorkProvider, daoObject);
+    registerResources(catalogConfig, environment, jdbi, jdbiUnitOfWorkProvider, collectionDAO);
 
     // Register Event Handler
     registerEventFilter(catalogConfig, environment, jdbiUnitOfWorkProvider);
     environment.lifecycle().manage(new ManagedShutdown());
     // Register Event publishers
-    registerEventPublisher(catalogConfig, daoObject);
+    registerEventPublisher(catalogConfig);
 
     // update entities secrets if required
     new SecretsManagerUpdateService(secretsManager, catalogConfig.getClusterName()).updateEntities();
 
     // start authorizer after event publishers
     // authorizer creates admin/bot users, ES publisher should start before to index users created by authorizer
-    authorizer.init(catalogConfig, daoObject);
+    authorizer.init(catalogConfig, collectionDAO);
 
     // authenticationHandler Handles auth related activities
-    authenticatorHandler.init(catalogConfig, daoObject);
+    authenticatorHandler.init(catalogConfig, collectionDAO);
 
     webAnalyticEvents = MicrometerBundleSingleton.latencyTimer(catalogConfig.getEventMonitorConfiguration());
     FilterRegistration.Dynamic micrometerFilter =
@@ -430,12 +432,11 @@ public class OpenMetadataApplication extends Application<OpenMetadataApplication
     }
   }
 
-  private void registerEventPublisher(
-      OpenMetadataApplicationConfig openMetadataApplicationConfig, CollectionDAO daoObject) {
+  private void registerEventPublisher(OpenMetadataApplicationConfig openMetadataApplicationConfig) {
     // register ElasticSearch Event publisher
     if (openMetadataApplicationConfig.getElasticSearchConfiguration() != null) {
       SearchEventPublisher searchEventPublisher =
-          new SearchEventPublisher(openMetadataApplicationConfig.getElasticSearchConfiguration(), daoObject);
+          new SearchEventPublisher(openMetadataApplicationConfig.getElasticSearchConfiguration(), collectionDAO);
       EventPubSub.addEventHandler(searchEventPublisher);
     }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/events/scheduled/ReportsHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/events/scheduled/ReportsHandler.java
@@ -26,6 +26,7 @@ import javax.ws.rs.core.Response;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.entity.events.EventSubscription;
 import org.openmetadata.schema.entity.events.TriggerConfig;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.DataInsightJobException;
 import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.DataInsightChartRepository;
@@ -56,7 +57,7 @@ public class ReportsHandler {
 
   private ReportsHandler(CollectionDAO dao, SearchRepository searchRepository) throws SchedulerException {
     this.searchRepository = searchRepository;
-    this.chartRepository = new DataInsightChartRepository(dao);
+    this.chartRepository = (DataInsightChartRepository) Entity.getEntityRepository(Entity.DATA_INSIGHT_CHART);
     this.reportScheduler.start();
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/events/scheduled/ReportsHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/events/scheduled/ReportsHandler.java
@@ -28,7 +28,6 @@ import org.openmetadata.schema.entity.events.EventSubscription;
 import org.openmetadata.schema.entity.events.TriggerConfig;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.DataInsightJobException;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.DataInsightChartRepository;
 import org.openmetadata.service.search.SearchRepository;
 import org.quartz.JobBuilder;
@@ -55,7 +54,7 @@ public class ReportsHandler {
   private final Scheduler reportScheduler = new StdSchedulerFactory().getScheduler();
   private static final ConcurrentHashMap<UUID, JobDetail> reportJobKeyMap = new ConcurrentHashMap<>();
 
-  private ReportsHandler(CollectionDAO dao, SearchRepository searchRepository) throws SchedulerException {
+  private ReportsHandler(SearchRepository searchRepository) throws SchedulerException {
     this.searchRepository = searchRepository;
     this.chartRepository = (DataInsightChartRepository) Entity.getEntityRepository(Entity.DATA_INSIGHT_CHART);
     this.reportScheduler.start();
@@ -70,9 +69,9 @@ public class ReportsHandler {
     return reportJobKeyMap;
   }
 
-  public static void initialize(CollectionDAO dao, SearchRepository searchRepository) throws SchedulerException {
+  public static void initialize(SearchRepository searchRepository) throws SchedulerException {
     if (!initialized) {
-      instance = new ReportsHandler(dao, searchRepository);
+      instance = new ReportsHandler(searchRepository);
       initialized = true;
     } else {
       LOG.info("Reindexing Handler is already initialized");

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/BotRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/BotRepository.java
@@ -25,7 +25,6 @@ import org.openmetadata.service.util.EntityUtil.Fields;
 
 @Slf4j
 public class BotRepository extends EntityRepository<Bot> {
-
   static final String BOT_UPDATE_FIELDS = "botUser";
 
   public BotRepository(CollectionDAO dao) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ChangeEventRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ChangeEventRepository.java
@@ -20,13 +20,16 @@ import java.util.ArrayList;
 import java.util.List;
 import org.jdbi.v3.sqlobject.transaction.Transaction;
 import org.openmetadata.schema.type.ChangeEvent;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.util.JsonUtils;
 
+@Repository
 public class ChangeEventRepository {
   private final CollectionDAO.ChangeEventDAO dao;
 
   public ChangeEventRepository(CollectionDAO dao) {
     this.dao = dao.changeEventDAO();
+    Entity.setChangeEventRepository(this);
   }
 
   public List<ChangeEvent> list(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ChangeEventRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ChangeEventRepository.java
@@ -15,7 +15,6 @@ package org.openmetadata.service.jdbi3;
 
 import static org.openmetadata.schema.type.EventType.*;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.jdbi.v3.sqlobject.transaction.Transaction;
@@ -37,8 +36,7 @@ public class ChangeEventRepository {
       List<String> entityCreatedList,
       List<String> entityUpdatedList,
       List<String> entityRestoredList,
-      List<String> entityDeletedList)
-      throws IOException {
+      List<String> entityDeletedList) {
     List<String> jsons = new ArrayList<>();
     jsons.addAll(dao.list(ENTITY_CREATED.value(), entityCreatedList, timestamp));
     jsons.addAll(dao.list(ENTITY_UPDATED.value(), entityUpdatedList, timestamp));

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DashboardServiceRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DashboardServiceRepository.java
@@ -30,6 +30,7 @@ public class DashboardServiceRepository extends ServiceEntityRepository<Dashboar
         dao,
         dao.dashboardServiceDAO(),
         DashboardConnection.class,
+        "",
         ServiceType.DASHBOARD);
     supportsSearch = true;
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DatabaseServiceRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DatabaseServiceRepository.java
@@ -29,6 +29,7 @@ public class DatabaseServiceRepository extends ServiceEntityRepository<DatabaseS
         dao,
         dao.dbServiceDAO(),
         DatabaseConnection.class,
+        "",
         ServiceType.DATABASE);
     supportsSearch = true;
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityTimeSeriesDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityTimeSeriesDAO.java
@@ -292,14 +292,10 @@ public interface EntityTimeSeriesDAO {
       @Bind("extension") String extension,
       @Bind("startTs") Long startTs,
       @Bind("endTs") long endTs,
-      @Define("orderBy") CollectionDAO.EntityExtensionTimeSeriesDAO.OrderBy orderBy);
+      @Define("orderBy") OrderBy orderBy);
 
   default List<String> listBetweenTimestampsByOrder(
-      String entityFQNHash,
-      String extension,
-      Long startTs,
-      long endTs,
-      CollectionDAO.EntityExtensionTimeSeriesDAO.OrderBy orderBy) {
+      String entityFQNHash, String extension, Long startTs, long endTs, OrderBy orderBy) {
     return listBetweenTimestampsByOrder(getTimeSeriesTableName(), entityFQNHash, extension, startTs, endTs, orderBy);
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityTimeSeriesRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityTimeSeriesRepository.java
@@ -5,9 +5,11 @@ import static org.openmetadata.service.resources.EntityResource.searchRepository
 import java.util.UUID;
 import lombok.Getter;
 import org.openmetadata.schema.EntityTimeSeriesInterface;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.util.JsonUtils;
 
-public class EntityTimeSeriesRepository<T extends EntityTimeSeriesInterface> {
+@Repository
+public abstract class EntityTimeSeriesRepository<T extends EntityTimeSeriesInterface> {
   @Getter protected final String collectionPath;
   @Getter protected final EntityTimeSeriesDAO timeSeriesDao;
   @Getter protected final CollectionDAO daoCollection;
@@ -27,6 +29,7 @@ public class EntityTimeSeriesRepository<T extends EntityTimeSeriesInterface> {
     this.daoCollection = daoCollection;
     this.entityClass = entityClass;
     this.entityType = entityType;
+    Entity.registerEntity(entityClass, entityType, this);
   }
 
   public T createNewRecord(T record, String extension, String recordFQN) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/FeedRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/FeedRepository.java
@@ -101,12 +101,14 @@ import org.openmetadata.service.util.ResultList;
  * - 'thread' --- isAbout ---> 'entity' in entity_relationship
  */
 @Slf4j
+@Repository
 public class FeedRepository {
   private final CollectionDAO dao;
   private static final MessageDecorator<FeedMessage> FEED_MESSAGE_FORMATTER = new FeedMessageDecorator();
 
   public FeedRepository(CollectionDAO dao) {
     this.dao = dao;
+    Entity.setFeedRepository(this);
     ResourceRegistry.addResource("feed", null, Entity.getEntityFields(Thread.class));
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/KpiRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/KpiRepository.java
@@ -23,6 +23,7 @@ import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.Relationship;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.EntityNotFoundException;
+import org.openmetadata.service.jdbi3.EntityTimeSeriesDAO.OrderBy;
 import org.openmetadata.service.resources.kpi.KpiResource;
 import org.openmetadata.service.util.EntityUtil;
 import org.openmetadata.service.util.JsonUtils;
@@ -151,8 +152,7 @@ public class KpiRepository extends EntityRepository<Kpi> {
     return JsonUtils.readValue(getLatestExtensionFromTimeseries(fqn, KPI_RESULT_EXTENSION), KpiResult.class);
   }
 
-  public ResultList<KpiResult> getKpiResults(
-      String fqn, Long startTs, Long endTs, CollectionDAO.EntityExtensionTimeSeriesDAO.OrderBy orderBy) {
+  public ResultList<KpiResult> getKpiResults(String fqn, Long startTs, Long endTs, OrderBy orderBy) {
     List<KpiResult> kpiResults;
     kpiResults =
         JsonUtils.readObjects(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/LineageRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/LineageRepository.java
@@ -32,11 +32,13 @@ import org.openmetadata.service.jdbi3.CollectionDAO.EntityRelationshipRecord;
 import org.openmetadata.service.util.FullyQualifiedName;
 import org.openmetadata.service.util.JsonUtils;
 
+@Repository
 public class LineageRepository {
   private final CollectionDAO dao;
 
   public LineageRepository(CollectionDAO dao) {
     this.dao = dao;
+    Entity.setLineageRepository(this);
   }
 
   public EntityLineage get(String entityType, String id, int upstreamDepth, int downstreamDepth) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ListFilter.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ListFilter.java
@@ -117,8 +117,8 @@ public class ListFilter {
 
   public String getDisabledCondition(String tableName, String disabledStr) {
     boolean disabled = Boolean.parseBoolean(disabledStr);
-    String disabledCondition;
-    if (Boolean.TRUE.equals(DatasourceConfig.getInstance().isMySQL())) {
+    String disabledCondition = "";
+    if (DatasourceConfig.getInstance().isMySQL()) {
       if (disabled) {
         disabledCondition = "JSON_EXTRACT(json, '$.disabled') = TRUE";
       } else {
@@ -187,12 +187,12 @@ public class ListFilter {
 
     switch (testSuiteType) {
       case ("executable"):
-        if (Boolean.TRUE.equals(DatasourceConfig.getInstance().isMySQL())) {
+        if (DatasourceConfig.getInstance().isMySQL()) {
           return "(JSON_UNQUOTE(JSON_EXTRACT(json, '$.executable')) = 'true')";
         }
         return "(json->>'executable' = 'true')";
       case ("logical"):
-        if (Boolean.TRUE.equals(DatasourceConfig.getInstance().isMySQL())) {
+        if (DatasourceConfig.getInstance().isMySQL()) {
           return "(JSON_UNQUOTE(JSON_EXTRACT(json, '$.executable')) = 'false' OR JSON_UNQUOTE(JSON_EXTRACT(json, '$.executable')) IS NULL)";
         }
         return "(json->>'executable' = 'false' or json -> 'executable' is null)";
@@ -218,7 +218,7 @@ public class ListFilter {
   private String getPipelineTypePrefixCondition(String tableName, String pipelineType) {
     pipelineType = escape(pipelineType);
     String inCondition = getInConditionFromString(pipelineType);
-    if (Boolean.TRUE.equals(DatasourceConfig.getInstance().isMySQL())) {
+    if (DatasourceConfig.getInstance().isMySQL()) {
       return tableName == null
           ? String.format(
               "JSON_UNQUOTE(JSON_EXTRACT(ingestion_pipeline_entity.json, '$.pipelineType')) IN (%s)", inCondition)
@@ -279,6 +279,6 @@ public class ListFilter {
     // "'" is used for indicated start and end of the string. Use "''" to escape it.
     name = escapeApostrophe(name);
     // "_" is a wildcard and looks for any single character. Add "\\" in front of it to escape it
-    return name.replace("_", "\\\\_");
+    return name.replaceAll("_", "\\\\_");
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ListFilter.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ListFilter.java
@@ -117,8 +117,8 @@ public class ListFilter {
 
   public String getDisabledCondition(String tableName, String disabledStr) {
     boolean disabled = Boolean.parseBoolean(disabledStr);
-    String disabledCondition = "";
-    if (DatasourceConfig.getInstance().isMySQL()) {
+    String disabledCondition;
+    if (Boolean.TRUE.equals(DatasourceConfig.getInstance().isMySQL())) {
       if (disabled) {
         disabledCondition = "JSON_EXTRACT(json, '$.disabled') = TRUE";
       } else {
@@ -187,12 +187,12 @@ public class ListFilter {
 
     switch (testSuiteType) {
       case ("executable"):
-        if (DatasourceConfig.getInstance().isMySQL()) {
+        if (Boolean.TRUE.equals(DatasourceConfig.getInstance().isMySQL())) {
           return "(JSON_UNQUOTE(JSON_EXTRACT(json, '$.executable')) = 'true')";
         }
         return "(json->>'executable' = 'true')";
       case ("logical"):
-        if (DatasourceConfig.getInstance().isMySQL()) {
+        if (Boolean.TRUE.equals(DatasourceConfig.getInstance().isMySQL())) {
           return "(JSON_UNQUOTE(JSON_EXTRACT(json, '$.executable')) = 'false' OR JSON_UNQUOTE(JSON_EXTRACT(json, '$.executable')) IS NULL)";
         }
         return "(json->>'executable' = 'false' or json -> 'executable' is null)";
@@ -218,7 +218,7 @@ public class ListFilter {
   private String getPipelineTypePrefixCondition(String tableName, String pipelineType) {
     pipelineType = escape(pipelineType);
     String inCondition = getInConditionFromString(pipelineType);
-    if (DatasourceConfig.getInstance().isMySQL()) {
+    if (Boolean.TRUE.equals(DatasourceConfig.getInstance().isMySQL())) {
       return tableName == null
           ? String.format(
               "JSON_UNQUOTE(JSON_EXTRACT(ingestion_pipeline_entity.json, '$.pipelineType')) IN (%s)", inCondition)
@@ -279,6 +279,6 @@ public class ListFilter {
     // "'" is used for indicated start and end of the string. Use "''" to escape it.
     name = escapeApostrophe(name);
     // "_" is a wildcard and looks for any single character. Add "\\" in front of it to escape it
-    return name.replaceAll("_", "\\\\_");
+    return name.replace("_", "\\\\_");
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/PipelineServiceRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/PipelineServiceRepository.java
@@ -30,6 +30,7 @@ public class PipelineServiceRepository extends ServiceEntityRepository<PipelineS
         dao,
         dao.pipelineServiceDAO(),
         PipelineConnection.class,
+        "",
         ServiceType.PIPELINE);
     supportsSearch = true;
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/QueryRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/QueryRepository.java
@@ -29,8 +29,6 @@ import org.openmetadata.service.util.RestUtil;
 public class QueryRepository extends EntityRepository<Query> {
   private static final String QUERY_USED_IN_FIELD = "queryUsedIn";
   private static final String QUERY_USERS_FIELD = "users";
-
-  private static final String QUERY_USED_BY_FIELD = "usedBy";
   private static final String QUERY_PATCH_FIELDS = "users,query,queryUsedIn,processedLineage";
   private static final String QUERY_UPDATE_FIELDS = "users,queryUsedIn,processedLineage";
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ReportDataRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ReportDataRepository.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import org.openmetadata.schema.analytics.ReportData;
 import org.openmetadata.schema.analytics.ReportData.ReportDataType;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.util.JsonUtils;
 import org.openmetadata.service.util.ResultList;
 
@@ -14,7 +15,12 @@ public class ReportDataRepository extends EntityTimeSeriesRepository<ReportData>
   public static final String REPORT_DATA_EXTENSION = "reportData.reportDataResult";
 
   public ReportDataRepository(CollectionDAO daoCollection) {
-    super(COLLECTION_PATH, daoCollection, daoCollection.reportDataTimeSeriesDao(), ReportData.class, "reportData");
+    super(
+        COLLECTION_PATH,
+        daoCollection,
+        daoCollection.reportDataTimeSeriesDao(),
+        ReportData.class,
+        Entity.ENTITY_REPORT_DATA);
   }
 
   public ResultList<ReportData> getReportData(ReportDataType reportDataType, Long startTs, Long endTs) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/Repository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/Repository.java
@@ -1,0 +1,12 @@
+package org.openmetadata.service.jdbi3;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.CONSTRUCTOR})
+public @interface Repository {}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/Repository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/Repository.java
@@ -9,4 +9,7 @@ import java.lang.annotation.Target;
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.CONSTRUCTOR})
-public @interface Repository {}
+public @interface Repository {
+  /** Order of initialization of repository starting from 0. Only order from 0 to 9 (inclusive) are allowed */
+  int order() default 9;
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/Repository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/Repository.java
@@ -9,7 +9,4 @@ import java.lang.annotation.Target;
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.CONSTRUCTOR})
-public @interface Repository {
-  /** Order of initialization of repository starting from 0. Only order from 0 to 9 (inclusive) are allowed */
-  int order() default 9;
-}
+public @interface Repository {}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SearchServiceRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SearchServiceRepository.java
@@ -14,6 +14,7 @@ public class SearchServiceRepository extends ServiceEntityRepository<SearchServi
         dao,
         dao.searchServiceDAO(),
         SearchConnection.class,
+        "",
         ServiceType.SEARCH);
     supportsSearch = true;
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ServiceEntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ServiceEntityRepository.java
@@ -29,19 +29,7 @@ public abstract class ServiceEntityRepository<
         T extends ServiceEntityInterface, S extends ServiceConnectionEntityInterface>
     extends EntityRepository<T> {
   @Getter private final Class<S> serviceConnectionClass;
-
   @Getter private final ServiceType serviceType;
-
-  protected ServiceEntityRepository(
-      String collectionPath,
-      String service,
-      CollectionDAO dao,
-      EntityDAO<T> entityDAO,
-      Class<S> serviceConnectionClass,
-      ServiceType serviceType) {
-    this(collectionPath, service, dao, entityDAO, serviceConnectionClass, "", serviceType);
-    quoteFqn = true;
-  }
 
   protected ServiceEntityRepository(
       String collectionPath,
@@ -54,6 +42,7 @@ public abstract class ServiceEntityRepository<
     super(collectionPath, service, entityDAO.getEntityClass(), entityDAO, dao, "", updateFields);
     this.serviceConnectionClass = serviceConnectionClass;
     this.serviceType = serviceType;
+    quoteFqn = true;
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/StorageServiceRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/StorageServiceRepository.java
@@ -14,6 +14,7 @@ public class StorageServiceRepository extends ServiceEntityRepository<StorageSer
         dao,
         dao.storageServiceDAO(),
         StorageConnection.class,
+        "",
         ServiceType.STORAGE);
     supportsSearch = true;
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SystemRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SystemRepository.java
@@ -12,6 +12,7 @@ import org.openmetadata.schema.settings.Settings;
 import org.openmetadata.schema.settings.SettingsType;
 import org.openmetadata.schema.util.EntitiesCount;
 import org.openmetadata.schema.util.ServicesCount;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.CustomExceptionMessage;
 import org.openmetadata.service.fernet.Fernet;
 import org.openmetadata.service.jdbi3.CollectionDAO.SystemDAO;
@@ -21,13 +22,15 @@ import org.openmetadata.service.util.RestUtil;
 import org.openmetadata.service.util.ResultList;
 
 @Slf4j
+@Repository
 public class SystemRepository {
   private static final String FAILED_TO_UPDATE_SETTINGS = "Failed to Update Settings";
   public static final String INTERNAL_SERVER_ERROR_WITH_REASON = "Internal Server Error. Reason :";
   private final SystemDAO dao;
 
-  public SystemRepository(SystemDAO dao) {
-    this.dao = dao;
+  public SystemRepository(CollectionDAO dao) {
+    this.dao = dao.systemDAO();
+    Entity.setSystemRepository(this);
   }
 
   public EntitiesCount getAllEntitiesCount(ListFilter filter) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TokenRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TokenRepository.java
@@ -4,18 +4,17 @@ import java.util.List;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.TokenInterface;
-import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.EntityNotFoundException;
 import org.openmetadata.service.util.JsonUtils;
 
 @Slf4j
+@Repository
 public class TokenRepository {
   static final String TOKEN_NOT_PRESENT_MSG = "Token not present for the user";
   private final CollectionDAO dao;
 
   public TokenRepository(CollectionDAO dao) {
     this.dao = dao;
-    Entity.setTokenRepository(this);
   }
 
   public TokenInterface findByToken(String token) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TokenRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TokenRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.TokenInterface;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.EntityNotFoundException;
 import org.openmetadata.service.util.JsonUtils;
 
@@ -14,6 +15,7 @@ public class TokenRepository {
 
   public TokenRepository(CollectionDAO dao) {
     this.dao = dao;
+    Entity.setTokenRepository(this);
   }
 
   public TokenInterface findByToken(String token) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/UsageRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/UsageRepository.java
@@ -48,6 +48,7 @@ import org.openmetadata.service.exception.UnhandledServerException;
 import org.openmetadata.service.util.RestUtil;
 
 @Slf4j
+@Repository
 public class UsageRepository {
   private static final String PUT = "createOrUpdate";
   private static final String POST = "createNew";
@@ -55,6 +56,7 @@ public class UsageRepository {
 
   public UsageRepository(CollectionDAO dao) {
     this.dao = dao;
+    Entity.setUsageRepository(this);
   }
 
   public EntityUsage get(String entityType, UUID id, String date, int days) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/V112/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/V112/MigrationUtil.java
@@ -7,6 +7,7 @@ import org.openmetadata.schema.entity.teams.User;
 import org.openmetadata.schema.tests.TestSuite;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.utils.EntityInterfaceUtil;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.jdbi3.TestSuiteRepository;
@@ -18,7 +19,7 @@ public class MigrationUtil {
   private MigrationUtil() {}
 
   public static void fixExecutableTestSuiteFQN(CollectionDAO collectionDAO) {
-    TestSuiteRepository testSuiteRepository = new TestSuiteRepository(collectionDAO);
+    TestSuiteRepository testSuiteRepository = (TestSuiteRepository) Entity.getEntityRepository(Entity.TEST_SUITE);
     List<TestSuite> testSuites =
         testSuiteRepository.listAll(new EntityUtil.Fields(Set.of("id")), new ListFilter(Include.ALL));
     for (TestSuite suite : testSuites) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/V112/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/V112/MigrationUtil.java
@@ -7,7 +7,6 @@ import org.openmetadata.schema.entity.teams.User;
 import org.openmetadata.schema.tests.TestSuite;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.utils.EntityInterfaceUtil;
-import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.jdbi3.TestSuiteRepository;
@@ -19,7 +18,7 @@ public class MigrationUtil {
   private MigrationUtil() {}
 
   public static void fixExecutableTestSuiteFQN(CollectionDAO collectionDAO) {
-    TestSuiteRepository testSuiteRepository = (TestSuiteRepository) Entity.getEntityRepository(Entity.TEST_SUITE);
+    TestSuiteRepository testSuiteRepository = new TestSuiteRepository(collectionDAO);
     List<TestSuite> testSuites =
         testSuiteRepository.listAll(new EntityUtil.Fields(Set.of("id")), new ListFilter(Include.ALL));
     for (TestSuite suite : testSuites) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/V114/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/V114/MigrationUtil.java
@@ -43,7 +43,7 @@ public class MigrationUtil {
    */
   public static void fixTestSuites(CollectionDAO collectionDAO) {
     // Fix any FQN issues for executable TestSuite
-    TestSuiteRepository testSuiteRepository = (TestSuiteRepository) Entity.getEntityRepository(TEST_SUITE);
+    TestSuiteRepository testSuiteRepository = new TestSuiteRepository(collectionDAO);
     List<TestSuite> testSuites =
         testSuiteRepository.listAll(new EntityUtil.Fields(Set.of("id")), new ListFilter(Include.ALL));
     for (TestSuite suite : testSuites) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/V114/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/V114/MigrationUtil.java
@@ -43,7 +43,7 @@ public class MigrationUtil {
    */
   public static void fixTestSuites(CollectionDAO collectionDAO) {
     // Fix any FQN issues for executable TestSuite
-    TestSuiteRepository testSuiteRepository = new TestSuiteRepository(collectionDAO);
+    TestSuiteRepository testSuiteRepository = (TestSuiteRepository) Entity.getEntityRepository(TEST_SUITE);
     List<TestSuite> testSuites =
         testSuiteRepository.listAll(new EntityUtil.Fields(Set.of("id")), new ListFilter(Include.ALL));
     for (TestSuite suite : testSuites) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/V114/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/V114/MigrationUtil.java
@@ -38,8 +38,6 @@ public class MigrationUtil {
    * relationships Step 7: Iterate through the testSuite relation to check if the executableTestSuite FQN matches. If it
    * matches there exists a relation from testCase to a executable Test suite Step 8: If we can't find a match, create a
    * relationship.
-   *
-   * @param collectionDAO
    */
   public static void fixTestSuites(CollectionDAO collectionDAO) {
     // Fix any FQN issues for executable TestSuite
@@ -59,7 +57,7 @@ public class MigrationUtil {
     }
     // Let's iterate through the test cases and make sure there exists a relationship between testcases and its native
     // TestSuite
-    Map<String, ArrayList<TestCase>> testCasesGroupByTable = groupTestCasesByTable(collectionDAO);
+    Map<String, ArrayList<TestCase>> testCasesGroupByTable = groupTestCasesByTable();
     for (String tableFQN : testCasesGroupByTable.keySet()) {
       try {
         List<TestCase> testCases = testCasesGroupByTable.get(tableFQN);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/V117/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/V117/MigrationUtil.java
@@ -8,6 +8,7 @@ import org.jdbi.v3.core.Handle;
 import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.schema.tests.TestCase;
 import org.openmetadata.schema.type.Include;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.jdbi3.TableRepository;
@@ -27,8 +28,8 @@ public class MigrationUtil {
   private static final String POSTGRES_LIST_TABLE_FQNS = "SELECT json #>> '{fullyQualifiedName}' FROM table_entity";
 
   public static void fixTestCases(Handle handle, CollectionDAO collectionDAO) {
-    TestCaseRepository testCaseRepository = new TestCaseRepository(collectionDAO);
-    TableRepository tableRepository = new TableRepository(collectionDAO);
+    TestCaseRepository testCaseRepository = (TestCaseRepository) Entity.getEntityRepository(Entity.TEST_CASE);
+    TableRepository tableRepository = (TableRepository) Entity.getEntityRepository(Entity.TABLE);
     List<TestCase> testCases =
         testCaseRepository.listAll(new EntityUtil.Fields(Set.of("id")), new ListFilter(Include.ALL));
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/V117/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/V117/MigrationUtil.java
@@ -8,7 +8,6 @@ import org.jdbi.v3.core.Handle;
 import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.schema.tests.TestCase;
 import org.openmetadata.schema.type.Include;
-import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.jdbi3.TableRepository;
@@ -28,8 +27,8 @@ public class MigrationUtil {
   private static final String POSTGRES_LIST_TABLE_FQNS = "SELECT json #>> '{fullyQualifiedName}' FROM table_entity";
 
   public static void fixTestCases(Handle handle, CollectionDAO collectionDAO) {
-    TestCaseRepository testCaseRepository = (TestCaseRepository) Entity.getEntityRepository(Entity.TEST_CASE);
-    TableRepository tableRepository = (TableRepository) Entity.getEntityRepository(Entity.TABLE);
+    TestCaseRepository testCaseRepository = new TestCaseRepository(collectionDAO);
+    TableRepository tableRepository = new TableRepository(collectionDAO);
     List<TestCase> testCases =
         testCaseRepository.listAll(new EntityUtil.Fields(Set.of("id")), new ListFilter(Include.ALL));
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v110/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v110/MigrationUtil.java
@@ -442,7 +442,7 @@ public class MigrationUtil {
             .withDisplayName(create.getDisplayName())
             .withName(create.getName());
     if (create.getExecutableEntityReference() != null) {
-      TableRepository tableRepository = (TableRepository) Entity.getEntityRepository(Entity.TABLE);
+      TableRepository tableRepository = new TableRepository(dao);
       Table table =
           JsonUtils.readValue(
               tableRepository.getDao().findJsonByFqn(create.getExecutableEntityReference(), Include.ALL), Table.class);
@@ -484,7 +484,7 @@ public class MigrationUtil {
     migrateExistingTestSuitesToLogical(collectionDAO);
 
     // create native test suites
-    TestSuiteRepository testSuiteRepository = (TestSuiteRepository) Entity.getEntityRepository(TEST_SUITE);
+    TestSuiteRepository testSuiteRepository = new TestSuiteRepository(collectionDAO);
     Map<String, ArrayList<TestCase>> testCasesByTable = groupTestCasesByTable(collectionDAO);
     for (String tableFQN : testCasesByTable.keySet()) {
       String nativeTestSuiteFqn = tableFQN + ".testSuite";
@@ -528,9 +528,8 @@ public class MigrationUtil {
   }
 
   private static void migrateExistingTestSuitesToLogical(CollectionDAO collectionDAO) {
-    IngestionPipelineRepository ingestionPipelineRepository =
-        (IngestionPipelineRepository) Entity.getEntityRepository(INGESTION_PIPELINE);
-    TestSuiteRepository testSuiteRepository = (TestSuiteRepository) Entity.getEntityRepository(TEST_SUITE);
+    IngestionPipelineRepository ingestionPipelineRepository = new IngestionPipelineRepository(collectionDAO);
+    TestSuiteRepository testSuiteRepository = new TestSuiteRepository(collectionDAO);
     ListFilter filter = new ListFilter(Include.ALL);
     List<TestSuite> testSuites = testSuiteRepository.listAll(new Fields(Set.of("id")), filter);
     for (TestSuite testSuite : testSuites) {
@@ -550,7 +549,7 @@ public class MigrationUtil {
 
   public static Map<String, ArrayList<TestCase>> groupTestCasesByTable(CollectionDAO collectionDAO) {
     Map<String, ArrayList<TestCase>> testCasesByTable = new HashMap<>();
-    TestCaseRepository testCaseRepository = (TestCaseRepository) Entity.getEntityRepository(TEST_CASE);
+    TestCaseRepository testCaseRepository = new TestCaseRepository(collectionDAO);
     List<TestCase> testCases = testCaseRepository.listAll(new Fields(Set.of("id")), new ListFilter(Include.ALL));
     for (TestCase testCase : testCases) {
       // Create New Executable Test Suites

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v110/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v110/MigrationUtil.java
@@ -226,20 +226,6 @@ public class MigrationUtil {
     return result;
   }
 
-  public static List<MigrationDAO.ServerMigrationSQLTable> addInListIfToBeExecuted(
-      String version, Set<String> lookUp, List<String> queries) {
-    List<MigrationDAO.ServerMigrationSQLTable> result = new ArrayList<>();
-    for (String query : queries) {
-      MigrationDAO.ServerMigrationSQLTable tableContent = buildServerMigrationTable(version, query);
-      if (!lookUp.contains(tableContent.getCheckSum())) {
-        result.add(tableContent);
-      } else {
-        LOG.debug("Query will be skipped in Migration Step , as this has already been executed");
-      }
-    }
-    return result;
-  }
-
   public static void dataMigrationFQNHashing(Handle handle, CollectionDAO collectionDAO, int limitParam) {
     // Migration for Entities with Name as their FQN
     // We need to quote the FQN, if these entities have "." in their name we are storing it as it is
@@ -474,8 +460,6 @@ public class MigrationUtil {
    * to System created native TestSuite Per Table 2. Our Goal with this migration is to list all the test cases and
    * create .testSuite with executable set to true and associate all of the respective test cases with new native test
    * suite.
-   *
-   * @param collectionDAO
    */
   @SneakyThrows
   public static void testSuitesMigration(CollectionDAO collectionDAO) {
@@ -485,7 +469,7 @@ public class MigrationUtil {
 
     // create native test suites
     TestSuiteRepository testSuiteRepository = (TestSuiteRepository) Entity.getEntityRepository(TEST_SUITE);
-    Map<String, ArrayList<TestCase>> testCasesByTable = groupTestCasesByTable(collectionDAO);
+    Map<String, ArrayList<TestCase>> testCasesByTable = groupTestCasesByTable();
     for (String tableFQN : testCasesByTable.keySet()) {
       String nativeTestSuiteFqn = tableFQN + ".testSuite";
       List<TestCase> testCases = testCasesByTable.get(tableFQN);
@@ -548,7 +532,7 @@ public class MigrationUtil {
     }
   }
 
-  public static Map<String, ArrayList<TestCase>> groupTestCasesByTable(CollectionDAO collectionDAO) {
+  public static Map<String, ArrayList<TestCase>> groupTestCasesByTable() {
     Map<String, ArrayList<TestCase>> testCasesByTable = new HashMap<>();
     TestCaseRepository testCaseRepository = (TestCaseRepository) Entity.getEntityRepository(TEST_CASE);
     List<TestCase> testCases = testCaseRepository.listAll(new Fields(Set.of("id")), new ListFilter(Include.ALL));

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v110/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v110/MigrationUtil.java
@@ -442,7 +442,7 @@ public class MigrationUtil {
             .withDisplayName(create.getDisplayName())
             .withName(create.getName());
     if (create.getExecutableEntityReference() != null) {
-      TableRepository tableRepository = new TableRepository(dao);
+      TableRepository tableRepository = (TableRepository) Entity.getEntityRepository(Entity.TABLE);
       Table table =
           JsonUtils.readValue(
               tableRepository.getDao().findJsonByFqn(create.getExecutableEntityReference(), Include.ALL), Table.class);
@@ -484,7 +484,7 @@ public class MigrationUtil {
     migrateExistingTestSuitesToLogical(collectionDAO);
 
     // create native test suites
-    TestSuiteRepository testSuiteRepository = new TestSuiteRepository(collectionDAO);
+    TestSuiteRepository testSuiteRepository = (TestSuiteRepository) Entity.getEntityRepository(TEST_SUITE);
     Map<String, ArrayList<TestCase>> testCasesByTable = groupTestCasesByTable(collectionDAO);
     for (String tableFQN : testCasesByTable.keySet()) {
       String nativeTestSuiteFqn = tableFQN + ".testSuite";
@@ -528,8 +528,9 @@ public class MigrationUtil {
   }
 
   private static void migrateExistingTestSuitesToLogical(CollectionDAO collectionDAO) {
-    IngestionPipelineRepository ingestionPipelineRepository = new IngestionPipelineRepository(collectionDAO);
-    TestSuiteRepository testSuiteRepository = new TestSuiteRepository(collectionDAO);
+    IngestionPipelineRepository ingestionPipelineRepository =
+        (IngestionPipelineRepository) Entity.getEntityRepository(INGESTION_PIPELINE);
+    TestSuiteRepository testSuiteRepository = (TestSuiteRepository) Entity.getEntityRepository(TEST_SUITE);
     ListFilter filter = new ListFilter(Include.ALL);
     List<TestSuite> testSuites = testSuiteRepository.listAll(new Fields(Set.of("id")), filter);
     for (TestSuite testSuite : testSuites) {
@@ -549,7 +550,7 @@ public class MigrationUtil {
 
   public static Map<String, ArrayList<TestCase>> groupTestCasesByTable(CollectionDAO collectionDAO) {
     Map<String, ArrayList<TestCase>> testCasesByTable = new HashMap<>();
-    TestCaseRepository testCaseRepository = new TestCaseRepository(collectionDAO);
+    TestCaseRepository testCaseRepository = (TestCaseRepository) Entity.getEntityRepository(TEST_CASE);
     List<TestCase> testCases = testCaseRepository.listAll(new Fields(Set.of("id")), new ListFilter(Include.ALL));
     for (TestCase testCase : testCases) {
       // Create New Executable Test Suites

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v120/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v120/MigrationUtil.java
@@ -6,6 +6,7 @@ import javax.json.JsonObjectBuilder;
 import lombok.extern.slf4j.Slf4j;
 import org.jdbi.v3.core.Handle;
 import org.openmetadata.schema.entity.data.Query;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.QueryRepository;
 import org.openmetadata.service.util.JsonUtils;
@@ -56,7 +57,7 @@ public class MigrationUtil {
    * the Query.service EntityRef
    */
   public static void addQueryService(Handle handle, CollectionDAO collectionDAO) {
-    QueryRepository queryRepository = new QueryRepository(collectionDAO);
+    QueryRepository queryRepository = (QueryRepository) Entity.getEntityRepository(Entity.QUERY);
 
     try {
       handle

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v120/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v120/MigrationUtil.java
@@ -6,7 +6,6 @@ import javax.json.JsonObjectBuilder;
 import lombok.extern.slf4j.Slf4j;
 import org.jdbi.v3.core.Handle;
 import org.openmetadata.schema.entity.data.Query;
-import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.QueryRepository;
 import org.openmetadata.service.util.JsonUtils;
@@ -57,7 +56,7 @@ public class MigrationUtil {
    * the Query.service EntityRef
    */
   public static void addQueryService(Handle handle, CollectionDAO collectionDAO) {
-    QueryRepository queryRepository = (QueryRepository) Entity.getEntityRepository(Entity.QUERY);
+    QueryRepository queryRepository = new QueryRepository(collectionDAO);
 
     try {
       handle

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/CollectionRegistry.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/CollectionRegistry.java
@@ -19,6 +19,7 @@ import io.swagger.annotations.Api;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -40,6 +41,7 @@ import org.openmetadata.schema.type.CollectionDescriptor;
 import org.openmetadata.schema.type.CollectionInfo;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
 import org.openmetadata.service.jdbi3.CollectionDAO;
+import org.openmetadata.service.jdbi3.Repository;
 import org.openmetadata.service.jdbi3.unitofwork.JdbiUnitOfWorkProvider;
 import org.openmetadata.service.security.Authorizer;
 import org.openmetadata.service.security.auth.AuthenticatorHandler;
@@ -56,6 +58,7 @@ import org.reflections.util.ConfigurationBuilder;
 @Slf4j
 public final class CollectionRegistry {
   private static CollectionRegistry instance = null;
+  private volatile boolean initializedRepositories = false;
   private static volatile boolean initialized = false;
 
   /** Map of collection endpoint path to collection details */
@@ -101,6 +104,25 @@ public final class CollectionRegistry {
 
   public Map<String, CollectionDetails> getCollectionMap() {
     return Collections.unmodifiableMap(collectionMap);
+  }
+
+  public void initializeRepositories(CollectionDAO daoObject) {
+    if (!initializedRepositories) {
+      // Check Collection DAO
+      Objects.requireNonNull(daoObject, "CollectionDAO must not be null");
+      Set<Class<?>> repositories = getRepositories();
+      for (Class<?> clz : repositories) {
+        if (Modifier.isAbstract(clz.getModifiers())) {
+          continue; // Don't instantiate abstract classes
+        }
+        try {
+          clz.getDeclaredConstructor(CollectionDAO.class).newInstance(daoObject);
+        } catch (Exception e) {
+          LOG.warn("Exception encountered", e);
+        }
+      }
+      initializedRepositories = true;
+    }
   }
 
   /**
@@ -165,6 +187,7 @@ public final class CollectionRegistry {
       CollectionDAO daoObject,
       Authorizer authorizer,
       AuthenticatorHandler authenticatorHandler) {
+    initializeRepositories(daoObject);
     // Build list of ResourceDescriptors
     for (Map.Entry<String, CollectionDetails> e : collectionMap.entrySet()) {
       CollectionDetails details = e.getValue();
@@ -211,6 +234,13 @@ public final class CollectionRegistry {
   }
 
   /** Compile a list of REST collections based on Resource classes marked with {@code Collection} annotation */
+  private static Set<Class<?>> getRepositories() {
+    // Get classes marked with @Repository annotation
+    Reflections reflections = new Reflections("org.openmetadata.service.jdbi3");
+    return reflections.getTypesAnnotatedWith(Repository.class);
+  }
+
+  /** Compile a list of REST collections based on Resource classes marked with {@code Collection} annotation */
   private static List<CollectionDetails> getCollections() {
     Reflections reflections = new Reflections("org.openmetadata.service.resources");
     // Get classes marked with @Collection annotation
@@ -241,7 +271,7 @@ public final class CollectionRegistry {
       throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException,
           InstantiationException {
 
-    // Decorate Collection DAO
+    // Check Collection DAO
     Objects.requireNonNull(daoObject, "CollectionDAO must not be null");
 
     Object resource = null;
@@ -249,12 +279,12 @@ public final class CollectionRegistry {
 
     // Create the resource identified by resourceClass
     try {
-      resource = clz.getDeclaredConstructor(CollectionDAO.class, Authorizer.class).newInstance(daoObject, authorizer);
+      resource = clz.getDeclaredConstructor(Authorizer.class).newInstance(authorizer);
     } catch (NoSuchMethodException e) {
       try {
         resource =
-            clz.getDeclaredConstructor(CollectionDAO.class, Authorizer.class, AuthenticatorHandler.class)
-                .newInstance(daoObject, authorizer, authHandler);
+            clz.getDeclaredConstructor(Authorizer.class, AuthenticatorHandler.class)
+                .newInstance(authorizer, authHandler);
       } catch (NoSuchMethodException ex) {
         try {
           resource = clz.getDeclaredConstructor(Jdbi.class, Authorizer.class).newInstance(jdbi, authorizer);
@@ -263,7 +293,7 @@ public final class CollectionRegistry {
         }
       }
     } catch (Exception ex) {
-      LOG.warn("Exception encountered", ex);
+      LOG.warn("Exception encountered while creating resource for {}", clz, ex);
     }
 
     // Call initialize method, if it exists
@@ -273,7 +303,7 @@ public final class CollectionRegistry {
     } catch (NoSuchMethodException ignored) {
       // Method does not exist and initialize is not called
     } catch (Exception ex) {
-      LOG.warn("Encountered exception ", ex);
+      LOG.warn("Encountered exception while initializing resource for {}", clz, ex);
     }
 
     // Call upgrade method, if it exists

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/CollectionRegistry.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/CollectionRegistry.java
@@ -41,7 +41,6 @@ import org.openmetadata.schema.type.CollectionInfo;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
 import org.openmetadata.service.jdbi3.CollectionDAO;
-import org.openmetadata.service.jdbi3.unitofwork.JdbiUnitOfWorkProvider;
 import org.openmetadata.service.security.Authorizer;
 import org.openmetadata.service.security.auth.AuthenticatorHandler;
 import org.reflections.Reflections;
@@ -160,7 +159,6 @@ public final class CollectionRegistry {
   /** Register resources from CollectionRegistry */
   public void registerResources(
       Jdbi jdbi,
-      JdbiUnitOfWorkProvider jdbiUnitOfWorkProvider,
       Environment environment,
       OpenMetadataApplicationConfig config,
       CollectionDAO daoObject,

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/CollectionRegistry.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/CollectionRegistry.java
@@ -108,6 +108,7 @@ public final class CollectionRegistry {
 
   public void initializeRepositories(CollectionDAO daoObject) {
     if (!initializedRepositories) {
+      System.out.println("XXX initializing repositories");
       // Check Collection DAO
       Objects.requireNonNull(daoObject, "CollectionDAO must not be null");
       Set<Class<?>> repositories = getRepositories();
@@ -122,6 +123,7 @@ public final class CollectionRegistry {
         }
       }
       initializedRepositories = true;
+      System.out.println("XXX initializing repositories done");
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/EntityResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/EntityResource.java
@@ -59,14 +59,14 @@ public abstract class EntityResource<T extends EntityInterface, K extends Entity
   public static SearchRepository searchRepository;
   public static ElasticSearchConfiguration esConfig;
 
-  protected EntityResource(Class<T> entityClass, K repository, Authorizer authorizer) {
-    this.entityClass = entityClass;
-    entityType = repository.getEntityType();
+  protected EntityResource(String entityType, Authorizer authorizer) {
+    this.entityType = entityType;
+    this.repository = (K) Entity.getEntityRepository(entityType);
+    this.entityClass = (Class<T>) Entity.getEntityClassFromType(entityType);
     allowedFields = repository.getAllowedFields();
-    this.repository = repository;
     this.authorizer = authorizer;
     addViewOperation("owner,followers,votes,tags,extension,domain,dataProducts,experts", VIEW_BASIC);
-    Entity.registerEntity(entityClass, entityType, repository, getEntitySpecificOperations());
+    Entity.registerResourcePermissions(entityType, getEntitySpecificOperations());
   }
 
   /** Method used for initializing a resource, such as creating default policies, roles, etc. */

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/EntityTimeSeriesResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/EntityTimeSeriesResource.java
@@ -2,12 +2,10 @@ package org.openmetadata.service.resources;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.util.List;
 import javax.ws.rs.core.Response;
 import lombok.Getter;
 import org.openmetadata.schema.EntityTimeSeriesInterface;
 import org.openmetadata.schema.service.configuration.elasticsearch.ElasticSearchConfiguration;
-import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
 import org.openmetadata.service.jdbi3.EntityTimeSeriesRepository;
@@ -15,7 +13,8 @@ import org.openmetadata.service.search.IndexUtil;
 import org.openmetadata.service.search.SearchRepository;
 import org.openmetadata.service.security.Authorizer;
 
-public class EntityTimeSeriesResource<T extends EntityTimeSeriesInterface, K extends EntityTimeSeriesRepository<T>> {
+public abstract class EntityTimeSeriesResource<
+    T extends EntityTimeSeriesInterface, K extends EntityTimeSeriesRepository<T>> {
   protected final Class<T> entityClass;
   protected final String entityType;
   @Getter protected final K repository;
@@ -23,12 +22,12 @@ public class EntityTimeSeriesResource<T extends EntityTimeSeriesInterface, K ext
   public static SearchRepository searchRepository;
   public static ElasticSearchConfiguration esConfig;
 
-  protected EntityTimeSeriesResource(Class<T> entityClass, K repository, Authorizer authorizer) {
-    entityType = entityClass.getTypeName();
-    this.entityClass = entityClass;
-    this.repository = repository;
+  protected EntityTimeSeriesResource(String entityType, Authorizer authorizer) {
+    this.entityType = entityType;
+    this.entityClass = (Class<T>) Entity.getEntityClassFromType(entityType);
+    this.repository = (K) Entity.getEntityTimeSeriesRepository(entityType);
     this.authorizer = authorizer;
-    Entity.registerEntity(entityClass, entityType, repository, getEntitySpecificOperations());
+    //    Entity.registerResourcePermissions(entityType, getEntitySpecificOperations());
   }
 
   public void initialize(OpenMetadataApplicationConfig config)
@@ -42,9 +41,5 @@ public class EntityTimeSeriesResource<T extends EntityTimeSeriesInterface, K ext
   protected Response create(T entity, String extension, String recordFQN) {
     entity = repository.createNewRecord(entity, extension, recordFQN);
     return Response.ok(entity).build();
-  }
-
-  protected List<MetadataOperation> getEntitySpecificOperations() {
-    return null;
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/EntityTimeSeriesResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/EntityTimeSeriesResource.java
@@ -1,7 +1,5 @@
 package org.openmetadata.service.resources;
 
-import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import javax.ws.rs.core.Response;
 import lombok.Getter;
 import org.openmetadata.schema.EntityTimeSeriesInterface;
@@ -27,12 +25,10 @@ public abstract class EntityTimeSeriesResource<
     this.entityClass = (Class<T>) Entity.getEntityClassFromType(entityType);
     this.repository = (K) Entity.getEntityTimeSeriesRepository(entityType);
     this.authorizer = authorizer;
-    //    Entity.registerResourcePermissions(entityType, getEntitySpecificOperations());
+    Entity.registerTimeSeriesResourcePermissions(entityType);
   }
 
-  public void initialize(OpenMetadataApplicationConfig config)
-      throws IOException, ClassNotFoundException, NoSuchMethodException, InvocationTargetException,
-          InstantiationException, IllegalAccessException {
+  public void initialize(OpenMetadataApplicationConfig config) {
     esConfig = config.getElasticSearchConfiguration();
     searchRepository = IndexUtil.getSearchClient(esConfig, repository.getDaoCollection());
     // Nothing to do in the default implementation

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/analytics/ReportDataResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/analytics/ReportDataResource.java
@@ -28,7 +28,6 @@ import org.openmetadata.schema.analytics.ReportData;
 import org.openmetadata.schema.analytics.ReportData.ReportDataType;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.ReportDataRepository;
 import org.openmetadata.service.resources.Collection;
 import org.openmetadata.service.resources.EntityTimeSeriesResource;
@@ -48,8 +47,8 @@ import org.openmetadata.service.util.ResultList;
 public class ReportDataResource extends EntityTimeSeriesResource<ReportData, ReportDataRepository> {
   public static final String COLLECTION_PATH = "v1/analytics/dataInsights/data";
 
-  public ReportDataResource(CollectionDAO repository, Authorizer authorizer) {
-    super(ReportData.class, new ReportDataRepository(repository), authorizer);
+  public ReportDataResource(Authorizer authorizer) {
+    super(Entity.ENTITY_REPORT_DATA, authorizer);
   }
 
   public static class ReportDataResultList extends ResultList<ReportData> {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/analytics/WebAnalyticEventResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/analytics/WebAnalyticEventResource.java
@@ -43,8 +43,8 @@ import org.openmetadata.schema.api.tests.CreateWebAnalyticEvent;
 import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.jdbi3.WebAnalyticEventRepository;
 import org.openmetadata.service.resources.Collection;
@@ -64,8 +64,8 @@ public class WebAnalyticEventResource extends EntityResource<WebAnalyticEvent, W
   public static final String COLLECTION_PATH = WebAnalyticEventRepository.COLLECTION_PATH;
   static final String FIELDS = "owner";
 
-  public WebAnalyticEventResource(CollectionDAO dao, Authorizer authorizer) {
-    super(WebAnalyticEvent.class, new WebAnalyticEventRepository(dao), authorizer);
+  public WebAnalyticEventResource(Authorizer authorizer) {
+    super(Entity.WEB_ANALYTIC_EVENT, authorizer);
   }
 
   public static class WebAnalyticEventList extends ResultList<WebAnalyticEvent> {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/automations/WorkflowResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/automations/WorkflowResource.java
@@ -54,7 +54,6 @@ import org.openmetadata.sdk.PipelineServiceClient;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
 import org.openmetadata.service.clients.pipeline.PipelineServiceClientFactory;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.EntityRepository;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.jdbi3.WorkflowRepository;
@@ -85,8 +84,8 @@ public class WorkflowResource extends EntityResource<Workflow, WorkflowRepositor
   private PipelineServiceClient pipelineServiceClient;
   private OpenMetadataApplicationConfig openMetadataApplicationConfig;
 
-  public WorkflowResource(CollectionDAO dao, Authorizer authorizer) {
-    super(Workflow.class, new WorkflowRepository(dao), authorizer);
+  public WorkflowResource(Authorizer authorizer) {
+    super(Entity.WORKFLOW, authorizer);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/bots/BotResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/bots/BotResource.java
@@ -61,7 +61,6 @@ import org.openmetadata.service.Entity;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
 import org.openmetadata.service.exception.CatalogExceptionMessage;
 import org.openmetadata.service.jdbi3.BotRepository;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.CollectionDAO.EntityRelationshipRecord;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.resources.Collection;
@@ -87,8 +86,8 @@ import org.openmetadata.service.util.UserUtil;
 public class BotResource extends EntityResource<Bot, BotRepository> {
   public static final String COLLECTION_PATH = "/v1/bots/";
 
-  public BotResource(CollectionDAO dao, Authorizer authorizer) {
-    super(Bot.class, new BotRepository(dao), authorizer);
+  public BotResource(Authorizer authorizer) {
+    super(Entity.BOT, authorizer);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/charts/ChartResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/charts/ChartResource.java
@@ -56,7 +56,6 @@ import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.ChartRepository;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.resources.Collection;
 import org.openmetadata.service.resources.EntityResource;
@@ -82,8 +81,8 @@ public class ChartResource extends EntityResource<Chart, ChartRepository> {
     return chart;
   }
 
-  public ChartResource(CollectionDAO dao, Authorizer authorizer) {
-    super(Chart.class, new ChartRepository(dao), authorizer);
+  public ChartResource(Authorizer authorizer) {
+    super(Entity.CHART, authorizer);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/dashboards/DashboardResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/dashboards/DashboardResource.java
@@ -55,7 +55,6 @@ import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.DashboardRepository;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.resources.Collection;
@@ -86,8 +85,8 @@ public class DashboardResource extends EntityResource<Dashboard, DashboardReposi
     return dashboard;
   }
 
-  public DashboardResource(CollectionDAO dao, Authorizer authorizer) {
-    super(Dashboard.class, new DashboardRepository(dao), authorizer);
+  public DashboardResource(Authorizer authorizer) {
+    super(Entity.DASHBOARD, authorizer);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/dataInsight/DataInsightChartResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/dataInsight/DataInsightChartResource.java
@@ -46,7 +46,6 @@ import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.DataInsightChartRepository;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.resources.Collection;
@@ -66,13 +65,11 @@ import org.openmetadata.service.util.ResultList;
 @Collection(name = "analytics")
 public class DataInsightChartResource extends EntityResource<DataInsightChart, DataInsightChartRepository> {
   private SearchRepository searchRepository;
-  private final CollectionDAO collectionDao;
   public static final String COLLECTION_PATH = DataInsightChartRepository.COLLECTION_PATH;
   public static final String FIELDS = "owner";
 
-  public DataInsightChartResource(CollectionDAO dao, Authorizer authorizer) {
-    super(DataInsightChart.class, new DataInsightChartRepository(dao), authorizer);
-    collectionDao = dao;
+  public DataInsightChartResource(Authorizer authorizer) {
+    super(Entity.DATA_INSIGHT_CHART, authorizer);
   }
 
   public static class DataInsightChartList extends ResultList<DataInsightChart> {
@@ -87,7 +84,8 @@ public class DataInsightChartResource extends EntityResource<DataInsightChart, D
   public void initialize(OpenMetadataApplicationConfig config) throws IOException {
     // instantiate an elasticsearch client
     if (config.getElasticSearchConfiguration() != null) {
-      searchRepository = IndexUtil.getSearchClient(config.getElasticSearchConfiguration(), collectionDao);
+      searchRepository =
+          IndexUtil.getSearchClient(config.getElasticSearchConfiguration(), repository.getDaoCollection());
     }
     // Find the existing webAnalyticEventTypes and add them from json files
     List<DataInsightChart> dataInsightCharts = repository.getEntitiesFromSeedData(".*json/data/dataInsight/.*\\.json$");

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/DatabaseResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/DatabaseResource.java
@@ -55,7 +55,6 @@ import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.DatabaseRepository;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.resources.Collection;
@@ -90,8 +89,8 @@ public class DatabaseResource extends EntityResource<Database, DatabaseRepositor
     return listOf(MetadataOperation.VIEW_USAGE, MetadataOperation.EDIT_USAGE);
   }
 
-  public DatabaseResource(CollectionDAO dao, Authorizer authorizer) {
-    super(Database.class, new DatabaseRepository(dao), authorizer);
+  public DatabaseResource(Authorizer authorizer) {
+    super(Entity.DATABASE, authorizer);
   }
 
   public static class DatabaseList extends ResultList<Database> {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/DatabaseSchemaResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/DatabaseSchemaResource.java
@@ -55,7 +55,6 @@ import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.DatabaseSchemaRepository;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.resources.Collection;
@@ -83,8 +82,8 @@ public class DatabaseSchemaResource extends EntityResource<DatabaseSchema, Datab
     return schema;
   }
 
-  public DatabaseSchemaResource(CollectionDAO dao, Authorizer authorizer) {
-    super(DatabaseSchema.class, new DatabaseSchemaRepository(dao), authorizer);
+  public DatabaseSchemaResource(Authorizer authorizer) {
+    super(Entity.DATABASE_SCHEMA, authorizer);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/StoredProcedureResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/StoredProcedureResource.java
@@ -25,7 +25,6 @@ import org.openmetadata.schema.type.ChangeEvent;
 import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.jdbi3.StoredProcedureRepository;
 import org.openmetadata.service.resources.Collection;
@@ -53,8 +52,8 @@ public class StoredProcedureResource extends EntityResource<StoredProcedure, Sto
     return storedProcedure;
   }
 
-  public StoredProcedureResource(CollectionDAO dao, Authorizer authorizer) {
-    super(StoredProcedure.class, new StoredProcedureRepository(dao), authorizer);
+  public StoredProcedureResource(Authorizer authorizer) {
+    super(Entity.STORED_PROCEDURE, authorizer);
   }
 
   public static class StoredProcedureList extends ResultList<StoredProcedure> {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/TableResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/TableResource.java
@@ -66,7 +66,6 @@ import org.openmetadata.schema.type.TableJoins;
 import org.openmetadata.schema.type.TableProfile;
 import org.openmetadata.schema.type.TableProfilerConfig;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.jdbi3.TableRepository;
 import org.openmetadata.service.resources.Collection;
@@ -97,8 +96,8 @@ public class TableResource extends EntityResource<Table, TableRepository> {
     return table;
   }
 
-  public TableResource(CollectionDAO dao, Authorizer authorizer) {
-    super(Table.class, new TableRepository(dao), authorizer);
+  public TableResource(Authorizer authorizer) {
+    super(Entity.TABLE, authorizer);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/datamodels/DashboardDataModelResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/datamodels/DashboardDataModelResource.java
@@ -51,7 +51,6 @@ import org.openmetadata.schema.type.ChangeEvent;
 import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.DashboardDataModelRepository;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.resources.Collection;
@@ -79,8 +78,8 @@ public class DashboardDataModelResource extends EntityResource<DashboardDataMode
     return dashboardDataModel;
   }
 
-  public DashboardDataModelResource(CollectionDAO dao, Authorizer authorizer) {
-    super(DashboardDataModel.class, new DashboardDataModelRepository(dao), authorizer);
+  public DashboardDataModelResource(Authorizer authorizer) {
+    super(Entity.DASHBOARD_DATA_MODEL, authorizer);
   }
 
   public static class DashboardDataModelList extends ResultList<DashboardDataModel> {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/docstore/DocStoreResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/docstore/DocStoreResource.java
@@ -52,7 +52,7 @@ import org.openmetadata.schema.entities.docStore.Document;
 import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
-import org.openmetadata.service.jdbi3.CollectionDAO;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.DocumentRepository;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.resources.Collection;
@@ -81,8 +81,8 @@ public class DocStoreResource extends EntityResource<Document, DocumentRepositor
     return listOf(MetadataOperation.EDIT_ALL);
   }
 
-  public DocStoreResource(CollectionDAO dao, Authorizer authorizer) {
-    super(Document.class, new DocumentRepository(dao), authorizer);
+  public DocStoreResource(Authorizer authorizer) {
+    super(Entity.DOCUMENT, authorizer);
   }
 
   public static class DocumentList extends ResultList<Document> {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/docstore/DocStoreResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/docstore/DocStoreResource.java
@@ -142,7 +142,7 @@ public class DocStoreResource extends EntityResource<Document, DocumentRepositor
   @Operation(
       operationId = "listAllDocumentVersion",
       summary = "List Document versions",
-      description = "Get a list of all the versions of a Dcouemtn identified by `id`",
+      description = "Get a list of all the versions of a Document identified by `id`",
       responses = {
         @ApiResponse(
             responseCode = "200",

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/domains/DataProductResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/domains/DataProductResource.java
@@ -55,7 +55,6 @@ import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.DataProductRepository;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.resources.Collection;
@@ -78,8 +77,8 @@ public class DataProductResource extends EntityResource<DataProduct, DataProduct
   public static final String COLLECTION_PATH = "/v1/dataProducts/";
   static final String FIELDS = "domain,owner,experts,assets";
 
-  public DataProductResource(CollectionDAO dao, Authorizer authorizer) {
-    super(DataProduct.class, new DataProductRepository(dao), authorizer);
+  public DataProductResource(Authorizer authorizer) {
+    super(Entity.DATA_PRODUCT, authorizer);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/domains/DomainResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/domains/DomainResource.java
@@ -50,7 +50,6 @@ import org.openmetadata.schema.entity.domains.Domain;
 import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.DomainRepository;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.resources.Collection;
@@ -72,8 +71,8 @@ public class DomainResource extends EntityResource<Domain, DomainRepository> {
   public static final String COLLECTION_PATH = "/v1/domains/";
   static final String FIELDS = "children,owner,experts";
 
-  public DomainResource(CollectionDAO dao, Authorizer authorizer) {
-    super(Domain.class, new DomainRepository(dao), authorizer);
+  public DomainResource(Authorizer authorizer) {
+    super(Entity.DOMAIN, authorizer);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResource.java
@@ -43,7 +43,6 @@ import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.jdbi3.TestCaseRepository;
 import org.openmetadata.service.resources.Collection;
@@ -84,8 +83,8 @@ public class TestCaseResource extends EntityResource<TestCase, TestCaseRepositor
     return test;
   }
 
-  public TestCaseResource(CollectionDAO dao, Authorizer authorizer) {
-    super(TestCase.class, new TestCaseRepository(dao), authorizer);
+  public TestCaseResource(Authorizer authorizer) {
+    super(Entity.TEST_CASE, authorizer);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestDefinitionResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestDefinitionResource.java
@@ -41,8 +41,8 @@ import org.openmetadata.schema.type.ColumnDataType;
 import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.TestDefinitionEntityType;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.jdbi3.TestDefinitionRepository;
 import org.openmetadata.service.resources.Collection;
@@ -64,8 +64,8 @@ public class TestDefinitionResource extends EntityResource<TestDefinition, TestD
   public static final String COLLECTION_PATH = "/v1/dataQuality/testDefinitions";
   static final String FIELDS = "owner";
 
-  public TestDefinitionResource(CollectionDAO dao, Authorizer authorizer) {
-    super(TestDefinition.class, new TestDefinitionRepository(dao), authorizer);
+  public TestDefinitionResource(Authorizer authorizer) {
+    super(Entity.TEST_DEFINITION, authorizer);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestSuiteResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestSuiteResource.java
@@ -44,7 +44,6 @@ import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.jdbi3.TestSuiteRepository;
 import org.openmetadata.service.resources.Collection;
@@ -71,8 +70,8 @@ public class TestSuiteResource extends EntityResource<TestSuite, TestSuiteReposi
 
   static final String FIELDS = "owner,tests,summary";
 
-  public TestSuiteResource(CollectionDAO dao, Authorizer authorizer) {
-    super(TestSuite.class, new TestSuiteRepository(dao), authorizer);
+  public TestSuiteResource(Authorizer authorizer) {
+    super(Entity.TEST_SUITE, authorizer);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/events/EventResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/events/EventResource.java
@@ -21,7 +21,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;
 import java.util.List;
-import java.util.Objects;
 import javax.validation.Valid;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -33,9 +32,9 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriInfo;
 import lombok.Getter;
 import org.openmetadata.schema.type.ChangeEvent;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.Entity.EntityList;
 import org.openmetadata.service.jdbi3.ChangeEventRepository;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.resources.Collection;
 import org.openmetadata.service.security.Authorizer;
 import org.openmetadata.service.util.EntityUtil;
@@ -62,9 +61,8 @@ public class EventResource {
     }
   }
 
-  public EventResource(CollectionDAO dao, Authorizer authorizer) {
-    Objects.requireNonNull(dao, "ChangeEventRepository must not be null");
-    this.repository = new ChangeEventRepository(dao);
+  public EventResource(Authorizer authorizer) {
+    this.repository = Entity.getChangeEventRepository();
   }
 
   @GET

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/events/subscription/EventSubscriptionResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/events/subscription/EventSubscriptionResource.java
@@ -119,7 +119,7 @@ public class EventSubscriptionResource extends EntityResource<EventSubscription,
       repository.initSeedDataFromResources();
       EventsSubscriptionRegistry.initialize(listOrEmpty(EventSubscriptionResource.getDescriptors()));
       searchRepository = IndexUtil.getSearchClient(config.getElasticSearchConfiguration(), daoCollection);
-      ReportsHandler.initialize(daoCollection, searchRepository);
+      ReportsHandler.initialize(searchRepository);
       initializeEventSubscriptions();
     } catch (Exception ex) {
       // Starting application should not fail

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/events/subscription/EventSubscriptionResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/events/subscription/EventSubscriptionResource.java
@@ -61,6 +61,7 @@ import org.openmetadata.schema.type.Function;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.schema.type.SubscriptionResourceDescriptor;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
 import org.openmetadata.service.events.scheduled.ReportsHandler;
 import org.openmetadata.service.events.subscription.AlertUtil;
@@ -91,11 +92,9 @@ import org.quartz.SchedulerException;
 public class EventSubscriptionResource extends EntityResource<EventSubscription, EventSubscriptionRepository> {
   public static final String COLLECTION_PATH = "/v1/events/subscriptions";
   public static final String FIELDS = "owner,filteringRules";
-  private final CollectionDAO daoCollection;
 
-  public EventSubscriptionResource(CollectionDAO dao, Authorizer authorizer) {
-    super(EventSubscription.class, new EventSubscriptionRepository(dao), authorizer);
-    this.daoCollection = dao;
+  public EventSubscriptionResource(Authorizer authorizer) {
+    super(Entity.EVENT_SUBSCRIPTION, authorizer);
   }
 
   @Override
@@ -116,6 +115,7 @@ public class EventSubscriptionResource extends EntityResource<EventSubscription,
   public void initialize(OpenMetadataApplicationConfig config) {
     SearchRepository searchRepository;
     try {
+      CollectionDAO daoCollection = repository.getDaoCollection();
       repository.initSeedDataFromResources();
       EventsSubscriptionRegistry.initialize(listOrEmpty(EventSubscriptionResource.getDescriptors()));
       searchRepository = IndexUtil.getSearchClient(config.getElasticSearchConfiguration(), daoCollection);
@@ -129,6 +129,7 @@ public class EventSubscriptionResource extends EntityResource<EventSubscription,
 
   private void initializeEventSubscriptions() {
     try {
+      CollectionDAO daoCollection = repository.getDaoCollection();
       List<String> listAllEventsSubscriptions =
           daoCollection
               .eventSubscriptionDAO()

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/glossary/GlossaryResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/glossary/GlossaryResource.java
@@ -55,7 +55,6 @@ import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.schema.type.csv.CsvImportResult;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.GlossaryRepository;
 import org.openmetadata.service.jdbi3.GlossaryRepository.GlossaryCsv;
 import org.openmetadata.service.jdbi3.ListFilter;
@@ -74,8 +73,8 @@ public class GlossaryResource extends EntityResource<Glossary, GlossaryRepositor
   public static final String COLLECTION_PATH = "v1/glossaries/";
   static final String FIELDS = "owner,tags,reviewers,usageCount,termCount,domain,extension";
 
-  public GlossaryResource(CollectionDAO dao, Authorizer authorizer) {
-    super(Glossary.class, new GlossaryRepository(dao), authorizer);
+  public GlossaryResource(Authorizer authorizer) {
+    super(Entity.GLOSSARY, authorizer);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/glossary/GlossaryTermResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/glossary/GlossaryTermResource.java
@@ -56,7 +56,6 @@ import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.CatalogExceptionMessage;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.GlossaryTermRepository;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.resources.Collection;
@@ -84,8 +83,8 @@ public class GlossaryTermResource extends EntityResource<GlossaryTerm, GlossaryT
     return term;
   }
 
-  public GlossaryTermResource(CollectionDAO dao, Authorizer authorizer) {
-    super(GlossaryTerm.class, new GlossaryTermRepository(dao), authorizer);
+  public GlossaryTermResource(Authorizer authorizer) {
+    super(Entity.GLOSSARY_TERM, authorizer);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/kpi/KpiResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/kpi/KpiResource.java
@@ -42,7 +42,7 @@ import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.jdbi3.CollectionDAO;
+import org.openmetadata.service.jdbi3.EntityTimeSeriesDAO.OrderBy;
 import org.openmetadata.service.jdbi3.KpiRepository;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.resources.Collection;
@@ -68,8 +68,8 @@ public class KpiResource extends EntityResource<Kpi, KpiRepository> {
     return kpi;
   }
 
-  public KpiResource(CollectionDAO dao, Authorizer authorizer) {
-    super(Kpi.class, new KpiRepository(dao), authorizer);
+  public KpiResource(Authorizer authorizer) {
+    super(Entity.KPI, authorizer);
   }
 
   @Override
@@ -414,7 +414,7 @@ public class KpiResource extends EntityResource<Kpi, KpiRepository> {
           @Valid
           @QueryParam("orderBy")
           @DefaultValue("DESC")
-          CollectionDAO.EntityExtensionTimeSeriesDAO.OrderBy orderBy) {
+          OrderBy orderBy) {
     return repository.getKpiResults(name, startTs, endTs, orderBy);
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/lineage/LineageResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/lineage/LineageResource.java
@@ -42,7 +42,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
-import lombok.NonNull;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.api.lineage.AddLineage;
 import org.openmetadata.schema.type.EntityLineage;
@@ -50,7 +49,6 @@ import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.LineageRepository;
 import org.openmetadata.service.resources.Collection;
 import org.openmetadata.service.security.Authorizer;
@@ -71,8 +69,8 @@ public class LineageResource {
   private final LineageRepository dao;
   private final Authorizer authorizer;
 
-  public LineageResource(@NonNull CollectionDAO dao, Authorizer authorizer) {
-    this.dao = new LineageRepository(dao);
+  public LineageResource(Authorizer authorizer) {
+    this.dao = Entity.getLineageRepository();
     this.authorizer = authorizer;
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/metrics/MetricsResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/metrics/MetricsResource.java
@@ -46,7 +46,7 @@ import org.openmetadata.schema.entity.data.Metrics;
 import org.openmetadata.schema.type.ChangeEvent;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
-import org.openmetadata.service.jdbi3.CollectionDAO;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.jdbi3.MetricsRepository;
 import org.openmetadata.service.resources.Collection;
@@ -67,8 +67,8 @@ public class MetricsResource extends EntityResource<Metrics, MetricsRepository> 
   public static final String COLLECTION_PATH = "/v1/metrics/";
   static final String FIELDS = "owner,usageSummary,domain";
 
-  public MetricsResource(CollectionDAO dao, Authorizer authorizer) {
-    super(Metrics.class, new MetricsRepository(dao), authorizer);
+  public MetricsResource(Authorizer authorizer) {
+    super(Entity.METRICS, authorizer);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/mlmodels/MlModelResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/mlmodels/MlModelResource.java
@@ -55,7 +55,6 @@ import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.jdbi3.MlModelRepository;
 import org.openmetadata.service.resources.Collection;
@@ -82,8 +81,8 @@ public class MlModelResource extends EntityResource<MlModel, MlModelRepository> 
     return mlmodel;
   }
 
-  public MlModelResource(CollectionDAO dao, Authorizer authorizer) {
-    super(MlModel.class, new MlModelRepository(dao), authorizer);
+  public MlModelResource(Authorizer authorizer) {
+    super(Entity.MLMODEL, authorizer);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/permissions/PermissionsResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/permissions/PermissionsResource.java
@@ -29,12 +29,10 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.SecurityContext;
-import lombok.NonNull;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.schema.type.ResourcePermission;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.resources.Collection;
 import org.openmetadata.service.security.Authorizer;
 import org.openmetadata.service.security.policyevaluator.OperationContext;
@@ -51,7 +49,7 @@ public class PermissionsResource {
   private final Authorizer authorizer;
 
   @SuppressWarnings("unused")
-  public PermissionsResource(CollectionDAO dao, @NonNull Authorizer authorizer) {
+  public PermissionsResource(Authorizer authorizer) {
     this.authorizer = authorizer;
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/pipelines/PipelineResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/pipelines/PipelineResource.java
@@ -57,7 +57,6 @@ import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.jdbi3.PipelineRepository;
 import org.openmetadata.service.resources.Collection;
@@ -86,8 +85,8 @@ public class PipelineResource extends EntityResource<Pipeline, PipelineRepositor
     return pipeline;
   }
 
-  public PipelineResource(CollectionDAO dao, Authorizer authorizer) {
-    super(Pipeline.class, new PipelineRepository(dao), authorizer);
+  public PipelineResource(Authorizer authorizer) {
+    super(Entity.PIPELINE, authorizer);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/policies/PolicyResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/policies/PolicyResource.java
@@ -60,7 +60,6 @@ import org.openmetadata.service.Entity;
 import org.openmetadata.service.FunctionList;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
 import org.openmetadata.service.ResourceRegistry;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.jdbi3.PolicyRepository;
 import org.openmetadata.service.resources.Collection;
@@ -92,8 +91,8 @@ public class PolicyResource extends EntityResource<Policy, PolicyRepository> {
     return policy;
   }
 
-  public PolicyResource(CollectionDAO dao, Authorizer authorizer) {
-    super(Policy.class, new PolicyRepository(dao), authorizer);
+  public PolicyResource(Authorizer authorizer) {
+    super(Entity.POLICY, authorizer);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/query/QueryResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/query/QueryResource.java
@@ -44,7 +44,6 @@ import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.schema.type.Votes;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.jdbi3.QueryRepository;
 import org.openmetadata.service.resources.Collection;
@@ -66,8 +65,8 @@ public class QueryResource extends EntityResource<Query, QueryRepository> {
   public static final String COLLECTION_PATH = "v1/queries/";
   static final String FIELDS = "owner,followers,users,votes,tags,queryUsedIn";
 
-  public QueryResource(CollectionDAO dao, Authorizer authorizer) {
-    super(Query.class, new QueryRepository(dao), authorizer);
+  public QueryResource(Authorizer authorizer) {
+    super(Entity.QUERY, authorizer);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/reports/ReportResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/reports/ReportResource.java
@@ -44,7 +44,7 @@ import org.openmetadata.schema.entity.data.Report;
 import org.openmetadata.schema.type.ChangeEvent;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
-import org.openmetadata.service.jdbi3.CollectionDAO;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.jdbi3.ReportRepository;
 import org.openmetadata.service.resources.Collection;
@@ -66,8 +66,8 @@ public class ReportResource extends EntityResource<Report, ReportRepository> {
   public static final String COLLECTION_PATH = "/v1/reports/";
   static final String FIELDS = "owner,usageSummary";
 
-  public ReportResource(CollectionDAO dao, Authorizer authorizer) {
-    super(Report.class, new ReportRepository(dao), authorizer);
+  public ReportResource(Authorizer authorizer) {
+    super(Entity.REPORT, authorizer);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/search/SearchResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/search/SearchResource.java
@@ -49,7 +49,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.search.suggest.Suggest;
 import org.openmetadata.schema.api.CreateEventPublisherJob;
 import org.openmetadata.schema.system.EventPublisherJob;
-import org.openmetadata.service.OpenMetadataApplication;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
 import org.openmetadata.service.resources.Collection;
 import org.openmetadata.service.search.IndexUtil;
@@ -74,8 +74,7 @@ public class SearchResource {
 
   public void initialize(OpenMetadataApplicationConfig config) {
     if (config.getElasticSearchConfiguration() != null) {
-      searchRepository =
-          IndexUtil.getSearchClient(config.getElasticSearchConfiguration(), OpenMetadataApplication.getCollectionDAO());
+      searchRepository = IndexUtil.getSearchClient(config.getElasticSearchConfiguration(), Entity.getCollectionDAO());
       ReIndexingHandler.initialize(searchRepository);
     }
   }
@@ -366,7 +365,7 @@ public class SearchResource {
     // Check if there is a running job for reindex for requested entity
     String jobRecord;
     jobRecord =
-        OpenMetadataApplication.getCollectionDAO()
+        Entity.getCollectionDAO()
             .entityExtensionTimeSeriesDao()
             .getLatestExtension(ELASTIC_SEARCH_ENTITY_FQN_STREAM, ELASTIC_SEARCH_EXTENSION);
     if (jobRecord != null) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/search/SearchResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/search/SearchResource.java
@@ -49,8 +49,8 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.search.suggest.Suggest;
 import org.openmetadata.schema.api.CreateEventPublisherJob;
 import org.openmetadata.schema.system.EventPublisherJob;
+import org.openmetadata.service.OpenMetadataApplication;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.resources.Collection;
 import org.openmetadata.service.search.IndexUtil;
 import org.openmetadata.service.search.SearchRepository;
@@ -65,18 +65,17 @@ import org.openmetadata.service.util.ReIndexingHandler;
 @Produces(MediaType.APPLICATION_JSON)
 @Collection(name = "elasticsearch")
 public class SearchResource {
-  private final CollectionDAO dao;
   private final Authorizer authorizer;
   private SearchRepository searchRepository;
 
-  public SearchResource(CollectionDAO dao, Authorizer authorizer) {
-    this.dao = dao;
+  public SearchResource(Authorizer authorizer) {
     this.authorizer = authorizer;
   }
 
   public void initialize(OpenMetadataApplicationConfig config) {
     if (config.getElasticSearchConfiguration() != null) {
-      searchRepository = IndexUtil.getSearchClient(config.getElasticSearchConfiguration(), dao);
+      searchRepository =
+          IndexUtil.getSearchClient(config.getElasticSearchConfiguration(), OpenMetadataApplication.getCollectionDAO());
       ReIndexingHandler.initialize(searchRepository);
     }
   }
@@ -367,7 +366,8 @@ public class SearchResource {
     // Check if there is a running job for reindex for requested entity
     String jobRecord;
     jobRecord =
-        dao.entityExtensionTimeSeriesDao()
+        OpenMetadataApplication.getCollectionDAO()
+            .entityExtensionTimeSeriesDao()
             .getLatestExtension(ELASTIC_SEARCH_ENTITY_FQN_STREAM, ELASTIC_SEARCH_EXTENSION);
     if (jobRecord != null) {
       return Response.status(Response.Status.OK)

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/searchindex/SearchIndexResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/searchindex/SearchIndexResource.java
@@ -56,7 +56,6 @@ import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.schema.type.searchindex.SearchIndexSampleData;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.jdbi3.SearchIndexRepository;
 import org.openmetadata.service.resources.Collection;
@@ -84,8 +83,8 @@ public class SearchIndexResource extends EntityResource<SearchIndex, SearchIndex
     return searchIndex;
   }
 
-  public SearchIndexResource(CollectionDAO dao, Authorizer authorizer) {
-    super(SearchIndex.class, new SearchIndexRepository(dao), authorizer);
+  public SearchIndexResource(Authorizer authorizer) {
+    super(Entity.SEARCH_INDEX, authorizer);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/connections/TestConnectionDefinitionResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/connections/TestConnectionDefinitionResource.java
@@ -29,8 +29,8 @@ import javax.ws.rs.core.UriInfo;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.entity.services.connections.TestConnectionDefinition;
 import org.openmetadata.schema.type.Include;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.jdbi3.TestConnectionDefinitionRepository;
 import org.openmetadata.service.resources.Collection;
@@ -51,8 +51,8 @@ public class TestConnectionDefinitionResource
   public static final String COLLECTION_PATH = "/v1/services/testConnectionDefinitions";
   static final String FIELDS = "owner";
 
-  public TestConnectionDefinitionResource(CollectionDAO dao, Authorizer authorizer) {
-    super(TestConnectionDefinition.class, new TestConnectionDefinitionRepository(dao), authorizer);
+  public TestConnectionDefinitionResource(Authorizer authorizer) {
+    super(Entity.TEST_CONNECTION_DEFINITION, authorizer);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/dashboard/DashboardServiceResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/dashboard/DashboardServiceResource.java
@@ -55,7 +55,7 @@ import org.openmetadata.schema.type.DashboardConnection;
 import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
-import org.openmetadata.service.jdbi3.CollectionDAO;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.DashboardServiceRepository;
 import org.openmetadata.service.resources.Collection;
 import org.openmetadata.service.resources.services.ServiceEntityResource;
@@ -74,8 +74,8 @@ public class DashboardServiceResource
   public static final String COLLECTION_PATH = "v1/services/dashboardServices";
   static final String FIELDS = "owner,domain";
 
-  public DashboardServiceResource(CollectionDAO dao, Authorizer authorizer) {
-    super(DashboardService.class, new DashboardServiceRepository(dao), authorizer, ServiceType.DASHBOARD);
+  public DashboardServiceResource(Authorizer authorizer) {
+    super(Entity.DASHBOARD_SERVICE, authorizer, ServiceType.DASHBOARD);
   }
 
   public static class DashboardServiceList extends ResultList<DashboardService> {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/database/DatabaseServiceResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/database/DatabaseServiceResource.java
@@ -56,7 +56,6 @@ import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.DatabaseServiceRepository;
 import org.openmetadata.service.resources.Collection;
 import org.openmetadata.service.resources.services.ServiceEntityResource;
@@ -93,8 +92,8 @@ public class DatabaseServiceResource
     return null;
   }
 
-  public DatabaseServiceResource(CollectionDAO dao, Authorizer authorizer) {
-    super(DatabaseService.class, new DatabaseServiceRepository(dao), authorizer, ServiceType.DATABASE);
+  public DatabaseServiceResource(Authorizer authorizer) {
+    super(Entity.DATABASE_SERVICE, authorizer, ServiceType.DATABASE);
   }
 
   public static class DatabaseServiceList extends ResultList<DatabaseService> {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/ingestionpipelines/IngestionPipelineResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/ingestionpipelines/IngestionPipelineResource.java
@@ -74,10 +74,8 @@ import org.openmetadata.sdk.PipelineServiceClient;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
 import org.openmetadata.service.clients.pipeline.PipelineServiceClientFactory;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.IngestionPipelineRepository;
 import org.openmetadata.service.jdbi3.ListFilter;
-import org.openmetadata.service.jdbi3.MetadataServiceRepository;
 import org.openmetadata.service.resources.Collection;
 import org.openmetadata.service.resources.EntityResource;
 import org.openmetadata.service.secrets.SecretsManager;
@@ -107,7 +105,6 @@ public class IngestionPipelineResource extends EntityResource<IngestionPipeline,
   public static final String COLLECTION_PATH = "v1/services/ingestionPipelines/";
   private PipelineServiceClient pipelineServiceClient;
   private OpenMetadataApplicationConfig openMetadataApplicationConfig;
-  private final MetadataServiceRepository metadataServiceRepository;
   static final String FIELDS = FIELD_OWNER;
 
   @Override
@@ -117,9 +114,8 @@ public class IngestionPipelineResource extends EntityResource<IngestionPipeline,
     return ingestionPipeline;
   }
 
-  public IngestionPipelineResource(CollectionDAO dao, Authorizer authorizer) {
-    super(IngestionPipeline.class, new IngestionPipelineRepository(dao), authorizer);
-    this.metadataServiceRepository = new MetadataServiceRepository(dao);
+  public IngestionPipelineResource(Authorizer authorizer) {
+    super(Entity.INGESTION_PIPELINE, authorizer);
   }
 
   @Override
@@ -137,9 +133,7 @@ public class IngestionPipelineResource extends EntityResource<IngestionPipeline,
     if (config.getElasticSearchConfiguration() != null) {
       try {
         EntityReference metadataService =
-            this.metadataServiceRepository
-                .getByName(null, OPENMETADATA_SERVICE, repository.getFields("id"))
-                .getEntityReference();
+            this.repository.getByName(null, OPENMETADATA_SERVICE, repository.getFields("id")).getEntityReference();
         // Create Data Insights Pipeline
         CreateIngestionPipeline createPipelineRequest =
             new CreateIngestionPipeline()

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/messaging/MessagingServiceResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/messaging/MessagingServiceResource.java
@@ -55,7 +55,7 @@ import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MessagingConnection;
 import org.openmetadata.schema.type.MetadataOperation;
-import org.openmetadata.service.jdbi3.CollectionDAO;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.MessagingServiceRepository;
 import org.openmetadata.service.resources.Collection;
 import org.openmetadata.service.resources.services.ServiceEntityResource;
@@ -74,8 +74,8 @@ public class MessagingServiceResource
   public static final String COLLECTION_PATH = "v1/services/messagingServices/";
   public static final String FIELDS = "owner,domain";
 
-  public MessagingServiceResource(CollectionDAO dao, Authorizer authorizer) {
-    super(MessagingService.class, new MessagingServiceRepository(dao), authorizer, ServiceType.MESSAGING);
+  public MessagingServiceResource(Authorizer authorizer) {
+    super(Entity.MESSAGING_SERVICE, authorizer, ServiceType.MESSAGING);
   }
 
   public static class MessagingServiceList extends ResultList<MessagingService> {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/metadata/MetadataServiceResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/metadata/MetadataServiceResource.java
@@ -55,7 +55,6 @@ import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.MetadataServiceRepository;
 import org.openmetadata.service.resources.Collection;
 import org.openmetadata.service.resources.services.ServiceEntityResource;
@@ -118,8 +117,8 @@ public class MetadataServiceResource
     return service;
   }
 
-  public MetadataServiceResource(CollectionDAO dao, Authorizer authorizer) {
-    super(MetadataService.class, new MetadataServiceRepository(dao), authorizer, ServiceType.METADATA);
+  public MetadataServiceResource(Authorizer authorizer) {
+    super(Entity.METADATA_SERVICE, authorizer, ServiceType.METADATA);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/mlmodel/MlModelServiceResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/mlmodel/MlModelServiceResource.java
@@ -58,7 +58,6 @@ import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.schema.type.MlModelConnection;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.MlModelServiceRepository;
 import org.openmetadata.service.resources.Collection;
 import org.openmetadata.service.resources.services.ServiceEntityResource;
@@ -84,8 +83,8 @@ public class MlModelServiceResource
     return service;
   }
 
-  public MlModelServiceResource(CollectionDAO dao, Authorizer authorizer) {
-    super(MlModelService.class, new MlModelServiceRepository(dao), authorizer, ServiceType.ML_MODEL);
+  public MlModelServiceResource(Authorizer authorizer) {
+    super(Entity.MLMODEL_SERVICE, authorizer, ServiceType.ML_MODEL);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/pipeline/PipelineServiceResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/pipeline/PipelineServiceResource.java
@@ -56,7 +56,6 @@ import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.schema.type.PipelineConnection;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.PipelineServiceRepository;
 import org.openmetadata.service.resources.Collection;
 import org.openmetadata.service.resources.services.ServiceEntityResource;
@@ -82,8 +81,8 @@ public class PipelineServiceResource
     return service;
   }
 
-  public PipelineServiceResource(CollectionDAO dao, Authorizer authorizer) {
-    super(PipelineService.class, new PipelineServiceRepository(dao), authorizer, ServiceType.PIPELINE);
+  public PipelineServiceResource(Authorizer authorizer) {
+    super(Entity.PIPELINE_SERVICE, authorizer, ServiceType.PIPELINE);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/searchIndexes/SearchServiceResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/searchIndexes/SearchServiceResource.java
@@ -44,7 +44,6 @@ import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.schema.type.SearchConnection;
 import org.openmetadata.schema.utils.EntityInterfaceUtil;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.SearchServiceRepository;
 import org.openmetadata.service.resources.Collection;
 import org.openmetadata.service.resources.services.ServiceEntityResource;
@@ -73,8 +72,8 @@ public class SearchServiceResource
     return service;
   }
 
-  public SearchServiceResource(CollectionDAO dao, Authorizer authorizer) {
-    super(SearchService.class, new SearchServiceRepository(dao), authorizer, ServiceType.SEARCH);
+  public SearchServiceResource(Authorizer authorizer) {
+    super(Entity.SEARCH_SERVICE, authorizer, ServiceType.SEARCH);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/storage/StorageServiceResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/storage/StorageServiceResource.java
@@ -44,7 +44,6 @@ import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.schema.type.StorageConnection;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.StorageServiceRepository;
 import org.openmetadata.service.resources.Collection;
 import org.openmetadata.service.resources.services.ServiceEntityResource;
@@ -73,8 +72,8 @@ public class StorageServiceResource
     return service;
   }
 
-  public StorageServiceResource(CollectionDAO dao, Authorizer authorizer) {
-    super(StorageService.class, new StorageServiceRepository(dao), authorizer, ServiceType.STORAGE);
+  public StorageServiceResource(Authorizer authorizer) {
+    super(Entity.STORAGE_SERVICE, authorizer, ServiceType.STORAGE);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/settings/SettingsCache.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/settings/SettingsCache.java
@@ -26,9 +26,9 @@ import org.openmetadata.api.configuration.LogoConfiguration;
 import org.openmetadata.schema.email.SmtpSettings;
 import org.openmetadata.schema.settings.Settings;
 import org.openmetadata.schema.settings.SettingsType;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
 import org.openmetadata.service.exception.EntityNotFoundException;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.SystemRepository;
 import org.openmetadata.service.util.JsonUtils;
 
@@ -44,9 +44,9 @@ public class SettingsCache {
   }
 
   // Expected to be called only once from the DefaultAuthorizer
-  public static void initialize(CollectionDAO dao, OpenMetadataApplicationConfig config) {
+  public static void initialize(OpenMetadataApplicationConfig config) {
     if (!initialized) {
-      systemRepository = new SystemRepository(dao.systemDAO());
+      systemRepository = Entity.getSystemRepository();
       initialized = true;
       createDefaultConfiguration(config);
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/settings/SettingsCache.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/settings/SettingsCache.java
@@ -26,7 +26,6 @@ import org.openmetadata.api.configuration.LogoConfiguration;
 import org.openmetadata.schema.email.SmtpSettings;
 import org.openmetadata.schema.settings.Settings;
 import org.openmetadata.schema.settings.SettingsType;
-import org.openmetadata.service.Entity;
 import org.openmetadata.service.OpenMetadataApplication;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
 import org.openmetadata.service.exception.EntityNotFoundException;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/settings/SettingsCache.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/settings/SettingsCache.java
@@ -26,7 +26,7 @@ import org.openmetadata.api.configuration.LogoConfiguration;
 import org.openmetadata.schema.email.SmtpSettings;
 import org.openmetadata.schema.settings.Settings;
 import org.openmetadata.schema.settings.SettingsType;
-import org.openmetadata.service.OpenMetadataApplication;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
 import org.openmetadata.service.exception.EntityNotFoundException;
 import org.openmetadata.service.jdbi3.SystemRepository;
@@ -46,7 +46,7 @@ public class SettingsCache {
   // Expected to be called only once from the DefaultAuthorizer
   public static void initialize(OpenMetadataApplicationConfig config) {
     if (!initialized) {
-      systemRepository = new SystemRepository(OpenMetadataApplication.getCollectionDAO());
+      systemRepository = Entity.getSystemRepository();
       initialized = true;
       createDefaultConfiguration(config);
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/settings/SettingsCache.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/settings/SettingsCache.java
@@ -27,6 +27,7 @@ import org.openmetadata.schema.email.SmtpSettings;
 import org.openmetadata.schema.settings.Settings;
 import org.openmetadata.schema.settings.SettingsType;
 import org.openmetadata.service.Entity;
+import org.openmetadata.service.OpenMetadataApplication;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
 import org.openmetadata.service.exception.EntityNotFoundException;
 import org.openmetadata.service.jdbi3.SystemRepository;
@@ -46,7 +47,7 @@ public class SettingsCache {
   // Expected to be called only once from the DefaultAuthorizer
   public static void initialize(OpenMetadataApplicationConfig config) {
     if (!initialized) {
-      systemRepository = Entity.getSystemRepository();
+      systemRepository = new SystemRepository(OpenMetadataApplication.getCollectionDAO());
       initialized = true;
       createDefaultConfiguration(config);
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/storages/ContainerResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/storages/ContainerResource.java
@@ -40,7 +40,6 @@ import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.ContainerRepository;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.resources.Collection;
@@ -70,8 +69,8 @@ public class ContainerResource extends EntityResource<Container, ContainerReposi
     return container;
   }
 
-  public ContainerResource(CollectionDAO dao, Authorizer authorizer) {
-    super(Container.class, new ContainerRepository(dao), authorizer);
+  public ContainerResource(Authorizer authorizer) {
+    super(Entity.CONTAINER, authorizer);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/system/SystemResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/system/SystemResource.java
@@ -10,7 +10,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.Objects;
 import javax.json.JsonPatch;
 import javax.validation.Valid;
 import javax.ws.rs.Consumes;
@@ -33,8 +32,8 @@ import org.openmetadata.schema.settings.SettingsType;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.util.EntitiesCount;
 import org.openmetadata.schema.util.ServicesCount;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.jdbi3.SystemRepository;
 import org.openmetadata.service.resources.Collection;
@@ -54,9 +53,8 @@ public class SystemResource {
   private final Authorizer authorizer;
   private OpenMetadataApplicationConfig applicationConfig;
 
-  public SystemResource(CollectionDAO dao, Authorizer authorizer) {
-    Objects.requireNonNull(dao, "SystemRepository must not be null");
-    this.systemRepository = new SystemRepository(dao.systemDAO());
+  public SystemResource(Authorizer authorizer) {
+    this.systemRepository = Entity.getSystemRepository();
     this.authorizer = authorizer;
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/tags/ClassificationResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/tags/ClassificationResource.java
@@ -23,7 +23,6 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
 import javax.json.JsonPatch;
 import javax.validation.Valid;
@@ -53,8 +52,8 @@ import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.ClassificationRepository;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.resources.Collection;
 import org.openmetadata.service.resources.EntityResource;
@@ -82,9 +81,8 @@ public class ClassificationResource extends EntityResource<Classification, Class
     /* Required for serde */
   }
 
-  public ClassificationResource(CollectionDAO collectionDAO, Authorizer authorizer) {
-    super(Classification.class, new ClassificationRepository(collectionDAO), authorizer);
-    Objects.requireNonNull(collectionDAO, "TagRepository must not be null");
+  public ClassificationResource(Authorizer authorizer) {
+    super(Entity.CLASSIFICATION, authorizer);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/PersonaResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/PersonaResource.java
@@ -40,7 +40,6 @@ import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.jdbi3.PersonaRepository;
 import org.openmetadata.service.resources.Collection;
@@ -70,8 +69,8 @@ public class PersonaResource extends EntityResource<Persona, PersonaRepository> 
     return persona;
   }
 
-  public PersonaResource(CollectionDAO dao, Authorizer authorizer) {
-    super(Persona.class, new PersonaRepository(dao), authorizer);
+  public PersonaResource(Authorizer authorizer) {
+    super(Entity.PERSONA, authorizer);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/RoleResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/RoleResource.java
@@ -57,7 +57,6 @@ import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.jdbi3.RoleRepository;
 import org.openmetadata.service.resources.Collection;
@@ -90,8 +89,8 @@ public class RoleResource extends EntityResource<Role, RoleRepository> {
     return role;
   }
 
-  public RoleResource(CollectionDAO collectionDAO, Authorizer authorizer) {
-    super(Role.class, new RoleRepository(collectionDAO), authorizer);
+  public RoleResource(Authorizer authorizer) {
+    super(Entity.ROLE, authorizer);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/TeamResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/TeamResource.java
@@ -61,7 +61,6 @@ import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.schema.type.csv.CsvImportResult;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.jdbi3.TeamRepository;
 import org.openmetadata.service.jdbi3.TeamRepository.TeamCsv;
@@ -98,8 +97,8 @@ public class TeamResource extends EntityResource<Team, TeamRepository> {
     return team;
   }
 
-  public TeamResource(CollectionDAO dao, Authorizer authorizer) {
-    super(Team.class, new TeamRepository(dao), authorizer);
+  public TeamResource(Authorizer authorizer) {
+    super(Entity.TEAM, authorizer);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java
@@ -173,12 +173,12 @@ public class UserResource extends EntityResource<User, UserRepository> {
     return user;
   }
 
-  public UserResource(CollectionDAO dao, Authorizer authorizer, AuthenticatorHandler authenticatorHandler) {
-    super(User.class, new UserRepository(dao), authorizer);
+  public UserResource(Authorizer authorizer, AuthenticatorHandler authenticatorHandler) {
+    super(Entity.USER, authorizer);
     jwtTokenGenerator = JWTTokenGenerator.getInstance();
     allowedFields.remove(USER_PROTECTED_FIELDS);
-    tokenRepository = new TokenRepository(dao);
-    UserTokenCache.initialize(dao);
+    tokenRepository = Entity.getTokenRepository();
+    UserTokenCache.initialize();
     authHandler = authenticatorHandler;
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/topics/TopicResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/topics/TopicResource.java
@@ -56,7 +56,6 @@ import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.schema.type.topic.TopicSampleData;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.jdbi3.TopicRepository;
 import org.openmetadata.service.resources.Collection;
@@ -86,8 +85,8 @@ public class TopicResource extends EntityResource<Topic, TopicRepository> {
     return topic;
   }
 
-  public TopicResource(CollectionDAO dao, Authorizer authorizer) {
-    super(Topic.class, new TopicRepository(dao), authorizer);
+  public TopicResource(Authorizer authorizer) {
+    super(Entity.TOPIC, authorizer);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/types/TypeResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/types/TypeResource.java
@@ -57,7 +57,6 @@ import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.jdbi3.TypeRepository;
 import org.openmetadata.service.resources.Collection;
@@ -88,8 +87,8 @@ public class TypeResource extends EntityResource<Type, TypeRepository> {
     return type;
   }
 
-  public TypeResource(CollectionDAO dao, Authorizer authorizer) {
-    super(Type.class, new TypeRepository(dao), authorizer);
+  public TypeResource(Authorizer authorizer) {
+    super(Entity.TYPE, authorizer);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/usage/UsageResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/usage/UsageResource.java
@@ -20,7 +20,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.Date;
-import java.util.Objects;
 import java.util.UUID;
 import javax.validation.Valid;
 import javax.ws.rs.Consumes;
@@ -41,7 +40,6 @@ import org.openmetadata.schema.type.DailyCount;
 import org.openmetadata.schema.type.EntityUsage;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.UsageRepository;
 import org.openmetadata.service.resources.Collection;
 import org.openmetadata.service.security.Authorizer;
@@ -59,10 +57,9 @@ public class UsageResource {
   private final UsageRepository dao;
   private final Authorizer authorizer;
 
-  public UsageResource(CollectionDAO dao, Authorizer authorizer) {
-    Objects.requireNonNull(dao, "UsageRepository must not be null");
+  public UsageResource(Authorizer authorizer) {
     this.authorizer = authorizer;
-    this.dao = new UsageRepository(dao);
+    this.dao = Entity.getUsageRepository();
   }
 
   @GET

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/IndexUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/IndexUtil.java
@@ -35,7 +35,6 @@ public class IndexUtil {
   public static final String WEB_ANALYTIC_USER_ACTIVITY_REPORT_DATA = "webAnalyticUserActivityReportData";
   public static final String RAW_COST_ANALYSIS_REPORT_DATA = "rawCostAnalysisReportData";
   public static final String AGGREGATED_COST_ANALYSIS_REPORT_DATA = "AggregatedCostAnalysisReportData";
-  public static final String REPORT_DATA = "reportData";
   public static final Map<String, String> ENTITY_TYPE_TO_INDEX_MAP;
 
   private static final Map<SearchIndexDefinition.ElasticSearchIndexType, Set<String>> INDEX_TO_MAPPING_FIELDS_MAP =

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchClientImpl.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchClientImpl.java
@@ -169,6 +169,7 @@ public class ElasticSearchClientImpl implements SearchRepository {
     this.dao = dao;
   }
 
+  @Override
   public CollectionDAO getDao() {
     return dao;
   }
@@ -1039,12 +1040,6 @@ public class ElasticSearchClientImpl implements SearchRepository {
     }
   }
 
-  /**
-   * @param entity
-   * @param delete
-   * @param field
-   * @param alias
-   */
   @Override
   public void softDeleteOrRestoreChildren(EntityInterface entity, boolean delete, String field, String alias) {
     if (entity != null) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchClientImpl.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchClientImpl.java
@@ -154,6 +154,7 @@ import org.openmetadata.service.search.indexes.UserIndex;
 import org.openmetadata.service.util.JsonUtils;
 
 @Slf4j
+// Not tagged with Repository annotation as it is programmatically initialized
 public class ElasticSearchClientImpl implements SearchRepository {
 
   @SuppressWarnings("deprecated")

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchClientImpl.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchClientImpl.java
@@ -1171,7 +1171,7 @@ public class OpenSearchClientImpl implements SearchRepository {
     if (updateByQueryRequest != null) {
       LOG.debug(SENDING_REQUEST_TO_ELASTIC_SEARCH, updateByQueryRequest);
       ActionListener<BulkByScrollResponse> listener =
-          new ActionListener<BulkByScrollResponse>() {
+          new ActionListener<>() {
             @Override
             public void onResponse(BulkByScrollResponse response) {
               LOG.info("Update by query succeeded: " + response.toString());

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchClientImpl.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchClientImpl.java
@@ -154,6 +154,7 @@ import org.opensearch.search.suggest.completion.CompletionSuggestionBuilder;
 import org.opensearch.search.suggest.completion.context.CategoryQueryContext;
 
 @Slf4j
+// Not tagged with Repository annotation as it is programmatically initialized
 public class OpenSearchClientImpl implements SearchRepository {
   private final RestHighLevelClient client;
   private final CollectionDAO dao;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/secrets/SecretsManagerUpdateService.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/secrets/SecretsManagerUpdateService.java
@@ -178,8 +178,7 @@ public class SecretsManagerUpdateService {
   private Optional<ServiceEntityRepository<?, ?>> retrieveServiceRepository(CollectionDetails collectionDetails) {
     Class<?> collectionDetailsClass = extractCollectionDetailsClass(collectionDetails);
     if (ServiceEntityResource.class.isAssignableFrom(collectionDetailsClass)) {
-      return Optional.of(
-          ((ServiceEntityResource<?, ?, ?>) collectionDetails.getResource()).getServiceEntityRepository());
+      return Optional.of(((ServiceEntityResource<?, ?, ?>) collectionDetails.getResource()).getRepository());
     }
     return Optional.empty();
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/auth/BasicAuthenticator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/auth/BasicAuthenticator.java
@@ -61,6 +61,7 @@ import org.openmetadata.schema.auth.TokenRefreshRequest;
 import org.openmetadata.schema.email.SmtpSettings;
 import org.openmetadata.schema.entity.teams.AuthenticationMechanism;
 import org.openmetadata.schema.entity.teams.User;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
 import org.openmetadata.service.auth.JwtResponse;
 import org.openmetadata.service.exception.CustomExceptionMessage;
@@ -90,8 +91,8 @@ public class BasicAuthenticator implements AuthenticatorHandler {
 
   @Override
   public void init(OpenMetadataApplicationConfig config, CollectionDAO collectionDAO) {
-    this.userRepository = new UserRepository(collectionDAO);
-    this.tokenRepository = new TokenRepository(collectionDAO);
+    this.userRepository = (UserRepository) Entity.getEntityRepository(Entity.USER);
+    this.tokenRepository = Entity.getTokenRepository();
     this.authorizerConfiguration = config.getAuthorizerConfiguration();
     this.loginAttemptCache = new LoginAttemptCache(config);
     SmtpSettings smtpSettings = config.getSmtpSettings();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/auth/LdapAuthenticator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/auth/LdapAuthenticator.java
@@ -35,6 +35,7 @@ import org.openmetadata.schema.auth.LoginRequest;
 import org.openmetadata.schema.auth.RefreshToken;
 import org.openmetadata.schema.entity.teams.User;
 import org.openmetadata.schema.services.connections.metadata.AuthProvider;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
 import org.openmetadata.service.auth.JwtResponse;
 import org.openmetadata.service.exception.CustomExceptionMessage;
@@ -65,8 +66,8 @@ public class LdapAuthenticator implements AuthenticatorHandler {
     } else {
       throw new IllegalStateException("Invalid or Missing Ldap Configuration.");
     }
-    this.userRepository = new UserRepository(collectionDAO);
-    this.tokenRepository = new TokenRepository(collectionDAO);
+    this.userRepository = (UserRepository) Entity.getEntityRepository(Entity.USER);
+    this.tokenRepository = Entity.getTokenRepository();
     this.ldapConfiguration = config.getAuthenticationConfiguration().getLdapConfiguration();
     this.loginAttemptCache = new LoginAttemptCache(config);
     this.loginConfiguration = config.getApplicationConfiguration().getLoginConfig();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/auth/UserTokenCache.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/auth/UserTokenCache.java
@@ -19,7 +19,6 @@ import org.openmetadata.schema.auth.PersonalAccessToken;
 import org.openmetadata.schema.auth.TokenType;
 import org.openmetadata.schema.entity.teams.User;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.TokenRepository;
 import org.openmetadata.service.jdbi3.UserRepository;
 import org.openmetadata.service.resources.teams.UserResource;
@@ -36,9 +35,9 @@ public class UserTokenCache {
     /* Private constructor for singleton */
   }
 
-  public static void initialize(CollectionDAO dao) {
+  public static void initialize() {
     if (!initialized) {
-      tokenRepository = new TokenRepository(dao);
+      tokenRepository = Entity.getTokenRepository();
       initialized = true;
       LOG.info("User Token cache is initialized");
     } else {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/TablesInitializer.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/TablesInitializer.java
@@ -42,6 +42,7 @@ import org.flywaydb.core.api.MigrationVersion;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 import org.jdbi.v3.sqlobject.SqlObjects;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
 import org.openmetadata.service.fernet.Fernet;
 import org.openmetadata.service.jdbi3.CollectionDAO;
@@ -357,7 +358,9 @@ public final class TablesInitializer {
       Jdbi jdbi, ConnectionType connType, String nativeMigrationSQLPath, boolean forceMigrations) {
     DatasourceConfig.initialize(connType.label);
     MigrationWorkflow workflow = new MigrationWorkflow(jdbi, nativeMigrationSQLPath, connType, forceMigrations);
+    Entity.initializeRepositories(jdbi.onDemand(CollectionDAO.class));
     workflow.runMigrationWorkflows();
+    Entity.cleanup();
   }
 
   private static void printError(String message) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/TablesInitializer.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/TablesInitializer.java
@@ -48,7 +48,6 @@ import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.locator.ConnectionAwareAnnotationSqlLocator;
 import org.openmetadata.service.jdbi3.locator.ConnectionType;
 import org.openmetadata.service.migration.api.MigrationWorkflow;
-import org.openmetadata.service.resources.CollectionRegistry;
 import org.openmetadata.service.resources.databases.DatasourceConfig;
 import org.openmetadata.service.search.IndexUtil;
 import org.openmetadata.service.search.SearchIndexDefinition;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/TablesInitializer.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/TablesInitializer.java
@@ -358,8 +358,6 @@ public final class TablesInitializer {
       Jdbi jdbi, ConnectionType connType, String nativeMigrationSQLPath, boolean forceMigrations) {
     DatasourceConfig.initialize(connType.label);
     MigrationWorkflow workflow = new MigrationWorkflow(jdbi, nativeMigrationSQLPath, connType, forceMigrations);
-    CollectionRegistry.initialize(null);
-    CollectionRegistry.getInstance().initializeRepositories(jdbi.onDemand(CollectionDAO.class));
     workflow.runMigrationWorkflows();
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/TablesInitializer.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/TablesInitializer.java
@@ -48,6 +48,7 @@ import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.locator.ConnectionAwareAnnotationSqlLocator;
 import org.openmetadata.service.jdbi3.locator.ConnectionType;
 import org.openmetadata.service.migration.api.MigrationWorkflow;
+import org.openmetadata.service.resources.CollectionRegistry;
 import org.openmetadata.service.resources.databases.DatasourceConfig;
 import org.openmetadata.service.search.IndexUtil;
 import org.openmetadata.service.search.SearchIndexDefinition;
@@ -357,6 +358,8 @@ public final class TablesInitializer {
       Jdbi jdbi, ConnectionType connType, String nativeMigrationSQLPath, boolean forceMigrations) {
     DatasourceConfig.initialize(connType.label);
     MigrationWorkflow workflow = new MigrationWorkflow(jdbi, nativeMigrationSQLPath, connType, forceMigrations);
+    CollectionRegistry.initialize(null);
+    CollectionRegistry.getInstance().initializeRepositories(jdbi.onDemand(CollectionDAO.class));
     workflow.runMigrationWorkflows();
   }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/csv/EntityCsvTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/csv/EntityCsvTest.java
@@ -40,7 +40,7 @@ public class EntityCsvTest {
 
   @BeforeAll
   public static void setup() {
-    Entity.registerEntity(Table.class, Entity.TABLE, Mockito.mock(TableRepository.class), null);
+    Entity.registerEntity(Table.class, Entity.TABLE, Mockito.mock(TableRepository.class));
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/EnumBackwardCompatibilityTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/EnumBackwardCompatibilityTest.java
@@ -34,7 +34,9 @@ class EnumBackwardCompatibilityTest {
   /** */
   @Test
   void testRelationshipEnumBackwardCompatible() {
-    assertEquals(21, Relationship.values().length);
+    assertEquals(22, Relationship.values().length);
+    assertEquals(21, Relationship.DEFAULTS_TO.ordinal());
+    assertEquals(20, Relationship.EDITED_BY.ordinal());
     assertEquals(19, Relationship.EXPERT.ordinal());
     assertEquals(18, Relationship.VOTED.ordinal());
     assertEquals(17, Relationship.REACTED_TO.ordinal());

--- a/openmetadata-service/src/test/java/org/openmetadata/service/OpenMetadataApplicationTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/OpenMetadataApplicationTest.java
@@ -117,26 +117,10 @@ public abstract class OpenMetadataApplicationTest {
       String[] parts = ELASTIC_SEARCH_CONTAINER.getHttpHostAddress().split(":");
       HOST = parts[0];
       PORT = parts[1];
-      // elastic search overrides
-      configOverrides.add(ConfigOverride.config("elasticsearch.host", HOST));
-      configOverrides.add(ConfigOverride.config("elasticsearch.port", PORT));
-      configOverrides.add(ConfigOverride.config("elasticsearch.scheme", "http"));
-      configOverrides.add(ConfigOverride.config("elasticsearch.username", ""));
-      configOverrides.add(ConfigOverride.config("elasticsearch.password", ""));
-      configOverrides.add(ConfigOverride.config("elasticsearch.truststorePath", ""));
-      configOverrides.add(ConfigOverride.config("elasticsearch.truststorePassword", ""));
-      configOverrides.add(ConfigOverride.config("elasticsearch.connectionTimeoutSecs", "5"));
-      configOverrides.add(ConfigOverride.config("elasticsearch.socketTimeoutSecs", "60"));
-      configOverrides.add(ConfigOverride.config("elasticsearch.keepAliveTimeoutSecs", "600"));
-      configOverrides.add(ConfigOverride.config("elasticsearch.batchSize", "10"));
-      configOverrides.add(ConfigOverride.config("elasticsearch.searchIndexMappingLanguage", "EN"));
-      configOverrides.add(ConfigOverride.config("elasticsearch.searchType", "elasticsearch"));
+      overrideElasticSearchConfig();
     }
-    // Database overrides
-    configOverrides.add(ConfigOverride.config("database.driverClass", sqlContainer.getDriverClassName()));
-    configOverrides.add(ConfigOverride.config("database.url", sqlContainer.getJdbcUrl()));
-    configOverrides.add(ConfigOverride.config("database.user", sqlContainer.getUsername()));
-    configOverrides.add(ConfigOverride.config("database.password", sqlContainer.getPassword()));
+    overrideDatabaseConfig(sqlContainer);
+
     // Migration overrides
     configOverrides.add(ConfigOverride.config("migrationConfiguration.flywayPath", flyWayMigrationScripsLocation));
     configOverrides.add(ConfigOverride.config("migrationConfiguration.nativePath", nativeMigrationScripsLocation));
@@ -151,7 +135,6 @@ public abstract class OpenMetadataApplicationTest {
         .setSqlLocator(new ConnectionAwareAnnotationSqlLocator(sqlContainer.getDriverClassName()));
     validateAndRunSystemDataMigrations(
         jdbi, ConnectionType.from(sqlContainer.getDriverClassName()), nativeMigrationScripsLocation, false);
-
     APP.before();
   }
 
@@ -185,5 +168,30 @@ public abstract class OpenMetadataApplicationTest {
 
   public static WebTarget getConfigResource(String resource) {
     return getClient().target(format("http://localhost:%s/api/v1/system/config/%s", APP.getLocalPort(), resource));
+  }
+
+  private static void overrideElasticSearchConfig() {
+    // elastic search overrides
+    configOverrides.add(ConfigOverride.config("elasticsearch.host", HOST));
+    configOverrides.add(ConfigOverride.config("elasticsearch.port", PORT));
+    configOverrides.add(ConfigOverride.config("elasticsearch.scheme", "http"));
+    configOverrides.add(ConfigOverride.config("elasticsearch.username", ""));
+    configOverrides.add(ConfigOverride.config("elasticsearch.password", ""));
+    configOverrides.add(ConfigOverride.config("elasticsearch.truststorePath", ""));
+    configOverrides.add(ConfigOverride.config("elasticsearch.truststorePassword", ""));
+    configOverrides.add(ConfigOverride.config("elasticsearch.connectionTimeoutSecs", "5"));
+    configOverrides.add(ConfigOverride.config("elasticsearch.socketTimeoutSecs", "60"));
+    configOverrides.add(ConfigOverride.config("elasticsearch.keepAliveTimeoutSecs", "600"));
+    configOverrides.add(ConfigOverride.config("elasticsearch.batchSize", "10"));
+    configOverrides.add(ConfigOverride.config("elasticsearch.searchIndexMappingLanguage", "EN"));
+    configOverrides.add(ConfigOverride.config("elasticsearch.searchType", "elasticsearch"));
+  }
+
+  private static void overrideDatabaseConfig(JdbcDatabaseContainer<?> sqlContainer) {
+    // Database overrides
+    configOverrides.add(ConfigOverride.config("database.driverClass", sqlContainer.getDriverClassName()));
+    configOverrides.add(ConfigOverride.config("database.url", sqlContainer.getJdbcUrl()));
+    configOverrides.add(ConfigOverride.config("database.user", sqlContainer.getUsername()));
+    configOverrides.add(ConfigOverride.config("database.password", sqlContainer.getPassword()));
   }
 }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/policies/PolicyResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/policies/PolicyResourceTest.java
@@ -366,7 +366,7 @@ public class PolicyResourceTest extends EntityResourceTest<Policy, CreatePolicy>
               .filter(rd -> rd.getName().equals(entity))
               .findFirst()
               .orElse(null);
-      assertNotNull(resourceDescriptor);
+      assertNotNull(resourceDescriptor, String.format("Resource descriptor not found for entity %s", entity));
     }
   }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/RuleEvaluatorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/RuleEvaluatorTest.java
@@ -46,7 +46,7 @@ class RuleEvaluatorTest {
   @BeforeAll
   public static void setup() {
     TeamRepository teamRepository = mock(TeamRepository.class);
-    Entity.registerEntity(Team.class, Entity.TEAM, teamRepository, null);
+    Entity.registerEntity(Team.class, Entity.TEAM, teamRepository);
     Mockito.when(teamRepository.find(any(UUID.class), any(Include.class)))
         .thenAnswer(i -> EntityRepository.CACHE_WITH_ID.get(new ImmutablePair<>(Entity.TEAM, i.getArgument(0))));
     Mockito.when(teamRepository.getReference(any(UUID.class), any(Include.class)))
@@ -66,7 +66,7 @@ class RuleEvaluatorTest {
         .thenAnswer(i -> EntityRepository.CACHE_WITH_ID.get(new ImmutablePair<>(Entity.TEAM, i.getArgument(1))));
 
     TableRepository tableRepository = mock(TableRepository.class);
-    Entity.registerEntity(Table.class, Entity.TABLE, tableRepository, null);
+    Entity.registerEntity(Table.class, Entity.TABLE, tableRepository);
     Mockito.when(tableRepository.getAllTags(any()))
         .thenAnswer((Answer<List<TagLabel>>) invocationOnMock -> table.getTags());
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/SubjectContextTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/SubjectContextTest.java
@@ -74,22 +74,22 @@ public class SubjectContextTest {
   @BeforeAll
   public static void setup() {
     UserRepository userRepository = mock(UserRepository.class);
-    Entity.registerEntity(User.class, Entity.USER, userRepository, null);
+    Entity.registerEntity(User.class, Entity.USER, userRepository);
     Mockito.when(userRepository.getByName(isNull(), anyString(), isNull(), any(Include.class), anyBoolean()))
         .thenAnswer(i -> EntityRepository.CACHE_WITH_NAME.get(new ImmutablePair<>(Entity.USER, i.getArgument(1))));
 
     TeamRepository teamRepository = mock(TeamRepository.class);
-    Entity.registerEntity(Team.class, Entity.TEAM, teamRepository, null);
+    Entity.registerEntity(Team.class, Entity.TEAM, teamRepository);
     Mockito.when(teamRepository.get(isNull(), any(UUID.class), isNull(), any(Include.class), anyBoolean()))
         .thenAnswer(i -> EntityRepository.CACHE_WITH_ID.get(new ImmutablePair<>(Entity.TEAM, i.getArgument(1))));
 
     RoleRepository roleRepository = mock(RoleRepository.class);
-    Entity.registerEntity(Role.class, Entity.ROLE, roleRepository, null);
+    Entity.registerEntity(Role.class, Entity.ROLE, roleRepository);
     Mockito.when(roleRepository.get(isNull(), any(UUID.class), isNull(), any(Include.class), anyBoolean()))
         .thenAnswer(i -> EntityRepository.CACHE_WITH_ID.get(new ImmutablePair<>(Entity.ROLE, i.getArgument(1))));
 
     PolicyRepository policyRepository = mock(PolicyRepository.class);
-    Entity.registerEntity(Policy.class, Entity.POLICY, policyRepository, null);
+    Entity.registerEntity(Policy.class, Entity.POLICY, policyRepository);
     Mockito.when(policyRepository.get(isNull(), any(UUID.class), isNull(), any(Include.class), anyBoolean()))
         .thenAnswer(i -> EntityRepository.CACHE_WITH_ID.get(new ImmutablePair<>(Entity.POLICY, i.getArgument(1))));
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

This change initializes the Repositories for various entities first and makes them available in the Entity registry. Resources are initialized after Repositories and pick up the entities that are already initialized. This helps in reusing EntityRepositories for migration.

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
