### PR TITLE
FIXES #14396: Exclude empty test suites from quality page

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ListFilter.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ListFilter.java
@@ -58,6 +58,7 @@ public class ListFilter {
     condition = addCondition(condition, getTestCaseCondition());
     condition = addCondition(condition, getTestSuiteTypeCondition());
     condition = addCondition(condition, getTestSuiteFQNCondition());
+    condition = addCondition(condition, getEmptyTestSuiteCondition());
     condition = addCondition(condition, getDomainCondition());
     condition = addCondition(condition, getEntityFQNHashCondition());
     condition = addCondition(condition, getTestCaseResolutionStatusType());
@@ -225,6 +226,20 @@ public class ListFilter {
       default:
         return "";
     }
+  }
+
+  private String getEmptyTestSuiteCondition() {
+    String includeEmptyTestSuites = getQueryParam("includeEmptyTestSuites");
+    if (includeEmptyTestSuites == null || Boolean.parseBoolean(includeEmptyTestSuites)) {
+      // if we want to include empty test suites, then we don't need to add a condition
+      return "";
+    }
+
+    if (Boolean.TRUE.equals(DatasourceConfig.getInstance().isMySQL())) {
+      return "!JSON_CONTAINS(json, JSON_ARRAY() , '$.testCaseResultSummary')";
+    }
+
+    return "jsonb_array_length(json#>'{testCaseResultSummary}') != 0";
   }
 
   private String getFqnPrefixCondition(String tableName, String fqnPrefix) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestSuiteResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestSuiteResource.java
@@ -126,12 +126,11 @@ public class TestSuiteResource extends EntityResource<TestSuite, TestSuiteReposi
           @QueryParam("testSuiteType")
           String testSuiteType,
       @Parameter(
-              description =
-                      "Include empty test suite in the response.",
+              description = "Include empty test suite in the response.",
               schema = @Schema(type = "boolean", example = "true"))
-      @QueryParam("includeEmptyTestSuites")
-      @DefaultValue("true")
-      Boolean includeEmptyTestSuites,
+          @QueryParam("includeEmptyTestSuites")
+          @DefaultValue("true")
+          Boolean includeEmptyTestSuites,
       @Parameter(
               description = "Returns list of test definitions before this cursor",
               schema = @Schema(type = "string"))

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestSuiteResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestSuiteResource.java
@@ -126,6 +126,13 @@ public class TestSuiteResource extends EntityResource<TestSuite, TestSuiteReposi
           @QueryParam("testSuiteType")
           String testSuiteType,
       @Parameter(
+              description =
+                      "Include empty test suite in the response.",
+              schema = @Schema(type = "boolean", example = "true"))
+      @QueryParam("includeEmptyTestSuites")
+      @DefaultValue("true")
+      Boolean includeEmptyTestSuites,
+      @Parameter(
               description = "Returns list of test definitions before this cursor",
               schema = @Schema(type = "string"))
           @QueryParam("before")
@@ -143,6 +150,7 @@ public class TestSuiteResource extends EntityResource<TestSuite, TestSuiteReposi
           Include include) {
     ListFilter filter = new ListFilter(include);
     filter.addQueryParam("testSuiteType", testSuiteType);
+    filter.addQueryParam("includeEmptyTestSuites", includeEmptyTestSuites);
     EntityUtil.Fields fields = getFields(fieldsParam);
 
     ResourceContext<?> resourceContext = getResourceContext();

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/dqtests/TestSuiteResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/dqtests/TestSuiteResourceTest.java
@@ -356,6 +356,10 @@ public class TestSuiteResourceTest extends EntityResourceTest<TestSuite, CreateT
     queryParams.put("testSuiteType", "logical");
     testSuiteResultList = listEntities(queryParams, ADMIN_AUTH_HEADERS);
     testSuiteResultList.getData().forEach(ts -> assertEquals(false, ts.getExecutable()));
+
+    queryParams.put("includeEmptyTestSuites", "false");
+    testSuiteResultList = listEntities(queryParams, ADMIN_AUTH_HEADERS);
+    assertEquals(0, testSuiteResultList.getData().size());
   }
 
   @Test

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestSuites/TestSuites.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestSuites/TestSuites.component.tsx
@@ -145,6 +145,7 @@ export const TestSuites = ({ summaryPanel }: { summaryPanel: ReactNode }) => {
       const result = await getListTestSuites({
         ...params,
         fields: 'owner,summary',
+        includeEmptyTestSuites: false,
         testSuiteType:
           tab === DataQualityPageTabs.TABLES
             ? TestSuiteType.executable

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestSuites/TestSuites.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestSuites/TestSuites.test.tsx
@@ -102,6 +102,7 @@ describe('TestSuites component', () => {
     ).toBeInTheDocument();
     expect(mockGetListTestSuites).toHaveBeenCalledWith({
       fields: 'owner,summary',
+      includeEmptyTestSuites: false,
       limit: 15,
       testSuiteType: 'executable',
     });
@@ -138,6 +139,7 @@ describe('TestSuites component', () => {
     ).toBeInTheDocument();
     expect(mockGetListTestSuites).toHaveBeenCalledWith({
       fields: 'owner,summary',
+      includeEmptyTestSuites: false,
       limit: 15,
       testSuiteType: 'logical',
     });

--- a/openmetadata-ui/src/main/resources/ui/src/rest/testAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/testAPI.ts
@@ -34,6 +34,7 @@ export enum TestSuiteType {
 
 export type ListTestSuitePrams = ListParams & {
   testSuiteType?: TestSuiteType;
+  includeEmptyTestSuites?: boolean;
 };
 
 export type ListTestCaseParams = ListParams & {


### PR DESCRIPTION
### Describe your changes:

Fixes #14396 

Add parameter to exclude test suite without test cases from listing

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

Improvement
- [x] I have added tests around the new logic.
- [x] For connector/ingestion changes: I updated the documentation.

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
