### PR TITLE
Minor: Fix typo on the ingestion word

### DIFF
--- a/openmetadata-docs/content/v1.4.x/developers/contribute/developing-a-new-connector/define-json-schema.md
+++ b/openmetadata-docs/content/v1.4.x/developers/contribute/developing-a-new-connector/define-json-schema.md
@@ -363,7 +363,7 @@ Now that you have your Connection defined in the JSON Schema, we can proceed to 
 
 {%inlineCallout
   color="violet-70"
-  bold="Develop the Ingesion Code"
+  bold="Develop the Ingestion Code"
   icon="MdArrowForward"
   href="/developers/contribute/developing-a-new-connector/develop-ingestion-code"%}
   Learn what you need to implement for the Connector's logic

--- a/openmetadata-docs/content/v1.5.x/developers/contribute/developing-a-new-connector/define-json-schema.md
+++ b/openmetadata-docs/content/v1.5.x/developers/contribute/developing-a-new-connector/define-json-schema.md
@@ -363,7 +363,7 @@ Now that you have your Connection defined in the JSON Schema, we can proceed to 
 
 {%inlineCallout
   color="violet-70"
-  bold="Develop the Ingesion Code"
+  bold="Develop the Ingestion Code"
   icon="MdArrowForward"
   href="/developers/contribute/developing-a-new-connector/develop-ingestion-code"%}
   Learn what you need to implement for the Connector's logic

--- a/openmetadata-docs/content/v1.6.x-SNAPSHOT/developers/contribute/developing-a-new-connector/define-json-schema.md
+++ b/openmetadata-docs/content/v1.6.x-SNAPSHOT/developers/contribute/developing-a-new-connector/define-json-schema.md
@@ -363,7 +363,7 @@ Now that you have your Connection defined in the JSON Schema, we can proceed to 
 
 {%inlineCallout
   color="violet-70"
-  bold="Develop the Ingesion Code"
+  bold="Develop the Ingestion Code"
   icon="MdArrowForward"
   href="/developers/contribute/developing-a-new-connector/develop-ingestion-code"%}
   Learn what you need to implement for the Connector's logic


### PR DESCRIPTION
### Describe your changes:

I found a minor typo in the docs.
Minor fix of a typo on the https://docs.open-metadata.org/latest/developers/contribute/developing-a-new-connector/define-json-schema page footer where the `ingestion` word is `ingesion` for the 3 supported versions.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
