### PR TITLE
Fix #14161 - Add skip on failure when listing entities in DI

### DIFF
--- a/ingestion/src/metadata/data_insight/producer/web_analytics_producer.py
+++ b/ingestion/src/metadata/data_insight/producer/web_analytics_producer.py
@@ -65,6 +65,7 @@ class WebAnalyticsProducer(ProducerInterface):
                 after=after,
                 limit=limit,
                 fields=fields,
+                skip_on_failure=True,
             )  # type: ignore
             self._cache_events(after, events)
         return events

--- a/ingestion/tests/integration/ometa/test_ometa_table_api.py
+++ b/ingestion/tests/integration/ometa/test_ometa_table_api.py
@@ -625,6 +625,7 @@ class OMetaTableTest(TestCase):
                     entity=Table,
                     limit=1,  # paginate in batches of pairs
                 )
+                list(res)
 
         with patch.object(REST, "get", return_value=BAD_RESPONSE):
             res = self.metadata.list_all_entities(


### PR DESCRIPTION
### Describe your changes:

Fixes #14161 

- Skip on failure when listing entities in DI

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
