### PR TITLE
Docs: Fix the missing 1.4 image references in the documentation

### DIFF
--- a/openmetadata-docs/content/v1.5.x/connectors/messaging/kinesis/index.md
+++ b/openmetadata-docs/content/v1.5.x/connectors/messaging/kinesis/index.md
@@ -56,7 +56,7 @@ For more information on Kinesis permissions visit the [AWS Kinesis official docu
   variables={
     connector: "Kinesis", 
     selectServicePath: "/images/v1.5/connectors/kinesis/select-service.png",
-    addNewServicePath: "/images/v1.5/connectors//add-new-service.png",
+    addNewServicePath: "/images/v1.5/connectors/add-new-service.png",
     serviceConnectionPath: "/images/v1.5/connectors/kinesis/service-connection.png",
 } 
 /%}

--- a/openmetadata-docs/content/v1.5.x/connectors/pipeline/dbtcloud/index.md
+++ b/openmetadata-docs/content/v1.5.x/connectors/pipeline/dbtcloud/index.md
@@ -17,7 +17,7 @@ In this section, we provide guides and references to use the dbt Cloud connector
 Configure and schedule dbt Cloud metadata and profiler workflows from the OpenMetadata UI:
 
 - [Requirements](#requirements)
-    - [dbt Cloud Versions](#dbtcloud-versions)
+    - [dbt Cloud Versions](#dbt-cloud-versions)
 - [Metadata Ingestion](#metadata-ingestion)
     - [Service Name](#service-name)
     - [Connection Details](#connection-details)

--- a/openmetadata-docs/content/v1.5.x/deployment/secrets-manager/supported-implementations/gcp-secret-manager/index.md
+++ b/openmetadata-docs/content/v1.5.x/deployment/secrets-manager/supported-implementations/gcp-secret-manager/index.md
@@ -85,7 +85,7 @@ If everything goes as planned, all the data would be displayed using the paramet
 `/openmetadata/...` in your GCP Secret Manager console. The following image shows what it should look 
 like:
 
-{% image src="/images/v1.4/deployment/secrets-manager/supported-implementations/gcp-secret-manager/gcp-secret-manager-console.png" alt="gcp-secret-manager-console" /%} 
+{% image src="/images/v1.5/deployment/secrets-manager/supported-implementations/gcp-secret-manager/gcp-secret-manager-console.png" alt="gcp-secret-manager-console" /%} 
 
 **Note:** If we want to change the starting path for our secrets names from `openmetadata` to a different one, we have 
 to change the property `clusterName` in our `openmetadata.yaml`. Also, if you inform the `prefix` value, it will be

--- a/openmetadata-docs/content/v1.6.x/connectors/messaging/kinesis/index.md
+++ b/openmetadata-docs/content/v1.6.x/connectors/messaging/kinesis/index.md
@@ -56,7 +56,7 @@ For more information on Kinesis permissions visit the [AWS Kinesis official docu
   variables={
     connector: "Kinesis", 
     selectServicePath: "/images/v1.6/connectors/kinesis/select-service.png",
-    addNewServicePath: "/images/v1.6/connectors//add-new-service.png",
+    addNewServicePath: "/images/v1.6/connectors/add-new-service.png",
     serviceConnectionPath: "/images/v1.6/connectors/kinesis/service-connection.png",
 } 
 /%}

--- a/openmetadata-docs/content/v1.6.x/connectors/pipeline/dbtcloud/index.md
+++ b/openmetadata-docs/content/v1.6.x/connectors/pipeline/dbtcloud/index.md
@@ -17,7 +17,7 @@ In this section, we provide guides and references to use the dbt Cloud connector
 Configure and schedule dbt Cloud metadata and profiler workflows from the OpenMetadata UI:
 
 - [Requirements](#requirements)
-    - [dbt Cloud Versions](#dbtcloud-versions)
+    - [dbt Cloud Versions](#dbt-cloud-versions)
 - [Metadata Ingestion](#metadata-ingestion)
     - [Service Name](#service-name)
     - [Connection Details](#connection-details)

--- a/openmetadata-docs/content/v1.6.x/connectors/pipeline/matillion/yaml.md
+++ b/openmetadata-docs/content/v1.6.x/connectors/pipeline/matillion/yaml.md
@@ -19,11 +19,7 @@ In this section, we provide guides and references to use the Matillion connector
 Configure and schedule Matillion metadata and profiler workflows from the OpenMetadata UI:
 
 - [Requirements](#requirements)
-    - [Matillion Versions](#matillion-versions)
 - [Metadata Ingestion](#metadata-ingestion)
-    - [Connection Details](#connection-details)
-- [Troubleshooting](#troubleshooting)
-    - [Workflow Deployment Error](#workflow-deployment-error)
 
 {% partial file="/v1.6/connectors/ingestion-modes-tiles.md" variables={yamlPath: "/connectors/pipeline/matillion/yaml"} /%}
 

--- a/openmetadata-docs/content/v1.6.x/deployment/secrets-manager/supported-implementations/gcp-secret-manager/index.md
+++ b/openmetadata-docs/content/v1.6.x/deployment/secrets-manager/supported-implementations/gcp-secret-manager/index.md
@@ -85,7 +85,7 @@ If everything goes as planned, all the data would be displayed using the paramet
 `/openmetadata/...` in your GCP Secret Manager console. The following image shows what it should look 
 like:
 
-{% image src="/images/v1.4/deployment/secrets-manager/supported-implementations/gcp-secret-manager/gcp-secret-manager-console.png" alt="gcp-secret-manager-console" /%} 
+{% image src="/images/v1.6/deployment/secrets-manager/supported-implementations/gcp-secret-manager/gcp-secret-manager-console.png" alt="gcp-secret-manager-console" /%} 
 
 **Note:** If we want to change the starting path for our secrets names from `openmetadata` to a different one, we have 
 to change the property `clusterName` in our `openmetadata.yaml`. Also, if you inform the `prefix` value, it will be

--- a/openmetadata-docs/content/v1.6.x/deployment/security/enable-jwt-tokens.md
+++ b/openmetadata-docs/content/v1.6.x/deployment/security/enable-jwt-tokens.md
@@ -104,7 +104,7 @@ wget -O - {your domain}/api/v1/system/config/jwks
 
 Once the above configuration is updated, the server is restarted. Admin can go to Settings -> Bots page.
 
-{% image src="/images/v1.4/deployment/security/enable-jwt/settings-bot.png" alt="Settings Page" caption="Settings Page" /%} 
+{% image src="/images/v1.6/deployment/security/enable-jwt/settings-bot.png" alt="Settings Page" caption="Settings Page" /%} 
 
 {% image src="/images/v1.6/deployment/security/enable-jwt/bot.png" alt="Bot settings page" caption="Bot settings page" /%} 
 

--- a/openmetadata-docs/content/v1.6.x/deployment/security/saml/bare-metal.md
+++ b/openmetadata-docs/content/v1.6.x/deployment/security/saml/bare-metal.md
@@ -51,4 +51,4 @@ are divided into the following three sections:-
     keyStorePassword: ${SAML_KEYSTORE_PASSWORD:-""}
 ```
 
-{% partial file="/v1.4/deployment/configure-ingestion.md" /%}
+{% partial file="/v1.6/deployment/configure-ingestion.md" /%}

--- a/openmetadata-docs/content/v1.6.x/deployment/security/saml/docker.md
+++ b/openmetadata-docs/content/v1.6.x/deployment/security/saml/docker.md
@@ -56,4 +56,4 @@ SAML_KEYSTORE_PASSWORD=myKeystorePassword
 docker compose --env-file ~/openmetadata_saml.env up -d
 ```
 
-{% partial file="/v1.4/deployment/configure-ingestion.md" /%}
+{% partial file="/v1.6/deployment/configure-ingestion.md" /%}

--- a/openmetadata-docs/content/v1.6.x/deployment/security/saml/kubernetes.md
+++ b/openmetadata-docs/content/v1.6.x/deployment/security/saml/kubernetes.md
@@ -41,4 +41,4 @@ openmetadata:
       keyStorePassword: ${SAML_KEYSTORE_PASSWORD:-""}
 ```
 
-{% partial file="/v1.4/deployment/configure-ingestion.md" /%}
+{% partial file="/v1.6/deployment/configure-ingestion.md" /%}

--- a/openmetadata-docs/content/v1.6.x/how-to-guides/admin-guide/cli-ingestion-with-basic-auth.md
+++ b/openmetadata-docs/content/v1.6.x/how-to-guides/admin-guide/cli-ingestion-with-basic-auth.md
@@ -22,7 +22,7 @@ From `0.12.1` OpenMetadata has changed the default `no-auth` to `Basic` auth, So
 **1.** Go to the `settings` page from the `activity bar` Section. Click on the `Bots` and you will see the list of bots, then click on the `ingestion-bot`.
    
    {% image
-    src="/images/v1.4/cli-ingestion-with-basic-auth/settings-bot.png"
+    src="/images/v1.6/cli-ingestion-with-basic-auth/settings-bot.png"
     alt="settings-bot" /%}
 
    {% image

--- a/openmetadata-docs/content/v1.6.x/how-to-guides/data-governance/domain-&-data-products/data-products.md
+++ b/openmetadata-docs/content/v1.6.x/how-to-guides/data-governance/domain-&-data-products/data-products.md
@@ -33,7 +33,7 @@ By following these steps, you can effectively set up and manage data products in
 
 
 {% image
-  src="/images/v1.4/how-to-guides/governance/data-products.gif"
+  src="/images/v1.6/how-to-guides/governance/data-products.gif"
   alt="Data Products"
  /%}
 

--- a/openmetadata-docs/content/v1.6.x/how-to-guides/data-quality-observability/incident-manager/IM-workflow.md
+++ b/openmetadata-docs/content/v1.6.x/how-to-guides/data-quality-observability/incident-manager/IM-workflow.md
@@ -16,7 +16,7 @@ The Incident Dashboard is the central hub where all incidents are displayed. Use
 - **Time:** Sort incidents by the time they were reported or last updated.
 
 {% image
-src="/images/v1.4/how-to-guides/observability/incident-manager-1.png"
+src="/images/v1.6/how-to-guides/observability/incident-manager-1.png"
 alt="Incident Manager Dashboard"
 caption="Incident Manager Dashboard"
 /%}
@@ -33,13 +33,13 @@ Incident status can be updated to reflect the current stage of the incident reso
 5. You can review the Test Case Details.
 
 {% image
-src="/images/v1.4/how-to-guides/observability/incident-manager-2.png"
+src="/images/v1.6/how-to-guides/observability/incident-manager-2.png"
 alt="Incident Test Case Details"
 caption="Incident Test Case Details"
 /%}
 
 {% image
-src="/images/v1.4/how-to-guides/observability/incident-manager-3.png"
+src="/images/v1.6/how-to-guides/observability/incident-manager-3.png"
 alt="Incident Status Change"
 caption="Incident Status Change"
 /%}
@@ -55,7 +55,7 @@ Once an incident has been resolved, it can be officially closed. Ensure to descr
 4. Confirm the closure to update the incident in the dashboard.
 
 {% image
-src="/images/v1.4/how-to-guides/observability/incident-manager-4.png"
+src="/images/v1.6/how-to-guides/observability/incident-manager-4.png"
 alt="Incident Resolution"
 caption="Incident Resolution"
 /%}
@@ -70,7 +70,7 @@ Each incident includes a detailed timeline where all relevant information is con
 3. Review the chronological events, RCA, and closure updates associated with the incident.
 
 {% image
-src="/images/v1.4/how-to-guides/observability/incident-manager-5.png"
+src="/images/v1.6/how-to-guides/observability/incident-manager-5.png"
 alt="Incident Activities"
 caption="Incident Activities"
 /%}

--- a/openmetadata-docs/content/v1.6.x/how-to-guides/data-quality-observability/incident-manager/index.md
+++ b/openmetadata-docs/content/v1.6.x/how-to-guides/data-quality-observability/incident-manager/index.md
@@ -11,7 +11,7 @@ Using Incident Manager, managing data quality issues becomes streamlined and eff
  In v1.1.0, we introduced the ability for user to manage and triage incidents linked to failures. When a test case fails, it will automatically open a new incident and mark it as new. If enough information is available, OpenMetadata will automatically assign a severity to the incident; note that you can override this severity. It indicates that a new failure has happened.
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/data-quality/resolution-workflow-new.png"
+  src="/images/v1.6/features/ingestion/workflows/data-quality/resolution-workflow-new.png"
   alt="Test suite results table"
   caption="Test suite results table"
  /%}
@@ -23,12 +23,12 @@ The Incident Manager serves as a centralized hub to handle the resolution flow o
 - **Log the Root Cause:** Document the underlying cause of the failure for future reference and analysis.
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/data-quality/resolution-workflow-ack-form.png"
+  src="/images/v1.6/features/ingestion/workflows/data-quality/resolution-workflow-ack-form.png"
   alt="Test suite results table"
   caption="Test suite results table"
  /%}
 {% image
-  src="/images/v1.4/features/ingestion/workflows/data-quality/resolution-workflow-ack.png"
+  src="/images/v1.6/features/ingestion/workflows/data-quality/resolution-workflow-ack.png"
   alt="Test suite results table"
   caption="Test suite results table"
  /%}
@@ -36,13 +36,13 @@ The Incident Manager serves as a centralized hub to handle the resolution flow o
 You can mark the incident as `resolved`. The user will be required to specify the reason and add a comment. This provides context regarding the incident and helps users further understand what might have gone wrong
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/data-quality/resolution-workflow-resolved-form.png"
+  src="/images/v1.6/features/ingestion/workflows/data-quality/resolution-workflow-resolved-form.png"
   alt="Test suite results table"
   caption="Test suite results table"
  /%}
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/data-quality/resolution-workflow-resolved.png"
+  src="/images/v1.6/features/ingestion/workflows/data-quality/resolution-workflow-resolved.png"
   alt="Test suite results table"
   caption="Test suite results table"
  /%}
@@ -64,7 +64,7 @@ When clicking on an open incident you will different information:
 **Closed Incidents:** this section will show you incidents that have been resolved in the past with the timeline and any comments/collaboration that might have been happening and the resolution reason.
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/data-quality/incident-management-page.png"
+  src="/images/v1.6/features/ingestion/workflows/data-quality/incident-management-page.png"
   alt="Test suite results table"
   caption="Test suite results table"
  /%}

--- a/openmetadata-docs/content/v1.6.x/how-to-guides/data-quality-observability/incident-manager/root-cause-analysis.md
+++ b/openmetadata-docs/content/v1.6.x/how-to-guides/data-quality-observability/incident-manager/root-cause-analysis.md
@@ -27,19 +27,19 @@ The sample will be collected when the option `computePassedFailedRowCount` is se
 If you wish to delete sample rows, you can do so by clicking on the three dots above the table of sample rows. This will open a window with the `Delete` option. Note that failed sample rows will automatically be deleted upon test success.
 
 {% image 
-src="/images/v1.4/features/ingestion/workflows/data-quality/sample-row-failure-deletion.png"
+src="/images/v1.6/features/ingestion/workflows/data-quality/sample-row-failure-deletion.png"
 alt="set compute row count"
 /%}
 
 ### Example
 
 {% image 
-src="/images/v1.4/features/ingestion/workflows/data-quality/set_compute_row_count.png"
+src="/images/v1.6/features/ingestion/workflows/data-quality/set_compute_row_count.png"
 alt="set compute row count"
 /%}
 
-![test definition](/images/v1.4/features/ingestion/workflows/data-quality/failed_rows_sample_1.png)
-![failed rows sampls](/images/v1.4/features/ingestion/workflows/data-quality/failed_rows_sample_2.png)
+![test definition](/images/v1.6/features/ingestion/workflows/data-quality/failed_rows_sample_1.png)
+![failed rows sampls](/images/v1.6/features/ingestion/workflows/data-quality/failed_rows_sample_2.png)
 
 ## Inspection Query
 

--- a/openmetadata-docs/content/v1.6.x/how-to-guides/data-quality-observability/observability/alerts.md
+++ b/openmetadata-docs/content/v1.6.x/how-to-guides/data-quality-observability/observability/alerts.md
@@ -10,7 +10,7 @@ OpenMetadata provides a native way to get alerted in case of test case failure a
 To set up an alert on a test case or test suite, navigate to the observability menu and select `Alerts` and click on `Add Alert`.
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/alerts-menu.png"
+  src="/images/v1.6/features/ingestion/workflows/profiler/alerts-menu.png"
   alt="Alerts Menu"
   caption="Alerts Menu"
  /%}
@@ -21,7 +21,7 @@ The first will be to select a source. For data quality you have 2 relevant optio
 - `Test Suite`: it will trigger an alert for any test case event linked to the test suite. This is a great way to group alerts and reducing notification fatigue
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/alert-source-selection.png"
+  src="/images/v1.6/features/ingestion/workflows/profiler/alert-source-selection.png"
   alt="Alerts Menu"
   caption="Alerts Menu"
  /%}
@@ -33,7 +33,7 @@ The first will be to select a source. For data quality you have 2 relevant optio
 You can filter alerts based on specific condition to narrow down which test suite/test case should trigger an alert. This is interesting for user to dispatch alerts to different channels/users.
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/alerts-filter.png"
+  src="/images/v1.6/features/ingestion/workflows/profiler/alerts-filter.png"
   alt="Alerts Menu"
   caption="Alerts Menu"
  /%}
@@ -42,7 +42,7 @@ You can filter alerts based on specific condition to narrow down which test suit
 Trigger section will allow you set the condition for which an alert should be triggered
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/alerts-trigger.png"
+  src="/images/v1.6/features/ingestion/workflows/profiler/alerts-trigger.png"
   alt="Alerts Menu"
   caption="Alerts Menu"
  /%}
@@ -53,7 +53,7 @@ In the destination section you will be able to select between `internal` and `ex
 - `external`: allow you to select an external destination such as a slack or teams channel  
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/alerts-destination.png"
+  src="/images/v1.6/features/ingestion/workflows/profiler/alerts-destination.png"
   alt="Alerts Menu"
   caption="Alerts Menu"
  /%}

--- a/openmetadata-docs/content/v1.6.x/how-to-guides/data-quality-observability/observability/webhooks.md
+++ b/openmetadata-docs/content/v1.6.x/how-to-guides/data-quality-observability/observability/webhooks.md
@@ -39,7 +39,7 @@ OpenMetadata also allows the user to customise the webhook with a wide range of 
    Event data for specific action can be achieved.
 
 {% image
-src="/images/v1.4/how-to-guides/observability/webhook.png"
+src="/images/v1.6/how-to-guides/observability/webhook.png"
 alt="Generic Webhook"
 caption="Generic Webhook"
 /%}
@@ -54,7 +54,7 @@ caption="Generic Webhook"
 
 
 {% image
-src="/images/v1.4/how-to-guides/observability/slack.png"
+src="/images/v1.6/how-to-guides/observability/slack.png"
 alt="Slack Webhook"
 caption="Slack Webhook"
 /%}
@@ -68,7 +68,7 @@ caption="Slack Webhook"
    Event data for specific action can be achieved.
 
 {% image
-src="/images/v1.4/how-to-guides/observability/msteam.png"
+src="/images/v1.6/how-to-guides/observability/msteam.png"
 alt="MS Team Webhook"
 caption="MS Team Webhook"
 /%} 
@@ -82,7 +82,7 @@ caption="MS Team Webhook"
    Event data for specific action can be achieved.
 
 {% image
-src="/images/v1.4/how-to-guides/observability/gchat.png"
+src="/images/v1.6/how-to-guides/observability/gchat.png"
 alt="Gchat Webhook"
 caption="Gchat Webhook"
 /%} 

--- a/openmetadata-docs/content/v1.6.x/how-to-guides/data-quality-observability/profiler/external_workflow.md
+++ b/openmetadata-docs/content/v1.6.x/how-to-guides/data-quality-observability/profiler/external_workflow.md
@@ -34,7 +34,7 @@ Note that running a single profiler workflow is only supported if you run the wo
 
 {% /note %}
 
-{% partial file="/v1.4/connectors/external-ingestion-deployment.md" /%}
+{% partial file="/v1.6/connectors/external-ingestion-deployment.md" /%}
 
 ### Requirements
 

--- a/openmetadata-docs/content/v1.6.x/how-to-guides/data-quality-observability/profiler/metrics.md
+++ b/openmetadata-docs/content/v1.6.x/how-to-guides/data-quality-observability/profiler/metrics.md
@@ -38,7 +38,7 @@ Returns the number of columns in the Table.
 System metrics provide information related to DML operations performed on the table. These metrics present a concise view of your data freshness. In a typical data processing flow tables are updated at a certain frequency. Table freshness will be monitored by confirming a set of operations has been performed against the table. To increase trust in your data assets, OpenMetadata will monitor the `INSERT`, `UPDATE` and `DELETE` operations performed against your table to showcase 2 metrics related to freshness (see below for more details). With this information, you are able to see when a specific operation was last perform and how many rows it affected. 
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/profiler-freshness-metrics.png"
+  src="/images/v1.6/features/ingestion/workflows/profiler/profiler-freshness-metrics.png"
   alt="table profile freshness metrics"
   caption="table profile freshness metrics"
  /%}

--- a/openmetadata-docs/content/v1.6.x/how-to-guides/data-quality-observability/profiler/profiler-workflow.md
+++ b/openmetadata-docs/content/v1.6.x/how-to-guides/data-quality-observability/profiler/profiler-workflow.md
@@ -19,13 +19,13 @@ After the metadata ingestion has been done correctly, we can configure and deplo
 This Pipeline will be in charge of feeding the Profiler tab of the Table Entity, as well as running any tests configured in the Entity.
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/profiler-summary-table.png"
+  src="/images/v1.6/features/ingestion/workflows/profiler/profiler-summary-table.png"
   alt="Table profile summary page"
   caption="Table profile summary page"
  /%}
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/profiler-summary-column.png"
+  src="/images/v1.6/features/ingestion/workflows/profiler/profiler-summary-column.png"
   alt="Column profile summary page"
   caption="Column profile summary page"
  /%}
@@ -34,7 +34,7 @@ This Pipeline will be in charge of feeding the Profiler tab of the Table Entity,
 From the Service Page, go to the Ingestions tab to add a new ingestion and click on Add Profiler Ingestion.
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/add-profiler-workflow.png"
+  src="/images/v1.6/features/ingestion/workflows/profiler/add-profiler-workflow.png"
   alt="Add a profiler service"
   caption="Add a profiler service"
  /%}
@@ -43,7 +43,7 @@ From the Service Page, go to the Ingestions tab to add a new ingestion and click
 Here you can enter the Profiler Ingestion details.
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/configure-profiler-workflow.png"
+  src="/images/v1.6/features/ingestion/workflows/profiler/configure-profiler-workflow.png"
   alt="Set profiler configuration"
   caption="Set profiler configuration"
  /%}
@@ -110,13 +110,13 @@ After clicking Next, you will be redirected to the Scheduling form. This will be
 Once you have created your profiler you can adjust some behavior at the table level by going to the table and clicking on the profiler tab 
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/accessing-table-profile-settings.png"
+  src="/images/v1.6/features/ingestion/workflows/profiler/accessing-table-profile-settings.png"
   alt="table profile settings"
   caption="table profile settings"
  /%}
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/table-profile-summary-view.png"
+  src="/images/v1.6/features/ingestion/workflows/profiler/table-profile-summary-view.png"
   alt="table profile settings"
   caption="table profile settings"
  /%}
@@ -168,7 +168,7 @@ Once you have picked the `Interval Type` you will need to define the configurati
 The behavior of the profiler can be configured at the platform level. Navigating to `Settings > Preferences > Profiler Configuration` you will find settings to adjust the behavior of the profiler.
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/profiler-global-configuration.png"
+  src="/images/v1.6/features/ingestion/workflows/profiler/profiler-global-configuration.png"
   alt="table profile global settings"
   caption="table profile global settings"
  /%}
@@ -177,7 +177,7 @@ The behavior of the profiler can be configured at the platform level. Navigating
 Select the data type you want to disable all metric for. Then toggle disable on. When running the profiler all metric computation will be skipped for the data type.
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/disable-metric-computation.png"
+  src="/images/v1.6/features/ingestion/workflows/profiler/disable-metric-computation.png"
   alt="table profile global settings"
   caption="table profile global settings"
  /%}
@@ -186,7 +186,7 @@ Select the data type you want to disable all metric for. Then toggle disable on.
 Select the data type you want to disable a metric for. Then in the `Metric Type` section select the metric you to compute (or unselect the ones you don't want to compute). When running the profiler the unselected metric will not be computed.
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/disable-specific-metric-computation.png"
+  src="/images/v1.6/features/ingestion/workflows/profiler/disable-specific-metric-computation.png"
   alt="table profile global settings"
   caption="table profile global settings"
  /%}

--- a/openmetadata-docs/content/v1.6.x/how-to-guides/data-quality-observability/profiler/sample_data.md
+++ b/openmetadata-docs/content/v1.6.x/how-to-guides/data-quality-observability/profiler/sample_data.md
@@ -33,7 +33,7 @@ You can configure the Sample Data Storage Credentials at Database Service level 
 You will provide the storage credential details in advance config section of connection details form.
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/sample-data-config-service.png"
+  src="/images/v1.6/features/ingestion/workflows/profiler/sample-data-config-service.png"
   alt="Database Service Storage Config"
   caption="Database Service Storage Config"
  /%}
@@ -44,14 +44,14 @@ You will provide the storage credential details in advance config section of con
 You can configure the Sample Data Storage Credentials at the Database level via the `Profiler Settings` option from the menu.
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/sample-data-config-database-1.png"
+  src="/images/v1.6/features/ingestion/workflows/profiler/sample-data-config-database-1.png"
   alt="Database Storage Config - 1"
   caption="Database Storage Config - 1"
  /%}
 
 
  {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/sample-data-config-database-2.png"
+  src="/images/v1.6/features/ingestion/workflows/profiler/sample-data-config-database-2.png"
   alt="Database Storage Config - 2"
   caption="Database Storage Config - 2"
  /%}
@@ -61,14 +61,14 @@ You can configure the Sample Data Storage Credentials at the Database level via 
 You can configure the Sample Data Storage Credentials at the Database Schema level via the `Profiler Settings` option from the menu.
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/sample-data-config-schema-1.png"
+  src="/images/v1.6/features/ingestion/workflows/profiler/sample-data-config-schema-1.png"
   alt="Database Schema Storage Config - 1"
   caption="Database Schema Storage Config - 1"
  /%}
 
 
  {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/sample-data-config-schema-2.png"
+  src="/images/v1.6/features/ingestion/workflows/profiler/sample-data-config-schema-2.png"
   alt="Database Schema Storage Config - 2"
   caption="Database Schema Storage Config - 2"
  /%}

--- a/openmetadata-docs/content/v1.6.x/how-to-guides/data-quality-observability/profiler/tab.md
+++ b/openmetadata-docs/content/v1.6.x/how-to-guides/data-quality-observability/profiler/tab.md
@@ -12,7 +12,7 @@ The Profiler & Data Quality tab is displayed only for Tables. It has three sub-t
 The table profile helps to monitor and understand the table structure. It displays the number of **rows and columns** in the table. You can view these details over a timeframe to understand how the table has been evolving. It displays the **profile sample** either as an absolute number or as a percentage of data. You also get details on the **size of the data** as well as when the table was created.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/tp.png"
+src="/images/v1.6/how-to-guides/quality/tp.png"
 alt="Table Profile"
 caption="Table Profile"
 /%}
@@ -24,7 +24,7 @@ The Table Profile tab also displays timeseries graphs on **Data Volume, Table Up
 The **Data Volume** chart gives an overview on how the data is evolving across a time period. 
 
 {% image
-src="/images/v1.4/how-to-guides/quality/dv.png"
+src="/images/v1.6/how-to-guides/quality/dv.png"
 alt="Table Profile: Data Volume"
 caption="Table Profile: Data Volume"
 /%}
@@ -33,7 +33,7 @@ caption="Table Profile: Data Volume"
 In **Table Updates** chart, users can view the changes that happened in the table in terms of data inserts, updates, and deletes.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/tu.png"
+src="/images/v1.6/how-to-guides/quality/tu.png"
 alt="Table Profile: Table Updates"
 caption="Table Profile: Table Updates"
 /%}
@@ -43,7 +43,7 @@ caption="Table Profile: Table Updates"
 In **Volume Change** chart, users can view the changes that happened in the table in terms of data volume for inserts, updates, and deletes.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/vc.png"
+src="/images/v1.6/how-to-guides/quality/vc.png"
 alt="Table Profile: Volume Change"
 caption="Table Profile: Volume Change"
 /%}
@@ -55,7 +55,7 @@ The Column Profile tab provides a summary of table metrics similar to the Table 
 The column profile helps to monitor and understand the column structure with a summary of metrics for every column. You can view the type of each column, the value count, null value %, distinct value %, unique %, the tests run as well as the test status.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/cp.png"
+src="/images/v1.6/how-to-guides/quality/cp.png"
 alt="Column Profile of a Table"
 caption="Column Profile of a Table"
 /%}
@@ -63,7 +63,7 @@ caption="Column Profile of a Table"
 By clicking on any column, you can view more detailed reports about that column.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/cp1.png"
+src="/images/v1.6/how-to-guides/quality/cp1.png"
 alt="Column Profile of a Column"
 caption="Column Profile of a Column"
 /%}
