### PR TITLE
Fix wait for consumers and status for Sink

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/SearchIndexApp.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/SearchIndexApp.java
@@ -323,12 +323,15 @@ public class SearchIndexApp extends AbstractNativeApplication {
   private void processEntityReindex(JobExecutionContext jobExecutionContext)
       throws InterruptedException {
     int numConsumers = jobData.getConsumerThreads();
-    CountDownLatch producerLatch = new CountDownLatch(getTotalLatchCount(jobData.getEntities()));
+    int latchCount = getTotalLatchCount(jobData.getEntities());
+    CountDownLatch producerLatch = new CountDownLatch(latchCount);
+    CountDownLatch consumerLatch = new CountDownLatch(latchCount + numConsumers);
     submitProducerTask(producerLatch);
-    submitConsumerTask(jobExecutionContext);
+    submitConsumerTask(jobExecutionContext, consumerLatch);
 
     producerLatch.await();
     sendPoisonPills(numConsumers);
+    consumerLatch.await();
   }
 
   private void submitProducerTask(CountDownLatch producerLatch) {
@@ -369,12 +372,12 @@ public class SearchIndexApp extends AbstractNativeApplication {
     }
   }
 
-  private void submitConsumerTask(JobExecutionContext jobExecutionContext) {
+  private void submitConsumerTask(JobExecutionContext jobExecutionContext, CountDownLatch latch) {
     for (int i = 0; i < jobData.getConsumerThreads(); i++) {
       consumerExecutor.submit(
           () -> {
             try {
-              consumeTasks(jobExecutionContext);
+              consumeTasks(jobExecutionContext, latch);
             } catch (InterruptedException e) {
               Thread.currentThread().interrupt();
               LOG.warn("Consumer thread interrupted.");
@@ -383,7 +386,8 @@ public class SearchIndexApp extends AbstractNativeApplication {
     }
   }
 
-  private void consumeTasks(JobExecutionContext jobExecutionContext) throws InterruptedException {
+  private void consumeTasks(JobExecutionContext jobExecutionContext, CountDownLatch latch)
+      throws InterruptedException {
     while (true) {
       IndexingTask<?> task = taskQueue.take();
       LOG.info(
@@ -392,9 +396,10 @@ public class SearchIndexApp extends AbstractNativeApplication {
           task.currentEntityOffset());
       if (task == IndexingTask.POISON_PILL) {
         LOG.debug("Received POISON_PILL. Consumer thread terminating.");
+        latch.countDown();
         break;
       }
-      processTask(task, jobExecutionContext);
+      processTask(task, jobExecutionContext, latch);
     }
   }
 
@@ -590,7 +595,8 @@ public class SearchIndexApp extends AbstractNativeApplication {
     shutdownExecutor(consumerExecutor, "ConsumerExecutor", 60, TimeUnit.SECONDS);
   }
 
-  private void processTask(IndexingTask<?> task, JobExecutionContext jobExecutionContext) {
+  private void processTask(
+      IndexingTask<?> task, JobExecutionContext jobExecutionContext, CountDownLatch latch) {
     String entityType = task.entityType();
     ResultList<?> entities = task.entities();
     Map<String, Object> contextData = new HashMap<>();
@@ -633,7 +639,7 @@ public class SearchIndexApp extends AbstractNativeApplication {
 
     } catch (Exception e) {
       synchronized (jobDataLock) {
-        jobData.setStatus(EventPublisherJob.Status.FAILED);
+        jobData.setStatus(EventPublisherJob.Status.ACTIVE_ERROR);
         jobData.setFailure(
             new IndexingError()
                 .withErrorSource(IndexingError.ErrorSource.JOB)
@@ -647,6 +653,7 @@ public class SearchIndexApp extends AbstractNativeApplication {
       LOG.error("Unexpected error during processing task for entity {}", entityType, e);
     } finally {
       sendUpdates(jobExecutionContext);
+      latch.countDown();
     }
   }
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

- Added latch for consumers
- update status to active error

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
