### PR TITLE
Fix Redshift profiler for external tables in Redshift Spectrum

### DIFF
--- a/ingestion/src/metadata/profiler/orm/functions/table_metric_computer.py
+++ b/ingestion/src/metadata/profiler/orm/functions/table_metric_computer.py
@@ -412,7 +412,7 @@ class RedshiftTableMetricComputer(BaseTableMetricComputer):
         )
         res = self.runner._session.execute(query).first()
         if not res:
-            return None
+            return super().compute()
         if res.rowCount is None or (
             res.rowCount == 0 and self._entity.tableType == TableType.View
         ):


### PR DESCRIPTION
Fixes: No issue number

The issue was that OpenMetadata's Redshift profiler used the `svv_table_info` system table to fetch details for both internal and external tables. However, `svv_table_info` does not contain metadata for external tables, causing the profiler to return empty results and does not fetches `Row Count`.

The previous implementation handled this scenario by returning `None` when no results were found, which prevented `Row Count` metric computation for Redshift Spectrum external tables.

### **Solution:**
The fix introduces a fallback mechanism that, if `svv_table_info` returns empty results, triggers a call to the base profiler’s method (`super().compute()`), which directly queries the target external table to compute the metrics. This ensures that profiling works for both internal and external tables.

### **Reason for Change:**
I had a use case where I needed to run the profiler on Redshift Spectrum external tables, but it was failing due to the above issue. After performing Root Cause Analysis (RCA), I identified the source of the problem and made the necessary changes to ensure the profiler runs successfully for external tables as well.

### Type of change:
- [x] Bug fix

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

# 
### Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, I have commented on the issue number in the test for future reference.


