### PR TITLE
Resolved <NoneType object has no attribute rsplit> issue

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/db2/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/database/db2/service_spec.py
@@ -1,3 +1,4 @@
+from metadata.ingestion.source.database.db2.lineage import Db2LineageSource
 from metadata.ingestion.source.database.db2.metadata import Db2Source
 from metadata.profiler.interface.sqlalchemy.db2.profiler_interface import (
     DB2ProfilerInterface,
@@ -5,5 +6,7 @@ from metadata.profiler.interface.sqlalchemy.db2.profiler_interface import (
 from metadata.utils.service_spec.default import DefaultDatabaseSpec
 
 ServiceSpec = DefaultDatabaseSpec(
-    metadata_source_class=Db2Source, profiler_class=DB2ProfilerInterface
+    metadata_source_class=Db2Source,
+    profiler_class=DB2ProfilerInterface,
+    lineage_source_class=Db2LineageSource,
 )

--- a/ingestion/src/metadata/ingestion/source/database/druid/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/database/druid/service_spec.py
@@ -1,4 +1,8 @@
+from metadata.ingestion.source.database.druid.lineage import DruidLineageSource
 from metadata.ingestion.source.database.druid.metadata import DruidSource
 from metadata.utils.service_spec.default import DefaultDatabaseSpec
 
-ServiceSpec = DefaultDatabaseSpec(metadata_source_class=DruidSource)
+ServiceSpec = DefaultDatabaseSpec(
+    metadata_source_class=DruidSource,
+    lineage_source_class=DruidLineageSource,
+)

--- a/ingestion/src/metadata/ingestion/source/database/greenplum/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/database/greenplum/service_spec.py
@@ -1,4 +1,8 @@
+from metadata.ingestion.source.database.greenplum.lineage import GreenplumLineageSource
 from metadata.ingestion.source.database.greenplum.metadata import GreenplumSource
 from metadata.utils.service_spec.default import DefaultDatabaseSpec
 
-ServiceSpec = DefaultDatabaseSpec(metadata_source_class=GreenplumSource)
+ServiceSpec = DefaultDatabaseSpec(
+    metadata_source_class=GreenplumSource,
+    lineage_source_class=GreenplumLineageSource,
+)

--- a/ingestion/src/metadata/ingestion/source/database/hive/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/service_spec.py
@@ -1,4 +1,8 @@
+from metadata.ingestion.source.database.hive.lineage import HiveLineageSource
 from metadata.ingestion.source.database.hive.metadata import HiveSource
 from metadata.utils.service_spec.default import DefaultDatabaseSpec
 
-ServiceSpec = DefaultDatabaseSpec(metadata_source_class=HiveSource)
+ServiceSpec = DefaultDatabaseSpec(
+    metadata_source_class=HiveSource,
+    lineage_source_class=HiveLineageSource,
+)

--- a/ingestion/src/metadata/ingestion/source/database/impala/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/database/impala/service_spec.py
@@ -1,4 +1,8 @@
+from metadata.ingestion.source.database.impala.lineage import ImpalaLineageSource
 from metadata.ingestion.source.database.impala.metadata import ImpalaSource
 from metadata.utils.service_spec.default import DefaultDatabaseSpec
 
-ServiceSpec = DefaultDatabaseSpec(metadata_source_class=ImpalaSource)
+ServiceSpec = DefaultDatabaseSpec(
+    metadata_source_class=ImpalaSource,
+    lineage_source_class=ImpalaLineageSource,
+)

--- a/ingestion/src/metadata/ingestion/source/database/mariadb/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/database/mariadb/service_spec.py
@@ -1,4 +1,12 @@
+from metadata.ingestion.source.database.mariadb.lineage import MariadbLineageSource
 from metadata.ingestion.source.database.mariadb.metadata import MariadbSource
+from metadata.profiler.interface.sqlalchemy.mariadb.profiler_interface import (
+    MariaDBProfilerInterface,
+)
 from metadata.utils.service_spec.default import DefaultDatabaseSpec
 
-ServiceSpec = DefaultDatabaseSpec(metadata_source_class=MariadbSource)
+ServiceSpec = DefaultDatabaseSpec(
+    metadata_source_class=MariadbSource,
+    lineage_source_class=MariadbLineageSource,
+    profiler_class=MariaDBProfilerInterface,
+)

--- a/ingestion/src/metadata/ingestion/source/database/pinotdb/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/database/pinotdb/service_spec.py
@@ -1,4 +1,8 @@
+from metadata.ingestion.source.database.pinotdb.lineage import PinotdbLineageSource
 from metadata.ingestion.source.database.pinotdb.metadata import PinotdbSource
 from metadata.utils.service_spec.default import DefaultDatabaseSpec
 
-ServiceSpec = DefaultDatabaseSpec(metadata_source_class=PinotdbSource)
+ServiceSpec = DefaultDatabaseSpec(
+    metadata_source_class=PinotdbSource,
+    lineage_source_class=PinotdbLineageSource,
+)

--- a/ingestion/src/metadata/ingestion/source/database/singlestore/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/database/singlestore/service_spec.py
@@ -1,3 +1,6 @@
+from metadata.ingestion.source.database.singlestore.lineage import (
+    SinglestoreLineageSource,
+)
 from metadata.ingestion.source.database.singlestore.metadata import SinglestoreSource
 from metadata.profiler.interface.sqlalchemy.single_store.profiler_interface import (
     SingleStoreProfilerInterface,
@@ -5,5 +8,7 @@ from metadata.profiler.interface.sqlalchemy.single_store.profiler_interface impo
 from metadata.utils.service_spec.default import DefaultDatabaseSpec
 
 ServiceSpec = DefaultDatabaseSpec(
-    metadata_source_class=SinglestoreSource, profiler_class=SingleStoreProfilerInterface
+    metadata_source_class=SinglestoreSource,
+    profiler_class=SingleStoreProfilerInterface,
+    lineage_source_class=SinglestoreLineageSource,
 )

--- a/ingestion/src/metadata/ingestion/source/database/sqlite/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/database/sqlite/service_spec.py
@@ -1,4 +1,8 @@
+from metadata.ingestion.source.database.sqlite.lineage import SqliteLineageSource
 from metadata.ingestion.source.database.sqlite.metadata import SqliteSource
 from metadata.utils.service_spec.default import DefaultDatabaseSpec
 
-ServiceSpec = DefaultDatabaseSpec(metadata_source_class=SqliteSource)
+ServiceSpec = DefaultDatabaseSpec(
+    metadata_source_class=SqliteSource,
+    lineage_source_class=SqliteLineageSource,
+)

--- a/ingestion/src/metadata/ingestion/source/database/teradata/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/database/teradata/service_spec.py
@@ -1,4 +1,8 @@
+from metadata.ingestion.source.database.teradata.lineage import TeradataLineageSource
 from metadata.ingestion.source.database.teradata.metadata import TeradataSource
 from metadata.utils.service_spec.default import DefaultDatabaseSpec
 
-ServiceSpec = DefaultDatabaseSpec(metadata_source_class=TeradataSource)
+ServiceSpec = DefaultDatabaseSpec(
+    metadata_source_class=TeradataSource,
+    lineage_source_class=TeradataLineageSource,
+)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Added lineage_source_class and profiler_class inside service_spec of different connectors


Short blurb explaining:
- What changes did you make?
    - Added lineage source class 
- Why did you make them?
    - We were facing an error :-
    ```
    File "/opt/airflow/venv-1.6.1/lib64/python3.9/site-packages/metadata/utils/importer.py", line 130, in import_from_module
        module_name, obj_name = key.rsplit(MODULE_SEPARATOR, 1)
    AttributeError: 'NoneType' object has no attribute 'rsplit'
    ```
    - This occured because during the lneage execution the code was expecting a lineage_source_class from service_spec and it got None.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
