### PR TITLE
fix: 404 page layout

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/AppContainer/AppContainer.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AppContainer/AppContainer.tsx
@@ -19,6 +19,7 @@ import { Redirect, Route, Switch } from 'react-router-dom';
 import { ROUTES } from '../../constants/constants';
 import { useApplicationStore } from '../../hooks/useApplicationStore';
 import { useDomainStore } from '../../hooks/useDomainStore';
+import PageNotFound from '../../pages/PageNotFound/PageNotFound';
 import SignUpPage from '../../pages/SignUp/SignUpPage';
 import applicationRoutesClass from '../../utils/ApplicationRoutesClassBase';
 import Appbar from '../AppBar/Appbar';
@@ -46,6 +47,8 @@ const AppContainer = () => {
       <Route exact component={SignUpPage} path={ROUTES.SIGNUP}>
         {!isEmpty(currentUser) && <Redirect to={ROUTES.HOME} />}
       </Route>
+      {/* Do not move this route as we don't want to render the sidebar and header in 404 page */}
+      <Route exact component={PageNotFound} path={ROUTES.NOT_FOUND} />
 
       <Layout className="app-container">
         <Sider

--- a/openmetadata-ui/src/main/resources/ui/src/components/AppRouter/AppRouter.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AppRouter/AppRouter.tsx
@@ -13,12 +13,11 @@
 
 import { isNil } from 'lodash';
 import React, { useCallback, useEffect } from 'react';
-import { Route, Switch, useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import { useAnalytics } from 'use-analytics';
-import AppContainer from '../../components/AppContainer/AppContainer';
-import { ROUTES } from '../../constants/constants';
 import { CustomEventTypes } from '../../generated/analytics/webAnalyticEventData';
 import { useApplicationStore } from '../../hooks/useApplicationStore';
+import AppContainer from '../AppContainer/AppContainer';
 import { UnAuthenticatedAppRouter } from './UnAuthenticatedAppRouter';
 import withSuspenseFallback from './withSuspenseFallback';
 
@@ -70,12 +69,7 @@ const AppRouter = () => {
     return () => targetNode.removeEventListener('click', handleClickEvent);
   }, [handleClickEvent]);
 
-  return (
-    <Switch>
-      {isAuthenticated ? <AppContainer /> : <UnAuthenticatedAppRouter />}
-      <Route exact component={PageNotFound} path={ROUTES.NOT_FOUND} />
-    </Switch>
-  );
+  return isAuthenticated ? <AppContainer /> : <UnAuthenticatedAppRouter />;
 };
 
 export default AppRouter;

--- a/openmetadata-ui/src/main/resources/ui/src/components/AppRouter/AppRouter.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AppRouter/AppRouter.tsx
@@ -19,11 +19,6 @@ import { CustomEventTypes } from '../../generated/analytics/webAnalyticEventData
 import { useApplicationStore } from '../../hooks/useApplicationStore';
 import AppContainer from '../AppContainer/AppContainer';
 import { UnAuthenticatedAppRouter } from './UnAuthenticatedAppRouter';
-import withSuspenseFallback from './withSuspenseFallback';
-
-const PageNotFound = withSuspenseFallback(
-  React.lazy(() => import('../../pages/PageNotFound/PageNotFound'))
-);
 
 const AppRouter = () => {
   const location = useLocation();

--- a/openmetadata-ui/src/main/resources/ui/src/components/AppRouter/AuthenticatedAppRouter.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AppRouter/AuthenticatedAppRouter.tsx
@@ -224,10 +224,6 @@ const AddQueryPage = withSuspenseFallback(
   React.lazy(() => import('../../pages/AddQueryPage/AddQueryPage.component'))
 );
 
-const PageNotFound = withSuspenseFallback(
-  React.lazy(() => import('../../pages/PageNotFound/PageNotFound'))
-);
-
 const IncidentManagerPage = withSuspenseFallback(
   React.lazy(() => import('../../pages/IncidentManager/IncidentManagerPage'))
 );
@@ -508,7 +504,7 @@ const AuthenticatedAppRouter: FunctionComponent = () => {
         ]}>
         <Redirect to={ROUTES.MY_DATA} />
       </Route>
-      <Route exact component={PageNotFound} path={ROUTES.NOT_FOUND} />
+
       <Redirect to={ROUTES.NOT_FOUND} />
     </Switch>
   );

--- a/openmetadata-ui/src/main/resources/ui/src/components/AppRouter/UnAuthenticatedAppRouter.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AppRouter/UnAuthenticatedAppRouter.tsx
@@ -16,6 +16,7 @@ import { Redirect, Route, Switch } from 'react-router-dom';
 import { ROUTES } from '../../constants/constants';
 import { AuthProvider } from '../../generated/configuration/authenticationConfiguration';
 import { useApplicationStore } from '../../hooks/useApplicationStore';
+import PageNotFound from '../../pages/PageNotFound/PageNotFound';
 import SamlCallback from '../../pages/SamlCallback';
 import AccountActivationConfirmation from '../../pages/SignUp/account-activation-confirmation.component';
 import { isProtectedRoute } from '../../utils/AuthProvider.util';
@@ -82,6 +83,9 @@ export const UnAuthenticatedAppRouter = () => {
           <Redirect to={ROUTES.SIGNIN} />
         </Route>
       )}
+
+      {/* keep this route before any conditional JSX.Element rendering */}
+      <Route exact component={PageNotFound} path={ROUTES.NOT_FOUND} />
 
       {isBasicAuthProvider && (
         <>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Auth/AppAuthenticators/OidcAuthenticator.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Auth/AppAuthenticators/OidcAuthenticator.tsx
@@ -26,7 +26,6 @@ import { Redirect, Route, Switch, useHistory } from 'react-router-dom';
 import { ROUTES } from '../../../constants/constants';
 import { useApplicationStore } from '../../../hooks/useApplicationStore';
 import SignInPage from '../../../pages/LoginPage/SignInPage';
-import PageNotFound from '../../../pages/PageNotFound/PageNotFound';
 import { showErrorToast } from '../../../utils/ToastUtils';
 import Loader from '../../common/Loader/Loader';
 import {
@@ -121,7 +120,6 @@ const OidcAuthenticator = forwardRef<AuthenticatorRef, Props>(
               <Redirect to={ROUTES.MY_DATA} />
             )}
           </Route>
-          <Route exact component={PageNotFound} path={ROUTES.NOT_FOUND} />
           {!isSigningIn ? (
             <Route exact component={SignInPage} path={ROUTES.SIGNIN} />
           ) : null}


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:


<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

This PR will fix the issue of the 404-page layout and will only show the 404-page content without the header and sidebar.

<img width="1437" alt="image" src="https://github.com/open-metadata/OpenMetadata/assets/59080942/912b089b-d133-4f72-b392-cc88b62e9c0f">


<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] Improvement


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
