### PR TITLE
Fixes 16582: support SASL_SSL kafka auth for OpenLineage pipeline connector

### DIFF
--- a/ingestion/src/metadata/ingestion/source/pipeline/openlineage/connection.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/openlineage/connection.py
@@ -52,6 +52,15 @@ def get_connection(connection: OpenLineageConnection) -> KafkaConsumer:
                     "ssl.key.location": connection.sslConfig.root.sslKey,
                 }
             )
+        elif connection.securityProtocol.value == KafkaSecProtocol.SASL_SSL.value:
+            config.update(
+                {
+                    "security.protocol": connection.securityProtocol.value,
+                    "sasl.mechanism": connection.saslConfig.saslMechanism.value,
+                    "sasl.username": connection.saslConfig.saslUsername,
+                    "sasl.password": connection.saslConfig.saslPassword,
+                }
+            )
 
         kafka_consumer = KafkaConsumer(config)
         kafka_consumer.subscribe([connection.topicName])

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/pipeline/openLineageConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/pipeline/openLineageConnection.json
@@ -73,7 +73,8 @@
       "type": "string",
       "enum": [
         "PLAINTEXT",
-        "SSL"
+        "SSL",
+        "SASL_SSL"
       ],
       "javaEnums": [
         {
@@ -81,6 +82,9 @@
         },
         {
           "name": "SSL"
+        },
+        {
+          "name": "SASL_SSL"
         }
       ]
     },
@@ -88,6 +92,11 @@
       "title": "SSL",
       "description": "SSL Configuration details.",
       "$ref": "../../../../security/ssl/verifySSLConfig.json#/definitions/sslConfig"
+    },
+    "saslConfig": {
+      "title": "SASL",
+      "description": "SASL Configuration details.",
+      "$ref": "../../../../security/sasl/saslClientConfig.json"
     },
     "supportsMetadataExtraction": {
       "$ref": "../connectionBasicType.json#/definitions/supportsMetadataExtraction"

--- a/openmetadata-spec/src/main/resources/json/schema/security/sasl/saslClientConfig.json
+++ b/openmetadata-spec/src/main/resources/json/schema/security/sasl/saslClientConfig.json
@@ -1,0 +1,35 @@
+{
+  "$id": "https://open-metadata.org/schema/security/sasl/SASLClientConfig.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "SASL Client Config",
+  "description": "SASL client configuration.",
+  "type": "object",
+  "javaType": "org.openmetadata.schema.security.sasl.SASLClientConfig",
+  "additionalProperties": false,
+  "properties": {
+    "saslMechanism": {
+      "title": "SASL Mechanism",
+      "description": "SASL security mechanism",
+      "default": "PLAIN",
+      "type": "string",
+      "enum": [
+        "PLAIN"
+      ],
+      "javaEnums": [
+        {
+          "name": "PLAIN"
+        }
+      ]
+    },
+    "saslUsername": {
+      "title": "SASL Username",
+      "description": "The SASL authentication username.",
+      "type": "string"
+    },
+    "saslPassword": {
+      "title": "SASL Password",
+      "description": "The SASL authentication password.",
+      "type": "string"
+    }
+  }
+}

--- a/openmetadata-spec/src/main/resources/json/schema/security/sasl/saslClientConfig.json
+++ b/openmetadata-spec/src/main/resources/json/schema/security/sasl/saslClientConfig.json
@@ -10,16 +10,8 @@
     "saslMechanism": {
       "title": "SASL Mechanism",
       "description": "SASL security mechanism",
-      "default": "PLAIN",
-      "type": "string",
-      "enum": [
-        "PLAIN"
-      ],
-      "javaEnums": [
-        {
-          "name": "PLAIN"
-        }
-      ]
+      "$ref": "../../entity/services/connections/messaging/saslMechanismType.json",
+      "default": "PLAIN"
     },
     "saslUsername": {
       "title": "SASL Username",

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Pipeline/OpenLineage.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Pipeline/OpenLineage.md
@@ -59,7 +59,28 @@ $$section
 ### Kafka securityProtocol $(id="securityProtocol")
 Kafka Security protocol config.
 
-This should be specified as `PLAINTEXT` or `SSL` .
+This should be specified as `PLAINTEXT`, `SSL`, or `SASL_SSL` .
+$$
+
+$$section
+### Kafka SASL mechanism $(id="saslMechanism")
+When Kafka security protocol is set to `SASL_SSL` then the SASL mechanism is needed.
+
+This should be specified as `PLAIN` .
+$$
+
+$$section
+### Kafka SASL username $(id="saslUsername")
+When Kafka security protocol is set to `SASL_SSL` then the SASL username is needed.
+
+This should be specified as a username or API key string .
+$$
+
+$$section
+### Kafka SASL password $(id="saslPassword")
+When Kafka security protocol is set to `SASL_SSL` then the SASL password is needed.
+
+This should be specified as a password or API secret string .
 $$
 
 $$section


### PR DESCRIPTION
### Describe your changes:

Fixes [16582](https://github.com/open-metadata/OpenMetadata/issues/16582).

Update OpenLineage pipeline connector config to support `SASL_SSL` kafka client connections, for use with e.g. [Confluent Cloud](https://docs.confluent.io/kafka-clients/python/current/overview.html#id1) kafka clusters.

![Screenshot 2024-06-10 at 4 06 09 PM](https://github.com/open-metadata/OpenMetadata/assets/4731479/2ef1f14e-2259-4833-9414-9cb96c2bd35e)

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [x] For connector/ingestion changes: I updated the documentation.
