### PR TITLE
Fix #14764: Profiler make compute metric configurable

### DIFF
--- a/ingestion/src/metadata/profiler/processor/core.py
+++ b/ingestion/src/metadata/profiler/processor/core.py
@@ -92,6 +92,7 @@ class Profiler(Generic[TMetric]):
         """
 
         self.profiler_interface = profiler_interface
+        self.source_config = self.profiler_interface.source_config
         self.include_columns = include_columns
         self.exclude_columns = exclude_columns
         self._metrics = metrics
@@ -519,30 +520,26 @@ class Profiler(Generic[TMetric]):
 
         return self
 
-    def process(
-        self,
-        generate_sample_data: Optional[bool],
-        compute_metrics: Optional[bool],
-    ) -> ProfilerResponse:
+    def process(self) -> ProfilerResponse:
         """
         Given a table, we will prepare the profiler for
         all its columns and return all the run profilers
         in a Dict in the shape {col_name: Profiler}
         """
 
-        if compute_metrics:
+        if self.source_config.computeMetrics:
             logger.debug(
                 f"Computing profile metrics for {self.profiler_interface.table_entity.fullyQualifiedName.__root__}..."
             )
             self.compute_metrics()
 
-        if generate_sample_data:
+        if self.source_config.generateSampleData:
             sample_data = self.generate_sample_data()
         else:
             sample_data = None
 
         profile = self.get_profile()
-        if compute_metrics:
+        if self.source_config.computeMetrics:
             self._check_profile_and_handle(profile)
 
         table_profile = ProfilerResponse(

--- a/ingestion/src/metadata/profiler/processor/processor.py
+++ b/ingestion/src/metadata/profiler/processor/processor.py
@@ -60,6 +60,7 @@ class ProfilerProcessor(Processor):
         try:
             profile: ProfilerResponse = profiler_runner.process(
                 self.source_config.generateSampleData,
+                self.source_config.computeMetrics,
             )
         except Exception as exc:
             self.status.failed(

--- a/ingestion/src/metadata/profiler/processor/processor.py
+++ b/ingestion/src/metadata/profiler/processor/processor.py
@@ -58,10 +58,7 @@ class ProfilerProcessor(Processor):
         )
 
         try:
-            profile: ProfilerResponse = profiler_runner.process(
-                self.source_config.generateSampleData,
-                self.source_config.computeMetrics,
-            )
+            profile: ProfilerResponse = profiler_runner.process()
         except Exception as exc:
             self.status.failed(
                 StackTraceError(

--- a/openmetadata-spec/src/main/resources/json/schema/metadataIngestion/databaseServiceProfilerPipeline.json
+++ b/openmetadata-spec/src/main/resources/json/schema/metadataIngestion/databaseServiceProfilerPipeline.json
@@ -67,6 +67,12 @@
       "default": true,
       "title": "Generate Sample Data"
     },
+    "computeMetrics": {
+      "description": "Option to turn on/off computing profiler metrics.",
+      "type": "boolean",
+      "default": true,
+      "title": "Compute Metrics"
+    },
     "sampleDataCount": {
       "description": "Number of row of sample data to be generated",
       "type": "integer",


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fix #14764: Profiler make compute metric configurable

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
