### PR TITLE
GEN-927 - Add bot default roles

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/RoleRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/RoleRepository.java
@@ -35,6 +35,7 @@ import org.openmetadata.service.util.EntityUtil.Fields;
 @Slf4j
 public class RoleRepository extends EntityRepository<Role> {
   public static final String DOMAIN_ONLY_ACCESS_ROLE = "DomainOnlyAccessRole";
+  public static final String DEFAULT_BOT_ROLE = "DefaultBotRole";
 
   public RoleRepository() {
     super(

--- a/openmetadata-service/src/main/resources/json/data/role/DefaultBotRole.json
+++ b/openmetadata-service/src/main/resources/json/data/role/DefaultBotRole.json
@@ -1,0 +1,17 @@
+{
+  "name": "DefaultBotRole",
+  "displayName": "Default Bot Role",
+  "description": "Role Corresponding to a Bot by default.",
+  "allowDelete": false,
+  "provider": "system",
+  "policies" : [
+    {
+      "type" : "policy",
+      "name" : "DefaultBotPolicy"
+    },
+    {
+      "type" : "policy",
+      "name" : "DataConsumerPolicy"
+    }
+  ]
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/EntityResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/EntityResourceTest.java
@@ -272,6 +272,8 @@ public abstract class EntityResourceTest<T extends EntityInterface, K extends Cr
   public static EntityReference USER2_REF;
   public static User USER_TEAM21;
   public static User BOT_USER;
+  public static EntityReference DEFAULT_BOT_ROLE_REF;
+  public static EntityReference DOMAIN_ONLY_ACCESS_ROLE_REF;
 
   public static Team ORG_TEAM;
   public static Team TEAM1;

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/system/SystemResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/system/SystemResourceTest.java
@@ -40,12 +40,12 @@ import org.openmetadata.schema.api.services.CreateStorageService;
 import org.openmetadata.schema.api.teams.CreateTeam;
 import org.openmetadata.schema.api.teams.CreateUser;
 import org.openmetadata.schema.api.tests.CreateTestSuite;
-import org.openmetadata.schema.auth.SSOAuthMechanism;
+import org.openmetadata.schema.auth.JWTAuthMechanism;
+import org.openmetadata.schema.auth.JWTTokenExpiry;
 import org.openmetadata.schema.email.SmtpSettings;
 import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.schema.entity.teams.AuthenticationMechanism;
 import org.openmetadata.schema.profiler.MetricType;
-import org.openmetadata.schema.security.client.GoogleSSOClientConfig;
 import org.openmetadata.schema.settings.Settings;
 import org.openmetadata.schema.settings.SettingsType;
 import org.openmetadata.schema.system.ValidationResponse;
@@ -321,13 +321,10 @@ public class SystemResourceTest extends OpenMetadataApplicationTest {
             .withIsBot(true)
             .withAuthenticationMechanism(
                 new AuthenticationMechanism()
-                    .withAuthType(AuthenticationMechanism.AuthType.SSO)
+                    .withAuthType(AuthenticationMechanism.AuthType.JWT)
                     .withConfig(
-                        new SSOAuthMechanism()
-                            .withSsoServiceType(SSOAuthMechanism.SsoServiceType.GOOGLE)
-                            .withAuthConfig(
-                                new GoogleSSOClientConfig()
-                                    .withSecretKey("/fake/path/secret.json"))));
+                        new JWTAuthMechanism().withJWTTokenExpiry(JWTTokenExpiry.Unlimited)));
+
     userResourceTest.createEntity(createUser, ADMIN_AUTH_HEADERS);
 
     int afterUserCount = getEntitiesCount().getUserCount();

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/teams/UserResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/teams/UserResourceTest.java
@@ -44,6 +44,8 @@ import static org.openmetadata.service.exception.CatalogExceptionMessage.entityN
 import static org.openmetadata.service.exception.CatalogExceptionMessage.notAdmin;
 import static org.openmetadata.service.exception.CatalogExceptionMessage.operationNotAllowed;
 import static org.openmetadata.service.exception.CatalogExceptionMessage.permissionNotAllowed;
+import static org.openmetadata.service.jdbi3.RoleRepository.DEFAULT_BOT_ROLE;
+import static org.openmetadata.service.jdbi3.RoleRepository.DOMAIN_ONLY_ACCESS_ROLE;
 import static org.openmetadata.service.resources.teams.UserResource.USER_PROTECTED_FIELDS;
 import static org.openmetadata.service.security.SecurityUtil.authHeaders;
 import static org.openmetadata.service.util.EntityUtil.fieldAdded;
@@ -109,18 +111,17 @@ import org.openmetadata.schema.auth.PersonalAccessToken;
 import org.openmetadata.schema.auth.RegistrationRequest;
 import org.openmetadata.schema.auth.RevokePersonalTokenRequest;
 import org.openmetadata.schema.auth.RevokeTokenRequest;
-import org.openmetadata.schema.auth.SSOAuthMechanism;
 import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.schema.entity.teams.AuthenticationMechanism;
 import org.openmetadata.schema.entity.teams.AuthenticationMechanism.AuthType;
 import org.openmetadata.schema.entity.teams.Role;
 import org.openmetadata.schema.entity.teams.Team;
 import org.openmetadata.schema.entity.teams.User;
-import org.openmetadata.schema.security.client.GoogleSSOClientConfig;
 import org.openmetadata.schema.type.ApiStatus;
 import org.openmetadata.schema.type.ChangeDescription;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.ImageList;
+import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.schema.type.Profile;
 import org.openmetadata.schema.type.Webhook;
@@ -129,6 +130,7 @@ import org.openmetadata.schema.type.profile.SubscriptionConfig;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.auth.JwtResponse;
 import org.openmetadata.service.exception.CatalogExceptionMessage;
+import org.openmetadata.service.jdbi3.RoleRepository;
 import org.openmetadata.service.jdbi3.TeamRepository.TeamCsv;
 import org.openmetadata.service.jdbi3.UserRepository.UserCsv;
 import org.openmetadata.service.resources.EntityResourceTest;
@@ -150,11 +152,13 @@ public class UserResourceTest extends EntityResourceTest<User, CreateUser> {
   private static final Profile PROFILE =
       new Profile().withImages(new ImageList().withImage(URI.create("https://image.com")));
   private static final TeamResourceTest TEAM_TEST = new TeamResourceTest();
+  private final RoleRepository roleRepository;
 
   public UserResourceTest() {
     super(USER, User.class, UserList.class, "users", UserResource.FIELDS);
     supportedNameCharacters = "_-.";
     supportsSearchIndex = true;
+    roleRepository = Entity.getRoleRepository();
   }
 
   public void setupUsers(TestInfo test) throws HttpResponseException {
@@ -193,6 +197,11 @@ public class UserResourceTest extends EntityResourceTest<User, CreateUser> {
     Set<String> userFields = Entity.getEntityFields(User.class);
     userFields.remove("authenticationMechanism");
     BOT_USER = getEntityByName(INGESTION_BOT, String.join(",", userFields), ADMIN_AUTH_HEADERS);
+
+    // Get the bot roles
+    DEFAULT_BOT_ROLE_REF = roleRepository.getReferenceByName(DEFAULT_BOT_ROLE, Include.NON_DELETED);
+    DOMAIN_ONLY_ACCESS_ROLE_REF =
+        roleRepository.getReferenceByName(DOMAIN_ONLY_ACCESS_ROLE, Include.NON_DELETED);
   }
 
   @Test
@@ -886,12 +895,8 @@ public class UserResourceTest extends EntityResourceTest<User, CreateUser> {
   void put_generateToken_bot_user_200_ok() throws HttpResponseException {
     AuthenticationMechanism authMechanism =
         new AuthenticationMechanism()
-            .withAuthType(AuthType.SSO)
-            .withConfig(
-                new SSOAuthMechanism()
-                    .withSsoServiceType(SSOAuthMechanism.SsoServiceType.GOOGLE)
-                    .withAuthConfig(
-                        new GoogleSSOClientConfig().withSecretKey("/path/to/secret.json")));
+            .withAuthType(AuthType.JWT)
+            .withConfig(new JWTAuthMechanism().withJWTTokenExpiry(JWTTokenExpiry.Unlimited));
     CreateUser create =
         createBotUserRequest("ingestion-bot-jwt")
             .withEmail("ingestion-bot-jwt@email.com")
@@ -899,7 +904,8 @@ public class UserResourceTest extends EntityResourceTest<User, CreateUser> {
             .withAuthenticationMechanism(authMechanism);
     User user = createEntity(create, USER_WITH_CREATE_HEADERS);
     user = getEntity(user.getId(), "*", ADMIN_AUTH_HEADERS);
-    assertEquals(1, user.getRoles().size());
+    // Has the given role and the default bot role
+    assertEquals(2, user.getRoles().size());
     TestUtils.put(
         getResource(String.format("users/generateToken/%s", user.getId())),
         new GenerateTokenRequest().withJWTTokenExpiry(JWTTokenExpiry.Seven),
@@ -907,7 +913,8 @@ public class UserResourceTest extends EntityResourceTest<User, CreateUser> {
         ADMIN_AUTH_HEADERS);
     user = getEntity(user.getId(), "*", ADMIN_AUTH_HEADERS);
     assertNull(user.getAuthenticationMechanism());
-    assertEquals(1, user.getRoles().size());
+    // Has the given role and the default bot role
+    assertEquals(2, user.getRoles().size());
     JWTAuthMechanism jwtAuthMechanism =
         TestUtils.get(
             getResource(String.format("users/token/%s", user.getId())),
@@ -1440,6 +1447,14 @@ public class UserResourceTest extends EntityResourceTest<User, CreateUser> {
     List<EntityReference> expectedRoles = new ArrayList<>();
     for (UUID roleId : listOrEmpty(createRequest.getRoles())) {
       expectedRoles.add(new EntityReference().withId(roleId).withType(Entity.ROLE));
+    }
+
+    // bots are created with default roles
+    if (createRequest.getIsBot()) {
+      expectedRoles.add(DEFAULT_BOT_ROLE_REF);
+      if (!nullOrEmpty(createRequest.getDomains())) {
+        expectedRoles.add(DOMAIN_ONLY_ACCESS_ROLE_REF);
+      }
     }
     assertRoles(user, expectedRoles);
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes GEN-927

- Create `DefaultBotRole` that is added to any bot created. It contains the `DefaultBotPolicy` and `DataConsumerPolicy`. Without it, newly created bots did not have any kind of access to the data on a default installation of OM.
- If bots are created with a Domain, the bot user will also have the `DomainOnlyAccessRole` so that unless admins change it, that bot can only access its own data

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
