### PR TITLE
Adds percona server for postgresql support

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/postgres/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/postgres/queries.py
@@ -193,7 +193,7 @@ POSTGRES_SQL_COLUMNS = """
     """
 
 POSTGRES_GET_SERVER_VERSION = """
-show server_version
+show server_version_num
 """
 
 POSTGRES_FETCH_FK = """

--- a/ingestion/src/metadata/ingestion/source/database/postgres/utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/postgres/utils.py
@@ -45,7 +45,7 @@ from metadata.utils.sqlalchemy_utils import (
 
 logger = utils_logger()
 
-OLD_POSTGRES_VERSION = "13.0"
+OLD_POSTGRES_VERSION = "130000"
 
 
 def get_etable_owner(
@@ -523,9 +523,6 @@ def get_postgres_version(engine) -> Optional[str]:
         results = engine.execute(POSTGRES_GET_SERVER_VERSION)
         for res in results:
             version_string = str(res[0])
-            opening_parenthesis_index = version_string.find("(")
-            if opening_parenthesis_index != -1:
-                return version_string[:opening_parenthesis_index].strip()
             return version_string
     except Exception as err:
         logger.warning(f"Unable to fetch the Postgres Version - {err}")

--- a/ingestion/tests/unit/topology/database/test_postgres.py
+++ b/ingestion/tests/unit/topology/database/test_postgres.py
@@ -316,14 +316,15 @@ class PostgresUnitTest(TestCase):
 
     @patch("sqlalchemy.engine.base.Engine")
     def test_get_version_info(self, engine):
-        engine.execute.return_value = [["15.3 (Debian 15.3-1.pgdg110+1)"]]
-        self.assertEqual("15.3", get_postgres_version(engine))
+        # outdated with a switch to get_server_version_num instead of get_+server_version
+        # engine.execute.return_value = [["15.3 (Debian 15.3-1.pgdg110+1)"]]
+        # self.assertEqual("15.3", get_postgres_version(engine))
 
-        engine.execute.return_value = [["11.16"]]
-        self.assertEqual("11.16", get_postgres_version(engine))
+        engine.execute.return_value = [["110016"]]
+        self.assertEqual("110016", get_postgres_version(engine))
 
-        engine.execute.return_value = [["9.6.24"]]
-        self.assertEqual("9.6.24", get_postgres_version(engine))
+        engine.execute.return_value = [["90624"]]
+        self.assertEqual("90624", get_postgres_version(engine))
 
         engine.execute.return_value = [[]]
         self.assertIsNone(get_postgres_version(engine))


### PR DESCRIPTION



### Describe your changes:

Fixes issue with inability to collect metadata from percona for postgresql server

discussed here: [slack thread](https://openmetadata.slack.com/archives/C02B6955S4S/p1736347276281429)

The only meaningful difference between vanilla postgreSQL and Percona is version string in percona server for postgresql. So commit propose universal and safe way to detect server version by integer string and not complicated parsing of unformatted string.

tested on both postgresql and percona instances, fix is not affecting anything except version check logic in this particular scenario, works the same for vanilla postgreSQL

I worked on it because we need it in out infrastructure and we are using it everyday



#
### Type of change:
- [x] Improvement


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

 Improvement - no changes in tests and docs necessary
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.


<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
