### PR TITLE
chore(ui): add `tagType` prop in TagSuggestion component

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsContainerV2/TagsContainerV2.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsContainerV2/TagsContainerV2.tsx
@@ -27,15 +27,11 @@ import {
   KNOWLEDGE_CENTER_CLASSIFICATION,
 } from '../../../constants/constants';
 import { TAG_CONSTANT, TAG_START_WITH } from '../../../constants/Tag.constants';
-import { SearchIndex } from '../../../enums/search.enum';
-import { GlossaryTerm } from '../../../generated/entity/data/glossaryTerm';
-import { Paging } from '../../../generated/type/paging';
 import { TagSource } from '../../../generated/type/tagLabel';
-import { getGlossaryTerms } from '../../../rest/glossaryAPI';
-import { searchQuery } from '../../../rest/searchAPI';
 import { getEntityFeedLink } from '../../../utils/EntityUtils';
 import { getFilterTags } from '../../../utils/TableTags/TableTags.utils';
 import {
+  fetchGlossaryList,
   fetchTagsElasticSearch,
   getTagPlaceholder,
 } from '../../../utils/TagsUtils';
@@ -96,42 +92,6 @@ const TagsContainerV2 = ({
     [tagType, permission, tags?.[tagType], tags, layoutType]
   );
 
-  const fetchGlossaryList = useCallback(
-    async (
-      searchQueryParam: string,
-      page: number
-    ): Promise<{
-      data: {
-        label: string;
-        value: string;
-        data: GlossaryTerm;
-      }[];
-      paging: Paging;
-    }> => {
-      const glossaryResponse = await searchQuery({
-        query: searchQueryParam ? `*${searchQueryParam}*` : '*',
-        pageNumber: page,
-        pageSize: 10,
-        queryFilter: {},
-        searchIndex: SearchIndex.GLOSSARY,
-      });
-
-      const hits = glossaryResponse.hits.hits;
-
-      return {
-        data: hits.map(({ _source }) => ({
-          label: _source.fullyQualifiedName ?? '',
-          value: _source.fullyQualifiedName ?? '',
-          data: _source,
-        })),
-        paging: {
-          total: glossaryResponse.hits.total.value,
-        },
-      };
-    },
-    [searchQuery, getGlossaryTerms]
-  );
-
   const fetchAPI = useCallback(
     (searchValue: string, page: number) => {
       if (tagType === TagSource.Classification) {
@@ -140,7 +100,7 @@ const TagsContainerV2 = ({
         return fetchGlossaryList(searchValue, page);
       }
     },
-    [tagType, fetchGlossaryList]
+    [tagType, filterClassifications]
   );
 
   const showNoDataPlaceholder = useMemo(

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/TagSuggestion.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/TagSuggestion.tsx
@@ -15,18 +15,33 @@ import { DefaultOptionType } from 'antd/lib/select';
 import { t } from 'i18next';
 import { isArray, isEmpty } from 'lodash';
 import { EntityTags } from 'Models';
-import React from 'react';
+import React, { useMemo } from 'react';
 import AsyncSelectList from '../../../components/AsyncSelectList/AsyncSelectList';
 import { TagSource } from '../../../generated/entity/data/container';
 import { TagLabel } from '../../../generated/type/tagLabel';
-import { fetchTagsElasticSearch } from '../../../utils/TagsUtils';
+import {
+  fetchGlossaryList,
+  fetchTagsElasticSearch,
+} from '../../../utils/TagsUtils';
 
 export interface TagSuggestionProps {
-  onChange?: (newTags: TagLabel[]) => void;
+  placeholder?: string;
+  tagType?: TagSource;
   value?: TagLabel[];
+  onChange?: (newTags: TagLabel[]) => void;
 }
 
-const TagSuggestion: React.FC<TagSuggestionProps> = ({ onChange, value }) => {
+const TagSuggestion: React.FC<TagSuggestionProps> = ({
+  onChange,
+  value,
+  placeholder,
+  tagType = TagSource.Classification,
+}) => {
+  const isGlossaryType = useMemo(
+    () => tagType === TagSource.Glossary,
+    [tagType]
+  );
+
   const handleTagSelection = (
     newValue: DefaultOptionType | DefaultOptionType[]
   ) => {
@@ -40,7 +55,9 @@ const TagSuggestion: React.FC<TagSuggestionProps> = ({ onChange, value }) => {
           }
           let tagData: EntityTags = {
             tagFQN: tag.value,
-            source: TagSource.Classification,
+            source: isGlossaryType
+              ? TagSource.Glossary
+              : TagSource.Classification,
           };
 
           if (tag.data) {
@@ -64,11 +81,14 @@ const TagSuggestion: React.FC<TagSuggestionProps> = ({ onChange, value }) => {
   return (
     <AsyncSelectList
       defaultValue={value?.map((item) => item.tagFQN) || []}
-      fetchOptions={fetchTagsElasticSearch}
+      fetchOptions={isGlossaryType ? fetchGlossaryList : fetchTagsElasticSearch}
       mode="multiple"
-      placeholder={t('label.select-field', {
-        field: t('label.tag-plural'),
-      })}
+      placeholder={
+        placeholder ??
+        t('label.select-field', {
+          field: t('label.tag-plural'),
+        })
+      }
       onChange={(value) => handleTagSelection(value)}
     />
   );

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TagsUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TagsUtils.tsx
@@ -29,6 +29,7 @@ import { ExplorePageTabs } from '../enums/Explore.enum';
 import { SearchIndex } from '../enums/search.enum';
 import { Classification } from '../generated/entity/classification/classification';
 import { Tag } from '../generated/entity/classification/tag';
+import { GlossaryTerm } from '../generated/entity/data/glossaryTerm';
 import { Column } from '../generated/entity/data/table';
 import { Paging } from '../generated/type/paging';
 import { LabelType, State, TagLabel } from '../generated/type/tagLabel';
@@ -335,6 +336,39 @@ export const fetchTagsElasticSearch = async (
     }, []),
     paging: {
       total: res.hits.total.value,
+    },
+  };
+};
+
+export const fetchGlossaryList = async (
+  searchQueryParam: string,
+  page: number
+): Promise<{
+  data: {
+    label: string;
+    value: string;
+    data: GlossaryTerm;
+  }[];
+  paging: Paging;
+}> => {
+  const glossaryResponse = await searchQuery({
+    query: searchQueryParam ? `*${searchQueryParam}*` : '*',
+    pageNumber: page,
+    pageSize: 10,
+    queryFilter: {},
+    searchIndex: SearchIndex.GLOSSARY,
+  });
+
+  const hits = glossaryResponse.hits.hits;
+
+  return {
+    data: hits.map(({ _source }) => ({
+      label: _source.fullyQualifiedName ?? '',
+      value: _source.fullyQualifiedName ?? '',
+      data: _source,
+    })),
+    paging: {
+      total: glossaryResponse.hits.total.value,
     },
   };
 };


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:


<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on adding a `tagType` prop in the TagSuggestion component to make it reusable for both tags and glossary tag sources.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] Improvement


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
