### PR TITLE
DPLAT-743 Updating CI workflows to use mirror

### DIFF
--- a/.github/workflows/docker-openmetadata-db.yml
+++ b/.github/workflows/docker-openmetadata-db.yml
@@ -19,13 +19,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-config-inline: |
+            [registry."docker.io"]
+              mirrors = ["docker-registry-proxy.internal.stuart.com"]
 
       - name: Login to DockerHub
         uses: docker/login-action@v1 

--- a/.github/workflows/docker-openmetadata-ingestion.yml
+++ b/.github/workflows/docker-openmetadata-ingestion.yml
@@ -19,13 +19,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-config-inline: |
+            [registry."docker.io"]
+              mirrors = ["docker-registry-proxy.internal.stuart.com"]
 
       - name: Login to DockerHub
         uses: docker/login-action@v1 

--- a/.github/workflows/docker-openmetadata-server.yml
+++ b/.github/workflows/docker-openmetadata-server.yml
@@ -19,16 +19,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-config-inline: |
+            [registry."docker.io"]
+              mirrors = ["docker-registry-proxy.internal.stuart.com"]
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v3 
         with:
           username: ${{ secrets.DOCKERHUB_OPENMETADATA_USERNAME }}
           password: ${{ secrets.DOCKERHUB_OPENMETADATA_TOKEN }}


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

We need to update our CI workflows to address throttling issues from Docker Hub in CI jobs. These issues often result in errors like “You have reached your pull rate limit." The root cause is the buildx plugin downloading images from Docker Hub during builds.

Solution:
Use our Docker registry as a registry mirror. Update the buildx setup step in GitHub workflows to reflect this configuration

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

https://stuart-team.atlassian.net/browse/DPLAT-743
