### PR TITLE
FIX #13475 - Add Parameter Validation for Min/Max tests

### DIFF
--- a/bootstrap/sql/migrations/native/1.4.0/mysql/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.4.0/mysql/postDataMigrationSQLScript.sql
@@ -1,0 +1,364 @@
+-- Start of Test Definition Parameter Definition Validation Migration
+UPDATE test_definition
+set json = JSON_INSERT(
+	JSON_REMOVE(json, '$.parameterDefinition'),
+	'$.parameterDefinition',
+	JSON_ARRAY(
+		JSON_OBJECT(
+		  'name', 'minValue',
+	      'dataType', 'INT',
+	      'required', false,
+	      'description', 'The {minValue} value for the column entry. If minValue is not included, maxValue is treated as upperBound and there will be no minimum',
+	      'displayName', 'Min',
+	      'optionValues', JSON_ARRAY(),
+	      'validationRule', JSON_OBJECT(
+	      	'parameterField', 'maxValue',
+        	'rule', 'LESS_THAN_OR_EQUALS'
+	      )
+		),
+		JSON_OBJECT(
+		  'name', 'maxValue',
+	      'dataType', 'INT',
+	      'required', false,
+	      'description', 'The {maxValue} value for the column entry. if maxValue is not included, minValue is treated as lowerBound and there will be no maximum',
+	      'displayName', 'Max',
+	      'optionValues', JSON_ARRAY(),
+	      'validationRule', JSON_OBJECT(
+	      	'parameterField', 'minValue',
+        	'rule', 'GREATER_THAN_OR_EQUALS'
+	      )
+		)
+	)
+)
+WHERE name = 'columnValuesToBeBetween';
+
+UPDATE test_definition
+set json = JSON_INSERT(
+	JSON_REMOVE(json, '$.parameterDefinition'),
+	'$.parameterDefinition',
+	JSON_ARRAY(
+		JSON_OBJECT(
+	      'name', 'minValueForMaxInCol',
+	      'dataType', 'INT',
+	      'required', false,
+	      'description', 'Expected minimum value in the column to be greater or equal than',
+	      'displayName', 'Min',
+	      'optionValues', JSON_ARRAY(),
+	      'validationRule', JSON_OBJECT(
+	      	'parameterField', 'maxValueForMaxInCol',
+        	'rule', 'LESS_THAN_OR_EQUALS'
+	      )
+		),
+		JSON_OBJECT(
+	      'name', 'maxValueForMaxInCol',
+	      'dataType', 'INT',
+	      'required', false,
+	      'description', 'Expected maximum value in the column to be lower or equal than',
+	      'displayName', 'Max',
+	      'optionValues', JSON_ARRAY(),
+	      'validationRule', JSON_OBJECT(
+	      	'parameterField', 'minValueForMaxInCol',
+        	'rule', 'GREATER_THAN_OR_EQUALS'
+	      )
+		)
+	)
+)
+WHERE name = 'columnValueMaxToBeBetween';
+
+UPDATE test_definition
+set json = JSON_INSERT(
+	JSON_REMOVE(json, '$.parameterDefinition'),
+	'$.parameterDefinition',
+	JSON_ARRAY(
+		JSON_OBJECT(
+	      'name', 'minValueForMeanInCol',
+	      'dataType', 'INT',
+	      'required', false,
+	      'description', 'Expected mean value for the column to be greater or equal than',
+	      'displayName', 'Min',
+	      'optionValues', JSON_ARRAY(),
+	      'validationRule', JSON_OBJECT(
+	      	'parameterField', 'maxValueForMeanInCol',
+        	'rule', 'LESS_THAN_OR_EQUALS'
+	      )
+		),
+		JSON_OBJECT(
+	      'name', 'maxValueForMeanInCol',
+	      'dataType', 'INT',
+	      'required', false,
+	      'description', 'Expected mean value for the column to be lower or equal than',
+	      'displayName', 'Max',
+	      'optionValues', JSON_ARRAY(),
+	      'validationRule', JSON_OBJECT(
+	      	'parameterField', 'minValueForMeanInCol',
+        	'rule', 'GREATER_THAN_OR_EQUALS'
+	      )
+		)
+	)
+)
+WHERE name = 'columnValueMeanToBeBetween';
+
+UPDATE test_definition
+set json = JSON_INSERT(
+	JSON_REMOVE(json, '$.parameterDefinition'),
+	'$.parameterDefinition',
+	JSON_ARRAY(
+		JSON_OBJECT(
+	      'name', 'minValueForMedianInCol',
+	      'dataType', 'INT',
+	      'required', false,
+	      'description', 'Expected median value for the column to be greater or equal than',
+	      'displayName', 'Min',
+	      'optionValues', JSON_ARRAY(),
+	      'validationRule', JSON_OBJECT(
+	      	'parameterField', 'maxValueForMedianInCol',
+        	'rule', 'LESS_THAN_OR_EQUALS'
+	      )
+		),
+		JSON_OBJECT(
+	      'name', 'maxValueForMedianInCol',
+	      'dataType', 'INT',
+	      'required', false,
+	      'description', 'Expected median value for the column to be lower or equal than',
+	      'displayName', 'Max',
+	      'optionValues', JSON_ARRAY(),
+	      'validationRule', JSON_OBJECT(
+	      	'parameterField', 'minValueForMedianInCol',
+        	'rule', 'GREATER_THAN_OR_EQUALS'
+	      )
+		)
+	)
+)
+WHERE name = 'columnValueMedianToBeBetween';
+
+UPDATE test_definition
+set json = JSON_INSERT(
+	JSON_REMOVE(json, '$.parameterDefinition'),
+	'$.parameterDefinition',
+	JSON_ARRAY(
+		JSON_OBJECT(
+	      'name', 'minValueForMinInCol',
+	      'dataType', 'INT',
+	      'required', false,
+	      'description', 'Expected minimum value in the column to be greater or equal than',
+	      'displayName', 'Min',
+	      'optionValues', JSON_ARRAY(),
+	      'validationRule', JSON_OBJECT(
+	      	'parameterField', 'maxValueForMinInCol',
+        	'rule', 'LESS_THAN_OR_EQUALS'
+	      )
+		),
+		JSON_OBJECT(
+	      'name', 'maxValueForMinInCol',
+	      'dataType', 'INT',
+	      'required', false,
+	      'description', 'Expect minimum value in the column to be lower or equal than',
+	      'displayName', 'Max',
+	      'optionValues', JSON_ARRAY(),
+	      'validationRule', JSON_OBJECT(
+	      	'parameterField', 'minValueForMeanInCol',
+        	'rule', 'GREATER_THAN_OR_EQUALS'
+	      )
+		)
+	)
+)
+WHERE name = 'columnValueMinToBeBetween';
+
+UPDATE test_definition
+set json = JSON_INSERT(
+	JSON_REMOVE(json, '$.parameterDefinition'),
+	'$.parameterDefinition',
+	JSON_ARRAY(
+		JSON_OBJECT(
+	      'name', 'minLength',
+	      'dataType', 'INT',
+	      'required', false,
+	      'description', 'The {minLength} for the column value. If minLength is not included, maxLength is treated as upperBound and there will be no minimum value length',
+	      'displayName', 'Min',
+	      'optionValues', JSON_ARRAY(),
+	      'validationRule', JSON_OBJECT(
+	      	'parameterField', 'maxLength',
+        	'rule', 'LESS_THAN_OR_EQUALS'
+	      )
+		),
+		JSON_OBJECT(
+	      'name', 'maxLength',
+	      'dataType', 'INT',
+	      'required', false,
+	      'description', 'The {maxLength} for the column value. if maxLength is not included, minLength is treated as lowerBound and there will be no maximum value length',
+	      'displayName', 'Max',
+	      'optionValues', JSON_ARRAY(),
+	      'validationRule', JSON_OBJECT(
+	      	'parameterField', 'minLength',
+        	'rule', 'GREATER_THAN_OR_EQUALS'
+	      )
+		)
+	)
+)
+WHERE name = 'columnValueLengthsToBeBetween';
+
+UPDATE test_definition
+set json = JSON_INSERT(
+	JSON_REMOVE(json, '$.parameterDefinition'),
+	'$.parameterDefinition',
+	JSON_ARRAY(
+		JSON_OBJECT(
+	      'name', 'minValueForColSum',
+	      'dataType', 'INT',
+	      'required', false,
+	      'description', 'Expected sum of values in the column to be greater or equal than',
+	      'displayName', 'Min',
+	      'optionValues', JSON_ARRAY(),
+	      'validationRule', JSON_OBJECT(
+	      	'parameterField', 'maxValueForColSum',
+        	'rule', 'LESS_THAN_OR_EQUALS'
+	      )
+		),
+		JSON_OBJECT(
+	      'name', 'maxValueForColSum',
+	      'dataType', 'INT',
+	      'required', false,
+	      'description', 'Expected sum values in the column to be lower or equal than',
+	      'displayName', 'Max',
+	      'optionValues', JSON_ARRAY(),
+	      'validationRule', JSON_OBJECT(
+	      	'parameterField', 'minValueForColSum',
+        	'rule', 'GREATER_THAN_OR_EQUALS'
+	      )
+		)
+	)
+)
+WHERE name = 'columnValuesSumToBeBetween';
+
+UPDATE test_definition
+set json = JSON_INSERT(
+	JSON_REMOVE(json, '$.parameterDefinition'),
+	'$.parameterDefinition',
+	JSON_ARRAY(
+		JSON_OBJECT(
+	      'name', 'minValueForStdDevInCol',
+	      'dataType', 'INT',
+	      'required', false,
+	      'description', 'Expected std. dev value for the column to be greater or equal than',
+	      'displayName', 'Min',
+	      'optionValues', JSON_ARRAY(),
+	      'validationRule', JSON_OBJECT(
+	      	'parameterField', 'maxValueForStdDevInCol',
+        	'rule', 'LESS_THAN_OR_EQUALS'
+	      )
+		),
+		JSON_OBJECT(
+	      'name', 'maxValueForStdDevInCol',
+	      'dataType', 'INT',
+	      'required', false,
+	      'description', 'Expected std. dev value for the column to be lower or equal than',
+	      'displayName', 'Max',
+	      'optionValues', JSON_ARRAY(),
+	      'validationRule', JSON_OBJECT(
+	      	'parameterField', 'minValueForStdDevInCol',
+        	'rule', 'GREATER_THAN_OR_EQUALS'
+	      )
+		)
+	)
+)
+WHERE name = 'columnValueStdDevToBeBetween';
+
+UPDATE test_definition
+set json = JSON_INSERT(
+	JSON_REMOVE(json, '$.parameterDefinition'),
+	'$.parameterDefinition',
+	JSON_ARRAY(
+		JSON_OBJECT(
+	      'name', 'minColValue',
+	      'dataType', 'INT',
+	      'required', false,
+	      'description', 'Expected number of columns should be greater than or equal to {minValue}. If minValue is not included, maxValue is treated as upperBound and there will be no minimum number of column',
+	      'displayName', 'Min',
+	      'optionValues', JSON_ARRAY(),
+	      'validationRule', JSON_OBJECT(
+	      	'parameterField', 'maxColValue',
+        	'rule', 'LESS_THAN_OR_EQUALS'
+	      )
+		),
+		JSON_OBJECT(
+	      'name', 'maxColValue',
+	      'dataType', 'INT',
+	      'required', false,
+	      'description', 'Expected number of columns should be less than or equal to {maxValue}. If maxValue is not included, minValue is treated as lowerBound and there will be no maximum number of column',
+	      'displayName', 'Max',
+	      'optionValues', JSON_ARRAY(),
+	      'validationRule', JSON_OBJECT(
+	      	'parameterField', 'minColValue',
+        	'rule', 'GREATER_THAN_OR_EQUALS'
+	      )
+		)
+	)
+)
+WHERE name = 'tableColumnCountToBeBetween';
+
+UPDATE test_definition
+set json = JSON_INSERT(
+	JSON_REMOVE(json, '$.parameterDefinition'),
+	'$.parameterDefinition',
+	JSON_ARRAY(
+		JSON_OBJECT(
+	      'name', 'minValue',
+	      'dataType', 'INT',
+	      'required', false,
+	      'description', 'Expected number of columns should be greater than or equal to {minValue}. If minValue is not included, maxValue is treated as upperBound and there will be no minimum',
+	      'displayName', 'Min',
+	      'optionValues', JSON_ARRAY(),
+	      'validationRule', JSON_OBJECT(
+	      	'parameterField', 'maxValue',
+        	'rule', 'LESS_THAN_OR_EQUALS'
+	      )
+		),
+		JSON_OBJECT(
+	      'name', 'maxValue',
+	      'dataType', 'INT',
+	      'required', false,
+	      'description', 'Expected number of columns should be less than or equal to {maxValue}. If maxValue is not included, minValue is treated as lowerBound and there will be no maximum',
+	      'displayName', 'Max',
+	      'optionValues', JSON_ARRAY(),
+	      'validationRule', JSON_OBJECT(
+	      	'parameterField', 'minValue',
+        	'rule', 'GREATER_THAN_OR_EQUALS'
+	      )
+		)
+	)
+)
+WHERE name = 'tableRowCountToBeBetween';
+
+UPDATE test_definition
+set json = JSON_INSERT(
+	JSON_REMOVE(json, '$.parameterDefinition'),
+	'$.parameterDefinition',
+	JSON_ARRAY(
+		JSON_OBJECT(
+	      'name', 'min',
+	      'dataType', 'INT',
+	      'required', false,
+	      'description', 'Lower Bound of the Count',
+	      'displayName', 'Min Row Count',
+	      'optionValues', JSON_ARRAY(),
+	      'validationRule', JSON_OBJECT(
+	      	'parameterField', 'max',
+        	'rule', 'LESS_THAN_OR_EQUALS'
+	      )
+		),
+		JSON_OBJECT(
+	      'name', 'max',
+	      'dataType', 'INT',
+	      'required', false,
+	      'description', 'Upper Bound of the Count',
+	      'displayName', 'Max Row Count',
+	      'optionValues', JSON_ARRAY(),
+	      'validationRule', JSON_OBJECT(
+	      	'parameterField', 'min',
+        	'rule', 'GREATER_THAN_OR_EQUALS'
+	      )
+		)
+	)
+)
+WHERE name = 'tableRowInsertedCountToBeBetween';
+-- End of Test Definition Parameter Definition Validation Migration

