### PR TITLE
#10502 Show dbt node fields in the UI

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableDetailsPageV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableDetailsPageV1.test.tsx
@@ -305,6 +305,54 @@ describe('TestDetailsPageV1 component', () => {
     expect(screen.queryByText('label.view-definition')).not.toBeInTheDocument();
   });
 
+  it('TableDetailsPageV1 should dbt tab for rawSql, when sql is empty', async () => {
+    (usePermissionProvider as jest.Mock).mockImplementationOnce(() => ({
+      getEntityPermissionByFqn: jest.fn().mockImplementationOnce(() => ({
+        ViewBasic: true,
+      })),
+    }));
+
+    (getTableDetailsByFQN as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        name: 'test',
+        id: '123',
+        tableFqn: 'fqn',
+        dataModel: { sql: '', rawSql: 'rawSql' },
+      })
+    );
+
+    await act(async () => {
+      render(<TableDetailsPageV1 />);
+    });
+
+    expect(await screen.findByText('label.dbt-lowercase')).toBeInTheDocument();
+    expect(screen.queryByText('label.view-definition')).not.toBeInTheDocument();
+  });
+
+  it('TableDetailsPageV1 should dbt tab for rawSql, when there is no sql available', async () => {
+    (usePermissionProvider as jest.Mock).mockImplementationOnce(() => ({
+      getEntityPermissionByFqn: jest.fn().mockImplementationOnce(() => ({
+        ViewBasic: true,
+      })),
+    }));
+
+    (getTableDetailsByFQN as jest.Mock).mockImplementationOnce(() =>
+      Promise.resolve({
+        name: 'test',
+        id: '123',
+        tableFqn: 'fqn',
+        dataModel: { rawSql: 'rawSql' },
+      })
+    );
+
+    await act(async () => {
+      render(<TableDetailsPageV1 />);
+    });
+
+    expect(await screen.findByText('label.dbt-lowercase')).toBeInTheDocument();
+    expect(screen.queryByText('label.view-definition')).not.toBeInTheDocument();
+  });
+
   it('TableDetailsPageV1 should render schema definition tab table type is not view', async () => {
     (usePermissionProvider as jest.Mock).mockImplementationOnce(() => ({
       getEntityPermissionByFqn: jest.fn().mockImplementationOnce(() => ({
@@ -325,6 +373,7 @@ describe('TestDetailsPageV1 component', () => {
     });
 
     expect(screen.getByText('label.schema-definition')).toBeInTheDocument();
+    expect(screen.queryByText('label.dbt-lowercase')).not.toBeInTheDocument();
   });
 
   it('TableDetailsPageV1 should render view definition tab if table type is view', async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableDetailsPageV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableDetailsPageV1.tsx
@@ -14,7 +14,7 @@ import { Col, Row, Space, Tabs, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import classNames from 'classnames';
 import { compare } from 'fast-json-patch';
-import { isEmpty, isEqual, isUndefined } from 'lodash';
+import { get, isEmpty, isEqual, isUndefined } from 'lodash';
 import { EntityTags } from 'Models';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -733,15 +733,14 @@ const TableDetailsPageV1: React.FC = () => {
           <TabsLabel id={EntityTabs.DBT} name={t('label.dbt-lowercase')} />
         ),
         isHidden: !(
-          tableDetails?.dataModel?.sql ?? tableDetails?.dataModel?.rawSql
+          tableDetails?.dataModel?.sql || tableDetails?.dataModel?.rawSql
         ),
         key: EntityTabs.DBT,
         children: (
           <QueryViewer
             sqlQuery={
-              tableDetails?.dataModel?.sql ??
-              tableDetails?.dataModel?.rawSql ??
-              ''
+              get(tableDetails, 'dataModel.sql', '') ||
+              get(tableDetails, 'dataModel.rawSql', '')
             }
             title={
               <Space className="p-y-xss">


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #10502

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

#10502 Show dbt node fields in the UI

I've made changes to display the dbt tab for rawSql, even when the SQL query is empty. Additionally, I've added unit tests for these modifications.

Scenario Checked:
- When there is SQL and rawSql present, the SQL query is displayed in the DBT tab.
- When SQL is empty or not present but rawSql is present, the rawSql is displayed in the DBT tab.
- When both SQL and rawSql are not present, the DBT tab is not displayed.

<img width="1440" alt="image" src="https://github.com/open-metadata/OpenMetadata/assets/71748675/2b5e2ddf-6cd3-45d4-96d2-ab79f2493c33">
<img width="1440" alt="image" src="https://github.com/open-metadata/OpenMetadata/assets/71748675/50147cdd-a731-4bcd-9c5f-ff81bcb9edff">
<img width="1440" alt="image" src="https://github.com/open-metadata/OpenMetadata/assets/71748675/4b4cf154-c1e8-4a21-84d8-305c7d7f07d1">


<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
