### PR TITLE
MINOR: Enable Primary Key Constraint for DB2

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/db2/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/db2/metadata.py
@@ -12,8 +12,7 @@
 import traceback
 from typing import Optional
 
-from ibm_db_sa.base import DB2Dialect, ischema_names
-from sqlalchemy.engine import reflection
+from ibm_db_sa.base import ischema_names
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.engine.row import LegacyRow
 from sqlalchemy.sql.sqltypes import BOOLEAN
@@ -31,15 +30,6 @@ from metadata.utils.logger import ingestion_logger
 
 logger = ingestion_logger()
 
-
-@reflection.cache
-def get_pk_constraint(
-    self, bind, table_name, schema=None, **kw
-):  # pylint: disable=unused-argument
-    return {"constrained_columns": [], "name": "undefined"}
-
-
-DB2Dialect.get_pk_constraint = get_pk_constraint
 
 ischema_names.update({"BOOLEAN": BOOLEAN})
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Removing custom `get_pk_constraint` method that disabled Primary Keys on DB2 after testing it with:

- One Primary Key
- Multiple Primary Key
- No Primary Key

The ingestion was successfull without any issues or warnings/errors on the log in DEBUG mode


<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
