### PR TITLE
[WIP] Fix Successfully Sent Change Events for Alerts For Debuggability API

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertUtil.java
@@ -203,7 +203,8 @@ public final class AlertUtil {
   }
 
   public static EventSubscriptionOffset getStartingOffset(UUID eventSubscriptionId) {
-    long eventSubscriptionOffset;
+    long startingOffset;
+    long currentOffset;
     String json =
         Entity.getCollectionDAO()
             .eventSubscriptionDAO()
@@ -211,11 +212,15 @@ public final class AlertUtil {
     if (json != null) {
       EventSubscriptionOffset offsetFromDb =
           JsonUtils.readValue(json, EventSubscriptionOffset.class);
-      eventSubscriptionOffset = offsetFromDb.getOffset();
+      startingOffset = offsetFromDb.getStartingOffset();
+      currentOffset = offsetFromDb.getCurrentOffset();
     } else {
-      eventSubscriptionOffset = Entity.getCollectionDAO().changeEventDAO().getLatestOffset();
+      currentOffset = Entity.getCollectionDAO().changeEventDAO().getLatestOffset();
+      startingOffset = currentOffset;
     }
-    return new EventSubscriptionOffset().withOffset(eventSubscriptionOffset);
+    return new EventSubscriptionOffset()
+        .withCurrentOffset(currentOffset)
+        .withStartingOffset(startingOffset);
   }
 
   public static FilteringRules validateAndBuildFilteringConditions(

--- a/openmetadata-spec/src/main/resources/json/schema/events/eventSubscriptionOffset.json
+++ b/openmetadata-spec/src/main/resources/json/schema/events/eventSubscriptionOffset.json
@@ -2,12 +2,17 @@
   "$id": "https://open-metadata.org/schema/events/eventSubscriptionOffset.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "EventSubscriptionOffset",
-  "description": "Event Subscription Offset",
+  "description": "Represents the offsets for an event subscription, tracking the starting point and current position of events processed.",
   "type": "object",
   "javaType": "org.openmetadata.schema.entity.events.EventSubscriptionOffset",
   "properties": {
-    "offset": {
-      "description": "Name of this Event Filter.",
+    "startingOffset": {
+      "description": "The offset from where event processing starts.",
+      "type": "integer",
+      "existingJavaType": "Long"
+    },
+    "currentOffset": {
+      "description": "The current position in the events.",
       "type": "integer",
       "existingJavaType": "Long"
     },
@@ -16,6 +21,6 @@
       "$ref": "../type/basic.json#/definitions/timestamp"
     }
   },
-  "required": ["offset"],
+  "required": ["startingOffset", "currentOffset"],
   "additionalProperties": false
 }


### PR DESCRIPTION
Retrieving a list of `changeEvent` entries that represent successfully sent change events from the `change_event` table, filtering these events based on an offset range, and ensuring they do not have corresponding failed entries in the `consumers_dlq` table. The offset range helps identify the starting point from which an alert began polling the changeEvent entries, ensuring that only relevant records are fetched for the alert process.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
