### PR TITLE
FIX: index in CSV export for table entities

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
@@ -1231,7 +1231,7 @@ public class TableRepository extends EntityRepository<Table> {
       addRecord(csvFile, recordList, table.getColumns().get(0), false);
 
       for (int i = 1; i < entity.getColumns().size(); i++) {
-        addRecord(csvFile, new ArrayList<>(), table.getColumns().get(1), true);
+        addRecord(csvFile, new ArrayList<>(), table.getColumns().get(i), true);
       }
     }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/databases/TableResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/databases/TableResourceTest.java
@@ -2316,9 +2316,10 @@ public class TableResourceTest extends EntityResourceTest<Table, CreateTable> {
     Column c1 = new Column().withName("c1").withDataType(STRUCT);
     Column c11 = new Column().withName("c11").withDataType(INT);
     Column c2 = new Column().withName("c2").withDataType(INT);
+    Column c3 = new Column().withName("c3").withDataType(BIGINT);
     c1.withChildren(listOf(c11));
     CreateTable createTable =
-        createRequest("s1").withColumns(listOf(c1, c2)).withTableConstraints(null);
+        createRequest("s1").withColumns(listOf(c1, c2, c3)).withTableConstraints(null);
     Table table = createEntity(createTable, ADMIN_AUTH_HEADERS);
 
     // Headers: name, displayName, description, owner, tags, retentionPeriod, sourceUrl, domain
@@ -2330,7 +2331,8 @@ public class TableResourceTest extends EntityResourceTest<Table, CreateTable> {
                     + "dsp1-new,desc1,type,PII.Sensitive",
                 user1, escapeCsv(DOMAIN.getFullyQualifiedName())),
             ",,,,,,,,c1.c11,dsp11-new,desc11,type1,PII.Sensitive",
-            ",,,,,,,,c2,,,,");
+            ",,,,,,,,c2,,,,",
+            ",,,,,,,,c3,,,,");
 
     // Update created entity with changes
     importCsvAndValidate(table.getFullyQualifiedName(), TableCsv.HEADERS, null, updateRecords);


### PR DESCRIPTION
### Describe your changes:
Fixes column index when exporting table entity metadata

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [x] New feature
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

Bug fix
- [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.


<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
