### PR TITLE
Fix #18512: Return s3 endpoint as str() instead of Url

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/iceberg/fs/s3.py
+++ b/ingestion/src/metadata/ingestion/source/database/iceberg/fs/s3.py
@@ -67,7 +67,7 @@ class S3FileSystem(IcebergFileSystemBase):
             )
 
         return {
-            S3_ENDPOINT: fs_config.endPointURL,
+            S3_ENDPOINT: str(fs_config.endPointURL),
             S3_ACCESS_KEY_ID: fs_config.awsAccessKeyId,
             S3_SECRET_ACCESS_KEY: fs_config.awsSecretAccessKey.get_secret_value()
             if fs_config.awsSecretAccessKey

--- a/ingestion/tests/unit/topology/database/test_iceberg.py
+++ b/ingestion/tests/unit/topology/database/test_iceberg.py
@@ -464,6 +464,7 @@ MOCK_DYNAMO_CONFIG = {
                     "connection": {
                         "tableName": "table",
                         "awsConfig": {
+                            "endPointURL": "http://example.com",
                             "awsAccessKeyId": "access_key",
                             "awsSecretAccessKey": "secret",
                             "awsRegion": "us-east-2",


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #18512

Small fix to return the `S3_ENDPOINT` as `str` instead of `Url`.
Needed since the migration to Pydantic V2

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
