### PR TITLE
Revert "Update Dockerfile.ci file to use new MySQL Keys"

### DIFF
--- a/ingestion/Dockerfile
+++ b/ingestion/Dockerfile
@@ -2,10 +2,6 @@ FROM apache/airflow:2.6.3-python3.10
 USER root
 RUN curl -sS https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 RUN curl -sS https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list
-
-# Remove expired mysql keys
-RUN rm /etc/apt/sources.list.d/mysql.list
-
 # Install Dependencies (listed in alphabetical order)
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -qq update \

--- a/ingestion/Dockerfile.ci
+++ b/ingestion/Dockerfile.ci
@@ -2,10 +2,6 @@ FROM apache/airflow:2.6.3-python3.10
 USER root
 RUN curl -sS https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 RUN curl -sS https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list
-
-# Remove expired mysql keys
-RUN rm /etc/apt/sources.list.d/mysql.list
-
 # Install Dependencies (listed in alphabetical order)
 RUN apt-get -qq update \
     && apt-get -qq install -y \

--- a/ingestion/operators/docker/Dockerfile
+++ b/ingestion/operators/docker/Dockerfile
@@ -3,9 +3,6 @@ FROM python:3.10-bullseye
 RUN curl -sS https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 RUN curl -sS https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list
 
-# Remove expired mysql keys
-RUN rm /etc/apt/sources.list.d/mysql.list
-
 # Install Dependencies (listed in alphabetical order)
 RUN apt-get -qq update \
     && apt-get -qq install -y \


### PR DESCRIPTION
Reverts open-metadata/OpenMetadata#14400

We're now getting

```
#44 [ingestion  4/25] RUN rm /etc/apt/sources.list.d/mysql.list
#44 0.247 rm: cannot remove '/etc/apt/sources.list.d/mysql.list': No such file or directory
#44 ERROR: process "/bin/bash -o pipefail -o errexit -o nounset -o nolog -c rm /etc/apt/sources.list.d/mysql.list" did not complete successfully: exit code: 1
------
 > [ingestion  4/25] RUN rm /etc/apt/sources.list.d/mysql.list:
0.247 rm: cannot remove '/etc/apt/sources.list.d/mysql.list': No such file or directory
------
failed to solve: process "/bin/bash -o pipefail -o errexit -o nounset -o nolog -c rm /etc/apt/sources.list.d/mysql.list" did not complete successfully: exit code: 1
Failed to start Docker instances!
Error: Final attempt failed. Child_process exited with error code 1
```

due to this