### PR TITLE
MINOR: Enable community apps

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/templates/CommunityApp.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/templates/CommunityApp.java
@@ -1,0 +1,11 @@
+package org.openmetadata.service.apps.templates;
+
+import org.openmetadata.service.apps.AbstractNativeApplication;
+import org.openmetadata.service.jdbi3.CollectionDAO;
+import org.openmetadata.service.search.SearchRepository;
+
+public class CommunityApp extends AbstractNativeApplication {
+  public CommunityApp(CollectionDAO collectionDAO, SearchRepository searchRepository) {
+    super(collectionDAO, searchRepository);
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/apps/AppMarketPlaceResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/apps/AppMarketPlaceResource.java
@@ -480,7 +480,8 @@ public class AppMarketPlaceResource
             .withFeatures(create.getFeatures())
             .withSourcePythonClass(create.getSourcePythonClass())
             .withAllowConfiguration(create.getAllowConfiguration())
-            .withSystem(create.getSystem());
+            .withSystem(create.getSystem())
+            .withConfigSchema(create.getConfigSchema());
 
     // Validate App
     validateApplication(app);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/secrets/converter/AppConfigSchemaConverter.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/secrets/converter/AppConfigSchemaConverter.java
@@ -1,0 +1,26 @@
+package org.openmetadata.service.secrets.converter;
+
+import java.util.Map;
+import javax.validation.ValidationException;
+import org.openmetadata.schema.entity.app.ConfigFormParameter;
+import org.openmetadata.schema.type.app.configuration.IntParameter;
+import org.openmetadata.schema.type.app.configuration.StringParameter;
+
+public class AppConfigSchemaConverter extends ClassConverter {
+  private static final Map<String, Class<?>> PARAMETER_CLASSES =
+      Map.of(
+          StringParameter.Type.STRING.toString(), StringParameter.class,
+          IntParameter.Type.INTEGER.toString(), IntParameter.class);
+
+  public AppConfigSchemaConverter() {
+    super(ConfigFormParameter.class);
+  }
+
+  public Object convertByType(Map<String, Object> map) {
+    if (!map.containsKey("type")) {
+      throw new ValidationException("type is required");
+    }
+    Class<?> clazz = PARAMETER_CLASSES.get(map.get("type"));
+    return ClassConverterFactory.getConverter(clazz).convert(map);
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/apps/AppMarketPlaceResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/apps/AppMarketPlaceResourceTest.java
@@ -1,6 +1,7 @@
 package org.openmetadata.service.resources.apps;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.openmetadata.service.util.TestUtils.ADMIN_AUTH_HEADERS;
 
 import java.net.URI;
@@ -8,8 +9,12 @@ import java.net.URISyntaxException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.client.HttpResponseException;
+import org.junit.jupiter.api.Test;
 import org.openmetadata.schema.entity.app.AppConfiguration;
 import org.openmetadata.schema.entity.app.AppMarketPlaceDefinition;
 import org.openmetadata.schema.entity.app.AppType;
@@ -23,93 +28,102 @@ import org.openmetadata.service.util.TestUtils;
 
 @Slf4j
 public class AppMarketPlaceResourceTest
-    extends EntityResourceTest<AppMarketPlaceDefinition, CreateAppMarketPlaceDefinitionReq> {
+        extends EntityResourceTest<AppMarketPlaceDefinition, CreateAppMarketPlaceDefinitionReq> {
 
-  public AppMarketPlaceResourceTest() {
-    super(
-        Entity.APP_MARKET_PLACE_DEF,
-        AppMarketPlaceDefinition.class,
-        AppMarketPlaceResource.AppMarketPlaceDefinitionList.class,
-        "apps/marketplace",
-        AppMarketPlaceResource.FIELDS);
-    supportsFieldsQueryParam = false;
-    supportedNameCharacters = "_-.";
-  }
-
-  @Override
-  public CreateAppMarketPlaceDefinitionReq createRequest(String name) {
-    try {
-      return new CreateAppMarketPlaceDefinitionReq()
-          .withName(name)
-          .withOwner(USER1_REF)
-          .withDeveloper("OM")
-          .withDeveloperUrl("https://test.com")
-          .withSupportEmail("test@openmetadata.org")
-          .withPrivacyPolicyUrl("https://privacy@openmetadata.org")
-          .withClassName("org.openmetadata.service.apps.bundles.test.NoOpTestApplication")
-          .withAppType(AppType.Internal)
-          .withScheduleType(ScheduleType.Scheduled)
-          .withRuntime(new ScheduledExecutionContext().withEnabled(true))
-          .withAppConfiguration(new AppConfiguration().withAdditionalProperty("test", "20"))
-          .withPermission(NativeAppPermission.All)
-          .withAppLogoUrl(new URI("https://test.com"))
-          .withAppScreenshots(new HashSet<>(List.of("AppLogo")))
-          .withFeatures("App Features");
-    } catch (URISyntaxException ex) {
-      LOG.error(
-          "Encountered error in Create Request for AppMarketPlaceResourceTest for App Logo Url.");
+    public AppMarketPlaceResourceTest() {
+        super(
+                Entity.APP_MARKET_PLACE_DEF,
+                AppMarketPlaceDefinition.class,
+                AppMarketPlaceResource.AppMarketPlaceDefinitionList.class,
+                "apps/marketplace",
+                AppMarketPlaceResource.FIELDS);
+        supportsFieldsQueryParam = false;
+        supportedNameCharacters = "_-.";
     }
-    return null;
-  }
 
-  @Override
-  public void validateCreatedEntity(
-      AppMarketPlaceDefinition createdEntity,
-      CreateAppMarketPlaceDefinitionReq request,
-      Map<String, String> authHeaders)
-      throws HttpResponseException {}
+    @Override
+    public CreateAppMarketPlaceDefinitionReq createRequest(String name) {
+        try {
+            return new CreateAppMarketPlaceDefinitionReq()
+                    .withName(name)
+                    .withOwner(USER1_REF)
+                    .withDeveloper("OM")
+                    .withDeveloperUrl("https://test.com")
+                    .withSupportEmail("test@openmetadata.org")
+                    .withPrivacyPolicyUrl("https://privacy@openmetadata.org")
+                    .withClassName("org.openmetadata.service.apps.bundles.test.NoOpTestApplication")
+                    .withAppType(AppType.Internal)
+                    .withScheduleType(ScheduleType.Scheduled)
+                    .withRuntime(new ScheduledExecutionContext().withEnabled(true))
+                    .withAppConfiguration(new AppConfiguration().withAdditionalProperty("test", "20"))
+                    .withPermission(NativeAppPermission.All)
+                    .withAppLogoUrl(new URI("https://test.com"))
+                    .withAppScreenshots(new HashSet<>(List.of("AppLogo")))
+                    .withFeatures("App Features");
+        } catch (URISyntaxException ex) {
+            LOG.error(
+                    "Encountered error in Create Request for AppMarketPlaceResourceTest for App Logo Url.");
+        }
+        return null;
+    }
 
-  @Override
-  public void compareEntities(
-      AppMarketPlaceDefinition expected,
-      AppMarketPlaceDefinition updated,
-      Map<String, String> authHeaders)
-      throws HttpResponseException {
-    assertEquals(expected.getDeveloper(), updated.getDeveloper());
-    assertEquals(expected.getDeveloperUrl(), updated.getDeveloperUrl());
-    assertEquals(expected.getSupportEmail(), updated.getSupportEmail());
-    assertEquals(expected.getPrivacyPolicyUrl(), updated.getPrivacyPolicyUrl());
-    assertEquals(expected.getClassName(), updated.getClassName());
-    assertEquals(expected.getAppType(), updated.getAppType());
-    assertEquals(expected.getScheduleType(), updated.getScheduleType());
-    assertEquals(expected.getAppConfiguration(), updated.getAppConfiguration());
-    assertEquals(expected.getPermission(), updated.getPermission());
-    assertEquals(expected.getAppLogoUrl(), updated.getAppLogoUrl());
-    assertEquals(expected.getAppScreenshots(), updated.getAppScreenshots());
-    assertEquals(expected.getAppScreenshots(), updated.getAppScreenshots());
-    assertEquals(expected.getFeatures(), updated.getFeatures());
-  }
+    @Override
+    public void validateCreatedEntity(
+            AppMarketPlaceDefinition createdEntity,
+            CreateAppMarketPlaceDefinitionReq request,
+            Map<String, String> authHeaders)
+            throws HttpResponseException {
+    }
 
-  @Override
-  public AppMarketPlaceDefinition validateGetWithDifferentFields(
-      AppMarketPlaceDefinition entity, boolean byName) throws HttpResponseException {
-    String fields = "";
-    entity =
-        byName
-            ? getEntityByName(entity.getFullyQualifiedName(), fields, ADMIN_AUTH_HEADERS)
-            : getEntity(entity.getId(), fields, ADMIN_AUTH_HEADERS);
-    TestUtils.assertListNull(entity.getOwner());
+    @Override
+    public void compareEntities(
+            AppMarketPlaceDefinition expected,
+            AppMarketPlaceDefinition updated,
+            Map<String, String> authHeaders)
+            throws HttpResponseException {
+        assertEquals(expected.getDeveloper(), updated.getDeveloper());
+        assertEquals(expected.getDeveloperUrl(), updated.getDeveloperUrl());
+        assertEquals(expected.getSupportEmail(), updated.getSupportEmail());
+        assertEquals(expected.getPrivacyPolicyUrl(), updated.getPrivacyPolicyUrl());
+        assertEquals(expected.getClassName(), updated.getClassName());
+        assertEquals(expected.getAppType(), updated.getAppType());
+        assertEquals(expected.getScheduleType(), updated.getScheduleType());
+        assertEquals(expected.getAppConfiguration(), updated.getAppConfiguration());
+        assertEquals(expected.getPermission(), updated.getPermission());
+        assertEquals(expected.getAppLogoUrl(), updated.getAppLogoUrl());
+        assertEquals(expected.getAppScreenshots(), updated.getAppScreenshots());
+        assertEquals(expected.getAppScreenshots(), updated.getAppScreenshots());
+        assertEquals(expected.getFeatures(), updated.getFeatures());
+    }
 
-    fields = "owner,tags";
-    entity =
-        byName
-            ? getEntityByName(entity.getFullyQualifiedName(), fields, ADMIN_AUTH_HEADERS)
-            : getEntity(entity.getId(), fields, ADMIN_AUTH_HEADERS);
-    return entity;
-  }
+    @Override
+    public AppMarketPlaceDefinition validateGetWithDifferentFields(
+            AppMarketPlaceDefinition entity, boolean byName) throws HttpResponseException {
+        String fields = "";
+        entity =
+                byName
+                        ? getEntityByName(entity.getFullyQualifiedName(), fields, ADMIN_AUTH_HEADERS)
+                        : getEntity(entity.getId(), fields, ADMIN_AUTH_HEADERS);
+        TestUtils.assertListNull(entity.getOwner());
 
-  @Override
-  public void assertFieldChange(String fieldName, Object expected, Object actual) {
-    assertCommonFieldChange(fieldName, expected, actual);
-  }
+        fields = "owner,tags";
+        entity =
+                byName
+                        ? getEntityByName(entity.getFullyQualifiedName(), fields, ADMIN_AUTH_HEADERS)
+                        : getEntity(entity.getId(), fields, ADMIN_AUTH_HEADERS);
+        return entity;
+    }
+
+    @Override
+    public void assertFieldChange(String fieldName, Object expected, Object actual) {
+        assertCommonFieldChange(fieldName, expected, actual);
+    }
+
+    @Test
+    void get_example_community_app() throws HttpResponseException {
+        WebTarget target = getResourceByName("TestCommunityApp");
+        target = target.queryParam("fields", "[\"*\"]");
+        AppMarketPlaceDefinition response = TestUtils.get(target, entityClass, ADMIN_AUTH_HEADERS);
+        assertNotNull(response.getConfigSchema());
+    }
 }

--- a/openmetadata-service/src/test/resources/json/data/appMarketPlaceDefinition/AppWithBadConfig.json
+++ b/openmetadata-service/src/test/resources/json/data/appMarketPlaceDefinition/AppWithBadConfig.json
@@ -1,0 +1,29 @@
+{
+  "name": "AppWithBadConfig",
+  "displayName": "App with Bad Config",
+  "description": "It should not be published in the marketplace.",
+  "features": "Dont try this at home.",
+  "appType": "external",
+  "appScreenshots": [
+  ],
+  "developer": "ACME Labs",
+  "developerUrl": "https://www.example.com",
+  "privacyPolicyUrl": "https://www.example.com",
+  "supportEmail": "use@example.com",
+  "scheduleType": "Scheduled",
+  "permission": "All",
+  "className": "org.openmetadata.service.apps.bundles.searchIndex.SearchIndexApp",
+  "runtime": {
+    "enabled": true
+  },
+  "appConfiguration": {},
+  "configSchema": {
+    "nonParameter": {
+      "type": "non_existent",
+      "displayName": "Should not resolve",
+      "description": "If it does, there is a bug.",
+      "properties": {
+      }
+    }
+  }
+}

--- a/openmetadata-service/src/test/resources/json/data/appMarketPlaceDefinition/AppWithBadConfig2.json
+++ b/openmetadata-service/src/test/resources/json/data/appMarketPlaceDefinition/AppWithBadConfig2.json
@@ -1,0 +1,30 @@
+{
+  "name": "AppWithBadConfig",
+  "displayName": "App with Bad Config",
+  "description": "It should not be published in the marketplace.",
+  "features": "Dont try this at home.",
+  "appType": "external",
+  "appScreenshots": [
+  ],
+  "developer": "ACME Labs",
+  "developerUrl": "https://www.example.com",
+  "privacyPolicyUrl": "https://www.example.com",
+  "supportEmail": "use@example.com",
+  "scheduleType": "Scheduled",
+  "permission": "All",
+  "className": "org.openmetadata.service.apps.bundles.searchIndex.SearchIndexApp",
+  "runtime": {
+    "enabled": true
+  },
+  "appConfiguration": {},
+  "configSchema": {
+    "invalidString": {
+      "type": "string",
+      "displayName": "Should not resolve",
+      "description": "If it does, there is a bug.",
+      "properties": {
+        "invalid": "This is not a valid property."
+      }
+    }
+  }
+}

--- a/openmetadata-service/src/test/resources/json/data/appMarketPlaceDefinition/TestCommunityApp.json
+++ b/openmetadata-service/src/test/resources/json/data/appMarketPlaceDefinition/TestCommunityApp.json
@@ -1,0 +1,51 @@
+{
+  "name": "TestCommunityApp",
+  "displayName": "Example App No Trigger",
+  "description": "An example app without manual trigger.",
+  "features": "Dont try this at home.",
+  "appType": "internal",
+  "appScreenshots": [
+  ],
+  "developer": "ACME Labs",
+  "developerUrl": "https://www.example.com",
+  "privacyPolicyUrl": "https://www.example.com",
+  "supportEmail": "use@example.com",
+  "scheduleType": "Scheduled",
+  "permission": "All",
+  "className": "org.openmetadata.service.apps.bundles.searchIndex.SearchIndexApp",
+  "runtime": {
+    "enabled": true
+  },
+  "appConfiguration": {},
+  "configSchema": {
+    "exampleString": {
+      "type": "textBox",
+      "displayName": "Example String",
+      "description": "An example string parameter",
+      "properties": {
+        "default": "the default value"
+      }
+    },
+    "exampleString2": {
+      "type": "textBox",
+      "displayName": "Another string",
+      "description": "An example string parameter without default value",
+      "properties": {}
+    },
+    "exampleInteger": {
+      "name": "exampleInteger",
+      "type": "integer",
+      "displayName": "Example Integer",
+      "description": "An example integer parameter",
+      "properties": {
+        "default": 100
+      }
+    },
+    "dropdownExample": {
+      "lookup": "user",
+      "type": "dropdown",
+      "multiple": true/false,
+
+    }
+  }
+}

--- a/openmetadata-spec/src/main/resources/json/schema/entity/applications/configuration/applicationConfig.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/applications/configuration/applicationConfig.json
@@ -18,6 +18,9 @@
         },
         {
           "$ref": "internal/searchIndexingAppConfig.json"
+        },
+        {
+          "$ref": "external/communityAppConfig.json"
         }
       ]
     },

--- a/openmetadata-spec/src/main/resources/json/schema/entity/applications/configuration/configForm.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/applications/configuration/configForm.json
@@ -1,0 +1,276 @@
+{
+  "$id": "https://open-metadata.org/schema/entity/applications/configuration/applicationConfig.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ApplicationConfigModel",
+  "description": "Application Pipeline Configuration.",
+  "javaType": "org.openmetadata.schema.entity.app.ConfigFormParameter",
+  "type": "object",
+  "definitions": {
+    "base": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean"
+        }
+      }
+    },
+    "types": {
+      "stringParameter": {
+        "type": "string",
+        "enum": [
+          "string"
+        ],
+        "default": "string"
+      },
+      "integerParameter": {
+        "type": "string",
+        "enum": [
+          "integer"
+        ],
+        "default": "integer"
+      },
+      "secretParameter": {
+        "type": "string",
+        "enum": [
+          "secret"
+        ],
+        "default": "secret"
+      },
+      "enumParameter": {
+        "type": "string",
+        "enum": [
+          "enum"
+        ],
+        "default": "enum"
+      },
+      "booleanParameter": {
+        "type": "string",
+        "enum": [
+          "boolean"
+        ],
+        "default": "boolean"
+      },
+      "menuParameter": {
+        "type": "string",
+        "enum": [
+          "menu"
+        ],
+        "default": "menu"
+      }
+    },
+    "textBox": {
+      "type": "object",
+      "description": "A configuration parameter of type string.",
+      "javaType": "org.openmetadata.schema.entity.app.configuration.StringParameter",
+      "allOf": [
+        {
+          "$ref": "#/definitions/base"
+        }
+      ],
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/types/stringParameter"
+        },
+        "properties": {
+          "default": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      }
+    },
+    "integer": {
+      "type": "object",
+      "description": "A configuration parameter of type integer",
+      "javaType": "org.openmetadata.schema.entity.app.configuration.IntParameter",
+      "allOf": [
+        {
+          "$ref": "#/definitions/base"
+        }
+      ],
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/types/integerParameter"
+        },
+        "properties": {
+          "default": {
+            "type": "integer",
+            "nullable": true
+          }
+        }
+      }
+    },
+    "secret": {
+      "type": "object",
+      "description": "A configuration parameter of type secret.",
+      "javaType": "org.openmetadata.schema.entity.app.configuration.SecretParameter",
+      "allOf": [
+        {
+          "$ref": "#/definitions/base"
+        }
+      ],
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/types/secretParameter"
+        }
+      }
+    },
+    "enum": {
+      "type": "object",
+      "description": "A configuration parameter of type enum.",
+      "javaType": "org.openmetadata.schema.entity.app.configuration.EnumParameter",
+      "allOf": [
+        {
+          "$ref": "#/definitions/base"
+        }
+      ],
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/types/enumParameter"
+        },
+        "properties": {
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "default": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      }
+    },
+    "checkbox": {
+      "type": "object",
+      "description": "A configuration parameter of type boolean.",
+      "javaType": "org.openmetadata.schema.entity.app.configuration.BooleanParameter",
+      "allOf": [
+        {
+          "$ref": "#/definitions/base"
+        }
+      ],
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/types/booleanParameter"
+        },
+        "properties": {
+          "default": {
+            "type": "boolean",
+            "nullable": true
+          }
+        }
+      }
+    },
+    "dropdown": {
+      "type": "object",
+      "description": "A configuration parameter of type dropdown.",
+      "javaType": "org.openmetadata.schema.entity.app.configuration.MenuParameter",
+      "allOf": [
+        {
+          "$ref": "#/definitions/base"
+        }
+      ],
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/types/menuParameter"
+        },
+        "properties": {
+          "multiple": {
+            "type": "boolean",
+            "default": false
+          },
+          "lookup": {
+            "type": "string",
+            "description": "Lookup for the dropdown values. Exclusive with `values`.",
+            "enum": [
+              "database",
+              "databaseSchema",
+              "table",
+              "glossary",
+              "user",
+              "domain"
+            ],
+            "nullable": true
+          },
+          "values": {
+            "type": "array",
+            "description": "Values for the dropdown. Exclusive with `lookup`.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "string"
+                },
+                "label": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "type": "string",
+            "description": "Default value for the dropdown",
+            "nullable": true
+          }
+        }
+      }
+    }
+  },
+  "properties": {
+    "stringParameter": {
+      "$ref": "#/definitions/string"
+    },
+    "integerParameter": {
+      "$ref": "#/definitions/integer"
+    },
+    "secretParameter": {
+      "$ref": "#/definitions/secret"
+    },
+    "enumParameter": {
+      "$ref": "#/definitions/enum"
+    },
+    "booleanParameter": {
+      "$ref": "#/definitions/boolean"
+    },
+    "menuParameter": {
+      "$ref": "#/definitions/menu"
+    }
+  },
+  "patternProperties": {
+    "^.*$": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/string"
+        },
+        {
+          "$ref": "#/definitions/integer"
+        },
+        {
+          "$ref": "#/definitions/secret"
+        },
+        {
+          "$ref": "#/definitions/enum"
+        },
+        {
+          "$ref": "#/definitions/boolean"
+        },
+        {
+          "$ref": "#/definitions/menu"
+        }
+      ]
+    }
+  },
+  "maxItems": 1,
+  "additionalProperties": true
+}

