### PR TITLE
Fixes #16697: Modify the Query to avoid Numeric Data Overflow

### DIFF
--- a/ingestion/src/metadata/profiler/metrics/static/mean.py
+++ b/ingestion/src/metadata/profiler/metrics/static/mean.py
@@ -52,6 +52,15 @@ def _(element, compiler, **kw):
     return f"if(isNaN(avg({proc})), null, avg({proc}))"
 
 
+@compiles(avg, Dialects.Redshift)
+def _(element, compiler, **kw):
+    """
+    Cast to decimal to get around potential integer overflow error
+    """
+    proc = compiler.process(element.clauses, **kw)
+    return f"avg(CAST({proc} AS DECIMAL(38,0)))"
+
+
 @compiles(avg, Dialects.MSSQL)
 def _(element, compiler, **kw):
     """

--- a/ingestion/src/metadata/profiler/orm/functions/sum.py
+++ b/ingestion/src/metadata/profiler/orm/functions/sum.py
@@ -32,6 +32,13 @@ def _(element, compiler, **kw):
     return f"SUM(CAST({proc} AS BIGINT))"
 
 
+@compiles(SumFn, Dialects.Redshift)
+def _(element, compiler, **kw):
+    """Cast to Decimal to address overflow error from summing 32-bit int in most database dialects"""
+    proc = compiler.process(element.clauses, **kw)
+    return f"SUM(CAST({proc} AS Decimal(38,0)))"
+
+
 @compiles(SumFn, Dialects.Athena)
 @compiles(SumFn, Dialects.Trino)
 @compiles(SumFn, Dialects.Presto)

--- a/ingestion/tests/cli_e2e/test_cli_redshift.py
+++ b/ingestion/tests/cli_e2e/test_cli_redshift.py
@@ -26,7 +26,8 @@ class RedshiftCliTest(CliCommonDB.TestSuite, SQACommonMethods):
         CREATE TABLE IF NOT EXISTS e2e_cli_tests.dbt_jaffle.persons (
             person_id int,
             full_name varchar(255),
-            birthdate date
+            birthdate date,
+            bigint_col bigint
         )
     """
 
@@ -38,13 +39,13 @@ class RedshiftCliTest(CliCommonDB.TestSuite, SQACommonMethods):
 
     insert_data_queries: List[str] = [
         """
-    INSERT INTO e2e_cli_tests.dbt_jaffle.persons (person_id, full_name, birthdate) VALUES
-        (1,'Peter Parker', '2004-08-10'),
-        (2,'Bruce Banner', '1988-12-18'),
-        (3,'Steve Rogers', '1988-07-04'),
-        (4,'Natasha Romanoff', '1997-12-03'),
-        (5,'Wanda Maximoff', '1998-02-10'),
-        (6,'Diana Prince', '1976-03-17');
+    INSERT INTO e2e_cli_tests.dbt_jaffle.persons (person_id, full_name, birthdate, bigint_col) VALUES
+        (1,'Peter Parker', '2004-08-10', 9223372036854775807),
+        (2,'Bruce Banner', '1988-12-18', 9223372036854775807),
+        (3,'Steve Rogers', '1988-07-04', 9223372036854775807),
+        (4,'Natasha Romanoff', '1997-12-03', 9223372036854775807),
+        (5,'Wanda Maximoff', '1998-02-10', 9223372036854775807),
+        (6,'Diana Prince', '1976-03-17', 9000000000000000007);
     """
     ]
 

--- a/ingestion/tests/cli_e2e/test_cli_redshift.py
+++ b/ingestion/tests/cli_e2e/test_cli_redshift.py
@@ -200,7 +200,7 @@ class RedshiftCliTest(CliCommonDB.TestSuite, SQACommonMethods):
                         "minLength": None,
                         "missingCount": None,
                         "missingPercentage": None,
-                        "nonParametricSkew": 0.24351799263849705,
+                        "nonParametricSkew": 0.24571372424720792,
                         "nullCount": 0.0,
                         "nullProportion": 0.0,
                         "stddev": 528.297718809555,

--- a/ingestion/tests/cli_e2e/test_cli_redshift.py
+++ b/ingestion/tests/cli_e2e/test_cli_redshift.py
@@ -194,7 +194,7 @@ class RedshiftCliTest(CliCommonDB.TestSuite, SQACommonMethods):
                         "interQuartileRange": 467.7975,
                         "max": 856.41,
                         "maxLength": None,
-                        "mean": -160.16,
+                        "mean": -159.0,
                         "median": -288.81,
                         "min": -999.63,
                         "minLength": None,


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #16697 

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on fixing Numeric Data Overflow for Redshift

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