@@ -75,7 +75,7 @@ The Column Profile for a particular column also displays timeseries graphs on **
 The data counts chart provides information on the **Distinct Count, Null Count, Unique Count, and Values Count**.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/dc.png"
+src="/images/v1.6/how-to-guides/quality/dc.png"
 alt="Column Profile: Data Counts"
 caption="Column Profile: Data Counts"
 /%}
@@ -85,7 +85,7 @@ caption="Column Profile: Data Counts"
 The data proportions chart displays the **Distinct, Null, and Unique Proportions**.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/dp.png"
+src="/images/v1.6/how-to-guides/quality/dp.png"
 alt="Column Profile: Data Proportions"
 caption="Column Profile: Data Proportions"
 /%}
@@ -95,7 +95,7 @@ caption="Column Profile: Data Proportions"
 The length of the string that are stored in the database is profiled. The data range displays the Minimum, Maximum, and Mean values, which can be helpful for users who are doing an NLP or Text analysis.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/dr.png"
+src="/images/v1.6/how-to-guides/quality/dr.png"
 alt="Column Profile: Data Range"
 caption="Column Profile: Data Range"
 /%}
@@ -103,7 +103,7 @@ caption="Column Profile: Data Range"
 ### Data Aggregate
 
 {% image
-src="/images/v1.4/how-to-guides/quality/da.png"
+src="/images/v1.6/how-to-guides/quality/da.png"
 alt="Column Profile: Data Aggregate"
 caption="Column Profile: Data Aggregate"
 /%}