--- a/openmetadata-spec/src/main/resources/json/schema/entity/applications/configuration/external/communityAppConfig.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/applications/configuration/external/communityAppConfig.json
@@ -1,0 +1,25 @@
+{
+  "$id": "https://open-metadata.org/schema/entity/applications/configuration/external/communityAppConfig.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CommunityAppConfig",
+  "description": "Configuration for community applications.",
+  "javaType": "org.openmetadata.schema.entity.app.external.CommunityAppConfig",
+  "type": "object",
+  "definitions": {
+    "communityAppType": {
+      "description": "Application type.",
+      "type": "string",
+      "enum": ["CommunityApp"],
+      "default": "CommunityApp"
+    }
+  },
+  "properties": {
+    "type": {
+      "title": "Application Type",
+      "description": "Application Type",
+      "$ref": "#/definitions/communityAppType",
+      "default": "CommunityApp"
+    }
+  },
+  "additionalProperties": true
+}

--- a/openmetadata-spec/src/main/resources/json/schema/entity/applications/marketplace/appMarketPlaceDefinition.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/applications/marketplace/appMarketPlaceDefinition.json
@@ -3,14 +3,21 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "AppMarketPlaceDefinition",
   "javaType": "org.openmetadata.schema.entity.app.AppMarketPlaceDefinition",
