### PR TITLE
minor: add support for ttf file extension in openmetadata-ui/pom.xml

### DIFF
--- a/openmetadata-ui/pom.xml
+++ b/openmetadata-ui/pom.xml
@@ -182,6 +182,7 @@
                 <nonFilteredFileExtension>gz</nonFilteredFileExtension>
                 <nonFilteredFileExtension>woff</nonFilteredFileExtension>
                 <nonFilteredFileExtension>woff2</nonFilteredFileExtension>
+                <nonFilteredFileExtension>ttf</nonFilteredFileExtension>
                 <nonFilteredFileExtension>eot</nonFilteredFileExtension>
                 <nonFilteredFileExtension>svg</nonFilteredFileExtension>
                 <nonFilteredFileExtension>png</nonFilteredFileExtension>


### PR DESCRIPTION
[Here](https://github.com/open-metadata/OpenMetadata/pull/18900/files#diff-bd9dbd93da4e6e791ee7af355ef4ea97849582e18a3396e8501d4119f9f28b1c) we have added support for a few extensions as nonFilteredExtension in pom.xml. `ttf` is missing, so this PR will add it.