### PR TITLE
FIX: partitionColumn Migration

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v140/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v140/MigrationUtil.java
@@ -66,62 +66,66 @@ public class MigrationUtil {
   }
 
   private static void handleTablePartitionMigration(String jsonRow, CollectionDAO collectionDAO) {
-    JsonObject jsonObj = JsonUtils.readJson(jsonRow).asJsonObject();
+      try {
+          JsonObject jsonObj = JsonUtils.readJson(jsonRow).asJsonObject();
 
-    // We need to pop the tablePartition from the json before serializing it
-    JsonObject tablePartition = jsonObj.getJsonObject("tablePartition");
+          // We need to pop the tablePartition from the json before serializing it
+          JsonObject tablePartition = jsonObj.getJsonObject("tablePartition");
 
-    // Remove the tablePartition from the json. We need to convert it to a map to remove the key
-    // as JsonObject is immutable
-    HashMap<String, Object> jsonMap = JsonUtils.readValue(jsonObj.toString(), HashMap.class);
-    jsonMap.remove("tablePartition");
+          // Remove the tablePartition from the json. We need to convert it to a map to remove the key
+          // as JsonObject is immutable
+          HashMap<String, Object> jsonMap = JsonUtils.readValue(jsonObj.toString(), HashMap.class);
+          jsonMap.remove("tablePartition");
 
-    jsonObj = JsonUtils.readJson(JsonUtils.pojoToJson(jsonMap)).asJsonObject();
+          jsonObj = JsonUtils.readJson(JsonUtils.pojoToJson(jsonMap)).asJsonObject();
 
-    Table table = JsonUtils.readValue(jsonObj.toString(), Table.class);
+          Table table = JsonUtils.readValue(jsonObj.toString(), Table.class);
 
-    JsonArray partitionColumns = tablePartition.getJsonArray("columns");
-    if (tablePartition.isEmpty()) {
-      LOG.info("Table {} does not have partition details", table.getId());
-      return;
-    }
+          if (tablePartition.isEmpty()) {
+              LOG.info("Table {} does not have partition details", table.getId());
+              return;
+          }
+          JsonArray partitionColumns = tablePartition.getJsonArray("columns");
 
-    List<PartitionColumnDetails> partitionColumnDetails = new ArrayList<PartitionColumnDetails>();
+          List<PartitionColumnDetails> partitionColumnDetails = new ArrayList<PartitionColumnDetails>();
 
-    if ((partitionColumns == null || partitionColumns.isEmpty())
-        && table.getServiceType() == CreateDatabaseService.DatabaseServiceType.BigQuery) {
-      // BigQuery tables have pseudo columns for partitioning that were not being set in the
-      // partitionColumns entity
-      String interval = tablePartition.getString("interval");
-      if (interval != null) {
-        JsonArrayBuilder jsonArrayBuilder = Json.createArrayBuilder();
-        switch (interval) {
-          case "HOUR" -> partitionColumns = jsonArrayBuilder.add("_PARTITIONTIME").build();
-          case "DAY" -> partitionColumns = jsonArrayBuilder.add("_PARTITIONDATE").build();
-        }
+          if ((partitionColumns == null || partitionColumns.isEmpty())
+                  && table.getServiceType() == CreateDatabaseService.DatabaseServiceType.BigQuery) {
+              // BigQuery tables have pseudo columns for partitioning that were not being set in the
+              // partitionColumns entity
+              String interval = tablePartition.getString("interval", null);
+              if (interval != null) {
+                  JsonArrayBuilder jsonArrayBuilder = Json.createArrayBuilder();
+                  switch (interval) {
+                      case "HOUR" -> partitionColumns = jsonArrayBuilder.add("_PARTITIONTIME").build();
+                      case "DAY" -> partitionColumns = jsonArrayBuilder.add("_PARTITIONDATE").build();
+                  }
+              }
+              ;
+          }
+
+          if (partitionColumns == null || partitionColumns.isEmpty()) {
+              LOG.info("Columns partition details field for Table {} is empty. Nothing to do. Skipping migration.", table.getId());
+              return;
+          }
+
+          for (JsonValue column : partitionColumns) {
+              PartitionColumnDetails partitionColumnDetail = new PartitionColumnDetails();
+              partitionColumnDetail.setColumnName(((JsonString) column).getString());
+              String intervalType = tablePartition.getString("intervalType", null);
+              if (intervalType != null) {
+                  partitionColumnDetail.setIntervalType(PartitionIntervalTypes.fromValue(intervalType));
+              }
+              partitionColumnDetail.setInterval(tablePartition.getString("interval", null));
+              partitionColumnDetails.add(partitionColumnDetail);
+          }
+
+          table.withTablePartition(new TablePartition().withColumns(partitionColumnDetails));
+
+          collectionDAO.tableDAO().update(table);
+      } catch (Exception exc) {
+          LOG.warn("Fail to migrate table partition. The partition detail may have been migrated already.");
+          LOG.debug(String.format("Table JSON %s\n", jsonRow), exc);
       }
-      ;
-    }
-
-    if (partitionColumns == null || partitionColumns.isEmpty()) {
-      throw new RuntimeException(
-          "tablePartition is not null but not column partition was defined for table "
-              + table.getId());
-    }
-
-    for (JsonValue column : partitionColumns) {
-      PartitionColumnDetails partitionColumnDetail = new PartitionColumnDetails();
-      partitionColumnDetail.setColumnName(((JsonString) column).getString());
-      String intervalType = tablePartition.getString("intervalType");
-      if (intervalType != null) {
-        partitionColumnDetail.setIntervalType(PartitionIntervalTypes.fromValue(intervalType));
-      }
-      partitionColumnDetail.setInterval(tablePartition.getString("interval"));
-      partitionColumnDetails.add(partitionColumnDetail);
-    }
-
-    table.withTablePartition(new TablePartition().withColumns(partitionColumnDetails));
-
-    collectionDAO.tableDAO().update(table);
   }
 }


### PR DESCRIPTION
### Describe your changes:
- Add `null` as a fallback to `getString` method of JsonObject instance (l.96, l.115, l.119). **[ROOT CAUSE OF THE MIGRATION ERROR]**
e.g.
```java
String intervalType = tablePartition.getString("intervalType", null);
```
- Add try/catch in record migration processing


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [X] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [X] My PR title is `Fixes <issue-number>: <short explanation>`
- [X] I have commented on my code, particularly in hard-to-understand areas. 
- [X] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
