### PR TITLE
Fix #14653: Fix Unity Catalog no children struct issue

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/metadata.py
@@ -479,6 +479,9 @@ class UnitycatalogSource(DatabaseServiceSource, MultiDBSource):
         for column in column_data:
             if column.type_text.lower().startswith("union"):
                 column.type_text = column.Type.replace(" ", "")
+            if column.type_text.lower() == "struct":
+                column.type_text = "struct<>"
+
             parsed_string = ColumnTypeParser._parse_datatype_string(  # pylint: disable=protected-access
                 column.type_text.lower()
             )

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/metadata.py
@@ -474,7 +474,9 @@ class UnitycatalogSource(DatabaseServiceSource, MultiDBSource):
             )
 
     def get_columns(self, column_data: List[ColumnInfo]) -> Iterable[Column]:
-        # process table regular columns info
+        """
+        process table regular columns info
+        """
 
         for column in column_data:
             if column.type_text.lower().startswith("union"):

--- a/ingestion/tests/unit/resources/expected_output_column_parser.json
+++ b/ingestion/tests/unit/resources/expected_output_column_parser.json
@@ -22,6 +22,11 @@
       "dataType": "STRUCT"
     },
     {
+      "dataType": "STRUCT",
+      "dataTypeDisplay": "struct<unknown>",
+      "children": []
+    },
+    {
       "children": [
         {
           "children": [

--- a/ingestion/tests/unit/test_column_type_parser.py
+++ b/ingestion/tests/unit/test_column_type_parser.py
@@ -23,6 +23,7 @@ from metadata.utils.datalake.datalake_utils import fetch_col_types
 COLUMN_TYPE_PARSE = [
     "array<string>",
     "struct<a:int,b:string>",
+    "struct<>",
     "struct<a:struct<b:array<string>,c:bigint>>",
     "struct<a:array<string>>",
     "struct<bigquerytestdatatype51:array<struct<bigquery_test_datatype_511:array<string>>>>",


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fix #14653: Fix Unity Catalog no children struct issue

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
