### PR TITLE
Minor: Fixes #15776 Numeric out of value error Trino

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/trino/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/trino/metadata.py
@@ -205,7 +205,8 @@ class TrinoSource(CommonDbSourceService):
         new_service_connection = deepcopy(self.service_connection)
         new_service_connection.catalog = database_name
         self.engine = get_connection(new_service_connection)
-        self.inspector = inspect(self.engine)
+        self._connection_map = {}  # Lazy init as well
+        self._inspector_map = {}
 
     def get_database_names(self) -> Iterable[str]:
         configured_catalog = self.service_connection.catalog

--- a/ingestion/src/metadata/ingestion/source/database/trino/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/trino/metadata.py
@@ -16,7 +16,7 @@ import traceback
 from copy import deepcopy
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
-from sqlalchemy import exc, inspect, sql, util
+from sqlalchemy import exc, sql, util
 from sqlalchemy.engine.base import Connection
 from sqlalchemy.sql import sqltypes
 from trino.sqlalchemy import datatype, error

--- a/ingestion/src/metadata/profiler/orm/functions/sum.py
+++ b/ingestion/src/metadata/profiler/orm/functions/sum.py
@@ -32,7 +32,9 @@ def _(element, compiler, **kw):
     return f"SUM(CAST({proc} AS BIGINT))"
 
 
+@compiles(SumFn, Dialects.Athena)
 @compiles(SumFn, Dialects.Trino)
+@compiles(SumFn, Dialects.Presto)
 def _(element, compiler, **kw):
     """Cast to DECIMAL to address cannot cast nan to bigint"""
     proc = compiler.process(element.clauses, **kw)

--- a/ingestion/src/metadata/profiler/orm/functions/sum.py
+++ b/ingestion/src/metadata/profiler/orm/functions/sum.py
@@ -34,9 +34,9 @@ def _(element, compiler, **kw):
 
 @compiles(SumFn, Dialects.Trino)
 def _(element, compiler, **kw):
-    """Cast to BIGINT to address cannot cast nan to bigint"""
+    """Cast to DECIMAL to address cannot cast nan to bigint"""
     proc = compiler.process(element.clauses, **kw)
-    return f"SUM(TRY_CAST({proc} AS BIGINT))"
+    return f"SUM(TRY_CAST({proc} AS DECIMAL))"
 
 
 @compiles(SumFn, Dialects.BigQuery)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #15776

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on fixing numeric out of value for value bigger than bigint.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
