### PR TITLE
Fix #11357 - DB migration for custom metrics

### DIFF
--- a/bootstrap/sql/migrations/native/1.3.0/mysql/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.3.0/mysql/postDataMigrationSQLScript.sql
@@ -1,0 +1,8 @@
+-- Rename customMetricsProfile to customMetrics
+UPDATE profiler_data_time_series
+SET json = REPLACE(json, '"customMetricsProfile"', '"customMetrics"');
+
+-- Delete customMetricsProfile from entity_extension
+-- This was not supported on the processing side before 1.3.
+DELETE FROM openmetadata_db.entity_extension ee   
+where extension  like '%customMetrics';

--- a/bootstrap/sql/migrations/native/1.3.0/postgres/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.3.0/postgres/postDataMigrationSQLScript.sql
@@ -1,0 +1,8 @@
+-- Rename customMetricsProfile to customMetrics
+UPDATE profiler_data_time_series
+SET json = REPLACE(json::text, '"customMetricsProfile"', '"customMetrics"')::jsonb;
+
+-- Delete customMetricsProfile from entity_extension
+-- This was not supported on the processing side before 1.3.
+DELETE FROM entity_extension ee   
+where extension  like '%customMetrics';


### PR DESCRIPTION
### Describe your changes:

Fixes #11357 
- rename profile metric key to `customMetrics`
- Delete customMetrics for extension. Implementation has been overhauled and OM has not had support for computing custom metrics since now. As a result we are deleting the existing data if any were ingested from via the API. Users we'll need to recreate it if there were some customMetrics definition

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

- [x] I have added tests around the new logic.
- [x] For connector/ingestion changes: I updated the documentation.

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
