### PR TITLE
ui: add support for edit custom property in entity right panel

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DashboardDetails/DashboardDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DashboardDetails/DashboardDetails.component.tsx
@@ -636,16 +636,18 @@ const DashboardDetails = ({
               className="entity-tag-right-panel-container"
               data-testid="entity-right-panel"
               flex="320px">
-              <EntityRightPanel
+              <EntityRightPanel<EntityType.DASHBOARD>
                 customProperties={dashboardDetails}
                 dataProducts={dashboardDetails?.dataProducts ?? []}
                 domain={dashboardDetails?.domain}
+                editCustomAttributePermission={editCustomAttributePermission}
                 editTagPermission={editTagsPermission}
                 entityFQN={decodedDashboardFQN}
                 entityId={dashboardDetails.id}
                 entityType={EntityType.DASHBOARD}
                 selectedTags={dashboardTags}
                 viewAllPermission={viewAllPermission}
+                onExtensionUpdate={onExtensionUpdate}
                 onTagSelectionChange={handleTagSelection}
                 onThreadLinkSelect={onThreadLinkSelect}
               />

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityRightPanel/EntityRightPanel.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityRightPanel/EntityRightPanel.test.tsx
@@ -19,6 +19,9 @@ import { EntityReference } from '../../../generated/entity/type';
 import entityRightPanelClassBase from '../../../utils/EntityRightPanelClassBase';
 import EntityRightPanel from './EntityRightPanel';
 
+const editPermission = true;
+const mockExtensionUpdate = jest.fn();
+
 jest.mock(
   '../../DataProducts/DataProductsContainer/DataProductsContainer.component',
   () => {
@@ -62,10 +65,12 @@ describe('EntityRightPanel component test', () => {
         editTagPermission
         customProperties={mockCustomProperties}
         dataProducts={mockDataProducts}
+        editCustomAttributePermission={editPermission}
         entityFQN="testEntityFQN"
         entityId="testEntityId"
         entityType={EntityType.TABLE}
         selectedTags={mockSelectedTags}
+        onExtensionUpdate={mockExtensionUpdate}
         onTagSelectionChange={mockOnTagSelectionChange}
         onThreadLinkSelect={mockOnThreadLinkSelect}
       />
@@ -81,11 +86,13 @@ describe('EntityRightPanel component test', () => {
         editTagPermission
         customProperties={mockCustomProperties}
         dataProducts={mockDataProducts}
+        editCustomAttributePermission={editPermission}
         entityFQN="testEntityFQN"
         entityId="testEntityId"
         entityType={EntityType.TABLE}
         selectedTags={mockSelectedTags}
         showDataProductContainer={false}
+        onExtensionUpdate={mockExtensionUpdate}
         onTagSelectionChange={mockOnTagSelectionChange}
         onThreadLinkSelect={mockOnThreadLinkSelect}
       />
@@ -102,11 +109,13 @@ describe('EntityRightPanel component test', () => {
         beforeSlot={<div>beforeSlot</div>}
         customProperties={mockCustomProperties}
         dataProducts={mockDataProducts}
+        editCustomAttributePermission={editPermission}
         entityFQN="testEntityFQN"
         entityId="testEntityId"
         entityType={EntityType.TABLE}
         selectedTags={mockSelectedTags}
         showDataProductContainer={false}
+        onExtensionUpdate={mockExtensionUpdate}
         onTagSelectionChange={mockOnTagSelectionChange}
         onThreadLinkSelect={mockOnThreadLinkSelect}
       />
@@ -122,11 +131,13 @@ describe('EntityRightPanel component test', () => {
         editTagPermission
         customProperties={mockCustomProperties}
         dataProducts={mockDataProducts}
+        editCustomAttributePermission={editPermission}
         entityFQN="testEntityFQN"
         entityId="testEntityId"
         entityType={EntityType.TABLE}
         selectedTags={mockSelectedTags}
         showDataProductContainer={false}
+        onExtensionUpdate={mockExtensionUpdate}
         onTagSelectionChange={mockOnTagSelectionChange}
         onThreadLinkSelect={mockOnThreadLinkSelect}
       />
@@ -148,11 +159,13 @@ describe('EntityRightPanel component test', () => {
         editTagPermission
         customProperties={mockCustomProperties}
         dataProducts={mockDataProducts}
+        editCustomAttributePermission={editPermission}
         entityFQN="testEntityFQN"
         entityId="testEntityId"
         entityType={EntityType.TABLE}
         selectedTags={mockSelectedTags}
         showDataProductContainer={false}
+        onExtensionUpdate={mockExtensionUpdate}
         onTagSelectionChange={mockOnTagSelectionChange}
         onThreadLinkSelect={mockOnThreadLinkSelect}
       />
@@ -172,11 +185,13 @@ describe('EntityRightPanel component test', () => {
         editTagPermission
         customProperties={mockCustomProperties}
         dataProducts={mockDataProducts}
+        editCustomAttributePermission={editPermission}
         entityFQN="testEntityFQN"
         entityId="testEntityId"
         entityType={EntityType.TABLE}
         selectedTags={mockSelectedTags}
         showDataProductContainer={false}
+        onExtensionUpdate={mockExtensionUpdate}
         onTagSelectionChange={mockOnTagSelectionChange}
         onThreadLinkSelect={mockOnThreadLinkSelect}
       />
@@ -194,11 +209,13 @@ describe('EntityRightPanel component test', () => {
         viewAllPermission
         customProperties={mockCustomProperties}
         dataProducts={mockDataProducts}
+        editCustomAttributePermission={editPermission}
         entityFQN="testEntityFQN"
         entityId="testEntityId"
         entityType={EntityType.TABLE}
         selectedTags={mockSelectedTags}
         showDataProductContainer={false}
+        onExtensionUpdate={mockExtensionUpdate}
         onTagSelectionChange={mockOnTagSelectionChange}
         onThreadLinkSelect={mockOnThreadLinkSelect}
       />
@@ -217,11 +234,13 @@ describe('EntityRightPanel component test', () => {
         viewAllPermission
         customProperties={{} as Table}
         dataProducts={mockDataProducts}
+        editCustomAttributePermission={editPermission}
         entityFQN="testEntityFQN"
         entityId="testEntityId"
         entityType={EntityType.TABLE}
         selectedTags={mockSelectedTags}
         showDataProductContainer={false}
+        onExtensionUpdate={mockExtensionUpdate}
         onTagSelectionChange={mockOnTagSelectionChange}
         onThreadLinkSelect={mockOnThreadLinkSelect}
       />

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityRightPanel/EntityRightPanel.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityRightPanel/EntityRightPanel.tsx
@@ -46,6 +46,8 @@ interface EntityRightPanelProps<T extends ExtentionEntitiesKeys> {
   viewAllPermission?: boolean;
   customProperties?: ExtentionEntities[T];
   tablePartition?: TablePartition;
+  editCustomAttributePermission?: boolean;
+  onExtensionUpdate?: (updatedTable: ExtentionEntities[T]) => Promise<void>;
 }
 
 const EntityRightPanel = <T extends ExtentionEntitiesKeys>({
@@ -65,6 +67,8 @@ const EntityRightPanel = <T extends ExtentionEntitiesKeys>({
   viewAllPermission,
   customProperties,
   tablePartition,
+  editCustomAttributePermission,
+  onExtensionUpdate,
 }: EntityRightPanelProps<T>) => {
   const KnowledgeArticles =
     entityRightPanelClassBase.getKnowLedgeArticlesWidget();
@@ -108,11 +112,12 @@ const EntityRightPanel = <T extends ExtentionEntitiesKeys>({
           <KnowledgeArticles entityId={entityId} entityType={entityType} />
         )}
         {customProperties && (
-          <CustomPropertyTable
+          <CustomPropertyTable<T>
             isRenderedInRightPanel
             entityDetails={customProperties}
-            entityType={entityType as ExtentionEntitiesKeys}
-            hasEditAccess={false}
+            entityType={entityType as T}
+            handleExtensionUpdate={onExtensionUpdate}
+            hasEditAccess={Boolean(editCustomAttributePermission)}
             hasPermission={Boolean(viewAllPermission)}
             maxDataCap={5}
           />

--- a/openmetadata-ui/src/main/resources/ui/src/components/MlModel/MlModelDetail/MlModelDetail.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MlModel/MlModelDetail/MlModelDetail.component.tsx
@@ -426,16 +426,18 @@ const MlModelDetail: FC<MlModelDetailProp> = ({
               className="entity-tag-right-panel-container"
               data-testid="entity-right-panel"
               flex="320px">
-              <EntityRightPanel
+              <EntityRightPanel<EntityType.MLMODEL>
                 customProperties={mlModelDetail}
                 dataProducts={mlModelDetail?.dataProducts ?? []}
                 domain={mlModelDetail?.domain}
+                editCustomAttributePermission={editCustomAttributePermission}
                 editTagPermission={editTagsPermission}
                 entityFQN={decodedMlModelFqn}
                 entityId={mlModelDetail.id}
                 entityType={EntityType.MLMODEL}
                 selectedTags={mlModelTags}
                 viewAllPermission={viewAllPermission}
+                onExtensionUpdate={onExtensionUpdate}
                 onTagSelectionChange={handleTagSelection}
                 onThreadLinkSelect={handleThreadLinkSelect}
               />

--- a/openmetadata-ui/src/main/resources/ui/src/components/Pipeline/PipelineDetails/PipelineDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Pipeline/PipelineDetails/PipelineDetails.component.tsx
@@ -624,16 +624,18 @@ const PipelineDetails = ({
               className="entity-tag-right-panel-container"
               data-testid="entity-right-panel"
               flex="320px">
-              <EntityRightPanel
+              <EntityRightPanel<EntityType.PIPELINE>
                 customProperties={pipelineDetails}
                 dataProducts={pipelineDetails?.dataProducts ?? []}
                 domain={pipelineDetails?.domain}
+                editCustomAttributePermission={editCustomAttributePermission}
                 editTagPermission={editTagsPermission}
                 entityFQN={pipelineFQN}
                 entityId={pipelineDetails.id}
                 entityType={EntityType.PIPELINE}
                 selectedTags={tags}
                 viewAllPermission={viewAllPermission}
+                onExtensionUpdate={onExtensionUpdate}
                 onTagSelectionChange={handleTagSelection}
                 onThreadLinkSelect={onThreadLinkSelect}
               />

--- a/openmetadata-ui/src/main/resources/ui/src/components/Topic/TopicDetails/TopicDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Topic/TopicDetails/TopicDetails.component.tsx
@@ -336,16 +336,18 @@ const TopicDetails: React.FC<TopicDetailsProps> = ({
               className="entity-tag-right-panel-container"
               data-testid="entity-right-panel"
               flex="320px">
-              <EntityRightPanel
+              <EntityRightPanel<EntityType.TOPIC>
                 customProperties={topicDetails}
                 dataProducts={topicDetails?.dataProducts ?? []}
                 domain={topicDetails?.domain}
+                editCustomAttributePermission={editCustomAttributePermission}
                 editTagPermission={editTagsPermission}
                 entityFQN={decodedTopicFQN}
                 entityId={topicDetails.id}
                 entityType={EntityType.TOPIC}
                 selectedTags={topicTags}
                 viewAllPermission={viewAllPermission}
+                onExtensionUpdate={onExtensionUpdate}
                 onTagSelectionChange={handleTagSelection}
                 onThreadLinkSelect={onThreadLinkSelect}
               />

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/CustomPropertyTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/CustomPropertyTable.tsx
@@ -286,6 +286,7 @@ export const CustomPropertyTable = <T extends ExtentionEntitiesKeys>({
             loading={entityTypeDetailLoading}
             pagination={false}
             rowKey="name"
+            scroll={isRenderedInRightPanel ? { x: true } : undefined}
             size="small"
           />
         </>

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ContainerPage/ContainerPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ContainerPage/ContainerPage.tsx
@@ -598,10 +598,11 @@ const ContainerPage = () => {
               className="entity-tag-right-panel-container"
               data-testid="entity-right-panel"
               flex="320px">
-              <EntityRightPanel
+              <EntityRightPanel<EntityType.CONTAINER>
                 customProperties={containerData}
                 dataProducts={containerData?.dataProducts ?? []}
                 domain={containerData?.domain}
+                editCustomAttributePermission={editCustomAttributePermission}
                 editTagPermission={
                   editTagsPermission && !containerData?.deleted
                 }
@@ -610,6 +611,7 @@ const ContainerPage = () => {
                 entityType={EntityType.CONTAINER}
                 selectedTags={tags}
                 viewAllPermission={viewAllPermission}
+                onExtensionUpdate={handleExtensionUpdate}
                 onTagSelectionChange={handleTagSelection}
                 onThreadLinkSelect={onThreadLinkSelect}
               />

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseDetailsPage/DatabaseDetailsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseDetailsPage/DatabaseDetailsPage.tsx
@@ -529,16 +529,18 @@ const DatabaseDetails: FunctionComponent = () => {
               className="entity-tag-right-panel-container"
               data-testid="entity-right-panel"
               flex="320px">
-              <EntityRightPanel
+              <EntityRightPanel<EntityType.DATABASE>
                 customProperties={database}
                 dataProducts={database?.dataProducts ?? []}
                 domain={database?.domain}
+                editCustomAttributePermission={editCustomAttributePermission}
                 editTagPermission={editTagsPermission}
                 entityFQN={decodedDatabaseFQN}
                 entityId={database?.id ?? ''}
                 entityType={EntityType.DATABASE}
                 selectedTags={tags}
                 viewAllPermission={viewAllPermission}
+                onExtensionUpdate={settingsUpdateHandler}
                 onTagSelectionChange={handleTagSelection}
                 onThreadLinkSelect={onThreadLinkSelect}
               />

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaPage/DatabaseSchemaPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaPage/DatabaseSchemaPage.component.tsx
@@ -590,16 +590,18 @@ const DatabaseSchemaPage: FunctionComponent = () => {
             className="entity-tag-right-panel-container"
             data-testid="entity-right-panel"
             flex="320px">
-            <EntityRightPanel
+            <EntityRightPanel<EntityType.DATABASE_SCHEMA>
               customProperties={databaseSchema}
               dataProducts={databaseSchema?.dataProducts ?? []}
               domain={databaseSchema?.domain}
+              editCustomAttributePermission={editCustomAttributePermission}
               editTagPermission={editTagsPermission}
               entityFQN={decodedDatabaseSchemaFQN}
               entityId={databaseSchema?.id ?? ''}
               entityType={EntityType.DATABASE_SCHEMA}
               selectedTags={tags}
               viewAllPermission={viewAllPermission}
+              onExtensionUpdate={handleExtensionUpdate}
               onTagSelectionChange={handleTagSelection}
               onThreadLinkSelect={onThreadLinkSelect}
             />

--- a/openmetadata-ui/src/main/resources/ui/src/pages/SearchIndexDetailsPage/SearchIndexDetailsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/SearchIndexDetailsPage/SearchIndexDetailsPage.tsx
@@ -415,16 +415,18 @@ function SearchIndexDetailsPage() {
               className="entity-tag-right-panel-container"
               data-testid="entity-right-panel"
               flex="320px">
-              <EntityRightPanel
+              <EntityRightPanel<EntityType.SEARCH_INDEX>
                 customProperties={searchIndexDetails}
                 dataProducts={searchIndexDetails?.dataProducts ?? []}
                 domain={searchIndexDetails?.domain}
+                editCustomAttributePermission={editCustomAttributePermission}
                 editTagPermission={editTagsPermission}
                 entityFQN={decodedSearchIndexFQN}
                 entityId={searchIndexDetails?.id ?? ''}
                 entityType={EntityType.SEARCH_INDEX}
                 selectedTags={searchIndexTags}
                 viewAllPermission={viewAllPermission}
+                onExtensionUpdate={onExtensionUpdate}
                 onTagSelectionChange={handleTagSelection}
                 onThreadLinkSelect={onThreadLinkSelect}
               />

--- a/openmetadata-ui/src/main/resources/ui/src/pages/StoredProcedure/StoredProcedurePage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/StoredProcedure/StoredProcedurePage.tsx
@@ -576,16 +576,18 @@ const StoredProcedurePage = () => {
               className="entity-tag-right-panel-container"
               data-testid="entity-right-panel"
               flex="320px">
-              <EntityRightPanel
+              <EntityRightPanel<EntityType.STORED_PROCEDURE>
                 customProperties={storedProcedure}
                 dataProducts={storedProcedure?.dataProducts ?? []}
                 domain={storedProcedure?.domain}
+                editCustomAttributePermission={editCustomAttributePermission}
                 editTagPermission={editTagsPermission}
                 entityFQN={decodedStoredProcedureFQN}
                 entityId={storedProcedure?.id ?? ''}
                 entityType={EntityType.STORED_PROCEDURE}
                 selectedTags={tags}
                 viewAllPermission={viewAllPermission}
+                onExtensionUpdate={onExtensionUpdate}
                 onTagSelectionChange={handleTagSelection}
                 onThreadLinkSelect={onThreadLinkSelect}
               />

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableDetailsPageV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableDetailsPageV1.tsx
@@ -551,7 +551,7 @@ const TableDetailsPageV1: React.FC = () => {
           className="entity-tag-right-panel-container"
           data-testid="entity-right-panel"
           flex="320px">
-          <EntityRightPanel
+          <EntityRightPanel<EntityType.TABLE>
             afterSlot={
               <Space
                 className="w-full m-t-lg"
@@ -570,6 +570,7 @@ const TableDetailsPageV1: React.FC = () => {
             customProperties={tableDetails}
             dataProducts={tableDetails?.dataProducts ?? []}
             domain={tableDetails?.domain}
+            editCustomAttributePermission={editCustomAttributePermission}
             editTagPermission={editTagsPermission}
             entityFQN={datasetFQN}
             entityId={tableDetails?.id ?? ''}
@@ -577,6 +578,7 @@ const TableDetailsPageV1: React.FC = () => {
             selectedTags={tableTags}
             tablePartition={tableDetails?.tablePartition}
             viewAllPermission={viewAllPermission}
+            onExtensionUpdate={onExtensionUpdate}
             onTagSelectionChange={handleTagSelection}
             onThreadLinkSelect={onThreadLinkSelect}
           />


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:



<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on adding support for editing custom properties in the entity right panel if the user has edit permission.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

https://github.com/open-metadata/OpenMetadata/assets/59080942/0df84020-278e-46fb-8128-ce14a68ea4a3



#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] Improvement


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
