### PR TITLE
Update Glossary Approval Workflow

### DIFF
--- a/openmetadata-service/src/main/resources/json/data/governance/workflows/GlossaryApprovalWorkflow.json
+++ b/openmetadata-service/src/main/resources/json/data/governance/workflows/GlossaryApprovalWorkflow.json
@@ -28,6 +28,12 @@
     {
       "type": "endEvent",
       "subType": "endEvent",
+      "name": "ApprovedEndAfterUserTask",
+      "displayName": "Glossary Term Status: Approved"
+    },
+    {
+      "type": "endEvent",
+      "subType": "endEvent",
       "name": "RejectedEnd",
       "displayName": "Glossary Term Status: Rejected"
     },
@@ -96,6 +102,15 @@
     {
       "type": "automatedTask",
       "subType": "setGlossaryTermStatusTask",
+      "name": "SetGlossaryTermStatusToApprovedAfterUserTask",
+      "displayName": "Set Status to 'Approved'",
+      "config": {
+        "glossaryTermStatus": "Approved"
+      }
+    },
+    {
+      "type": "automatedTask",
+      "subType": "setGlossaryTermStatusTask",
       "name": "SetGlossaryTermStatusToRejected",
       "displayName": "Set Status to 'Rejected'",
       "config": {
@@ -138,7 +153,7 @@
     },
     {
       "from": "ApproveGlossaryTerm",
-      "to": "SetGlossaryTermStatusToApproved",
+      "to": "SetGlossaryTermStatusToApprovedAfterUserTask",
       "condition": true
     },
     {
@@ -149,6 +164,10 @@
     {
       "from": "SetGlossaryTermStatusToApproved",
       "to": "ApprovedEnd"
+    },
+    {
+      "from": "SetGlossaryTermStatusToApprovedAfterUserTask",
+      "to": "ApprovedEndAfterUserTask"
     },
     {
       "from": "SetGlossaryTermStatusToRejected",


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

Changing the default Glossary Approval Workflow to make independent the Approval Task from the Has Reviewers test.
The way we have it until now there is only one node that sets the status to approved and if the users want to change how either one of the sides behaves, he is unable to change the other side.

Only the default workflow is changed. There are no migrations to avoid messing with any workflow that could have been changed so far, but the new instances should spin up with this improved format.

You can check the difference in the screenshots below.

CURRENT
![image](https://github.com/user-attachments/assets/e252eeea-ec7a-42ef-a21a-8dbd11d68475)


NEW
![image](https://github.com/user-attachments/assets/10b3e600-2eac-4f00-abd8-d8802a52a0cc)


<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
