### PR TITLE
[ER Diagrams]: Fix EntityRelationship data disappeared after reindexing

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -2613,6 +2613,25 @@ public interface CollectionDAO {
       return listAfter(
           getTableName(), filter.getQueryParams(), condition, condition, limit, afterName, afterId);
     }
+
+    @ConnectionAwareSqlQuery(
+        value =
+            "SELECT json FROM table_entity "
+                + "WHERE JSON_SEARCH(JSON_EXTRACT(json, '$.tableConstraints[*].referredColumns'), "
+                + "'one', :fqn) IS NOT NULL",
+        connectionType = MYSQL)
+    @ConnectionAwareSqlQuery(
+        value =
+            "SELECT json "
+                + "FROM table_entity "
+                + "WHERE EXISTS ("
+                + "    SELECT 1"
+                + "    FROM jsonb_array_elements(json->'tableConstraints') AS constraints"
+                + "    CROSS JOIN jsonb_array_elements_text(constraints->'referredColumns') AS referredColumn "
+                + "    WHERE referredColumn LIKE :fqn"
+                + ")",
+        connectionType = POSTGRES)
+    List<String> findRelatedTables(@Bind("fqn") String fqn);
   }
 
   interface StoredProcedureDAO extends EntityDAO<StoredProcedure> {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/SearchIndex.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/SearchIndex.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
-import org.openmetadata.common.utils.CommonUtil;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.schema.type.EntityReference;
@@ -174,62 +173,91 @@ public interface SearchIndex {
     return data;
   }
 
-  static List<Map<String, Object>> populateEntityRelationshipData(Table entity) {
-    List<Map<String, Object>> constraints = new ArrayList<>();
-    if (CommonUtil.nullOrEmpty(entity.getTableConstraints())) {
-      return constraints;
-    }
-    for (TableConstraint tableConstraint : entity.getTableConstraints()) {
-      if (!tableConstraint
-          .getConstraintType()
-          .value()
-          .equalsIgnoreCase(TableConstraint.ConstraintType.FOREIGN_KEY.value())) {
-        continue;
-      }
-      for (String referredColumn : tableConstraint.getReferredColumns()) {
-        String relatedEntityFQN = getParentFQN(referredColumn);
-        Table relatedEntity;
-        try {
-          relatedEntity = getEntityByName(Entity.TABLE, relatedEntityFQN, "*", NON_DELETED);
-          IndexMapping destinationIndexMapping =
-              Entity.getSearchRepository()
-                  .getIndexMapping(relatedEntity.getEntityReference().getType());
-          String destinationIndexName =
-              destinationIndexMapping.getIndexName(Entity.getSearchRepository().getClusterAlias());
-          Map<String, Object> relationshipsMap = buildRelationshipsMap(entity, relatedEntity);
-          int relatedEntityIndex =
-              checkRelatedEntity(relatedEntity.getFullyQualifiedName(), constraints);
-          if (relatedEntityIndex >= 0) {
-            updateExistingConstraint(
-                entity,
-                tableConstraint,
-                constraints.get(relatedEntityIndex),
-                destinationIndexName,
-                relatedEntity,
-                referredColumn);
-          } else {
-            addNewConstraint(
-                entity,
-                tableConstraint,
-                constraints,
-                relationshipsMap,
-                destinationIndexName,
-                relatedEntity,
-                referredColumn);
+  private static void processConstraints(
+      Table entity,
+      Table relatedEntity,
+      List<Map<String, Object>> constraints,
+      Boolean updateForeignTableIndex) {
+    if (!nullOrEmpty(entity.getTableConstraints())) {
+      for (TableConstraint tableConstraint : entity.getTableConstraints()) {
+        if (!tableConstraint
+            .getConstraintType()
+            .value()
+            .equalsIgnoreCase(TableConstraint.ConstraintType.FOREIGN_KEY.value())) {
+          continue;
+        }
+        for (String referredColumn : tableConstraint.getReferredColumns()) {
+          String relatedEntityFQN = getParentFQN(referredColumn);
+          String destinationIndexName = null;
+          try {
+            if (updateForeignTableIndex) {
+              relatedEntity = getEntityByName(Entity.TABLE, relatedEntityFQN, "*", NON_DELETED);
+              IndexMapping destinationIndexMapping =
+                  Entity.getSearchRepository()
+                      .getIndexMapping(relatedEntity.getEntityReference().getType());
+              destinationIndexName =
+                  destinationIndexMapping.getIndexName(
+                      Entity.getSearchRepository().getClusterAlias());
+            }
+            Map<String, Object> relationshipsMap = buildRelationshipsMap(entity, relatedEntity);
+            int relatedEntityIndex =
+                checkRelatedEntity(
+                    entity.getFullyQualifiedName(),
+                    relatedEntity.getFullyQualifiedName(),
+                    constraints);
+            if (relatedEntityIndex >= 0) {
+              updateExistingConstraint(
+                  entity,
+                  tableConstraint,
+                  constraints.get(relatedEntityIndex),
+                  destinationIndexName,
+                  relatedEntity,
+                  referredColumn,
+                  updateForeignTableIndex);
+            } else {
+              addNewConstraint(
+                  entity,
+                  tableConstraint,
+                  constraints,
+                  relationshipsMap,
+                  destinationIndexName,
+                  relatedEntity,
+                  referredColumn,
+                  updateForeignTableIndex);
+            }
+          } catch (EntityNotFoundException ex) {
           }
-        } catch (EntityNotFoundException ex) {
         }
       }
+    }
+  }
+
+  static List<Map<String, Object>> populateEntityRelationshipData(Table entity) {
+    List<Map<String, Object>> constraints = new ArrayList<>();
+    processConstraints(entity, null, constraints, true);
+
+    // We need to query the table_entity table to find the references this current table
+    // has with other tables. We pick this info from the ES however in case of re-indexing this info
+    // needs to be picked from the db
+    CollectionDAO dao = Entity.getCollectionDAO();
+    List<String> json_array =
+        dao.tableDAO().findRelatedTables(entity.getFullyQualifiedName() + "%");
+    for (String json : json_array) {
+      Table foreign_table = JsonUtils.readValue(json, Table.class);
+      processConstraints(foreign_table, entity, constraints, false);
     }
     return constraints;
   }
 
-  static int checkRelatedEntity(String relatedEntityFQN, List<Map<String, Object>> constraints) {
+  static int checkRelatedEntity(
+      String entityFQN, String relatedEntityFQN, List<Map<String, Object>> constraints) {
     int index = 0;
     for (Map<String, Object> constraint : constraints) {
       Map<String, Object> relatedConstraintEntity =
           (Map<String, Object>) constraint.get("relatedEntity");
-      if (relatedConstraintEntity.get("fqn").equals(relatedEntityFQN)) {
+      Map<String, Object> constraintEntity = (Map<String, Object>) constraint.get("entity");
+      if (relatedConstraintEntity.get("fqn").equals(relatedEntityFQN)
+          && constraintEntity.get("fqn").equals(entityFQN)) {
         return index;
       }
       index++;
@@ -259,7 +287,8 @@ public interface SearchIndex {
       Map<String, Object> presentConstraint,
       String destinationIndexName,
       Table relatedEntity,
-      String referredColumn) {
+      String referredColumn,
+      Boolean updateForeignTableIndex) {
     for (String currentColumn : tableConstraint.getColumns()) {
       if (currentColumn.equals(FullyQualifiedName.getColumnName(referredColumn))) {
         String columnFQN = FullyQualifiedName.add(entity.getFullyQualifiedName(), currentColumn);
@@ -272,9 +301,9 @@ public interface SearchIndex {
         List<Map<String, Object>> presentColumns =
             (List<Map<String, Object>>) presentConstraint.get("columns");
         presentColumns.add(columnMap);
-
-        updateRelatedEntityIndex(destinationIndexName, relatedEntity, presentConstraint);
-        break;
+        if (updateForeignTableIndex) {
+          updateRelatedEntityIndex(destinationIndexName, relatedEntity, presentConstraint);
+        }
       }
     }
   }
@@ -286,7 +315,8 @@ public interface SearchIndex {
       Map<String, Object> relationshipsMap,
       String destinationIndexName,
       Table relatedEntity,
-      String referredColumn) {
+      String referredColumn,
+      Boolean updateForeignTableIndex) {
     for (String currentColumn : tableConstraint.getColumns()) {
       if (currentColumn.equals(FullyQualifiedName.getColumnName(referredColumn))) {
         List<Map<String, Object>> columns = new ArrayList<>();
@@ -299,8 +329,9 @@ public interface SearchIndex {
         columns.add(columnMap);
         relationshipsMap.put("columns", columns);
         constraints.add(JsonUtils.getMap(relationshipsMap));
-
-        updateRelatedEntityIndex(destinationIndexName, relatedEntity, relationshipsMap);
+        if (updateForeignTableIndex) {
+          updateRelatedEntityIndex(destinationIndexName, relatedEntity, relationshipsMap);
+        }
       }
     }
   }


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fix EntityRelationship data disappeared after reindexing

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
