### PR TITLE
FIX: Add docStore endpoints to Ometa API routes

### DIFF
--- a/ingestion/src/metadata/ingestion/ometa/routes.py
+++ b/ingestion/src/metadata/ingestion/ometa/routes.py
@@ -54,6 +54,7 @@ from metadata.generated.schema.api.data.createStoredProcedure import (
 )
 from metadata.generated.schema.api.data.createTable import CreateTableRequest
 from metadata.generated.schema.api.data.createTopic import CreateTopicRequest
+from metadata.generated.schema.api.docStore.createDocument import CreateDocumentRequest
 from metadata.generated.schema.api.domains.createDataProduct import (
     CreateDataProductRequest,
 )
@@ -136,6 +137,7 @@ from metadata.generated.schema.entity.data.searchIndex import SearchIndex
 from metadata.generated.schema.entity.data.storedProcedure import StoredProcedure
 from metadata.generated.schema.entity.data.table import Table
 from metadata.generated.schema.entity.data.topic import Topic
+from metadata.generated.schema.entity.docStore.document import Document
 from metadata.generated.schema.entity.domains.dataProduct import DataProduct
 from metadata.generated.schema.entity.domains.domain import Domain
 from metadata.generated.schema.entity.feed.suggestion import Suggestion
@@ -198,6 +200,8 @@ ROUTES = {
     CreateAPIEndpointRequest.__name__: "/apiEndpoints",
     APICollection.__name__: "/apiCollections",
     CreateAPICollectionRequest.__name__: "/apiCollections",
+    Document.__name__: "/docStore",
+    CreateDocumentRequest.__name__: "/docStore",
     # Classifications
     Tag.__name__: "/tags",
     CreateTagRequest.__name__: "/tags",

--- a/openmetadata-spec/src/main/resources/json/schema/api/docStore/createDocument.json
+++ b/openmetadata-spec/src/main/resources/json/schema/api/docStore/createDocument.json
@@ -1,7 +1,7 @@
 {
   "$id": "https://open-metadata.org/schema/entity/docStore/document.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Document",
+  "title": "CreateDocumentRequest",
   "description": "This schema defines Document. A Generic entity to capture any kind of Json Payload.",
   "type": "object",
   "javaType": "org.openmetadata.schema.entities.docStore.CreateDocument",


### PR DESCRIPTION
Add missing `/docStore` endpoints to OMeta API client routes.

The title of the create document request schema needed to be changed to `CreateDocumentRequest` to match the existing pattern so that the generated pydantic model is appropriately named for the entity/route lookup.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.