### PR TITLE
FIX - e2e test for pydantic v2

### DIFF
--- a/ingestion/src/metadata/ingestion/source/dashboard/metabase/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/metabase/metadata.py
@@ -148,7 +148,7 @@ class MetabaseSource(DashboardServiceSource):
                 f"{replace_special_with(raw=dashboard_details.name.lower(), replacement='-')}"
             )
             dashboard_request = CreateDashboardRequest(
-                name=EntityName(dashboard_details.id),
+                name=EntityName(str(dashboard_details.id)),
                 sourceUrl=SourceUrl(dashboard_url),
                 displayName=dashboard_details.name,
                 description=Markdown(dashboard_details.description)

--- a/ingestion/src/metadata/ingestion/source/dashboard/metabase/models.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/metabase/models.py
@@ -33,7 +33,7 @@ class MetabaseCollection(BaseModel):
     """
 
     name: str
-    id: str
+    id: int
 
 
 class MetabaseDashboardList(BaseModel):

--- a/ingestion/src/metadata/ingestion/source/dashboard/redash/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/redash/metadata.py
@@ -158,7 +158,7 @@ class RedashSource(DashboardServiceSource):
                 dashboard_description = widgets.get("text")
 
             dashboard_request = CreateDashboardRequest(
-                name=EntityName(dashboard_details["id"]),
+                name=EntityName(str(dashboard_details["id"])),
                 displayName=dashboard_details.get("name"),
                 description=Markdown(dashboard_description)
                 if dashboard_description
@@ -274,7 +274,7 @@ class RedashSource(DashboardServiceSource):
                     continue
                 yield Either(
                     right=CreateChartRequest(
-                        name=EntityName(widgets["id"]),
+                        name=EntityName(str(widgets["id"])),
                         displayName=chart_display_name
                         if visualization and visualization["query"]
                         else "",

--- a/ingestion/src/metadata/ingestion/source/database/dbt/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/metadata.py
@@ -446,7 +446,7 @@ class DbtSource(DbtServiceSource):
                                 if dbt_raw_query
                                 else None,
                                 # SQL Is a required param for the DataModel
-                                sql=SqlQuery(dbt_compiled_query or dbt_raw_query),
+                                sql=SqlQuery(dbt_compiled_query or dbt_raw_query or ""),
                                 columns=self.parse_data_model_columns(
                                     manifest_node, catalog_node
                                 ),


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes

### Metabase

```
E           metadata.ingestion.connections.test_connections.SourceConnectionException: Some steps failed when testing 
the connection: [failed=["'GetDashboards': This is a mandatory step and we won't be able to extract neces***ry 
metadata. Failed due to: 1 validation error for MetabaseCollectionList\ncollections.1.id\n  Input should be a valid string 
[type=string_type, input_value=1, input_type=int]\n    For further information visit 
[https://errors.pydantic.***/2.7/v/string_type](https://errors.pydantic.%2A%2A%2A/2.7/v/string_type)"] success=[] 
warning=[]]
```

### Redash

```
1 validation error for EntityName
E             Input should be a valid string [type=string_type, input_value=5, input_type=int]
E               For further information visit [https://errors.pydantic.***/2.7/v/string_type](https://errors.pydantic.%2A%2A%2A/2.7/v/string_type)
E           [2024-06-08 10:29:15] DEBUG    {metadata.Ingestion:status:76} - Traceback (most recent call last):
E             File "/home/runner/work/***/***/env/lib/python3.9/site-packages/metadata/ingestion/source/dashboard/redash/metadata.py", line 277, in yield_dashboard_chart
E               name=EntityName(widgets["id"]),
E             File "/home/runner/work/***/***/env/lib/python3.9/site-packages/pydantic/root_model.py", line 71, in __init__
E               self.__pydantic_validator__.validate_python(root, self_instance=self)
E           pydantic_core._pydantic_core.ValidationError: 1 validation error for EntityName
E             Input should be a valid string [type=string_type, input_value=5, input_type=int]
E               For further information visit [https://errors.pydantic.***/2.7/v/string_type](https://errors.pydantic.%2A%2A%2A/2.7/v/string_type)
```

### Redshift dbt

Passing an empty string when generating the `sql` model. This is a temporary fix. @OnkarVO7 please go over the JSON Schema and check if we're ok leaving the `sql` of the datamodels as non-required, if we're not always able to pick it up

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
