### PR TITLE
fix(ui): capture and update profile info for oidc users

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/utils/AuthProvider.util.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AuthProvider.util.ts
@@ -293,7 +293,7 @@ export const getNameFromUserData = (
     }
   }
 
-  return { name: userName, email: email };
+  return { name: userName, email: email, picture: user.picture };
 };
 
 export const isProtectedRoute = (pathname: string) => {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AuthProviderUtil.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AuthProviderUtil.test.ts
@@ -23,12 +23,13 @@ const userProfile = {
 
 describe('Test Auth Provider utils', () => {
   it('getNameFromUserData should return name and email from claim: preferred_username', () => {
-    const { name, email } = getNameFromUserData(userProfile, [
+    const { name, email, picture } = getNameFromUserData(userProfile, [
       'preferred_username',
     ]);
 
     expect(name).toEqual('i_am_preferred_username');
     expect(email).toEqual('i_am_preferred_username@');
+    expect(picture).toEqual('');
   });
 
   it('getNameFromUserData should return name and email from claim: email', () => {
@@ -98,6 +99,18 @@ describe('Test Auth Provider utils', () => {
 
     expect(name).toEqual('i_am_preferred_username');
     expect(email).toEqual('i_am_preferred_username@test.com');
+  });
+
+  it('getNameFromUserData should return picture details as it is', () => {
+    const { name, email, picture } = getNameFromUserData(
+      { ...userProfile, picture: 'test_picture' },
+      ['preferred_username', 'email', 'sub'],
+      'test.com'
+    );
+
+    expect(name).toEqual('i_am_preferred_username');
+    expect(email).toEqual('i_am_preferred_username@test.com');
+    expect(picture).toEqual('test_picture');
   });
 });
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes: Missing profile picture info for OIDC user login

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
