### PR TITLE
MINOR: Add Governance Bot to the workflow automated tasks

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/nodes/automatedTask/impl/SetEntityCertificationImpl.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/nodes/automatedTask/impl/SetEntityCertificationImpl.java
@@ -40,7 +40,7 @@ public class SetEntityCertificationImpl implements JavaDelegate {
               .orElse(null);
       String user =
           Optional.ofNullable((String) execution.getVariable(RESOLVED_BY_VARIABLE))
-              .orElse(entity.getUpdatedBy());
+              .orElse("governance-bot");
 
       setStatus(entity, entityType, user, certification);
     } catch (Exception exc) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/nodes/automatedTask/impl/SetGlossaryTermStatusImpl.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/nodes/automatedTask/impl/SetGlossaryTermStatusImpl.java
@@ -35,7 +35,7 @@ public class SetGlossaryTermStatusImpl implements JavaDelegate {
       String status = (String) statusExpr.getValue(execution);
       String user =
           Optional.ofNullable((String) execution.getVariable(RESOLVED_BY_VARIABLE))
-              .orElse(glossaryTerm.getUpdatedBy());
+              .orElse("governance-bot");
 
       setStatus(glossaryTerm, user, status);
     } catch (Exception exc) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/FeedRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/FeedRepository.java
@@ -972,7 +972,8 @@ public class FeedRepository {
       String createdByUserName = thread.getCreatedBy();
       User createdByUser =
           Entity.getEntityByName(USER, createdByUserName, TEAMS_FIELD, NON_DELETED);
-      if (Boolean.TRUE.equals(createdByUser.getIsBot())) {
+      if (Boolean.TRUE.equals(createdByUser.getIsBot())
+          && !createdByUser.getName().equals("governance-bot")) {
         throw new IllegalArgumentException("Task cannot be created by bot only by user or teams");
       }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/glossary/GlossaryTermResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/glossary/GlossaryTermResourceTest.java
@@ -68,6 +68,8 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.openmetadata.schema.api.data.CreateGlossary;
 import org.openmetadata.schema.api.data.CreateGlossaryTerm;
 import org.openmetadata.schema.api.data.CreateTable;
@@ -88,6 +90,7 @@ import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.schema.type.TaskDetails;
 import org.openmetadata.schema.type.TaskStatus;
 import org.openmetadata.service.Entity;
+import org.openmetadata.service.governance.workflows.WorkflowHandler;
 import org.openmetadata.service.resources.EntityResourceTest;
 import org.openmetadata.service.resources.databases.TableResourceTest;
 import org.openmetadata.service.resources.feeds.FeedResource.ThreadList;
@@ -264,7 +267,11 @@ public class GlossaryTermResourceTest extends EntityResourceTest<GlossaryTerm, C
   }
 
   @Test
+  @Execution(ExecutionMode.SAME_THREAD)
   void patch_addDeleteReviewers(TestInfo test) throws IOException {
+    // Note: We are disabling the GlossaryTermApprovalWorkflow to avoid the Workflow Kicking it and
+    // adding extra ChangeDescriptions.
+    WorkflowHandler.getInstance().suspendWorkflow("GlossaryTermApprovalWorkflow");
     CreateGlossaryTerm create =
         createRequest(getEntityName(test), "desc", "", null).withReviewers(null).withSynonyms(null);
     GlossaryTerm term = createEntity(create, ADMIN_AUTH_HEADERS);
@@ -281,14 +288,11 @@ public class GlossaryTermResourceTest extends EntityResourceTest<GlossaryTerm, C
     term.withReviewers(List.of(USER1_REF))
         .withSynonyms(List.of("synonym1"))
         .withReferences(List.of(reference1));
-    patchEntity(term.getId(), origJson, term, ADMIN_AUTH_HEADERS);
-    waitForTaskToBeCreated(term.getFullyQualifiedName());
 
     ChangeDescription change = getChangeDescription(term, MINOR_UPDATE);
     fieldAdded(change, "reviewers", List.of(USER1_REF));
     fieldAdded(change, "synonyms", List.of("synonym1"));
     fieldAdded(change, "references", List.of(reference1));
-    fieldUpdated(change, "status", Status.APPROVED, Status.IN_REVIEW);
     term = patchEntityAndCheck(term, origJson, ADMIN_AUTH_HEADERS, MINOR_UPDATE, change);
 
     // Add reviewer USER2, synonym2, reference2 in PATCH request
@@ -303,7 +307,6 @@ public class GlossaryTermResourceTest extends EntityResourceTest<GlossaryTerm, C
     fieldAdded(change, "reviewers", List.of(USER1_REF, USER2_REF));
     fieldAdded(change, "synonyms", List.of("synonym1", "synonym2"));
     fieldAdded(change, "references", List.of(reference1, reference2));
-    fieldUpdated(change, "status", Status.APPROVED, Status.IN_REVIEW);
     term = patchEntityAndCheck(term, origJson, ADMIN_AUTH_HEADERS, CHANGE_CONSOLIDATED, change);
 
     // Remove a reviewer USER1, synonym1, reference1 in PATCH request
@@ -316,8 +319,10 @@ public class GlossaryTermResourceTest extends EntityResourceTest<GlossaryTerm, C
     fieldAdded(change, "reviewers", List.of(USER2_REF));
     fieldAdded(change, "synonyms", List.of("synonym2"));
     fieldAdded(change, "references", List.of(reference2));
-    fieldUpdated(change, "status", Status.APPROVED, Status.IN_REVIEW);
     patchEntityAndCheck(term, origJson, ADMIN_AUTH_HEADERS, CHANGE_CONSOLIDATED, change);
+
+    // Note: We are re-enabling the GlossaryTermApprovalWorkflow.
+    WorkflowHandler.getInstance().resumeWorkflow("GlossaryTermApprovalWorkflow");
   }
 
   @Test
@@ -485,12 +490,19 @@ public class GlossaryTermResourceTest extends EntityResourceTest<GlossaryTerm, C
     String origJson = JsonUtils.pojoToJson(g2t5);
 
     // Add reviewer DATA_CONSUMER  in PATCH request
-    g2t5.withReviewers(List.of(DATA_CONSUMER_REF, USER1_REF, USER2_REF));
+    List<EntityReference> newReviewers = List.of(DATA_CONSUMER_REF, USER1_REF, USER2_REF);
+    g2t5.withReviewers(newReviewers);
 
-    ChangeDescription change = getChangeDescription(g2t5, MINOR_UPDATE);
-    fieldAdded(change, "reviewers", List.of(DATA_CONSUMER_REF));
-    fieldUpdated(change, "status", Status.DRAFT.value(), Status.IN_REVIEW.value());
-    g2t5 = patchEntityUsingFqnAndCheck(g2t5, origJson, ADMIN_AUTH_HEADERS, MINOR_UPDATE, change);
+    double previousVersion = g2t5.getVersion();
+    g2t5 = patchEntityUsingFqn(g2t5.getFullyQualifiedName(), origJson, g2t5, ADMIN_AUTH_HEADERS);
+
+    // Due to the Glossary Workflow changing the Status from 'DRAFT' to 'IN_REVIEW' as a
+    // GovernanceBot, two changes are created.
+    assertEquals(g2t5.getVersion(), previousVersion + 0.2, 0.0001);
+    assertTrue(
+        g2t5.getReviewers().containsAll(newReviewers)
+            && newReviewers.containsAll(g2t5.getReviewers()));
+    assertEquals(g2t5.getStatus(), Status.IN_REVIEW);
 
     Thread approvalTask1 =
         assertApprovalTask(g2t5, TaskStatus.Open); // A Request Approval task is opened

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/TestUtils.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/TestUtils.java
@@ -105,6 +105,9 @@ public final class TestUtils {
   public static String LONG_ENTITY_NAME = "a".repeat(256 + 1);
   public static final Map<String, String> ADMIN_AUTH_HEADERS =
       authHeaders(ADMIN_USER_NAME + "@open-metadata.org");
+  public static final String GOVERNANCE_BOT = "governance-bot";
+  public static final Map<String, String> GOVERNANCE_BOT_AUTH_HEADERS =
+      authHeaders(GOVERNANCE_BOT + "@open-metadata.org");
   public static final String INGESTION_BOT = "ingestion-bot";
   public static final Map<String, String> INGESTION_BOT_AUTH_HEADERS =
       authHeaders(INGESTION_BOT + "@open-metadata.org");


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

Currently the automated tasks are picking up the user that has last updated the entity and using it for the `updatedBy` value.
This PR aims to change that by introducing the GovernanceBot that will be used when no manual tasks are in place before an automated action takes place. 

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
