### PR TITLE
Fixes 18156: upgrde pyiceberg; add optional OAuth2 scope

### DIFF
--- a/ingestion/setup.py
+++ b/ingestion/setup.py
@@ -240,12 +240,14 @@ plugins: Dict[str, Set[str]] = {
         "impyla~=0.18.0",
     },
     "iceberg": {
-        "pyiceberg==0.5.1",
+        "pyiceberg[hive,glue,dynamodb,s3fs,adlfs,gcsfs]==0.7.1",
         # Forcing the version of a few packages so it plays nicely with other requirements.
         VERSIONS["pydantic"],
         VERSIONS["adlfs"],
         VERSIONS["gcsfs"],
         VERSIONS["pyarrow"],
+        VERSIONS["boto3"],
+        *COMMONS["hive"],
     },
     "impala": {
         "presto-types-parser>=0.0.2",

--- a/ingestion/src/metadata/ingestion/source/database/iceberg/catalog/rest.py
+++ b/ingestion/src/metadata/ingestion/source/database/iceberg/catalog/rest.py
@@ -51,6 +51,7 @@ class IcebergRestCatalog(IcebergCatalogBase):
             "warehouse": catalog.warehouseLocation,
             "uri": str(catalog.connection.uri),
             "credential": credential,
+            "scope": catalog.connection.credential.scope,
             "token": catalog.connection.token.get_secret_value()
             if catalog.connection.token
             else None,

--- a/ingestion/tests/unit/topology/database/test_iceberg.py
+++ b/ingestion/tests/unit/topology/database/test_iceberg.py
@@ -404,7 +404,14 @@ MOCK_REST_CONFIG = {
                 "type": "Iceberg",
                 "catalog": {
                     "name": "Batata",
-                    "connection": {"uri": "http://localhost:8181"},
+                    "connection": {
+                        "uri": "http://localhost:8181",
+                        "credential": {
+                            "clientId": "client_id",
+                            "clientSecret": "client_secret",
+                            "scope": "scope",
+                        },
+                    },
                 },
             }
         },

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/iceberg/restCatalogConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/iceberg/restCatalogConnection.json
@@ -28,6 +28,11 @@
           "description": "OAuth2 Client Secret",
           "type": "string",
           "format": "password"
+        },
+        "scope": {
+          "title": "Scope",
+          "description": "OAuth2 Scope",
+          "type": "string"
         }
       },
       "additionalProperties": false

--- a/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Iceberg.md
+++ b/openmetadata-ui/src/main/resources/ui/public/locales/en-US/Database/Iceberg.md
@@ -97,6 +97,14 @@ To get the client secret, follow these steps:
 $$
 $$section
 
+### Scope $(id="scope")
+
+#### REST Catalog
+OAuth2 Scope to use for the Authentication Flow
+
+$$
+$$section
+
 ### Token $(id="token")
 
 #### REST Catalog


### PR DESCRIPTION
### Describe your changes:

Fixes 18156, 17797

- Upgrade `pyiceberg` to version `0.7.1`, which includes support for custom OAuth2 Scope.
- Add OAuth2 `scope` parameter to the database service connection configuration for Iceberg REST Catalogs.

It is often necessary to provide an OAuth2 scope along with client credentials for an Iceberg REST Catalog, particularly for [Snowflake's deployment](https://other-docs.snowflake.com/en/opencatalog/overview) of the [Apache Polaris](https://polaris.apache.org/) REST catalog. Here we add the ability to configure a scope for an Iceberg REST catalog connection in an Iceberg database ingestion service. We also upgrade `pyiceberg` and associated dependencies to the latest version (`0.7.1`), which now supports specifying a custom scope in the REST catalog config.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [x] I have added tests around the new logic.
- [x] For connector/ingestion changes: I updated the documentation.
-->