--- a/bootstrap/sql/migrations/native/1.4.0/postgres/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.4.0/postgres/postDataMigrationSQLScript.sql
@@ -1,0 +1,364 @@
+-- Start of Test Definition Parameter Definition Validation Migration
+UPDATE test_definition
+SET json = jsonb_set(
+    jsonb_delete(json, '$.parameterDefinition'),
+    '{parameterDefinition}',
+    jsonb_build_array(
+        jsonb_build_object(
+            'name', 'minValue',
+            'dataType', 'INT',
+            'required', false,
+            'description', 'The {minValue} value for the column entry. If minValue is not included, maxValue is treated as upperBound and there will be no minimum',
+            'displayName', 'Min',
+            'optionValues', '[]'::jsonb,
+            'validationRule', jsonb_build_object(
+                'parameterField', 'maxValue',
+                'rule', 'LESS_THAN_OR_EQUALS'
+            )
+        ),
+        jsonb_build_object(
+            'name', 'maxValue',
+            'dataType', 'INT',
+            'required', false,
+            'description', 'The {maxValue} value for the column entry. if maxValue is not included, minValue is treated as lowerBound and there will be no maximum',
+            'displayName', 'Max',
+            'optionValues', '[]'::jsonb,
+            'validationRule', jsonb_build_object(
+                'parameterField', 'minValue',
+                'rule', 'GREATER_THAN_OR_EQUALS'
+            )
+        )
+    )
+)
+WHERE name = 'columnValuesToBeBetween';
+
+UPDATE test_definition
+SET json = jsonb_set(
+    jsonb_delete(json, '$.parameterDefinition'),
+    '{parameterDefinition}',
+    jsonb_build_array(
+        jsonb_build_object(
+            'name', 'minValueForMaxInCol',
+            'dataType', 'INT',
+            'required', false,
+            'description', 'Expected minimum value in the column to be greater or equal than',
+            'displayName', 'Min',
+            'optionValues', '[]'::jsonb,
+            'validationRule', jsonb_build_object(
+                'parameterField', 'maxValueForMaxInCol',
+                'rule', 'LESS_THAN_OR_EQUALS'
+            )
+        ),
+        jsonb_build_object(
+            'name', 'maxValueForMaxInCol',
+            'dataType', 'INT',
+            'required', false,
+            'description', 'Expected maximum value in the column to be lower or equal than',
+            'displayName', 'Max',
+            'optionValues', '[]'::jsonb,
+            'validationRule', jsonb_build_object(
+                'parameterField', 'minValueForMaxInCol',
+                'rule', 'GREATER_THAN_OR_EQUALS'
+            )
+        )
+    )
+)
+WHERE name = 'columnValueMaxToBeBetween';
+
+UPDATE test_definition
+SET json = jsonb_set(
+    jsonb_delete(json, '$.parameterDefinition'),
+    '{parameterDefinition}',
+    jsonb_build_array(
+        jsonb_build_object(
+            'name', 'minValueForMeanInCol',
+            'dataType', 'INT',
+            'required', false,
+            'description', 'Expected mean value for the column to be greater or equal than',
+            'displayName', 'Min',
+            'optionValues', '[]'::jsonb,
+            'validationRule', jsonb_build_object(
+                'parameterField', 'maxValueForMeanInCol',
+                'rule', 'LESS_THAN_OR_EQUALS'
+            )
+        ),
+        jsonb_build_object(
+            'name', 'maxValueForMeanInCol',
+            'dataType', 'INT',
+            'required', false,
+            'description', 'Expected mean value for the column to be lower or equal than',
+            'displayName', 'Max',
+            'optionValues', '[]'::jsonb,
+            'validationRule', jsonb_build_object(
+                'parameterField', 'minValueForMeanInCol',
+                'rule', 'GREATER_THAN_OR_EQUALS'
+            )
+        )
+    )
+)
+WHERE name = 'columnValueMeanToBeBetween';
+
+UPDATE test_definition
+SET json = jsonb_set(
+    jsonb_delete(json, '$.parameterDefinition'),
+    '{parameterDefinition}',
+    jsonb_build_array(
+        jsonb_build_object(
+            'name', 'minValueForMedianInCol',
+            'dataType', 'INT',
+            'required', false,
+            'description', 'Expected median value for the column to be greater or equal than',
+            'displayName', 'Min',
+            'optionValues', '[]'::jsonb,
+            'validationRule', jsonb_build_object(
+                'parameterField', 'maxValueForMedianInCol',
+                'rule', 'LESS_THAN_OR_EQUALS'
+            )
+        ),
+        jsonb_build_object(
+            'name', 'maxValueForMedianInCol',
+            'dataType', 'INT',
+            'required', false,
+            'description', 'Expected median value for the column to be lower or equal than',
+            'displayName', 'Max',
+            'optionValues', '[]'::jsonb,
+            'validationRule', jsonb_build_object(
+                'parameterField', 'minValueForMedianInCol',
+                'rule', 'GREATER_THAN_OR_EQUALS'
+            )
+        )
+    )
+)
+WHERE name = 'columnValueMedianToBeBetween';
+
+UPDATE test_definition
+SET json = jsonb_set(
+    jsonb_delete(json, '$.parameterDefinition'),
+    '{parameterDefinition}',
+    jsonb_build_array(
+        jsonb_build_object(
+            'name', 'minValueForMinInCol',
+            'dataType', 'INT',
+            'required', false,
+            'description', 'Expected minimum value in the column to be greater or equal than',
+            'displayName', 'Min',
+            'optionValues', '[]'::jsonb,
+            'validationRule', jsonb_build_object(
+                'parameterField', 'maxValueForMinInCol',
+                'rule', 'LESS_THAN_OR_EQUALS'
+            )
+        ),
+        jsonb_build_object(
+            'name', 'maxValueForMinInCol',
+            'dataType', 'INT',
+            'required', false,
+            'description', 'Expect minimum value in the column to be lower or equal than',
+            'displayName', 'Max',
+            'optionValues', '[]'::jsonb,
+            'validationRule', jsonb_build_object(
+                'parameterField', 'minValueForMeanInCol',
+                'rule', 'GREATER_THAN_OR_EQUALS'
+            )
+        )
+    )
+)
+WHERE name = 'columnValueMinToBeBetween';
+
+UPDATE test_definition
+SET json = jsonb_set(
+    jsonb_delete(json, '$.parameterDefinition'),
+    '{parameterDefinition}',
+    jsonb_build_array(
+        jsonb_build_object(
+            'name', 'minLength',
+            'dataType', 'INT',
+            'required', false,
+            'description', 'The {minLength} for the column value. If minLength is not included, maxLength is treated as upperBound and there will be no minimum value length',
+            'displayName', 'Min',
+            'optionValues', '[]'::jsonb,
+            'validationRule', jsonb_build_object(
+                'parameterField', 'maxLength',
+                'rule', 'LESS_THAN_OR_EQUALS'
+            )
+        ),
+        jsonb_build_object(
+            'name', 'maxLength',
+            'dataType', 'INT',
+            'required', false,
+            'description', 'The {maxLength} for the column value. if maxLength is not included, minLength is treated as lowerBound and there will be no maximum value length',
+            'displayName', 'Max',
+            'optionValues', '[]'::jsonb,
+            'validationRule', jsonb_build_object(
+                'parameterField', 'minLength',
+                'rule', 'GREATER_THAN_OR_EQUALS'
+            )
+        )
+    )
+)
+WHERE name = 'columnValueLengthsToBeBetween';
+
+UPDATE test_definition
+SET json = jsonb_set(
+    jsonb_delete(json, '$.parameterDefinition'),
+    '{parameterDefinition}',
+    jsonb_build_array(
+        jsonb_build_object(
+            'name', 'minValueForColSum',
+            'dataType', 'INT',
+            'required', false,
+            'description', 'Expected sum of values in the column to be greater or equal than',
+            'displayName', 'Min',
+            'optionValues', '[]'::jsonb,
+            'validationRule', jsonb_build_object(
+                'parameterField', 'maxValueForColSum',
+                'rule', 'LESS_THAN_OR_EQUALS'
+            )
+        ),
+        jsonb_build_object(
+            'name', 'maxValueForColSum',
+            'dataType', 'INT',
+            'required', false,
+            'description', 'Expected sum values in the column to be lower or equal than',
+            'displayName', 'Max',
+            'optionValues', '[]'::jsonb,
+            'validationRule', jsonb_build_object(
+                'parameterField', 'minValueForColSum',
+                'rule', 'GREATER_THAN_OR_EQUALS'
+            )
+        )
+    )
+)
+WHERE name = 'columnValuesSumToBeBetween';
+
+UPDATE test_definition
+SET json = jsonb_set(
+    jsonb_delete(json, '$.parameterDefinition'),
+    '{parameterDefinition}',
+    jsonb_build_array(
+        jsonb_build_object(
+            'name', 'minValueForStdDevInCol',
+            'dataType', 'INT',
+            'required', false,
+            'description', 'Expected std. dev value for the column to be greater or equal than',
+            'displayName', 'Min',
+            'optionValues', '[]'::jsonb,
+            'validationRule', jsonb_build_object(
+                'parameterField', 'maxValueForStdDevInCol',
+                'rule', 'LESS_THAN_OR_EQUALS'
+            )
+        ),
+        jsonb_build_object(
+            'name', 'maxValueForStdDevInCol',
+            'dataType', 'INT',
+            'required', false,
+            'description', 'Expected std. dev value for the column to be lower or equal than',
+            'displayName', 'Max',
+            'optionValues', '[]'::jsonb,
+            'validationRule', jsonb_build_object(
+                'parameterField', 'minValueForStdDevInCol',
+                'rule', 'GREATER_THAN_OR_EQUALS'
+            )
+        )
+    )
+)
+WHERE name = 'columnValueStdDevToBeBetween';
+
+UPDATE test_definition
+SET json = jsonb_set(
+    jsonb_delete(json, '$.parameterDefinition'),
+    '{parameterDefinition}',
+    jsonb_build_array(
+        jsonb_build_object(
+            'name', 'minColValue',
+            'dataType', 'INT',
+            'required', false,
+            'description', 'Expected number of columns should be greater than or equal to {minValue}. If minValue is not included, maxValue is treated as upperBound and there will be no minimum number of column',
+            'displayName', 'Min',
+            'optionValues', '[]'::jsonb,
+            'validationRule', jsonb_build_object(
+                'parameterField', 'maxColValue',
+                'rule', 'LESS_THAN_OR_EQUALS'
+            )
+        ),
+        jsonb_build_object(
+            'name', 'maxColValue',
+            'dataType', 'INT',
+            'required', false,
+            'description', 'Expected number of columns should be less than or equal to {maxValue}. If maxValue is not included, minValue is treated as lowerBound and there will be no maximum number of column',
+            'displayName', 'Max',
+            'optionValues', '[]'::jsonb,
+            'validationRule', jsonb_build_object(
+                'parameterField', 'minColValue',
+                'rule', 'GREATER_THAN_OR_EQUALS'
+            )
+        )
+    )
+)
+WHERE name = 'tableColumnCountToBeBetween';
+
+UPDATE test_definition
+SET json = jsonb_set(
+    jsonb_delete(json, '$.parameterDefinition'),
+    '{parameterDefinition}',
+    jsonb_build_array(
+        jsonb_build_object(
+            'name', 'minValue',
+            'dataType', 'INT',
+            'required', false,
+            'description', 'Expected number of columns should be greater than or equal to {minValue}. If minValue is not included, maxValue is treated as upperBound and there will be no minimum',
+            'displayName', 'Min',
+            'optionValues', '[]'::jsonb,
+            'validationRule', jsonb_build_object(
+                'parameterField', 'maxValue',
+                'rule', 'LESS_THAN_OR_EQUALS'
+            )
+        ),
+        jsonb_build_object(
+            'name', 'maxValue',
+            'dataType', 'INT',
+            'required', false,
+            'description', 'Expected number of columns should be less than or equal to {maxValue}. If maxValue is not included, minValue is treated as lowerBound and there will be no maximum',
+            'displayName', 'Max',
+            'optionValues', '[]'::jsonb,
+            'validationRule', jsonb_build_object(
+                'parameterField', 'minValue',
+                'rule', 'GREATER_THAN_OR_EQUALS'
+            )
+        )
+    )
+)
+WHERE name = 'tableRowCountToBeBetween';
+
+UPDATE test_definition
+SET json = jsonb_set(
+    jsonb_delete(json, '$.parameterDefinition'),
+    '{parameterDefinition}',
+    jsonb_build_array(
+        jsonb_build_object(
+            'name', 'min',
+            'dataType', 'INT',
+            'required', false,
+            'description', 'Lower Bound of the Count',
+            'displayName', 'Min Row Count',
+            'optionValues', '[]'::jsonb,
+            'validationRule', jsonb_build_object(
+                'parameterField', 'max',
+                'rule', 'LESS_THAN_OR_EQUALS'
+            )
+        ),
+        jsonb_build_object(
+            'name', 'max',
+            'dataType', 'INT',
+            'required', false,
+            'description', 'Upper Bound of the Count',
+            'displayName', 'Max Row Count',
+            'optionValues', '[]'::jsonb,
+            'validationRule', jsonb_build_object(
+                'parameterField', 'min',
+                'rule', 'GREATER_THAN_OR_EQUALS'
+            )
+        )
+    )
+)
+WHERE name = 'tableRowInsertedCountToBeBetween';
+-- End of Test Definition Parameter Definition Validation Migration

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
@@ -24,6 +24,8 @@ import java.util.UUID;
 import javax.json.JsonPatch;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
