### PR TITLE
Minor: disable time, dateTime and timeInterval custom property type from UI

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/cypress/common/Utils/CustomProperty.ts
+++ b/openmetadata-ui/src/main/resources/ui/cypress/common/Utils/CustomProperty.ts
@@ -40,7 +40,7 @@ export enum CustomPropertyTypeByName {
   ENUM = 'enum',
   SQL_QUERY = 'sqlQuery',
   TIMESTAMP = 'timestamp',
-  TIME_INTERVAL = 'timeInterval',
+  // TIME_INTERVAL = 'timeInterval',
 }
 
 export interface CustomProperty {
@@ -108,11 +108,11 @@ export const getPropertyValues = (type: string) => {
         value: '1710831125922',
         newValue: '1710831125923',
       };
-    case 'timeInterval':
-      return {
-        value: '1710831125922,1710831125923',
-        newValue: '1710831125923,1710831125924',
-      };
+    // case 'timeInterval':
+    //   return {
+    //     value: '1710831125922,1710831125923',
+    //     newValue: '1710831125923,1710831125924',
+    //   };
 
     default:
       return {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/CustomProperty/AddCustomProperty/AddCustomProperty.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/CustomProperty/AddCustomProperty/AddCustomProperty.tsx
@@ -14,7 +14,7 @@
 import { Button, Col, Form, Row } from 'antd';
 import { AxiosError } from 'axios';
 import { t } from 'i18next';
-import { isUndefined, map, omit, omitBy, startCase } from 'lodash';
+import { isUndefined, omit, omitBy, startCase } from 'lodash';
 import React, {
   FocusEvent,
   useCallback,
@@ -24,6 +24,7 @@ import React, {
 } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import {
+  DISABLED_PROPERTY_TYPES,
   ENTITY_REFERENCE_OPTIONS,
   PROPERTY_TYPES_WITH_ENTITY_REFERENCE,
   PROPERTY_TYPES_WITH_FORMAT,
@@ -56,6 +57,8 @@ import { showErrorToast } from '../../../../utils/ToastUtils';
 import ResizablePanels from '../../../common/ResizablePanels/ResizablePanels';
 import ServiceDocPanel from '../../../common/ServiceDocPanel/ServiceDocPanel';
 import TitleBreadcrumb from '../../../common/TitleBreadcrumb/TitleBreadcrumb.component';
+
+type PropertyType = { key: string; label: string; value: string | undefined };
 
 const AddCustomProperty = () => {
   const [form] = Form.useForm();
@@ -94,11 +97,20 @@ const AddCustomProperty = () => {
   );
 
   const propertyTypeOptions = useMemo(() => {
-    return map(propertyTypes, (type) => ({
-      key: type.name,
-      label: startCase(type.displayName ?? type.name),
-      value: type.id,
-    }));
+    return propertyTypes.reduce((acc: PropertyType[], type) => {
+      if (DISABLED_PROPERTY_TYPES.includes(type.name)) {
+        return acc;
+      }
+
+      return [
+        ...acc,
+        {
+          key: type.name,
+          label: startCase(type.displayName ?? type.name),
+          value: type.id,
+        },
+      ];
+    }, []);
   }, [propertyTypes]);
 
   const { hasEnumConfig, hasFormatConfig, hasEntityReferenceConfig } =

--- a/openmetadata-ui/src/main/resources/ui/src/constants/CustomProperty.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/CustomProperty.constants.ts
@@ -12,6 +12,8 @@
  */
 export const PROPERTY_TYPES_WITH_FORMAT = ['date', 'dateTime'];
 
+export const DISABLED_PROPERTY_TYPES = ['time', 'dateTime', 'timeInterval'];
+
 export const PROPERTY_TYPES_WITH_ENTITY_REFERENCE = [
   'entityReference',
   'entityReferenceList',


### PR DESCRIPTION


<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:


<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on disabling the following custom property types
- time
- dateTime
- timeInterval

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] Improvement


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
