### PR TITLE
Fixes #18848: "Failed to parse query parameters from JDBC URL" when query is an empty string

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/jdbi/DatabaseAuthenticationProviderFactory.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/jdbi/DatabaseAuthenticationProviderFactory.java
@@ -1,5 +1,7 @@
 package org.openmetadata.service.util.jdbi;
 
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
+
 import java.net.URI;
 import java.net.URLDecoder;
 import java.util.LinkedHashMap;
@@ -35,7 +37,7 @@ public class DatabaseAuthenticationProviderFactory {
       URI uri = new URI(jdbcURL.substring(jdbcURL.indexOf(":") + 1));
       Map<String, String> queryPairs = new LinkedHashMap<>();
       String query = uri.getQuery();
-      if (query != null && !query.isEmpty()) {
+      if (!nullOrEmpty(query)) {
         String[] pairs = query.split("&");
         for (String pair : pairs) {
           int idx = pair.indexOf("=");

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/jdbi/DatabaseAuthenticationProviderFactory.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/jdbi/DatabaseAuthenticationProviderFactory.java
@@ -35,7 +35,7 @@ public class DatabaseAuthenticationProviderFactory {
       URI uri = new URI(jdbcURL.substring(jdbcURL.indexOf(":") + 1));
       Map<String, String> queryPairs = new LinkedHashMap<>();
       String query = uri.getQuery();
-      if (query != null) {
+      if (query != null && !query.isEmpty()) {
         String[] pairs = query.split("&");
         for (String pair : pairs) {
           int idx = pair.indexOf("=");


### PR DESCRIPTION
### Describe your changes:

Fixes #18848 

When `query` is an empty string, `indexOf` returns -1, which results in `subtring(0, -1)`, causing an error.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
