### PR TITLE
ui: handle tab navigation if no access token

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
@@ -112,7 +112,7 @@ const Users = ({ userData, queryFilters, updateUserDetails }: Props) => {
 
   useEffect(() => {
     handleTabRedirection();
-  }, [activeTab]);
+  }, []);
 
   const handlePersonaUpdate = useCallback(
     async (personas: EntityReference[]) => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Users/Users.component.tsx
@@ -101,6 +101,19 @@ const Users = ({ userData, queryFilters, updateUserDetails }: Props) => {
     setPreviewAsset(asset);
   }, []);
 
+  const handleTabRedirection = useCallback(() => {
+    if (!isLoggedInUser && activeTab === UserPageTabs.ACCESS_TOKEN) {
+      history.push({
+        pathname: getUserPath(decodedUsername, UserPageTabs.ACTIVITY),
+        search: location.search,
+      });
+    }
+  }, [activeTab, decodedUsername, isLoggedInUser]);
+
+  useEffect(() => {
+    handleTabRedirection();
+  }, [activeTab]);
+
   const handlePersonaUpdate = useCallback(
     async (personas: EntityReference[]) => {
       await updateUserDetails({ ...userData, personas });


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on handling the navigation because if there is no access token of a user, the user should not be direct to the /access-token and so now redirects to the activity tab.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

https://github.com/open-metadata/OpenMetadata/assets/58542468/cfe77acf-6239-4b91-b626-10a8b80aa7e2

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
