### PR TITLE
MINOR: Fix App Insights not processing URL Encoded Data Assets

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/webAnalytics/processors/WebAnalyticsEntityViewProcessor.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/webAnalytics/processors/WebAnalyticsEntityViewProcessor.java
@@ -99,7 +99,7 @@ public class WebAnalyticsEntityViewProcessor
           EntityInterface entity =
               Entity.getEntityByName(
                   URLDecoder.decode(entityType, StandardCharsets.UTF_8),
-                  entityFqn,
+                  URLDecoder.decode(entityFqn, StandardCharsets.UTF_8),
                   "*",
                   Include.NON_DELETED,
                   true);

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/apps/AppsResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/apps/AppsResourceTest.java
@@ -140,7 +140,7 @@ public class AppsResourceTest extends EntityResourceTest<App, CreateApp> {
     DatabaseService databaseService =
         databaseServiceResourceTest.createEntity(
             databaseServiceResourceTest
-                .createRequest("DI_Test_Snowflake")
+                .createRequest("DI Test Snowflake")
                 .withServiceType(CreateDatabaseService.DatabaseServiceType.Snowflake),
             ADMIN_AUTH_HEADERS);
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

The WebAnalytics insights processor isn't properly processing Data Assets with URL Encoded characters on their name.

This PR aims to fix that by decoding it before searching for the asset.


<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
