### PR TITLE
minor: fix custom property playwright test for AUT

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/customProperty.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/customProperty.ts
@@ -540,7 +540,10 @@ export const addCustomPropertiesForEntity = async ({
   // Enum configuration
   if (customType === 'Enum' && enumConfig) {
     for (const val of enumConfig.values) {
-      await page.fill('#root\\/enumConfig', `${val}{Enter}`);
+      await page.click('#root\\/enumConfig');
+      await page.fill('#root\\/enumConfig', val);
+      await page.press('#root\\/enumConfig', 'Enter');
+      await page.mouse.click(0, 0);
     }
 
     if (enumConfig.multiSelect) {
@@ -615,16 +618,17 @@ export const editCreatedProperty = async (
   await page.locator(descriptionBox).fill('This is new description');
 
   if (type === 'Enum') {
-    await page
-      .locator('#root\\/customPropertyConfig')
-      .fill(`updatedValue{Enter}`);
-    await page.click('body'); // Equivalent to clicking outside
+    await page.click('#root\\/customPropertyConfig');
+    await page.fill('#root\\/customPropertyConfig', 'updatedValue');
+    await page.press('#root\\/customPropertyConfig', 'Enter');
+    await page.mouse.click(0, 0);
   }
 
   if (ENTITY_REFERENCE_PROPERTIES.includes(type ?? '')) {
-    await page.locator('#root\\/customPropertyConfig').click();
-    await page.locator('#root\\/customPropertyConfig').fill(`Table{Enter}`);
-    await page.click('body'); // Equivalent to clicking outside
+    await page.click('#root\\/customPropertyConfig');
+    await page.fill('#root\\/customPropertyConfig', 'Table');
+    await page.press('#root\\/customPropertyConfig', 'Enter');
+    await page.mouse.click(0, 0);
   }
 
   const patchRequest = page.waitForResponse('/api/v1/metadata/types/*');


### PR DESCRIPTION
In some places, we were using `.fill('value{enter}')`, which was causing the test to be flaky, so I updated it to use the `.press` method instead.