### PR TITLE
MINOR: Fix Vertica E2E Counts

### DIFF
--- a/ingestion/tests/cli_e2e/test_cli_vertica.py
+++ b/ingestion/tests/cli_e2e/test_cli_vertica.py
@@ -24,9 +24,9 @@ from .common_e2e_sqa_mixins import SQACommonMethods
 
 class VerticaCliTest(CliCommonDB.TestSuite, SQACommonMethods):
     create_table_query: str = """
-        CREATE TABLE vendor_dimension_new AS 
-            SELECT * 
-            FROM vendor_dimension 
+        CREATE TABLE vendor_dimension_new AS
+            SELECT *
+            FROM vendor_dimension
             WHERE 1=0;
     """
 
@@ -99,7 +99,7 @@ class VerticaCliTest(CliCommonDB.TestSuite, SQACommonMethods):
 
     @staticmethod
     def expected_filtered_table_includes() -> int:
-        return 8
+        return 5
 
     @staticmethod
     def expected_filtered_table_excludes() -> int:
@@ -107,4 +107,4 @@ class VerticaCliTest(CliCommonDB.TestSuite, SQACommonMethods):
 
     @staticmethod
     def expected_filtered_mix() -> int:
-        return 7
+        return 4


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

Vertica E2E Tests were failing due to the State of the Database changing. With @pmbrull's help we restarted the Database to its initial state while also adjusting the expected values.

In the near future it'd be great if we could move this to be an Integration test with TestContainers. It should be farily easy since in order to setup the Database the only thing needed is to spin up a docker container:

```bash
docker run -p 5433:5433 -p 5444:5444 --mount type=volume,source=vertica-data,target=/data --name vertica_ce vertica/vertica-ce
```

It already comes with the default Vmart database setup.
The only thing we could do is to update to a newer image version if needed.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
