### PR TITLE
fix: CI Workflows concurrency group names

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -47,7 +47,7 @@ permissions:
   checks: write
 
 concurrency: 
-  group: maven-build-${{ github.head_ref || github.run_id }}
+  group: maven-build-mysql-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 jobs:
   maven-mysql-ci:

--- a/.github/workflows/maven-postgres-tests-build-skip.yml
+++ b/.github/workflows/maven-postgres-tests-build-skip.yml
@@ -31,7 +31,7 @@ permissions:
   checks: write
 
 concurrency: 
-  group: maven-build-${{ github.head_ref || github.run_id }}
+  group: maven-postgres-tests-skip-build-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 jobs:
     maven-postgresql-ci:

--- a/.github/workflows/maven-postgres-tests-build-skip.yml
+++ b/.github/workflows/maven-postgres-tests-build-skip.yml
@@ -30,9 +30,6 @@ permissions:
   contents: read
   checks: write
 
-concurrency: 
-  group: maven-postgres-tests-skip-build-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
 jobs:
     maven-postgresql-ci:
         runs-on: ubuntu-latest

--- a/.github/workflows/maven-postgres-tests-build.yml
+++ b/.github/workflows/maven-postgres-tests-build.yml
@@ -46,7 +46,7 @@ permissions:
   checks: write
 
 concurrency: 
-  group: maven-postgres-tests-build-${{ github.head_ref || github.run_id }}
+  group: maven-postgres-build-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 jobs:
   maven-postgresql-ci:

--- a/.github/workflows/maven-postgres-tests-build.yml
+++ b/.github/workflows/maven-postgres-tests-build.yml
@@ -46,7 +46,7 @@ permissions:
   checks: write
 
 concurrency: 
-  group: maven-postgres-build-${{ github.head_ref || github.run_id }}
+  group: maven-build-postgres-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 jobs:
   maven-postgresql-ci:

--- a/.github/workflows/maven-postgres-tests-build.yml
+++ b/.github/workflows/maven-postgres-tests-build.yml
@@ -46,7 +46,7 @@ permissions:
   checks: write
 
 concurrency: 
-  group: maven-build-${{ github.head_ref || github.run_id }}
+  group: maven-postgres-tests-build-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 jobs:
   maven-postgresql-ci:


### PR DESCRIPTION
### Describe your changes:

I worked on changing the concurrency group names for a couple of workflow files - maven-postgres-tests-build-skip.yml and maven-postgres-tests-build.yml. Since these workflows had the same group name as maven-build.yml workflow. So at any given point of time, only 1 workflow can execute among the 3 (which will be the one with latest commit) and it will cancel any in-progress workflow executions (as we have set concurrency.cancel-in-progress to true). With this change, this conflict will not happen.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.