### PR TITLE
Minor: Fix the wrong test result options on add observability alert page

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/utils/Alerts/AlertsUtil.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Alerts/AlertsUtil.tsx
@@ -702,7 +702,7 @@ export const getFieldByArgumentType = (
               className="w-full"
               data-testid="test-status-select"
               mode="multiple"
-              options={getSelectOptionsFromEnum(StatusType)}
+              options={getSelectOptionsFromEnum(TestCaseStatus)}
               placeholder={t('label.select-field', {
                 field: t('label.test-suite-status'),
               })}


### PR DESCRIPTION
I worked on fixing the wrong test result options on add observability alert page
<img width="606" alt="Screenshot 2024-02-05 at 10 28 40 PM" src="https://github.com/open-metadata/OpenMetadata/assets/51777795/6e6cd19b-e8af-4c04-9236-523adf61e7a8">


<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
