### PR TITLE
minor: add supportsMetadataExtraction property in restConnection.json

### DIFF
--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/apiService/restConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/apiService/restConnection.json
@@ -32,6 +32,12 @@
       "description": "Generated Token to connect to OpenAPI Schema.",
       "type": "string",
       "format": "password"
+    },
+    "supportsMetadataExtraction": {
+      "title": "Supports Metadata Extraction",
+      "description": "Supports Metadata Extraction.",
+      "type": "boolean",
+      "default": true
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
We support metadata ingestion pipelines for API services, but the `supportsMetadataExtraction` was missing in the connection config. This PR addresses that issue.