### PR TITLE
chore(ui): add `initialOptions` prop in tag suggestion component

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/AsyncSelectList/AsyncSelectList.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AsyncSelectList/AsyncSelectList.interface.ts
@@ -28,7 +28,7 @@ export interface AsyncSelectListProps {
   placeholder?: string;
   debounceTimeout?: number;
   defaultValue?: string[];
-  initialData?: SelectOption[];
+  initialOptions?: SelectOption[];
   onChange?: (option: DefaultOptionType | DefaultOptionType[]) => void;
   fetchOptions: (
     search: string,

--- a/openmetadata-ui/src/main/resources/ui/src/components/AsyncSelectList/AsyncSelectList.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AsyncSelectList/AsyncSelectList.tsx
@@ -42,7 +42,7 @@ const AsyncSelectList: FC<AsyncSelectListProps> = ({
   onChange,
   fetchOptions,
   debounceTimeout = 800,
-  initialData,
+  initialOptions,
   className,
   ...props
 }) => {
@@ -52,7 +52,7 @@ const AsyncSelectList: FC<AsyncSelectListProps> = ({
   const [searchValue, setSearchValue] = useState<string>('');
   const [paging, setPaging] = useState<Paging>({} as Paging);
   const [currentPage, setCurrentPage] = useState(1);
-  const selectedTagsRef = useRef<SelectOption[]>(initialData ?? []);
+  const selectedTagsRef = useRef<SelectOption[]>(initialOptions ?? []);
 
   const loadOptions = useCallback(
     async (value: string) => {
@@ -204,7 +204,7 @@ const AsyncSelectList: FC<AsyncSelectListProps> = ({
         data ?? {
           value,
           label: value,
-          data: initialData?.find((item) => item.value === value)?.data,
+          data: initialOptions?.find((item) => item.value === value)?.data,
         }
       );
     });

--- a/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsSelectForm/TagsSelectForm.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsSelectForm/TagsSelectForm.component.tsx
@@ -66,7 +66,7 @@ const TagSelectForm = ({
             <AsyncSelectList
               className="tag-select-box"
               fetchOptions={fetchApi}
-              initialData={tagData}
+              initialOptions={tagData}
               mode="multiple"
               placeholder={placeholder}
             />

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/TagSuggestion.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/TagSuggestion.tsx
@@ -29,7 +29,7 @@ export interface TagSuggestionProps {
   placeholder?: string;
   tagType?: TagSource;
   value?: TagLabel[];
-  initialData?: SelectOption[];
+  initialOptions?: SelectOption[];
   onChange?: (newTags: TagLabel[]) => void;
 }
 
@@ -37,7 +37,7 @@ const TagSuggestion: React.FC<TagSuggestionProps> = ({
   onChange,
   value,
   placeholder,
-  initialData,
+  initialOptions,
   tagType = TagSource.Classification,
 }) => {
   const isGlossaryType = useMemo(
@@ -85,7 +85,7 @@ const TagSuggestion: React.FC<TagSuggestionProps> = ({
     <AsyncSelectList
       defaultValue={value?.map((item) => item.tagFQN) || []}
       fetchOptions={isGlossaryType ? fetchGlossaryList : fetchTagsElasticSearch}
-      initialData={initialData}
+      initialOptions={initialOptions}
       mode="multiple"
       placeholder={
         placeholder ??

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/TagSuggestion.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/TagSuggestion.tsx
@@ -17,6 +17,7 @@ import { isArray, isEmpty } from 'lodash';
 import { EntityTags } from 'Models';
 import React, { useMemo } from 'react';
 import AsyncSelectList from '../../../components/AsyncSelectList/AsyncSelectList';
+import { SelectOption } from '../../../components/AsyncSelectList/AsyncSelectList.interface';
 import { TagSource } from '../../../generated/entity/data/container';
 import { TagLabel } from '../../../generated/type/tagLabel';
 import {
@@ -28,6 +29,7 @@ export interface TagSuggestionProps {
   placeholder?: string;
   tagType?: TagSource;
   value?: TagLabel[];
+  initialData?: SelectOption[];
   onChange?: (newTags: TagLabel[]) => void;
 }
 
@@ -35,6 +37,7 @@ const TagSuggestion: React.FC<TagSuggestionProps> = ({
   onChange,
   value,
   placeholder,
+  initialData,
   tagType = TagSource.Classification,
 }) => {
   const isGlossaryType = useMemo(
@@ -82,6 +85,7 @@ const TagSuggestion: React.FC<TagSuggestionProps> = ({
     <AsyncSelectList
       defaultValue={value?.map((item) => item.tagFQN) || []}
       fetchOptions={isGlossaryType ? fetchGlossaryList : fetchTagsElasticSearch}
+      initialData={initialData}
       mode="multiple"
       placeholder={
         placeholder ??


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:


<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on adding `initialOptions` prop in the tag suggestion component so that it can render the initial values options with proper styling and label.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] Improvement


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
