### PR TITLE
Fixes ISSUE-13473: Ensure MSSQL columns query filters to tables and views

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/mssql/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/mssql/queries.py
@@ -46,27 +46,27 @@ MSSQL_GET_TABLE_COMMENTS = textwrap.dedent(
 SELECT obj.name AS table_name,
         ep.value AS table_comment,
         s.name AS "schema"
-FROM sys.tables AS obj
+FROM sys.objects AS obj
 LEFT JOIN sys.extended_properties AS ep
-    ON obj.object_id = ep.major_id AND ep.minor_id = 0
+    ON obj.object_id = ep.major_id AND ep.minor_id = 0 AND ep.name = 'MS_Description'
 JOIN sys.schemas AS s
     ON obj.schema_id = s.schema_id
-WHERE ep.name = 'MS_Description'
+WHERE
+    obj.type IN ('U', 'V') /* User tables and views */
 """
 )
 
 MSSQL_ALL_VIEW_DEFINITIONS = textwrap.dedent(
     """
-select
-	definition view_def,
-	views.name view_name,
-	sch.name "schema"
-from sys.sql_modules as mod,
-sys.views as views,
-sys.schemas as sch
- where
-mod.object_id=views.object_id and
-views.schema_id=sch.schema_id
+SELECT
+    definition view_def,
+    views.name view_name,
+    sch.name "schema"
+FROM sys.sql_modules as mod
+INNER JOIN sys.views as views
+    ON mod.object_id = views.object_id
+INNER JOIN sys.schemas as sch
+    ON views.schema_id = sch.schema_id
 """
 )
 

--- a/ingestion/src/metadata/ingestion/source/database/mssql/utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/mssql/utils.py
@@ -183,7 +183,7 @@ def get_columns(
                 extended_properties.c.major_id == sys_columns.c.object_id,
                 extended_properties.c.minor_id == sys_columns.c.column_id,
                 extended_properties.c.class_desc == "OBJECT_OR_COLUMN",
-                extended_properties.c.name == "MS_Description"
+                extended_properties.c.name == "MS_Description",
             ),
             isouter=True,
         )

--- a/ingestion/src/metadata/ingestion/source/database/mssql/utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/mssql/utils.py
@@ -124,6 +124,7 @@ def get_columns(
         Column("minor_id", Integer, primary_key=True),
         Column("name", String, primary_key=True),
         Column("value", String),
+        Column("class_desc", String),
         schema="sys",
     )
     sys_columns = alias(

--- a/ingestion/src/metadata/ingestion/source/database/mssql/utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/mssql/utils.py
@@ -182,6 +182,8 @@ def get_columns(
             onclause=sql.and_(
                 extended_properties.c.major_id == sys_columns.c.object_id,
                 extended_properties.c.minor_id == sys_columns.c.column_id,
+                extended_properties.c.class_desc == "OBJECT_OR_COLUMN",
+                extended_properties.c.name == "MS_Description"
             ),
             isouter=True,
         )


### PR DESCRIPTION
### Describe your changes:

Partially Fixes ISSUE-13473

Modified the join to `sys.extended_properties` on MSSQL for column descriptions to make sure it only retrieves the column or table information. Previously it would pick up other related descriptions like indexes, foreign keys etc.

### Type of change:
- [X] Bug fix


### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->
Ive manually tested locally. I'm not sure how I could add unit/integration tests for this change

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
