### PR TITLE
Fixes #15660 - Compute unique and count at the same time

### DIFF
--- a/ingestion/src/metadata/data_quality/validations/column/sqlalchemy/columnValuesToBeUnique.py
+++ b/ingestion/src/metadata/data_quality/validations/column/sqlalchemy/columnValuesToBeUnique.py
@@ -16,6 +16,7 @@ Validator for column values to be unique test case
 from typing import Optional
 
 from sqlalchemy import Column, inspect
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm.util import AliasedClass
 
 from metadata.data_quality.validations.column.base.columnValuesToBeUnique import (
@@ -50,24 +51,34 @@ class ColumnValuesToBeUniqueValidator(
             metric: metric
             column: column
         """
-        return self.run_query_results(self.runner, metric, column)
+        count = Metrics.COUNT.value(column).fn()
+        unique_count = Metrics.UNIQUE_COUNT.value(column).query(
+            sample=self.runner._sample  # pylint: disable=protected-access
+            if isinstance(
+                self.runner._sample,  # pylint: disable=protected-access
+                AliasedClass,
+            )
+            else self.runner.table,
+            session=self.runner._session,  # pylint: disable=protected-access
+        )  # type: ignore
+
+        try:
+            self.value = dict(self.runner.dispatch_query_select_first(count, unique_count.subquery("uniqueCount")))  # type: ignore
+            res = self.value.get(Metrics.COUNT.name)
+        except Exception as exc:
+            raise SQLAlchemyError(exc)
+
+        if res is None:
+            raise ValueError(
+                f"\nQuery on table/column {column.name if column is not None else ''} returned None. Your table might be empty. "
+                "If you confirmed your table is not empty and are still seeing this message you can:\n"
+                "\t1. check the documentation: https://docs.open-metadata.org/v1.3.x/connectors/ingestion/workflows/data-quality/tests\n"
+                "\t2. reach out to the Collate team for support"
+            )
+
+        return res
 
     def _get_unique_count(self, metric: Metrics, column: Column) -> Optional[int]:
         """Get unique count of values"""
-        unique_count = dict(
-            self.runner.select_all_from_query(
-                metric.value(column).query(
-                    sample=self.runner._sample  # pylint: disable=protected-access
-                    if isinstance(
-                        self.runner._sample,  # pylint: disable=protected-access
-                        AliasedClass,
-                    )
-                    else self.runner.table,
-                    session=self.runner._session,  # pylint: disable=protected-access
-                )  # type: ignore
-            )[
-                0
-            ]  # query result is a list of tuples
-        )
 
-        return unique_count.get(metric.name)
+        return self.value.get(metric.name)

--- a/ingestion/src/metadata/profiler/metrics/static/unique_count.py
+++ b/ingestion/src/metadata/profiler/metrics/static/unique_count.py
@@ -61,8 +61,8 @@ class UniqueCount(QueryMetric):
         unique_count_query = _unique_count_query_mapper[session.bind.dialect.name](
             col, session, sample
         )
-        only_once_cte = unique_count_query.cte("only_once")
-        return session.query(func.count().label(self.name())).select_from(only_once_cte)
+        only_once_sub = unique_count_query.subquery("only_once")
+        return session.query(func.count().label(self.name())).select_from(only_once_sub)
 
     def df_fn(self, dfs=None):
         """

--- a/ingestion/tests/integration/profiler/conftest.py
+++ b/ingestion/tests/integration/profiler/conftest.py
@@ -1,7 +1,6 @@
 from typing import TYPE_CHECKING
 
 import boto3
-import botocore
 import pytest
 from testcontainers.localstack import LocalStackContainer
 


### PR DESCRIPTION
### Describe your changes:

Fixes #15660 

- move computation of unique and count in the same query

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

Bug fix
- [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.

Improvement
- [x] I have added tests around the new logic.
- [x] For connector/ingestion changes: I updated the documentation.

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
