### PR TITLE
docs: run bootstrap from correct folder

### DIFF
--- a/openmetadata-docs/content/v1.2.x-SNAPSHOT/developers/contribute/build-code-and-run-tests/openmetadata-server.md
+++ b/openmetadata-docs/content/v1.2.x-SNAPSHOT/developers/contribute/build-code-and-run-tests/openmetadata-server.md
@@ -24,8 +24,8 @@ docker compose -f docker/development/docker-compose-postgres.yml up postgresql e
   2. Extract the distribution tar.gz file and run the following command
 
 ```shell
-cd open-metadata-<version>/bootstrap
-sh bootstrap_storage.sh drop-create-all
+cd open-metadata-<version>
+sh bootstrap/bootstrap_storage.sh drop-create-all
 ```
 
 - Bootstrap ES with indexes and load sample data into MySQL


### PR DESCRIPTION
### Describe your changes:

If I cd into bootstrap folder as the current docs suggest, I get `Error: Could not find or load main class`. However, if run from repo root, then it works!

Updating the docs to reflect the working behavior

I worked on this because I noticed it while setting up my local development environment

### Type of change:
- [X] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.