### PR TITLE
fix: application support email link with `mailto:` URI schema

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Applications/MarketPlaceAppDetails/MarketPlaceAppDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Applications/MarketPlaceAppDetails/MarketPlaceAppDetails.component.tsx
@@ -203,7 +203,10 @@ const MarketPlaceAppDetails = () => {
         <Space className="p-t-lg" direction="vertical" size={8}>
           <Typography.Text>
             {appData?.supportEmail && (
-              <Typography.Link href={appData?.supportEmail} target="_blank">
+              <Typography.Link
+                data-testid="app-support-email"
+                href={`mailto:${appData?.supportEmail}`}
+                target="_blank">
                 <Space>{t('label.get-app-support')}</Space>
               </Typography.Link>
             )}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Applications/MarketPlaceAppDetails/MarketPlaceAppDetails.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Applications/MarketPlaceAppDetails/MarketPlaceAppDetails.test.tsx
@@ -179,4 +179,15 @@ describe('MarketPlaceAppDetails component', () => {
 
     expect(mockPush).toHaveBeenCalledWith('app install path');
   });
+
+  it("should render the correct support email url with 'mailto:' schema", async () => {
+    render(<MarketPlaceAppDetails />);
+
+    await waitForElementToBeRemoved(() => screen.getByText('Loader'));
+
+    expect(screen.getByTestId('app-support-email')).toHaveAttribute(
+      'href',
+      'mailto:support@email.com'
+    );
+  });
 });


### PR DESCRIPTION
**Issue**: We were directly using the email address as the `href` value for the anchor element for application support. This is causing an issue where the link `https://domain.com/path/apps/emailid` is created incorrectly. Instead of opening the email client when clicking on `Get App Support`, it opens the application path and treats the email address as a fully qualified name of the application.


https://github.com/user-attachments/assets/a3758c8c-8f26-4956-ba8d-56cd371c9a9b


**Fix**: Added a `mailto:` URI scheme so that the `Get App Support` link opens the user's default email client with the provided support email address.


https://github.com/user-attachments/assets/64798636-0a4d-460d-a51d-56c80d2af894

