### PR TITLE
fix(ui): navigate to listing for deleting a service

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/ServiceDetailsPage/ServiceDetailsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ServiceDetailsPage/ServiceDetailsPage.tsx
@@ -48,6 +48,7 @@ import {
   pagingObject,
   ROUTES,
 } from '../../constants/constants';
+import { GlobalSettingsMenuCategory } from '../../constants/GlobalSettings.constants';
 import {
   OPEN_METADATA,
   SERVICE_INGESTION_PIPELINE_TYPES,
@@ -113,12 +114,14 @@ import { DEFAULT_ENTITY_PERMISSION } from '../../utils/PermissionsUtils';
 import {
   getEditConnectionPath,
   getServiceVersionPath,
+  getSettingPath,
 } from '../../utils/RouterUtils';
 import {
   getCountLabel,
   getEntityTypeFromServiceCategory,
   getResourceEntityFromServiceCategory,
   getServiceDisplayNameQueryFilter,
+  getServiceRouteFromServiceType,
   shouldTestConnection,
 } from '../../utils/ServiceUtils';
 import {
@@ -795,8 +798,15 @@ const ServiceDetailsPage: FunctionComponent = () => {
 
   const afterDeleteAction = useCallback(
     (isSoftDelete?: boolean, version?: number) =>
-      isSoftDelete ? handleToggleDelete(version) : history.goBack(),
-    [handleToggleDelete]
+      isSoftDelete
+        ? handleToggleDelete(version)
+        : history.push(
+            getSettingPath(
+              GlobalSettingsMenuCategory.SERVICES,
+              getServiceRouteFromServiceType(serviceCategory)
+            )
+          ),
+    [handleToggleDelete, serviceCategory]
   );
 
   const handleRestoreService = useCallback(async () => {


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes: Fixed navigation to non-exist page to existing page for deleting a service





I worked on:

#### Issue

- When deleting a service from details page, UI tries to move back to older in history which may contain a page which no longer available due to hard delete of service.
- i.e. User visit a table page and navigate to it's service page from breadcrumbs. Now if user delete that service parmenatly UI will try to throw user to table page which no longer exist and trun into an error 

#### Fix

- Instead throwing user to back in history navigate them to relevant service listing page.

#### Tests:

- [x] Have manually tested below services deletion operation

- API
- Databases
- Messaging
- Dashboard
- Pipeline
- ML Model
- Storages
- Search
- Metadata


https://github.com/user-attachments/assets/09aa3dd2-070c-4ee8-b2be-b9f99e3f7e08
#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
