### PR TITLE
fix: Teams and owner fields are not being passed in the policy API call.

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Policies.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Policies.spec.ts
@@ -287,4 +287,42 @@ test.describe('Policy page should work properly', () => {
       ).not.toBeVisible();
     });
   });
+
+  test('Policy should have associated rules and teams', async ({ page }) => {
+    const policyResponsePromise = page.waitForResponse(
+      '/api/v1/policies/name/OrganizationPolicy?fields=owners%2Clocation%2Cteams%2Croles'
+    );
+
+    await page
+      .getByRole('link', {
+        name: DEFAULT_POLICIES.organizationPolicy,
+        exact: true,
+      })
+      .click();
+
+    await policyResponsePromise;
+
+    // validate rules tab
+
+    await expect(
+      page.getByText('OrganizationPolicy-NoOwner-Rule')
+    ).toBeVisible();
+
+    await expect(page.getByText('OrganizationPolicy-Owner-Rule')).toBeVisible();
+
+    // validate roles tab
+    await page.getByRole('tab', { name: 'Roles', exact: true }).click();
+
+    await expect(
+      page.getByRole('tabpanel', { name: 'Roles', exact: true })
+    ).toBeVisible();
+
+    // validate teams tab
+
+    await page.getByRole('tab', { name: 'Teams', exact: true }).click();
+
+    await expect(
+      page.getByRole('link', { name: 'Organization', exact: true })
+    ).toBeVisible();
+  });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/AddRulePage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/AddRulePage.test.tsx
@@ -13,6 +13,8 @@
 
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { TabSpecificField } from '../../../enums/entity.enum';
+import { getPolicyByName } from '../../../rest/rolesAPIV1';
 import { POLICY_DATA } from '../PoliciesData.mock';
 import AddRulePage from './AddRulePage';
 
