### PR TITLE
fix: checkmark saves wrong custom property field

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/PropertyValue.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/PropertyValue.tsx
@@ -241,6 +241,8 @@ export const PropertyValue: FC<PropertyValueProps> = ({
           enumValues: (isArray(value) ? value : [value]).filter(Boolean),
         };
 
+        const formId = `enum-form-${propertyName}`;
+
         return (
           <InlineEdit
             className="custom-property-inline-edit-container"
@@ -248,12 +250,12 @@ export const PropertyValue: FC<PropertyValueProps> = ({
             saveButtonProps={{
               disabled: isLoading,
               htmlType: 'submit',
-              form: 'enum-form',
+              form: formId,
             }}
             onCancel={onHideInput}
             onSave={noop}>
             <Form
-              id="enum-form"
+              id={formId}
               initialValues={initialValues}
               layout="vertical"
               onFinish={(values: { enumValues: string | string[] }) =>
@@ -285,6 +287,8 @@ export const PropertyValue: FC<PropertyValueProps> = ({
           dateTimeValue: value ? moment(value, format) : undefined,
         };
 
+        const formId = `dateTime-form-${propertyName}`;
+
         return (
           <InlineEdit
             className="custom-property-inline-edit-container"
@@ -292,12 +296,12 @@ export const PropertyValue: FC<PropertyValueProps> = ({
             saveButtonProps={{
               disabled: isLoading,
               htmlType: 'submit',
-              form: 'dateTime-form',
+              form: formId,
             }}
             onCancel={onHideInput}
             onSave={noop}>
             <Form
-              id="dateTime-form"
+              id={formId}
               initialValues={initialValues}
               layout="vertical"
               onFinish={(values: { dateTimeValue: Moment }) => {
@@ -329,6 +333,8 @@ export const PropertyValue: FC<PropertyValueProps> = ({
           time: value ? moment(value, format) : undefined,
         };
 
+        const formId = `time-form-${propertyName}`;
+
         return (
           <InlineEdit
             className="custom-property-inline-edit-container"
@@ -336,12 +342,12 @@ export const PropertyValue: FC<PropertyValueProps> = ({
             saveButtonProps={{
               disabled: isLoading,
               htmlType: 'submit',
-              form: 'time-form',
+              form: formId,
             }}
             onCancel={onHideInput}
             onSave={noop}>
             <Form
-              id="time-form"
+              id={formId}
               initialValues={initialValues}
               layout="vertical"
               validateMessages={VALIDATION_MESSAGES}
@@ -369,6 +375,8 @@ export const PropertyValue: FC<PropertyValueProps> = ({
           email: value,
         };
 
+        const formId = `email-form-${propertyName}`;
+
         return (
           <InlineEdit
             className="custom-property-inline-edit-container"
@@ -376,12 +384,12 @@ export const PropertyValue: FC<PropertyValueProps> = ({
             saveButtonProps={{
               disabled: isLoading,
               htmlType: 'submit',
-              form: 'email-form',
+              form: formId,
             }}
             onCancel={onHideInput}
             onSave={noop}>
             <Form
-              id="email-form"
+              id={formId}
               initialValues={initialValues}
               layout="vertical"
               validateMessages={VALIDATION_MESSAGES}
@@ -415,6 +423,8 @@ export const PropertyValue: FC<PropertyValueProps> = ({
           timestamp: value,
         };
 
+        const formId = `timestamp-form-${propertyName}`;
+
         return (
           <InlineEdit
             className="custom-property-inline-edit-container"
@@ -422,12 +432,12 @@ export const PropertyValue: FC<PropertyValueProps> = ({
             saveButtonProps={{
               disabled: isLoading,
               htmlType: 'submit',
-              form: 'timestamp-form',
+              form: formId,
             }}
             onCancel={onHideInput}
             onSave={noop}>
             <Form
-              id="timestamp-form"
+              id={formId}
               initialValues={initialValues}
               layout="vertical"
               onFinish={(values: { timestamp: string }) => {
@@ -466,6 +476,8 @@ export const PropertyValue: FC<PropertyValueProps> = ({
           end: value?.end ? value.end?.toString() : undefined,
         };
 
+        const formId = `timeInterval-form-${propertyName}`;
+
         return (
           <InlineEdit
             className="custom-property-inline-edit-container"
@@ -473,12 +485,12 @@ export const PropertyValue: FC<PropertyValueProps> = ({
             saveButtonProps={{
               disabled: isLoading,
               htmlType: 'submit',
-              form: 'timeInterval-form',
+              form: formId,
             }}
             onCancel={onHideInput}
             onSave={noop}>
             <Form
-              id="timeInterval-form"
+              id={formId}
               initialValues={initialValues}
               layout="vertical"
               onFinish={(values: { start: string; end: string }) => {
@@ -540,6 +552,8 @@ export const PropertyValue: FC<PropertyValueProps> = ({
           duration: value,
         };
 
+        const formId = `duration-form-${propertyName}`;
+
         return (
           <InlineEdit
             className="custom-property-inline-edit-container"
@@ -547,12 +561,12 @@ export const PropertyValue: FC<PropertyValueProps> = ({
             saveButtonProps={{
               disabled: isLoading,
               htmlType: 'submit',
-              form: 'duration-form',
+              form: formId,
             }}
             onCancel={onHideInput}
             onSave={noop}>
             <Form
-              id="duration-form"
+              id={formId}
               initialValues={initialValues}
               layout="vertical"
               validateMessages={VALIDATION_MESSAGES}
@@ -577,6 +591,8 @@ export const PropertyValue: FC<PropertyValueProps> = ({
           sqlQuery: value,
         };
 
+        const formId = `sqlQuery-form-${propertyName}`;
+
         return (
           <InlineEdit
             className="custom-property-inline-edit-container sql-query-custom-property"
@@ -584,12 +600,12 @@ export const PropertyValue: FC<PropertyValueProps> = ({
             saveButtonProps={{
               disabled: isLoading,
               htmlType: 'submit',
-              form: 'sqlQuery-form',
+              form: formId,
             }}
             onCancel={onHideInput}
             onSave={noop}>
             <Form
-              id="sqlQuery-form"
+              id={formId}
               initialValues={initialValues}
               layout="vertical"
               validateMessages={VALIDATION_MESSAGES}
@@ -650,6 +666,8 @@ export const PropertyValue: FC<PropertyValueProps> = ({
           entityReference: initialValue,
         };
 
+        const formId = `entity-reference-form-${propertyName}`;
+
         return (
           <InlineEdit
             className="custom-property-inline-edit-container"
@@ -657,12 +675,12 @@ export const PropertyValue: FC<PropertyValueProps> = ({
             saveButtonProps={{
               disabled: isLoading,
               htmlType: 'submit',
-              form: 'entity-reference-form',
+              form: formId,
             }}
             onCancel={onHideInput}
             onSave={noop}>
             <Form
-              id="entity-reference-form"
+              id={formId}
               initialValues={initialValues}
               layout="vertical"
               validateMessages={VALIDATION_MESSAGES}


### PR DESCRIPTION
**Issue:** We have a common component called PropertyValue that renders input fields based on custom property types. Each input field is associated with a unique form ID. However, when two properties of the same type are being edited simultaneously with the same form ID, the input for the last opened property is triggered instead of the selected one.

**Resolution:** Updated the form ID for each property to ensure a unique name, allowing each property to render with a distinct form ID and preventing conflicts.


https://github.com/user-attachments/assets/cd47fc29-2e5c-4ab0-bea2-b3a8addcf53f