@@ -113,7 +113,7 @@ caption="Column Profile: Data Aggregate"
 This chart displays the First Quartile, Median, Inter Quartile Range, and the Third Quartile.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/dq.png"
+src="/images/v1.6/how-to-guides/quality/dq.png"
 alt="Column Profile: Data Quartiles"
 caption="Column Profile: Data Quartiles"
 /%}
@@ -123,7 +123,7 @@ caption="Column Profile: Data Quartiles"
 The distribution of the character length inside the column is displayed to help you get a sense of the structure of your data.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/dd.png"
+src="/images/v1.6/how-to-guides/quality/dd.png"
 alt="Column Profile: Data Distribution"
 caption="Column Profile: Data Distribution"
 /%}

--- a/openmetadata-docs/content/v1.6.x/how-to-guides/data-quality-observability/quality/custom-tests.md
+++ b/openmetadata-docs/content/v1.6.x/how-to-guides/data-quality-observability/quality/custom-tests.md
@@ -195,13 +195,13 @@ class ColumnEntropyToBeBetweenValidator(BaseTestValidator):
 Once you have completed A) and B) you should only need to `pip install` your package in the environment where openmetadata python SDK is install.
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/data-quality/custom-test-definition.png"
+  src="/images/v1.6/features/ingestion/workflows/data-quality/custom-test-definition.png"
   alt="Create test case"
   caption="Create test case"
  /%}
 
  {% image
-  src="/images/v1.4/features/ingestion/workflows/data-quality/custom-test-result.png"
+  src="/images/v1.6/features/ingestion/workflows/data-quality/custom-test-result.png"
   alt="Create test case"
   caption="Create test case"
  /%}

