### PR TITLE
Fix Airflow Pipeline Toggle On

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/clients/pipeline/airflow/AirflowRESTClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/clients/pipeline/airflow/AirflowRESTClient.java
@@ -222,7 +222,7 @@ public class AirflowRESTClient extends PipelineServiceClient {
         response = post(toggleUrl, requestPayload.toString());
         if (response.statusCode() == 200) {
           ingestionPipeline.setEnabled(true);
-          ingestionPipeline.setEnabled(false);
+          return getResponse(200, response.getBody());
         } else if (response.statusCode() == 404) {
           ingestionPipeline.setDeployed(false);
           return getResponse(404, response.body());

--- a/openmetadata-service/src/main/java/org/openmetadata/service/clients/pipeline/airflow/AirflowRESTClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/clients/pipeline/airflow/AirflowRESTClient.java
@@ -222,7 +222,7 @@ public class AirflowRESTClient extends PipelineServiceClient {
         response = post(toggleUrl, requestPayload.toString());
         if (response.statusCode() == 200) {
           ingestionPipeline.setEnabled(true);
-          return getResponse(200, response.getBody());
+          return getResponse(200, response.body());
         } else if (response.statusCode() == 404) {
           ingestionPipeline.setDeployed(false);
           return getResponse(404, response.body());


### PR DESCRIPTION
In [this thread](https://openmetadata.slack.com/archives/C02B6955S4S/p1718753793799799?thread_ts=1717612791.169119&cid=C02B6955S4S) we discovered that it was impossible to toggle an airflow pipeline back on after it was paused without manually editing the Openmetadata database. After some code reviewing, it was found that there was a bug in the code for the state change from "paused" to "unpaused" which would cause the Openmetadata service to become out-of-sync with the underlying Airflow process.

This should resolve the issue.

Thank you to @ulixius9 and @harshach for the suggestion to submit a PR!