### PR TITLE
Fixes: update java version in ldap auth docs

### DIFF
--- a/openmetadata-docs/content/v1.2.x/deployment/security/ldap/docker.md
+++ b/openmetadata-docs/content/v1.2.x/deployment/security/ldap/docker.md
@@ -22,7 +22,7 @@ In `docker/docker-compose-quickstart/docker-compose.yml` file configure the volu
 For docker container to access cacerts, copy the cacerts to `docker/ldap/config` and add the path in volumes.
 ```shell
     volumes:
-      - docker/ldap/config/cacerts:/usr/lib/jvm/java-11-openjdk/lib/security/cacerts
+      - docker/ldap/config/cacerts:/usr/lib/jvm/java-17-openjdk/lib/security/cacerts
 ```
 
 ### **Using CustomTrustStore**
@@ -41,7 +41,7 @@ Create a docker file and add the following details based on the `truststoreConfi
    For docker container to access cacerts, copy the cacerts to `docker/ldap/config` as shown below.
 ```shell
 FROM docker.getcollate.io/openmetadata/server:0.13.2
-COPY docker/ldap/config/cacerts /usr/lib/jvm/java-11-openjdk/lib/security/cacerts
+COPY docker/ldap/config/cacerts /usr/lib/jvm/java-17-openjdk/lib/security/cacerts
 ```
 
 ### **Using CustomTrustStore**

--- a/openmetadata-docs/content/v1.3.x/deployment/security/ldap/docker.md
+++ b/openmetadata-docs/content/v1.3.x/deployment/security/ldap/docker.md
@@ -22,7 +22,7 @@ In `docker/docker-compose-quickstart/docker-compose.yml` file configure the volu
 For docker container to access cacerts, copy the cacerts to `docker/ldap/config` and add the path in volumes.
 ```shell
     volumes:
-      - docker/ldap/config/cacerts:/usr/lib/jvm/java-11-openjdk/lib/security/cacerts
+      - docker/ldap/config/cacerts:/usr/lib/jvm/java-17-openjdk/lib/security/cacerts
 ```
 
 ### **Using CustomTrustStore**
@@ -41,7 +41,7 @@ Create a docker file and add the following details based on the `truststoreConfi
    For docker container to access cacerts, copy the cacerts to `docker/ldap/config` as shown below.
 ```shell
 FROM docker.getcollate.io/openmetadata/server:0.13.2
-COPY docker/ldap/config/cacerts /usr/lib/jvm/java-11-openjdk/lib/security/cacerts
+COPY docker/ldap/config/cacerts /usr/lib/jvm/java-17-openjdk/lib/security/cacerts
 ```
 
 ### **Using CustomTrustStore**


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:
update java version in ldap auth docs.
OpenMetadata uses JDK 17 from version 1.2.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
