### PR TITLE
[MINOR] add support for Teradata LDAP logon mechanism

### DIFF
--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/teradataConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/teradataConnection.json
@@ -51,7 +51,7 @@
       "title": "LOGMECH",
       "description": "Specifies the logon authentication method. Possible values are TD2 (the default), JWT, LDAP, KRB5 for Kerberos, or TDNEGO",
       "type": "string",
-      "enum": ["TD2", "JWT", "KRB5", "CUSTOM", "TDNEGO"],
+      "enum": ["TD2", "LDAP", "JWT", "KRB5", "CUSTOM", "TDNEGO"],
       "default": "TD2"
     },
     "logdata": {


### PR DESCRIPTION
### Describe your changes:

Add LDAP option for LOGMECH to use ldap for Teradata connections. This option is described in docs but missing in implementation

### Type of change:
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation


### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
