### PR TITLE
MINOR: Fix 'calculate_execution_time_generator'

### DIFF
--- a/ingestion/src/metadata/utils/helpers.py
+++ b/ingestion/src/metadata/utils/helpers.py
@@ -125,12 +125,23 @@ def calculate_execution_time_generator(func):
     """
 
     def calculate_debug_time(*args, **kwargs):
-        start = perf_counter()
-        yield from func(*args, **kwargs)
-        end = perf_counter()
-        logger.debug(
-            f"{func.__name__} executed in { pretty_print_time_duration(end - start)}"
-        )
+        generator = func(*args, **kwargs)
+
+        while True:
+            start = perf_counter()
+
+            try:
+                element = next(generator)
+            except StopIteration:
+                return
+
+            end = perf_counter()
+
+            logger.debug(
+                f"{func.__name__} executed in { pretty_print_time_duration(end - start)}"
+            )
+
+            yield element
 
     return calculate_debug_time
 

--- a/ingestion/src/metadata/utils/helpers.py
+++ b/ingestion/src/metadata/utils/helpers.py
@@ -125,6 +125,10 @@ def calculate_execution_time_generator(func):
     """
 
     def calculate_debug_time(*args, **kwargs):
+        # NOTE: We are basically implementing by hand a simplified version of 'yield from'
+        # in order to be able to calculate the time difference correctly.
+        # The 'while True' loop allows us to guarantee we are iterating over all thje values
+        # from func(*args, **kwargs).
         generator = func(*args, **kwargs)
 
         while True:


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

While trying some different ways of actually being able to log the time spent on the Source related activities I found out that when I used a similar logic to the one on the `calculate_execution_time_generator` function, I was getting basically the same time stated at the end of the Workflow run.

After some research I found the following:

> time.perf_counter() → float
> Return the value (in fractional seconds) of a performance counter, i.e. a clock with the highest available resolution to measure a short duration. It does include time elapsed during sleep and is system-wide. The reference point of the returned value is undefined, so that only the difference between the results of two calls is valid.

From this I relized that all the time spent outside the method after yielding the value was taken into account when calling `perf_counter()` the second time.

In order to fix this behaviour, I'm actually calculating the time spent before yielding.

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->


<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
