### PR TITLE
fix: wrong dataset and project id in filter

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/bigquery/profiler/system.py
+++ b/ingestion/src/metadata/ingestion/source/database/bigquery/profiler/system.py
@@ -29,8 +29,8 @@ class BigQuerySystemMetricsSource(
         runner: QueryRunner = kwargs.get("runner")
         return {
             "table": runner.table_name,
-            "database": runner.session.get_bind().url.database,
-            "schema": runner.schema_name,
+            "project_id": runner.session.get_bind().url.host,
+            "dataset_id": runner.schema_name,
             "usage_location": kwargs.get("usage_location"),
         }
 


### PR DESCRIPTION
### Describe your changes:
- Wrong dataset and project id pass to system metric query

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

Bug fix
- [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
