### PR TITLE
fix(ui): #13963 glossary term custom property update

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/GlossaryTermsV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/GlossaryTermsV1.component.tsx
@@ -109,12 +109,15 @@ const GlossaryTermsV1 = ({
     tab !== 'assets' && activeTabHandler('assets');
   }, [assetTabRef, tab]);
 
-  const onExtensionUpdate = async (updatedTable: GlossaryTerm) => {
-    await handleGlossaryTermUpdate({
-      ...glossaryTerm,
-      extension: updatedTable.extension,
-    });
-  };
+  const onExtensionUpdate = useCallback(
+    async (updatedTable: GlossaryTerm) => {
+      await handleGlossaryTermUpdate({
+        ...glossaryTerm,
+        extension: updatedTable.extension,
+      });
+    },
+    [glossaryTerm, handleGlossaryTermUpdate]
+  );
 
   const tabItems = useMemo(() => {
     const items = [
@@ -241,6 +244,7 @@ const GlossaryTermsV1 = ({
     isVersionView,
     assetPermissions,
     handleAssetSave,
+    onExtensionUpdate,
   ]);
 
   const fetchGlossaryTermAssets = async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/CustomPropertyTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/CustomPropertyTable.tsx
@@ -34,6 +34,7 @@ import {
   getDiffByFieldName,
   getUpdatedExtensionDiffFields,
 } from '../../../utils/EntityVersionUtils';
+import { getDecodedFqn } from '../../../utils/StringsUtils';
 import { showErrorToast } from '../../../utils/ToastUtils';
 import { usePermissionProvider } from '../../PermissionProvider/PermissionProvider';
 import {
@@ -67,11 +68,12 @@ export const CustomPropertyTable = <T extends ExtentionEntitiesKeys>({
   const [entityTypeDetailLoading, setEntityTypeDetailLoading] =
     useState<boolean>(false);
   const { fqn } = useParams<{ fqn: string; tab: string; version: string }>();
+  const decodedeFqn = getDecodedFqn(fqn);
 
   const fetchExtentiondetails = async () => {
     const response = await getEntityExtentionDetailsFromEntityType<T>(
       entityType,
-      fqn
+      decodedeFqn
     );
 
     setExtentionDetails(response as ExtentionEntities[T]);
@@ -79,7 +81,7 @@ export const CustomPropertyTable = <T extends ExtentionEntitiesKeys>({
 
   useEffect(() => {
     fetchExtentiondetails();
-  }, [fqn]);
+  }, [decodedeFqn]);
 
   const [typePermission, setPermission] = useState<OperationPermission>();
   const versionDetails = entityDetails ?? extentionDetails;
@@ -128,7 +130,7 @@ export const CustomPropertyTable = <T extends ExtentionEntitiesKeys>({
         setExtentionDetails(updatedData);
       }
     },
-    [versionDetails]
+    [versionDetails, handleExtensionUpdate]
   );
 
   const extensionObject: {


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes: #13963

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on the fix glossary term not updating Custom properties


https://github.com/open-metadata/OpenMetadata/assets/12962843/3a80237a-6b33-4986-b7d9-f3be18baf108



#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
