### PR TITLE
MINOR: Fix the Daily Active Users Summary Card

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataInsightUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataInsightUtils.tsx
@@ -22,6 +22,7 @@ import {
   isString,
   isUndefined,
   last,
+  meanBy,
   round,
   startCase,
   sumBy,
@@ -373,14 +374,15 @@ export const getWebChartSummary = (
 
     const { chartType, data } = chartData;
 
+    if (chartType === DataInsightChartType.DailyActiveUsers) {
+      const latest = round(meanBy(data, 'activeUsers'));
+    } else {
+      const latest = sumBy(data, 'pageViews');
+    }
+
     updatedSummary.push({
       ...summary,
-      latest: sumBy(
-        data,
-        chartType === DataInsightChartType.DailyActiveUsers
-          ? 'activeUsers'
-          : 'pageViews'
-      ),
+      latest: latest,
     });
   }
 


### PR DESCRIPTION

The `Daily Active Users Summary Card` is summing the value of the Daily Active Users for the whole period.
This is causing some confusion since we could have higher Daily Active Users than the total amount of users that we have, not making much sense.

This PR aims to fix it by changing the `sum` to `mean`, displaying the `Average Active Users` during the selected period.



<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
