### PR TITLE
fix(ui): removed the persona settings option for non-admin users

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/MyDataPage/MyDataPageV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/MyDataPage/MyDataPageV1.component.tsx
@@ -21,7 +21,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { Responsive, WidthProvider } from 'react-grid-layout';
+import RGL, { WidthProvider } from 'react-grid-layout';
 import { useLocation } from 'react-router-dom';
 import AppState from '../../AppState';
 import ActivityFeedProvider from '../../components/ActivityFeed/ActivityFeedProvider/ActivityFeedProvider';
@@ -45,7 +45,7 @@ import { showErrorToast } from '../../utils/ToastUtils';
 import { WidgetConfig } from '../CustomizablePage/CustomizablePage.interface';
 import './my-data.less';
 
-const ResponsiveGridLayout = WidthProvider(Responsive);
+const ReactGridLayout = WidthProvider(RGL);
 
 const MyDataPageV1 = () => {
   const location = useLocation();
@@ -245,12 +245,10 @@ const MyDataPageV1 = () => {
         {isLoading ? (
           <Loader />
         ) : (
-          <ResponsiveGridLayout
-            autoSize
-            breakpoints={{ lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0 }}
+          <ReactGridLayout
             className="bg-white"
-            cols={{ lg: 4, md: 4, sm: 4, xs: 4, xxs: 4 }}
-            draggableHandle=".drag-widget-icon"
+            cols={4}
+            isDraggable={false}
             isResizable={false}
             margin={[
               customizePageClassBase.landingPageWidgetMargin,
@@ -258,7 +256,7 @@ const MyDataPageV1 = () => {
             ]}
             rowHeight={100}>
             {widgets}
-          </ResponsiveGridLayout>
+          </ReactGridLayout>
         )}
       </ActivityFeedProvider>
     </div>

--- a/openmetadata-ui/src/main/resources/ui/src/utils/GlobalSettingsUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/GlobalSettingsUtils.tsx
@@ -104,10 +104,7 @@ export const getGlobalSettingsMenuWithPermission = (
 
         {
           label: i18next.t('label.persona-plural'),
-          isProtected: userPermissions.hasViewPermissions(
-            ResourceEntity.USER,
-            permissions
-          ),
+          isProtected: Boolean(isAdminUser),
           key: 'members.persona',
           icon: <PersonasIcon className="side-panel-icons" />,
         },


### PR DESCRIPTION
I worked on removing the persona settings option for non-admin users

https://github.com/open-metadata/OpenMetadata/assets/51777795/57402865-4bfe-4c8f-bf9c-bdd944a17d95

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
