### PR TITLE
Fixes #19619

### DIFF
--- a/ingestion/setup.py
+++ b/ingestion/setup.py
@@ -226,8 +226,6 @@ plugins: Dict[str, Set[str]] = {
         *COMMONS["datalake"],
     },
     "datalake-s3": {
-        # vendoring 'boto3' to keep all dependencies aligned (s3fs, boto3, botocore, aiobotocore)
-        "s3fs[boto3]",
         *COMMONS["datalake"],
     },
     "deltalake": {

--- a/ingestion/src/metadata/readers/dataframe/parquet.py
+++ b/ingestion/src/metadata/readers/dataframe/parquet.py
@@ -64,32 +64,22 @@ class ParquetDataFrameReader(DataFrameReader):
     @_read_parquet_dispatch.register
     def _(self, _: S3Config, key: str, bucket_name: str) -> DatalakeColumnWrapper:
         # pylint: disable=import-outside-toplevel
-        import s3fs
+        from pyarrow.fs import S3FileSystem
         from pyarrow.parquet import ParquetDataset
 
-        client_kwargs = {}
-        if self.config_source.securityConfig.endPointURL:
-            client_kwargs["endpoint_url"] = str(
-                self.config_source.securityConfig.endPointURL
-            )
+        client_kwargs = {
+            "endpoint_override": self.config_source.securityConfig.endPointURL,
+            "region": self.config_source.securityConfig.awsRegion,
+            "access_key": self.config_source.securityConfig.awsAccessKeyId,
+            "session_token": self.config_source.securityConfig.awsSessionToken,
+            "role_arn": self.config_source.securityConfig.assumeRoleArn,
+            "session_name": self.config_source.securityConfig.assumeRoleSessionName,
+        }
+        if self.config_source.securityConfig.awsSecretAccessKey:
+            client_kwargs["secret_key"] = self.config_source.securityConfig.awsSecretAccessKey.get_secret_value()
+        s3_fs = S3FileSystem(**client_kwargs)
 
-        if self.config_source.securityConfig.awsRegion:
-            client_kwargs["region_name"] = self.config_source.securityConfig.awsRegion
-
-        s3_fs = s3fs.S3FileSystem(client_kwargs=client_kwargs)
-
-        if (
-            self.config_source.securityConfig.awsAccessKeyId
-            and self.config_source.securityConfig.awsSecretAccessKey
-        ):
-            s3_fs = s3fs.S3FileSystem(
-                key=self.config_source.securityConfig.awsAccessKeyId,
-                secret=self.config_source.securityConfig.awsSecretAccessKey.get_secret_value(),
-                token=self.config_source.securityConfig.awsSessionToken,
-                client_kwargs=client_kwargs,
-            )
-
-        bucket_uri = f"s3://{bucket_name}/{key}"
+        bucket_uri = f"{bucket_name}/{key}"
         dataset = ParquetDataset(bucket_uri, filesystem=s3_fs)
 
         return dataframe_to_chunks(dataset.read_pandas().to_pandas())

--- a/ingestion/src/metadata/readers/dataframe/parquet.py
+++ b/ingestion/src/metadata/readers/dataframe/parquet.py
@@ -68,7 +68,7 @@ class ParquetDataFrameReader(DataFrameReader):
         from pyarrow.parquet import ParquetDataset
 
         client_kwargs = {
-            "endpoint_override": self.config_source.securityConfig.endPointURL,
+            "endpoint_override": str(self.config_source.securityConfig.endPointURL),
             "region": self.config_source.securityConfig.awsRegion,
             "access_key": self.config_source.securityConfig.awsAccessKeyId,
             "session_token": self.config_source.securityConfig.awsSessionToken,

--- a/ingestion/src/metadata/readers/dataframe/parquet.py
+++ b/ingestion/src/metadata/readers/dataframe/parquet.py
@@ -76,7 +76,9 @@ class ParquetDataFrameReader(DataFrameReader):
             "session_name": self.config_source.securityConfig.assumeRoleSessionName,
         }
         if self.config_source.securityConfig.awsSecretAccessKey:
-            client_kwargs["secret_key"] = self.config_source.securityConfig.awsSecretAccessKey.get_secret_value()
+            client_kwargs[
+                "secret_key"
+            ] = self.config_source.securityConfig.awsSecretAccessKey.get_secret_value()
         s3_fs = S3FileSystem(**client_kwargs)
 
         bucket_uri = f"{bucket_name}/{key}"


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #19619

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

`s3fs.S3FileSystem` has been replaced with `pyarrow.fs.S3FileSystem` in ParquetDataFrameReader, as:

- it allows `role_arn` as argument, which is not supported by s3fs (hence fixes bug - `assumeRoleArn` was not passed to the filesystem, so it couldn't access the files),
- it's more compatible with ParquetDataFrameReader, which is using pyarrow package anyway,
- s3fs is an unnecessary addition to project dependencies.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`