### PR TITLE
Docs: ApiMetadata ingestion source-config

### DIFF
--- a/openmetadata-docs/content/partials/v1.6/connectors/yaml/api/source-config-def.md
+++ b/openmetadata-docs/content/partials/v1.6/connectors/yaml/api/source-config-def.md
@@ -1,0 +1,13 @@
+#### Source Configuration - Source Config
+
+{% codeInfo srNumber=100 %}
+
+The `sourceConfig` is defined [here](https://github.com/open-metadata/OpenMetadata/blob/main/openmetadata-spec/src/main/resources/json/schema/metadataIngestion/apiServiceMetadataPipeline.json):
+
+**markDeletedApiCollections**: To flag API collections as soft-deleted if they are not present anymore in the source system.
+
+**overrideMetadata**: Set the Override Metadata toggle to control whether to override the metadata if it already exists.
+
+**apiCollectionFilterPattern**: Note that the filter supports regex as include or exclude.
+
+{% /codeInfo %}

--- a/openmetadata-docs/content/partials/v1.6/connectors/yaml/api/source-config.md
+++ b/openmetadata-docs/content/partials/v1.6/connectors/yaml/api/source-config.md
@@ -1,0 +1,14 @@
+```yaml {% srNumber=100 %}
+  sourceConfig:
+    config:
+      type: ApiMetadata
+      markDeletedApiCollections: true
+      overrideMetadata: false
+      # apiCollectionFilterPattern:
+      #   includes:
+      #     - apiCollection1
+      #     - apiCollection2
+      #   excludes:
+      #     - apiCollection3
+      #     - apiCollection4
+```

--- a/openmetadata-docs/content/v1.6.x/connectors/api/rest/yaml.md
+++ b/openmetadata-docs/content/v1.6.x/connectors/api/rest/yaml.md
@@ -46,7 +46,7 @@ This is a sample config for OpenAPI:
 
 {% codeInfo srNumber=1 %}
 
-**OpenAPI Schema URL**: 
+**OpenAPI Schema URL**:
 An OpenAPI schema URL typically refers to the URL where the OpenAPI Specification (OAS) document of a web service is hosted. The document defines the service's API, including available endpoints, request/response formats, authentication methods, etc. It is usually in JSON format. for e.g. `https://petstore3.swagger.io/api/v3/openapi.json`
 
 **Token**: An authentication token to connect to an OpenAPI schema URL. It is only required if the API schema is protected or secured.
@@ -63,7 +63,7 @@ source:
   serviceName: openapi_rest
   serviceConnection:
     config:
-      type: REST
+      type: ApiMetadata
 ```
 ```yaml {% srNumber=1 %}
       openAPISchemaURL: https://docs.open-metadata.org/swagger.json
@@ -71,7 +71,7 @@ source:
 ```
 
 
-{% partial file="/v1.6/connectors/yaml/database/source-config.md" /%}
+{% partial file="/v1.6/connectors/yaml/api/source-config.md" /%}
 
 {% partial file="/v1.6/connectors/yaml/ingestion-sink.md" /%}
 

--- a/openmetadata-docs/content/v1.7.x-SNAPSHOT/connectors/api/rest/yaml.md
+++ b/openmetadata-docs/content/v1.7.x-SNAPSHOT/connectors/api/rest/yaml.md
@@ -46,7 +46,7 @@ This is a sample config for OpenAPI:
 
 {% codeInfo srNumber=1 %}
 
-**OpenAPI Schema URL**: 
+**OpenAPI Schema URL**:
 An OpenAPI schema URL typically refers to the URL where the OpenAPI Specification (OAS) document of a web service is hosted. The document defines the service's API, including available endpoints, request/response formats, authentication methods, etc. It is usually in JSON format. for e.g. `https://petstore3.swagger.io/api/v3/openapi.json`
 
 **Token**: An authentication token to connect to an OpenAPI schema URL. It is only required if the API schema is protected or secured.
@@ -63,7 +63,7 @@ source:
   serviceName: openapi_rest
   serviceConnection:
     config:
-      type: REST
+      type: ApiMetadata
 ```
 ```yaml {% srNumber=1 %}
       openAPISchemaURL: https://docs.open-metadata.org/swagger.json
@@ -71,7 +71,7 @@ source:
 ```
 
 
-{% partial file="/v1.7/connectors/yaml/database/source-config.md" /%}
+{% partial file="/v1.7/connectors/yaml/api/source-config.md" /%}
 
 {% partial file="/v1.7/connectors/yaml/ingestion-sink.md" /%}
 


### PR DESCRIPTION
### Describe your changes:

Trivial change of documentation about ApiMetadata ingestion to reflect the [expected schema](https://github.com/open-metadata/OpenMetadata/blob/main/openmetadata-spec/src/main/resources/json/schema/metadataIngestion/apiServiceMetadataPipeline.json).

The current documentation references the wrong `source-config` section.

#
### Type of change:

- [x] Documentation

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
