### PR TITLE
Fix #19425: BigQuery External Table with Partition

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/bigquery/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/bigquery/metadata.py
@@ -671,8 +671,10 @@ class BigquerySource(LifeCycleQueryMixin, CommonDbSourceService, MultiDBSource):
             database = self.context.get().database
             table = self.client.get_table(fqn._build(database, schema_name, table_name))
             columns = inspector.get_columns(table_name, schema_name, db_name=database)
-            if hasattr(table, "external_data_configuration") and hasattr(
-                table.external_data_configuration, "hive_partitioning"
+            if (
+                hasattr(table, "external_data_configuration")
+                and hasattr(table.external_data_configuration, "hive_partitioning")
+                and table.external_data_configuration.hive_partitioning
             ):
                 # Ingesting External Hive Partitioned Tables
                 from google.cloud.bigquery.external_config import (  # pylint: disable=import-outside-toplevel
@@ -739,6 +741,30 @@ class BigquerySource(LifeCycleQueryMixin, CommonDbSourceService, MultiDBSource):
                     table_partition.interval = table.range_partitioning.range_.interval
                 table_partition.columnName = table.range_partitioning.field
                 return True, TablePartition(columns=[table_partition])
+            if (
+                hasattr(table, "_properties")
+                and table._properties.get("partitionDefinition")
+                and table._properties.get("partitionDefinition").get(
+                    "partitionedColumn"
+                )
+            ):
+
+                return True, TablePartition(
+                    columns=[
+                        PartitionColumnDetails(
+                            columnName=self._get_partition_column_name(
+                                columns=columns,
+                                partition_field_name=field.get("field"),
+                            ),
+                            intervalType=PartitionIntervalTypes.OTHER,
+                        )
+                        for field in table._properties.get("partitionDefinition").get(
+                            "partitionedColumn"
+                        )
+                        if field and field.get("field")
+                    ]
+                )
+
         except Exception as exc:
             logger.debug(traceback.format_exc())
             logger.warning(


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fix #19425: BigQuery External Table with Partition

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
