### PR TITLE
fix: convert imageRepository to string type

### DIFF
--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/mlmodels/MlModelResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/mlmodels/MlModelResourceTest.java
@@ -85,7 +85,7 @@ public class MlModelResourceTest extends EntityResourceTest<MlModel, CreateMlMod
   public static final MlStore ML_STORE =
       new MlStore()
           .withStorage(URI.create("s3://my-bucket.com/mlModel"))
-          .withImageRepository(URI.create("https://12345.dkr.ecr.region.amazonaws.com"));
+          .withImageRepository(URI.create("https://12345.dkr.ecr.region.amazonaws.com").toString());
 
   public static final List<MlFeature> ML_FEATURES =
       Arrays.asList(

--- a/openmetadata-spec/src/main/resources/json/schema/entity/data/mlmodel.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/data/mlmodel.json
@@ -145,7 +145,7 @@
         },
         "imageRepository": {
           "description": "Container Repository with the ML Model image.",
-          "$ref": "../../type/basic.json#/definitions/href"
+          "type": "string"
         }
       }
     }


### PR DESCRIPTION
### Describe your changes:

Fixes #14899 
- container image may not necessarily be a URL (see #14899). If not it will fail Pydantic URL validation -- hence converting to plain string

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