--- a/openmetadata-docs/content/v1.6.x/how-to-guides/data-quality-observability/quality/index.md
+++ b/openmetadata-docs/content/v1.6.x/how-to-guides/data-quality-observability/quality/index.md
@@ -16,7 +16,7 @@ OpenMetadata provides Data Quality workflows, which helps with:
 The data quality in OpenMetadata is also **extensible** to adapt to your needs. 
 
 {% image
-src="/images/v1.4/how-to-guides/quality/quality1.png"
+src="/images/v1.6/how-to-guides/quality/quality1.png"
 alt="Profiler & Data Quality"
 caption="Profiler & Data Quality"
 /%}

--- a/openmetadata-docs/content/v1.6.x/how-to-guides/data-quality-observability/quality/tab.md
+++ b/openmetadata-docs/content/v1.6.x/how-to-guides/data-quality-observability/quality/tab.md
@@ -10,7 +10,7 @@ The Profiler & Data Quality tab is displayed only for Tables. It has three sub-t
 Data quality tests can be run on the sample data. We can add tests at the table and column level. The Data Quality tab displays the total number of tests that were run, and also the number of tests that were successful, aborted, or failed. The list of test cases displays the details of the table or column on which the test was run.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/dq1.png"
+src="/images/v1.6/how-to-guides/quality/dq1.png"
 alt="Profiler & Data Quality"
 caption="Profiler & Data Quality"
 /%}
@@ -18,7 +18,7 @@ caption="Profiler & Data Quality"
 You can click on a Test Case to view further details. You can use a time filter on these reports. You can also edit these tests by clicking on the pencil icon next to each test.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/dq2.png"
+src="/images/v1.6/how-to-guides/quality/dq2.png"
 alt="Details of a Test Case"
 caption="Details of a Test Case"
 /%}

--- a/openmetadata-docs/content/v1.6.x/how-to-guides/data-quality-observability/quality/test-cases-from-yaml-config.md
+++ b/openmetadata-docs/content/v1.6.x/how-to-guides/data-quality-observability/quality/test-cases-from-yaml-config.md
@@ -3,4 +3,4 @@ title: Adding Data Quality Test Cases from yaml config
 slug: /how-to-guides/data-quality-observability/quality/test-cases-from-yaml-config
 ---
 
-{% partial file="/v1.4/connectors/yaml/data-quality.md" /%}
+{% partial file="/v1.6/connectors/yaml/data-quality.md" /%}

--- a/openmetadata-docs/content/v1.6.x/how-to-guides/data-quality-observability/quality/test.md
+++ b/openmetadata-docs/content/v1.6.x/how-to-guides/data-quality-observability/quality/test.md
@@ -15,7 +15,7 @@ To create a test in OpenMetadata:
 - Click on **Add Test** to select a `Table` or `Column` level test.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/test1.png"
+src="/images/v1.6/how-to-guides/quality/test1.png"
 alt="Write and Deploy No-Code Test Cases"
 caption="Write and Deploy No-Code Test Cases"
 /%}
@@ -41,7 +41,7 @@ OpenMetadata currently supports the following table level test types:
 10. Table Data to Be Fresh: Validate the freshness of a table's data.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/test4.png"
+src="/images/v1.6/how-to-guides/quality/test4.png"
 alt="Configure a Table Level Test"
 caption="Configure a Table Level Test"
 /%}
@@ -73,7 +73,7 @@ OpenMetadata currently supports the following column level test types:
 15. Column Values to Not Match Regex: Define the regular expression that the column entries should not match.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/test2.png"
+src="/images/v1.6/how-to-guides/quality/test2.png"
 alt="Configure a Column Level Test"
 caption="Configure a Column Level Test"
 /%}
@@ -81,7 +81,7 @@ caption="Configure a Column Level Test"
 Once the test has been created, you can view the test suite. The test case will be displayed in the Data Quality tab. You can also edit the Display Name and Description for the test.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/test3.png"
+src="/images/v1.6/how-to-guides/quality/test3.png"
 alt="Column Level Test Created"
 caption="Column Level Test Created"
 /%}
@@ -91,7 +91,7 @@ A pipeline can be set up for the tests to run at a regular cadence.
 - Add a pipeline
 
 {% image
-src="/images/v1.4/how-to-guides/quality/test5.png"
+src="/images/v1.6/how-to-guides/quality/test5.png"
 alt="Set up a Pipeline"
 caption="Set up a Pipeline"
 /%}
@@ -100,7 +100,7 @@ caption="Set up a Pipeline"
 - Click on **Submit**.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/test6.png"
