### PR TITLE
ISSUE-14095: added overloaded method for method initClient to accept Feign.Builder as one of the method's parameter.

### DIFF
--- a/openmetadata-clients/openmetadata-java-client/src/main/java/org/openmetadata/client/gateway/OpenMetadata.java
+++ b/openmetadata-clients/openmetadata-java-client/src/main/java/org/openmetadata/client/gateway/OpenMetadata.java
@@ -51,13 +51,17 @@ public class OpenMetadata {
   }
 
   public void initClient(OpenMetadataConnection config) {
-    apiClient = new ApiClient();
     Feign.Builder builder =
         Feign.builder()
             .encoder(new FormEncoder(new JacksonEncoder(apiClient.getObjectMapper())))
             .decoder(new JacksonDecoder(apiClient.getObjectMapper()))
             .logger(new Slf4jLogger())
             .client(new OkHttpClient());
+    initClient(config, builder);
+  }
+
+  public void initClient(OpenMetadataConnection config, Feign.Builder builder) {
+    apiClient = new ApiClient();
     apiClient.setFeignBuilder(builder);
     AuthenticationProviderFactory factory = new AuthenticationProviderFactory();
     apiClient.addAuthorization("oauth", factory.getAuthProvider(config));


### PR DESCRIPTION
Fixes ISSUE-14095

- What changes did you make?
I added overloaded method for method initClient in org.openmetadata.client.gateway.OpenMetadata class to accept Feign.Builder as one of the method's parameter.
- Why did you make them?
To allow users to be able to configure the ApiClient, eg. set timeouts, add custom error handlers, use other Client besides OkHttpClient.
- How did you test your changes?
I made sure mvn compile passes on openmetadata-clients/openmetadata-java-client/pom.xml

