### PR TITLE
Fixes 19073 : Resolve NullPointerException in MS Teams DQ template handling

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/formatter/decorators/MSTeamsMessageDecorator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/formatter/decorators/MSTeamsMessageDecorator.java
@@ -175,9 +175,8 @@ public class MSTeamsMessageDecorator implements MessageDecorator<TeamsMessage> {
 
   private TeamsMessage createDQMessage(
       String publisherName, ChangeEvent event, OutgoingMessage outgoingMessage) {
-
     Map<DQ_Template_Section, Map<Enum<?>, Object>> dqTemplateData =
-        buildDQTemplateData(publisherName, event, outgoingMessage);
+        MessageDecorator.buildDQTemplateData(event, outgoingMessage);
 
     TextBlock changeEventDetailsTextBlock = createHeader();
 
@@ -565,33 +564,6 @@ public class MSTeamsMessageDecorator implements MessageDecorator<TeamsMessage> {
             General_Template_Section.EVENT_DETAILS,
             EventDetailsKeys.OUTGOING_MESSAGE,
             outgoingMessage);
-
-    return builder.build();
-  }
-
-  // todo - complete buildDQTemplateData fn
-  private Map<DQ_Template_Section, Map<Enum<?>, Object>> buildDQTemplateData(
-      String publisherName, ChangeEvent event, OutgoingMessage outgoingMessage) {
-
-    TemplateDataBuilder<DQ_Template_Section> builder = new TemplateDataBuilder<>();
-
-    // Use DQ_Template_Section directly
-    builder
-        .add(
-            DQ_Template_Section.EVENT_DETAILS,
-            EventDetailsKeys.EVENT_TYPE,
-            event.getEventType().value())
-        .add(DQ_Template_Section.EVENT_DETAILS, EventDetailsKeys.UPDATED_BY, event.getUserName())
-        .add(DQ_Template_Section.EVENT_DETAILS, EventDetailsKeys.ENTITY_TYPE, event.getEntityType())
-        .add(
-            DQ_Template_Section.EVENT_DETAILS,
-            EventDetailsKeys.ENTITY_FQN,
-            MessageDecorator.getFQNForChangeEventEntity(event))
-        .add(
-            DQ_Template_Section.EVENT_DETAILS,
-            EventDetailsKeys.TIME,
-            new Date(event.getTimestamp()).toString())
-        .add(DQ_Template_Section.EVENT_DETAILS, EventDetailsKeys.OUTGOING_MESSAGE, outgoingMessage);
 
     return builder.build();
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/formatter/decorators/MSTeamsMessageDecorator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/formatter/decorators/MSTeamsMessageDecorator.java
@@ -42,6 +42,7 @@ import org.openmetadata.service.apps.bundles.changeEvent.msteams.TeamsMessage.Te
 import org.openmetadata.service.exception.UnhandledServerException;
 
 public class MSTeamsMessageDecorator implements MessageDecorator<TeamsMessage> {
+  private static final String TEST_CASE_RESULT = "testCaseResult";
 
   @Override
   public String getBold() {
@@ -123,13 +124,12 @@ public class MSTeamsMessageDecorator implements MessageDecorator<TeamsMessage> {
 
   private TeamsMessage createTestCaseMessage(
       String publisherName, ChangeEvent event, OutgoingMessage outgoingMessage) {
-    final String testCaseResult = "testCaseResult";
     List<FieldChange> fieldsAdded = event.getChangeDescription().getFieldsAdded();
     List<FieldChange> fieldsUpdated = event.getChangeDescription().getFieldsUpdated();
 
     boolean hasRelevantChange =
-        fieldsAdded.stream().anyMatch(field -> testCaseResult.equals(field.getName()))
-            || fieldsUpdated.stream().anyMatch(field -> testCaseResult.equals(field.getName()));
+        fieldsAdded.stream().anyMatch(field -> TEST_CASE_RESULT.equals(field.getName()))
+            || fieldsUpdated.stream().anyMatch(field -> TEST_CASE_RESULT.equals(field.getName()));
 
     return hasRelevantChange
         ? createDQMessage(event, outgoingMessage)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

 1. Use buildDQTemplateData from MessageDecorator in MSTeamsMessageDecorator.

> **Issue:**
> Reason: Failed to publish event of destination type MsTeams due to Cannot invoke "java.util.Map.getOrDefault(Object, Object)" because "testCaseDetails" is null

Fixes: #19073
<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