+src="/images/v1.6/how-to-guides/quality/test6.png"
 alt="Schedule the Pipeline"
 caption="Schedule the Pipeline"
 /%}
@@ -108,7 +108,7 @@ caption="Schedule the Pipeline"
 The pipeline has been set up and will run at the scheduled time.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/test7.png"
+src="/images/v1.6/how-to-guides/quality/test7.png"
 alt="Pipeline Scheduled"
 caption="Pipeline Scheduled"
 /%}
@@ -116,7 +116,7 @@ caption="Pipeline Scheduled"
 The tests will be run and the results will be updated in the Data Quality tab.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/test8.png"
+src="/images/v1.6/how-to-guides/quality/test8.png"
 alt="Data Quality Tests"
 caption="Data Quality Tests"
 /%}
@@ -124,14 +124,14 @@ caption="Data Quality Tests"
 If a **test fails**, you can **Edit the Test Status** to New, Acknowledged, or Resolved status by clicking on the Status icon.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/test9.png"
+src="/images/v1.6/how-to-guides/quality/test9.png"
 alt="Failed Test: Edit Status"
 caption="Failed Test: Edit Status"
 /%}
 
 - Select the Test Status
 {% image
-src="/images/v1.4/how-to-guides/quality/test10.png"
+src="/images/v1.6/how-to-guides/quality/test10.png"
 alt="Edit Test Status"
 caption="Edit Test Status"
 /%}
@@ -139,7 +139,7 @@ caption="Edit Test Status"
 - If you are marking the test status as **Resolved**, you must specify the **Reason** for the failure and add a **Comment**. The reasons for failure can be Duplicates, False Positive, Missing Data, Other, or Out of Bounds.
 - Click on **Submit**.
 {% image
-src="/images/v1.4/how-to-guides/quality/test11.png"
+src="/images/v1.6/how-to-guides/quality/test11.png"
 alt="Resolved Status: Reason"
 caption="Resolved Status: Reason"
 /%}

--- a/openmetadata-docs/content/v1.7.x-SNAPSHOT/connectors/messaging/kinesis/index.md
+++ b/openmetadata-docs/content/v1.7.x-SNAPSHOT/connectors/messaging/kinesis/index.md
@@ -56,7 +56,7 @@ For more information on Kinesis permissions visit the [AWS Kinesis official docu
   variables={
     connector: "Kinesis", 
     selectServicePath: "/images/v1.7/connectors/kinesis/select-service.png",
-    addNewServicePath: "/images/v1.7/connectors//add-new-service.png",
+    addNewServicePath: "/images/v1.7/connectors/add-new-service.png",
     serviceConnectionPath: "/images/v1.7/connectors/kinesis/service-connection.png",
 } 
 /%}