-  "javaInterfaces": ["org.openmetadata.schema.EntityInterface"],
+  "javaInterfaces": [
+    "org.openmetadata.schema.EntityInterface"
+  ],
   "description": "This schema defines the applications for Open-Metadata.",
   "type": "object",
   "definitions": {
     "appConfigSchema": {
       "javaType": "org.openmetadata.schema.type.AppConfigSchema",
-      "type": "object",
-      "additionalProperties": true
+      "additionalProperties": true,
+      "description": "Configuration Schema for the application.",
+      "type": "array",
+      "items": {
+        "$ref": "../configuration/configForm.json"
+      },
+      "maxItems": 20
     }
   },
   "properties": {
@@ -149,10 +156,16 @@
       "default": false
     },
     "configSchema": {
-      "description": "Configuration Schema for the application.",
-      "$ref": "#/definitions/appConfigSchema"
+      "$ref": "../configuration/configForm.json"
     }
   },
   "additionalProperties": false,
-  "required": ["id", "name", "appType", "className", "scheduleType", "permission"]
+  "required": [
+    "id",
+    "name",
+    "appType",
+    "className",
+    "scheduleType",
+    "permission"
+  ]
 }

--- a/openmetadata-spec/src/main/resources/json/schema/entity/applications/marketplace/appMarketPlaceDefinition.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/applications/marketplace/appMarketPlaceDefinition.json
@@ -126,7 +126,7 @@
     "appScreenshots": {
       "description": "Application Screenshots.",
       "type": "array",
-      "items":{
+      "items": {
         "type": "string"
       },
       "uniqueItems": true
@@ -140,6 +140,10 @@
       "type": "boolean",
       "description": "Flag to enable/disable preview for the application. If the app is in preview mode, it can't be installed.",
       "default": false
+    },
+    "configSchema": {
+      "description": "Configuration Schema for the application.",
+      "$ref": "../type.json#/definitions/appConfigSchema"
     }
   },
   "additionalProperties": false,

