### PR TITLE
Minor: Prevent Multiple CSV export download if no active job is present

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityExportModalProvider/EntityExportModalProvider.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityExportModalProvider/EntityExportModalProvider.component.tsx
@@ -114,6 +114,10 @@ export const EntityExportModalProvider = ({
   const handleCSVExportJobUpdate = (
     response: Partial<CSVExportWebsocketResponse>
   ) => {
+    // If multiple tab is open, then we need to check if the tab has active job or not before initiating the download
+    if (!csvExportJobRef.current) {
+      return;
+    }
     const updatedCSVExportJob: Partial<CSVExportJob> = {
       ...response,
       ...csvExportJobRef.current,


### PR DESCRIPTION
**Problem:** When multiple tabs are open and a user starts an export in one tab, multiple files are downloaded once we receive a response from the WebSocket.

**Resolution:** A check has been implemented to verify if an active CSV job reference is available. This ensures that the export is only initiated if a reference exists. As a result, even with multiple tabs open, only the tab where the export job started will have the job reference, preventing multiple files from being downloaded.


https://github.com/user-attachments/assets/fac9b481-82ad-42ca-8421-996b3a3ab11f

