### PR TITLE
Fix patch permissions

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/ResourceRegistry.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/ResourceRegistry.java
@@ -37,8 +37,6 @@ public class ResourceRegistry {
               MetadataOperation.EDIT_DISPLAY_NAME));
 
   static {
-    mapFieldOperation(MetadataOperation.EDIT_DESCRIPTION, Entity.FIELD_DESCRIPTION);
-    mapFieldOperation(MetadataOperation.EDIT_DISPLAY_NAME, Entity.FIELD_DISPLAY_NAME);
     mapFieldOperation(MetadataOperation.EDIT_TAGS, Entity.FIELD_TAGS);
     mapFieldOperation(MetadataOperation.EDIT_OWNERS, Entity.FIELD_OWNERS);
     mapFieldOperation(MetadataOperation.EDIT_CUSTOM_FIELDS, "extension");
@@ -47,6 +45,8 @@ public class ResourceRegistry {
     mapFieldOperation(MetadataOperation.EDIT_ROLE, "roles");
     mapFieldOperation(MetadataOperation.EDIT_POLICY, "policies");
     mapFieldOperation(MetadataOperation.EDIT_TEAMS, "teams");
+    mapFieldOperation(MetadataOperation.EDIT_DESCRIPTION, Entity.FIELD_DESCRIPTION);
+    mapFieldOperation(MetadataOperation.EDIT_DISPLAY_NAME, Entity.FIELD_DISPLAY_NAME);
 
     // Set up "all" resource descriptor that includes operations for all entities
     List<MetadataOperation> allOperations = Arrays.asList(MetadataOperation.values());
@@ -118,6 +118,10 @@ public class ResourceRegistry {
   /** Given an entity field name get the corresponding entity edit operation */
   public static MetadataOperation getEditOperation(String field) {
     return FIELD_TO_EDIT_OPERATION_MAP.get(field);
+  }
+
+  public static boolean hasEditOperation(String field) {
+    return FIELD_TO_EDIT_OPERATION_MAP.containsKey(field);
   }
 
   /** Given an edit operation get the corresponding entity field */

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/JsonPatchUtils.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/JsonPatchUtils.java
@@ -48,8 +48,7 @@ public class JsonPatchUtils {
   public static MetadataOperation getMetadataOperation(Object jsonPatchObject) {
     // JsonPatch operation example - {"op":"add","path":"/defaultRoles/0","value"..."}
     Map<String, Object> jsonPatchMap = JsonUtils.getMap(jsonPatchObject);
-    String path =
-        getPath(jsonPatchMap.get("path").toString()); // Get "path" node - "/defaultRoles/0"
+    String path = jsonPatchMap.get("path").toString(); // Get "path" node - "/defaultRoles/0"
     return getMetadataOperation(path);
   }
 
@@ -57,11 +56,14 @@ public class JsonPatchUtils {
     return Arrays.stream(path.split("/")).filter(part -> !part.isEmpty()).findFirst().orElse(path);
   }
 
+  //Its important that we parse the path from starting down to end
+  // In case of /owners/0/displayName we should see if the user has permission to EDIT_OWNERS
+  // If not, we will end up returning user does not have permission to edit the displayName
   public static MetadataOperation getMetadataOperation(String path) {
-    String[] fields = ResourceRegistry.getEditableFields(); // Get editable fields of an entity
-    for (String field : fields) {
-      if (path.contains(field)) { // If path contains the editable field
-        return ResourceRegistry.getEditOperation(field); // Return the corresponding operation
+    String[] paths =  path.contains("/") ? path.split("/"): new String[]{path};
+    for (String p : paths) {
+      if (ResourceRegistry.hasEditOperation(p)) {
+        return ResourceRegistry.getEditOperation(p);
       }
     }
     LOG.warn("Failed to find specific operation for patch path {}", path);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/JsonPatchUtils.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/JsonPatchUtils.java
@@ -56,11 +56,11 @@ public class JsonPatchUtils {
     return Arrays.stream(path.split("/")).filter(part -> !part.isEmpty()).findFirst().orElse(path);
   }
 
-  //Its important that we parse the path from starting down to end
+  // Its important that we parse the path from starting down to end
   // In case of /owners/0/displayName we should see if the user has permission to EDIT_OWNERS
   // If not, we will end up returning user does not have permission to edit the displayName
   public static MetadataOperation getMetadataOperation(String path) {
-    String[] paths =  path.contains("/") ? path.split("/"): new String[]{path};
+    String[] paths = path.contains("/") ? path.split("/") : new String[] {path};
     for (String p : paths) {
       if (ResourceRegistry.hasEditOperation(p)) {
         return ResourceRegistry.getEditOperation(p);


### PR DESCRIPTION
### Describe your changes:
Patch operations must be evaluated in hierarchical order.
For ex: if a User is adding a owner or tag they can be
/owners/0/displayname, /owners/0/fullyQualifiedName or /messageScheam/schemaFields/order/tags
in first case we should look up owners and return the operation immediately if try to match operation with the path
then we will get user might not have permissions edit_display_name


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