--- a/openmetadata-spec/src/main/resources/json/schema/entity/applications/marketplace/appMarketPlaceDefinition.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/applications/marketplace/appMarketPlaceDefinition.json
@@ -6,6 +6,13 @@
   "javaInterfaces": ["org.openmetadata.schema.EntityInterface"],
   "description": "This schema defines the applications for Open-Metadata.",
   "type": "object",
+  "definitions": {
+    "appConfigSchema": {
+      "javaType": "org.openmetadata.schema.type.AppConfigSchema",
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
   "properties": {
     "id": {
       "description": "Unique identifier of this application.",
@@ -143,7 +150,7 @@
     },
     "configSchema": {
       "description": "Configuration Schema for the application.",
-      "$ref": "../type.json#/definitions/appConfigSchema"
+      "$ref": "#/definitions/appConfigSchema"
     }
   },
   "additionalProperties": false,

--- a/openmetadata-spec/src/main/resources/json/schema/entity/applications/marketplace/createAppMarketPlaceDefinitionReq.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/applications/marketplace/createAppMarketPlaceDefinitionReq.json
@@ -3,7 +3,9 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "CreateAppMarketPlaceDefinitionRequest",
   "javaType": "org.openmetadata.schema.entity.app.CreateAppMarketPlaceDefinitionReq",
-  "javaInterfaces": ["org.openmetadata.schema.CreateEntity"],
+  "javaInterfaces": [
+    "org.openmetadata.schema.CreateEntity"
+  ],
   "description": "This schema defines the applications for Open-Metadata.",
   "type": "object",
   "properties": {
@@ -93,7 +95,7 @@
     "appScreenshots": {
       "description": "Application Screenshots.",
       "type": "array",
-      "items":{
+      "items": {
         "type": "string"
       },
       "uniqueItems": true
@@ -105,9 +107,15 @@
     },
     "configSchema": {
       "description": "Configuration Schema for the application.",
-      "$ref": "./appMarketPlaceDefinition.json#/definitions/appConfigSchema"
+      "$ref": "../configuration/configForm.json"
     }
   },
   "additionalProperties": false,
-  "required": ["name", "appType", "className", "scheduleType", "permission"]
+  "required": [
+    "name",
+    "appType",
+    "className",
+    "scheduleType",
+    "permission"
+  ]
 }

--- a/openmetadata-spec/src/main/resources/json/schema/entity/applications/marketplace/createAppMarketPlaceDefinitionReq.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/applications/marketplace/createAppMarketPlaceDefinitionReq.json
@@ -102,6 +102,10 @@
       "description": "A system app cannot be uninstalled or modified.",
       "type": "boolean",
       "default": false
+    },
+    "configSchema": {
+      "description": "Configuration Schema for the application.",
+      "$ref": "../type.json#/definitions/appConfigSchema"
     }
   },
   "additionalProperties": false,

