### PR TITLE
[HOTFIX] - Re-enable ryuk for pytests

### DIFF
--- a/.github/workflows/py-tests-skip.yml
+++ b/.github/workflows/py-tests-skip.yml
@@ -9,7 +9,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-name: py-tests
+name: py-tests (skip)
 on:
   pull_request_target:
     types: [labeled, opened, synchronize, reopened]

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -33,11 +33,14 @@ permissions:
 
 jobs:
   py-run-tests:
-    runs-on: ubuntu-latest
+    #runs-on: ubuntu-latest
+    runs-on:
+      group: collate-x86
     strategy:
       fail-fast: false
       matrix:
-        py-version: ['3.8', '3.9', '3.10', '3.11']
+        #py-version: ['3.8', '3.9', '3.10', '3.11']
+        py-version: ['3.10']
     steps:
     - name: Free Disk Space (Ubuntu)
       uses: jlumbroso/free-disk-space@main

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -84,14 +84,14 @@ jobs:
     - name: Run Python Tests
       if: ${{ matrix.py-version != '3.9' }}
       run: |
+        df -h
         source env/bin/activate
         make run_python_tests
-      env:
-        TESTCONTAINERS_RYUK_DISABLED: true
       
     - name: Run Python Tests & record coverage
       if: ${{ matrix.py-version == '3.9' }}
       run: |
+        df -h
         source env/bin/activate
         make coverage
         rm pom.xml

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -34,8 +34,7 @@ permissions:
 jobs:
   py-run-tests:
     #runs-on: ubuntu-latest
-    runs-on:
-      group: collate-x86
+    runs-on: mgmt-x86
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### Describe your changes:

This PR will re-enable ryuk in the pytest workflow to cleanup unused images during build time and improve the disk usage.
It is a workflow change and has no impact on the application itself.

Also updated the name of the `pytest-skip` because it was showing under the same name as the real pytests.

#
### Type of change:
- [ x ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
