### PR TITLE
Minor: Change log localization improvement

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/WhatsNewModal/WhatsNewModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/WhatsNewModal/WhatsNewModal.tsx
@@ -139,7 +139,7 @@ const WhatsNewModal: FunctionComponent<WhatsNewModalProps> = ({
                         onClick={() => {
                           handleToggleChange(ToggleType.CHANGE_LOG);
                         }}>
-                        {t('label.change-log')}
+                        {t('label.change-log-plural')}
                       </Button>
                     </Button.Group>
                   </div>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/WhatsNewModal/WhatsNewModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/WhatsNewModal/WhatsNewModal.tsx
@@ -139,9 +139,7 @@ const WhatsNewModal: FunctionComponent<WhatsNewModalProps> = ({
                         onClick={() => {
                           handleToggleChange(ToggleType.CHANGE_LOG);
                         }}>
-                        {t('label.change-entity', {
-                          entity: t('label.log-plural'),
-                        })}
+                        {t('label.change-log')}
                       </Button>
                     </Button.Group>
                   </div>

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/de-de.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/de-de.json
@@ -149,6 +149,7 @@
     "category-plural": "Categories",
     "certification": "Certification",
     "change-entity": "{{entity}} ändern",
+    "change-log-plural": "Änderungsprotokolle",
     "change-parent-entity": "Change Parent {{entity}}",
     "chart": "Diagramm",
     "chart-entity": "{{entity}} Diagramm",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
@@ -149,6 +149,7 @@
     "category-plural": "Categories",
     "certification": "Certification",
     "change-entity": "Change {{entity}}",
+    "change-log-plural": "Change Logs",
     "change-parent-entity": "Change Parent {{entity}}",
     "chart": "Chart",
     "chart-entity": "Chart {{entity}}",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/es-es.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/es-es.json
@@ -149,6 +149,7 @@
     "category-plural": "Categorías",
     "certification": "Certification",
     "change-entity": "Cambiar {{entity}}",
+    "change-log-plural": "Registros de cambios",
     "change-parent-entity": "Change Parent {{entity}}",
     "chart": "Gráfico",
     "chart-entity": "Gráfico {{entity}}",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/fr-fr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/fr-fr.json
@@ -149,6 +149,7 @@
     "category-plural": "Categories",
     "certification": "Certification",
     "change-entity": "Changer {{entity}}",
+    "change-log-plural": "Journaux de Modifications",
     "change-parent-entity": "Change Parent {{entity}}",
     "chart": "Graphique",
     "chart-entity": "Graphique {{entity}}",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/gl-es.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/gl-es.json
@@ -149,6 +149,7 @@
     "category-plural": "Categorías",
     "certification": "Certificación",
     "change-entity": "Cambiar {{entity}}",
+    "change-log-plural": "Rexistros de cambios",
     "change-parent-entity": "Cambiar {{entity}} pai",
     "chart": "Gráfico",
     "chart-entity": "Gráfico {{entity}}",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/he-he.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/he-he.json
@@ -149,6 +149,7 @@
     "category-plural": "קטגוריות",
     "certification": "Certification",
     "change-entity": "שנה {{entity}}",
+    "change-log-plural": "יומני שינויים",
     "change-parent-entity": "Change Parent {{entity}}",
     "chart": "תרשים",
     "chart-entity": "תרשים {{entity}}",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ja-jp.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ja-jp.json
@@ -149,6 +149,7 @@
     "category-plural": "Categories",
     "certification": "Certification",
     "change-entity": "{{entity}}を変更",
+    "change-log-plural": "変更ログ",
     "change-parent-entity": "Change Parent {{entity}}",
     "chart": "チャート",
     "chart-entity": "{{entity}}のチャート",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/mr-in.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/mr-in.json
@@ -149,6 +149,7 @@
     "category-plural": "श्रेण्या",
     "certification": "प्रमाणपत्र",
     "change-entity": "{{entity}} बदला",
+    "change-log-plural": "बदल नोंदी",
     "change-parent-entity": "पालक {{entity}} बदला",
     "chart": "तक्ता",
     "chart-entity": "तक्ता {{entity}}",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/nl-nl.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/nl-nl.json
@@ -149,6 +149,7 @@
     "category-plural": "Categorieën",
     "certification": "Certification",
     "change-entity": "Verander {{entity}}",
+    "change-log-plural": "Wijzigingslogboeken",
     "change-parent-entity": "Change Parent {{entity}}",
     "chart": "Chart",
     "chart-entity": "Chart {{entity}}",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pr-pr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pr-pr.json
@@ -149,6 +149,7 @@
     "category-plural": "دسته‌بندی‌ها",
     "certification": "Certification",
     "change-entity": "تغییر {{entity}}",
+    "change-log-plural": "لاگ‌های تغییر",
     "change-parent-entity": "تغییر والد {{entity}}",
     "chart": "نمودار",
     "chart-entity": "نمودار {{entity}}",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-br.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-br.json
@@ -149,6 +149,7 @@
     "category-plural": "Categorias",
     "certification": "Certification",
     "change-entity": "Mudar {{entity}}",
+    "change-log-plural": "Logs de Mudança",
     "change-parent-entity": "Change Parent {{entity}}",
     "chart": "Gráfico",
     "chart-entity": "Gráfico {{entity}}",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-pt.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-pt.json
@@ -149,6 +149,7 @@
     "category-plural": "Categorias",
     "certification": "Certification",
     "change-entity": "Mudar {{entity}}",
+    "change-log-plural": "Registros de Alteração",
     "change-parent-entity": "Change Parent {{entity}}",
     "chart": "Gráfico",
     "chart-entity": "Gráfico {{entity}}",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ru-ru.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ru-ru.json
@@ -149,6 +149,7 @@
     "category-plural": "Categories",
     "certification": "Certification",
     "change-entity": "Изменить {{entity}}",
+    "change-log-plural": "Журналы изменений",
     "change-parent-entity": "Change Parent {{entity}}",
     "chart": "Диаграмма",
     "chart-entity": "Диаграмма {{entity}}",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/th-th.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/th-th.json
@@ -149,6 +149,7 @@
     "category-plural": "หมวดหมู่หลายรายการ",
     "certification": "Certification",
     "change-entity": "เปลี่ยน {{entity}}",
+    "change-log-plural": "บันทึกการเปลี่ยนแปลง",
     "change-parent-entity": "เปลี่ยนผู้ปกครอง {{entity}}",
     "chart": "กราฟ",
     "chart-entity": "กราฟ {{entity}}",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-cn.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-cn.json
@@ -149,6 +149,7 @@
     "category-plural": "分类",
     "certification": "Certification",
     "change-entity": "更改{{entity}}",
+    "change-log-plural": "变更日志",
     "change-parent-entity": "更改父级{{entity}}",
     "chart": "图表",
     "chart-entity": "图表{{entity}}",


### PR DESCRIPTION
I worked on changing the localisation key for the `Change Logs` since previous use resulted in a translation where `change` in the `Change Logs` was taken as a verb.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
