### PR TITLE
ISSUE-19454: Fixes broken looker lineage

### DIFF
--- a/ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py
@@ -24,7 +24,18 @@ import os
 import traceback
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Sequence, Set, Type, Union, cast
+from typing import (
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Type,
+    Union,
+    cast,
+    get_args,
+)
 
 import giturlparse
 import lkml
@@ -39,6 +50,8 @@ from looker_sdk.sdk.api40.models import (
     LookmlModelNavExplore,
     Project,
 )
+from pydantic import ValidationError
+
 from metadata.generated.schema.api.data.createChart import CreateChartRequest
 from metadata.generated.schema.api.data.createDashboard import CreateDashboardRequest
 from metadata.generated.schema.api.data.createDashboardDataModel import (
@@ -115,8 +128,6 @@ from metadata.utils import fqn
 from metadata.utils.filters import filter_by_chart, filter_by_datamodel
 from metadata.utils.helpers import clean_uri, get_standard_chart_type
 from metadata.utils.logger import ingestion_logger
-from pydantic import ValidationError
-from typing import get_args
 
 logger = ingestion_logger()
 

--- a/ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/looker/metadata.py
@@ -729,7 +729,7 @@ class LookerSource(DashboardServiceSource):
         return None
 
     @staticmethod
-    def _clean_table_name(table_name: str, dialect: Dialect) -> str:
+    def _clean_table_name(table_name: str, dialect: Dialect = Dialect.ANSI) -> str:
         """
         sql_table_names might be renamed when defining
         an explore. E.g., customers as cust

--- a/ingestion/tests/unit/topology/dashboard/test_looker.py
+++ b/ingestion/tests/unit/topology/dashboard/test_looker.py
@@ -47,6 +47,7 @@ from metadata.generated.schema.type.entityReference import EntityReference
 from metadata.generated.schema.type.usageDetails import UsageDetails, UsageStats
 from metadata.generated.schema.type.usageRequest import UsageRequest
 from metadata.ingestion.api.steps import InvalidSourceException
+from metadata.ingestion.lineage.models import Dialect
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.dashboard.dashboard_service import DashboardUsage
 from metadata.ingestion.source.dashboard.looker.metadata import LookerSource
@@ -292,13 +293,33 @@ class LookerUnitTest(TestCase):
         """
         Check table cleaning
         """
-        self.assertEqual(self.looker._clean_table_name("MY_TABLE"), "my_table")
+        self.assertEqual(
+            self.looker._clean_table_name("MY_TABLE", Dialect.MYSQL), "my_table"
+        )
 
-        self.assertEqual(self.looker._clean_table_name("  MY_TABLE  "), "my_table")
+        self.assertEqual(
+            self.looker._clean_table_name("  MY_TABLE  ", Dialect.REDSHIFT), "my_table"
+        )
 
-        self.assertEqual(self.looker._clean_table_name("  my_table"), "my_table")
+        self.assertEqual(
+            self.looker._clean_table_name("  my_table", Dialect.SNOWFLAKE), "my_table"
+        )
 
-        self.assertEqual(self.looker._clean_table_name("TABLE AS ALIAS"), "table")
+        self.assertEqual(
+            self.looker._clean_table_name("TABLE AS ALIAS", Dialect.BIGQUERY), "table"
+        )
+
+        self.assertEqual(
+            self.looker._clean_table_name(
+                "`project_id.dataset_id.table_id` AS ALIAS", Dialect.BIGQUERY
+            ),
+            "project_id.dataset_id.table_id",
+        )
+
+        self.assertEqual(
+            self.looker._clean_table_name("`db.schema.table`", Dialect.POSTGRES),
+            "`db.schema.table`",
+        )
 
     def test_render_table_name(self):
         """


### PR DESCRIPTION
### Describe your changes:

Fixes [19454](https://github.com/open-metadata/OpenMetadata/pull/19456)

Looker lineage is broken when a table reference is enclosed by backticks (common when using BigQuery).
This addresses that issue.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

- [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
