### PR TITLE
chore(ui): add support for custom messages and options in delete widget modal

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/DeleteWidget/DeleteWidget.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/DeleteWidget/DeleteWidget.interface.ts
@@ -11,6 +11,13 @@
  *  limitations under the License.
  */
 
+export interface DeleteOption {
+  title: string;
+  description: string;
+  type: DeleteType;
+  isAllowed: boolean;
+}
+
 export interface DeleteWidgetModalProps {
   visible: boolean;
   onCancel: () => void;
@@ -24,6 +31,8 @@ export interface DeleteWidgetModalProps {
   entityId?: string;
   prepareType?: boolean;
   isRecursiveDelete?: boolean;
+  successMessage?: string;
+  deleteOptions?: DeleteOption[];
   afterDeleteAction?: (isSoftDelete?: boolean) => void;
 }
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/DeleteWidget/DeleteWidgetModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/DeleteWidget/DeleteWidgetModal.tsx
@@ -54,6 +54,8 @@ const DeleteWidgetModal = ({
   prepareType = true,
   isRecursiveDelete,
   afterDeleteAction,
+  successMessage,
+  deleteOptions,
 }: DeleteWidgetModalProps) => {
   const { t } = useTranslation();
   const [entityDeleteState, setEntityDeleteState] =
@@ -123,9 +125,10 @@ const DeleteWidgetModal = ({
 
       if (response.status === 200) {
         showSuccessToast(
-          t('server.entity-deleted-successfully', {
-            entity: startCase(entityType),
-          })
+          successMessage ??
+            t('server.entity-deleted-successfully', {
+              entity: startCase(entityType),
+            })
         );
         if (afterDeleteAction) {
           afterDeleteAction(entityDeleteState.softDelete);
@@ -217,7 +220,7 @@ const DeleteWidgetModal = ({
       title={`${t('label.delete')} ${entityName}`}
       onCancel={handleOnEntityDeleteCancel}>
       <Radio.Group value={value} onChange={onChange}>
-        {DELETE_OPTION.map(
+        {(deleteOptions ?? DELETE_OPTION).map(
           (option) =>
             option.isAllowed && (
               <Radio

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/entityPageInfo/ManageButton/ManageButton.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/entityPageInfo/ManageButton/ManageButton.tsx
@@ -29,6 +29,7 @@ import { NO_PERMISSION_FOR_ACTION } from '../../../../constants/HelperTextUtil';
 import { DROPDOWN_ICON_SIZE_PROPS } from '../../../../constants/ManageButton.constants';
 import { EntityType } from '../../../../enums/entity.enum';
 import { ANNOUNCEMENT_ENTITIES } from '../../../../utils/AnnouncementsUtils';
+import { DeleteOption } from '../../DeleteWidget/DeleteWidget.interface';
 import DeleteWidgetModal from '../../DeleteWidget/DeleteWidgetModal';
 import './ManageButton.less';
 
@@ -54,6 +55,9 @@ interface Props {
   onEditDisplayName?: (data: EntityName) => Promise<void>;
   allowRename?: boolean;
   prepareType?: boolean;
+  successMessage?: string;
+  deleteButtonDescription?: string;
+  deleteOptions?: DeleteOption[];
 }
 
 const ManageButton: FC<Props> = ({
@@ -77,6 +81,9 @@ const ManageButton: FC<Props> = ({
   onEditDisplayName,
   allowRename,
   prepareType = true,
+  successMessage,
+  deleteButtonDescription,
+  deleteOptions,
 }) => {
   const { t } = useTranslation();
   const [isDelete, setIsDelete] = useState<boolean>(false);
@@ -199,12 +206,12 @@ const ManageButton: FC<Props> = ({
           {
             label: (
               <ManageButtonItemLabel
-                description={t(
-                  'message.delete-entity-type-action-description',
-                  {
+                description={
+                  deleteButtonDescription ??
+                  t('message.delete-entity-type-action-description', {
                     entityType,
-                  }
-                )}
+                  })
+                }
                 icon={
                   <IconDelete
                     className="m-t-xss"
@@ -254,6 +261,7 @@ const ManageButton: FC<Props> = ({
           afterDeleteAction={afterDeleteAction}
           allowSoftDelete={allowSoftDelete}
           deleteMessage={deleteMessage}
+          deleteOptions={deleteOptions}
           entityId={entityId || ''}
           entityName={entityName || ''}
           entityType={entityType || ''}
@@ -261,6 +269,7 @@ const ManageButton: FC<Props> = ({
           isRecursiveDelete={isRecursiveDelete}
           prepareType={prepareType}
           softDeleteMessagePostFix={softDeleteMessagePostFix}
+          successMessage={successMessage}
           visible={isDelete}
           onCancel={() => setIsDelete(false)}
         />


### PR DESCRIPTION


<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:


<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on adding support for custom messages and options in delete widget modal.
<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] Improvement


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
