### PR TITLE
Minor: add query_filter for filtering bots

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetAsyncSelectList/DataAssetAsyncSelectList.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetAsyncSelectList/DataAssetAsyncSelectList.test.tsx
@@ -262,11 +262,15 @@ describe('DataAssetAsyncSelectList', () => {
     expect(screen.getByText('Test')).toBeInTheDocument();
   });
 
-  it('searchQuery should be called with filter isBot:false when search index is user', async () => {
+  it('searchQuery should be called with queryFilter', async () => {
     const mockSearchQuery = searchQuery as jest.Mock;
     mockSearchQuery.mockImplementationOnce((params) => {
       expect(params).toEqual(
-        expect.objectContaining({ filters: 'isBot:false' })
+        expect.objectContaining({
+          queryFilter: {
+            query: { bool: { must_not: [{ match: { isBot: true } }] } },
+          },
+        })
       );
 
       return Promise.resolve(mockUserData.data);
@@ -277,52 +281,6 @@ describe('DataAssetAsyncSelectList', () => {
         mode="multiple"
         searchIndex={SearchIndex.USER}
       />
-    );
-
-    await act(async () => {
-      toggleOpen(container);
-    });
-
-    expect(searchQuery).toHaveBeenCalledTimes(1);
-  });
-
-  it('searchQuery should be called with filter isBot:false when search index includes user', async () => {
-    const indexes = ['user', 'team', 'user_search_index'].join(
-      ','
-    ) as SearchIndex;
-    const mockSearchQuery = searchQuery as jest.Mock;
-    mockSearchQuery.mockImplementationOnce((params) => {
-      expect(params).toEqual(
-        expect.objectContaining({ filters: 'isBot:false' })
-      );
-
-      return Promise.resolve(mockUserData.data);
-    });
-
-    const { container } = render(
-      <DataAssetAsyncSelectList mode="multiple" searchIndex={indexes} />
-    );
-
-    await act(async () => {
-      toggleOpen(container);
-    });
-
-    expect(searchQuery).toHaveBeenCalledTimes(1);
-  });
-
-  it("searchQuery should not be called with filter isBot:false when search index doesn't include user", async () => {
-    const indexes = ['team', 'glossary'].join(',') as SearchIndex;
-    const mockSearchQuery = searchQuery as jest.Mock;
-    mockSearchQuery.mockImplementationOnce((params) => {
-      expect(params).not.toEqual(
-        expect.objectContaining({ filters: 'isBot:false' })
-      );
-
-      return Promise.resolve(mockUserData.data);
-    });
-
-    const { container } = render(
-      <DataAssetAsyncSelectList mode="multiple" searchIndex={indexes} />
     );
 
     await act(async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetAsyncSelectList/DataAssetAsyncSelectList.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetAsyncSelectList/DataAssetAsyncSelectList.tsx
@@ -67,12 +67,11 @@ const DataAssetAsyncSelectList: FC<DataAssetAsyncSelectListProps> = ({
         query: searchQueryParam ? `*${searchQueryParam}*` : '*',
         pageNumber: page,
         pageSize: pageSize,
-        queryFilter: {},
         searchIndex: searchIndex,
         // Filter out bots from user search
-        ...(searchIndex === SearchIndex.USER || searchIndex.includes('user')
-          ? { filters: 'isBot:false' }
-          : {}),
+        queryFilter: {
+          query: { bool: { must_not: [{ match: { isBot: true } }] } },
+        },
       });
 
       const hits = dataAssetsResponse.hits.hits;
@@ -132,8 +131,9 @@ const DataAssetAsyncSelectList: FC<DataAssetAsyncSelectListProps> = ({
       let label;
       if (
         searchIndex === SearchIndex.USER ||
-        searchIndex.includes('user') ||
-        searchIndex.includes('team')
+        searchIndex === SearchIndex.TEAM ||
+        reference.type === EntityType.USER ||
+        reference.type === EntityType.TEAM
       ) {
         label = (
           <Space>


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:


<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

Earlier we were sending queries like this which caused the issue we were only getting back the user and team results.

```
q: * AND isBot:false
index: user,tag,searchIndex,team,database
from: 0
size: 10
```

To fix the issue now we will be using query_filter to filter out the bots
```
query_filter: {"query":{"bool":{"must_not":[{"match":{"isBot":true}}]}}}
```

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->


https://github.com/open-metadata/OpenMetadata/assets/59080942/ce9116b6-7b04-4770-8f9f-ca27e57645dc



#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] Improvement


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
