### PR TITLE
Update Dockerfiles to run OMD as non-root user

### DIFF
--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -19,7 +19,7 @@ RUN mkdir -p /opt/openmetadata && \
     rm openmetadata-*.tar.gz
 
 # Final stage
-FROM alpine:3.16
+FROM alpine:3
 
 EXPOSE 8585
 

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -30,6 +30,10 @@ COPY docker/openmetadata-start.sh /
 
 RUN chmod 777 openmetadata-start.sh
 
+RUN adduser -D openmetadata
+RUN chown -R openmetadata:openmetadata /opt/openmetadata
+USER openmetadata
+
 WORKDIR /opt/openmetadata
 ENTRYPOINT [ "/bin/bash" ]
 CMD ["/openmetadata-start.sh"]

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -10,7 +10,7 @@
 #  limitations under the License.
 
 # Build stage
-FROM alpine:3.16 AS build
+FROM alpine:3 AS build
 
 COPY openmetadata-dist/target/openmetadata-*.tar.gz /
 

--- a/docker/docker-compose-quickstart/Dockerfile
+++ b/docker/docker-compose-quickstart/Dockerfile
@@ -10,7 +10,7 @@
 #  limitations under the License.
 
 # Build stage
-FROM alpine:3.15 AS build
+FROM alpine:3 AS build
 ARG RI_VERSION="1.2.0"
 ENV RELEASE_URL="https://github.com/open-metadata/OpenMetadata/releases/download/${RI_VERSION}-release/openmetadata-${RI_VERSION}.tar.gz"
 
@@ -20,7 +20,7 @@ RUN mkdir -p /opt/openmetadata && \
     rm openmetadata-*.tar.gz
 
 # Final stage
-FROM alpine:3.15
+FROM alpine:3
 ARG RI_VERSION="1.2.0"
 ARG BUILD_DATE
 ARG COMMIT_ID

--- a/docker/docker-compose-quickstart/Dockerfile
+++ b/docker/docker-compose-quickstart/Dockerfile
@@ -39,6 +39,11 @@ COPY docker/openmetadata-start.sh ./
 COPY --from=build /opt/openmetadata /opt/openmetadata
 RUN apk add --update --no-cache bash openjdk17-jre && \
     chmod 777 openmetadata-start.sh
+
+RUN adduser -D openmetadata
+RUN chown -R openmetadata:openmetadata /opt/openmetadata
+USER openmetadata
+
 WORKDIR /opt/openmetadata
 ENTRYPOINT [ "/bin/bash" ]
 CMD ["/openmetadata-start.sh"]


### PR DESCRIPTION
### Describe your changes:

I worked on updating openmetadata-server image to execute the container as non-root user as users may need to run it with non-root user due to their security requirements. 
We got such request here: [Thread](https://openmetadata.slack.com/archives/C02B6955S4S/p1697535889992959)

#
### Type of change:
- [x] Improvement

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.