### PR TITLE
Fixes: `GetTags-403 Permission denied on resource project None.`

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/bigquery/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/bigquery/connection.py
@@ -44,7 +44,9 @@ from metadata.ingestion.connections.test_connections import (
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.database.bigquery.queries import BIGQUERY_TEST_STATEMENT
 from metadata.utils.credentials import set_google_credentials
+from metadata.utils.logger import ingestion_logger
 
+logger = ingestion_logger()
 
 def get_connection_url(connection: BigQueryConnection) -> str:
     """
@@ -107,9 +109,27 @@ def test_connection(
             return policy_tags
 
     def test_tags():
-        taxonomies = PolicyTagManagerClient().list_taxonomies(
-            parent=f"projects/{engine.url.host}/locations/{service_connection.taxonomyLocation}"
-        )
+        taxonomy_project_ids = []
+        if engine.url.host:
+            taxonomy_project_ids.append(engine.url.host)
+        if service_connection.taxonomyProjectId:
+            taxonomy_project_ids.extend(service_connection.taxonomyProjectId)
+        if not taxonomy_project_ids:
+            logger.info("'taxonomyProjectID' is not set, so skipping this test.")
+            return
+
+        taxonomy_location = service_connection.taxonomyLocation
+        if not taxonomy_location:
+            logger.info("'taxonomyLocation' is not set, so skipping this test.")
+            return
+
+        taxonomies = []
+        for project_id in taxonomy_project_ids:
+            taxonomies.extend(
+                PolicyTagManagerClient().list_taxonomies(
+                    parent=f"projects/{project_id}/locations/{taxonomy_location}"
+                )
+            )
         return get_tags(taxonomies)
 
     def test_connection_inner(engine):

--- a/ingestion/src/metadata/ingestion/source/database/bigquery/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/bigquery/connection.py
@@ -48,6 +48,7 @@ from metadata.utils.logger import ingestion_logger
 
 logger = ingestion_logger()
 
+
 def get_connection_url(connection: BigQueryConnection) -> str:
     """
     Build the connection URL and set the project

--- a/ingestion/src/metadata/ingestion/source/database/bigquery/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/bigquery/connection.py
@@ -117,12 +117,12 @@ def test_connection(
             taxonomy_project_ids.extend(service_connection.taxonomyProjectId)
         if not taxonomy_project_ids:
             logger.info("'taxonomyProjectID' is not set, so skipping this test.")
-            return
+            return None
 
         taxonomy_location = service_connection.taxonomyLocation
         if not taxonomy_location:
             logger.info("'taxonomyLocation' is not set, so skipping this test.")
-            return
+            return None
 
         taxonomies = []
         for project_id in taxonomy_project_ids:


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

Fixed an issue in the BigQuery `test_connection` process where a `GetTags-403 Permission denied on resource project None.` error was encountered during the execution of `test_tags`. The previous implementation erroneously executed `list_taxonomies` without utilizing the specified `taxonomyProjectID`, leading to the error. While I am uncertain if `engine.url.host` can contain a GCP Project ID, I have made efforts to maintain backward compatibility as much as possible. However, there is one backward-incompatible change regarding the behavior when `taxonomyLocation` is not set. To prevent errors when `taxonomyLocation` is not configured, I have altered the process to log an info message and skip the execution of `list_taxonomies`.

<details><summary>Ingestion Error Log</summary>
<p>

```
[2023-12-29 00:48:56] DEBUG    {metadata.OMetaAPI:server_mixin:63} - Validating client and server versions
[2023-12-29 00:49:02] DEBUG    {metadata.Metadata:test_connections:197} - Traceback (most recent call last):
  File "/app/.venv/lib/python3.10/site-packages/google/api_core/grpc_helpers.py", line 79, in error_remapped_callable
    return callable_(*args, **kwargs)
  File "/app/.venv/lib/python3.10/site-packages/grpc/_channel.py", line 1160, in __call__
    return _end_unary_response_blocking(state, call, False, None)
  File "/app/.venv/lib/python3.10/site-packages/grpc/_channel.py", line 1003, in _end_unary_response_blocking
    raise _InactiveRpcError(state)  # pytype: disable=not-instantiable
grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
	status = StatusCode.PERMISSION_DENIED
	details = "Permission denied on resource project None."
	debug_error_string = "UNKNOWN:Error received from peer ipv4:172.217.161.234:443 {grpc_message:"Permission denied on resource project None.", grpc_status:7, created_time:"2023-12-29T00:49:02.216984256+00:00"}"
>

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/app/.venv/lib/python3.10/site-packages/metadata/ingestion/connections/test_connections.py", line 193, in _test_connection_steps_during_ingestion
    step.function()
  File "/app/.venv/lib/python3.10/site-packages/metadata/ingestion/source/database/bigquery/connection.py", line 110, in test_tags
    taxonomies = PolicyTagManagerClient().list_taxonomies(
  File "/app/.venv/lib/python3.10/site-packages/google/cloud/datacatalog_v1/services/policy_tag_manager/client.py", line 908, in list_taxonomies
    response = rpc(
  File "/app/.venv/lib/python3.10/site-packages/google/api_core/gapic_v1/method.py", line 131, in __call__
    return wrapped_func(*args, **kwargs)
  File "/app/.venv/lib/python3.10/site-packages/google/api_core/grpc_helpers.py", line 81, in error_remapped_callable
    raise exceptions.from_grpc_error(exc) from exc
google.api_core.exceptions.PermissionDenied: 403 Permission denied on resource project None. [links {
  description: "Google developers console"
  url: "https://console.developers.google.com"
}
, reason: "CONSUMER_INVALID"
domain: "googleapis.com"
metadata {
  key: "service"
  value: "datacatalog.googleapis.com"
}
metadata {
  key: "consumer"
  value: "projects/None"
}
]

[2023-12-29 00:49:02] WARNING  {metadata.Metadata:test_connections:198} - GetTags-403 Permission denied on resource project None. [links {
  description: "Google developers console"
  url: "https://console.developers.google.com"
}
, reason: "CONSUMER_INVALID"
domain: "googleapis.com"
metadata {
  key: "service"
  value: "datacatalog.googleapis.com"
}
metadata {
  key: "consumer"
  value: "projects/None"
}
]
[2023-12-29 00:49:04] INFO     {metadata.Metadata:test_connections:215} - Test connection results:
[2023-12-29 00:49:04] INFO     {metadata.Metadata:test_connections:216} - failed=[] success=["'CheckAccess': Pass", "'GetSchemas': Pass", "'GetTables': Pass", "'GetViews': Pass", "'GetQueries': Pass"] warning=['\'GetTags\': This is a optional and the ingestion will continue to work as expected.Failed due to: 403 Permission denied on resource project None. [links {\n  description: "Google developers console"\n  url: "https://console.developers.google.com"\n}\n, reason: "CONSUMER_INVALID"\ndomain: "googleapis.com"\nmetadata {\n  key: "service"\n  value: "datacatalog.googleapis.com"\n}\nmetadata {\n  key: "consumer"\n  value: "projects/None"\n}\n]']
[2023-12-29 00:49:04] DEBUG    {metadata.Ingestion:metadata:62} - Source type:bigquery,<class 'metadata.ingestion.source.database.bigquery.metadata.BigquerySource'> configured
[2023-12-29 00:49:04] DEBUG    {metadata.Ingestion:metadata:64} - Source type:bigquery,<class 'metadata.ingestion.source.database.bigquery.metadata.BigquerySource'>  prepared
[2023-12-29 00:49:04] DEBUG    {metadata.Ingestion:metadata:73} - Sink type:metadata-rest, <class 'metadata.ingestion.sink.metadata_rest.MetadataRestSink'> configured

...<snip>...
```

</p>
</details> 

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
