### PR TITLE
MINOR: Fix error message in S3Source

### DIFF
--- a/ingestion/src/metadata/ingestion/source/storage/s3/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/storage/s3/metadata.py
@@ -90,7 +90,7 @@ class S3Source(StorageServiceSource):
         connection: S3Connection = config.serviceConnection.__root__.config
         if not isinstance(connection, S3Connection):
             raise InvalidSourceException(
-                f"Expected S3StoreConnection, but got {connection}"
+                f"Expected S3Connection, but got {connection}"
             )
         return cls(config, metadata)
 

--- a/ingestion/src/metadata/ingestion/source/storage/s3/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/storage/s3/metadata.py
@@ -89,9 +89,7 @@ class S3Source(StorageServiceSource):
         config: WorkflowSource = WorkflowSource.parse_obj(config_dict)
         connection: S3Connection = config.serviceConnection.__root__.config
         if not isinstance(connection, S3Connection):
-            raise InvalidSourceException(
-                f"Expected S3Connection, but got {connection}"
-            )
+            raise InvalidSourceException(f"Expected S3Connection, but got {connection}")
         return cls(config, metadata)
 
     def get_containers(self) -> Iterable[S3ContainerDetails]:


### PR DESCRIPTION
### Fix error message in S3Source

The error message was referring to `S3StoreConnection` which does not exist. Rather, it should be `S3Connection`.

I worked on fixing this small typo because I was reading the code 🤓 

#
### Type of change:

- [ ] Bug fix
- [x] Minor improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.

