### PR TITLE
MINOR: Update Data Insights Pipeline to change CustomProperty key based on entityType

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/search/DataInsightsSearchInterface.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/search/DataInsightsSearchInterface.java
@@ -25,5 +25,7 @@ public interface DataInsightsSearchInterface {
 
   void createDataAssetsDataStream() throws IOException;
 
+  void deleteDataAssetDataStream() throws IOException;
+
   Boolean dataAssetDataStreamExists(String name) throws IOException;
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/search/elasticsearch/ElasticSearchDataInsightsClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/search/elasticsearch/ElasticSearchDataInsightsClient.java
@@ -67,4 +67,9 @@ public class ElasticSearchDataInsightsClient implements DataInsightsSearchInterf
         "di-data-assets", readResource(String.format("%s/indexTemplate.json", resourcePath)));
     createDataStream("di-data-assets");
   }
+
+  @Override
+  public void deleteDataAssetDataStream() throws IOException {
+    performRequest("DELETE", "/_data_stream/di-data-assets");
+  }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/search/opensearch/OpenSearchDataInsightsClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/search/opensearch/OpenSearchDataInsightsClient.java
@@ -75,4 +75,9 @@ public class OpenSearchDataInsightsClient implements DataInsightsSearchInterface
         "di-data-assets", readResource(String.format("%s/indexTemplate.json", resourcePath)));
     createDataStream("di-data-assets");
   }
+
+  @Override
+  public void deleteDataAssetDataStream() throws IOException {
+    performRequest("DELETE", "_data_stream/di-data-assets");
+  }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/dataAssets/processors/DataInsightsEntityEnricherProcessor.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/dataAssets/processors/DataInsightsEntityEnricherProcessor.java
@@ -187,6 +187,11 @@ public class DataInsightsEntityEnricherProcessor
       entityMap.put("hasDescription", CommonUtil.nullOrEmpty(entity.getDescription()) ? 0 : 1);
     }
 
+    // Modify Custom Property key
+    Optional<Object> oCustomProperties = Optional.ofNullable(entityMap.remove("extension"));
+    oCustomProperties.ifPresent(
+        o -> entityMap.put(String.format("%sCustomProperty", entityType), o));
+
     // Remove 'changeDescription' field
     entityMap.remove("changeDescription");
     // Remove 'sampleData'

--- a/openmetadata-service/src/main/resources/json/data/app/DataInsightsApplication.json
+++ b/openmetadata-service/src/main/resources/json/data/app/DataInsightsApplication.json
@@ -3,6 +3,7 @@
   "displayName": "Data Insights",
   "appConfiguration": {
     "batchSize": 100,
+    "recreateDataAssetsIndex": false,
     "backfillConfiguration": {
         "enabled": false
     }

--- a/openmetadata-service/src/main/resources/json/data/appMarketPlaceDefinition/DataInsightsApplication.json
+++ b/openmetadata-service/src/main/resources/json/data/appMarketPlaceDefinition/DataInsightsApplication.json
@@ -17,6 +17,7 @@
   },
   "appConfiguration": {
     "batchSize": 100,
+    "recreateDataAssetsIndex": false,
     "backfillConfiguration": {
       "enabled": false
     }

--- a/openmetadata-spec/src/main/resources/json/schema/entity/applications/configuration/internal/dataInsightsAppConfig.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/applications/configuration/internal/dataInsightsAppConfig.json
@@ -47,6 +47,12 @@
       "type": "integer",
       "default": 100
     },
+    "recreateDataAssetsIndex": {
+      "title": "Recreate DataInsights DataAssets Index",
+      "description": "Recreates the DataAssets index on DataInsights. Useful if you changed a Custom Property Type and are facing errors. Bear in mind that recreating the index will delete your DataAssets and a backfill will be needed.",
+      "type": "boolean",
+      "default": false
+    },
     "backfillConfiguration": {
       "$ref": "#/definitions/backfillConfiguration"
     }

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ApplicationSchemas/DataInsightsApplication.json
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ApplicationSchemas/DataInsightsApplication.json
@@ -47,6 +47,12 @@
       "type": "integer",
       "default": 100
     },
+    "recreateDataAssetsIndex": {
+      "title": "Recreate DataInsights DataAssets Index",
+      "description": "Recreates the DataAssets index on DataInsights. Useful if you changed a Custom Property Type and are facing errors. Bear in mind that recreating the index will delete your DataAssets and a backfill will be needed.",
+      "type": "boolean",
+      "default": false
+    },
     "backfillConfiguration": {
       "$ref": "#/definitions/backfillConfiguration"
     }


### PR DESCRIPTION


<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

Since all Entities store CustomProperties as `extension` and can have name collision while having different types, we decided to change the attribute for which we are storing them for DataInsights based on the EntityType.

We also implemented the possibility of recreating the Data Assets Data Stream on the configuration.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
