### PR TITLE
MINOR: add env DEV_SERVER_TARGET for webpack.config.dev.js to specify the OpenMetadata server

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/README.md
+++ b/openmetadata-ui/src/main/resources/ui/README.md
@@ -29,6 +29,16 @@ Using the command below, spin up the server locally from the directory `openmeta
 >
 > Since typescript is heavily used in the OpenMetadata project, we generate the typescript types and the interface from JSON schema. We use the `QuickType` tool to generate the typescript types and interfaces. You can view the complete instructions [here](https://docs.open-metadata.org/developers/contribute/build-code-and-run-tests/generate-typescript-types-from-json-schema).
 
+Alternatively, you can connect to an already started OpenMetadata Server to develop UI by setting the `DEV_SERVER_TARGET` environment variable.
+```shell
+# For example, the openmetedata server service launched with docker compose:
+# https://github.com/open-metadata/OpenMetadata/blob/main/docker/development/docker-compose.yml
+export DEV_SERVER_TARGET=http://openmetadata-server:8585/
+
+# Follow the steps to Run OpenMetadata UI...
+make yarn_start_dev_ui
+```
+
 ## Steps to Run OpenMetadata UI
 
 Once the node and yarn are installed in the system, you can perform the following steps to run OpenMetadata UI.

--- a/openmetadata-ui/src/main/resources/ui/webpack.config.dev.js
+++ b/openmetadata-ui/src/main/resources/ui/webpack.config.dev.js
@@ -19,6 +19,7 @@ const process = require('process');
 
 const outputPath = path.join(__dirname, 'build');
 const subPath = process.env.APP_SUB_PATH ?? '';
+const devServerTarget = process.env.DEV_SERVER_TARGET ?? 'http://localhost:8585/';
 
 module.exports = {
   // Development mode
@@ -194,7 +195,7 @@ module.exports = {
     proxy: [
       {
         context: '/api/',
-        target: 'http://localhost:8585/',
+        target: devServerTarget,
         changeOrigin: true,
       },
     ],


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

(No issue opened explicitly)

- What changes did you make?
  - Allows us to change the backend OpenMetadata server that the development UI connects to easily by an environment variable.
- Why did you make them?
  - At the moment, the target server is hard-coded in `webpack.config.dev.js`.
    - In certain development scenarios, it would be useful to be able to make changes **without modifying the file**.
- How did you test your changes?
  - If the environment variable is not set, the behavior is unchanged.
  - I have verified in my local environment that it behaves as expected when environment variables are set.

#
### Type of change:
- [x] Improvement

#
### Checklist:

- [x] Update README to describe the usage of this feature.

