### PR TITLE
Fixes #13607: BigQuery lineage ingestion fails when using GcpCredentialsPath authentication config

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/bigquery/query_parser.py
+++ b/ingestion/src/metadata/ingestion/source/database/bigquery/query_parser.py
@@ -23,7 +23,7 @@ from metadata.generated.schema.entity.services.connections.database.bigQueryConn
 from metadata.generated.schema.metadataIngestion.workflow import (
     Source as WorkflowSource,
 )
-from metadata.generated.schema.security.credentials.gcpValues import MultipleProjectId
+from metadata.generated.schema.security.credentials.gcpValues import MultipleProjectId, GcpCredentialsValues
 from metadata.ingestion.api.steps import InvalidSourceException
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.database.bigquery.helper import get_inspector_details
@@ -69,6 +69,8 @@ class BigqueryQueryParserSource(QueryParserSource, ABC):
 
     def get_engine(self):
         if isinstance(
+                self.service_connection.credentials.gcpConfig, GcpCredentialsValues
+        ) and isinstance(
             self.service_connection.credentials.gcpConfig.projectId, MultipleProjectId
         ):
             project_ids = deepcopy(

--- a/ingestion/tests/unit/topology/database/test_bigquery.py
+++ b/ingestion/tests/unit/topology/database/test_bigquery.py
@@ -21,6 +21,7 @@ from metadata.generated.schema.entity.data.table import TableType
 from metadata.generated.schema.metadataIngestion.workflow import (
     OpenMetadataWorkflowConfig,
 )
+from metadata.ingestion.source.database.bigquery.lineage import BigqueryLineageSource
 from metadata.ingestion.source.database.bigquery.metadata import BigquerySource
 
 mock_bq_config = {
@@ -82,3 +83,18 @@ class BigqueryUnitTest(TestCase):
             ),
             EXPECTED_URL,
         )
+
+
+class BigqueryLineageSourceTest(TestCase):
+    @patch("metadata.ingestion.source.database.bigquery.connection.get_connection")
+    @patch("metadata.ingestion.source.database.bigquery.connection.test_connection")
+    @patch("metadata.ingestion.ometa.ometa_api.OpenMetadata")
+    def __init__(self, methodName, get_connection, test_connection, OpenMetadata) -> None:
+        super().__init__(methodName)
+
+        self.config = OpenMetadataWorkflowConfig.parse_obj(mock_bq_config)
+        self.bq_query_parser = BigqueryLineageSource(self.config.source, OpenMetadata())
+
+    def test_get_engine_without_project_id_specified(self):
+        for engine in self.bq_query_parser.get_engine():
+            assert engine is self.bq_query_parser.engine

--- a/ingestion/tests/unit/topology/database/test_bigquery.py
+++ b/ingestion/tests/unit/topology/database/test_bigquery.py
@@ -45,6 +45,11 @@ mock_bq_config = {
     },
 }
 
+mock_credentials_path_bq_config = mock_bq_config
+mock_credentials_path_bq_config["source"]["serviceConnection"]["config"]["credentials"]["gcpConfig"][
+    "__root__"
+] = "credentials.json"
+
 
 MOCK_DB_NAME = "random-project-id"
 MOCK_SCHEMA_NAME = "test_omd"
@@ -92,7 +97,7 @@ class BigqueryLineageSourceTest(TestCase):
     def __init__(self, methodName, get_connection, test_connection, OpenMetadata) -> None:
         super().__init__(methodName)
 
-        self.config = OpenMetadataWorkflowConfig.parse_obj(mock_bq_config)
+        self.config = OpenMetadataWorkflowConfig.parse_obj(mock_credentials_path_bq_config)
         self.bq_query_parser = BigqueryLineageSource(self.config.source, OpenMetadata())
 
     def test_get_engine_without_project_id_specified(self):


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #13607

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I slightly modified the `metadata.ingestion.source.database.bigquery.query_parser.BigqueryQueryParserSource.get_engine()` method so that it doesn't generate an error when used with the `GcpCredentialsPath` config model.
I tested it by building the `development-ingestion` Docker image and configuring our internal OpenMetadata instance to use the modified image instead of the original one.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.

