### PR TITLE
Fixes 16595: Parse Iceberg REST table FQN from identifier

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/iceberg/catalog/rest.py
+++ b/ingestion/src/metadata/ingestion/source/database/iceberg/catalog/rest.py
@@ -37,7 +37,7 @@ class IcebergRestCatalog(IcebergCatalogBase):
                 "'connection' is not an instance of 'RestCatalogConnection'"
             )
 
-        if catalog.connection.credential:
+        if catalog.connection.credential and catalog.connection.credential.clientSecret:
             client_id = catalog.connection.credential.clientId.get_secret_value()
             client_secret = (
                 catalog.connection.credential.clientSecret.get_secret_value()

--- a/ingestion/src/metadata/ingestion/source/database/iceberg/helper.py
+++ b/ingestion/src/metadata/ingestion/source/database/iceberg/helper.py
@@ -37,14 +37,14 @@ def namespace_to_str(namespace: tuple[str]) -> str:
     return ".".join(namespace)
 
 
-def get_table_name_as_str(table: pyiceberg.table.Table) -> str:
-    """Returns the Table Name as String from a PyIceberg Table.
+def get_table_name_as_str(table_identifier: Tuple) -> str:
+    """Returns the Table Name as String from a PyIceberg table identifier tuple.
 
     The PyIceberg table name is returned as tuple and we turn them into a String
     concatenating the items with a '.' in between.
     """
     # We are skipping the first item because it is the schema name.
-    return ".".join(table.name()[1:])
+    return ".".join(table_identifier[1:])
 
 
 def get_column_from_partition(

--- a/ingestion/src/metadata/ingestion/source/database/iceberg/helper.py
+++ b/ingestion/src/metadata/ingestion/source/database/iceberg/helper.py
@@ -38,7 +38,7 @@ def namespace_to_str(namespace: tuple[str]) -> str:
 
 
 def get_table_name_as_str(table: pyiceberg.table.Table) -> str:
-    """Returns the Table Name as Tring from a PyIceberg Table.
+    """Returns the Table Name as String from a PyIceberg Table.
 
     The PyIceberg table name is returned as tuple and we turn them into a String
     concatenating the items with a '.' in between.
@@ -94,7 +94,7 @@ def get_column_partition_type(
 def get_owner_from_table(
     table: pyiceberg.table.Table, property_key: str
 ) -> Optional[str]:
-    """Retrives the owner information from given Table Property."""
+    """Retrieves the owner information from given Table Property."""
     return table.properties.get(property_key)
 
 

--- a/ingestion/src/metadata/ingestion/source/database/iceberg/helper.py
+++ b/ingestion/src/metadata/ingestion/source/database/iceberg/helper.py
@@ -37,14 +37,14 @@ def namespace_to_str(namespace: tuple[str]) -> str:
     return ".".join(namespace)
 
 
-def get_table_name_as_str(table_identifier: Tuple) -> str:
+def get_table_name_as_str(table: Tuple[str]) -> str:
     """Returns the Table Name as String from a PyIceberg table identifier tuple.
 
     The PyIceberg table name is returned as tuple and we turn them into a String
     concatenating the items with a '.' in between.
     """
     # We are skipping the first item because it is the schema name.
-    return ".".join(table_identifier[1:])
+    return ".".join(table[1:])
 
 
 def get_column_from_partition(

--- a/ingestion/src/metadata/ingestion/source/database/iceberg/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/iceberg/metadata.py
@@ -181,7 +181,7 @@ class IcebergSource(DatabaseServiceSource):
         for table_identifier in self.iceberg.list_tables(namespace):
             try:
                 table = self.iceberg.load_table(table_identifier)
-                table_name = get_table_name_as_str(table)
+                table_name = get_table_name_as_str(table_identifier)
                 table_fqn = fqn.build(
                     self.metadata,
                     entity_type=Table,

--- a/ingestion/src/metadata/ingestion/source/database/iceberg/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/iceberg/metadata.py
@@ -181,6 +181,7 @@ class IcebergSource(DatabaseServiceSource):
         for table_identifier in self.iceberg.list_tables(namespace):
             try:
                 table = self.iceberg.load_table(table_identifier)
+                # extract table name from table identifier, which does not include catalog name
                 table_name = get_table_name_as_str(table_identifier)
                 table_fqn = fqn.build(
                     self.metadata,

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/iceberg/restCatalogConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/iceberg/restCatalogConnection.json
@@ -30,11 +30,7 @@
           "format": "password"
         }
       },
-      "additionalProperties": false,
-      "required": [
-        "clientId",
-        "clientSecret"
-      ]
+      "additionalProperties": false
     },
     "token": {
       "title": "Token",


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes [16595](https://github.com/open-metadata/OpenMetadata/issues/16595)

Pass the Iceberg table identifier tuple to the [get_table_name_as_str() helper function](https://github.com/open-metadata/OpenMetadata/blob/1.4.1-release/ingestion/src/metadata/ingestion/source/database/iceberg/helper.py#L40-L47) to ensure the namespace/schema is properly stripped. 

Tables loaded using pyiceberg's [catalog.load_table()](https://github.com/open-metadata/OpenMetadata/blob/1.4.1-release/ingestion/src/metadata/ingestion/source/database/iceberg/metadata.py#L180) including the catalog name in the table identifier, whereas the [catalog.list_tables()](https://github.com/open-metadata/OpenMetadata/blob/1.4.1-release/ingestion/src/metadata/ingestion/source/database/iceberg/metadata.py#L178) does not. So the [get_table_name_as_str() helper function](https://github.com/open-metadata/OpenMetadata/blob/1.4.1-release/ingestion/src/metadata/ingestion/source/database/iceberg/helper.py#L40-L47) strips only the catalog name, leaving the namespace/schema name in the first case:

```python
>>> from pyiceberg.catalog import load_rest
>>> catalog = load_rest("my_catalog", {"uri": "..."})
>>> catalog.list_tables("my_namespace")
[('my_namespace', 'my_table')]
>>> table = catalog.load_table("my_namespace.my_table")
>>> table.name()
('my_catalog', 'my_namespace', 'my_table')
```

**Before change:**

```python
>>> get_table_name_as_str(table)
'my_namespace.my_table'
```

**After change:**

```python
>>> get_table_name_as_str(table_identifier)
'my_table'
```

Additionally, the Iceberg `RestCatalogConnection` schema is updated to not require OAuth credentials. Even though the `credential` property is not required, it contains properties (`clientId` and `clientSecret`) which _are_ required, and show up as such in the top-level config in the UI:

![Screenshot 2024-06-10 at 3 33 20 PM](https://github.com/open-metadata/OpenMetadata/assets/4731479/e588c91a-b294-4241-9c2d-500661aba7f1)

#
### Type of change:
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