@@ -65,6 +67,11 @@ jest.mock('../RuleForm/RuleForm', () =>
 describe('Test Add rule page Component', () => {
   it('Should render the rule form fields', async () => {
     render(<AddRulePage />);
+
+    expect(getPolicyByName).toHaveBeenCalledWith(
+      'data-consumer',
+      `${TabSpecificField.OWNERS},${TabSpecificField.LOCATION},${TabSpecificField.TEAMS},${TabSpecificField.ROLES}`
+    );
 
     const breadcrumb = await screen.findByTestId('breadcrumb');
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/AddRulePage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/AddRulePage.tsx
@@ -84,12 +84,7 @@ const AddRulePage = () => {
     try {
       const data = await getPolicyByName(
         fqn,
-        `${
-          (TabSpecificField.OWNERS,
-          TabSpecificField.LOCATION,
-          TabSpecificField.TEAMS,
-          TabSpecificField.ROLES)
-        }`
+        `${TabSpecificField.OWNERS},${TabSpecificField.LOCATION},${TabSpecificField.TEAMS},${TabSpecificField.ROLES}`
       );
       setPolicy(data ?? ({} as Policy));
     } catch (error) {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/EditRulePage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/EditRulePage.test.tsx
@@ -13,6 +13,8 @@
 
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { TabSpecificField } from '../../../enums/entity.enum';
+import { getPolicyByName } from '../../../rest/rolesAPIV1';
 import { POLICY_DATA } from '../PoliciesData.mock';
 import EditRulePage from './EditRulePage';
 
@@ -65,6 +67,11 @@ jest.mock('../RuleForm/RuleForm', () =>
 describe('Test Edit rule page Component', () => {
   it('Should render the rule form fields', async () => {
     render(<EditRulePage />);
+
+    expect(getPolicyByName).toHaveBeenCalledWith(
+      'data-consumer',
+      `${TabSpecificField.OWNERS},${TabSpecificField.LOCATION},${TabSpecificField.TEAMS},${TabSpecificField.ROLES}`
+    );
 
     const breadcrumb = await screen.findByTestId('breadcrumb');
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/EditRulePage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/EditRulePage.tsx
@@ -84,12 +84,7 @@ const EditRulePage = () => {
     try {
       const data = await getPolicyByName(
         fqn,
-        `${
-          (TabSpecificField.OWNERS,
-          TabSpecificField.LOCATION,
-          TabSpecificField.TEAMS,
-          TabSpecificField.ROLES)
-        }`
+        `${TabSpecificField.OWNERS},${TabSpecificField.LOCATION},${TabSpecificField.TEAMS},${TabSpecificField.ROLES}`
       );
       if (data) {
         setPolicy(data);

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/PoliciesDetailPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/PoliciesDetailPage.test.tsx
@@ -13,6 +13,8 @@
 
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { TabSpecificField } from '../../../enums/entity.enum';
+import { getPolicyByName } from '../../../rest/rolesAPIV1';
 import { POLICY_DATA } from '../PoliciesData.mock';
 import PoliciesDetailPage from './PoliciesDetailPage';
 
@@ -95,6 +97,11 @@ jest.mock('../../../components/PageLayoutV1/PageLayoutV1', () => {
 describe('Test Policy details page', () => {
   it('Should render the policy details page component', async () => {
     render(<PoliciesDetailPage />);
+
+    expect(getPolicyByName).toHaveBeenCalledWith(
+      'policy',
+      `${TabSpecificField.OWNERS},${TabSpecificField.LOCATION},${TabSpecificField.TEAMS},${TabSpecificField.ROLES}`
+    );
 
     const container = await screen.findByTestId('policy-details-container');
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/PoliciesDetailPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/PoliciesDetailPage.tsx
@@ -108,12 +108,7 @@ const PoliciesDetailPage = () => {
     try {
       const data = await getPolicyByName(
         fqn,
-        `${
-          (TabSpecificField.OWNERS,
-          TabSpecificField.LOCATION,
-          TabSpecificField.TEAMS,
-          TabSpecificField.ROLES)
-        }`
+        `${TabSpecificField.OWNERS},${TabSpecificField.LOCATION},${TabSpecificField.TEAMS},${TabSpecificField.ROLES}`
       );
       setPolicy(data ?? ({} as Policy));
     } catch (error) {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/AddRolePage/AddRolePage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/AddRolePage/AddRolePage.test.tsx
@@ -14,6 +14,8 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
+import { TabSpecificField } from '../../../enums/entity.enum';
+import { getPolicies } from '../../../rest/rolesAPIV1';
 import AddRolePage from './AddRolePage';
 
 jest.mock('react-router-dom', () => ({
@@ -69,6 +71,13 @@ jest.mock('../../../components/common/ResizablePanels/ResizablePanels', () =>
 describe('Test Add Role Page', () => {
   it('Should Render the Add Role page component', async () => {
     render(<AddRolePage />, { wrapper: MemoryRouter });
+
+    expect(getPolicies).toHaveBeenCalledWith(
+      `${TabSpecificField.OWNERS},${TabSpecificField.LOCATION},${TabSpecificField.TEAMS},${TabSpecificField.ROLES}`,
+      undefined,
+      undefined,
+      100
+    );
 
     const container = await screen.findByTestId('add-role-container');
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/AddRolePage/AddRolePage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/AddRolePage/AddRolePage.tsx
@@ -62,12 +62,7 @@ const AddRolePage = () => {
   const fetchPolicies = async () => {
     try {
       const data = await getPolicies(
-        `${
-          (TabSpecificField.OWNERS,
-          TabSpecificField.LOCATION,
-          TabSpecificField.TEAMS,
-          TabSpecificField.ROLES)
-        }`,
+        `${TabSpecificField.OWNERS},${TabSpecificField.LOCATION},${TabSpecificField.TEAMS},${TabSpecificField.ROLES}`,
         undefined,
         undefined,
         100

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ServiceDetailsPage/ServiceDetailsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ServiceDetailsPage/ServiceDetailsPage.tsx
@@ -574,7 +574,7 @@ const ServiceDetailsPage: FunctionComponent = () => {
         {
           fields: `${TabSpecificField.OWNERS},${TabSpecificField.TAGS},${
             isMetadataService ? '' : TabSpecificField.DATA_PRODUCTS
-          },${isMetadataService ? '' : 'domain'}`,
+          },${isMetadataService ? '' : TabSpecificField.DOMAIN}`,
           include: Include.All,
         }
       );


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:


<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->


The issue lies in the way the fields are being passed to the `getPolicyByName` function. The expression inside the template literal is using the comma operator, which only evaluates the last operand. Therefore, only `TabSpecificField.ROLES` is being passed. 
Was introduced in https://github.com/open-metadata/OpenMetadata/pull/17013

```js
const data = await getPolicyByName( fqn, ${ (TabSpecificField.OWNERS, TabSpecificField.LOCATION, TabSpecificField.TEAMS, TabSpecificField.ROLES) } );
```

To fix the issue now we are passing fields like this

```js
const data = await getPolicyByName(
        fqn,
        `${TabSpecificField.OWNERS},${TabSpecificField.LOCATION},${TabSpecificField.TEAMS},${TabSpecificField.ROLES}`
      );
```

https://github.com/user-attachments/assets/f6ab16dd-4239-4c6a-8920-debb29159e0e



<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->


- [x] I have added a test that covers the exact scenario we are fixing. 


<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
