### PR TITLE
Fix #15208: Lineage - log query parsing issue summary

### DIFF
--- a/ingestion/src/metadata/ingestion/lineage/sql_lineage.py
+++ b/ingestion/src/metadata/ingestion/lineage/sql_lineage.py
@@ -27,7 +27,11 @@ from metadata.generated.schema.type.entityLineage import (
 from metadata.generated.schema.type.entityLineage import Source as LineageSource
 from metadata.generated.schema.type.entityReference import EntityReference
 from metadata.ingestion.api.models import Either
-from metadata.ingestion.lineage.models import Dialect
+from metadata.ingestion.lineage.models import (
+    Dialect,
+    QueryParsingError,
+    QueryParsingFailures,
+)
 from metadata.ingestion.lineage.parser import LINEAGE_PARSING_TIMEOUT, LineageParser
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.utils import fqn
@@ -380,6 +384,7 @@ def get_lineage_by_query(
     and returns True if target table is found to create lineage otherwise returns False.
     """
     column_lineage = {}
+    query_parsing_failures = QueryParsingFailures()
 
     try:
         logger.debug(f"Running lineage with query: {query}")
@@ -427,6 +432,12 @@ def get_lineage_by_query(
                         column_lineage_map=column_lineage,
                         lineage_source=lineage_source,
                     )
+        if not lineage_parser.query_parsing_success:
+            query_parsing_failures.add(
+                QueryParsingError(
+                    query=query, error=lineage_parser.query_parsing_failure_reason
+                )
+            )
     except Exception as exc:
         yield Either(
             left=StackTraceError(
@@ -450,6 +461,7 @@ def get_lineage_via_table_entity(
 ) -> Iterable[Either[AddLineageRequest]]:
     """Get lineage from table entity"""
     column_lineage = {}
+    query_parsing_failures = QueryParsingFailures()
 
     try:
         logger.debug(f"Getting lineage via table entity using query: {query}")
@@ -468,6 +480,12 @@ def get_lineage_via_table_entity(
                 column_lineage_map=column_lineage,
                 lineage_source=lineage_source,
             ) or []
+        if not lineage_parser.query_parsing_success:
+            query_parsing_failures.add(
+                QueryParsingError(
+                    query=query, error=lineage_parser.query_parsing_failure_reason
+                )
+            )
     except Exception as exc:  # pylint: disable=broad-except
         Either(
             left=StackTraceError(

--- a/ingestion/src/metadata/ingestion/lineage/sql_lineage.py
+++ b/ingestion/src/metadata/ingestion/lineage/sql_lineage.py
@@ -369,6 +369,7 @@ def populate_column_lineage_map(raw_column_lineage):
     return lineage_map
 
 
+# pylint: disable=too-many-locals
 def get_lineage_by_query(
     metadata: OpenMetadata,
     service_name: str,

--- a/ingestion/src/metadata/ingestion/ometa/mixins/lineage_mixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/lineage_mixin.py
@@ -184,3 +184,7 @@ class OMetaLineageMixin(Generic[T]):
                         logger.info(
                             f"added lineage between table {node.get('name')} and {entity_name} "
                         )
+                elif lineage_request.left:
+                    logger.error(
+                        f"Error while adding lineage: {lineage_request.left.error}"
+                    )

--- a/ingestion/src/metadata/workflow/output_handler.py
+++ b/ingestion/src/metadata/workflow/output_handler.py
@@ -26,6 +26,7 @@ from metadata.generated.schema.entity.services.ingestionPipelines.status import 
 )
 from metadata.generated.schema.metadataIngestion.workflow import LogLevels
 from metadata.ingestion.api.step import Summary
+from metadata.ingestion.lineage.models import QueryParsingFailures
 from metadata.utils.execution_time_tracker import ExecutionTimeTracker
 from metadata.utils.helpers import pretty_print_time_duration
 from metadata.utils.logger import ANSI, log_ansi_encoded_string
@@ -158,6 +159,26 @@ def print_execution_time_summary():
     log_ansi_encoded_string(message=f"\n{tabulate(summary_table, tablefmt='grid')}")
 
 
+def print_query_parsing_issues():
+    """Log the QueryParsingFailures Summary."""
+    query_failures = QueryParsingFailures()
+
+    summary_table = {
+        "Query": [],
+        "Error": [],
+    }
+
+    for failure in query_failures:
+        summary_table["Query"].append(failure.query)
+        summary_table["Error"].append(failure.error)
+
+    if summary_table["Query"]:
+        log_ansi_encoded_string(bold=True, message="Query Parsing Error Summary")
+        log_ansi_encoded_string(
+            message=f"\n{tabulate(summary_table, tablefmt='grid', headers=summary_table.keys())}"
+        )
+
+
 def print_workflow_summary(workflow: "BaseWorkflow") -> None:
     """
     Args:
@@ -170,6 +191,7 @@ def print_workflow_summary(workflow: "BaseWorkflow") -> None:
     if is_debug_enabled(workflow):
         print_workflow_status_debug(workflow)
         print_execution_time_summary()
+        print_query_parsing_issues()
 
     failures = []
     total_records = 0


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fix #15208: Lineage - log query parsing issue summary

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
