### PR TITLE
fix: add cypress around assets

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/cypress/constants/constants.js
+++ b/openmetadata-ui/src/main/resources/ui/cypress/constants/constants.js
@@ -553,4 +553,18 @@ export const DOMAIN_2 = {
   experts: 'Alex Pollard',
   owner: 'Alex Pollard',
   domainType: 'Source-aligned',
+  assets: [
+    {
+      name: 'dim_customer',
+      fullyQualifiedName: 'sample_data.ecommerce_db.shopify.dim_address',
+    },
+    {
+      name: 'raw_order',
+      fullyQualifiedName: 'sample_data.ecommerce_db.shopify.raw_order',
+    },
+    {
+      name: 'presto_etl',
+      fullyQualifiedName: 'sample_airflow.presto_etl',
+    },
+  ],
 };

--- a/openmetadata-ui/src/main/resources/ui/cypress/constants/constants.js
+++ b/openmetadata-ui/src/main/resources/ui/cypress/constants/constants.js
@@ -518,6 +518,7 @@ export const NAME_MAX_LENGTH_VALIDATION_ERROR =
 export const DOMAIN_1 = {
   name: 'Cypress%Domain',
   updatedName: 'Cypress_Domain_Name',
+  fullyQualifiedName: 'Cypress%Domain',
   updatedDisplayName: 'Cypress_Domain_Display_Name',
   description:
     'This is the Cypress for testing domain creation with percent and dot',
@@ -549,10 +550,34 @@ export const DOMAIN_2 = {
   name: 'Cypress.Domain.New',
   updatedName: 'Cypress.Domain.New',
   updatedDisplayName: 'Cypress.Domain.New',
+  fullyQualifiedName: '"Cypress.Domain.New"',
   description: 'This is the Cypress for testing domain creation',
   experts: 'Alex Pollard',
   owner: 'Alex Pollard',
   domainType: 'Source-aligned',
+  dataProducts: [
+    {
+      name: 'Cypress DataProduct Assets',
+      description:
+        'This is the data product description for Cypress DataProduct Assets',
+      experts: 'Aaron Johnson',
+      owner: 'Aaron Johnson',
+      assets: [
+        {
+          name: 'dim_customer',
+          fullyQualifiedName: 'sample_data.ecommerce_db.shopify.dim_address',
+        },
+        {
+          name: 'raw_order',
+          fullyQualifiedName: 'sample_data.ecommerce_db.shopify.raw_order',
+        },
+        {
+          name: 'presto_etl',
+          fullyQualifiedName: 'sample_airflow.presto_etl',
+        },
+      ],
+    },
+  ],
   assets: [
     {
       name: 'dim_customer',

--- a/openmetadata-ui/src/main/resources/ui/cypress/e2e/Pages/Domains.spec.js
+++ b/openmetadata-ui/src/main/resources/ui/cypress/e2e/Pages/Domains.spec.js
@@ -14,6 +14,7 @@
 /// <reference types="Cypress" />
 
 import {
+  addAssets,
   createDataProducts,
   createDomain,
   deleteDomain,
@@ -42,6 +43,10 @@ describe('Domain page should work properly', () => {
   it('Verify domain after creation', () => {
     verifyDomain(DOMAIN_1);
     verifyDomain(DOMAIN_2);
+  });
+
+  it('Add assets to domain should work properly', () => {
+    addAssets(DOMAIN_2);
   });
 
   it('Create new data product should work properly', () => {

--- a/openmetadata-ui/src/main/resources/ui/cypress/e2e/Pages/Domains.spec.js
+++ b/openmetadata-ui/src/main/resources/ui/cypress/e2e/Pages/Domains.spec.js
@@ -14,8 +14,8 @@
 /// <reference types="Cypress" />
 
 import {
-  addAssetsToDomain,
   addAssetsToDataProduct,
+  addAssetsToDomain,
   createDataProducts,
   createDomain,
   deleteDomain,

--- a/openmetadata-ui/src/main/resources/ui/cypress/e2e/Pages/Domains.spec.js
+++ b/openmetadata-ui/src/main/resources/ui/cypress/e2e/Pages/Domains.spec.js
@@ -14,7 +14,8 @@
 /// <reference types="Cypress" />
 
 import {
-  addAssets,
+  addAssetsToDomain,
+  addAssetsToDataProduct,
   createDataProducts,
   createDomain,
   deleteDomain,
@@ -46,7 +47,7 @@ describe('Domain page should work properly', () => {
   });
 
   it('Add assets to domain should work properly', () => {
-    addAssets(DOMAIN_2);
+    addAssetsToDomain(DOMAIN_2);
   });
 
   it('Create new data product should work properly', () => {
@@ -56,6 +57,17 @@ describe('Domain page should work properly', () => {
         .should('be.visible')
         .click({ force: true });
     });
+  });
+
+  it('Add data product assets should work properly', () => {
+    DOMAIN_2.dataProducts.forEach((dp) => {
+      createDataProducts(dp, DOMAIN_2);
+      cy.get('[data-testid="app-bar-item-domain"]')
+        .should('be.visible')
+        .click({ force: true });
+    });
+
+    addAssetsToDataProduct(DOMAIN_2.dataProducts[0], DOMAIN_2);
   });
 
   it('Update domain details should work properly', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Assets/AssetsSelectionModal/AssetSelectionModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Assets/AssetsSelectionModal/AssetSelectionModal.tsx
@@ -392,10 +392,14 @@ export const AssetSelectionModal = ({
       destroyOnClose
       closable={false}
       closeIcon={null}
+      data-testid="asset-selection-modal"
       footer={
         <>
-          <Button onClick={onCancel}>{t('label.cancel')}</Button>
+          <Button data-testid="cancel-btn" onClick={onCancel}>
+            {t('label.cancel')}
+          </Button>
           <Button
+            data-testid="save-btn"
             disabled={isLoading}
             loading={isSaveLoading}
             type="primary"

--- a/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
@@ -64,6 +64,7 @@ import {
   setMsalInstance,
 } from '../../../utils/AuthProvider.util';
 import localState from '../../../utils/LocalStorageUtils';
+import { escapeESReservedCharacters } from '../../../utils/StringsUtils';
 import { showErrorToast } from '../../../utils/ToastUtils';
 import {
   fetchAllUsers,
@@ -429,7 +430,9 @@ export const AuthProvider = ({
         // Parse and update the query parameter
         const queryParams = Qs.parse(config.url.split('?')[1]);
         // adding quotes for exact matching
-        const domainStatement = `(domain.fullyQualifiedName:${activeDomain})`;
+        const domainStatement = `(domain.fullyQualifiedName:${escapeESReservedCharacters(
+          activeDomain
+        )})`;
         queryParams.q = queryParams.q ?? '';
         queryParams.q += isEmpty(queryParams.q)
           ? domainStatement

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx
@@ -77,6 +77,7 @@ import {
   getDataProductVersionsPath,
   getDomainPath,
 } from '../../../utils/RouterUtils';
+import { escapeESReservedCharacters } from '../../../utils/StringsUtils';
 import { showErrorToast } from '../../../utils/ToastUtils';
 import { EntityDetailsObjectInterface } from '../../Explore/ExplorePage.interface';
 import StyleModal from '../../Modals/StyleModal/StyleModal.component';
@@ -202,13 +203,15 @@ const DataProductsDetailsPage = ({
   }, [permissions, isVersionsView]);
 
   const fetchDataProductAssets = async () => {
-    if (fqn) {
+    if (dataProduct) {
       try {
         const res = await searchData(
           '',
           1,
           0,
-          `(dataProducts.fullyQualifiedName:${fqn})`,
+          `(dataProducts.fullyQualifiedName:"${escapeESReservedCharacters(
+            dataProduct.fullyQualifiedName
+          )}")`,
           '',
           '',
           SearchIndex.ALL

--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetailsPage/DomainDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetailsPage/DomainDetailsPage.component.tsx
@@ -81,6 +81,7 @@ import {
   getDomainPath,
   getDomainVersionsPath,
 } from '../../../utils/RouterUtils';
+import { escapeESReservedCharacters } from '../../../utils/StringsUtils';
 import { showErrorToast } from '../../../utils/ToastUtils';
 import DeleteWidgetModal from '../../common/DeleteWidget/DeleteWidgetModal';
 import { EntityDetailsObjectInterface } from '../../Explore/ExplorePage.interface';
@@ -238,7 +239,9 @@ const DomainDetailsPage = ({
           '',
           1,
           0,
-          `(domain.fullyQualifiedName:${domainFqn})`,
+          `(domain.fullyQualifiedName:${escapeESReservedCharacters(
+            domain.fullyQualifiedName
+          )})`,
           '',
           '',
           SearchIndex.DATA_PRODUCT
@@ -258,7 +261,9 @@ const DomainDetailsPage = ({
           '',
           1,
           0,
-          `(domain.fullyQualifiedName:${fqn}) AND !(entityType:"dataProduct")`,
+          `(domain.fullyQualifiedName:"${escapeESReservedCharacters(
+            domain.fullyQualifiedName
+          )}") AND !(entityType:"dataProduct")`,
           '',
           '',
           SearchIndex.ALL

--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainTabs/DataProductsTab/DataProductsTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainTabs/DataProductsTab/DataProductsTab.component.tsx
@@ -29,6 +29,10 @@ import { SearchIndex } from '../../../../enums/search.enum';
 import { DataProduct } from '../../../../generated/entity/domains/dataProduct';
 import { searchData } from '../../../../rest/miscAPI';
 import { formatDataProductResponse } from '../../../../utils/APIUtils';
+import {
+  escapeESReservedCharacters,
+  getDecodedFqn,
+} from '../../../../utils/StringsUtils';
 import ErrorPlaceHolder from '../../../common/ErrorWithPlaceholder/ErrorPlaceHolder';
 import EntitySummaryPanel from '../../../Explore/EntitySummaryPanel/EntitySummaryPanel.component';
 import ExploreSearchCard from '../../../ExploreV1/ExploreSearchCard/ExploreSearchCard';
@@ -58,7 +62,9 @@ const DataProductsTab = forwardRef(
           '',
           1,
           PAGE_SIZE_LARGE,
-          `(domain.fullyQualifiedName:${domainFqn})`,
+          `(domain.fullyQualifiedName:"${escapeESReservedCharacters(
+            getDecodedFqn(domainFqn)
+          )}")`,
           '',
           '',
           SearchIndex.DATA_PRODUCT

--- a/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreSearchCard/ExploreSearchCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreSearchCard/ExploreSearchCard.tsx
@@ -176,7 +176,11 @@ const ExploreSearchCard: React.FC<ExploreSearchCardProps> = forwardRef<
               </div>
             </Col>
           )}
-          <Col data-testid={`${source.service?.name}-${source.name}`} span={24}>
+          <Col
+            data-testid={`${
+              source.service?.name ? `${source.service.name}-` : 'explore-card-'
+            }${source.name}`}
+            span={24}>
             {isTourOpen ? (
               <Button data-testid={source.fullyQualifiedName} type="link">
                 <Typography.Text

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/GlossaryTermsV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/GlossaryTermsV1.component.tsx
@@ -36,6 +36,7 @@ import { getCountBadge, getFeedCounts } from '../../../utils/CommonUtils';
 import { getEntityVersionByField } from '../../../utils/EntityVersionUtils';
 import { getQueryFilterToExcludeTerm } from '../../../utils/GlossaryUtils';
 import { getGlossaryTermsVersionsPath } from '../../../utils/RouterUtils';
+import { escapeESReservedCharacters } from '../../../utils/StringsUtils';
 import { ActivityFeedTab } from '../../ActivityFeed/ActivityFeedTab/ActivityFeedTab.component';
 import { AssetSelectionModal } from '../../Assets/AssetsSelectionModal/AssetSelectionModal';
 import { CustomPropertyTable } from '../../common/CustomPropertyTable/CustomPropertyTable';
@@ -250,13 +251,15 @@ const GlossaryTermsV1 = ({
   ]);
 
   const fetchGlossaryTermAssets = async () => {
-    if (glossaryFqn) {
+    if (glossaryTerm) {
       try {
         const res = await searchData(
           '',
           1,
           0,
-          `(tags.tagFQN:"${glossaryFqn}")`,
+          `(tags.tagFQN:"${escapeESReservedCharacters(
+            glossaryTerm.fullyQualifiedName
+          )}")`,
           '',
           '',
           SearchIndex.ALL

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/GlossaryTermsV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/GlossaryTermsV1.test.tsx
@@ -99,7 +99,7 @@ describe('Test Glossary-term component', () => {
     expect(tabs.map((tab) => tab.textContent)).toStrictEqual([
       'label.overview',
       'label.glossary-term-plural0',
-      'label.asset-plural0', // 1 added as its count for assets
+      'label.asset-plural1', // 1 added as its count for assets
       'label.activity-feed-and-task-plural0',
       'label.custom-property-plural',
     ]);

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/AssetsTabs.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/AssetsTabs.component.tsx
@@ -71,7 +71,10 @@ import {
 import { getCountBadge, Transi18next } from '../../../../utils/CommonUtils';
 import { getEntityName } from '../../../../utils/EntityUtils';
 import { getEntityTypeFromSearchIndex } from '../../../../utils/SearchUtils';
-import { getDecodedFqn } from '../../../../utils/StringsUtils';
+import {
+  escapeESReservedCharacters,
+  getDecodedFqn,
+} from '../../../../utils/StringsUtils';
 import { getEntityIcon } from '../../../../utils/TableUtils';
 import { showErrorToast } from '../../../../utils/ToastUtils';
 import ErrorPlaceHolder from '../../../common/ErrorWithPlaceholder/ErrorPlaceHolder';
@@ -149,10 +152,14 @@ const AssetsTabs = forwardRef(
     const queryParam = useMemo(() => {
       switch (type) {
         case AssetsOfEntity.DOMAIN:
-          return `(domain.fullyQualifiedName:${fqn}) AND !(entityType:"dataProduct")`;
+          return `(domain.fullyQualifiedName:"${escapeESReservedCharacters(
+            entityFqn
+          )}") AND !(entityType:"dataProduct")`;
 
         case AssetsOfEntity.DATA_PRODUCT:
-          return `(dataProducts.fullyQualifiedName:${fqn})`;
+          return `(dataProducts.fullyQualifiedName:"${escapeESReservedCharacters(
+            entityFqn
+          )}")`;
 
         case AssetsOfEntity.TEAM:
           return `(owner.fullyQualifiedName:"${fqn}")`;
@@ -162,9 +169,9 @@ const AssetsTabs = forwardRef(
           return queryFilter ?? '';
 
         default:
-          return `(tags.tagFQN:"${fqn}")`;
+          return `(tags.tagFQN:"${escapeESReservedCharacters(entityFqn)}")`;
       }
-    }, [type, fqn]);
+    }, [type, fqn, entityFqn]);
 
     const fetchAssets = useCallback(
       async ({

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/TableDataCardV2/TableDataCardV2.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/TableDataCardV2/TableDataCardV2.tsx
@@ -146,7 +146,7 @@ const TableDataCardV2: React.FC<TableDataCardPropsV2> = forwardRef<
           'table-data-card-container',
           className
         )}
-        data-testid="table-data-card"
+        data-testid={'table-data-card_' + (source.fullyQualifiedName ?? '')}
         id={id}
         ref={ref}
         onClick={() => {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DomainUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DomainUtils.tsx
@@ -136,6 +136,17 @@ export const getQueryFilterToIncludeDomain = (
             ],
           },
         },
+        {
+          bool: {
+            must_not: [
+              {
+                term: {
+                  entityType: 'dataProduct',
+                },
+              },
+            ],
+          },
+        },
       ],
     },
   },


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Contains cypress of assets on Domain, Data Product and Glossary Term

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
