### PR TITLE
fix(#14257): glossary term name get fully truncate for long text in glossary table

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
@@ -109,28 +109,30 @@ const GlossaryTermTab = ({
         title: t('label.term-plural'),
         dataIndex: 'name',
         key: 'name',
-        className: 'glossary-name-column w-max-400',
+        className: 'glossary-name-column',
+        ellipsis: true,
+        width: '40%',
         render: (_, record) => {
           const name = getEntityName(record);
 
           return (
-            <div className="inline-flex items-center w-max-85">
+            <>
               {record.style?.iconURL && (
                 <img
-                  className="m-r-xss"
+                  className="m-r-xss vertical-baseline"
                   data-testid="tag-icon"
                   src={record.style.iconURL}
                   width={16}
                 />
               )}
               <Link
-                className="cursor-pointer help-text truncate"
+                className="cursor-pointer vertical-baseline"
                 data-testid={name}
                 style={{ color: record.style?.color }}
                 to={getGlossaryPath(record.fullyQualifiedName || record.name)}>
                 {name}
               </Link>
-            </div>
+            </>
           );
         },
       },
@@ -138,6 +140,7 @@ const GlossaryTermTab = ({
         title: t('label.description'),
         dataIndex: 'description',
         key: 'description',
+        width: permissions.Create ? '21%' : '33%',
         render: (description: string) =>
           description.trim() ? (
             <RichTextEditorPreviewer
@@ -153,12 +156,14 @@ const GlossaryTermTab = ({
         title: t('label.owner'),
         dataIndex: 'owner',
         key: 'owner',
+        width: '15%',
         render: (owner: EntityReference) => <OwnerLabel owner={owner} />,
       },
       {
         title: t('label.status'),
         dataIndex: 'status',
         key: 'status',
+        width: '12%',
         filterIcon: FilterIcon,
         filters: StatusFilters,
         render: (_, record) => {
@@ -179,7 +184,7 @@ const GlossaryTermTab = ({
       data.push({
         title: t('label.action-plural'),
         key: 'new-term',
-        width: 80,
+        width: '12%',
         render: (_, record) => {
           const status = record.status ?? Status.Approved;
           const allowAddTerm = status === Status.Approved;
@@ -397,9 +402,8 @@ const GlossaryTermTab = ({
               loading={isTableLoading}
               pagination={false}
               rowKey="fullyQualifiedName"
-              scroll={{ x: true }}
               size="small"
-              tableLayout="auto"
+              tableLayout="fixed"
               onHeaderRow={onTableHeader}
               onRow={onTableRow}
             />

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
@@ -109,14 +109,16 @@ const GlossaryTermTab = ({
         title: t('label.term-plural'),
         dataIndex: 'name',
         key: 'name',
-        className: 'glossary-name-column w-max-400 truncate',
+        className: 'glossary-name-column w-max-400',
+        ellipsis: true,
         render: (_, record) => {
           const name = getEntityName(record);
 
           return (
-            <Space align="center">
+            <>
               {record.style?.iconURL && (
                 <img
+                  className="m-r-xss"
                   data-testid="tag-icon"
                   src={record.style.iconURL}
                   width={16}
@@ -129,7 +131,7 @@ const GlossaryTermTab = ({
                 to={getGlossaryPath(record.fullyQualifiedName || record.name)}>
                 {name}
               </Link>
-            </Space>
+            </>
           );
         },
       },

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
@@ -114,7 +114,7 @@ const GlossaryTermTab = ({
           const name = getEntityName(record);
 
           return (
-            <div className="d-inline-flex items-center w-max-90">
+            <div className="d-inline-flex items-center w-max-85">
               {record.style?.iconURL && (
                 <img
                   className="m-r-xss"

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
@@ -109,12 +109,12 @@ const GlossaryTermTab = ({
         title: t('label.term-plural'),
         dataIndex: 'name',
         key: 'name',
-        className: 'glossary-name-column',
+        className: 'glossary-name-column w-max-400',
         render: (_, record) => {
           const name = getEntityName(record);
 
           return (
-            <div className="d-inline-flex items-center w-max-400">
+            <div className="d-inline-flex items-center w-max-90">
               {record.style?.iconURL && (
                 <img
                   className="m-r-xss"

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
@@ -109,13 +109,12 @@ const GlossaryTermTab = ({
         title: t('label.term-plural'),
         dataIndex: 'name',
         key: 'name',
-        className: 'glossary-name-column w-max-400',
-        ellipsis: true,
+        className: 'glossary-name-column',
         render: (_, record) => {
           const name = getEntityName(record);
 
           return (
-            <>
+            <div className="d-inline-flex items-center w-max-400">
               {record.style?.iconURL && (
                 <img
                   className="m-r-xss"
@@ -125,13 +124,13 @@ const GlossaryTermTab = ({
                 />
               )}
               <Link
-                className="cursor-pointer help-text"
+                className="cursor-pointer help-text truncate"
                 data-testid={name}
                 style={{ color: record.style?.color }}
                 to={getGlossaryPath(record.fullyQualifiedName || record.name)}>
                 {name}
               </Link>
-            </>
+            </div>
           );
         },
       },

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
@@ -114,7 +114,7 @@ const GlossaryTermTab = ({
           const name = getEntityName(record);
 
           return (
-            <div className="d-inline-flex items-center w-max-85">
+            <div className="inline-flex items-center w-max-85">
               {record.style?.iconURL && (
                 <img
                   className="m-r-xss"

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
@@ -121,8 +121,8 @@ const GlossaryTermTab = ({
                 <img
                   className="m-r-xss vertical-baseline"
                   data-testid="tag-icon"
+                  height={12}
                   src={record.style.iconURL}
-                  width={16}
                 />
               )}
               <Link

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ExplorePage/ExplorePageV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ExplorePage/ExplorePageV1.component.tsx
@@ -344,7 +344,7 @@ const ExplorePageV1: FunctionComponent = () => {
         const counts: Record<string, number> = {};
 
         buckets.forEach((item) => {
-          if (item && TABS_SEARCH_INDEXES.includes(item.key)) {
+          if (item && TABS_SEARCH_INDEXES.includes(item.key as SearchIndex)) {
             counts[item.key ?? ''] = item.doc_count;
           }
         });

--- a/openmetadata-ui/src/main/resources/ui/src/styles/components/size.less
+++ b/openmetadata-ui/src/main/resources/ui/src/styles/components/size.less
@@ -92,6 +92,9 @@
 .w-max-20 {
   max-width: 20%;
 }
+.w-max-90 {
+  max-width: 90%;
+}
 .w-max-112 {
   max-width: 112px;
 }

--- a/openmetadata-ui/src/main/resources/ui/src/styles/components/size.less
+++ b/openmetadata-ui/src/main/resources/ui/src/styles/components/size.less
@@ -116,9 +116,6 @@
 .w-max-fit-content {
   max-width: fit-content;
 }
-.w-max-95 {
-  max-width: 95%;
-}
 .w-300 {
   width: 300px;
 }

--- a/openmetadata-ui/src/main/resources/ui/src/styles/components/size.less
+++ b/openmetadata-ui/src/main/resources/ui/src/styles/components/size.less
@@ -92,9 +92,6 @@
 .w-max-20 {
   max-width: 20%;
 }
-.w-max-85 {
-  max-width: 85%;
-}
 .w-max-112 {
   max-width: 112px;
 }

--- a/openmetadata-ui/src/main/resources/ui/src/styles/components/size.less
+++ b/openmetadata-ui/src/main/resources/ui/src/styles/components/size.less
@@ -92,8 +92,8 @@
 .w-max-20 {
   max-width: 20%;
 }
-.w-max-90 {
-  max-width: 90%;
+.w-max-85 {
+  max-width: 85%;
 }
 .w-max-112 {
   max-width: 112px;

--- a/openmetadata-ui/src/main/resources/ui/src/styles/components/table.less
+++ b/openmetadata-ui/src/main/resources/ui/src/styles/components/table.less
@@ -41,8 +41,8 @@
             }
 
             .expand-cell-empty-icon-container {
-              width: 18px;
-              height: 16px;
+              width: 8px;
+              height: 12px;
               display: inline-flex;
             }
           }

--- a/openmetadata-ui/src/main/resources/ui/src/styles/position.less
+++ b/openmetadata-ui/src/main/resources/ui/src/styles/position.less
@@ -121,14 +121,8 @@
 }
 
 // Alignment Items
-.align-middle {
-  vertical-align: middle;
-}
 .self-end {
   align-self: flex-end;
-}
-.vertical-align-inherit {
-  vertical-align: inherit;
 }
 
 .self-center {
@@ -207,4 +201,12 @@
 // Vertical Align
 .vertical-baseline {
   vertical-align: baseline;
+}
+
+.align-middle {
+  vertical-align: middle;
+}
+
+.vertical-align-inherit {
+  vertical-align: inherit;
 }

--- a/openmetadata-ui/src/main/resources/ui/src/utils/GlobalSettingsUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/GlobalSettingsUtils.tsx
@@ -205,7 +205,6 @@ export const getGlobalSettingsMenuWithPermission = (
         },
       ],
     },
-
     {
       category: i18next.t('label.integration-plural'),
       key: 'integrations',

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TableUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TableUtils.tsx
@@ -505,7 +505,7 @@ export function getTableExpandableConfig<T>(
   const expandableConfig: ExpandableConfig<T> = {
     expandIcon: ({ expanded, onExpand, expandable, record }) =>
       expandable ? (
-        <div className="items-center inline">
+        <div className="items-center inline-flex">
           {isDraggable && (
             <IconDrag className="m-r-xs drag-icon" height={12} width={12} />
           )}

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TableUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TableUtils.tsx
@@ -505,23 +505,23 @@ export function getTableExpandableConfig<T>(
   const expandableConfig: ExpandableConfig<T> = {
     expandIcon: ({ expanded, onExpand, expandable, record }) =>
       expandable ? (
-        <div className="items-center inline-flex">
+        <>
           {isDraggable && (
-            <IconDrag className="m-r-xs drag-icon" height={12} width={12} />
+            <IconDrag className="m-r-xs drag-icon" height={12} width={8} />
           )}
           <Icon
-            className="m-r-xs"
+            className="m-r-xs vertical-baseline"
             component={expanded ? IconDown : IconRight}
             data-testid="expand-icon"
             style={{ fontSize: '10px', color: TEXT_BODY_COLOR }}
             onClick={(e) => onExpand(record, e)}
           />
-        </div>
+        </>
       ) : (
         isDraggable && (
           <>
-            <IconDrag className="m-r-xs drag-icon" height={12} width={12} />
-            <div className="expand-cell-empty-icon-container" />
+            <IconDrag className="m-r-xs drag-icon" height={12} width={8} />
+            <span className="expand-cell-empty-icon-container" />
           </>
         )
       ),


### PR DESCRIPTION
this pr fix issue #14257 

**### Before**
<img width="1440" alt="Screenshot 2023-12-21 at 1 19 56 PM" src="https://github.com/open-metadata/OpenMetadata/assets/80886271/54d2f483-da96-4999-b866-468c0a6f995c">


**### After**

<img width="1512" alt="Screenshot 2023-12-22 at 2 37 22 PM" src="https://github.com/open-metadata/OpenMetadata/assets/12962843/08269f1c-e10e-4a4b-a233-0818e983a1ed">

<img width="1440" alt="Screenshot 2023-12-22 at 3 46 58 PM" src="https://github.com/open-metadata/OpenMetadata/assets/80886271/a47af4c5-4dab-4280-89da-388992cbab1f">
<img width="1440" alt="Screenshot 2023-12-22 at 3 46 07 PM" src="https://github.com/open-metadata/OpenMetadata/assets/80886271/4989b100-23d6-4c13-ba27-077ae5154c91">



