### PR TITLE
MINOR: Add unique count to data insights

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/dataInsightAggregators/ElasticSearchDynamicChartAggregatorInterface.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/dataInsightAggregators/ElasticSearchDynamicChartAggregatorInterface.java
@@ -14,8 +14,6 @@ import es.org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramAg
 import es.org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import es.org.elasticsearch.search.aggregations.bucket.histogram.ParsedDateHistogram;
 import es.org.elasticsearch.search.aggregations.metrics.ParsedCardinality;
-import es.org.elasticsearch.search.aggregations.metrics.ParsedMax;
-import es.org.elasticsearch.search.aggregations.metrics.ParsedMin;
 import es.org.elasticsearch.search.aggregations.metrics.ParsedSingleValueNumericMetricsAggregation;
 import es.org.elasticsearch.search.aggregations.metrics.ParsedValueCount;
 import es.org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
@@ -263,15 +261,15 @@ public interface ElasticSearchDynamicChartAggregatorInterface {
   }
 
   private void addProcessedSubResult(
-          ParsedCardinality aggregation,
-          List<DataInsightCustomChartResult> diChartResults,
-          Double day,
-          String group) {
+      ParsedCardinality aggregation,
+      List<DataInsightCustomChartResult> diChartResults,
+      Double day,
+      String group) {
     ParsedCardinality parsedValueCount = aggregation;
     Double value = Double.valueOf((double) parsedValueCount.getValue());
     if (!Double.isInfinite(value) && !Double.isNaN(value)) {
       DataInsightCustomChartResult diChartResult =
-              new DataInsightCustomChartResult().withCount(value).withDay(day).withGroup(group);
+          new DataInsightCustomChartResult().withCount(value).withDay(day).withGroup(group);
       diChartResults.add(diChartResult);
     }
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/dataInsightAggregators/ElasticSearchDynamicChartAggregatorInterface.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/dataInsightAggregators/ElasticSearchDynamicChartAggregatorInterface.java
@@ -13,6 +13,9 @@ import es.org.elasticsearch.search.aggregations.bucket.filter.ParsedFilter;
 import es.org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
 import es.org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import es.org.elasticsearch.search.aggregations.bucket.histogram.ParsedDateHistogram;
+import es.org.elasticsearch.search.aggregations.metrics.ParsedCardinality;
+import es.org.elasticsearch.search.aggregations.metrics.ParsedMax;
+import es.org.elasticsearch.search.aggregations.metrics.ParsedMin;
 import es.org.elasticsearch.search.aggregations.metrics.ParsedSingleValueNumericMetricsAggregation;
 import es.org.elasticsearch.search.aggregations.metrics.ParsedValueCount;
 import es.org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
@@ -54,6 +57,8 @@ public interface ElasticSearchDynamicChartAggregatorInterface {
         return AggregationBuilders.min(field + index).field(field);
       case MAX:
         return AggregationBuilders.max(field + index).field(field);
+      case UNIQUE:
+        return AggregationBuilders.cardinality(field + index).field(field);
     }
     return null;
   }
@@ -234,6 +239,8 @@ public interface ElasticSearchDynamicChartAggregatorInterface {
       String group) {
     if (subAggr instanceof ParsedValueCount)
       addProcessedSubResult((ParsedValueCount) subAggr, diChartResults, day, group);
+    else if (subAggr instanceof ParsedCardinality)
+      addProcessedSubResult((ParsedCardinality) subAggr, diChartResults, day, group);
     else if (subAggr instanceof ParsedSingleValueNumericMetricsAggregation)
       addProcessedSubResult(
           (ParsedSingleValueNumericMetricsAggregation) subAggr, diChartResults, day, group);
@@ -251,6 +258,20 @@ public interface ElasticSearchDynamicChartAggregatorInterface {
     if (!Double.isInfinite(value) && !Double.isNaN(value)) {
       DataInsightCustomChartResult diChartResult =
           new DataInsightCustomChartResult().withCount(value).withDay(day).withGroup(group);
+      diChartResults.add(diChartResult);
+    }
+  }
+
+  private void addProcessedSubResult(
+          ParsedCardinality aggregation,
+          List<DataInsightCustomChartResult> diChartResults,
+          Double day,
+          String group) {
+    ParsedCardinality parsedValueCount = aggregation;
+    Double value = Double.valueOf((double) parsedValueCount.getValue());
+    if (!Double.isInfinite(value) && !Double.isNaN(value)) {
+      DataInsightCustomChartResult diChartResult =
+              new DataInsightCustomChartResult().withCount(value).withDay(day).withGroup(group);
       diChartResults.add(diChartResult);
     }
   }

--- a/openmetadata-spec/src/main/resources/json/schema/dataInsight/custom/dataInsightCustomChart.json
+++ b/openmetadata-spec/src/main/resources/json/schema/dataInsight/custom/dataInsightCustomChart.json
@@ -18,7 +18,8 @@
                 "sum",
                 "avg",
                 "min",
-                "max"
+                "max",
+                "unique"
             ]
         },
         "kpiDetails": {


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

Our Data Insights Application didn't have a Unique Count function present. This hindered a lot of possibilities since anything that wasn't a `leaf` entity would be repeated n times (Such as Service Id).

This PR aims to add the Unique Count functionality by using the `cardinality` aggregation from ElasticSearch

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
