### PR TITLE
Fix OpenLineage ingestor

### DIFF
--- a/ingestion/src/metadata/ingestion/source/pipeline/openlineage/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/openlineage/metadata.py
@@ -77,7 +77,7 @@ class OpenlineageSource(PipelineServiceSource):
     """
 
     @classmethod
-    def create(cls, config_dict, metadata: OpenMetadata):
+    def create(cls, config_dict, metadata: OpenMetadata, pipeline_name: Optional[str] = None):
         """Create class instance"""
         config: WorkflowSource = WorkflowSource.parse_obj(config_dict)
         connection: OpenLineageConnection = config.serviceConnection.__root__.config
@@ -379,7 +379,7 @@ class OpenlineageSource(PipelineServiceSource):
             {json.dumps(pipeline_details.run_facet, indent=4).strip()}```"""
             request = CreatePipelineRequest(
                 name=pipeline_name,
-                service=self.context.pipeline_service,
+                service=self.context.get().pipeline_service,
                 description=description,
             )
 
@@ -433,8 +433,8 @@ class OpenlineageSource(PipelineServiceSource):
         pipeline_fqn = fqn.build(
             metadata=self.metadata,
             entity_type=Pipeline,
-            service_name=self.context.pipeline_service,
-            pipeline_name=self.context.pipeline,
+            service_name=self.context.get().pipeline_service,
+            pipeline_name=self.context.get().pipeline,
         )
 
         pipeline_entity = self.metadata.get_by_name(entity=Pipeline, fqn=pipeline_fqn)

--- a/ingestion/src/metadata/ingestion/source/pipeline/openlineage/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/openlineage/metadata.py
@@ -77,7 +77,9 @@ class OpenlineageSource(PipelineServiceSource):
     """
 
     @classmethod
-    def create(cls, config_dict, metadata: OpenMetadata, pipeline_name: Optional[str] = None):
+    def create(
+        cls, config_dict, metadata: OpenMetadata, pipeline_name: Optional[str] = None
+    ):
         """Create class instance"""
         config: WorkflowSource = WorkflowSource.parse_obj(config_dict)
         connection: OpenLineageConnection = config.serviceConnection.__root__.config


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

OpenLineage ingestion wasn't updated to include changes from #15201 and #15130. Ingestion failed with errors like:
```
[2024-05-24, 15:14:18 UTC] {taskinstance.py:1937} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/operators/python.py", line 192, in execute
    return_value = self.execute_callable()
  File "/home/airflow/.local/lib/python3.10/site-packages/airflow/operators/python.py", line 209, in execute_callable
    return self.python_callable(*self.op_args, **self.op_kwargs)
  File "/home/airflow/.local/lib/python3.10/site-packages/openmetadata_managed_apis/workflows/ingestion/common.py", line 207, in metadata_ingestion_workflow
    workflow = MetadataWorkflow.create(config)
  File "/home/airflow/.local/lib/python3.10/site-packages/metadata/workflow/ingestion.py", line 103, in create
    return cls(config)
  File "/home/airflow/.local/lib/python3.10/site-packages/metadata/workflow/ingestion.py", line 79, in __init__
    super().__init__(
  File "/home/airflow/.local/lib/python3.10/site-packages/metadata/workflow/base.py", line 107, in __init__
    self.post_init()
  File "/home/airflow/.local/lib/python3.10/site-packages/metadata/workflow/ingestion.py", line 98, in post_init
    self.set_steps()
  File "/home/airflow/.local/lib/python3.10/site-packages/metadata/workflow/metadata.py", line 35, in set_steps
    self.source = self._get_source()
  File "/home/airflow/.local/lib/python3.10/site-packages/metadata/workflow/metadata.py", line 66, in _get_source
    source: Source = source_class.create(
TypeError: OpenlineageSource.create() takes 3 positional arguments but 4 were given
```

```
[2024-05-24, 14:00:05 UTC] {step.py:230} WARNING - Object type defined in `def _iter()` /home/airflow/.local/lib/python3.10/site-packages/metadata/ingestion/api/topology_runner.py is not an Either: ['TopologyContextManager' object has no attribute 'pipeline']
[2024-05-24, 14:00:05 UTC] {status.py:76} WARNING - Object type defined in `def _iter()` /home/airflow/.local/lib/python3.10/site-packages/metadata/ingestion/api/topology_runner.py is not an Either: ['TopologyContextManager' object has no attribute 'pipeline']
```

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

Updated OpenLineage ingestor code to include changes from #15201 and #15130.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [X] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
