### PR TITLE
Update references to Airflow instead of Airbyte

### DIFF
--- a/openmetadata-docs/content/v1.1.x/connectors/pipeline/airflow/yaml.md
+++ b/openmetadata-docs/content/v1.1.x/connectors/pipeline/airflow/yaml.md
@@ -5,9 +5,9 @@ slug: /connectors/pipeline/airflow/yaml
 
 # Run the Airflow Connector Externally
 
-In this section, we provide guides and references to use the Airbyte connector.
+In this section, we provide guides and references to use the Airflow connector.
 
-Configure and schedule Airbyte metadata and profiler workflows from the OpenMetadata UI:
+Configure and schedule Airflow metadata and profiler workflows from the OpenMetadata UI:
 
 - [Requirements](#requirements)
 - [Metadata Ingestion](#metadata-ingestion)
@@ -40,8 +40,8 @@ The ingestion using Airflow version 2.3.3 as a source package has been tested ag
 ## Metadata Ingestion
 
 All connectors are defined as JSON Schemas.
-[Here](https://github.com/open-metadata/OpenMetadata/blob/main/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/pipeline/airbyteConnection.json)
-you can find the structure to create a connection to Airbyte.
+[Here](https://github.com/open-metadata/OpenMetadata/blob/main/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/pipeline/airflowConnection.json)
+you can find the structure to create a connection to Airflow.
 
 In order to create and run a Metadata Ingestion workflow, we will follow
 the steps to create a YAML configuration able to connect to the source,
@@ -52,7 +52,7 @@ The workflow is modeled around the following
 
 ### 1. Define the YAML Config
 
-This is a sample config for Airbyte:
+This is a sample config for Airflow:
 
 {% codePreview %}
 


### PR DESCRIPTION
### Describe your changes:

fix for seems like copy-paste documentation error when someone was documentation for Airflow connector using airbyte as a template page.