### PR TITLE
Fixes 13814 - Added DataProduct support for Glossary and GlossaryTerm.

### DIFF
--- a/openmetadata-spec/src/main/resources/json/schema/entity/data/glossary.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/data/glossary.json
@@ -97,6 +97,10 @@
       "description": "Domain the Glossary belongs to.",
       "$ref": "../../type/entityReference.json"
     },
+    "dataProducts" : {
+      "description": "List of data products this entity is part of.",
+      "$ref" : "../../type/entityReferenceList.json"
+    },
     "votes" : {
       "$ref": "../../type/votes.json"
     },

--- a/openmetadata-spec/src/main/resources/json/schema/entity/data/glossaryTerm.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/data/glossaryTerm.json
@@ -151,6 +151,10 @@
       "description": "Domain the Glossary Term belongs to. When not set, the Glossary TErm inherits the domain from the Glossary it belongs to.",
       "$ref": "../../type/entityReference.json"
     },
+    "dataProducts" : {
+      "description": "List of data products this entity is part of.",
+      "$ref" : "../../type/entityReferenceList.json"
+    },
     "votes" : {
       "$ref": "../../type/votes.json"
     },


### PR DESCRIPTION
Fixes 13814
I checked that all the entities have DataProduct support where the domain is present, except for Glossary and GlossaryTerm.


<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
