### PR TITLE
fix the glossary terms not showing when expand click

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/cypress/e2e/Pages/Glossary.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/cypress/e2e/Pages/Glossary.spec.ts
@@ -1318,8 +1318,14 @@ describe('Glossary page should work properly', { tags: 'Governance' }, () => {
       NEW_GLOSSARY_TERMS.term_2.name,
       NEW_GLOSSARY_TERMS.term_1.name
     );
-    // verify the term is moved under the parent term
-    cy.get('[data-testid="expand-collapse-all-button"]').click();
+
+    // clicking on the expand icon to view the child term
+    cy.get(
+      `[data-row-key=${Cypress.$.escapeSelector(
+        NEW_GLOSSARY_TERMS.term_1.fullyQualifiedName
+      )}] [data-testid="expand-icon"] > svg`
+    ).click();
+
     cy.get(
       `.ant-table-row-level-1[data-row-key="${Cypress.$.escapeSelector(
         NEW_GLOSSARY_TERMS.term_1.fullyQualifiedName

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/AsyncSelectList/TreeAsyncSelectList.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/AsyncSelectList/TreeAsyncSelectList.tsx
@@ -188,7 +188,8 @@ const TreeAsyncSelectList: FC<Omit<AsyncSelectListProps, 'fetchOptions'>> = ({
           ...searchOptions,
           ...(initialOptions ?? []),
         ] as ModifiedGlossaryTerm[],
-        value
+        value,
+        false
       );
 
       return initialData

--- a/openmetadata-ui/src/main/resources/ui/src/utils/GlossaryUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/GlossaryUtils.tsx
@@ -148,17 +148,23 @@ export const getGlossaryBreadcrumbs = (fqn: string) => {
   return breadcrumbList;
 };
 
+// This function finds and gives you the glossary term you're looking for.
+// You can then use this term or update its information in the Glossary or Term with it's reference created
+// Reference will only be created if withReference is true
 export const findGlossaryTermByFqn = (
   list: ModifiedGlossaryTerm[],
-  fullyQualifiedName: string
+  fullyQualifiedName: string,
+  withReference = true
 ): GlossaryTerm | Glossary | ModifiedGlossary | null => {
   for (const item of list) {
     if ((item.fullyQualifiedName ?? item.value) === fullyQualifiedName) {
-      return {
-        ...item,
-        fullyQualifiedName: item.fullyQualifiedName ?? item.data?.tagFQN,
-        ...(item.data ?? {}),
-      };
+      return withReference
+        ? item
+        : {
+            ...item,
+            fullyQualifiedName: item.fullyQualifiedName ?? item.data?.tagFQN,
+            ...(item.data ?? {}),
+          };
     }
     if (item.children) {
       const found = findGlossaryTermByFqn(


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:


<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

- I worked on fixing the glossary terms not showing when the expand click

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

Issue :   


https://github.com/open-metadata/OpenMetadata/assets/66266464/e934615d-2450-48db-a94d-208b5e9eb06b


Resolved : 

https://github.com/open-metadata/OpenMetadata/assets/66266464/2bc0b34c-a56c-4c51-88f8-321d441467b0




#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
