### PR TITLE
Add Match Any Certification to Policies

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/security/RBACConditionEvaluator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/security/RBACConditionEvaluator.java
@@ -200,6 +200,10 @@ public class RBACConditionEvaluator {
     String methodName = methodRef.getName();
 
     switch (methodName) {
+      case "matchAnyCertification" -> {
+        List<String> certificationLabels = extractMethodArguments(methodRef);
+        matchAnyCertification(certificationLabels, collector);
+      }
       case "matchAnyTag" -> {
         List<String> tags = extractMethodArguments(methodRef);
         matchAnyTag(tags, collector);
@@ -257,6 +261,22 @@ public class RBACConditionEvaluator {
       OMQueryBuilder tagQuery = queryBuilderFactory.termQuery("tags.tagFQN", tag);
       collector.addMust(tagQuery);
     }
+  }
+
+  public void matchAnyCertification(
+      List<String> certificationLabels, ConditionCollector collector) {
+    List<OMQueryBuilder> certificationQueries = new ArrayList<>();
+    for (String certificationLabel : certificationLabels) {
+      certificationQueries.add(
+          queryBuilderFactory.termQuery("certification.tagLabel.tagFQN", certificationLabel));
+    }
+    OMQueryBuilder certificationQueriesCombined;
+    if (certificationQueries.size() == 1) {
+      certificationQueriesCombined = certificationQueries.get(0);
+    } else {
+      certificationQueriesCombined = queryBuilderFactory.boolQuery().should(certificationQueries);
+    }
+    collector.addMust(certificationQueriesCombined);
   }
 
   public void isOwner(User user, ConditionCollector collector) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/RuleEvaluator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/RuleEvaluator.java
@@ -5,8 +5,10 @@ import static org.openmetadata.schema.type.Include.NON_DELETED;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.Function;
+import org.openmetadata.schema.type.AssetCertification;
 import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.security.policyevaluator.SubjectContext.PolicyContext;
@@ -156,6 +158,43 @@ public class RuleEvaluator {
       }
     }
     return false;
+  }
+
+  @Function(
+      name = "matchAnyCertification",
+      input = "List of comma separated Certification fully qualified names",
+      description =
+          "Returns true if the entity being accessed has any of the Certification given as input",
+      examples = {"matchAnyCertification('Certification.Silver', 'Certification.Gold')"})
+  @SuppressWarnings("unused") // Used in SpelExpressions
+  public boolean matchAnyCertification(String... tagFQNs) {
+    if (expressionValidation) {
+      for (String tagFqn : tagFQNs) {
+        Entity.getEntityReferenceByName(Entity.TAG, tagFqn, NON_DELETED); // Validate tag exists
+      }
+      return false;
+    }
+    if (resourceContext == null) {
+      return false;
+    }
+
+    Optional<AssetCertification> oCertification =
+        Optional.ofNullable(resourceContext.getEntity().getCertification());
+
+    if (oCertification.isEmpty()) {
+      LOG.debug(
+          "matchAnyCertification {} resourceCertification is null.", Arrays.toString(tagFQNs));
+      return false;
+    } else {
+      AssetCertification certification = oCertification.get();
+
+      LOG.debug(
+          "matchAnyCertification {} resourceCertification {}",
+          Arrays.toString(tagFQNs),
+          certification.getTagLabel().getTagFQN());
+      return Arrays.stream(tagFQNs)
+          .anyMatch(tagFQN -> tagFQN.equals(certification.getTagLabel().getTagFQN()));
+    }
   }
 
   @Function(

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/RuleEvaluatorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/RuleEvaluatorTest.java
@@ -25,6 +25,7 @@ import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.schema.entity.teams.Role;
 import org.openmetadata.schema.entity.teams.Team;
 import org.openmetadata.schema.entity.teams.User;
+import org.openmetadata.schema.type.AssetCertification;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.TagLabel;
@@ -185,6 +186,36 @@ class RuleEvaluatorTest {
     // Tag `tag4` is not present
     assertFalse(evaluateExpression("matchAnyTag('tag4')"));
     assertTrue(evaluateExpression("!matchAnyTag('tag4')"));
+  }
+
+  @Test
+  void test_matchAnyCertification() {
+    // Certification is not Present
+    assertFalse(evaluateExpression("!matchAnyCertification('Certification.Gold')"));
+    assertFalse(
+        evaluateExpression("!matchAnyCertification('Certification.Gold', 'Certification.Silver')"));
+    assertFalse(evaluateExpression("matchAnyCertification('Certification.Bronze')"));
+
+    table.withCertification(
+        new AssetCertification().withTagLabel(new TagLabel().withTagFQN("Certification.Gold")));
+
+    // Certification is present
+    assertTrue(
+        evaluateExpression("matchAnyCertification('Certification.Gold', 'Certification.Silver')"));
+    assertFalse(
+        evaluateExpression("!matchAnyCertification('Certification.Gold', 'Certification.Silver')"));
+    assertTrue(evaluateExpression("matchAnyCertification('Certification.Gold')"));
+    assertFalse(evaluateExpression("!matchAnyCertification('Certification.Gold')"));
+
+    // Certification is different
+    assertFalse(
+        evaluateExpression(
+            "matchAnyCertification('Certification.Bronze', 'Certification.Silver')"));
+    assertTrue(
+        evaluateExpression(
+            "!matchAnyCertification('Certification.Bronze', 'Certification.Silver')"));
+    assertFalse(evaluateExpression("matchAnyCertification('Certification.Bronze')"));
+    assertTrue(evaluateExpression("!matchAnyCertification('Certification.Bronze')"));
   }
 
   @Test


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Adding the possibility to define Policies based on the EntityCertification

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