--- a/openmetadata-docs/content/v1.7.x-SNAPSHOT/connectors/pipeline/dbtcloud/index.md
+++ b/openmetadata-docs/content/v1.7.x-SNAPSHOT/connectors/pipeline/dbtcloud/index.md
@@ -17,7 +17,7 @@ In this section, we provide guides and references to use the dbt Cloud connector
 Configure and schedule dbt Cloud metadata and profiler workflows from the OpenMetadata UI:
 
 - [Requirements](#requirements)
-    - [dbt Cloud Versions](#dbtcloud-versions)
+    - [dbt Cloud Versions](#dbt-cloud-versions)
 - [Metadata Ingestion](#metadata-ingestion)
     - [Service Name](#service-name)
     - [Connection Details](#connection-details)

--- a/openmetadata-docs/content/v1.7.x-SNAPSHOT/connectors/pipeline/matillion/yaml.md
+++ b/openmetadata-docs/content/v1.7.x-SNAPSHOT/connectors/pipeline/matillion/yaml.md
@@ -19,11 +19,7 @@ In this section, we provide guides and references to use the Matillion connector
 Configure and schedule Matillion metadata and profiler workflows from the OpenMetadata UI:
 
 - [Requirements](#requirements)
-    - [Matillion Versions](#matillion-versions)
 - [Metadata Ingestion](#metadata-ingestion)
-    - [Connection Details](#connection-details)
-- [Troubleshooting](#troubleshooting)
-    - [Workflow Deployment Error](#workflow-deployment-error)
 
 {% partial file="/v1.7/connectors/ingestion-modes-tiles.md" variables={yamlPath: "/connectors/pipeline/matillion/yaml"} /%}
 

--- a/openmetadata-docs/content/v1.7.x-SNAPSHOT/deployment/secrets-manager/supported-implementations/gcp-secret-manager/index.md
+++ b/openmetadata-docs/content/v1.7.x-SNAPSHOT/deployment/secrets-manager/supported-implementations/gcp-secret-manager/index.md
@@ -85,7 +85,7 @@ If everything goes as planned, all the data would be displayed using the paramet
 `/openmetadata/...` in your GCP Secret Manager console. The following image shows what it should look 
 like:
 
-{% image src="/images/v1.4/deployment/secrets-manager/supported-implementations/gcp-secret-manager/gcp-secret-manager-console.png" alt="gcp-secret-manager-console" /%} 
+{% image src="/images/v1.7/deployment/secrets-manager/supported-implementations/gcp-secret-manager/gcp-secret-manager-console.png" alt="gcp-secret-manager-console" /%} 
 
 **Note:** If we want to change the starting path for our secrets names from `openmetadata` to a different one, we have 
 to change the property `clusterName` in our `openmetadata.yaml`. Also, if you inform the `prefix` value, it will be

--- a/openmetadata-docs/content/v1.7.x-SNAPSHOT/deployment/security/enable-jwt-tokens.md
+++ b/openmetadata-docs/content/v1.7.x-SNAPSHOT/deployment/security/enable-jwt-tokens.md
@@ -104,7 +104,7 @@ wget -O - {your domain}/api/v1/system/config/jwks
 
 Once the above configuration is updated, the server is restarted. Admin can go to Settings -> Bots page.
 
-{% image src="/images/v1.4/deployment/security/enable-jwt/settings-bot.png" alt="Settings Page" caption="Settings Page" /%} 
+{% image src="/images/v1.7/deployment/security/enable-jwt/settings-bot.png" alt="Settings Page" caption="Settings Page" /%} 
 
 {% image src="/images/v1.7/deployment/security/enable-jwt/bot.png" alt="Bot settings page" caption="Bot settings page" /%} 
 

--- a/openmetadata-docs/content/v1.7.x-SNAPSHOT/deployment/security/saml/bare-metal.md
+++ b/openmetadata-docs/content/v1.7.x-SNAPSHOT/deployment/security/saml/bare-metal.md
@@ -51,4 +51,4 @@ are divided into the following three sections:-
     keyStorePassword: ${SAML_KEYSTORE_PASSWORD:-""}
 ```
 
-{% partial file="/v1.4/deployment/configure-ingestion.md" /%}
+{% partial file="/v1.7/deployment/configure-ingestion.md" /%}

--- a/openmetadata-docs/content/v1.7.x-SNAPSHOT/deployment/security/saml/docker.md
+++ b/openmetadata-docs/content/v1.7.x-SNAPSHOT/deployment/security/saml/docker.md
@@ -56,4 +56,4 @@ SAML_KEYSTORE_PASSWORD=myKeystorePassword
 docker compose --env-file ~/openmetadata_saml.env up -d
 ```
 
-{% partial file="/v1.4/deployment/configure-ingestion.md" /%}
+{% partial file="/v1.7/deployment/configure-ingestion.md" /%}

--- a/openmetadata-docs/content/v1.7.x-SNAPSHOT/deployment/security/saml/kubernetes.md
+++ b/openmetadata-docs/content/v1.7.x-SNAPSHOT/deployment/security/saml/kubernetes.md
@@ -41,4 +41,4 @@ openmetadata:
       keyStorePassword: ${SAML_KEYSTORE_PASSWORD:-""}
 ```
 
-{% partial file="/v1.4/deployment/configure-ingestion.md" /%}
+{% partial file="/v1.7/deployment/configure-ingestion.md" /%}

--- a/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/admin-guide/cli-ingestion-with-basic-auth.md
+++ b/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/admin-guide/cli-ingestion-with-basic-auth.md
@@ -22,7 +22,7 @@ From `0.12.1` OpenMetadata has changed the default `no-auth` to `Basic` auth, So
 **1.** Go to the `settings` page from the `activity bar` Section. Click on the `Bots` and you will see the list of bots, then click on the `ingestion-bot`.
    
    {% image
-    src="/images/v1.4/cli-ingestion-with-basic-auth/settings-bot.png"
+    src="/images/v1.7/cli-ingestion-with-basic-auth/settings-bot.png"
     alt="settings-bot" /%}
 
    {% image

--- a/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/data-governance/domain-&-data-products/data-products.md
+++ b/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/data-governance/domain-&-data-products/data-products.md
@@ -33,7 +33,7 @@ By following these steps, you can effectively set up and manage data products in
 
 
 {% image
-  src="/images/v1.4/how-to-guides/governance/data-products.gif"
+  src="/images/v1.7/how-to-guides/governance/data-products.gif"
   alt="Data Products"
  /%}
 

--- a/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/data-quality-observability/incident-manager/IM-workflow.md
+++ b/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/data-quality-observability/incident-manager/IM-workflow.md
@@ -16,7 +16,7 @@ The Incident Dashboard is the central hub where all incidents are displayed. Use
 - **Time:** Sort incidents by the time they were reported or last updated.
 
 {% image
-src="/images/v1.4/how-to-guides/observability/incident-manager-1.png"
+src="/images/v1.7/how-to-guides/observability/incident-manager-1.png"
 alt="Incident Manager Dashboard"
 caption="Incident Manager Dashboard"
 /%}
@@ -33,13 +33,13 @@ Incident status can be updated to reflect the current stage of the incident reso
 5. You can review the Test Case Details.
 
 {% image
-src="/images/v1.4/how-to-guides/observability/incident-manager-2.png"
+src="/images/v1.7/how-to-guides/observability/incident-manager-2.png"
 alt="Incident Test Case Details"
 caption="Incident Test Case Details"
 /%}
 
 {% image
-src="/images/v1.4/how-to-guides/observability/incident-manager-3.png"
+src="/images/v1.7/how-to-guides/observability/incident-manager-3.png"
 alt="Incident Status Change"
 caption="Incident Status Change"
 /%}
@@ -55,7 +55,7 @@ Once an incident has been resolved, it can be officially closed. Ensure to descr
 4. Confirm the closure to update the incident in the dashboard.
 
 {% image
-src="/images/v1.4/how-to-guides/observability/incident-manager-4.png"
+src="/images/v1.7/how-to-guides/observability/incident-manager-4.png"
 alt="Incident Resolution"
 caption="Incident Resolution"
 /%}
@@ -70,7 +70,7 @@ Each incident includes a detailed timeline where all relevant information is con
 3. Review the chronological events, RCA, and closure updates associated with the incident.
 
 {% image
-src="/images/v1.4/how-to-guides/observability/incident-manager-5.png"
+src="/images/v1.7/how-to-guides/observability/incident-manager-5.png"
 alt="Incident Activities"
 caption="Incident Activities"
 /%}

--- a/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/data-quality-observability/incident-manager/index.md
+++ b/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/data-quality-observability/incident-manager/index.md
@@ -11,7 +11,7 @@ Using Incident Manager, managing data quality issues becomes streamlined and eff
  In v1.1.0, we introduced the ability for user to manage and triage incidents linked to failures. When a test case fails, it will automatically open a new incident and mark it as new. If enough information is available, OpenMetadata will automatically assign a severity to the incident; note that you can override this severity. It indicates that a new failure has happened.
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/data-quality/resolution-workflow-new.png"
+  src="/images/v1.7/features/ingestion/workflows/data-quality/resolution-workflow-new.png"
   alt="Test suite results table"
   caption="Test suite results table"
  /%}
@@ -23,12 +23,12 @@ The Incident Manager serves as a centralized hub to handle the resolution flow o
 - **Log the Root Cause:** Document the underlying cause of the failure for future reference and analysis.
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/data-quality/resolution-workflow-ack-form.png"
+  src="/images/v1.7/features/ingestion/workflows/data-quality/resolution-workflow-ack-form.png"
   alt="Test suite results table"
   caption="Test suite results table"
  /%}
 {% image
-  src="/images/v1.4/features/ingestion/workflows/data-quality/resolution-workflow-ack.png"
+  src="/images/v1.7/features/ingestion/workflows/data-quality/resolution-workflow-ack.png"
   alt="Test suite results table"
   caption="Test suite results table"
  /%}
@@ -36,13 +36,13 @@ The Incident Manager serves as a centralized hub to handle the resolution flow o
 You can mark the incident as `resolved`. The user will be required to specify the reason and add a comment. This provides context regarding the incident and helps users further understand what might have gone wrong
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/data-quality/resolution-workflow-resolved-form.png"
+  src="/images/v1.7/features/ingestion/workflows/data-quality/resolution-workflow-resolved-form.png"
   alt="Test suite results table"
   caption="Test suite results table"
  /%}
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/data-quality/resolution-workflow-resolved.png"
+  src="/images/v1.7/features/ingestion/workflows/data-quality/resolution-workflow-resolved.png"
   alt="Test suite results table"
   caption="Test suite results table"
  /%}
@@ -64,7 +64,7 @@ When clicking on an open incident you will different information:
 **Closed Incidents:** this section will show you incidents that have been resolved in the past with the timeline and any comments/collaboration that might have been happening and the resolution reason.
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/data-quality/incident-management-page.png"
+  src="/images/v1.7/features/ingestion/workflows/data-quality/incident-management-page.png"
   alt="Test suite results table"
   caption="Test suite results table"
  /%}

--- a/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/data-quality-observability/incident-manager/root-cause-analysis.md
+++ b/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/data-quality-observability/incident-manager/root-cause-analysis.md
@@ -27,19 +27,19 @@ The sample will be collected when the option `computePassedFailedRowCount` is se
 If you wish to delete sample rows, you can do so by clicking on the three dots above the table of sample rows. This will open a window with the `Delete` option. Note that failed sample rows will automatically be deleted upon test success.
 
 {% image 
-src="/images/v1.4/features/ingestion/workflows/data-quality/sample-row-failure-deletion.png"
+src="/images/v1.7/features/ingestion/workflows/data-quality/sample-row-failure-deletion.png"
 alt="set compute row count"
 /%}
 
 ### Example
 
 {% image 
-src="/images/v1.4/features/ingestion/workflows/data-quality/set_compute_row_count.png"
+src="/images/v1.7/features/ingestion/workflows/data-quality/set_compute_row_count.png"
 alt="set compute row count"
 /%}
 
-![test definition](/images/v1.4/features/ingestion/workflows/data-quality/failed_rows_sample_1.png)
-![failed rows sampls](/images/v1.4/features/ingestion/workflows/data-quality/failed_rows_sample_2.png)
+![test definition](/images/v1.7/features/ingestion/workflows/data-quality/failed_rows_sample_1.png)
+![failed rows sampls](/images/v1.7/features/ingestion/workflows/data-quality/failed_rows_sample_2.png)
 
 ## Inspection Query
 

--- a/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/data-quality-observability/observability/alerts.md
+++ b/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/data-quality-observability/observability/alerts.md
@@ -10,7 +10,7 @@ OpenMetadata provides a native way to get alerted in case of test case failure a
 To set up an alert on a test case or test suite, navigate to the observability menu and select `Alerts` and click on `Add Alert`.
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/alerts-menu.png"
+  src="/images/v1.7/features/ingestion/workflows/profiler/alerts-menu.png"
   alt="Alerts Menu"
   caption="Alerts Menu"
  /%}
@@ -21,7 +21,7 @@ The first will be to select a source. For data quality you have 2 relevant optio
 - `Test Suite`: it will trigger an alert for any test case event linked to the test suite. This is a great way to group alerts and reducing notification fatigue
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/alert-source-selection.png"
+  src="/images/v1.7/features/ingestion/workflows/profiler/alert-source-selection.png"
   alt="Alerts Menu"
   caption="Alerts Menu"
  /%}
@@ -33,7 +33,7 @@ The first will be to select a source. For data quality you have 2 relevant optio
 You can filter alerts based on specific condition to narrow down which test suite/test case should trigger an alert. This is interesting for user to dispatch alerts to different channels/users.
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/alerts-filter.png"
+  src="/images/v1.7/features/ingestion/workflows/profiler/alerts-filter.png"
   alt="Alerts Menu"
   caption="Alerts Menu"
  /%}
@@ -42,7 +42,7 @@ You can filter alerts based on specific condition to narrow down which test suit
 Trigger section will allow you set the condition for which an alert should be triggered
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/alerts-trigger.png"
+  src="/images/v1.7/features/ingestion/workflows/profiler/alerts-trigger.png"
   alt="Alerts Menu"
   caption="Alerts Menu"
  /%}
@@ -53,7 +53,7 @@ In the destination section you will be able to select between `internal` and `ex
 - `external`: allow you to select an external destination such as a slack or teams channel  
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/alerts-destination.png"
+  src="/images/v1.7/features/ingestion/workflows/profiler/alerts-destination.png"
   alt="Alerts Menu"
   caption="Alerts Menu"
  /%}

--- a/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/data-quality-observability/observability/webhooks.md
+++ b/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/data-quality-observability/observability/webhooks.md
@@ -39,7 +39,7 @@ OpenMetadata also allows the user to customise the webhook with a wide range of 
    Event data for specific action can be achieved.
 
 {% image
-src="/images/v1.4/how-to-guides/observability/webhook.png"
+src="/images/v1.7/how-to-guides/observability/webhook.png"
 alt="Generic Webhook"
 caption="Generic Webhook"
 /%}
@@ -54,7 +54,7 @@ caption="Generic Webhook"
 
 
 {% image
-src="/images/v1.4/how-to-guides/observability/slack.png"
+src="/images/v1.7/how-to-guides/observability/slack.png"
 alt="Slack Webhook"
 caption="Slack Webhook"
 /%}
@@ -68,7 +68,7 @@ caption="Slack Webhook"
    Event data for specific action can be achieved.
 
 {% image
-src="/images/v1.4/how-to-guides/observability/msteam.png"
+src="/images/v1.7/how-to-guides/observability/msteam.png"
 alt="MS Team Webhook"
 caption="MS Team Webhook"
 /%} 
@@ -82,7 +82,7 @@ caption="MS Team Webhook"
    Event data for specific action can be achieved.
 
 {% image
-src="/images/v1.4/how-to-guides/observability/gchat.png"
+src="/images/v1.7/how-to-guides/observability/gchat.png"
 alt="Gchat Webhook"
 caption="Gchat Webhook"
 /%} 

--- a/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/data-quality-observability/profiler/external_workflow.md
+++ b/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/data-quality-observability/profiler/external_workflow.md
@@ -34,7 +34,7 @@ Note that running a single profiler workflow is only supported if you run the wo
 
 {% /note %}
 
-{% partial file="/v1.4/connectors/external-ingestion-deployment.md" /%}
+{% partial file="/v1.7/connectors/external-ingestion-deployment.md" /%}
 
 ### Requirements
 

--- a/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/data-quality-observability/profiler/metrics.md
+++ b/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/data-quality-observability/profiler/metrics.md
@@ -38,7 +38,7 @@ Returns the number of columns in the Table.
 System metrics provide information related to DML operations performed on the table. These metrics present a concise view of your data freshness. In a typical data processing flow tables are updated at a certain frequency. Table freshness will be monitored by confirming a set of operations has been performed against the table. To increase trust in your data assets, OpenMetadata will monitor the `INSERT`, `UPDATE` and `DELETE` operations performed against your table to showcase 2 metrics related to freshness (see below for more details). With this information, you are able to see when a specific operation was last perform and how many rows it affected. 
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/profiler-freshness-metrics.png"
+  src="/images/v1.7/features/ingestion/workflows/profiler/profiler-freshness-metrics.png"
   alt="table profile freshness metrics"
   caption="table profile freshness metrics"
  /%}

--- a/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/data-quality-observability/profiler/profiler-workflow.md
+++ b/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/data-quality-observability/profiler/profiler-workflow.md
@@ -19,13 +19,13 @@ After the metadata ingestion has been done correctly, we can configure and deplo
 This Pipeline will be in charge of feeding the Profiler tab of the Table Entity, as well as running any tests configured in the Entity.
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/profiler-summary-table.png"
+  src="/images/v1.7/features/ingestion/workflows/profiler/profiler-summary-table.png"
   alt="Table profile summary page"
   caption="Table profile summary page"
  /%}
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/profiler-summary-column.png"
+  src="/images/v1.7/features/ingestion/workflows/profiler/profiler-summary-column.png"
   alt="Column profile summary page"
   caption="Column profile summary page"
  /%}
@@ -34,7 +34,7 @@ This Pipeline will be in charge of feeding the Profiler tab of the Table Entity,
 From the Service Page, go to the Ingestions tab to add a new ingestion and click on Add Profiler Ingestion.
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/add-profiler-workflow.png"
+  src="/images/v1.7/features/ingestion/workflows/profiler/add-profiler-workflow.png"
   alt="Add a profiler service"
   caption="Add a profiler service"
  /%}
@@ -43,7 +43,7 @@ From the Service Page, go to the Ingestions tab to add a new ingestion and click
 Here you can enter the Profiler Ingestion details.
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/configure-profiler-workflow.png"
+  src="/images/v1.7/features/ingestion/workflows/profiler/configure-profiler-workflow.png"
   alt="Set profiler configuration"
   caption="Set profiler configuration"
  /%}
@@ -110,13 +110,13 @@ After clicking Next, you will be redirected to the Scheduling form. This will be
 Once you have created your profiler you can adjust some behavior at the table level by going to the table and clicking on the profiler tab 
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/accessing-table-profile-settings.png"
+  src="/images/v1.7/features/ingestion/workflows/profiler/accessing-table-profile-settings.png"
   alt="table profile settings"
   caption="table profile settings"
  /%}
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/table-profile-summary-view.png"
+  src="/images/v1.7/features/ingestion/workflows/profiler/table-profile-summary-view.png"
   alt="table profile settings"
   caption="table profile settings"
  /%}
@@ -168,7 +168,7 @@ Once you have picked the `Interval Type` you will need to define the configurati
 The behavior of the profiler can be configured at the platform level. Navigating to `Settings > Preferences > Profiler Configuration` you will find settings to adjust the behavior of the profiler.
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/profiler-global-configuration.png"
+  src="/images/v1.7/features/ingestion/workflows/profiler/profiler-global-configuration.png"
   alt="table profile global settings"
   caption="table profile global settings"
  /%}
@@ -177,7 +177,7 @@ The behavior of the profiler can be configured at the platform level. Navigating
 Select the data type you want to disable all metric for. Then toggle disable on. When running the profiler all metric computation will be skipped for the data type.
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/disable-metric-computation.png"
+  src="/images/v1.7/features/ingestion/workflows/profiler/disable-metric-computation.png"
   alt="table profile global settings"
   caption="table profile global settings"
  /%}
@@ -186,7 +186,7 @@ Select the data type you want to disable all metric for. Then toggle disable on.
 Select the data type you want to disable a metric for. Then in the `Metric Type` section select the metric you to compute (or unselect the ones you don't want to compute). When running the profiler the unselected metric will not be computed.
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/disable-specific-metric-computation.png"
+  src="/images/v1.7/features/ingestion/workflows/profiler/disable-specific-metric-computation.png"
   alt="table profile global settings"
   caption="table profile global settings"
  /%}

--- a/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/data-quality-observability/profiler/sample_data.md
+++ b/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/data-quality-observability/profiler/sample_data.md
@@ -33,7 +33,7 @@ You can configure the Sample Data Storage Credentials at Database Service level 
 You will provide the storage credential details in advance config section of connection details form.
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/sample-data-config-service.png"
+  src="/images/v1.7/features/ingestion/workflows/profiler/sample-data-config-service.png"
   alt="Database Service Storage Config"
   caption="Database Service Storage Config"
  /%}
@@ -44,14 +44,14 @@ You will provide the storage credential details in advance config section of con
 You can configure the Sample Data Storage Credentials at the Database level via the `Profiler Settings` option from the menu.
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/sample-data-config-database-1.png"
+  src="/images/v1.7/features/ingestion/workflows/profiler/sample-data-config-database-1.png"
   alt="Database Storage Config - 1"
   caption="Database Storage Config - 1"
  /%}
 
 
  {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/sample-data-config-database-2.png"
+  src="/images/v1.7/features/ingestion/workflows/profiler/sample-data-config-database-2.png"
   alt="Database Storage Config - 2"
   caption="Database Storage Config - 2"
  /%}