--- a/openmetadata-spec/src/main/resources/json/schema/entity/applications/marketplace/createAppMarketPlaceDefinitionReq.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/applications/marketplace/createAppMarketPlaceDefinitionReq.json
@@ -105,7 +105,7 @@
     },
     "configSchema": {
       "description": "Configuration Schema for the application.",
-      "$ref": "../type.json#/definitions/appConfigSchema"
+      "$ref": "./appMarketPlaceDefinition.json#/definitions/appConfigSchema"
     }
   },
   "additionalProperties": false,

--- a/openmetadata-spec/src/main/resources/json/schema/entity/applications/type.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/applications/type.json
@@ -1,0 +1,14 @@
+{
+  "$id": "https://open-metadata.org/schema/entity/applications/type.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "AppConfigSchema",
+  "description": "This schema defines basic common types that are used by other schemas.",
+  "definitions": {
+    "appConfigSchema": {
+      "description": "key/value pairs to pass to workflow component.",
+      "javaType": "org.openmetadata.schema.type.AppConfigSchema",
+      "type": "object",
+      "additionalProperties": true
+    }
+  }
+}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Applications/AppDetails/AppDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Applications/AppDetails/AppDetails.component.tsx
@@ -49,6 +49,7 @@ import {
   App,
   ScheduleTimeline,
 } from '../../../../generated/entity/applications/app';
