### PR TITLE
MINOR: Add method to list custom properties for a entity for python sdk

### DIFF
--- a/ingestion/src/metadata/ingestion/ometa/mixins/custom_property_mixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/custom_property_mixin.py
@@ -13,7 +13,9 @@ Mixin class containing Custom Property specific methods
 
 To be used by OpenMetadata class
 """
-from typing import Dict
+from typing import Dict, List, Optional, Type, TypeVar
+
+from pydantic import BaseModel
 
 from metadata.generated.schema.type.customProperty import PropertyType
 from metadata.generated.schema.type.entityReference import EntityReference
@@ -27,6 +29,8 @@ from metadata.utils.constants import ENTITY_REFERENCE_TYPE_MAP
 from metadata.utils.logger import ometa_logger
 
 logger = ometa_logger()
+
+T = TypeVar("T", bound=BaseModel)
 
 
 class OMetaCustomPropertyMixin:
@@ -76,3 +80,12 @@ class OMetaCustomPropertyMixin:
         """
         custom_property_type = self.get_custom_property_type(data_type=data_type)
         return PropertyType(EntityReference(id=custom_property_type.id, type="type"))
+
+    def get_entity_custom_properties(self, entity_type: Type[T]) -> Optional[List]:
+        """
+        Get all the custom properties of an entity
+        """
+        resp = self.client.get(
+            f"/metadata/types/name/{ENTITY_REFERENCE_TYPE_MAP.get(entity_type.__name__)}?fields=customProperties"
+        )
+        return resp.get("customProperties")

--- a/ingestion/tests/integration/ometa/test_ometa_custom_properties_api.py
+++ b/ingestion/tests/integration/ometa/test_ometa_custom_properties_api.py
@@ -326,22 +326,29 @@ class OMetaCustomAttributeTest(TestCase):
             entity_type=Table
         )
 
-        for i, custom_property in enumerate(custom_properties):
-            self.assertEquals(
-                custom_property["name"], EXPECTED_CUSTOM_PROPERTIES[i]["name"]
-            )
-            self.assertEquals(
-                custom_property["description"],
-                EXPECTED_CUSTOM_PROPERTIES[i]["description"],
-            )
-            self.assertEquals(
-                custom_property.get("customPropertyConfig"),
-                EXPECTED_CUSTOM_PROPERTIES[i].get("customPropertyConfig"),
-            )
-            self.assertEquals(
-                custom_property["propertyType"]["name"],
-                EXPECTED_CUSTOM_PROPERTIES[i]["propertyType"]["name"],
-            )
+        actual_custom_properties = []
+        for expected_custom_property in EXPECTED_CUSTOM_PROPERTIES:
+            for custom_property in custom_properties:
+                if expected_custom_property["name"] == custom_property["name"]:
+                    actual_custom_properties.append(custom_property)
+                    self.assertEquals(
+                        custom_property["name"], expected_custom_property["name"]
+                    )
+                    self.assertEquals(
+                        custom_property["description"],
+                        expected_custom_property["description"],
+                    )
+                    self.assertEquals(
+                        custom_property.get("customPropertyConfig"),
+                        expected_custom_property.get("customPropertyConfig"),
+                    )
+                    self.assertEquals(
+                        custom_property["propertyType"]["name"],
+                        expected_custom_property["propertyType"]["name"],
+                    )
+        self.assertEquals(
+            len(actual_custom_properties), len(EXPECTED_CUSTOM_PROPERTIES)
+        )
 
     def test_add_custom_property_table(self):
         """

--- a/ingestion/tests/integration/ometa/test_ometa_custom_properties_api.py
+++ b/ingestion/tests/integration/ometa/test_ometa_custom_properties_api.py
@@ -61,6 +61,46 @@ from metadata.ingestion.models.custom_properties import (
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.utils.constants import ENTITY_REFERENCE_TYPE_MAP
 
+EXPECTED_CUSTOM_PROPERTIES = [
+    {
+        "name": "DataEngineers",
+        "description": "Data Engineers of a table",
+        "propertyType": {
+            "name": "entityReferenceList",
+        },
+        "customPropertyConfig": {"config": ["user"]},
+    },
+    {
+        "name": "DataQuality",
+        "description": "Quality Details of a Table",
+        "propertyType": {
+            "name": "markdown",
+        },
+    },
+    {
+        "name": "Department",
+        "description": "Department of a table",
+        "propertyType": {
+            "type": "type",
+            "name": "enum",
+        },
+        "customPropertyConfig": {
+            "config": {"values": ["D1", "D2", "D3"], "multiSelect": True}
+        },
+    },
+    {
+        "name": "Rating",
+        "description": "Rating of a table",
+        "propertyType": {"name": "enum"},
+        "customPropertyConfig": {"config": {"values": ["Good", "Average", "Bad"]}},
+    },
+    {
+        "name": "TableSize",
+        "description": "Size of the Table",
+        "propertyType": {"name": "string"},
+    },
+]
+
 
 class OMetaCustomAttributeTest(TestCase):
     """
@@ -274,6 +314,34 @@ class OMetaCustomAttributeTest(TestCase):
         self.metadata.create_or_update_custom_property(
             ometa_custom_property=ometa_custom_property_request
         )
+
+    def test_get_custom_property(self):
+        """
+        Test getting the custom properties for an entity
+        """
+        # create the custom properties
+        self.create_custom_property()
+
+        custom_properties = self.metadata.get_entity_custom_properties(
+            entity_type=Table
+        )
+
+        for i, custom_property in enumerate(custom_properties):
+            self.assertEquals(
+                custom_property["name"], EXPECTED_CUSTOM_PROPERTIES[i]["name"]
+            )
+            self.assertEquals(
+                custom_property["description"],
+                EXPECTED_CUSTOM_PROPERTIES[i]["description"],
+            )
+            self.assertEquals(
+                custom_property.get("customPropertyConfig"),
+                EXPECTED_CUSTOM_PROPERTIES[i].get("customPropertyConfig"),
+            )
+            self.assertEquals(
+                custom_property["propertyType"]["name"],
+                EXPECTED_CUSTOM_PROPERTIES[i]["propertyType"]["name"],
+            )
 
     def test_add_custom_property_table(self):
         """


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Add method to list custom properties for a entity for python sdk

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
