### PR TITLE
Minor: Fix Databricks Pipeline Test Connection Fix

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/databricks/client.py
+++ b/ingestion/src/metadata/ingestion/source/database/databricks/client.py
@@ -135,6 +135,15 @@ class DatabricksClient:
             or query_text.startswith(QUERY_WITH_OM_VERSION)
         )
 
+    def list_jobs_test_connection(self) -> None:
+        data = {"limit": 1, "expand_tasks": True, "offset": 0}
+        self.client.get(
+            self.jobs_list_url,
+            data=json.dumps(data),
+            headers=self.headers,
+            timeout=API_TIMEOUT,
+        ).json()
+
     def list_jobs(self) -> List[dict]:
         """
         Method returns List all the created jobs in a Databricks Workspace

--- a/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/connection.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/connection.py
@@ -44,11 +44,7 @@ def test_connection(
     of a metadata workflow or during an Automation Workflow
     """
 
-    def custom_executor_for_pipeline():
-        result = client.list_jobs()
-        return list(result)
-
-    test_fn = {"GetPipelines": custom_executor_for_pipeline}
+    test_fn = {"GetPipelines": client.list_jobs_test_connection}
 
     test_connection_steps(
         metadata=metadata,


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Minor: Fix Databricks Pipeline Test Connection Fix

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
