### PR TITLE
fix: Update CI to add `run-name`, remove trivial steps, `default_author: github_actions`

### DIFF
--- a/.github/workflows/git-create-release-branch.yml
+++ b/.github/workflows/git-create-release-branch.yml
@@ -1,4 +1,5 @@
 name: Create Release Branches
+run-name: Create Release Branch ${{ inputs.release_branch_name }}
 on:
   workflow_dispatch:
     inputs:
@@ -20,26 +21,13 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ inputs.base_branch_name }}
-    - name: Set up JDK 17
-      uses: actions/setup-java@v3
-      with:
-        java-version: 17
-        distribution: 'temurin'
-    - name: Install antlr cli
-      run: |
-        sudo make install_antlr_cli
-    - name: Setup jq
-      run: |
-        sudo apt-get update
-        sudo apt-get install jq
     - name: Update application versions
       run: |
         make update_all RELEASE_VERSION=${{ inputs.release_branch_name }}
     - name: Commit changes to ${{ inputs.release_branch_name }} branch
       uses: EndBug/add-and-commit@v9
       with:
-        author_name: ${{ github.actor }}
-        author_email: ${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com
+        default_author: github_actions
         message: 'chore(release): Prepare Branch for `${{ inputs.release_branch_name }}`'
         add: '.'
         new_branch: ${{ inputs.release_branch_name }}


### PR DESCRIPTION
Update CI Workflow for Creating Github Release Branches.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
