### PR TITLE
Minor: mark params optional for test case reports end point

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/rest/testAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/testAPI.ts
@@ -107,8 +107,8 @@ export type ListTestCaseSearchResultsParams = {
   testCaseFQN?: string;
   testSuiteId?: string;
   latest?: boolean;
-  testCaseType: TestCaseType;
-  dataQualityDimension: DataQualityDimensions;
+  testCaseType?: TestCaseType;
+  dataQualityDimension?: DataQualityDimensions;
 };
 
 export type AddTestCaseToLogicalTestSuiteType = {


### PR DESCRIPTION
This pull request includes a minor change to mark the parameters as optional for the test case reports endpoint. This change allows for more flexibility when querying test case search results by allowing the testCaseType and dataQualityDimension parameters to be optional.