### PR TITLE
Update Dockerfile.ci file to use new MySQL Keys

### DIFF
--- a/ingestion/Dockerfile
+++ b/ingestion/Dockerfile
@@ -4,7 +4,7 @@ RUN curl -sS https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 RUN curl -sS https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list
 
 # Remove expired mysql keys and add new key/s to the trusted key store
-RUN rm /etc/apt/sources.list.d/mysql.list && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B7B3B788A8D3785C && gpg --export "B7B3B788A8D3785C" > "/etc/apt/trusted.gpg.d/mysql.gpg"
+RUN rm /etc/apt/sources.list.d/mysql.list
 
 # Install Dependencies (listed in alphabetical order)
 ENV DEBIAN_FRONTEND=noninteractive

--- a/ingestion/Dockerfile
+++ b/ingestion/Dockerfile
@@ -4,8 +4,7 @@ RUN curl -sS https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 RUN curl -sS https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list
 
 # Remove expired mysql keys and add new key/s to the trusted key store
-RUN rm /etc/apt/sources.list.d/mysql.list
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B7B3B788A8D3785C && gpg --export "B7B3B788A8D3785C" > "/etc/apt/trusted.gpg.d/mysql.gpg"
+RUN rm /etc/apt/sources.list.d/mysql.list && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B7B3B788A8D3785C && gpg --export "B7B3B788A8D3785C" > "/etc/apt/trusted.gpg.d/mysql.gpg"
 
 # Install Dependencies (listed in alphabetical order)
 ENV DEBIAN_FRONTEND=noninteractive

--- a/ingestion/Dockerfile
+++ b/ingestion/Dockerfile
@@ -3,7 +3,7 @@ USER root
 RUN curl -sS https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 RUN curl -sS https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list
 
-# Remove expired mysql keys and add new key/s to the trusted key store
+# Remove expired mysql keys
 RUN rm /etc/apt/sources.list.d/mysql.list
 
 # Install Dependencies (listed in alphabetical order)

--- a/ingestion/Dockerfile
+++ b/ingestion/Dockerfile
@@ -2,6 +2,11 @@ FROM apache/airflow:2.6.3-python3.10
 USER root
 RUN curl -sS https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 RUN curl -sS https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list
+
+# Remove expired mysql keys and add new key/s to the trusted key store
+RUN rm /etc/apt/sources.list.d/mysql.list
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B7B3B788A8D3785C && gpg --export "B7B3B788A8D3785C" > "/etc/apt/trusted.gpg.d/mysql.gpg"
+
 # Install Dependencies (listed in alphabetical order)
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -qq update \

--- a/ingestion/Dockerfile.ci
+++ b/ingestion/Dockerfile.ci
@@ -4,8 +4,7 @@ RUN curl -sS https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 RUN curl -sS https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list
 
 # Remove expired mysql keys and add new key/s to the trusted key store
-RUN rm /etc/apt/sources.list.d/mysql.list
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B7B3B788A8D3785C && gpg --export "B7B3B788A8D3785C" > "/etc/apt/trusted.gpg.d/mysql.gpg"
+RUN rm /etc/apt/sources.list.d/mysql.list && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B7B3B788A8D3785C && gpg --export "B7B3B788A8D3785C" > "/etc/apt/trusted.gpg.d/mysql.gpg"
 
 # Install Dependencies (listed in alphabetical order)
 RUN apt-get -qq update \

--- a/ingestion/Dockerfile.ci
+++ b/ingestion/Dockerfile.ci
@@ -2,8 +2,11 @@ FROM apache/airflow:2.6.3-python3.10
 USER root
 RUN curl -sS https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 RUN curl -sS https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list
+
+# Remove expired mysql keys and add new key/s to the trusted key store
 RUN rm /etc/apt/sources.list.d/mysql.list
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B7B3B788A8D3785C && gpg --export "B7B3B788A8D3785C" > "/etc/apt/trusted.gpg.d/mysql.gpg"
+
 # Install Dependencies (listed in alphabetical order)
 RUN apt-get -qq update \
     && apt-get -qq install -y \

--- a/ingestion/Dockerfile.ci
+++ b/ingestion/Dockerfile.ci
@@ -2,6 +2,8 @@ FROM apache/airflow:2.6.3-python3.10
 USER root
 RUN curl -sS https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 RUN curl -sS https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list
+RUN rm /etc/apt/sources.list.d/mysql.list
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B7B3B788A8D3785C && gpg --export "B7B3B788A8D3785C" > "/etc/apt/trusted.gpg.d/mysql.gpg"
 # Install Dependencies (listed in alphabetical order)
 RUN apt-get -qq update \
     && apt-get -qq install -y \

