### PR TITLE
Minor: Add ViewAll policy to enable default OrganizationPolicy to allow users to view metadata

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v160/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v160/Migration.java
@@ -1,6 +1,7 @@
 package org.openmetadata.service.migration.mysql.v160;
 
 import static org.openmetadata.service.migration.utils.v160.MigrationUtil.addAppExtensionName;
+import static org.openmetadata.service.migration.utils.v160.MigrationUtil.addViewAllRuleToOrgPolicy;
 import static org.openmetadata.service.migration.utils.v160.MigrationUtil.migrateServiceTypesAndConnections;
 
 import lombok.SneakyThrows;
@@ -18,5 +19,6 @@ public class Migration extends MigrationProcessImpl {
   public void runDataMigration() {
     addAppExtensionName(handle, collectionDAO, authenticationConfiguration, false);
     migrateServiceTypesAndConnections(handle, false);
+    addViewAllRuleToOrgPolicy(collectionDAO);
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v160/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v160/Migration.java
@@ -1,6 +1,7 @@
 package org.openmetadata.service.migration.postgres.v160;
 
 import static org.openmetadata.service.migration.utils.v160.MigrationUtil.addAppExtensionName;
+import static org.openmetadata.service.migration.utils.v160.MigrationUtil.addViewAllRuleToOrgPolicy;
 import static org.openmetadata.service.migration.utils.v160.MigrationUtil.migrateServiceTypesAndConnections;
 
 import lombok.SneakyThrows;
@@ -18,5 +19,6 @@ public class Migration extends MigrationProcessImpl {
   public void runDataMigration() {
     addAppExtensionName(handle, collectionDAO, authenticationConfiguration, true);
     migrateServiceTypesAndConnections(handle, true);
+    addViewAllRuleToOrgPolicy(collectionDAO);
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v160/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v160/MigrationUtil.java
@@ -79,29 +79,33 @@ public class MigrationUtil {
 
   public static void addViewAllRuleToOrgPolicy(CollectionDAO collectionDAO) {
     PolicyRepository repository = (PolicyRepository) Entity.getEntityRepository(Entity.POLICY);
-    Policy organizationPolicy = repository.findByName("OrganizationPolicy", Include.NON_DELETED);
-    boolean noViewAllRule = true;
-    for (Rule rule : organizationPolicy.getRules()) {
-      if (rule.getName().equals("OrganizationPolicy-View-All-Rule")) {
-        noViewAllRule = false;
-        break;
+    try {
+      Policy organizationPolicy = repository.findByName("OrganizationPolicy", Include.NON_DELETED);
+      boolean noViewAllRule = true;
+      for (Rule rule : organizationPolicy.getRules()) {
+        if (rule.getName().equals("OrganizationPolicy-View-All-Rule")) {
+          noViewAllRule = false;
+          break;
+        }
       }
-    }
-    if (noViewAllRule) {
-      Rule viewAllRule =
-          new Rule()
-              .withName("OrganizationPolicy-ViewAll-Rule")
-              .withResources(listOf("all"))
-              .withOperations(listOf(MetadataOperation.VIEW_ALL))
-              .withEffect(Rule.Effect.ALLOW)
-              .withDescription("Allow all users to view all metadata");
-      organizationPolicy.getRules().add(viewAllRule);
-      collectionDAO
-          .policyDAO()
-          .update(
-              organizationPolicy.getId(),
-              organizationPolicy.getFullyQualifiedName(),
-              JsonUtils.pojoToJson(organizationPolicy));
+      if (noViewAllRule) {
+        Rule viewAllRule =
+            new Rule()
+                .withName("OrganizationPolicy-ViewAll-Rule")
+                .withResources(listOf("all"))
+                .withOperations(listOf(MetadataOperation.VIEW_ALL))
+                .withEffect(Rule.Effect.ALLOW)
+                .withDescription("Allow all users to view all metadata");
+        organizationPolicy.getRules().add(viewAllRule);
+        collectionDAO
+            .policyDAO()
+            .update(
+                organizationPolicy.getId(),
+                organizationPolicy.getFullyQualifiedName(),
+                JsonUtils.pojoToJson(organizationPolicy));
+      }
+    } catch (EntityNotFoundException ex) {
+      LOG.warn("OrganizationPolicy not found", ex);
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v160/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v160/MigrationUtil.java
@@ -1,5 +1,7 @@
 package org.openmetadata.service.migration.utils.v160;
 
+import static org.openmetadata.common.utils.CommonUtil.listOf;
+
 import java.util.UUID;
 import javax.json.JsonObject;
 import lombok.extern.slf4j.Slf4j;
@@ -8,11 +10,15 @@ import org.jdbi.v3.core.statement.Update;
 import org.openmetadata.schema.api.security.AuthenticationConfiguration;
 import org.openmetadata.schema.entity.app.App;
 import org.openmetadata.schema.entity.app.AppExtension;
+import org.openmetadata.schema.entity.policies.Policy;
+import org.openmetadata.schema.entity.policies.accessControl.Rule;
 import org.openmetadata.schema.type.Include;
+import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.EntityNotFoundException;
 import org.openmetadata.service.jdbi3.AppRepository;
 import org.openmetadata.service.jdbi3.CollectionDAO;
+import org.openmetadata.service.jdbi3.PolicyRepository;
 import org.openmetadata.service.util.JsonUtils;
 
 @Slf4j
@@ -68,6 +74,34 @@ public class MigrationUtil {
               });
     } catch (Exception ex) {
       LOG.warn("Error running app extension migration ", ex);
+    }
+  }
+
+  public static void addViewAllRuleToOrgPolicy(CollectionDAO collectionDAO) {
+    PolicyRepository repository = (PolicyRepository) Entity.getEntityRepository(Entity.POLICY);
+    Policy organizationPolicy = repository.findByName("OrganizationPolicy", Include.NON_DELETED);
+    boolean noViewAllRule = true;
+    for (Rule rule : organizationPolicy.getRules()) {
+      if (rule.getName().equals("OrganizationPolicy-View-All-Rule")) {
+        noViewAllRule = false;
+        break;
+      }
+    }
+    if (noViewAllRule) {
+      Rule viewAllRule =
+          new Rule()
+              .withName("OrganizationPolicy-ViewAll-Rule")
+              .withResources(listOf("all"))
+              .withOperations(listOf(MetadataOperation.VIEW_ALL))
+              .withEffect(Rule.Effect.ALLOW)
+              .withDescription("Allow all users to view all metadata");
+      organizationPolicy.getRules().add(viewAllRule);
+      collectionDAO
+          .policyDAO()
+          .update(
+              organizationPolicy.getId(),
+              organizationPolicy.getFullyQualifiedName(),
+              JsonUtils.pojoToJson(organizationPolicy));
     }
   }
 


### PR DESCRIPTION
### Describe your changes:
Organization policy sets default Edit actions for owners and noowners.
However this doesn't put any ViewPolicy which restricts users access to metadata.
Since we added SearchRBAC, this by default doesn't show any results in explore page.
We should allow ViewAll as default Organization Policy to get the first user experience to discover the data assets

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
