### PR TITLE
MINOR: missing import in SearchIndexRepository class

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SearchIndexRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SearchIndexRepository.java
@@ -36,6 +36,7 @@ import org.openmetadata.schema.api.feed.ResolveTask;
 import org.openmetadata.schema.entity.data.SearchIndex;
 import org.openmetadata.schema.entity.services.SearchService;
 import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.Relationship;
 import org.openmetadata.schema.type.SearchIndexField;
 import org.openmetadata.schema.type.TagLabel;


### PR DESCRIPTION
Missing import in 1.2.3