### PR TITLE
by default make isBot : false in team index

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/TeamIndex.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/TeamIndex.java
@@ -32,6 +32,7 @@ public class TeamIndex implements SearchIndex {
             suggest.stream().map(SearchSuggest::getInput).collect(Collectors.toList())));
     doc.put("suggest", suggest);
     doc.put("entityType", Entity.TEAM);
+    doc.put("isBot", false);
     doc.put(
         "displayName",
         CommonUtil.nullOrEmpty(team.getDisplayName()) ? team.getName() : team.getDisplayName());

--- a/openmetadata-service/src/main/resources/elasticsearch/en/team_index_mapping.json
+++ b/openmetadata-service/src/main/resources/elasticsearch/en/team_index_mapping.json
@@ -249,6 +249,9 @@
       "deleted": {
         "type": "text"
       },
+      "isBot": {
+        "type": "boolean"
+      },
       "entityType": {
         "type": "keyword"
       },

--- a/openmetadata-service/src/main/resources/elasticsearch/jp/team_index_mapping.json
+++ b/openmetadata-service/src/main/resources/elasticsearch/jp/team_index_mapping.json
@@ -258,6 +258,9 @@
       "deleted": {
         "type": "text"
       },
+      "isBot": {
+        "type": "boolean"
+      },
       "entityType": {
         "type": "keyword"
       },

--- a/openmetadata-service/src/main/resources/elasticsearch/zh/team_index_mapping.json
+++ b/openmetadata-service/src/main/resources/elasticsearch/zh/team_index_mapping.json
@@ -203,6 +203,9 @@
       "deleted": {
         "type": "text"
       },
+      "isBot": {
+        "type": "boolean"
+      },
       "entityType": {
         "type": "keyword"
       },


### PR DESCRIPTION

I worked on ... because ... by default make isBot : false in team index

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
