### PR TITLE
Fixes ISSUE-13981: multiplied POSIX timestamp to match millisecond accuracy

### DIFF
--- a/ingestion/src/metadata/great_expectations/action.py
+++ b/ingestion/src/metadata/great_expectations/action.py
@@ -430,7 +430,7 @@ class OpenMetadataValidationAction(ValidationAction):
 
             self.ometa_conn.add_test_case_results(
                 test_results=TestCaseResult(
-                    timestamp=datetime.now(timezone.utc).timestamp(),
+                    timestamp=datetime.now(timezone.utc).timestamp()*1000,
                     testCaseStatus=TestCaseStatus.Success
                     if result["success"]
                     else TestCaseStatus.Failed,


### PR DESCRIPTION
…ontend

<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on the great-expectations ingestion module because it didn't put the correct timestamp values in our db

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [X] My PR title is `Fixes <issue-number>: <short explanation>`
