### PR TITLE
Fixes #17461: Unquote and interpret escaped characters in BigQuery dataset description

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/bigquery/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/bigquery/metadata.py
@@ -11,6 +11,7 @@
 """
 Bigquery source module
 """
+import ast
 import os
 import traceback
 from typing import Dict, Iterable, List, Optional, Tuple
@@ -412,7 +413,10 @@ class BigquerySource(
             )
 
             query_result = [result.schema_description for result in query_resp.result()]
-            return fqn.unquote_name(query_result[0])
+
+            return str(
+                ast.literal_eval(query_result[0])
+            )  # To safely evaluate the string, unquote and interpret escaped characters
         except IndexError:
             logger.debug(f"No dataset description found for {schema_name}")
         except Exception as err:

--- a/ingestion/tests/unit/topology/database/test_bigquery.py
+++ b/ingestion/tests/unit/topology/database/test_bigquery.py
@@ -119,7 +119,7 @@ MOCK_TABLE = Table(
     id="c3eb265f-5445-4ad3-ba5e-797d3a3071bb",
     name=EntityName("customers"),
     displayName=None,
-    description=None,
+    description="description\nwith new line",
     tableType="Regular",
     columns=[
         Column(
@@ -225,7 +225,7 @@ EXPTECTED_DATABASE_SCHEMA = [
     CreateDatabaseSchemaRequest(
         name=EntityName("sample_schema"),
         displayName=None,
-        description="",
+        description="Some description with it's own\nnew line",
         owners=None,
         database=FullyQualifiedEntityName("bigquery_source_test.random-project-id"),
         dataProducts=None,
@@ -241,7 +241,10 @@ EXPTECTED_DATABASE_SCHEMA = [
     )
 ]
 
-MOCK_TABLE_NAMES = [tuple(("customers", "Regular")), tuple(("orders", "Regular"))]
+MOCK_TABLE_NAMES = [
+    ("customers", "Regular", None),
+    ("orders", "Regular", "description\nwith new line"),
+]
 
 MOCK_COLUMN_DATA = [
     [
@@ -351,7 +354,6 @@ EXPECTED_TABLE = [
         CreateTableRequest(
             name=EntityName("customers"),
             displayName=None,
-            description=None,
             tableType="Regular",
             columns=[
                 Column(
@@ -437,7 +439,7 @@ EXPECTED_TABLE = [
         CreateTableRequest(
             name=EntityName("orders"),
             displayName=None,
-            description=None,
+            description="description\nwith new line",
             tableType="Regular",
             columns=[
                 Column(
@@ -592,6 +594,7 @@ class BigqueryUnitTest(TestCase):
         self.bq_source._inspector_map[
             self.thread_id
         ].get_columns = lambda table_name, schema, db_name: []
+        self.bq_source.client = Mock()
 
     def test_source_url(self):
         self.assertEqual(
@@ -614,6 +617,22 @@ class BigqueryUnitTest(TestCase):
         ]
 
     def test_yield_database_schema(self):
+        def schema_comment_query(query: str):
+            if query.strip().startswith(
+                "SELECT option_value as schema_description FROM"
+            ):
+                result = Mock()
+                mock_result = Mock()
+                mock_result.schema_description = (
+                    '"Some description with it\'s own\\nnew line"'
+                )
+                result.result.return_value = [mock_result]
+                return result
+            else:
+                raise NotImplementedError
+
+        self.bq_source.client.query = schema_comment_query
+
         assert EXPTECTED_DATABASE_SCHEMA == [
             either.right
             for either in self.bq_source.yield_database_schema(
@@ -664,11 +683,12 @@ class BigqueryUnitTest(TestCase):
             self.bq_source.inspector.get_table_ddl = (
                 lambda table_name, schema, db_name: None  # pylint: disable=cell-var-from-loop
             )
-            self.bq_source.inspector.get_table_comment = (
-                lambda table_name, schema, db_name: None  # pylint: disable=cell-var-from-loop
-            )
+            self.bq_source.inspector.get_table_comment = lambda table_name, schema: {
+                "text": table[2]
+            }  # pylint: disable=cell-var-from-loop
             assert EXPECTED_TABLE[i] == [
-                either.right for either in self.bq_source.yield_table(table)
+                either.right
+                for either in self.bq_source.yield_table((table[0], table[1]))
             ]
 
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #17461 

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

- What:  Unquote and interpret escaped characters in BigQuery dataset description
- Why: The query result from BigQuery includes double quote and converts `\` -> `\\`
- How: Using `ast.literal_eval`

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
