### PR TITLE
MINOR - Snowflake system queries to work with ES & IDENTIFIER

### DIFF
--- a/ingestion/src/metadata/profiler/metrics/system/queries/snowflake.py
+++ b/ingestion/src/metadata/profiler/metrics/system/queries/snowflake.py
@@ -19,6 +19,9 @@ from typing import Optional
 
 from sqlalchemy.engine.row import Row
 
+from metadata.generated.schema.entity.services.databaseService import DatabaseService
+from metadata.ingestion.lineage.sql_lineage import search_table_entities
+from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.utils.logger import profiler_logger
 from metadata.utils.profiler_utils import (
     SnowflakeQueryResult,
@@ -55,20 +58,52 @@ RESULT_SCAN = """
     """
 
 
-def get_snowflake_system_queries(
-    row: Row, database: str, schema: str
-) -> Optional[SnowflakeQueryResult]:
-    """get snowflake system queries for a specific database and schema. Parsing the query
-    is the only reliable way to get the DDL operation as fields in the table are not. If parsing
-    fails we'll fall back to regex lookup
+QUERY_PATTERN = r"(?:(INSERT\s*INTO\s*|INSERT\s*OVERWRITE\s*INTO\s*|UPDATE\s*|MERGE\s*INTO\s*|DELETE\s*FROM\s*))([\w._\"\'()]+)(?=[\s*\n])"  # pylint: disable=line-too-long
+IDENTIFIER_PATTERN = r"(IDENTIFIER\(\')([\w._\"]+)(\'\))"
 
-    1. Parse the query and check if we have an Identifier
-    2.
+
+def _parse_query(query: str) -> Optional[str]:
+    """Parse snowflake queries to extract the identifiers"""
+    match = re.match(QUERY_PATTERN, query, re.IGNORECASE)
+    try:
+        # This will match results like `DATABASE.SCHEMA.TABLE1` or IDENTIFIER('TABLE1')
+        # If we have `IDENTIFIER` type of queries coming from Stored Procedures, we'll need to further clean it up.
+        identifier = match.group(2)
+
+        match_internal_identifier = re.match(
+            IDENTIFIER_PATTERN, identifier, re.IGNORECASE
+        )
+        internal_identifier = (
+            match_internal_identifier.group(2) if match_internal_identifier else None
+        )
+        if internal_identifier:
+            return internal_identifier
+
+        return identifier
+    except (IndexError, AttributeError):
+        logger.debug("Could not find identifier in query. Skipping row.")
+        return None
+
+
+def get_snowflake_system_queries(
+    row: Row,
+    database: str,
+    schema: str,
+    ometa_client: OpenMetadata,
+    db_service: DatabaseService,
+) -> Optional[SnowflakeQueryResult]:
+    """
+    Run a regex lookup on the query to identify which operation ran against the table.
+
+    If the query does not have the complete set of `database.schema.table` when it runs,
+    we'll use ES to pick up the table, if we find it.
 
     Args:
         row (dict): row from the snowflake system queries table
         database (str): database name
         schema (str): schema name
+        ometa_client (OpenMetadata): OpenMetadata client to search against ES
+        db_service (DatabaseService): DB service where the process is running against
     Returns:
         QueryResult: namedtuple with the query result
     """
@@ -78,21 +113,42 @@ def get_snowflake_system_queries(
         query_text = dict_row.get("QUERY_TEXT", dict_row.get("query_text"))
         logger.debug(f"Trying to parse query:\n{query_text}\n")
 
-        pattern = r"(?:(INSERT\s*INTO\s*|INSERT\s*OVERWRITE\s*INTO\s*|UPDATE\s*|MERGE\s*INTO\s*|DELETE\s*FROM\s*))([\w._\"]+)(?=[\s*\n])"  # pylint: disable=line-too-long
-        match = re.match(pattern, query_text, re.IGNORECASE)
-        try:
-            identifier = match.group(2)
-        except (IndexError, AttributeError):
-            logger.debug("Could not find identifier in query. Skipping row.")
+        identifier = _parse_query(query_text)
+        if not identifier:
             return None
 
         database_name, schema_name, table_name = get_identifiers_from_string(identifier)
 
-        if not all([database_name, schema_name, table_name]):
-            logger.debug(
-                "Missing database, schema, or table. Can't link operation to table entity in OpenMetadata."
-            )
+        if not table_name:
+            logger.debug("Could not extract the table name. Skipping operation.")
             return None
+
+        if not all([database_name, schema_name]):
+            logger.debug(
+                "Missing database or schema info from the query. We'll look for it in ES."
+            )
+            es_tables = search_table_entities(
+                metadata=ometa_client,
+                service_name=db_service.fullyQualifiedName.__root__,
+                database=database_name,
+                database_schema=schema_name,
+                table=table_name,
+            )
+
+            if not es_tables:
+                logger.debug("No tables match the search criteria.")
+                return None
+
+            if len(es_tables) > 1:
+                logger.debug(
+                    "Found more than 1 table matching the search criteria."
+                    " Skipping the computation to not mix system data."
+                )
+                return None
+
+            matched_table = es_tables[0]
+            database_name = matched_table.database.name
+            schema_name = matched_table.databaseSchema.name
 
         if (
             database.lower() == database_name.lower()

--- a/ingestion/src/metadata/profiler/processor/default.py
+++ b/ingestion/src/metadata/profiler/processor/default.py
@@ -17,19 +17,28 @@ from typing import List, Optional
 from sqlalchemy.orm import DeclarativeMeta
 
 from metadata.generated.schema.entity.data.table import ColumnProfilerConfig
+from metadata.generated.schema.entity.services.databaseService import DatabaseService
+from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.profiler.interface.profiler_interface import ProfilerInterface
 from metadata.profiler.metrics.core import Metric, add_props
 from metadata.profiler.metrics.registry import Metrics
 from metadata.profiler.processor.core import Profiler
 
 
-def get_default_metrics(table: DeclarativeMeta) -> List[Metric]:
+def get_default_metrics(
+    table: DeclarativeMeta,
+    ometa_client: Optional[OpenMetadata] = None,
+    db_service: Optional[DatabaseService] = None,
+) -> List[Metric]:
     return [
         # Table Metrics
         Metrics.ROW_COUNT.value,
         add_props(table=table)(Metrics.COLUMN_COUNT.value),
         add_props(table=table)(Metrics.COLUMN_NAMES.value),
-        add_props(table=table)(Metrics.SYSTEM.value),
+        # We'll use the ometa_client & db_service in case we need to fetch info to ES
+        add_props(table=table, ometa_client=ometa_client, db_service=db_service)(
+            Metrics.SYSTEM.value
+        ),
         # Column Metrics
         Metrics.MEDIAN.value,
         Metrics.FIRST_QUARTILE.value,
@@ -65,7 +74,9 @@ class DefaultProfiler(Profiler):
         include_columns: Optional[List[ColumnProfilerConfig]] = None,
         exclude_columns: Optional[List[str]] = None,
     ):
-        _metrics = get_default_metrics(profiler_interface.table)
+        _metrics = get_default_metrics(
+            table=profiler_interface.table, ometa_client=profiler_interface.ometa_client
+        )
 
         super().__init__(
             *_metrics,

--- a/ingestion/src/metadata/profiler/source/base/profiler_source.py
+++ b/ingestion/src/metadata/profiler/source/base/profiler_source.py
@@ -279,7 +279,11 @@ class ProfilerSource(ProfilerSourceInterface):
         metrics = (
             [Metrics.get(name) for name in profiler_config.profiler.metrics]
             if profiler_config.profiler.metrics
-            else get_default_metrics(profiler_interface.table)
+            else get_default_metrics(
+                table=profiler_interface.table,
+                ometa_client=self.ometa_client,
+                db_service=db_service,
+            )
         )
 
         return Profiler(

--- a/ingestion/tests/unit/profiler/conftest.py
+++ b/ingestion/tests/unit/profiler/conftest.py
@@ -10,7 +10,7 @@
 #  limitations under the License.
 
 """
-Confest for profiler tests
+Conftest for profiler tests
 """
 
 from uuid import UUID
@@ -71,7 +71,7 @@ class Row:
         self.QUERY_TEXT = query_text
 
     def __iter__(self):
-        """implemetation to support dict(row)"""
+        """implementation to support dict(row)"""
         yield "QUERY_ID", self.QUERY_ID
         yield "QUERY_TYPE", self.QUERY_TYPE
         yield "START_TIME", self.START_TIME
@@ -92,7 +92,7 @@ class LowerRow:
         self.QUERY_TEXT = query_text
 
     def __iter__(self):
-        """implemetation to support dict(row)"""
+        """implementation to support dict(row)"""
         yield "query_id", self.QUERY_ID
         yield "query_type", self.QUERY_TYPE
         yield "start_time", self.START_TIME

--- a/ingestion/tests/unit/profiler/sqlalchemy/test_metrics.py
+++ b/ingestion/tests/unit/profiler/sqlalchemy/test_metrics.py
@@ -862,7 +862,9 @@ class MetricsTest(TestCase):
         assert res == 61
 
     def test_system_metric(self):
-        system = add_props(table=User)(Metrics.SYSTEM.value)
+        system = add_props(table=User, ometa_client=None, db_service=None)(
+            Metrics.SYSTEM.value
+        )
         session = self.sqa_profiler_interface.session
         system().sql(session)
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

System metrics now support DMLs such as 

```sql
INSERT INTO USERS (name, age) VALUES ('Lévy', 3), ('Lima', 3);

CREATE OR REPLACE PROCEDURE SILVER.PUBLIC.add_data(to_layer VARCHAR)
RETURNS VARCHAR NOT NULL
LANGUAGE SQL
AS
BEGIN
  INSERT INTO IDENTIFIER(:to_layer) (name, age) VALUES ('Lévy', 3), ('Lima', 3);
END;
CALL SILVER.PUBLIC.add_data('GOLD.PUBLIC.USERS');
```
- table does not have the full db.schema.table -> we search in ES
- table is called from within an stored proc dynamically

![image](https://github.com/open-metadata/OpenMetadata/assets/35870520/1df86a06-89a1-46ae-8673-cfee583acb30)


<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
