### PR TITLE
MINOR - Only timeout on main threads

### DIFF
--- a/ingestion/src/metadata/utils/timeout.py
+++ b/ingestion/src/metadata/utils/timeout.py
@@ -18,6 +18,7 @@ import inspect
 import os
 import platform
 import signal
+import threading
 from typing import Callable
 
 from metadata.utils.constants import TEN_MIN
@@ -47,7 +48,11 @@ def timeout(seconds: int = TEN_MIN) -> Callable:
     def decorator(fn):
         @functools.wraps(fn)
         def inner(*args, **kwargs):
-            if platform.system() != "Windows":  # SIGALRM not supported on Windows
+            # SIGALRM is not supported on Windows or sub-threads
+            if (
+                platform.system() != "Windows"
+                and threading.current_thread() == threading.main_thread()
+            ):
                 signal.signal(signal.SIGALRM, _handle_timeout)
                 signal.alarm(seconds)
                 try:


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Disable SIGALARM timeout on sub threads

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
