### PR TITLE
test: fix table type custom property AUT

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/customProperty.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/customProperty.ts
@@ -17,8 +17,8 @@ import {
   ENTITY_REFERENCE_PROPERTIES,
 } from '../constant/customProperty';
 import {
-  ENTITY_PATH,
   EntityTypeEndpoint,
+  ENTITY_PATH,
 } from '../support/entity/Entity.interface';
 import { UserClass } from '../support/user/UserClass';
 import { clickOutside, descriptionBox, uuid } from './common';
@@ -704,7 +704,11 @@ export const editCreatedProperty = async (
   }
 
   if (type === 'Table') {
-    await expect(page.getByText('Columns:pw-column1pw-column2')).toBeVisible();
+    await expect(
+      page
+        .locator(`[data-row-key="${propertyName}"]`)
+        .getByText('Columns:pw-column1pw-column2')
+    ).toBeVisible();
   }
 
   await editButton.click();


### PR DESCRIPTION
This PR fixes the table type custom property test. Since there can be multiple table type properties in the AUT, a specific row assertion based on row key locator has been added.