### PR TITLE
minor: add some spacing for table item action when floating icons are enabled

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/styles/app.less
+++ b/openmetadata-ui/src/main/resources/ui/src/styles/app.less
@@ -812,4 +812,9 @@ a[href].link-text-grey,
   .appearance-cta-buttons {
     padding-right: 64px;
   }
+  .policies-list-table,
+  .roles-list-table,
+  .list-table {
+    margin-right: 64px;
+  }
 }


### PR DESCRIPTION
This PR will add spacing for table item actions when floating icons are enabled in the application. These changes will also fix the AUT failure where actions were being blocked by the floating icons.