### PR TITLE
Minor: Add missing asset specific filter options for automator filters

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/PipelineActions/PipelineActions.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/PipelineActions/PipelineActions.interface.ts
@@ -24,7 +24,7 @@ export interface PipelineActionsProps {
   serviceName?: string;
   deployIngestion?: (id: string, displayName: string) => Promise<void>;
   triggerIngestion?: (id: string, displayName: string) => Promise<void>;
-  handleDeleteSelection: (row: SelectedRowDetails) => void;
+  handleDeleteSelection?: (row: SelectedRowDetails) => void;
   handleEditClick?: (fqn: string) => void;
   handleEnableDisableIngestion?: (id: string) => Promise<void>;
   handleIsConfirmationModalOpen: (value: boolean) => void;

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/PipelineActions/PipelineActionsDropdown.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/PipelineActions/PipelineActionsDropdown.interface.ts
@@ -24,7 +24,7 @@ export interface PipelineActionsDropdownProps {
   deployIngestion?: (id: string, displayName: string) => Promise<void>;
   handleEditClick: ((fqn: string) => void) | undefined;
   ingestionPipelinePermissions?: IngestionServicePermission;
-  handleDeleteSelection: (row: SelectedRowDetails) => void;
+  handleDeleteSelection?: (row: SelectedRowDetails) => void;
   handleIsConfirmationModalOpen: (value: boolean) => void;
   onIngestionWorkflowsUpdate?: () => void;
   moreActionButtonProps?: ButtonProps;

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/PipelineActions/PipelineActionsDropdown.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/PipelineActions/PipelineActionsDropdown.tsx
@@ -136,7 +136,7 @@ function PipelineActionsDropdown({
 
   const handleConfirmDelete = useCallback(
     (id: string, name: string, displayName?: string) => {
-      handleDeleteSelection({
+      handleDeleteSelection?.({
         id,
         name,
         displayName,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.test.ts
@@ -148,7 +148,10 @@ describe('getEntitySpecificQueryBuilderFields', () => {
       SearchIndex.GLOSSARY_TERM,
     ]);
 
-    expect(Object.keys(result)).toEqual([EntityFields.GLOSSARY_TERM_STATUS]);
+    expect(Object.keys(result)).toEqual([
+      EntityFields.GLOSSARY_TERM_STATUS,
+      EntityFields.GLOSSARY,
+    ]);
   });
 
   it('should return databaseSchema specific fields', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchClassBase.ts
@@ -337,7 +337,7 @@ class AdvancedSearchClassBase {
   /**
    * Fields specific to Glossary
    */
-  glossaryQueryBuilderFields: Fields = {
+  glossaryTermQueryBuilderFields: Fields = {
     [EntityFields.GLOSSARY_TERM_STATUS]: {
       label: t('label.status'),
       type: 'select',
@@ -346,6 +346,18 @@ class AdvancedSearchClassBase {
         asyncFetch: this.autocomplete({
           searchIndex: SearchIndex.GLOSSARY_TERM,
           entityField: EntityFields.GLOSSARY_TERM_STATUS,
+        }),
+        useAsyncSearch: true,
+      },
+    },
+    [EntityFields.GLOSSARY]: {
+      label: t('label.glossary'),
+      type: 'select',
+      mainWidgetProps: this.mainWidgetProps,
+      fieldSettings: {
+        asyncFetch: this.autocomplete({
+          searchIndex: SearchIndex.GLOSSARY_TERM,
+          entityField: EntityFields.GLOSSARY,
         }),
         useAsyncSearch: true,
       },
@@ -742,7 +754,7 @@ class AdvancedSearchClassBase {
       [SearchIndex.SEARCH_INDEX]: this.searchIndexQueryBuilderFields,
       [SearchIndex.DASHBOARD_DATA_MODEL]: this.dataModelQueryBuilderFields,
       [SearchIndex.API_ENDPOINT_INDEX]: this.apiEndpointQueryBuilderFields,
-      [SearchIndex.GLOSSARY_TERM]: this.glossaryQueryBuilderFields,
+      [SearchIndex.GLOSSARY_TERM]: this.glossaryTermQueryBuilderFields,
       [SearchIndex.DATABASE_SCHEMA]: this.databaseSchemaQueryBuilderFields,
       [SearchIndex.STORED_PROCEDURE]: this.storedProcedureQueryBuilderFields,
       [SearchIndex.ALL]: {
@@ -766,7 +778,7 @@ class AdvancedSearchClassBase {
         ...this.searchIndexQueryBuilderFields,
         ...this.dataModelQueryBuilderFields,
         ...this.apiEndpointQueryBuilderFields,
-        ...this.glossaryQueryBuilderFields,
+        ...this.glossaryTermQueryBuilderFields,
       },
     };
 
@@ -866,6 +878,8 @@ class AdvancedSearchClassBase {
       SearchIndex.API_SERVICE_INDEX,
       SearchIndex.API_ENDPOINT_INDEX,
       SearchIndex.API_COLLECTION_INDEX,
+      SearchIndex.DASHBOARD_DATA_MODEL,
+      SearchIndex.STORED_PROCEDURE,
     ];
 
     const shouldAddServiceField =

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityUtils.tsx
@@ -2352,6 +2352,9 @@ export const getEntityNameLabel = (entityName?: string) => {
     query: t('label.query'),
     THREAD: t('label.thread'),
     app: t('label.application'),
+    apiCollection: t('label.api-collection'),
+    apiEndpoint: t('label.api-endpoint'),
+    metric: t('label.metric'),
   };
 
   return (


### PR DESCRIPTION
I worked on adding the missing asset-specific filter options for Automator filters

**The tests will be covered in the https://github.com/open-metadata/openmetadata-collate/pull/1069**
#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
