### PR TITLE
MINOR: Fix usage datetime format for mssql

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/mssql/usage.py
+++ b/ingestion/src/metadata/ingestion/source/database/mssql/usage.py
@@ -11,8 +11,21 @@
 """
 MSSQL usage module
 """
+from datetime import datetime
+
+from metadata.generated.schema.metadataIngestion.workflow import (
+    Source as WorkflowSource,
+)
+from metadata.ingestion.ometa.ometa_api import OpenMetadata
+from metadata.ingestion.source.database.mssql.constants import (
+    DEFAULT_DATETIME_FORMAT,
+    MSSQL_DATEFORMAT_DATETIME_MAP,
+)
 from metadata.ingestion.source.database.mssql.queries import MSSQL_SQL_STATEMENT
 from metadata.ingestion.source.database.mssql.query_parser import MssqlQueryParserSource
+from metadata.ingestion.source.database.mssql.utils import (
+    get_sqlalchemy_engine_dateformat,
+)
 from metadata.ingestion.source.database.usage_source import UsageSource
 
 
@@ -24,3 +37,32 @@ class MssqlUsageSource(MssqlQueryParserSource, UsageSource):
         AND lower(t.text) NOT LIKE '%%create%%function%%'
         AND lower(t.text) NOT LIKE '%%declare%%'
         """
+
+    def __init__(
+        self,
+        config: WorkflowSource,
+        metadata: OpenMetadata,
+        get_engine: bool = True,
+    ):
+        super().__init__(config, metadata, get_engine)
+
+        self.dt_format = DEFAULT_DATETIME_FORMAT
+
+        if self.engine:
+            server_date_format = get_sqlalchemy_engine_dateformat(self.engine)
+            self.dt_format = MSSQL_DATEFORMAT_DATETIME_MAP.get(
+                server_date_format, DEFAULT_DATETIME_FORMAT
+            )
+
+    def get_sql_statement(self, start_time: datetime, end_time: datetime) -> str:
+        """
+        returns sql statement to fetch query logs.
+
+        Override if we have specific parameters
+        """
+        return self.sql_stmt.format(
+            start_time=start_time.replace(tzinfo=None).strftime(self.dt_format),
+            end_time=end_time.replace(tzinfo=None).strftime(self.dt_format),
+            filters=self.get_filters(),
+            result_limit=self.source_config.resultLimit,
+        )


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

Changing to a timezone aware datetime object broke our usage pipeline for mssql where the format is not supported.
This PR aims to fix that issue by using the same logic that fixed the same issue int he lineage pipeline: https://github.com/open-metadata/OpenMetadata/pull/17239

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
