### PR TITLE
Update security-scan CI to use OpenMetadata Organization

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      SNYK_ORGANIZATION: ${{ secrets.SNYK_ORGANIZATION_ID }}
 
     steps:
       - name: Free Disk Space (Ubuntu)
@@ -58,6 +59,7 @@ jobs:
           sudo make install_antlr_cli
           sudo npm install -g snyk
           snyk auth ${SNYK_TOKEN}
+          snyk config set org=${SNYK_ORGANIZATION}
 
       - name: Install Python dependencies
         run: |


### PR DESCRIPTION
### Describe your changes:

As of now, When Security scan CI is run, certain reports are throwing errors i.e. airflow-apis-code-scan.json, ingestion-code-scan.json, and server-code-scan.json. These are code scan tests that are failing. Snyk container tests are working fine. For example, we can check this Job's artifacts - [security-scan #201](https://github.com/open-metadata/OpenMetadata/actions/runs/7188904386).

Upon checking, we found that "Snyk Code" - The feature that allows code scan is already enabled for OpenMetadata organization in Snyk. However, The preferred organization is set to the user default organization by default.

Hence, with these changes, Snyk CLI will use OpenMetadata organization for all the following checks.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.