--- a/ingestion/Dockerfile.ci
+++ b/ingestion/Dockerfile.ci
@@ -4,7 +4,7 @@ RUN curl -sS https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 RUN curl -sS https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list
 
 # Remove expired mysql keys and add new key/s to the trusted key store
-RUN rm /etc/apt/sources.list.d/mysql.list && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B7B3B788A8D3785C && gpg --export "B7B3B788A8D3785C" > "/etc/apt/trusted.gpg.d/mysql.gpg"
+RUN rm /etc/apt/sources.list.d/mysql.list
 
 # Install Dependencies (listed in alphabetical order)
 RUN apt-get -qq update \

--- a/ingestion/Dockerfile.ci
+++ b/ingestion/Dockerfile.ci
@@ -3,7 +3,7 @@ USER root
 RUN curl -sS https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 RUN curl -sS https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list
 
-# Remove expired mysql keys and add new key/s to the trusted key store
+# Remove expired mysql keys
 RUN rm /etc/apt/sources.list.d/mysql.list
 
 # Install Dependencies (listed in alphabetical order)

--- a/ingestion/operators/docker/Dockerfile
+++ b/ingestion/operators/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.10-bullseye
 RUN curl -sS https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 RUN curl -sS https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list
 
-# Remove expired mysql keys and add new key/s to the trusted key store
+# Remove expired mysql keys
 RUN rm /etc/apt/sources.list.d/mysql.list
 
 # Install Dependencies (listed in alphabetical order)

--- a/ingestion/operators/docker/Dockerfile
+++ b/ingestion/operators/docker/Dockerfile
@@ -4,8 +4,7 @@ RUN curl -sS https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 RUN curl -sS https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list
 
 # Remove expired mysql keys and add new key/s to the trusted key store
-RUN rm /etc/apt/sources.list.d/mysql.list
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B7B3B788A8D3785C && gpg --export "B7B3B788A8D3785C" > "/etc/apt/trusted.gpg.d/mysql.gpg"
+RUN rm /etc/apt/sources.list.d/mysql.list && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B7B3B788A8D3785C && gpg --export "B7B3B788A8D3785C" > "/etc/apt/trusted.gpg.d/mysql.gpg"
 
 # Install Dependencies (listed in alphabetical order)
 RUN apt-get -qq update \

--- a/ingestion/operators/docker/Dockerfile
+++ b/ingestion/operators/docker/Dockerfile
@@ -3,6 +3,10 @@ FROM python:3.10-bullseye
 RUN curl -sS https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 RUN curl -sS https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list
 
+# Remove expired mysql keys and add new key/s to the trusted key store
+RUN rm /etc/apt/sources.list.d/mysql.list
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B7B3B788A8D3785C && gpg --export "B7B3B788A8D3785C" > "/etc/apt/trusted.gpg.d/mysql.gpg"
+
 # Install Dependencies (listed in alphabetical order)
 RUN apt-get -qq update \
     && apt-get -qq install -y \

--- a/ingestion/operators/docker/Dockerfile
+++ b/ingestion/operators/docker/Dockerfile
@@ -4,7 +4,7 @@ RUN curl -sS https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 RUN curl -sS https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list
 
 # Remove expired mysql keys and add new key/s to the trusted key store
-RUN rm /etc/apt/sources.list.d/mysql.list && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B7B3B788A8D3785C && gpg --export "B7B3B788A8D3785C" > "/etc/apt/trusted.gpg.d/mysql.gpg"
+RUN rm /etc/apt/sources.list.d/mysql.list
 
 # Install Dependencies (listed in alphabetical order)
 RUN apt-get -qq update \


### PR DESCRIPTION
### Describe your changes:

The GPG Signature key for MySQL `EXPKEYSIG 467B942D3A79BD29` - got recently expired [2023-12-14T15:39:35Z]. 
Our CI pipeline started failing due to this - [Security scan #204](https://github.com/open-metadata/OpenMetadata/actions/runs/7216175762/job/19667819467).
As per [the documentation](https://dev.mysql.com/doc/refman/8.0/en/checking-gpg-signature.html), This key is expired and new key to be used is `B7B3B788A8D3785C`.

However, the apt repository still has the old gpg key set - [reference](https://repo.mysql.com/apt/debian/conf/distributions). This bug is already reported [here](https://bugs.mysql.com/bug.php?id=113427).
Hence with this change, we are removing the old keys. 

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.