+
+import lombok.extern.slf4j.Slf4j;
 import org.jdbi.v3.sqlobject.transaction.Transaction;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.api.feed.CloseTask;
@@ -33,6 +35,7 @@ import org.openmetadata.schema.entity.teams.User;
 import org.openmetadata.schema.tests.ResultSummary;
 import org.openmetadata.schema.tests.TestCase;
 import org.openmetadata.schema.tests.TestCaseParameter;
+import org.openmetadata.schema.tests.TestCaseParameterValidationRule;
 import org.openmetadata.schema.tests.TestCaseParameterValue;
 import org.openmetadata.schema.tests.TestDefinition;
 import org.openmetadata.schema.tests.TestSuite;
@@ -49,6 +52,8 @@ import org.openmetadata.schema.type.FieldChange;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.Relationship;
 import org.openmetadata.schema.type.TaskType;
+import org.openmetadata.schema.type.TestCaseParameterDataType;
+import org.openmetadata.schema.type.TestCaseParameterValidationRuleType;
 import org.openmetadata.schema.utils.EntityInterfaceUtil;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.EntityNotFoundException;
@@ -60,6 +65,7 @@ import org.openmetadata.service.util.JsonUtils;
 import org.openmetadata.service.util.RestUtil;
 import org.openmetadata.service.util.ResultList;
 
