### PR TITLE
#14169: Support external_account type for GCP Auth

### DIFF
--- a/ingestion/src/metadata/utils/credentials.py
+++ b/ingestion/src/metadata/utils/credentials.py
@@ -113,10 +113,10 @@ def build_google_credentials_dict(gcp_values: GcpCredentialsValues) -> Dict[str,
     elif gcp_values.type == "external_account":
         return {
             "type": gcp_values.type,
-            "audience": gcp_values.authenticated,
+            "audience": gcp_values.audience,
             "subject_token_type": gcp_values.subjectTokenType,
             "token_url": gcp_values.tokenURL,
-            "credential_source": gcp_values.credential,
+            "credential_source": gcp_values.credentialSource,
         }
     else:
         raise InvalidGcpConfigException(

--- a/ingestion/src/metadata/utils/credentials.py
+++ b/ingestion/src/metadata/utils/credentials.py
@@ -110,7 +110,7 @@ def build_google_credentials_dict(gcp_values: GcpCredentialsValues) -> Dict[str,
             "auth_provider_x509_cert_url": str(gcp_values.authProviderX509CertUrl),
             "client_x509_cert_url": str(gcp_values.clientX509CertUrl),
         }
-    elif gcp_values.type == "external_account":
+    if gcp_values.type == "external_account":
         return {
             "type": gcp_values.type,
             "audience": gcp_values.audience,
@@ -118,10 +118,10 @@ def build_google_credentials_dict(gcp_values: GcpCredentialsValues) -> Dict[str,
             "token_url": gcp_values.tokenURL,
             "credential_source": gcp_values.credentialSource,
         }
-    else:
-        raise InvalidGcpConfigException(
-            f"Error not support credential type {gcp_values.type}"
-        )
+
+    raise InvalidGcpConfigException(
+        f"Error not support credential type {gcp_values.type}"
+    )
 
 
 def set_google_credentials(gcp_credentials: GCPCredentials) -> None:

--- a/ingestion/src/metadata/utils/credentials.py
+++ b/ingestion/src/metadata/utils/credentials.py
@@ -97,18 +97,31 @@ def build_google_credentials_dict(gcp_values: GcpCredentialsValues) -> Dict[str,
     private_key_str = private_key_str.replace("\\n", "\n")
     validate_private_key(private_key_str)
 
-    return {
-        "type": gcp_values.type,
-        "project_id": gcp_values.projectId.__root__,
-        "private_key_id": gcp_values.privateKeyId,
-        "private_key": private_key_str,
-        "client_email": gcp_values.clientEmail,
-        "client_id": gcp_values.clientId,
-        "auth_uri": str(gcp_values.authUri),
-        "token_uri": str(gcp_values.tokenUri),
-        "auth_provider_x509_cert_url": str(gcp_values.authProviderX509CertUrl),
-        "client_x509_cert_url": str(gcp_values.clientX509CertUrl),
-    }
+    if gcp_values.type == "service_account":
+        return {
+            "type": gcp_values.type,
+            "project_id": gcp_values.projectId.__root__,
+            "private_key_id": gcp_values.privateKeyId,
+            "private_key": private_key_str,
+            "client_email": gcp_values.clientEmail,
+            "client_id": gcp_values.clientId,
+            "auth_uri": str(gcp_values.authUri),
+            "token_uri": str(gcp_values.tokenUri),
+            "auth_provider_x509_cert_url": str(gcp_values.authProviderX509CertUrl),
+            "client_x509_cert_url": str(gcp_values.clientX509CertUrl),
+        }
+    elif gcp_values.type == "external_account":
+        return {
+            "type": gcp_values.type,
+            "audience": gcp_values.authenticated,
+            "subject_token_type": gcp_values.subjectTokenType,
+            "token_url": gcp_values.tokenURL,
+            "credential_source": gcp_values.credential,
+        }
+    else:
+        raise InvalidGcpConfigException(
+            f"Error not support credential type {gcp_values.type}"
+        )
 
 
 def set_google_credentials(gcp_credentials: GCPCredentials) -> None:

--- a/ingestion/src/metadata/utils/credentials.py
+++ b/ingestion/src/metadata/utils/credentials.py
@@ -92,12 +92,12 @@ def build_google_credentials_dict(gcp_values: GcpCredentialsValues) -> Dict[str,
     :param gcp_values: GCP credentials
     :return: Dictionary with credentials
     """
-    private_key_str = gcp_values.privateKey.get_secret_value()
-    # adding the replace string here to escape line break if passed from env
-    private_key_str = private_key_str.replace("\\n", "\n")
-    validate_private_key(private_key_str)
-
     if gcp_values.type == "service_account":
+        private_key_str = gcp_values.privateKey.get_secret_value()
+        # adding the replace string here to escape line break if passed from env
+        private_key_str = private_key_str.replace("\\n", "\n")
+        validate_private_key(private_key_str)
+
         return {
             "type": gcp_values.type,
             "project_id": gcp_values.projectId.__root__,

--- a/ingestion/tests/unit/test_credentials.py
+++ b/ingestion/tests/unit/test_credentials.py
@@ -15,6 +15,9 @@ from unittest import TestCase
 
 from pydantic import SecretStr
 
+from metadata.generated.schema.security.credentials.gcpExternalAccount import (
+    GcpCredentialsValuesExternalAccount,
+)
 from metadata.generated.schema.security.credentials.gcpValues import (
     GcpCredentialsValues,
 )
@@ -87,7 +90,7 @@ VEhPQF0i0tUU7Fl071hcYaiQoZx4nIjN+NG6p5QKbl6k
         """
         Check how we can validate GCS values
         """
-        gcp_values = GcpCredentialsValues(
+        gcp_values = GcpCredentialsValuesExternalAccount(
             type="external_account",
             audience="audience",
             subjectTokenType="subject_token_type",

--- a/ingestion/tests/unit/test_credentials.py
+++ b/ingestion/tests/unit/test_credentials.py
@@ -29,7 +29,7 @@ class TestCredentials(TestCase):
     Validate credentials handling
     """
 
-    def test_build_google_credentials_dict(self):
+    def test_build_service_account_google_credentials_dict(self):
         """
         Check how we can validate GCS values
         """
@@ -52,7 +52,7 @@ VEhPQF0i0tUU7Fl071hcYaiQoZx4nIjN+NG6p5QKbl6k
 -----END RSA PRIVATE KEY-----"""
 
         gcp_values = GcpCredentialsValues(
-            type="my_type",
+            type="service_account",
             projectId=["project_id"],
             privateKeyId="private_key_id",
             privateKey=private_key,
@@ -62,7 +62,7 @@ VEhPQF0i0tUU7Fl071hcYaiQoZx4nIjN+NG6p5QKbl6k
         )
 
         expected_dict = {
-            "type": "my_type",
+            "type": "service_account",
             "project_id": ["project_id"],
             "private_key_id": "private_key_id",
             "private_key": private_key,
@@ -82,3 +82,37 @@ VEhPQF0i0tUU7Fl071hcYaiQoZx4nIjN+NG6p5QKbl6k
 
         with self.assertRaises(InvalidPrivateKeyException):
             build_google_credentials_dict(gcp_values)
+
+    def test_build_external_account_google_credentials_dict(self):
+        """
+        Check how we can validate GCS values
+        """
+        gcp_values = GcpCredentialsValues(
+            type="service_account",
+            audience="audience",
+            subjectTokenType="subject_token_type",
+            tokenURL="token_url",
+            credentialSource={
+                "environmentId": "environment_id"
+            }
+        )
+
+        expected_dict = {
+            "type": "service_account",
+            "audience": "audience"
+            "subject_token_type": "subject_token_type",
+            "token_url": "token_url",
+            "credential_source":{
+                "environmentId": "environment_id"
+            }
+        }
+
+        build_google_credentials_dict(gcp_values)
+
+        self.assertEqual(expected_dict, build_google_credentials_dict(gcp_values))
+
+        gcp_values.privateKey = SecretStr("I don't think I am a proper Private Key")
+
+        with self.assertRaises(InvalidPrivateKeyException):
+            build_google_credentials_dict(gcp_values)
+

--- a/ingestion/tests/unit/test_credentials.py
+++ b/ingestion/tests/unit/test_credentials.py
@@ -92,9 +92,7 @@ VEhPQF0i0tUU7Fl071hcYaiQoZx4nIjN+NG6p5QKbl6k
             audience="audience",
             subjectTokenType="subject_token_type",
             tokenURL="token_url",
-            credentialSource={
-                "environmentId": "environment_id"
-            }
+            credentialSource={"environmentId": "environment_id"},
         )
 
         expected_dict = {
@@ -102,9 +100,7 @@ VEhPQF0i0tUU7Fl071hcYaiQoZx4nIjN+NG6p5QKbl6k
             "audience": "audience",
             "subject_token_type": "subject_token_type",
             "token_url": "token_url",
-            "credential_source": {
-                "environmentId": "environment_id"
-            }
+            "credential_source": {"environmentId": "environment_id"},
         }
 
         build_google_credentials_dict(gcp_values)
@@ -115,4 +111,3 @@ VEhPQF0i0tUU7Fl071hcYaiQoZx4nIjN+NG6p5QKbl6k
 
         with self.assertRaises(InvalidPrivateKeyException):
             build_google_credentials_dict(gcp_values)
-

--- a/ingestion/tests/unit/test_credentials.py
+++ b/ingestion/tests/unit/test_credentials.py
@@ -106,8 +106,3 @@ VEhPQF0i0tUU7Fl071hcYaiQoZx4nIjN+NG6p5QKbl6k
         build_google_credentials_dict(gcp_values)
 
         self.assertEqual(expected_dict, build_google_credentials_dict(gcp_values))
-
-        gcp_values.privateKey = SecretStr("I don't think I am a proper Private Key")
-
-        with self.assertRaises(InvalidPrivateKeyException):
-            build_google_credentials_dict(gcp_values)

--- a/ingestion/tests/unit/test_credentials.py
+++ b/ingestion/tests/unit/test_credentials.py
@@ -88,7 +88,7 @@ VEhPQF0i0tUU7Fl071hcYaiQoZx4nIjN+NG6p5QKbl6k
         Check how we can validate GCS values
         """
         gcp_values = GcpCredentialsValues(
-            type="service_account",
+            type="external_account",
             audience="audience",
             subjectTokenType="subject_token_type",
             tokenURL="token_url",
@@ -98,11 +98,11 @@ VEhPQF0i0tUU7Fl071hcYaiQoZx4nIjN+NG6p5QKbl6k
         )
 
         expected_dict = {
-            "type": "service_account",
-            "audience": "audience"
+            "type": "external_account",
+            "audience": "audience",
             "subject_token_type": "subject_token_type",
             "token_url": "token_url",
-            "credential_source":{
+            "credential_source": {
                 "environmentId": "environment_id"
             }
         }

--- a/openmetadata-docs/content/v1.2.x/connectors/database/bigquery/yaml.md
+++ b/openmetadata-docs/content/v1.2.x/connectors/database/bigquery/yaml.md
@@ -127,7 +127,7 @@ You can checkout [this](https://cloud.google.com/iam/docs/keys-create-delete#iam
 
 **1.** Passing the raw credential values provided by BigQuery. This requires us to provide the following information, all provided by BigQuery:
 
-  - **type**: Credentials Type is the type of the account, for a service account the value of this field is `service_account`. To fetch this key, look for the value associated with the `type` key in the service account key file.
+  - **type**: Supported values are service_account and external_account.For service accounts, the value of this field is service_account.For external identities, the value of this field is external_account.
   - **projectId**: A project ID is a unique string used to differentiate your project from all others in Google Cloud. To fetch this key, look for the value associated with the `project_id` key in the service account key file. You can also pass multiple project id to ingest metadata from different BigQuery projects into one service.
   - **privateKeyId**: This is a unique identifier for the private key associated with the service account. To fetch this key, look for the value associated with the `private_key_id` key in the service account file.
   - **privateKey**: This is the private key associated with the service account that is used to authenticate and authorize access to BigQuery. To fetch this key, look for the value associated with the `private_key` key in the service account file.
@@ -136,7 +136,11 @@ You can checkout [this](https://cloud.google.com/iam/docs/keys-create-delete#iam
   - **authUri**: This is the URI for the authorization server. To fetch this key, look for the value associated with the `auth_uri` key in the service account key file. The default value to Auth URI is https://accounts.google.com/o/oauth2/auth.
   - **tokenUri**: The Google Cloud Token URI is a specific endpoint used to obtain an OAuth 2.0 access token from the Google Cloud IAM service. This token allows you to authenticate and access various Google Cloud resources and APIs that require authorization. To fetch this key, look for the value associated with the `token_uri` key in the service account credentials file. Default Value to Token URI is https://oauth2.googleapis.com/token.
   - **authProviderX509CertUrl**: This is the URL of the certificate that verifies the authenticity of the authorization server. To fetch this key, look for the value associated with the `auth_provider_x509_cert_url` key in the service account key file. The Default value for Auth Provider X509Cert URL is https://www.googleapis.com/oauth2/v1/certs
-  - **clientX509CertUrl**: This is the URL of the certificate that verifies the authenticity of the service account. To fetch this key, look for the value associated with the `client_x509_cert_url` key in the service account key  file.
+  - **clientX509CertUrl**: This is the URL of the certificate that verifies the authenticity of the service account. To fetch this key, look for the value associated with the `client_x509_cert_url` key in the service account key file.
+  - **audience**: This is the Google Security Token Service audience which contains the resource name for the workload identity pool and the provider identifier in that pool.
+  - **subjectTokenType**: This is Google Security Token Service subject token type based on the OAuth 2.0 token exchange spec.Required when using type external_account.
+  - **tokenURL**: This is Google Security Token Service token exchange endpoint.Required when using type external_account.
+  - **credentialSource**: This object defines the mechanism used to retrieve the external credential from the local environment so that it can be exchanged for a GCP access token via the STS endpoint.
 
 **2.**  Passing a local file path that contains the credentials:
   - **gcpCredentialsPath**

--- a/openmetadata-spec/src/main/resources/json/schema/security/credentials/gcpCredentials.json
+++ b/openmetadata-spec/src/main/resources/json/schema/security/credentials/gcpCredentials.json
@@ -40,6 +40,9 @@
         },
         {
           "$ref": "#/definitions/gcpCredentialsPath"
+        },
+        {
+          "$ref": "gcpExternalAccount.json"
         }
       ]
     },
@@ -50,5 +53,7 @@
     }
   },
   "additionalProperties": false,
-  "required": ["gcpConfig"]
+  "required": [
+    "gcpConfig"
+  ]
 }

--- a/openmetadata-spec/src/main/resources/json/schema/security/credentials/gcpExternalAccount.json
+++ b/openmetadata-spec/src/main/resources/json/schema/security/credentials/gcpExternalAccount.json
@@ -1,0 +1,41 @@
+{
+  "$id": "https:./open-metadata.org/schema/security/credentials/gcpExternalAccount.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "javaType": "org.openmetadata.schema.security.credentials.GCPExternalAccount",
+  "title": "GCP Credentials Values ( External Account )",
+  "description": "Pass the raw credential values provided by GCP",
+  "definitions": {},
+  "properties": {
+    "type": {
+      "title": "Credentials Type",
+      "description": "Google Cloud Platform account type.",
+      "type": "string",
+      "default": "external_account"
+    },
+    "audience": {
+      "title": "Audience",
+      "description": "Google Security Token Service audience which contains the resource name for the workload identity pool and the provider identifier in that pool.",
+      "type": "string"
+    },
+    "subjectTokenType": {
+      "title": "Subject Token Type",
+      "description": "Google Security Token Service subject token type based on the OAuth 2.0 token exchange spec.",
+      "type": "string"
+    },
+    "tokenURL": {
+      "title": "Token URL",
+      "description": "Google Security Token Service token exchange endpoint.",
+      "type": "string"
+    },
+    "credentialSource": {
+      "title": "Credential Source",
+      "description": "This object defines the mechanism used to retrieve the external credential from the local environment so that it can be exchanged for a GCP access token via the STS endpoint",
+      "type": "object",
+      "javaType": "org.openmetadata.schema.security.credentials.GCPExternalAccount.credentialSource",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/openmetadata-spec/src/main/resources/json/schema/security/credentials/gcpExternalAccount.json
+++ b/openmetadata-spec/src/main/resources/json/schema/security/credentials/gcpExternalAccount.json
@@ -32,7 +32,7 @@
       "title": "Credential Source",
       "description": "This object defines the mechanism used to retrieve the external credential from the local environment so that it can be exchanged for a GCP access token via the STS endpoint",
       "type": "object",
-      "javaType": "org.openmetadata.schema.security.credentials.GCPExternalAccount.credentialSource",
+      "javaType": "org.openmetadata.schema.security.credentials.credentialSource",
       "additionalProperties": {
         "type": "string"
       }

--- a/openmetadata-spec/src/main/resources/json/schema/security/credentials/gcpValues.json
+++ b/openmetadata-spec/src/main/resources/json/schema/security/credentials/gcpValues.json
@@ -3,7 +3,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "javaType": "org.openmetadata.schema.security.credentials.GCPValues",
-  "title": "GCP Credentials Values",
+  "title": "GCP Credentials Values ( Service Account )",
   "description": "Pass the raw credential values provided by GCP",
   "definitions": {
     "singleProjectId": {
@@ -22,7 +22,11 @@
     "type": {
       "title": "Credentials Type",
       "description": "Google Cloud Platform account type.",
-      "type": "string"
+      "type": "string",
+      "enum": [
+        "service_account"
+      ],
+      "default": "service_account"
     },
     "projectId": {
       "title": "Project ID",
@@ -35,26 +39,6 @@
           "$ref": "#/definitions/multipleProjectId"
         }
       ]
-    },
-    "audience": {
-      "title": "Audience",
-      "description": "Google Security Token Service audience which contains the resource name for the workload identity pool and the provider identifier in that pool.",
-      "type": "string"
-    },
-    "subjectTokenType": {
-      "title": "Subject Token Type",
-      "description": "Google Security Token Service subject token type based on the OAuth 2.0 token exchange spec.",
-      "type": "string"
-    },
-    "tokenURL": {
-      "title": "Token URL",
-      "description": "Google Security Token Service token exchange endpoint.",
-      "type": "string"
-    },
-    "credentialSource": {
-      "title": "Credential Source",
-      "description": "This object defines the mechanism used to retrieve the external credential from the local environment so that it can be exchanged for a GCP access token via the STS endpoint",
-      "type": "object"
     },
     "privateKeyId": {
       "title": "Private Key ID",

--- a/openmetadata-spec/src/main/resources/json/schema/security/credentials/gcpValues.json
+++ b/openmetadata-spec/src/main/resources/json/schema/security/credentials/gcpValues.json
@@ -36,6 +36,54 @@
         }
       ]
     },
+    "audience": {
+      "title": "Audience",
+      "description": "Google Security Token Service audience which contains the resource name for the workload identity pool and the provider identifier in that pool.",
+      "type": "string"
+    },
+    "subjectTokenType": {
+      "title": "Subject Token Type",
+      "description": "Google Security Token Service subject token type based on the OAuth 2.0 token exchange spec.",
+      "type": "string"
+    },
+    "tokenURL": {
+      "title": "Token URL",
+      "description": "Google Security Token Service token exchange endpoint.",
+      "type": "string"
+    },
+    "credentialSource": {
+      "title": "Credential Source",
+      "description": "This object defines the mechanism used to retrieve the external credential from the local environment so that it can be exchanged for a GCP access token via the STS endpoint",
+      "javaType": "org.openmetadata.schema.security.credentials.GCPValues.credentialSource",
+      "type": "object",
+      "definitions": {
+        "environmentId": {
+          "title": "Environment ID",
+          "description": "https://google.aip.dev/auth/4117",
+          "type": "string"
+        },
+        "regionUrl": {
+          "title": "Region URL",
+          "description": "https://google.aip.dev/auth/4117",
+          "type": "string"
+        },
+        "URL": {
+          "title": "URL",
+          "description": "https://google.aip.dev/auth/4117",
+          "type": "string"
+        },
+        "regionalCredVerificationUrl": {
+          "title": "Regional Cred Verification Url",
+          "description": "https://google.aip.dev/auth/4117",
+          "type": "string"
+        },
+        "imdsv2SessionTokenUrl": {
+          "title": "IMDSv2 Session Token Url",
+          "description": "https://google.aip.dev/auth/4117",
+          "type": "string"
+        }
+      }
+    },
     "privateKeyId": {
       "title": "Private Key ID",
       "description": "Google Cloud private key id.",

--- a/openmetadata-spec/src/main/resources/json/schema/security/credentials/gcpValues.json
+++ b/openmetadata-spec/src/main/resources/json/schema/security/credentials/gcpValues.json
@@ -54,35 +54,7 @@
     "credentialSource": {
       "title": "Credential Source",
       "description": "This object defines the mechanism used to retrieve the external credential from the local environment so that it can be exchanged for a GCP access token via the STS endpoint",
-      "javaType": "org.openmetadata.schema.security.credentials.GCPValues.credentialSource",
-      "type": "object",
-      "definitions": {
-        "environmentId": {
-          "title": "Environment ID",
-          "description": "https://google.aip.dev/auth/4117",
-          "type": "string"
-        },
-        "regionUrl": {
-          "title": "Region URL",
-          "description": "https://google.aip.dev/auth/4117",
-          "type": "string"
-        },
-        "URL": {
-          "title": "URL",
-          "description": "https://google.aip.dev/auth/4117",
-          "type": "string"
-        },
-        "regionalCredVerificationUrl": {
-          "title": "Regional Cred Verification Url",
-          "description": "https://google.aip.dev/auth/4117",
-          "type": "string"
-        },
-        "imdsv2SessionTokenUrl": {
-          "title": "IMDSv2 Session Token Url",
-          "description": "https://google.aip.dev/auth/4117",
-          "type": "string"
-        }
-      }
+      "type": "object"
     },
     "privateKeyId": {
       "title": "Private Key ID",

--- a/openmetadata-spec/src/main/resources/json/schema/security/credentials/gcpValues.json
+++ b/openmetadata-spec/src/main/resources/json/schema/security/credentials/gcpValues.json
@@ -23,9 +23,6 @@
       "title": "Credentials Type",
       "description": "Google Cloud Platform account type.",
       "type": "string",
-      "enum": [
-        "service_account"
-      ],
       "default": "service_account"
     },
     "projectId": {

--- a/openmetadata-spec/src/main/resources/json/schema/security/credentials/gcpValues.json
+++ b/openmetadata-spec/src/main/resources/json/schema/security/credentials/gcpValues.json
@@ -3,7 +3,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "javaType": "org.openmetadata.schema.security.credentials.GCPValues",
-  "title": "GCP Credentials Values ( Service Account )",
+  "title": "GCP Credentials Values",
   "description": "Pass the raw credential values provided by GCP",
   "definitions": {
     "singleProjectId": {


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #14169: Suuport external_account type for GCP Auth 
Currently, the only gcp credentials that can be written in yaml are those with a type of service_account.
I want to use OIDC (external_account) authentication for ingestion, so I will add a configuration for that.


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

- [x] I have added tests around the new logic.
- [x] For connector/ingestion changes: I updated the documentation.

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