+import { AppMarketPlaceDefinition } from '../../../../generated/entity/applications/marketplace/appMarketPlaceDefinition';
 import { Include } from '../../../../generated/type/include';
 import { useFqn } from '../../../../hooks/useFqn';
 import {
@@ -60,6 +61,7 @@ import {
   triggerOnDemandApp,
   uninstallApp,
 } from '../../../../rest/applicationAPI';
+import { getMarketPlaceApplicationByFqn } from '../../../../rest/applicationMarketPlaceAPI';
 import { getRelativeTime } from '../../../../utils/date-time/DateTimeUtils';
 import { getEntityName } from '../../../../utils/EntityUtils';
 import { formatFormDataForSubmit } from '../../../../utils/JSONSchemaFormUtils';
@@ -106,9 +108,16 @@ const AppDetails = () => {
       });
       setAppData(data);
 
-      const schema = await applicationsClassBase.importSchema(fqn);
+      const marketPlaceDefinition: AppMarketPlaceDefinition =
+        await getMarketPlaceApplicationByFqn(fqn, {
+          fields: 'owner',
+        });
 
-      setJsonSchema(schema.default);
+      const schema =
+        marketPlaceDefinition.configSchema ||
+        (await applicationsClassBase.importSchema(fqn));
+
+      setJsonSchema(schema);
     } catch (error) {
       showErrorToast(error as AxiosError);
     } finally {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Applications/AppLogo/AppLogo.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Applications/AppLogo/AppLogo.component.tsx
@@ -39,7 +39,15 @@ const AppLogo = ({
     fetchLogo();
   }, [appName]);
 
-  return <Avatar className="flex-center bg-grey-1" icon={appLogo} size={100} />;
+  const props: any = {};
+
+  if (appLogo) {
+    props['icon'] = appLogo;
+  } else {
+    props['src'] = `/img/svg/${appName}.svg`;
+  }
+
+  return <Avatar className="flex-center bg-grey-1" size={100} {...props} />;
 };
 
 export default AppLogo;

