### PR TITLE
fix: typo description of default batchsize

### DIFF
--- a/openmetadata-spec/src/main/resources/json/schema/api/createEventPublisherJob.json
+++ b/openmetadata-spec/src/main/resources/json/schema/api/createEventPublisherJob.json
@@ -31,7 +31,7 @@
       "default": false
     },
     "batchSize": {
-      "description": "Maximum number of events sent in a batch (Default 10).",
+      "description": "Maximum number of events sent in a batch (Default 100).",
       "type": "integer",
       "default": 100
     },

--- a/openmetadata-spec/src/main/resources/json/schema/entity/applications/configuration/internal/searchIndexingAppConfig.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/applications/configuration/internal/searchIndexingAppConfig.json
@@ -34,7 +34,7 @@
       "default": false
     },
     "batchSize": {
-      "description": "Maximum number of events sent in a batch (Default 10).",
+      "description": "Maximum number of events sent in a batch (Default 100).",
       "type": "integer",
       "default": 100
     },

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/metadata/metadataESConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/metadata/metadataESConnection.json
@@ -60,7 +60,7 @@
     },
     "batchSize": {
       "title": "Batch Size",
-      "description": "Maximum number of events sentx in a batch (Default 10).",
+      "description": "Maximum number of events sent in a batch (Default 100).",
       "type": "integer",
       "default": 100
     },

--- a/openmetadata-spec/src/main/resources/json/schema/events/eventSubscription.json
+++ b/openmetadata-spec/src/main/resources/json/schema/events/eventSubscription.json
@@ -317,7 +317,7 @@
       "default": true
     },
     "batchSize": {
-      "description": "Maximum number of events sent in a batch (Default 10).",
+      "description": "Maximum number of events sent in a batch (Default 100).",
       "type": "integer",
       "default": 100
     },

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ApplicationSchemas/SearchIndexingApplication.json
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ApplicationSchemas/SearchIndexingApplication.json
@@ -6,7 +6,7 @@
   "properties": {
     "batchSize": {
       "title": "Batch Size",
-      "description": "Maximum number of events entities in a batch (Default 1000).",
+      "description": "Maximum number of events entities in a batch (Default 100).",
       "type": "integer",
       "default": 100
     },


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:
Fix Typo: description of default batchsize in json files.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

- [x] I have added tests around the new logic.
- [x] For connector/ingestion changes: I updated the documentation.


