### PR TITLE
#14043 - Fix metadata backup memory profile

### DIFF
--- a/ingestion/src/metadata/cli/db_dump.py
+++ b/ingestion/src/metadata/cli/db_dump.py
@@ -123,9 +123,12 @@ def get_hash_column_name(engine: Engine, table_name: str) -> Optional[str]:
 
 def run_query_iter(engine: Engine, query: str) -> Iterable[Row]:
     """Return a generator of rows, one row at a time, with a limit of 100 in-mem rows"""
-
-    for row in engine.execute(text(query)).yield_per(100):
-        yield row
+    with engine.connect() as conn:
+        result = conn.execution_options(
+            stream_results=True, max_row_buffer=100
+        ).execute(text(query))
+        for row in result:
+            yield row
 
 
 def dump_json(tables: List[str], engine: Engine, output: Path) -> None:

--- a/ingestion/src/metadata/cmd.py
+++ b/ingestion/src/metadata/cmd.py
@@ -435,12 +435,9 @@ def metadata(args=None):
     contains_args = vars(get_parser(args))
     metadata_workflow = contains_args.get("command")
     config_file = contains_args.get("config")
+    path = None
     if config_file:
         path = Path(config_file).expanduser()
-    else:
-        raise ValueError(
-            "Could not load config file! Please specify the config path with `-c` or `--config`."
-        )
     if contains_args.get("debug"):
         set_loggers_level(logging.DEBUG)
     elif contains_args.get("log_level"):

--- a/openmetadata-docs/content/v1.2.x/connectors/dashboard/looker/index.md
+++ b/openmetadata-docs/content/v1.2.x/connectors/dashboard/looker/index.md
@@ -45,6 +45,9 @@ with read only access to the repository. You can follow these steps from the Git
 The GitHub credentials are completely optional. Just note that without them, we won't be able to ingest metadata
 out of LookML Views, including their lineage to the source databases.
 
+Moreover, Looker lineage only supports LookML views configured with `sql_table_name` and `derived_table` in plain SQL.
+We do not yet support liquid variables.
+
 {% /note %}
 
 ## Metadata Ingestion

--- a/openmetadata-docs/content/v1.2.x/connectors/dashboard/looker/yaml.md
+++ b/openmetadata-docs/content/v1.2.x/connectors/dashboard/looker/yaml.md
@@ -50,6 +50,9 @@ with read only access to the repository. You can follow these steps from the Git
 The GitHub credentials are completely optional. Just note that without them, we won't be able to ingest metadata
 out of LookML Views, including their lineage to the source databases.
 
+Moreover, Looker lineage only supports LookML views configured with `sql_table_name` and `derived_table` in plain SQL.
+We do not yet support liquid variables.
+
 {% /note %}
 
 ### Python Requirements

--- a/openmetadata-docs/content/v1.3.x-SNAPSHOT/connectors/dashboard/looker/index.md
+++ b/openmetadata-docs/content/v1.3.x-SNAPSHOT/connectors/dashboard/looker/index.md
@@ -45,6 +45,9 @@ with read only access to the repository. You can follow these steps from the Git
 The GitHub credentials are completely optional. Just note that without them, we won't be able to ingest metadata
 out of LookML Views, including their lineage to the source databases.
 
+Moreover, Looker lineage only supports LookML views configured with `sql_table_name` and `derived_table` in plain SQL.
+We do not yet support liquid variables.
+
 {% /note %}
 
 ## Metadata Ingestion

--- a/openmetadata-docs/content/v1.3.x-SNAPSHOT/connectors/dashboard/looker/yaml.md
+++ b/openmetadata-docs/content/v1.3.x-SNAPSHOT/connectors/dashboard/looker/yaml.md
@@ -50,6 +50,9 @@ with read only access to the repository. You can follow these steps from the Git
 The GitHub credentials are completely optional. Just note that without them, we won't be able to ingest metadata
 out of LookML Views, including their lineage to the source databases.
 
+Moreover, Looker lineage only supports LookML views configured with `sql_table_name` and `derived_table` in plain SQL.
+We do not yet support liquid variables.
+
 {% /note %}
 
 ### Python Requirements


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #14043 ensuring that the db uses a cursor when lifting the data

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
