### PR TITLE
MINOR: Fix Databricks TableQuery timestamps to str

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/databricks/lineage.py
+++ b/ingestion/src/metadata/ingestion/source/database/databricks/lineage.py
@@ -42,8 +42,8 @@ class DatabricksLineageSource(DatabricksQueryParserSource, LineageSource):
                     yield TableQuery(
                         query=row.get("query_text"),
                         userName=row.get("user_name"),
-                        startTime=row.get("query_start_time_ms"),
-                        endTime=row.get("execution_end_time_ms"),
+                        startTime=str(row.get("query_start_time_ms")),
+                        endTime=str(row.get("execution_end_time_ms")),
                         analysisDate=DateTime(datetime.now()),
                         serviceName=self.config.serviceName,
                     )

--- a/ingestion/src/metadata/ingestion/source/database/databricks/usage.py
+++ b/ingestion/src/metadata/ingestion/source/database/databricks/usage.py
@@ -47,8 +47,8 @@ class DatabricksUsageSource(DatabricksQueryParserSource, UsageSource):
                         TableQuery(
                             query=row.get("query_text"),
                             userName=row.get("user_name"),
-                            startTime=row.get("query_start_time_ms"),
-                            endTime=row.get("execution_end_time_ms"),
+                            startTime=str(row.get("query_start_time_ms")),
+                            endTime=str(row.get("execution_end_time_ms")),
                             analysisDate=DateTime(datetime.now()),
                             serviceName=self.config.serviceName,
                             duration=row.get("duration")


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

TableQuery `startTime` and `endTime` are defined as `str`. Here we force the result from databricks into `str` to fix `lineage` and `usage` pipeline.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
