### PR TITLE
Enhanced Glue ingestion with external table features

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/glue/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/glue/metadata.py
@@ -26,7 +26,12 @@ from metadata.generated.schema.api.data.createTable import CreateTableRequest
 from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
 from metadata.generated.schema.entity.data.database import Database
 from metadata.generated.schema.entity.data.databaseSchema import DatabaseSchema
-from metadata.generated.schema.entity.data.table import Column, Table, TableType
+from metadata.generated.schema.entity.data.table import (
+    Column,
+    FileFormat,
+    Table,
+    TableType,
+)
 from metadata.generated.schema.entity.services.connections.database.glueConnection import (
     GlueConnection,
 )
@@ -52,6 +57,9 @@ from metadata.ingestion.source.connections import get_connection
 from metadata.ingestion.source.database.column_helpers import truncate_column_name
 from metadata.ingestion.source.database.column_type_parser import ColumnTypeParser
 from metadata.ingestion.source.database.database_service import DatabaseServiceSource
+from metadata.ingestion.source.database.external_table_lineage_mixin import (
+    ExternalTableLineageMixin,
+)
 from metadata.ingestion.source.database.glue.models import Column as GlueColumn
 from metadata.ingestion.source.database.glue.models import (
     DatabasePage,
@@ -66,7 +74,7 @@ from metadata.utils.logger import ingestion_logger
 logger = ingestion_logger()
 
 
-class GlueSource(DatabaseServiceSource):
+class GlueSource(ExternalTableLineageMixin, DatabaseServiceSource):
     """
     Implements the necessary methods to extract
     Database metadata from Glue Source
@@ -84,6 +92,7 @@ class GlueSource(DatabaseServiceSource):
 
         self.connection_obj = self.glue
         self.schema_description_map = {}
+        self.external_location_map = {}
         self.test_connection()
 
     @classmethod
@@ -305,9 +314,16 @@ class GlueSource(DatabaseServiceSource):
         table_name, table_type = table_name_and_type
         table = self.context.get().table_data
         table_constraints = None
+        storage_descriptor = table.StorageDescriptor
+        database_name = self.context.get().database
+        schema_name = self.context.get().database_schema
+        if storage_descriptor.Location:
+            # s3a doesn't occur as a path in containers, so it needs to be replaced for lineage to work
+            self.external_location_map[
+                (database_name, schema_name, table_name)
+            ] = storage_descriptor.Location.replace("s3a://", "s3://")
         try:
-            columns = self.get_columns(table.StorageDescriptor)
-
+            columns = self.get_columns(storage_descriptor)
             table_request = CreateTableRequest(
                 name=EntityName(table_name),
                 tableType=table_type,
@@ -319,8 +335,8 @@ class GlueSource(DatabaseServiceSource):
                         metadata=self.metadata,
                         entity_type=DatabaseSchema,
                         service_name=self.context.get().database_service,
-                        database_name=self.context.get().database,
-                        schema_name=self.context.get().database_schema,
+                        database_name=database_name,
+                        schema_name=schema_name,
                     )
                 ),
                 sourceUrl=self.get_source_url(
@@ -328,6 +344,8 @@ class GlueSource(DatabaseServiceSource):
                     schema_name=self.context.get().database_schema,
                     database_name=self.context.get().database,
                 ),
+                fileFormat=self.get_format(storage_descriptor),
+                locationPath=storage_descriptor.Location,
             )
             yield Either(right=table_request)
             self.register_record(table_request=table_request)
@@ -369,6 +387,19 @@ class GlueSource(DatabaseServiceSource):
         # process table regular columns info
         for column in self.context.get().table_data.PartitionKeys:
             yield self._get_column_object(column)
+
+    @classmethod
+    def get_format(cls, storage: StorageDetails) -> Optional[FileFormat]:
+        library = storage.SerdeInfo.SerializationLibrary
+        if library is None:
+            return None
+        if library.endswith(".LazySimpleSerDe"):
+            return (
+                FileFormat.tsv
+                if storage.SerdeInfo.Parameters.get("serialization.format") == "\t"
+                else FileFormat.csv
+            )
+        return next((fmt for fmt in FileFormat if fmt.value in library.lower()), None)
 
     def standardize_table_name(self, _: str, table: str) -> str:
         return table[:128]

--- a/ingestion/src/metadata/ingestion/source/database/glue/models.py
+++ b/ingestion/src/metadata/ingestion/source/database/glue/models.py
@@ -37,8 +37,15 @@ class Column(BaseModel):
     Comment: Optional[str] = None
 
 
+class SerializationDetails(BaseModel):
+    SerializationLibrary: Optional[str] = None
+    Parameters: Optional[dict] = {}
+
+
 class StorageDetails(BaseModel):
     Columns: Optional[List[Column]] = []
+    Location: Optional[str] = None
+    SerdeInfo: Optional[SerializationDetails] = SerializationDetails()
 
 
 class GlueTable(BaseModel):

--- a/ingestion/tests/unit/resources/datasets/glue_db_dataset.json
+++ b/ingestion/tests/unit/resources/datasets/glue_db_dataset.json
@@ -370,15 +370,13 @@
               }
             ],
             "Location": "s3://athena-postgres/map-test",
-            "InputFormat": "org.apache.hadoop.mapred.TextInputFormat",
-            "OutputFormat": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
+            "InputFormat": "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat",
+            "OutputFormat": "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat",
             "Compressed": false,
             "NumberOfBuckets": -1,
             "SerdeInfo": {
-              "SerializationLibrary": "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
-              "Parameters": {
-                "serialization.format": "1"
-              }
+              "SerializationLibrary": "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe",
+              "Parameters": {}
             },
             "BucketColumns": [],
             "SortColumns": [],

--- a/ingestion/tests/unit/topology/database/test_glue.py
+++ b/ingestion/tests/unit/topology/database/test_glue.py
@@ -21,7 +21,7 @@ from unittest.mock import patch
 
 from metadata.generated.schema.entity.data.database import Database
 from metadata.generated.schema.entity.data.databaseSchema import DatabaseSchema
-from metadata.generated.schema.entity.data.table import TableType
+from metadata.generated.schema.entity.data.table import FileFormat, TableType
 from metadata.generated.schema.entity.services.databaseService import (
     DatabaseConnection,
     DatabaseService,
@@ -68,6 +68,11 @@ mock_glue_config = {
         }
     },
 }
+
+
+def mock_fqn_build(*args, **kwargs) -> str:
+    return ".".join((kwargs[key] for key in kwargs if key.endswith("_name")))
+
 
 MOCK_CUSTOM_DB_NAME = "NEW_DB"
 
@@ -124,6 +129,14 @@ EXPECTED_TABLE_NAMES = ["cloudfront_logs", "cloudfront_logs2", "map_table"]
 
 EXPECTED_TABLE_TYPES = [TableType.External, TableType.Iceberg, TableType.View]
 
+EXPECTED_FILE_FORMATS = [None, FileFormat.tsv, FileFormat.parquet]
+
+EXPECTED_LOCATION_PATHS = [
+    "s3://athena-examples-MyRegion/cloudfront/plaintext",
+    "s3://athena-postgres/",
+    "s3://athena-postgres/map-test",
+]
+
 
 class GlueUnitTest(TestCase):
     @patch(
@@ -151,6 +164,11 @@ class GlueUnitTest(TestCase):
             TablePage(**mock_data.get("mock_table_paginator"))
         ]
 
+    def get_table_requests(self):
+        tables = self.glue_source.get_tables_name_and_type()
+        for table in tables:
+            yield next(self.glue_source.yield_table(table)).right
+
     def test_database_names(self):
         assert EXPECTED_DATABASE_NAMES == list(self.glue_source.get_database_names())
 
@@ -172,8 +190,26 @@ class GlueUnitTest(TestCase):
             self.glue_source.get_database_schema_names()
         )
 
-    def test_table_names(self):
+    @patch("metadata.ingestion.source.database.glue.metadata.fqn")
+    def test_table_names(self, fqn):
+        fqn.build = mock_fqn_build
         for table_and_table_type in list(self.glue_source.get_tables_name_and_type()):
             table_and_table_type[0]
             assert table_and_table_type[0] in EXPECTED_TABLE_NAMES
             assert table_and_table_type[1] in EXPECTED_TABLE_TYPES
+
+    @patch("metadata.ingestion.source.database.glue.metadata.fqn")
+    def test_file_formats(self, fqn):
+        fqn.build = mock_fqn_build
+        assert (
+            list(map(lambda x: x.fileFormat, self.get_table_requests()))
+            == EXPECTED_FILE_FORMATS
+        )
+
+    @patch("metadata.ingestion.source.database.glue.metadata.fqn")
+    def test_location_paths(self, fqn):
+        fqn.build = mock_fqn_build
+        assert (
+            list(map(lambda x: x.locationPath, self.get_table_requests()))
+            == EXPECTED_LOCATION_PATHS
+        )

--- a/openmetadata-docs/content/v1.6.x-SNAPSHOT/connectors/database/glue/index.md
+++ b/openmetadata-docs/content/v1.6.x-SNAPSHOT/connectors/database/glue/index.md
@@ -7,8 +7,8 @@ slug: /connectors/database/glue
 name="Glue"
 stage="PROD"
 platform="OpenMetadata"
-availableFeatures=["Metadata", "dbt"]
-unavailableFeatures=["Query Usage", "Owners", "Tags", "Stored Procedures", "Data Profiler", "Data Quality", "Lineage", "Column-level Lineage"]
+availableFeatures=["Metadata", "dbt", "Lineage"]
+unavailableFeatures=["Query Usage", "Owners", "Tags", "Stored Procedures", "Data Profiler", "Data Quality", "Column-level Lineage"]
 / %}
 
 

--- a/openmetadata-docs/content/v1.6.x-SNAPSHOT/connectors/database/glue/index.md
+++ b/openmetadata-docs/content/v1.6.x-SNAPSHOT/connectors/database/glue/index.md
@@ -7,7 +7,7 @@ slug: /connectors/database/glue
 name="Glue"
 stage="PROD"
 platform="OpenMetadata"
-availableFeatures=["Metadata", "dbt", "Lineage"]
+availableFeatures=["Metadata", "dbt", "External Table Lineage"]
 unavailableFeatures=["Query Usage", "Owners", "Tags", "Stored Procedures", "Data Profiler", "Data Quality", "Column-level Lineage"]
 / %}
 


### PR DESCRIPTION
### Describe your changes:

Added file format, location path and external table lineage to `GlueSource`.

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

AWS Glue connector is quite poor in comparison to what you can find e.g. in AWS console. Some of the interesting features, like lineage, we can find in Athena connector - however, Glue tables can be queried by other engines, such as Trino. Athena is not a popular solution for companies holding huge amounts of data, due to costs. Fetching storage metadata in Trino is difficult, so adding them to Glue instead is a quick win.

Changes summary:
- `GlueSource` now inherits from `ExternalTableLineageMixin`.
- Table location is extracted directly from StorageDescriptor (if present).
- File format is extracted from StorageDescriptor (if present) by parsing SerDe library class.
- `test_table_names` is fixed - with no patching, `get_tables_name_and_type` was throwing warnings and not returning anything, hence the test was iterating over an empty result and not asserting anything.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

- [x] I have added tests around the new logic.
- [x] For connector/ingestion changes: I updated the documentation.
-->