### PR TITLE
Fix #14610: includeEmptyTestSuite behavior causing not include newly created test suites

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/formatter/entity/TestCaseFormatter.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/formatter/entity/TestCaseFormatter.java
@@ -68,6 +68,7 @@ public class TestCaseFormatter implements EntityFormatter {
       case Success -> "<span style=\"color:#48CA9E\">Passed</span>";
       case Failed -> "<span style=\"color:#F24822\">Failed</span>";
       case Aborted -> "<span style=\"color:#FFBE0E\">Aborted</span>";
+      case Queued -> "<span style=\"color:#959595\">Queued</span>";
     };
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -3417,7 +3417,7 @@ public interface CollectionDAO {
       boolean includeEmptyTestSuite =
           Boolean.parseBoolean(filter.getQueryParam("includeEmptyTestSuites"));
       if (!includeEmptyTestSuite) {
-        groupBy = String.format("group by %s.json", getTableName());
+        groupBy = String.format("group by %s.json, %s.name", getTableName(), getTableName());
         String condition =
             String.format(
                 "INNER JOIN entity_relationship er ON %s.id=er.fromId AND er.relation=%s AND er.toEntity='%s'",
@@ -3440,7 +3440,7 @@ public interface CollectionDAO {
       boolean includeEmptyTestSuite =
           Boolean.parseBoolean(filter.getQueryParam("includeEmptyTestSuites"));
       if (!includeEmptyTestSuite) {
-        groupBy = String.format("group by %s.json", getTableName());
+        groupBy = String.format("group by %s.json, %s.name", getTableName(), getTableName());
         String condition =
             String.format(
                 "INNER JOIN entity_relationship er ON %s.id=er.fromId AND er.relation=%s AND er.toEntity='%s'",

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -3382,6 +3382,79 @@ public interface CollectionDAO {
     default String getNameHashColumn() {
       return "fqnHash";
     }
+
+    @Override
+    default int listCount(ListFilter filter) {
+      String mySqlCondition = filter.getCondition(getTableName());
+      String postgresCondition = filter.getCondition(getTableName());
+      boolean includeEmptyTestSuite =
+          Boolean.parseBoolean(filter.getQueryParam("includeEmptyTestSuites"));
+      if (!includeEmptyTestSuite) {
+        String condition =
+            String.format(
+                "INNER JOIN entity_relationship er ON %s.id=er.fromId AND er.relation=%s AND er.toEntity='%s'",
+                getTableName(), CONTAINS.ordinal(), Entity.TEST_CASE);
+        mySqlCondition = condition;
+        postgresCondition = condition;
+
+        mySqlCondition =
+            String.format("%s %s", mySqlCondition, filter.getCondition(getTableName()));
+        postgresCondition =
+            String.format("%s %s", postgresCondition, filter.getCondition(getTableName()));
+      }
+      return listCount(
+          getTableName(),
+          mySqlCondition,
+          postgresCondition,
+          String.format("%s.%s", getTableName(), getNameHashColumn()));
+    }
+
+    @Override
+    default List<String> listBefore(ListFilter filter, int limit, String before) {
+      String mySqlCondition = filter.getCondition(getTableName());
+      String postgresCondition = filter.getCondition(getTableName());
+      String groupBy = "";
+      boolean includeEmptyTestSuite =
+          Boolean.parseBoolean(filter.getQueryParam("includeEmptyTestSuites"));
+      if (!includeEmptyTestSuite) {
+        groupBy = String.format("group by %s.json", getTableName());
+        String condition =
+            String.format(
+                "INNER JOIN entity_relationship er ON %s.id=er.fromId AND er.relation=%s AND er.toEntity='%s'",
+                getTableName(), CONTAINS.ordinal(), Entity.TEST_CASE);
+        mySqlCondition = condition;
+        postgresCondition = condition;
+        mySqlCondition =
+            String.format("%s %s", mySqlCondition, filter.getCondition(getTableName()));
+        postgresCondition =
+            String.format("%s %s", postgresCondition, filter.getCondition(getTableName()));
+      }
+      return listBefore(getTableName(), mySqlCondition, postgresCondition, limit, before, groupBy);
+    }
+
+    @Override
+    default List<String> listAfter(ListFilter filter, int limit, String after) {
+      String mySqlCondition = filter.getCondition(getTableName());
+      String postgresCondition = filter.getCondition(getTableName());
+      String groupBy = "";
+      boolean includeEmptyTestSuite =
+          Boolean.parseBoolean(filter.getQueryParam("includeEmptyTestSuites"));
+      if (!includeEmptyTestSuite) {
+        groupBy = String.format("group by %s.json", getTableName());
+        String condition =
+            String.format(
+                "INNER JOIN entity_relationship er ON %s.id=er.fromId AND er.relation=%s AND er.toEntity='%s'",
+                getTableName(), CONTAINS.ordinal(), Entity.TEST_CASE);
+        mySqlCondition = condition;
+        postgresCondition = condition;
+
+        mySqlCondition =
+            String.format("%s %s", mySqlCondition, filter.getCondition(getTableName()));
+        postgresCondition =
+            String.format("%s %s", postgresCondition, filter.getCondition(getTableName()));
+      }
+      return listAfter(getTableName(), mySqlCondition, postgresCondition, limit, after, groupBy);
+    }
   }
 
   interface TestCaseDAO extends EntityDAO<TestCase> {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityDAO.java
@@ -202,6 +202,76 @@ public interface EntityDAO<T extends EntityInterface> {
   @SqlQuery("SELECT count(*) FROM <table>")
   int listTotalCount(@Define("table") String table);
 
+  @ConnectionAwareSqlQuery(
+      value = "SELECT count(distinct(<distinctColumn>)) FROM <table> <mysqlCond>",
+      connectionType = MYSQL)
+  @ConnectionAwareSqlQuery(
+      value = "SELECT count(distinct(<distinctColumn>)) FROM <table> <postgresCond>",
+      connectionType = POSTGRES)
+  int listCount(
+      @Define("table") String table,
+      @Define("mysqlCond") String mysqlCond,
+      @Define("postgresCond") String postgresCond,
+      @Define("distinctColumn") String distinctColumn);
+
+  @ConnectionAwareSqlQuery(
+      value =
+          "SELECT json FROM ("
+              + "SELECT <table>.name, <table>.json FROM <table> <mysqlCond> AND "
+              + "<table>.name < :before "
+              + "<groupBy> "
+              + // Pagination by entity fullyQualifiedName or name (when entity does not have fqn)
+              "ORDER BY <table>.name DESC "
+              + // Pagination ordering by entity fullyQualifiedName or name (when entity does not
+              // have fqn)
+              "LIMIT :limit"
+              + ") last_rows_subquery ORDER BY name",
+      connectionType = MYSQL)
+  @ConnectionAwareSqlQuery(
+      value =
+          "SELECT json FROM ("
+              + "SELECT <table>.name, <table>.json FROM <table> <postgresCond> AND "
+              + "<table>.name < :before "
+              + "<groupBy> "
+              + // Pagination by entity fullyQualifiedName or name (when entity does not have fqn)
+              "ORDER BY <table>.name DESC "
+              + // Pagination ordering by entity fullyQualifiedName or name (when entity does not
+              // have fqn)
+              "LIMIT :limit"
+              + ") last_rows_subquery ORDER BY name",
+      connectionType = POSTGRES)
+  List<String> listBefore(
+      @Define("table") String table,
+      @Define("mysqlCond") String mysqlCond,
+      @Define("postgresCond") String postgresCond,
+      @Bind("limit") int limit,
+      @Bind("before") String before,
+      @Define("groupBy") String groupBy);
+
+  @ConnectionAwareSqlQuery(
+      value =
+          "SELECT <table>.json FROM <table> <mysqlCond> AND "
+              + "<table>.name > :after "
+              + "<groupBy> "
+              + "ORDER BY <table>.name "
+              + "LIMIT :limit",
+      connectionType = MYSQL)
+  @ConnectionAwareSqlQuery(
+      value =
+          "SELECT <table>.json FROM <table> <postgresCond> AND "
+              + "<table>.name > :after "
+              + "<groupBy> "
+              + "ORDER BY <table>.name "
+              + "LIMIT :limit",
+      connectionType = POSTGRES)
+  List<String> listAfter(
+      @Define("table") String table,
+      @Define("mysqlCond") String mysqlCond,
+      @Define("postgresCond") String postgresCond,
+      @Bind("limit") int limit,
+      @Bind("after") String after,
+      @Define("groupBy") String groupBy);
+
   @SqlQuery(
       "SELECT json FROM ("
           + "SELECT name, json FROM <table> <cond> AND "

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ListFilter.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ListFilter.java
@@ -217,7 +217,7 @@ public class ListFilter {
           yield String.format(
               "(JSON_UNQUOTE(JSON_EXTRACT(%s.json, '$.executable')) = 'true')", tableName);
         }
-        yield "(json->>'executable' = 'true')";
+        yield String.format("(%s.json->>'executable' = 'true')", tableName);
       }
       case ("logical") -> {
         if (Boolean.TRUE.equals(DatasourceConfig.getInstance().isMySQL())) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/dqtests/TestCaseResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/dqtests/TestCaseResourceTest.java
@@ -443,7 +443,9 @@ public class TestCaseResourceTest extends EntityResourceTest<TestCase, CreateTes
     // test we get the right summary for the executable test suite
     TestSummary executableTestSummary =
         getTestSummary(ADMIN_AUTH_HEADERS, testCase.getTestSuite().getId().toString());
-    assertEquals(2, executableTestSummary.getTotal());
+    TestSuite testSuite =
+        testSuiteResourceTest.getEntity(testCase.getTestSuite().getId(), "*", ADMIN_AUTH_HEADERS);
+    assertEquals(testSuite.getTests().size(), executableTestSummary.getTotal());
 
     // test we get the right summary for the logical test suite
     TestSummary logicalTestSummary =
@@ -453,30 +455,22 @@ public class TestCaseResourceTest extends EntityResourceTest<TestCase, CreateTes
     testCaseIds.add(testCase.getId());
     testSuiteResourceTest.addTestCasesToLogicalTestSuite(logicalTestSuite, testCaseIds);
     logicalTestSummary = getTestSummary(ADMIN_AUTH_HEADERS, logicalTestSuite.getId().toString());
-    assertEquals(
-        2,
-        logicalTestSummary
-            .getTotal()); // we added a new test case to the logical test suite check if the summary
-    // is updated
-
+    assertEquals(2, logicalTestSummary.getTotal());
     deleteEntity(testCase1.getId(), ADMIN_AUTH_HEADERS);
-
     executableTestSummary =
         getTestSummary(ADMIN_AUTH_HEADERS, testCase.getTestSuite().getId().toString());
-    assertEquals(
-        1,
-        executableTestSummary
-            .getTotal()); // we deleted a test case from the executable test suite check if the
-    // summary is updated
+    testSuite =
+        testSuiteResourceTest.getEntity(testCase.getTestSuite().getId(), "*", ADMIN_AUTH_HEADERS);
+    assertEquals(testSuite.getTests().size(), executableTestSummary.getTotal());
 
     logicalTestSummary = getTestSummary(ADMIN_AUTH_HEADERS, logicalTestSuite.getId().toString());
-    assertEquals(1, logicalTestSummary.getTotal());
+    assertEquals(2, logicalTestSummary.getTotal());
     // check the deletion of the test case from the executable test suite
     // cascaded to the logical test suite
     deleteLogicalTestCase(logicalTestSuite, testCase.getId());
     logicalTestSummary = getTestSummary(ADMIN_AUTH_HEADERS, logicalTestSuite.getId().toString());
     // check the deletion of the test case from the logical test suite is reflected in the summary
-    assertNull(logicalTestSummary.getTotal());
+    assertEquals(1, logicalTestSummary.getTotal());
   }
 
   @Test

--- a/openmetadata-spec/src/main/resources/json/schema/tests/basic.json
+++ b/openmetadata-spec/src/main/resources/json/schema/tests/basic.json
@@ -21,6 +21,10 @@
           "description": "Number of test cases that aborted.",
           "type": "integer"
         },
+        "queued": {
+          "description": "Number of test cases that are queued for execution.",
+          "type": "integer"
+        },
         "total": {
           "description": "Total number of test cases.",
           "type": "integer"
@@ -46,7 +50,7 @@
       "description": "Status of Test Case run.",
       "javaType": "org.openmetadata.schema.tests.type.TestCaseStatus",
       "type": "string",
-      "enum": ["Success", "Failed", "Aborted"],
+      "enum": ["Success", "Failed", "Aborted", "Queued"],
       "javaEnums": [
         {
           "name": "Success"
@@ -56,6 +60,9 @@
         },
         {
           "name": "Aborted"
+        },
+        {
+          "name": "Queued"
         }
       ]
     },


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #14610 

- User creates a test case for the first time on a table, UI makes call to create a native testSuite and also creates the test case for it. This test suite must show up in DQ page.
- User deletes the last test case belonging to a native test suite. This test suite has zero tests and shouldn't be visible in DQ page.
- Added new status called "Queued" to the TestCaseStatus to indicate a newly created test case is yet to run @ShaileshParmar11 we need to display this in the DQ page as another metric after Aborted.

@TeddyCr give it a review please.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
