### PR TITLE
Minor: invoke analytics instance only when it's available

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/AppRouter/AppRouter.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AppRouter/AppRouter.tsx
@@ -11,6 +11,7 @@
  *  limitations under the License.
  */
 
+import { isNil } from 'lodash';
 import React, { useCallback, useEffect } from 'react';
 import { Redirect, Route, Switch, useLocation } from 'react-router-dom';
 import { useAnalytics } from 'use-analytics';
@@ -80,8 +81,9 @@ const AppRouter = () => {
     /**
      * Ignore the slash path because we are treating my data as
      * default path.
+     * And check if analytics instance is available
      */
-    if (pathname !== '/') {
+    if (pathname !== '/' && !isNil(analytics)) {
       // track page view on route change
       analytics.page();
     }
@@ -91,7 +93,11 @@ const AppRouter = () => {
     (event: MouseEvent) => {
       const eventValue =
         (event.target as HTMLElement)?.textContent || CustomEventTypes.Click;
-      if (eventValue) {
+      /**
+       * Ignore the click event if the event value is undefined
+       * And analytics instance is not available
+       */
+      if (eventValue && !isNil(analytics)) {
         analytics.track(eventValue);
       }
     },


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:



<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on adding a check for if an analytics instance is available then only track the event and collect the page data.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