+@Slf4j
 public class TestCaseRepository extends EntityRepository<TestCase> {
   private static final String TEST_SUITE_FIELD = "testSuite";
   private static final String TEST_CASE_RESULT_FIELD = "testCaseResult";
@@ -219,6 +225,7 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
           throw new IllegalArgumentException(
               "Required parameter " + parameter.getName() + " is not passed in parameterValues");
         }
+        validateParameterRule(parameter, values);
       }
     }
   }
@@ -921,5 +928,66 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
     EntityRepository<TestSuite>.EntityUpdater testSuiteUpdater =
         testSuiteRepository.getUpdater(original, testSuite, Operation.PUT);
     testSuiteUpdater.update();
+  }
+
+  private void validateParameterRule(TestCaseParameter parameter, Map<String, Object> values) {
+    if (parameter.getValidationRule() != null) {
+      TestCaseParameterValidationRule testCaseParameterValidationRule = parameter.getValidationRule();
+      String parameterFieldToValidateAgainst = testCaseParameterValidationRule.getParameterField(); // parameter name to validate against
+      Object valueToValidateAgainst = values.get(parameterFieldToValidateAgainst); // value to validate against
+      Object valueToValidate = values.get(parameter.getName()); // value to validate
+
+      if (valueToValidateAgainst != null && valueToValidate != null) {
+        // we only validate if the value to validate are not null
+        compareValue(valueToValidate.toString(), valueToValidateAgainst.toString(), testCaseParameterValidationRule.getRule());
+      }
+    }
+  }
+
+  private void compareValue(String valueToValidate, String valueToValidateAgainst, TestCaseParameterValidationRuleType validationRule) {
+    Double valueToValidateDouble = parseStringToDouble(valueToValidate);
+    Double valueToValidateAgainstDouble = parseStringToDouble(valueToValidateAgainst);
+    if (valueToValidateDouble != null && valueToValidateAgainstDouble != null) {
+      compareAndValidateParameterRule(validationRule, valueToValidateDouble, valueToValidateAgainstDouble);
+    } else {
+      LOG.warn("One of the 2 values to compare is not a number. Cannot compare values {} and {}. Skipping parameter validation", valueToValidate, valueToValidateAgainst);
+    }
+  }
+
+  private Double parseStringToDouble(String value) {
+    try {
+      return Double.parseDouble(value);
+    } catch (NumberFormatException e) {
+      LOG.warn("Failed to parse value {} to double", value, e);
+      return null;
+    }
+  }
+
+  private void compareAndValidateParameterRule(TestCaseParameterValidationRuleType validationRule, Double valueToValidate, Double valueToValidateAgainst) {
+    String message = "Value %s %s %s";
+    switch (validationRule) {
+      case GREATER_THAN_OR_EQUALS -> {
+        if (valueToValidate < valueToValidateAgainst) {
+          throw new IllegalArgumentException(String.format(message, valueToValidate, " is not greater than ", valueToValidateAgainst));
+        }
+      }
+      case LESS_THAN_OR_EQUALS -> {
+        if (valueToValidate > valueToValidateAgainst) {
+          throw new IllegalArgumentException(String.format(message, valueToValidate, " is not less than ", valueToValidateAgainst));
+        }
+      }
+      case EQUALS -> {
+        // we'll compare the values with a tolerance of 0.0001 as we are dealing with double values
+        if (Math.abs(valueToValidate - valueToValidateAgainst) > 0.0001) {
+          throw new IllegalArgumentException(String.format(message, valueToValidate, " is not equal to ", valueToValidateAgainst));
+        }
+      }
+      case NOT_EQUALS -> {
+        // we'll compare the values with a tolerance of 0.0001 as we are dealing with double values
+        if ((Math.abs(valueToValidate - valueToValidateAgainst) < 0.0001)) {
+          throw new IllegalArgumentException(String.format(message, valueToValidate, " is equal to ", valueToValidateAgainst));
+        }
+      }
+    }
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
@@ -24,7 +24,6 @@ import java.util.UUID;
 import javax.json.JsonPatch;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
-
 import lombok.extern.slf4j.Slf4j;
 import org.jdbi.v3.sqlobject.transaction.Transaction;
 import org.openmetadata.schema.EntityInterface;
@@ -52,7 +51,6 @@ import org.openmetadata.schema.type.FieldChange;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.Relationship;
 import org.openmetadata.schema.type.TaskType;
-import org.openmetadata.schema.type.TestCaseParameterDataType;
 import org.openmetadata.schema.type.TestCaseParameterValidationRuleType;
 import org.openmetadata.schema.utils.EntityInterfaceUtil;
 import org.openmetadata.service.Entity;
@@ -932,25 +930,38 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
 
   private void validateParameterRule(TestCaseParameter parameter, Map<String, Object> values) {
     if (parameter.getValidationRule() != null) {
-      TestCaseParameterValidationRule testCaseParameterValidationRule = parameter.getValidationRule();
-      String parameterFieldToValidateAgainst = testCaseParameterValidationRule.getParameterField(); // parameter name to validate against
-      Object valueToValidateAgainst = values.get(parameterFieldToValidateAgainst); // value to validate against
+      TestCaseParameterValidationRule testCaseParameterValidationRule =
+          parameter.getValidationRule();
+      String parameterFieldToValidateAgainst =
+          testCaseParameterValidationRule.getParameterField(); // parameter name to validate against
+      Object valueToValidateAgainst =
+          values.get(parameterFieldToValidateAgainst); // value to validate against
       Object valueToValidate = values.get(parameter.getName()); // value to validate
 
       if (valueToValidateAgainst != null && valueToValidate != null) {
         // we only validate if the value to validate are not null
-        compareValue(valueToValidate.toString(), valueToValidateAgainst.toString(), testCaseParameterValidationRule.getRule());
+        compareValue(
+            valueToValidate.toString(),
+            valueToValidateAgainst.toString(),
+            testCaseParameterValidationRule.getRule());
       }
     }
   }
 
-  private void compareValue(String valueToValidate, String valueToValidateAgainst, TestCaseParameterValidationRuleType validationRule) {
+  private void compareValue(
+      String valueToValidate,
+      String valueToValidateAgainst,
+      TestCaseParameterValidationRuleType validationRule) {
     Double valueToValidateDouble = parseStringToDouble(valueToValidate);
     Double valueToValidateAgainstDouble = parseStringToDouble(valueToValidateAgainst);
     if (valueToValidateDouble != null && valueToValidateAgainstDouble != null) {
-      compareAndValidateParameterRule(validationRule, valueToValidateDouble, valueToValidateAgainstDouble);
+      compareAndValidateParameterRule(
+          validationRule, valueToValidateDouble, valueToValidateAgainstDouble);
     } else {
-      LOG.warn("One of the 2 values to compare is not a number. Cannot compare values {} and {}. Skipping parameter validation", valueToValidate, valueToValidateAgainst);
+      LOG.warn(
+          "One of the 2 values to compare is not a number. Cannot compare values {} and {}. Skipping parameter validation",
+          valueToValidate,
+          valueToValidateAgainst);
     }
   }
 
@@ -963,29 +974,38 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
     }
   }
 
