### PR TITLE
MINOR: Fix issue with SQLAlchemy types not being correctly mapped to OM Type on the profiler

### DIFF
--- a/ingestion/src/metadata/profiler/processor/metric_filter.py
+++ b/ingestion/src/metadata/profiler/processor/metric_filter.py
@@ -168,7 +168,9 @@ class MetricFilter:
         if not isinstance(column, SQALikeColumn):
             mapper = converter_registry[service_type]
             sqa_to_om_types = mapper.map_sqa_to_om_types()
-            om_data_types: Optional[Set] = sqa_to_om_types.get(column.type.__class__, None)
+            om_data_types: Optional[Set] = sqa_to_om_types.get(
+                column.type.__class__, None
+            )
         else:
             om_data_types = {column.type}
 

--- a/ingestion/src/metadata/profiler/processor/metric_filter.py
+++ b/ingestion/src/metadata/profiler/processor/metric_filter.py
@@ -168,7 +168,7 @@ class MetricFilter:
         if not isinstance(column, SQALikeColumn):
             mapper = converter_registry[service_type]
             sqa_to_om_types = mapper.map_sqa_to_om_types()
-            om_data_types: Optional[Set] = sqa_to_om_types.get(column.type, None)
+            om_data_types: Optional[Set] = sqa_to_om_types.get(column.type.__class__, None)
         else:
             om_data_types = {column.type}
 

--- a/ingestion/tests/integration/profiler/test_sqa_profiler.py
+++ b/ingestion/tests/integration/profiler/test_sqa_profiler.py
@@ -112,7 +112,7 @@ class TestSQAProfiler(TestCase):
 
         tables: List[Table] = self.metadata.list_all_entities(Table)
         for table in tables:
-            if table.name != "users":
+            if table.name.__root__ != "users":
                 continue
             table = self.metadata.get_latest_table_profile(table.fullyQualifiedName)
             columns = table.columns
@@ -162,7 +162,7 @@ class TestSQAProfiler(TestCase):
 
         tables: List[Table] = self.metadata.list_all_entities(Table)
         for table in tables:
-            if table.name != "users":
+            if table.name.__root__ != "users":
                 continue
             table = self.metadata.get_latest_table_profile(table.fullyQualifiedName)
             columns = table.columns


### PR DESCRIPTION


<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

The Profiler global settings is not mapping properly SQLAlchemy Types to OM Types.
This PR aims to solve this issue.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
