### PR TITLE
Minor: improve custom properties e2e test

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/customProperty.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/customProperty.ts
@@ -447,9 +447,10 @@ export const createCustomPropertyForEntity = async (
   };
 
   for (const item of propertyList) {
+    const customPropertyName = `pwCustomProperty${uuid()}`;
     const payload = {
-      name: `pwCustomProperty${uuid()}`,
-      description: `pwCustomProperty${uuid()}`,
+      name: customPropertyName,
+      description: customPropertyName,
       propertyType: {
         id: item.id ?? '',
         type: 'type',
@@ -515,14 +516,13 @@ export const createCustomPropertyForEntity = async (
     const customProperty = await customPropertyResponse.json();
 
     // Process the custom properties
-    customProperties = customProperty.customProperties.reduce(
+    const newProperties = customProperty.customProperties.reduce(
       (
         prev: Record<string, string>,
         curr: Record<string, Record<string, string> | string>
       ) => {
         // only process the custom properties which are created via payload
-
-        if (curr.name !== payload.name) {
+        if (curr.name !== customPropertyName) {
           return prev;
         }
 
@@ -539,6 +539,8 @@ export const createCustomPropertyForEntity = async (
       },
       {}
     );
+
+    customProperties = { ...customProperties, ...newProperties };
   }
 
   return { customProperties, cleanupUser };

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/customProperty.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/customProperty.ts
@@ -447,67 +447,68 @@ export const createCustomPropertyForEntity = async (
   };
 
   for (const item of propertyList) {
+    const payload = {
+      name: `pwCustomProperty${uuid()}`,
+      description: `pwCustomProperty${uuid()}`,
+      propertyType: {
+        id: item.id ?? '',
+        type: 'type',
+      },
+      ...(item.name === 'enum'
+        ? {
+            customPropertyConfig: {
+              config: {
+                multiSelect: true,
+                values: ['small', 'medium', 'large'],
+              },
+            },
+          }
+        : {}),
+      ...(['entityReference', 'entityReferenceList'].includes(item.name)
+        ? {
+            customPropertyConfig: {
+              config: ['user', 'team'],
+            },
+          }
+        : {}),
+
+      ...(item.name === 'time-cp'
+        ? {
+            customPropertyConfig: {
+              config: 'HH:mm:ss',
+            },
+          }
+        : {}),
+
+      ...(item.name === 'date-cp'
+        ? {
+            customPropertyConfig: {
+              config: 'yyyy-MM-dd',
+            },
+          }
+        : {}),
+
+      ...(item.name === 'dateTime-cp'
+        ? {
+            customPropertyConfig: {
+              config: 'yyyy-MM-dd HH:mm:ss',
+            },
+          }
+        : {}),
+      ...(item.name === 'table-cp'
+        ? {
+            customPropertyConfig: {
+              config: {
+                columns: ['pw-column1', 'pw-column2'],
+              },
+            },
+          }
+        : {}),
+    };
     const customPropertyResponse = await apiContext.put(
       `/api/v1/metadata/types/${entitySchema.id}`,
       {
-        data: {
-          name: `pwCustomProperty${uuid()}`,
-          description: `pwCustomProperty${uuid()}`,
-          propertyType: {
-            id: item.id ?? '',
-            type: 'type',
-          },
-          ...(item.name === 'enum'
-            ? {
-                customPropertyConfig: {
-                  config: {
-                    multiSelect: true,
-                    values: ['small', 'medium', 'large'],
-                  },
-                },
-              }
-            : {}),
-          ...(['entityReference', 'entityReferenceList'].includes(item.name)
-            ? {
-                customPropertyConfig: {
-                  config: ['user', 'team'],
-                },
-              }
-            : {}),
-
-          ...(item.name === 'time-cp'
-            ? {
-                customPropertyConfig: {
-                  config: 'HH:mm:ss',
-                },
-              }
-            : {}),
-
-          ...(item.name === 'date-cp'
-            ? {
-                customPropertyConfig: {
-                  config: 'yyyy-MM-dd',
-                },
-              }
-            : {}),
-
-          ...(item.name === 'dateTime-cp'
-            ? {
-                customPropertyConfig: {
-                  config: 'yyyy-MM-dd HH:mm:ss',
-                },
-              }
-            : {}),
-          ...(item.name === 'table-cp'
-            ? {
-                customPropertyConfig: {
-                  config: {
-                    columns: ['pw-column1', 'pw-column2'],
-                  },
-                },
-              }
-            : {}),
-        },
+        data: payload,
       }
     );
 
@@ -517,9 +518,16 @@ export const createCustomPropertyForEntity = async (
     customProperties = customProperty.customProperties.reduce(
       (
         prev: Record<string, string>,
-        curr: Record<string, Record<string, string>>
+        curr: Record<string, Record<string, string> | string>
       ) => {
-        const propertyTypeName = curr.propertyType.name;
+        // only process the custom properties which are created via payload
+
+        if (curr.name !== payload.name) {
+          return prev;
+        }
+
+        const propertyTypeName = (curr.propertyType as Record<string, string>)
+          .name;
 
         return {
           ...prev,


### PR DESCRIPTION
Update the `createCustomPropertyForEntity` utility method to ensure it only processes custom properties created specifically for the current test run.