### PR TITLE
minor: improve types in ModalWithCustomPropertyEditor component

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
@@ -768,7 +768,6 @@ export const AuthProvider = ({
       handleFailedLogin,
       updateAxiosInterceptors: initializeAxiosInterceptors,
     });
-
   }, [handleSuccessfulLogin]);
 
   const isConfigLoading =

--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/ModalWithCustomProperty/ModalWithCustomPropertyEditor.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/ModalWithCustomProperty/ModalWithCustomPropertyEditor.component.tsx
@@ -15,8 +15,6 @@ import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { AxiosError } from 'axios';
-import { EntityType } from '../../../enums/entity.enum';
-import { GlossaryTerm } from '../../../generated/entity/data/glossaryTerm';
 import { Type } from '../../../generated/entity/type';
 import { getTypeByFQN } from '../../../rest/metadataTypeAPI';
 import {
@@ -25,6 +23,7 @@ import {
 } from '../../../utils/CSV/CSV.utils';
 import { showErrorToast } from '../../../utils/ToastUtils';
 import { CustomPropertyTable } from '../../common/CustomPropertyTable/CustomPropertyTable';
+import { ExtentionEntities } from '../../common/CustomPropertyTable/CustomPropertyTable.interface';
 import Loader from '../../common/Loader/Loader';
 import {
   ExtensionDataProps,
@@ -75,7 +74,9 @@ export const ModalWithCustomPropertyEditor = ({
     setIsSaveLoading(false);
   };
 
-  const onExtensionUpdate = async (data: GlossaryTerm) => {
+  const onExtensionUpdate = async (
+    data: ExtentionEntities[keyof ExtentionEntities]
+  ) => {
     setExtensionObject(data.extension);
   };
 
@@ -120,8 +121,12 @@ export const ModalWithCustomPropertyEditor = ({
           hasEditAccess
           hasPermission
           isRenderedInRightPanel
-          entityDetails={{ extension: extensionObject } as GlossaryTerm}
-          entityType={EntityType.GLOSSARY_TERM}
+          entityDetails={
+            {
+              extension: extensionObject,
+            } as ExtentionEntities[keyof ExtentionEntities]
+          }
+          entityType={entityType as keyof ExtentionEntities}
           handleExtensionUpdate={onExtensionUpdate}
         />
       )}

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TagClassBase.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TagClassBase.test.ts
@@ -16,7 +16,6 @@ import tagClassBase, { TagClassBase } from './TagClassBase';
 
 jest.mock('../rest/searchAPI');
 
-
 jest.mock('./StringsUtils', () => ({
   getEncodedFqn: jest.fn().mockReturnValue('test'),
   escapeESReservedCharacters: jest.fn().mockReturnValue('test'),


### PR DESCRIPTION
This PR include the following changes

- use `entityType` prop for custom property table
- remove harcoded type for entity details and use generic type