### PR TITLE
MINOR: Remove duplicated code in S3Source

### DIFF
--- a/ingestion/src/metadata/ingestion/source/storage/s3/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/storage/s3/metadata.py
@@ -126,10 +126,7 @@ class S3Source(StorageServiceSource):
                         # ingest all the relevant valid paths from it
                         yield from self._generate_structured_containers(
                             bucket_response=bucket_response,
-                            entries=self._manifest_entries_to_metadata_entries_by_container(
-                                container_name=bucket_name,
-                                manifest=self.global_manifest,
-                            ),
+                            entries=manifest_entries_for_current_bucket,
                             parent=parent_entity,
                         )
                         # nothing else do to for the current bucket, skipping to the next
@@ -142,23 +139,6 @@ class S3Source(StorageServiceSource):
                         entries=metadata_config.entries,
                         parent=parent_entity,
                     )
-                    for metadata_entry in metadata_config.entries:
-                        logger.info(
-                            f"Extracting metadata from path {metadata_entry.dataPath.strip(KEY_SEPARATOR)} "
-                            f"and generating structured container"
-                        )
-                        structured_container: Optional[
-                            S3ContainerDetails
-                        ] = self._generate_container_details(
-                            bucket_response=bucket_response,
-                            metadata_entry=metadata_entry,
-                            parent=EntityReference(
-                                id=self._bucket_cache[bucket_response.name].id.__root__,
-                                type="container",
-                            ),
-                        )
-                        if structured_container:
-                            yield structured_container
 
             except ValidationError as err:
                 self.status.failed(


### PR DESCRIPTION
### Remove duplicated code in S3Source

Fixes an issue of duplicated code in `S3Source.get_containers`.

I initially thought I was blind in that I did not see the difference between `_generate_structured_containers` and the for loop below it. Turns out the code was indeed identical!

The commit 5d8457b597dfc2e38aebce4431f0798798cf492a (#12017) introduced `_generate_structured_containers` which refactored the `for metadata_entry in metadata_config.entries` loop etc, but it looks like the original implementation was left in place.

This PR simply removes the duplicated code (and reuses the `manifest_entries_for_current_bucket` in the block above).



### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