--- a/openmetadata-ui/src/main/resources/ui/src/pages/AppInstall/AppInstall.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/AppInstall/AppInstall.component.tsx
@@ -111,12 +111,10 @@ const AppInstall = () => {
           fields: 'owner',
         });
       setAppData(data);
-      if (data.configSchema) {
-        setJsonSchema(data.configSchema);
-      } else {
-        const schema = await applicationSchemaClassBase.importSchema(fqn);
-        setJsonSchema(schema);
-      }
+      const schema =
+        data.configSchema ||
+        (await applicationSchemaClassBase.importSchema(fqn));
+      setJsonSchema(schema);
     } catch (error) {
       showErrorToast(error as AxiosError);
     } finally {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/AppInstall/AppInstall.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/AppInstall/AppInstall.component.tsx
@@ -106,14 +106,17 @@ const AppInstall = () => {
   const fetchAppDetails = useCallback(async () => {
     setIsLoading(true);
     try {
-      const data = await getMarketPlaceApplicationByFqn(fqn, {
-        fields: 'owner',
-      });
+      const data: AppMarketPlaceDefinition =
+        await getMarketPlaceApplicationByFqn(fqn, {
+          fields: 'owner',
+        });
       setAppData(data);
-
-      const schema = await applicationSchemaClassBase.importSchema(fqn);
-
-      setJsonSchema(schema);
+      if (data.configSchema) {
+        setJsonSchema(data.configSchema);
+      } else {
+        const schema = await applicationSchemaClassBase.importSchema(fqn);
+        setJsonSchema(schema);
+      }
     } catch (error) {
       showErrorToast(error as AxiosError);
     } finally {


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

# Description

Example for https://github.com/open-metadata/OpenMetadata/issues/15600

## Background

Referencing https://github.com/open-metadata/OpenMetadata/issues/15613, this PR introduces the capability to add minimal python apps as ingestion pipelines to OpenMetadata. The PR touches the 3 components of an app built by a user.

An example app can be found in [openmetadata-retention](https://github.com/open-metadata/openmetadata-retention).

## App Components

### Python Executable

The business logic of the application. The [python code](https://github.com/open-metadata/openmetadata-retention/blob/main/src/metadata/community/applications/OpenMetadataRetention/main.py) that will be run in the pipeline. It has access via the OpenMetadata API with whatever permissions are given to the application bot:

![image](https://github.com/user-attachments/assets/bb170b73-eb78-404c-a4b7-036db0eaa951) 

The PR introduces a generic [CommunityApp](https://github.com/open-metadata/OpenMetadata/pull/17145/files#diff-89c6494fdaca2079247315730875b2c81a6e3c610e2d6d00cae4aee7d8d3169a) base class that can be used as a vehicle to any pipeline based application.

### Marketplace Definition

The [marketplace defintion](https://github.com/open-metadata/openmetadata-retention/blob/main/src/json/data/appMarketPlaceDefinition/openMetadataRetention.json) is the manifest that the app publishes in order to let the user know the contents of the application. This PR introduces the `configSchema` as part of the marketplace definition so it can be consumed when installing the app.

### Images

Any images required for the app can be put under the [`assets`](https://github.com/open-metadata/openmetadata-retention/tree/main/src/assets) directory.

Relates to https://github.com/open-metadata/OpenMetadata/issues/15613

## Deployment

The [docker files](https://github.com/open-metadata/openmetadata-retention/tree/main/docker) demonstrate how the apps can be deployed on the existing docker images of OpenMetadata ingestion and server.

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

- added the community app generic config
- get the app config schema from the db
- get the app icon from assets

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] New feature

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

### Demo

https://github.com/user-attachments/assets/108deb69-c383-4121-b6a9-73d107c5c267

