### PR TITLE
minor: added entity type support in dq dashboard API

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/DataQuality/DataQualityPage.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DataQuality/DataQualityPage.interface.ts
@@ -1,5 +1,3 @@
-import { TestSummary } from '../../generated/tests/testCase';
-
 /*
  *  Copyright 2023 Collate.
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +10,10 @@ import { TestSummary } from '../../generated/tests/testCase';
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+
+import { EntityType } from '../../enums/entity.enum';
+import { TestSummary } from '../../generated/tests/testCase';
+
 export enum DataQualityPageTabs {
   TEST_SUITES = 'test-suites',
   TABLES = 'tables',
@@ -32,4 +34,5 @@ export type DataQualityDashboardChartFilters = {
   startTs?: number;
   endTs?: number;
   entityFQN?: string;
+  entityType?: EntityType;
 };

--- a/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityDashboardAPI.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityDashboardAPI.test.ts
@@ -12,6 +12,7 @@
  */
 /* eslint-disable max-len */
 import { IncidentTimeMetricsType } from '../components/DataQuality/DataQuality.interface';
+import { EntityType } from '../enums/entity.enum';
 import { TestCaseStatus } from '../generated/tests/testCase';
 import { TestCaseResolutionStatusTypes } from '../generated/tests/testCaseResolutionStatus';
 import {
@@ -1198,6 +1199,85 @@ describe('dataQualityDashboardAPI', () => {
                       lte: filters.endTs,
                       gte: filters.startTs,
                     },
+                  },
+                },
+              ],
+            },
+          },
+        }),
+        index: 'testCaseResult',
+        aggregationQuery:
+          'bucketName=byDay:aggType=date_histogram:field=timestamp&calendar_interval=day,bucketName=newIncidents:aggType=cardinality:field=testCase.fullyQualifiedName',
+      });
+    });
+
+    it('should call getDataQualityReport with provided entityType', async () => {
+      const status = TestCaseStatus.Success;
+      const filters = {
+        entityType: EntityType.TABLE,
+        entityFQN: 'entityFQN',
+        startTs: 1729073964962,
+        endTs: 1729678764965,
+      };
+
+      await fetchTestCaseStatusMetricsByDays(status, filters);
+
+      expect(getDataQualityReport).toHaveBeenCalledWith({
+        q: JSON.stringify({
+          query: {
+            bool: {
+              must: [
+                { term: { testCaseStatus: status } },
+                {
+                  range: {
+                    timestamp: {
+                      lte: filters.endTs,
+                      gte: filters.startTs,
+                    },
+                  },
+                },
+                {
+                  term: {
+                    'table.fullyQualifiedName.keyword': 'entityFQN',
+                  },
+                },
+              ],
+            },
+          },
+        }),
+        index: 'testCaseResult',
+        aggregationQuery:
+          'bucketName=byDay:aggType=date_histogram:field=timestamp&calendar_interval=day,bucketName=newIncidents:aggType=cardinality:field=testCase.fullyQualifiedName',
+      });
+    });
+
+    it('should call getDataQualityReport with normal entity fqn if entityType not provided', async () => {
+      const status = TestCaseStatus.Success;
+      const filters = {
+        entityFQN: 'entityFQN',
+        startTs: 1729073964962,
+        endTs: 1729678764965,
+      };
+
+      await fetchTestCaseStatusMetricsByDays(status, filters);
+
+      expect(getDataQualityReport).toHaveBeenCalledWith({
+        q: JSON.stringify({
+          query: {
+            bool: {
+              must: [
+                { term: { testCaseStatus: status } },
+                {
+                  range: {
+                    timestamp: {
+                      lte: filters.endTs,
+                      gte: filters.startTs,
+                    },
+                  },
+                },
+                {
+                  term: {
+                    'testCase.entityFQN': 'entityFQN',
                   },
                 },
               ],

--- a/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityDashboardAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityDashboardAPI.ts
@@ -317,7 +317,9 @@ export const fetchTestCaseStatusMetricsByDays = (
   if (filters?.entityFQN) {
     mustFilter.push({
       term: {
-        'testCase.entityFQN': filters.entityFQN,
+        [filters.entityType
+          ? `${filters.entityType}.fullyQualifiedName.keyword`
+          : 'testCase.entityFQN']: filters.entityFQN,
       },
     });
   }


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

added entity type support to fetch test case count

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
