### PR TITLE
Fix the custom test result timestamp in milliseconds

### DIFF
--- a/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/data-quality-observability/quality/custom-tests.md
+++ b/openmetadata-docs/content/v1.7.x-SNAPSHOT/how-to-guides/data-quality-observability/quality/custom-tests.md
@@ -126,7 +126,7 @@ Once you have your Test Case created you can write your results to it. You can u
 {
     "result": "<result message>",
     "testCaseStatus": "<Success or Failed or Aborted>",
-    "timestamp": <Unix timestamp>,
+    "timestamp": <Unix timestamp in milliseconds>,
     "testResultValue": [
       {
         "value": "<value>"
@@ -143,7 +143,7 @@ curl --location --request PUT 'http://localhost:8585/api/v1/dataQuality/testCase
 --data-raw '{
     "result": "found 1 values expected n",
     "testCaseStatus": "Success",
-    "timestamp": 1662129151,
+    "timestamp": 1662129151000,
     "testResultValue": [{
         "value": "10"
     }]


### PR DESCRIPTION
### Describe your changes:

This pull request updates the "Test Result" section in the [Data Quality Observability Custom Tests documentation](https://docs.open-metadata.org/v1.7.x-SNAPSHOT/how-to-guides/data-quality-observability/quality/custom-tests). The changes include:

- Clarifying the JSON payload timestamp format to create and run custom test result.

For more details, refer to the discussion on Slack: [Slack Link](https://openmetadata.slack.com/archives/C02B6955S4S/p1738804777439429)


### What changes did you make?
- Added a comment explaining the Unix timestamp format for writing `TestCaseResults`.

### Why did you make them?
- The Unix timestamp in milliseconds is the correct format that the API accepts, ensuring accurate and consistent test results.


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
