### PR TITLE
fix: exception on global search sometimes

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/constants/explore.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/explore.constants.ts
@@ -12,6 +12,7 @@
  */
 
 import { SortingField } from '../components/Explore/SortingDropDown';
+import { SearchIndex } from '../enums/search.enum';
 import i18n from '../utils/i18next/LocalUtil';
 
 export const INITIAL_SORT_FIELD = 'updatedAt';
@@ -56,4 +57,19 @@ export interface ExploreTabInfo {
 export const COMMON_FILTERS_FOR_DIFFERENT_TABS = [
   'owner.displayName',
   'tags.tagFQN',
+];
+
+export const TABS_SEARCH_INDEXES = [
+  SearchIndex.TABLE,
+  SearchIndex.STORED_PROCEDURE,
+  SearchIndex.DASHBOARD,
+  SearchIndex.DASHBOARD_DATA_MODEL,
+  SearchIndex.PIPELINE,
+  SearchIndex.TOPIC,
+  SearchIndex.MLMODEL,
+  SearchIndex.CONTAINER,
+  SearchIndex.SEARCH_INDEX,
+  SearchIndex.GLOSSARY,
+  SearchIndex.TAG,
+  SearchIndex.DATA_PRODUCT,
 ];

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ExplorePage/ExplorePageV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ExplorePage/ExplorePageV1.component.tsx
@@ -38,6 +38,7 @@ import { getExplorePath, PAGE_SIZE } from '../../constants/constants';
 import {
   COMMON_FILTERS_FOR_DIFFERENT_TABS,
   INITIAL_SORT_FIELD,
+  TABS_SEARCH_INDEXES,
 } from '../../constants/explore.constants';
 import {
   mockSearchData,
@@ -341,8 +342,9 @@ const ExplorePageV1: FunctionComponent = () => {
       }).then((res) => {
         const buckets = res.aggregations[`index_count`].buckets;
         const counts: Record<string, number> = {};
+
         buckets.forEach((item) => {
-          if (item) {
+          if (item && TABS_SEARCH_INDEXES.includes(item.key)) {
             counts[item.key ?? ''] = item.doc_count;
           }
         });


### PR DESCRIPTION
When searching in global search we get exception if the searchResult is not type of Tabs present. 

To resolve this filtering the data before setting.