### PR TITLE
fix(ui): AUT cypress tests

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/DashboardIndex.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/DashboardIndex.java
@@ -51,7 +51,6 @@ public class DashboardIndex implements SearchIndex {
       dataModelSuggest.add(SearchSuggest.builder().input(chart.getDisplayName()).weight(5).build());
     }
 
-    doc.put("name", dashboard.getDisplayName());
     doc.put("displayName", dashboard.getDisplayName() != null ? dashboard.getDisplayName() : dashboard.getName());
     doc.put("tags", parseTags.getTags());
     doc.put("followers", SearchIndexUtils.parseFollowers(dashboard.getFollowers()));

--- a/openmetadata-ui/src/main/resources/ui/cypress/common/common.js
+++ b/openmetadata-ui/src/main/resources/ui/cypress/common/common.js
@@ -1351,12 +1351,12 @@ export const visitDataModelPage = (dataModelFQN, dataModelName) => {
 
   interceptURL(
     'GET',
-    'api/v1/services/dashboardServices/name/sample_looker?fields=*',
+    'api/v1/services/dashboardServices/name/sample_looker*',
     'getDashboardDetails'
   );
   interceptURL(
     'GET',
-    '/api/v1/dashboard/datamodels?service=sample_looker&fields=*',
+    '/api/v1/dashboard/datamodels?service=sample_looker*',
     'getDataModels'
   );
 

--- a/openmetadata-ui/src/main/resources/ui/cypress/e2e/Features/SchemaSearch.spec.js
+++ b/openmetadata-ui/src/main/resources/ui/cypress/e2e/Features/SchemaSearch.spec.js
@@ -118,7 +118,7 @@ describe('Schema search', () => {
     );
     interceptURL(
       'GET',
-      `/api/v1/databaseSchemas?fields=*&database=${serviceName}.default&include=non-deleted`,
+      `/api/v1/databaseSchemas?fields=*&database=${serviceName}.default*`,
       'databaseSchema'
     );
     interceptURL(

--- a/openmetadata-ui/src/main/resources/ui/src/components/ClassificationDetails/ClassificationDetails.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ClassificationDetails/ClassificationDetails.tsx
@@ -73,6 +73,7 @@ export interface ClassificationDetailsProps {
   currentClassification?: Classification;
   deleteTags?: DeleteTagsType;
   isEditClassification?: boolean;
+  isAddingTag?: boolean;
   disableEditButton?: boolean;
   handleAfterDeleteAction?: () => void;
   handleEditTagClick?: (selectedTag: Tag) => void;
@@ -93,13 +94,14 @@ function ClassificationDetails({
   handleUpdateClassification,
   handleEditTagClick,
   deleteTags,
+  isAddingTag,
   handleActionDeleteTag,
   handleAddNewTagClick,
   handleEditDescriptionClick,
   handleCancelEditDescription,
   disableEditButton,
   isVersionView = false,
-}: ClassificationDetailsProps) {
+}: Readonly<ClassificationDetailsProps>) {
   const { permissions } = usePermissionProvider();
   const { t } = useTranslation();
   const { fqn: tagCategoryName } = useParams<{ fqn: string }>();
@@ -407,10 +409,19 @@ function ClassificationDetails({
   }, [currentClassification, changeDescription]);
 
   useEffect(() => {
-    if (currentClassification?.fullyQualifiedName) {
+    if (
+      currentClassification?.fullyQualifiedName &&
+      !deleteTags?.state &&
+      !isAddingTag
+    ) {
       fetchClassificationChildren(currentClassification.fullyQualifiedName);
     }
-  }, [currentClassification?.fullyQualifiedName, pageSize]);
+  }, [
+    currentClassification?.fullyQualifiedName,
+    pageSize,
+    deleteTags?.state,
+    isAddingTag,
+  ]);
 
   return (
     <div className="p-x-md" data-testid="tags-container">

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/OwnerLabel/OwnerLabel.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/OwnerLabel/OwnerLabel.component.tsx
@@ -13,7 +13,7 @@
 import Icon from '@ant-design/icons';
 import { Typography } from 'antd';
 import classNames from 'classnames';
-import { isUndefined } from 'lodash';
+import { isNil } from 'lodash';
 import React, { ReactNode, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
@@ -46,7 +46,7 @@ export const OwnerLabel = ({
   const { t } = useTranslation();
 
   const profilePicture = useMemo(() => {
-    if (isUndefined(owner)) {
+    if (isNil(owner)) {
       return (
         <Icon
           component={IconUser}

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TagsPage/TagsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TagsPage/TagsPage.tsx
@@ -718,6 +718,7 @@ const TagsPage = () => {
           handleEditDescriptionClick={handleEditDescriptionClick}
           handleEditTagClick={handleEditTagClick}
           handleUpdateClassification={handleUpdateClassification}
+          isAddingTag={isAddingTag}
           isEditClassification={isEditClassification}
         />
       )}


### PR DESCRIPTION
**UI:** 

I worked on 

- [x] AUT cypress test fixes

- [x] Fixed bug on service listing page
**Before:**

https://github.com/open-metadata/OpenMetadata/assets/51777795/6e91e2a0-c9b8-401b-aec0-1fc174b0d0cc

**After:**

https://github.com/open-metadata/OpenMetadata/assets/51777795/47b2f795-1f2f-4997-8390-feafa25e445f



**Backend:**

Fixed an issue mentioned in #12924 which was not fixed yet.


<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