@@ -61,14 +61,14 @@ You can configure the Sample Data Storage Credentials at the Database level via 
 You can configure the Sample Data Storage Credentials at the Database Schema level via the `Profiler Settings` option from the menu.
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/sample-data-config-schema-1.png"
+  src="/images/v1.7/features/ingestion/workflows/profiler/sample-data-config-schema-1.png"
   alt="Database Schema Storage Config - 1"
   caption="Database Schema Storage Config - 1"
  /%}
 
 
  {% image
-  src="/images/v1.4/features/ingestion/workflows/profiler/sample-data-config-schema-2.png"
+  src="/images/v1.7/features/ingestion/workflows/profiler/sample-data-config-schema-2.png"
   alt="Database Schema Storage Config - 2"
   caption="Database Schema Storage Config - 2"
  /%}

--- a/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/data-quality-observability/profiler/tab.md
+++ b/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/data-quality-observability/profiler/tab.md
@@ -12,7 +12,7 @@ The Profiler & Data Quality tab is displayed only for Tables. It has three sub-t
 The table profile helps to monitor and understand the table structure. It displays the number of **rows and columns** in the table. You can view these details over a timeframe to understand how the table has been evolving. It displays the **profile sample** either as an absolute number or as a percentage of data. You also get details on the **size of the data** as well as when the table was created.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/tp.png"
+src="/images/v1.7/how-to-guides/quality/tp.png"
 alt="Table Profile"
 caption="Table Profile"
 /%}
@@ -24,7 +24,7 @@ The Table Profile tab also displays timeseries graphs on **Data Volume, Table Up
 The **Data Volume** chart gives an overview on how the data is evolving across a time period. 
 
 {% image
-src="/images/v1.4/how-to-guides/quality/dv.png"
+src="/images/v1.7/how-to-guides/quality/dv.png"
 alt="Table Profile: Data Volume"
 caption="Table Profile: Data Volume"
 /%}
@@ -33,7 +33,7 @@ caption="Table Profile: Data Volume"
 In **Table Updates** chart, users can view the changes that happened in the table in terms of data inserts, updates, and deletes.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/tu.png"
+src="/images/v1.7/how-to-guides/quality/tu.png"
 alt="Table Profile: Table Updates"
 caption="Table Profile: Table Updates"
 /%}
@@ -43,7 +43,7 @@ caption="Table Profile: Table Updates"
 In **Volume Change** chart, users can view the changes that happened in the table in terms of data volume for inserts, updates, and deletes.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/vc.png"
+src="/images/v1.7/how-to-guides/quality/vc.png"
 alt="Table Profile: Volume Change"
 caption="Table Profile: Volume Change"
 /%}
@@ -55,7 +55,7 @@ The Column Profile tab provides a summary of table metrics similar to the Table 
 The column profile helps to monitor and understand the column structure with a summary of metrics for every column. You can view the type of each column, the value count, null value %, distinct value %, unique %, the tests run as well as the test status.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/cp.png"
+src="/images/v1.7/how-to-guides/quality/cp.png"
 alt="Column Profile of a Table"
 caption="Column Profile of a Table"
 /%}
@@ -63,7 +63,7 @@ caption="Column Profile of a Table"
 By clicking on any column, you can view more detailed reports about that column.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/cp1.png"