-  private void compareAndValidateParameterRule(TestCaseParameterValidationRuleType validationRule, Double valueToValidate, Double valueToValidateAgainst) {
+  private void compareAndValidateParameterRule(
+      TestCaseParameterValidationRuleType validationRule,
+      Double valueToValidate,
+      Double valueToValidateAgainst) {
     String message = "Value %s %s %s";
     switch (validationRule) {
       case GREATER_THAN_OR_EQUALS -> {
         if (valueToValidate < valueToValidateAgainst) {
-          throw new IllegalArgumentException(String.format(message, valueToValidate, " is not greater than ", valueToValidateAgainst));
+          throw new IllegalArgumentException(
+              String.format(
+                  message, valueToValidate, " is not greater than ", valueToValidateAgainst));
         }
       }
       case LESS_THAN_OR_EQUALS -> {
         if (valueToValidate > valueToValidateAgainst) {
-          throw new IllegalArgumentException(String.format(message, valueToValidate, " is not less than ", valueToValidateAgainst));
+          throw new IllegalArgumentException(
+              String.format(
+                  message, valueToValidate, " is not less than ", valueToValidateAgainst));
         }
       }
       case EQUALS -> {
         // we'll compare the values with a tolerance of 0.0001 as we are dealing with double values
         if (Math.abs(valueToValidate - valueToValidateAgainst) > 0.0001) {
-          throw new IllegalArgumentException(String.format(message, valueToValidate, " is not equal to ", valueToValidateAgainst));
+          throw new IllegalArgumentException(
+              String.format(message, valueToValidate, " is not equal to ", valueToValidateAgainst));
         }
       }
       case NOT_EQUALS -> {
         // we'll compare the values with a tolerance of 0.0001 as we are dealing with double values
         if ((Math.abs(valueToValidate - valueToValidateAgainst) < 0.0001)) {
-          throw new IllegalArgumentException(String.format(message, valueToValidate, " is equal to ", valueToValidateAgainst));
+          throw new IllegalArgumentException(
+              String.format(message, valueToValidate, " is equal to ", valueToValidateAgainst));
         }
       }
     }

--- a/openmetadata-service/src/main/resources/json/data/tests/columnValueMaxToBeBetween.json
+++ b/openmetadata-service/src/main/resources/json/data/tests/columnValueMaxToBeBetween.json
@@ -11,13 +11,21 @@
       "name": "minValueForMaxInCol",
       "displayName": "Min",
       "description": "Expected minimum value in the column to be greater or equal than",
-      "dataType": "INT"
+      "dataType": "INT",
+      "validationRule": {
+        "parameterField": "maxValueForMaxInCol",
+        "rule": "LESS_THAN_OR_EQUALS"
+      }
     },
     {
       "name": "maxValueForMaxInCol",
       "displayName": "Max",
       "description": "Expected maximum value in the column to be lower or equal than",
-      "dataType": "INT"
+      "dataType": "INT",
+      "validationRule": {
+        "parameterField": "minValueForMaxInCol",
+        "rule": "GREATER_THAN_OR_EQUALS"
+      }
     }
   ],
   "provider": "system"

--- a/openmetadata-service/src/main/resources/json/data/tests/columnValueMeanToBeBetween.json
+++ b/openmetadata-service/src/main/resources/json/data/tests/columnValueMeanToBeBetween.json
@@ -11,13 +11,21 @@
       "name": "minValueForMeanInCol",
       "displayName": "Min",
       "description": "Expected mean value for the column to be greater or equal than",
-      "dataType": "INT"
+      "dataType": "INT",
+      "validationRule": {
+        "parameterField": "maxValueForMeanInCol",
+        "rule": "LESS_THAN_OR_EQUALS"
+      }
     },
     {
       "name": "maxValueForMeanInCol",
       "displayName": "Max",
       "description": "Expected mean value for the column to be lower or equal than",
-      "dataType": "INT"
+      "dataType": "INT",
+      "validationRule": {
+            "parameterField": "minValueForMeanInCol",
+            "rule": "GREATER_THAN_OR_EQUALS"
+      }
     }
   ],
   "provider": "system"

