### PR TITLE
MINOR - AKS Airflow troubleshooting docs

### DIFF
--- a/openmetadata-docs/content/v1.3.x/deployment/kubernetes/aks.md
+++ b/openmetadata-docs/content/v1.3.x/deployment/kubernetes/aks.md
@@ -284,3 +284,50 @@ Give it again a few seconds for the pod to get ready. And when its ready, the se
 ```azure-cli
 kubectl port-forward service/openmetadata 8585:8585 -n openmetadata
 ```
+
+## Troubleshooting Airflow
+
+### JSONDecodeError: Unterminated string starting
+
+If you are using Airflow with Azure Blob Storage as `PersistentVolume` as explained in [Storage class using blobfuse](https://learn.microsoft.com/en-us/azure/aks/azure-csi-blob-storage-provision?tabs=mount-nfs%2Csecret),
+you may encounter the following error after a few days:
+
+```bash
+{dagbag.py:346} ERROR - Failed to import: /airflow-dags/dags/...py
+json.decoder.JSONDecodeError: Unterminated string starting at: line 1 column 3552
+```
+
+Moreover, the Executor pods would actually be using old files. This behaviour is caused by the recommended config by the 
+mentioned documentation:
+
+```yaml
+  - -o allow_other
+  - --file-cache-timeout-in-seconds=120
+  - --use-attr-cache=true
+  - --cancel-list-on-mount-seconds=10  # prevent billing charges on mounting
+  - -o attr_timeout=120
+  - -o entry_timeout=120
+  - -o negative_timeout=120
+  - --log-level=LOG_WARNING  # LOG_WARNING, LOG_INFO, LOG_DEBUG
+  - --cache-size-mb=1000  # Default will be 80% of available memory, eviction will happen beyond that.
+```
+
+**Disabling the cache** will help here. In this case it won't have any negative impact, since the `.py` and `.json`
+files are small enough and not heavily used.
+
+The same configuration without cache:
+
+```yaml
+  - --o direct_io
+  - --file-cache-timeout-in-seconds=0
+  - --use-attr-cache=false
+  - --cancel-list-on-mount-seconds=10
+  - --o attr_timeout=0
+  - --o entry_timeout=0
+  - --o negative_timeout=0
+  - --log-level=LOG_WARNING
+  - --cache-size-mb=0
+```
+
+You can find more information about this error [here](https://github.com/open-metadata/OpenMetadata/issues/15321), and similar
+discussions [here](https://github.com/Azure/azure-storage-fuse/issues/1171) and [here](https://github.com/Azure/azure-storage-fuse/issues/1139).


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Rel to https://github.com/open-metadata/OpenMetadata/issues/15321

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