+src="/images/v1.7/how-to-guides/quality/cp1.png"
 alt="Column Profile of a Column"
 caption="Column Profile of a Column"
 /%}
@@ -75,7 +75,7 @@ The Column Profile for a particular column also displays timeseries graphs on **
 The data counts chart provides information on the **Distinct Count, Null Count, Unique Count, and Values Count**.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/dc.png"
+src="/images/v1.7/how-to-guides/quality/dc.png"
 alt="Column Profile: Data Counts"
 caption="Column Profile: Data Counts"
 /%}
@@ -85,7 +85,7 @@ caption="Column Profile: Data Counts"
 The data proportions chart displays the **Distinct, Null, and Unique Proportions**.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/dp.png"
+src="/images/v1.7/how-to-guides/quality/dp.png"
 alt="Column Profile: Data Proportions"
 caption="Column Profile: Data Proportions"
 /%}
@@ -95,7 +95,7 @@ caption="Column Profile: Data Proportions"
 The length of the string that are stored in the database is profiled. The data range displays the Minimum, Maximum, and Mean values, which can be helpful for users who are doing an NLP or Text analysis.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/dr.png"
+src="/images/v1.7/how-to-guides/quality/dr.png"
 alt="Column Profile: Data Range"
 caption="Column Profile: Data Range"
 /%}
@@ -103,7 +103,7 @@ caption="Column Profile: Data Range"
 ### Data Aggregate
 
 {% image
-src="/images/v1.4/how-to-guides/quality/da.png"
+src="/images/v1.7/how-to-guides/quality/da.png"
 alt="Column Profile: Data Aggregate"
 caption="Column Profile: Data Aggregate"
 /%}
@@ -113,7 +113,7 @@ caption="Column Profile: Data Aggregate"
 This chart displays the First Quartile, Median, Inter Quartile Range, and the Third Quartile.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/dq.png"
+src="/images/v1.7/how-to-guides/quality/dq.png"
 alt="Column Profile: Data Quartiles"
 caption="Column Profile: Data Quartiles"
 /%}
@@ -123,7 +123,7 @@ caption="Column Profile: Data Quartiles"
 The distribution of the character length inside the column is displayed to help you get a sense of the structure of your data.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/dd.png"
+src="/images/v1.7/how-to-guides/quality/dd.png"
 alt="Column Profile: Data Distribution"
 caption="Column Profile: Data Distribution"
 /%}

--- a/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/data-quality-observability/quality/custom-tests.md
+++ b/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/data-quality-observability/quality/custom-tests.md
@@ -195,13 +195,13 @@ class ColumnEntropyToBeBetweenValidator(BaseTestValidator):
 Once you have completed A) and B) you should only need to `pip install` your package in the environment where openmetadata python SDK is install.
 
 {% image
-  src="/images/v1.4/features/ingestion/workflows/data-quality/custom-test-definition.png"
+  src="/images/v1.7/features/ingestion/workflows/data-quality/custom-test-definition.png"
   alt="Create test case"
   caption="Create test case"
  /%}
 
  {% image
-  src="/images/v1.4/features/ingestion/workflows/data-quality/custom-test-result.png"
+  src="/images/v1.7/features/ingestion/workflows/data-quality/custom-test-result.png"
   alt="Create test case"
   caption="Create test case"
  /%}

--- a/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/data-quality-observability/quality/index.md
+++ b/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/data-quality-observability/quality/index.md
@@ -16,7 +16,7 @@ OpenMetadata provides Data Quality workflows, which helps with:
 The data quality in OpenMetadata is also **extensible** to adapt to your needs. 
 
 {% image
-src="/images/v1.4/how-to-guides/quality/quality1.png"
+src="/images/v1.7/how-to-guides/quality/quality1.png"
 alt="Profiler & Data Quality"
 caption="Profiler & Data Quality"
 /%}

--- a/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/data-quality-observability/quality/tab.md
+++ b/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/data-quality-observability/quality/tab.md
@@ -10,7 +10,7 @@ The Profiler & Data Quality tab is displayed only for Tables. It has three sub-t
 Data quality tests can be run on the sample data. We can add tests at the table and column level. The Data Quality tab displays the total number of tests that were run, and also the number of tests that were successful, aborted, or failed. The list of test cases displays the details of the table or column on which the test was run.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/dq1.png"
+src="/images/v1.7/how-to-guides/quality/dq1.png"
 alt="Profiler & Data Quality"
 caption="Profiler & Data Quality"
 /%}
@@ -18,7 +18,7 @@ caption="Profiler & Data Quality"
 You can click on a Test Case to view further details. You can use a time filter on these reports. You can also edit these tests by clicking on the pencil icon next to each test.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/dq2.png"
+src="/images/v1.7/how-to-guides/quality/dq2.png"
 alt="Details of a Test Case"
 caption="Details of a Test Case"
 /%}

--- a/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/data-quality-observability/quality/test-cases-from-yaml-config.md
+++ b/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/data-quality-observability/quality/test-cases-from-yaml-config.md
@@ -3,4 +3,4 @@ title: Adding Data Quality Test Cases from yaml config
 slug: /how-to-guides/data-quality-observability/quality/test-cases-from-yaml-config
 ---
 
-{% partial file="/v1.4/connectors/yaml/data-quality.md" /%}
+{% partial file="/v1.7/connectors/yaml/data-quality.md" /%}

--- a/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/data-quality-observability/quality/test.md
+++ b/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/data-quality-observability/quality/test.md
@@ -15,7 +15,7 @@ To create a test in OpenMetadata:
 - Click on **Add Test** to select a `Table` or `Column` level test.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/test1.png"
+src="/images/v1.7/how-to-guides/quality/test1.png"
 alt="Write and Deploy No-Code Test Cases"
 caption="Write and Deploy No-Code Test Cases"
 /%}
@@ -41,7 +41,7 @@ OpenMetadata currently supports the following table level test types:
 10. Table Data to Be Fresh: Validate the freshness of a table's data.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/test4.png"
+src="/images/v1.7/how-to-guides/quality/test4.png"
 alt="Configure a Table Level Test"
 caption="Configure a Table Level Test"
 /%}
@@ -73,7 +73,7 @@ OpenMetadata currently supports the following column level test types:
 15. Column Values to Not Match Regex: Define the regular expression that the column entries should not match.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/test2.png"
+src="/images/v1.7/how-to-guides/quality/test2.png"
 alt="Configure a Column Level Test"
 caption="Configure a Column Level Test"
 /%}
@@ -81,7 +81,7 @@ caption="Configure a Column Level Test"
 Once the test has been created, you can view the test suite. The test case will be displayed in the Data Quality tab. You can also edit the Display Name and Description for the test.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/test3.png"
+src="/images/v1.7/how-to-guides/quality/test3.png"
 alt="Column Level Test Created"
 caption="Column Level Test Created"
 /%}
@@ -91,7 +91,7 @@ A pipeline can be set up for the tests to run at a regular cadence.
 - Add a pipeline
 
 {% image
-src="/images/v1.4/how-to-guides/quality/test5.png"
+src="/images/v1.7/how-to-guides/quality/test5.png"
 alt="Set up a Pipeline"
 caption="Set up a Pipeline"
 /%}
@@ -100,7 +100,7 @@ caption="Set up a Pipeline"
 - Click on **Submit**.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/test6.png"
+src="/images/v1.7/how-to-guides/quality/test6.png"
 alt="Schedule the Pipeline"
 caption="Schedule the Pipeline"
 /%}
@@ -108,7 +108,7 @@ caption="Schedule the Pipeline"
 The pipeline has been set up and will run at the scheduled time.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/test7.png"
+src="/images/v1.7/how-to-guides/quality/test7.png"
 alt="Pipeline Scheduled"
 caption="Pipeline Scheduled"
 /%}
@@ -116,7 +116,7 @@ caption="Pipeline Scheduled"
 The tests will be run and the results will be updated in the Data Quality tab.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/test8.png"
+src="/images/v1.7/how-to-guides/quality/test8.png"
 alt="Data Quality Tests"
 caption="Data Quality Tests"
 /%}
@@ -124,14 +124,14 @@ caption="Data Quality Tests"
 If a **test fails**, you can **Edit the Test Status** to New, Acknowledged, or Resolved status by clicking on the Status icon.
 
 {% image
-src="/images/v1.4/how-to-guides/quality/test9.png"
+src="/images/v1.7/how-to-guides/quality/test9.png"
 alt="Failed Test: Edit Status"
 caption="Failed Test: Edit Status"
 /%}
 
 - Select the Test Status
 {% image
-src="/images/v1.4/how-to-guides/quality/test10.png"
+src="/images/v1.7/how-to-guides/quality/test10.png"
 alt="Edit Test Status"
 caption="Edit Test Status"
 /%}
@@ -139,7 +139,7 @@ caption="Edit Test Status"
 - If you are marking the test status as **Resolved**, you must specify the **Reason** for the failure and add a **Comment**. The reasons for failure can be Duplicates, False Positive, Missing Data, Other, or Out of Bounds.
 - Click on **Submit**.
 {% image
-src="/images/v1.4/how-to-guides/quality/test11.png"
+src="/images/v1.7/how-to-guides/quality/test11.png"
 alt="Resolved Status: Reason"
 caption="Resolved Status: Reason"
 /%}


### PR DESCRIPTION
I worked on fixing the image references from 1.4 version

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
