### PR TITLE
Minor: Update the metadata service ingestion form configuration fields

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/utils/IngestionWorkflowUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/IngestionWorkflowUtils.test.ts
@@ -67,6 +67,9 @@ describe('Ingestion Workflow tests', () => {
     const databaseSchema = getMetadataSchemaByServiceCategory(
       ServiceCategory.DATABASE_SERVICES
     );
+    const metadataSchema = getMetadataSchemaByServiceCategory(
+      ServiceCategory.METADATA_SERVICES
+    );
     const dashboardSchema = getMetadataSchemaByServiceCategory(
       ServiceCategory.DASHBOARD_SERVICES
     );
@@ -75,6 +78,7 @@ describe('Ingestion Workflow tests', () => {
     );
 
     expect(databaseSchema).toBeDefined();
+    expect(metadataSchema).toBeDefined();
     expect(dashboardSchema).toBeDefined();
     expect(messagingSchema).toBeDefined();
   });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/IngestionWorkflowUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/IngestionWorkflowUtils.ts
@@ -36,6 +36,7 @@ export const getMetadataSchemaByServiceCategory = (
   serviceCategory: ServiceCategory
 ) => {
   switch (serviceCategory) {
+    case ServiceCategory.METADATA_SERVICES:
     case ServiceCategory.DATABASE_SERVICES:
       return databaseMetadataPipeline;
     case ServiceCategory.DASHBOARD_SERVICES:


### PR DESCRIPTION
I worked on updating the metadata service ingestion form configuration fields. The `Configure Ingestion` step for metadata services had no fields earlier. I've used the database services JSON schema for the same. cc. @OnkarVO7 

https://github.com/user-attachments/assets/386393a0-370c-45a2-aae1-f5f2442a2990

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
