### PR TITLE
add node 18 as pre-requisites 

### DIFF
--- a/scripts/check_prerequisites.sh
+++ b/scripts/check_prerequisites.sh
@@ -50,7 +50,7 @@ jq["required_version"]="any"
 declare -A node
 node["name"]="Node"
 node["version_command"]="node --version"
-node["required_version"]="16 17 18"
+node["required_version"]="18"
 
 declare -A yarn
 yarn["name"]="Yarn"


### PR DESCRIPTION
update pre-requisites for node version check

Node 16 & 17 are not longer in support hence removing it.
reference: https://endoflife.date/nodejs