--- a/openmetadata-service/src/main/resources/json/data/tests/columnValueMedianToBeBetween.json
+++ b/openmetadata-service/src/main/resources/json/data/tests/columnValueMedianToBeBetween.json
@@ -11,13 +11,21 @@
         "name": "minValueForMedianInCol",
         "displayName": "Min",
         "description": "Expected median value for the column to be greater or equal than",
-        "dataType": "INT"
+        "dataType": "INT",
+        "validationRule": {
+          "parameterField": "maxValueForMedianInCol",
+          "rule": "LESS_THAN_OR_EQUALS"
+        }
       },
       {
         "name": "maxValueForMedianInCol",
         "displayName": "Max",
         "description": "Expected median value for the column to be lower or equal than",
-        "dataType": "INT"
+        "dataType": "INT",
+        "validationRule": {
+          "parameterField": "minValueForMedianInCol",
+          "rule": "GREATER_THAN_OR_EQUALS"
+        }
       }
   ],
   "provider": "system"

--- a/openmetadata-service/src/main/resources/json/data/tests/columnValueMinToBeBetween.json
+++ b/openmetadata-service/src/main/resources/json/data/tests/columnValueMinToBeBetween.json
@@ -11,13 +11,21 @@
         "name": "minValueForMinInCol",
         "displayName": "Min",
         "description": "Expected minimum value in the column to be greater or equal than",
-        "dataType": "INT"
+        "dataType": "INT",
+        "validationRule": {
+          "parameterField": "maxValueForMinInCol",
+          "rule": "LESS_THAN_OR_EQUALS"
+        }
       },
       {
         "name": "maxValueForMinInCol",
         "displayName": "Max",
         "description": "Expect minimum value in the column to be lower or equal than",
-        "dataType": "INT"
+        "dataType": "INT",
+        "validationRule": {
+          "parameterField": "minValueForMeanInCol",
+          "rule": "GREATER_THAN_OR_EQUALS"
+        }
       }
     ],
     "provider": "system"

--- a/openmetadata-service/src/main/resources/json/data/tests/columnValueStdDevToBeBetween.json
+++ b/openmetadata-service/src/main/resources/json/data/tests/columnValueStdDevToBeBetween.json
@@ -11,13 +11,21 @@
         "name": "minValueForStdDevInCol",
         "displayName": "Min",
         "description": "Expected std. dev value for the column to be greater or equal than",
-        "dataType": "INT"
+        "dataType": "INT",
+        "validationRule": {
+          "parameterField": "maxValueForStdDevInCol",
+          "rule": "LESS_THAN_OR_EQUALS"
+        }
       },
       {
         "name": "maxValueForStdDevInCol",
         "displayName": "Max",
         "description": "Expected std. dev value for the column to be lower or equal than",
-        "dataType": "INT"
+        "dataType": "INT",
+        "validationRule": {
+          "parameterField": "minValueForStdDevInCol",
+          "rule": "GREATER_THAN_OR_EQUALS"
+        }
       }
     ],
     "provider": "system"

--- a/openmetadata-service/src/main/resources/json/data/tests/columnValuesLengthsToBeBetween.json
+++ b/openmetadata-service/src/main/resources/json/data/tests/columnValuesLengthsToBeBetween.json
@@ -11,13 +11,21 @@
       "name": "minLength",
       "displayName": "Min",
       "description": "The {minLength} for the column value. If minLength is not included, maxLength is treated as upperBound and there will be no minimum value length",
-      "dataType": "INT"
+      "dataType": "INT",
+      "validationRule": {
+        "parameterField": "maxLength",
+        "rule": "LESS_THAN_OR_EQUALS"
+      }
     },
     {
       "name": "maxLength",
       "displayName": "Max",
       "description": "The {maxLength} for the column value. if maxLength is not included, minLength is treated as lowerBound and there will be no maximum value length",
-      "dataType": "INT"
+      "dataType": "INT",
+      "validationRule": {
+        "parameterField": "minLength",
+        "rule": "GREATER_THAN_OR_EQUALS"
+      }
     }
   ],
   "supportsRowLevelPassedFailed": true,

--- a/openmetadata-service/src/main/resources/json/data/tests/columnValuesSumToBeBetween.json
+++ b/openmetadata-service/src/main/resources/json/data/tests/columnValuesSumToBeBetween.json
@@ -11,13 +11,21 @@
         "name": "minValueForColSum",
         "displayName": "Min",
         "description": "Expected sum of values in the column to be greater or equal than",
-        "dataType": "INT"
+        "dataType": "INT",
+        "validationRule": {
+          "parameterField": "maxValueForColSum",
+          "rule": "LESS_THAN_OR_EQUALS"
+        }
       },
       {
         "name": "maxValueForColSum",
         "displayName": "Max",
         "description": "Expected sum values in the column to be lower or equal than",
-        "dataType": "INT"
+        "dataType": "INT",
+        "validationRule": {
+          "parameterField": "minValueForColSum",
+          "rule": "GREATER_THAN_OR_EQUALS"
+        }
       }
     ],
     "provider": "system"

--- a/openmetadata-service/src/main/resources/json/data/tests/columnValuesToBeBetween.json
+++ b/openmetadata-service/src/main/resources/json/data/tests/columnValuesToBeBetween.json
@@ -11,13 +11,21 @@
       "name": "minValue",
       "displayName": "Min",
       "description": "The {minValue} value for the column entry. If minValue is not included, maxValue is treated as upperBound and there will be no minimum",
-      "dataType": "INT"
+      "dataType": "INT",
+      "validationRule": {
+        "parameterField": "maxValue",
+        "rule": "LESS_THAN_OR_EQUALS"
+      }
     },
     {
       "name": "maxValue",
       "displayName": "Max",
       "description": "The {maxValue} value for the column entry. if maxValue is not included, minValue is treated as lowerBound and there will be no maximum",
-      "dataType": "INT"
+      "dataType": "INT",
+      "validationRule": {
+          "parameterField": "minValue",
+          "rule": "GREATER_THAN_OR_EQUALS"
+      }
     }
   ],
   "supportsRowLevelPassedFailed": true,

--- a/openmetadata-service/src/main/resources/json/data/tests/tableColumnCountToBeBetween.json
+++ b/openmetadata-service/src/main/resources/json/data/tests/tableColumnCountToBeBetween.json
@@ -10,13 +10,21 @@
       "name": "minColValue",
       "displayName": "Min",
       "description": "Expected number of columns should be greater than or equal to {minValue}. If minValue is not included, maxValue is treated as upperBound and there will be no minimum number of column",
-      "dataType": "INT"
+      "dataType": "INT",
+      "validationRule": {
+        "parameterField": "maxColValue",
+        "rule": "LESS_THAN_OR_EQUALS"
+      }
     },
     {
       "name": "maxColValue",
       "displayName": "Max",
       "description": "Expected number of columns should be less than or equal to {maxValue}. If maxValue is not included, minValue is treated as lowerBound and there will be no maximum number of column",
-      "dataType": "INT"
+      "dataType": "INT",
+      "validationRule": {
+          "parameterField": "minColValue",
+          "rule": "GREATER_THAN_OR_EQUALS"
+      }
     }
   ],
   "provider": "system"

--- a/openmetadata-service/src/main/resources/json/data/tests/tableRowCountToBeBetween.json
+++ b/openmetadata-service/src/main/resources/json/data/tests/tableRowCountToBeBetween.json
@@ -10,13 +10,21 @@
       "name": "minValue",
       "displayName": "Min",
       "description": "Expected number of columns should be greater than or equal to {minValue}. If minValue is not included, maxValue is treated as upperBound and there will be no minimum",
-      "dataType": "INT"
+      "dataType": "INT",
+      "validationRule": {
+        "parameterField": "maxValue",
+        "rule": "LESS_THAN_OR_EQUALS"
+      }
     },
     {
       "name": "maxValue",
       "displayName": "Max",
       "description": "Expected number of columns should be less than or equal to {maxValue}. If maxValue is not included, minValue is treated as lowerBound and there will be no maximum",
-      "dataType": "INT"
+      "dataType": "INT",
+      "validationRule": {
+          "parameterField": "minValue",
+          "rule": "GREATER_THAN_OR_EQUALS"
+      }
     }
   ],
   "provider": "system"

