### PR TITLE
Minor: make password and username field non required in email config form

### DIFF
--- a/openmetadata-spec/src/main/resources/json/schema/email/smtpSettings.json
+++ b/openmetadata-spec/src/main/resources/json/schema/email/smtpSettings.json
@@ -52,5 +52,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["serverEndpoint", "serverPort", "username", "password", "senderMail", "openMetadataUrl"]
+  "required": ["serverEndpoint", "serverPort", "senderMail", "openMetadataUrl"]
 }

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Email/EmailConfigForm/EmailConfigForm.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Email/EmailConfigForm/EmailConfigForm.component.tsx
@@ -55,10 +55,7 @@ function EmailConfigForm({
         rules={[{ required: true }]}>
         <Input data-testid="username-input" id="root/username" />
       </Item>
-      <Item
-        label={t('label.password')}
-        name="password"
-        rules={[{ required: true }]}>
+      <Item label={t('label.password')} name="password">
         <Input
           data-testid="password-input"
           id="root/password"

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Email/EmailConfigForm/EmailConfigForm.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Email/EmailConfigForm/EmailConfigForm.component.tsx
@@ -49,10 +49,7 @@ function EmailConfigForm({
       validateMessages={VALIDATION_MESSAGES}
       onFinish={onSubmit}
       onFocus={onFocus}>
-      <Item
-        label={t('label.username')}
-        name="username"
-        rules={[{ required: true }]}>
+      <Item label={t('label.username')} name="username">
         <Input data-testid="username-input" id="root/username" />
       </Item>
       <Item label={t('label.password')} name="password">

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Email/EmailConfigForm/EmailConfigForm.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Email/EmailConfigForm/EmailConfigForm.test.tsx
@@ -145,13 +145,14 @@ describe('Email Config Form Component', () => {
     expect(mockOnSubmit).not.toHaveBeenCalled();
   });
 
-  it('should call onSubmit if password is not filled', async () => {
+  it('should call onSubmit if password and username is not filled', async () => {
     render(
       <EmailConfigForm
         {...mockProps}
         emailConfigValues={{
           ...emailConfigValues,
           password: '',
+          username: '',
         }}
       />
     );
@@ -163,6 +164,7 @@ describe('Email Config Form Component', () => {
     expect(mockOnSubmit).toHaveBeenCalledWith({
       ...emailConfigValues,
       password: '',
+      username: '',
     });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Email/EmailConfigForm/EmailConfigForm.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Email/EmailConfigForm/EmailConfigForm.test.tsx
@@ -144,4 +144,25 @@ describe('Email Config Form Component', () => {
 
     expect(mockOnSubmit).not.toHaveBeenCalled();
   });
+
+  it('should call onSubmit if password is not filled', async () => {
+    render(
+      <EmailConfigForm
+        {...mockProps}
+        emailConfigValues={{
+          ...emailConfigValues,
+          password: '',
+        }}
+      />
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('label.submit'));
+    });
+
+    expect(mockOnSubmit).toHaveBeenCalledWith({
+      ...emailConfigValues,
+      password: '',
+    });
+  });
 });


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:



<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on making the password and username fields non-required in the email config form.
<img width="1440" alt="image" src="https://github.com/open-metadata/OpenMetadata/assets/59080942/2cab3356-a064-43b7-a130-cf7af583d7f8">



<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] Improvement

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
