### PR TITLE
Update omd-server's base image to alpine:3.18.5

### DIFF
--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -10,7 +10,7 @@
 #  limitations under the License.
 
 # Build stage
-FROM alpine:3 AS build
+FROM alpine:3.18.5 AS build
 
 COPY openmetadata-dist/target/openmetadata-*.tar.gz /
 
@@ -19,7 +19,7 @@ RUN mkdir -p /opt/openmetadata && \
     rm openmetadata-*.tar.gz
 
 # Final stage
-FROM alpine:3
+FROM alpine:3.18.5
 
 EXPOSE 8585
 

--- a/docker/docker-compose-quickstart/Dockerfile
+++ b/docker/docker-compose-quickstart/Dockerfile
@@ -10,7 +10,7 @@
 #  limitations under the License.
 
 # Build stage
-FROM alpine:3 AS build
+FROM alpine:3.18.5 AS build
 ARG RI_VERSION="1.3.0-SNAPSHOT"
 ENV RELEASE_URL="https://github.com/open-metadata/OpenMetadata/releases/download/${RI_VERSION}-release/openmetadata-${RI_VERSION}.tar.gz"
 
@@ -20,7 +20,7 @@ RUN mkdir -p /opt/openmetadata && \
     rm openmetadata-*.tar.gz
 
 # Final stage
-FROM alpine:3
+FROM alpine:3.18.5
 ARG RI_VERSION="1.3.0-SNAPSHOT"
 ARG BUILD_DATE
 ARG COMMIT_ID


### PR DESCRIPTION
### Describe your changes:

Currently we are using alpine:3 image for OMD server's base image. This image has below listed (Score - High) vulnerabilities:
[CVE-2023-5363](https://scout.docker.com/v/CVE-2023-5363)
[CVE-2023-4586](https://scout.docker.com/v/CVE-2023-4586)
[CVE-2023-6378](https://scout.docker.com/v/CVE-2023-6378)
[CVE-2023-6378](https://scout.docker.com/v/CVE-2023-6378)

Using alpine:3.18.5 image, we can fix openssl vulnerabilities i.e. [CVE-2023-5363](https://scout.docker.com/v/CVE-2023-5363) (High) and [CVE-2023-5678](https://scout.docker.com/v/CVE-2023-5678) (Medium).

The execute-migrate-all container also uses the same image, hence we can apply fix for both.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.