### PR TITLE
Minor: Fix incorrect alert on signup page

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamsSelectable/TeamsSelectable.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamsSelectable/TeamsSelectable.test.tsx
@@ -11,9 +11,10 @@
  *  limitations under the License.
  */
 
-import { fireEvent, render } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
+import { getTeamsHierarchy } from '../../../../rest/teamsAPI';
 import TeamsSelectable from './TeamsSelectable';
 
 const mockSelChange = jest.fn();
@@ -28,6 +29,7 @@ jest.mock('antd', () => ({
     .mockImplementation(({ onChange }) => (
       <div onClick={() => onChange([])}>TreeSelect.component</div>
     )),
+  Alert: jest.fn().mockImplementation(() => <div>Alert</div>),
 }));
 
 jest.mock('../../../../rest/teamsAPI', () => ({
@@ -70,5 +72,34 @@ describe('TeamsSelectable component test', () => {
 
     expect(treeSelect).toBeInTheDocument();
     expect(mockSelChange).toHaveBeenCalled();
+  });
+
+  it('should show no teams alert when API returns no data', async () => {
+    await act(async () => {
+      render(<TeamsSelectable {...mockProps} showTeamsAlert />, {
+        wrapper: MemoryRouter,
+      });
+    });
+
+    const noTeamsAlert = screen.getByText('Alert');
+
+    expect(noTeamsAlert).toBeInTheDocument();
+  });
+
+  it('should not show no teams alert when API returns teams data', async () => {
+    (getTeamsHierarchy as jest.Mock).mockImplementation(() =>
+      Promise.resolve({
+        data: [{ name: 'testTeam' }],
+      })
+    );
+    await act(async () => {
+      render(<TeamsSelectable {...mockProps} showTeamsAlert />, {
+        wrapper: MemoryRouter,
+      });
+    });
+
+    const noTeamsAlert = screen.queryByText('Alert');
+
+    expect(noTeamsAlert).toBeNull();
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamsSelectable/TeamsSelectable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamsSelectable/TeamsSelectable.tsx
@@ -55,9 +55,9 @@ const TeamsSelectable = ({
   const loadOptions = async () => {
     try {
       setIsLoading(true);
-      const res = await getTeamsHierarchy(filterJoinable);
-      setTeams(res.data);
-      showTeamsAlert && setNoTeam(isEmpty(res.data));
+      const { data } = await getTeamsHierarchy(filterJoinable);
+      setTeams(data);
+      showTeamsAlert && setNoTeam(isEmpty(data));
     } catch (error) {
       showErrorToast(error as AxiosError);
     } finally {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamsSelectable/TeamsSelectable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamsSelectable/TeamsSelectable.tsx
@@ -15,6 +15,7 @@ import { Alert, TreeSelect } from 'antd';
 import { BaseOptionType } from 'antd/lib/select';
 import { AxiosError } from 'axios';
 import { t } from 'i18next';
+import { isEmpty } from 'lodash';
 import React, { useEffect, useMemo, useState } from 'react';
 import { TeamHierarchy } from '../../../../generated/entity/teams/teamHierarchy';
 import { EntityReference } from '../../../../generated/entity/type';
@@ -56,7 +57,7 @@ const TeamsSelectable = ({
       setIsLoading(true);
       const res = await getTeamsHierarchy(filterJoinable);
       setTeams(res.data);
-      showTeamsAlert && setNoTeam(teams.length === 0);
+      showTeamsAlert && setNoTeam(isEmpty(res.data));
     } catch (error) {
       showErrorToast(error as AxiosError);
     } finally {


### PR DESCRIPTION
I worked on fixing the no teams alert showing all the time on signup page 

**Before:**

https://github.com/open-metadata/OpenMetadata/assets/51777795/a68fdb31-9946-4015-b047-c6e684049a5b

**After:**

https://github.com/open-metadata/OpenMetadata/assets/51777795/b53ab51d-a14f-446a-b657-2bb7edf23c25

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
