### PR TITLE
Fix #12854: Executable TestSuite should inherit the ownership from it's table

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestSuiteRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestSuiteRepository.java
@@ -1,6 +1,8 @@
 package org.openmetadata.service.jdbi3;
 
 import static org.openmetadata.common.utils.CommonUtil.listOrEmpty;
+import static org.openmetadata.schema.type.Include.ALL;
+import static org.openmetadata.service.Entity.TABLE;
 import static org.openmetadata.service.Entity.TEST_CASE;
 import static org.openmetadata.service.Entity.TEST_SUITE;
 import static org.openmetadata.service.util.FullyQualifiedName.quoteName;
@@ -51,6 +53,15 @@ public class TestSuiteRepository extends EntityRepository<TestSuite> {
     entity.setSummary(
         fields.contains("summary") ? getTestCasesExecutionSummary(entity) : entity.getSummary());
     entity.withTests(fields.contains("tests") ? getTestCases(entity) : entity.getTests());
+  }
+
+  @Override
+  public void setInheritedFields(TestSuite testSuite, EntityUtil.Fields fields) {
+    if (Boolean.TRUE.equals(testSuite.getExecutable())) {
+      Table table =
+          Entity.getEntity(TABLE, testSuite.getExecutableEntityReference().getId(), "owner", ALL);
+      inheritOwner(testSuite, fields, table);
+    }
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestSuiteResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestSuiteResource.java
@@ -378,7 +378,6 @@ public class TestSuiteResource extends EntityResource<TestSuite, TestSuiteReposi
       @Valid CreateTestSuite create) {
     TestSuite testSuite = getTestSuite(create, securityContext.getUserPrincipal().getName());
     testSuite.setExecutable(true);
-    testSuite = setExecutableTestSuiteOwner(testSuite);
     return create(uriInfo, securityContext, testSuite);
   }
 
@@ -652,16 +651,5 @@ public class TestSuiteResource extends EntityResource<TestSuite, TestSuiteReposi
       testSuite.setExecutableEntityReference(entityReference);
     }
     return testSuite;
-  }
-
-  private TestSuite setExecutableTestSuiteOwner(TestSuite testSuite) {
-    Table tableEntity =
-        Entity.getEntity(
-            testSuite.getExecutableEntityReference().getType(),
-            testSuite.getExecutableEntityReference().getId(),
-            "owner",
-            ALL);
-    EntityReference ownerReference = tableEntity.getOwner();
-    return testSuite.withOwner(ownerReference);
   }
 }


### PR DESCRIPTION

<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