--- a/openmetadata-service/src/main/resources/json/data/tests/tableRowInsertedCountToBeBetween.json
+++ b/openmetadata-service/src/main/resources/json/data/tests/tableRowInsertedCountToBeBetween.json
@@ -11,14 +11,22 @@
         "displayName": "Min Row Count",
         "description": "Lower Bound of the Count",
         "dataType": "INT",
-        "required": false
+        "required": false,
+        "validationRule": {
+          "parameterField": "max",
+          "rule": "LESS_THAN_OR_EQUALS"
+        }
       },
       {
         "name": "max",
         "displayName": "Max Row Count",
         "description": "Upper Bound of the Count",
         "dataType": "INT",
-        "required": false
+        "required": false,
+        "validationRule": {
+          "parameterField": "min",
+          "rule": "GREATER_THAN_OR_EQUALS"
+        }
       },
       {
         "name": "columnName",

--- a/openmetadata-service/src/test/java/org/openmetadata/service/OpenMetadataApplicationTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/OpenMetadataApplicationTest.java
@@ -163,6 +163,7 @@ public abstract class OpenMetadataApplicationTest {
     ELASTIC_SEARCH_CONTAINER.withEnv("discovery.type", "single-node");
     ELASTIC_SEARCH_CONTAINER.withEnv("xpack.security.enabled", "false");
     ELASTIC_SEARCH_CONTAINER.withReuse(false);
+    ELASTIC_SEARCH_CONTAINER.withStartupAttempts(3);
     ELASTIC_SEARCH_CONTAINER.setWaitStrategy(
         new LogMessageWaitStrategy()
             .withRegEx(".*(\"message\":\\s?\"started[\\s?|\"].*|] started\n$)")

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/apps/AppsResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/apps/AppsResourceTest.java
@@ -5,6 +5,7 @@ import static javax.ws.rs.core.Response.Status.OK;
 import static org.openmetadata.service.util.TestUtils.ADMIN_AUTH_HEADERS;
 import static org.openmetadata.service.util.TestUtils.assertResponseContains;
 import static org.openmetadata.service.util.TestUtils.readResponse;
+import static org.openmetadata.service.util.TestUtils.waitForEsAsyncOp;
 
 import java.io.IOException;
 import java.util.Map;
@@ -80,7 +81,7 @@ public class AppsResourceTest extends EntityResourceTest<App, CreateApp> {
   @Test
   void post_trigger_app_200() throws HttpResponseException, InterruptedException {
     postTriggerApp("SearchIndexingApplication", ADMIN_AUTH_HEADERS);
-    TimeUnit.MILLISECONDS.sleep(200);
+    waitForEsAsyncOp();
     AppRunRecord latestRun = getLatestAppRun("SearchIndexingApplication", ADMIN_AUTH_HEADERS);
     assert latestRun.getStatus().equals(AppRunRecord.Status.RUNNING);
     TimeUnit timeout = TimeUnit.SECONDS;

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/dqtests/TestCaseResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/dqtests/TestCaseResourceTest.java
@@ -1851,6 +1851,36 @@ public class TestCaseResourceTest extends EntityResourceTest<TestCase, CreateTes
     assertEquals(7, testCases.getData().size());
   }
 
+  @Test
+  void wrongMinMaxTestParameter(TestInfo test) throws HttpResponseException {
+    CreateTestCase validTestCase = createRequest(test);
+    validTestCase.withTestDefinition(TEST_DEFINITION1.getFullyQualifiedName())
+            .withParameterValues(
+                    List.of(
+                            new TestCaseParameterValue().withName("minLength").withValue("10")));
+    createEntity(validTestCase, ADMIN_AUTH_HEADERS);
+
+    validTestCase = createRequest(test, 1);
+    validTestCase.withTestDefinition(TEST_DEFINITION1.getFullyQualifiedName())
+            .withParameterValues(
+                    List.of(
+                            new TestCaseParameterValue().withName("maxLength").withValue("10")));
+    createEntity(validTestCase, ADMIN_AUTH_HEADERS);
+
+    CreateTestCase invalidTestCase = createRequest(test, 2);
+    invalidTestCase.withTestDefinition(TEST_DEFINITION1.getFullyQualifiedName())
+            .withParameterValues(
+              List.of(
+                new TestCaseParameterValue().withName("minLength").withValue("10"),
+                new TestCaseParameterValue().withName("maxLength").withValue("5")));
+
+    assertResponse(
+            () -> createEntity(invalidTestCase, ADMIN_AUTH_HEADERS),
+            BAD_REQUEST,
+            "`Min value of 10 cannot be greater than Max value of 5");
+  }
+
+
   public void deleteTestCaseResult(String fqn, Long timestamp, Map<String, String> authHeaders)
       throws HttpResponseException {
     WebTarget target = getCollection().path("/" + fqn + "/testCaseResult/" + timestamp);

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/dqtests/TestCaseResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/dqtests/TestCaseResourceTest.java
@@ -1874,10 +1874,22 @@ public class TestCaseResourceTest extends EntityResourceTest<TestCase, CreateTes
                 new TestCaseParameterValue().withName("minLength").withValue("10"),
                 new TestCaseParameterValue().withName("maxLength").withValue("5")));
 
-    assertResponse(
+    assertResponseContains(
             () -> createEntity(invalidTestCase, ADMIN_AUTH_HEADERS),
             BAD_REQUEST,
-            "`Min value of 10 cannot be greater than Max value of 5");
+            "Value");
+
+    CreateTestCase invalidTestCaseMixedTypes = createRequest(test, 3);
+    invalidTestCaseMixedTypes.withTestDefinition(TEST_DEFINITION1.getFullyQualifiedName())
+            .withParameterValues(
+                    List.of(
+                            new TestCaseParameterValue().withName("minLength").withValue("10.6"),
+                            new TestCaseParameterValue().withName("maxLength").withValue("5")));
+
+    assertResponseContains(
+            () -> createEntity(invalidTestCaseMixedTypes, ADMIN_AUTH_HEADERS),
+            BAD_REQUEST,
+            "Value");
   }
 
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/dqtests/TestCaseResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/dqtests/TestCaseResourceTest.java
@@ -1854,44 +1854,41 @@ public class TestCaseResourceTest extends EntityResourceTest<TestCase, CreateTes
   @Test
   void wrongMinMaxTestParameter(TestInfo test) throws HttpResponseException {
     CreateTestCase validTestCase = createRequest(test);
-    validTestCase.withTestDefinition(TEST_DEFINITION1.getFullyQualifiedName())
-            .withParameterValues(
-                    List.of(
-                            new TestCaseParameterValue().withName("minLength").withValue("10")));
+    validTestCase
+        .withTestDefinition(TEST_DEFINITION1.getFullyQualifiedName())
+        .withParameterValues(
+            List.of(new TestCaseParameterValue().withName("minLength").withValue("10")));
     createEntity(validTestCase, ADMIN_AUTH_HEADERS);
 
     validTestCase = createRequest(test, 1);
-    validTestCase.withTestDefinition(TEST_DEFINITION1.getFullyQualifiedName())
-            .withParameterValues(
-                    List.of(
-                            new TestCaseParameterValue().withName("maxLength").withValue("10")));
+    validTestCase
+        .withTestDefinition(TEST_DEFINITION1.getFullyQualifiedName())
+        .withParameterValues(
+            List.of(new TestCaseParameterValue().withName("maxLength").withValue("10")));
     createEntity(validTestCase, ADMIN_AUTH_HEADERS);
 
     CreateTestCase invalidTestCase = createRequest(test, 2);
-    invalidTestCase.withTestDefinition(TEST_DEFINITION1.getFullyQualifiedName())
-            .withParameterValues(
-              List.of(
+    invalidTestCase
+        .withTestDefinition(TEST_DEFINITION1.getFullyQualifiedName())
+        .withParameterValues(
+            List.of(
                 new TestCaseParameterValue().withName("minLength").withValue("10"),
                 new TestCaseParameterValue().withName("maxLength").withValue("5")));
 
     assertResponseContains(
-            () -> createEntity(invalidTestCase, ADMIN_AUTH_HEADERS),
-            BAD_REQUEST,
-            "Value");
+        () -> createEntity(invalidTestCase, ADMIN_AUTH_HEADERS), BAD_REQUEST, "Value");
 
     CreateTestCase invalidTestCaseMixedTypes = createRequest(test, 3);
-    invalidTestCaseMixedTypes.withTestDefinition(TEST_DEFINITION1.getFullyQualifiedName())
-            .withParameterValues(
-                    List.of(
-                            new TestCaseParameterValue().withName("minLength").withValue("10.6"),
-                            new TestCaseParameterValue().withName("maxLength").withValue("5")));
+    invalidTestCaseMixedTypes
+        .withTestDefinition(TEST_DEFINITION1.getFullyQualifiedName())
+        .withParameterValues(
+            List.of(
+                new TestCaseParameterValue().withName("minLength").withValue("10.6"),
+                new TestCaseParameterValue().withName("maxLength").withValue("5")));
 
     assertResponseContains(
-            () -> createEntity(invalidTestCaseMixedTypes, ADMIN_AUTH_HEADERS),
-            BAD_REQUEST,
-            "Value");
+        () -> createEntity(invalidTestCaseMixedTypes, ADMIN_AUTH_HEADERS), BAD_REQUEST, "Value");
   }
-
 
   public void deleteTestCaseResult(String fqn, Long timestamp, Map<String, String> authHeaders)
       throws HttpResponseException {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/dqtests/TestDefinitionResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/dqtests/TestDefinitionResourceTest.java
@@ -10,15 +10,19 @@ import static org.openmetadata.service.util.TestUtils.assertResponse;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+
 import org.apache.http.client.HttpResponseException;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.openmetadata.schema.api.tests.CreateTestDefinition;
+import org.openmetadata.schema.tests.TestCaseParameter;
 import org.openmetadata.schema.tests.TestDefinition;
 import org.openmetadata.schema.tests.TestPlatform;
 import org.openmetadata.schema.type.TestDefinitionEntityType;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.resources.EntityResourceTest;
+import org.openmetadata.service.util.ResultList;
 
 public class TestDefinitionResourceTest
     extends EntityResourceTest<TestDefinition, CreateTestDefinition> {
@@ -57,6 +61,26 @@ public class TestDefinitionResourceTest
         () -> createEntity(createRequest(test).withName(null), ADMIN_AUTH_HEADERS),
         BAD_REQUEST,
         "[name must not be null]");
+  }
+
+  @Test
+  void checkValidationParamIsSet(TestInfo test) throws HttpResponseException {
+    ResultList<TestDefinition> testDefinitions = listEntities(null, ADMIN_AUTH_HEADERS);
+    // Get all test definitions that have min or max as parameter (infer from `between`)
+    List<TestDefinition> testDefinitionsWithMinMax = testDefinitions.getData().stream().filter(t -> t.getName().toLowerCase().contains("between")).toList();
+    for (TestDefinition testDefinition : testDefinitionsWithMinMax) {
+      List<TestCaseParameter> parameters = testDefinition.getParameterDefinition();
+      for (TestCaseParameter parameter : parameters) {
+          // If a test definition has a parameter with min or max in the name we'll test:
+          // 1. That the validation rule is set
+          // 2. That the validation rule is set to compare with the max field
+          if ((parameter.getName().toLowerCase().contains("min")
+                          || parameter.getName().toLowerCase().contains("max"))) {
+            Assertions.assertNotNull(parameter.getValidationRule());
+            Assertions.assertNotNull(parameters.stream().filter(p -> p.getName().equals(parameter.getValidationRule().getParameterField())).findFirst());
+          }
+      }
+    }
   }
 
   @Override

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/dqtests/TestDefinitionResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/dqtests/TestDefinitionResourceTest.java
@@ -10,7 +10,6 @@ import static org.openmetadata.service.util.TestUtils.assertResponse;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-
 import org.apache.http.client.HttpResponseException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -67,18 +66,25 @@ public class TestDefinitionResourceTest
   void checkValidationParamIsSet(TestInfo test) throws HttpResponseException {
     ResultList<TestDefinition> testDefinitions = listEntities(null, ADMIN_AUTH_HEADERS);
     // Get all test definitions that have min or max as parameter (infer from `between`)
-    List<TestDefinition> testDefinitionsWithMinMax = testDefinitions.getData().stream().filter(t -> t.getName().toLowerCase().contains("between")).toList();
+    List<TestDefinition> testDefinitionsWithMinMax =
+        testDefinitions.getData().stream()
+            .filter(t -> t.getName().toLowerCase().contains("between"))
+            .toList();
     for (TestDefinition testDefinition : testDefinitionsWithMinMax) {
       List<TestCaseParameter> parameters = testDefinition.getParameterDefinition();
       for (TestCaseParameter parameter : parameters) {
-          // If a test definition has a parameter with min or max in the name we'll test:
-          // 1. That the validation rule is set
-          // 2. That the validation rule is set to compare with the max field
-          if ((parameter.getName().toLowerCase().contains("min")
-                          || parameter.getName().toLowerCase().contains("max"))) {
-            Assertions.assertNotNull(parameter.getValidationRule());
-            Assertions.assertNotNull(parameters.stream().filter(p -> p.getName().equals(parameter.getValidationRule().getParameterField())).findFirst());
-          }
+        // If a test definition has a parameter with min or max in the name we'll test:
+        // 1. That the validation rule is set
+        // 2. That the validation rule is set to compare with the max field
+        if ((parameter.getName().toLowerCase().contains("min")
+            || parameter.getName().toLowerCase().contains("max"))) {
+          Assertions.assertNotNull(parameter.getValidationRule());
+          Assertions.assertNotNull(
+              parameters.stream()
+                  .filter(
+                      p -> p.getName().equals(parameter.getValidationRule().getParameterField()))
+                  .findFirst());
+        }
       }
     }
   }

--- a/openmetadata-spec/src/main/resources/json/schema/tests/testDefinition.json
+++ b/openmetadata-spec/src/main/resources/json/schema/tests/testDefinition.json
@@ -80,6 +80,30 @@
           "description": "List of values that can be passed for this parameter.",
           "type": "array",
           "default": []
+        },
+        "validationRule": {
+          "type": "object",
+          "javaType": "org.openmetadata.schema.tests.TestCaseParameterValidationRule",
+          "description": "Validation for the test parameter value.",
+          "properties": {
+            "parameterField": {
+              "description": "Name of the parameter to validate against.",
+              "type": "string"
+            },
+            "rule": {
+              "javaType": "org.openmetadata.schema.type.TestCaseParameterValidationRuleType",
+              "description": "This enum defines the type to use for a parameter validation rule.",
+              "type": "string",
+              "enum": [
+                  "EQUALS",
+                  "NOT_EQUALS",
+                  "GREATER_THAN",
+                  "LESS_THAN",
+                  "GREATER_THAN_OR_EQUALS",
+                  "LESS_THAN_OR_EQUALS"
+              ]
+            }
+          }
         }
       }
     }

--- a/openmetadata-spec/src/main/resources/json/schema/tests/testDefinition.json
+++ b/openmetadata-spec/src/main/resources/json/schema/tests/testDefinition.json
@@ -97,8 +97,6 @@
               "enum": [
                   "EQUALS",
                   "NOT_EQUALS",
-                  "GREATER_THAN",
-                  "LESS_THAN",
                   "GREATER_THAN_OR_EQUALS",
                   "LESS_THAN_OR_EQUALS"
               ]


### PR DESCRIPTION
### Describe your changes:

Fixes #13475 
- Add parameter validation for min/max tests.

⚠️ if the parameter value cannot be parsed to a double, we'll skip the validation entirely.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

Improvement
- [x] I have added tests around the new logic.
- [x] For connector/ingestion changes: I updated the documentation.

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
