### PR TITLE
fix: remove RESULT_SCAN dep.

### DIFF
--- a/ingestion/src/metadata/utils/profiler_utils.py
+++ b/ingestion/src/metadata/utils/profiler_utils.py
@@ -40,6 +40,14 @@ class QueryResult(BaseModel):
     rows: Optional[int] = None
 
 
+class SnowflakeQueryResult(QueryResult):
+    """Snowflake system metric query result"""
+
+    rows_inserted: Optional[int] = None
+    rows_updated: Optional[int] = None
+    rows_deleted: Optional[int] = None
+
+
 def clean_up_query(query: str) -> str:
     """remove comments and newlines from query"""
     return sqlparse.format(query, strip_comments=True).replace("\\n", "")


### PR DESCRIPTION
### Describe your changes:
- `result_scan` will only return the info for a query ran by the users, we need to get the info directly from the query_history

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
