### PR TITLE
Minor: Fix Postgres missing policy rule migrations for EditOwners

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v150/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v150/Migration.java
@@ -3,6 +3,7 @@ package org.openmetadata.service.migration.postgres.v150;
 import static org.openmetadata.service.migration.utils.v150.MigrationUtil.createSystemDICharts;
 import static org.openmetadata.service.migration.utils.v150.MigrationUtil.deleteLegacyDataInsightPipelines;
 import static org.openmetadata.service.migration.utils.v150.MigrationUtil.migrateAutomatorOwner;
+import static org.openmetadata.service.migration.utils.v150.MigrationUtil.migratePolicies;
 import static org.openmetadata.service.migration.utils.v150.MigrationUtil.migrateTestCaseDimension;
 import static org.openmetadata.service.migration.utils.v150.MigrationUtil.updateDataInsightsApplication;
 
@@ -19,6 +20,7 @@ public class Migration extends MigrationProcessImpl {
   @Override
   @SneakyThrows
   public void runDataMigration() {
+    migratePolicies(handle, collectionDAO);
     migrateTestCaseDimension(handle, collectionDAO);
     createSystemDICharts();
     deleteLegacyDataInsightPipelines(pipelineServiceClient);


### PR DESCRIPTION
Migrate Policies never called for postgres, causing migration to fail for EditOwner -> EditOwners
#
### Type of change:
- [ x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
