### PR TITLE
MINOR: Update Glossary Approval Workflow

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/triggers/PeriodicBatchEntityTrigger.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/triggers/PeriodicBatchEntityTrigger.java
@@ -121,12 +121,12 @@ public class PeriodicBatchEntityTrigger implements TriggerInterface {
             .build();
 
     IOParameter inputParameter = new IOParameter();
-    inputParameter.setSource(getNamespacedVariableName(GLOBAL_NAMESPACE, RELATED_ENTITY_VARIABLE));
+    inputParameter.setSource(RELATED_ENTITY_VARIABLE);
     inputParameter.setTarget(getNamespacedVariableName(GLOBAL_NAMESPACE, RELATED_ENTITY_VARIABLE));
 
     IOParameter outputParameter = new IOParameter();
     outputParameter.setSource(getNamespacedVariableName(GLOBAL_NAMESPACE, EXCEPTION_VARIABLE));
-    outputParameter.setTarget(getNamespacedVariableName(GLOBAL_NAMESPACE, EXCEPTION_VARIABLE));
+    outputParameter.setTarget(EXCEPTION_VARIABLE);
 
     workflowTrigger.setInParameters(List.of(inputParameter));
     workflowTrigger.setOutParameters(List.of(outputParameter));

--- a/openmetadata-service/src/main/resources/json/data/governance/workflows/GlossaryApprovalWorkflow.json
+++ b/openmetadata-service/src/main/resources/json/data/governance/workflows/GlossaryApprovalWorkflow.json
@@ -27,6 +27,12 @@
     {
       "type": "endEvent",
       "subType": "endEvent",
+      "name": "ApprovedEndAfterApproval",
+      "displayName": "Glossary Term Status: Approved"
+    },
+    {
+      "type": "endEvent",
+      "subType": "endEvent",
       "name": "RejectedEnd",
       "displayName": "Glossary Term Status: Rejected"
     },
@@ -182,7 +188,7 @@
     },
     {
       "from": "SetGlossaryTermStatusToApprovedAfterApproval",
-      "to": "ApprovedEnd"
+      "to": "ApprovedEndAfterApproval"
     },
     {
       "from": "SetGlossaryTermStatusToApproved",

--- a/openmetadata-service/src/main/resources/json/data/governance/workflows/GlossaryApprovalWorkflow.json
+++ b/openmetadata-service/src/main/resources/json/data/governance/workflows/GlossaryApprovalWorkflow.json
@@ -101,7 +101,7 @@
     {
       "type": "automatedTask",
       "subType": "setGlossaryTermStatusTask",
-      "name": "SetGlossaryTermStatusToApproved",
+      "name": "SetGlossaryTermStatusToApprovedAfterApproval",
       "displayName": "Set Status to 'Approved'",
       "config": {
         "glossaryTermStatus": "Approved"
@@ -109,6 +109,18 @@
       "inputNamespaceMap": {
         "relatedEntity": "global",
         "updatedBy": "ApproveGlossaryTerm"
+      }
+    },
+    {
+      "type": "automatedTask",
+      "subType": "setGlossaryTermStatusTask",
+      "name": "SetGlossaryTermStatusToApproved",
+      "displayName": "Set Status to 'Approved'",
+      "config": {
+        "glossaryTermStatus": "Approved"
+      },
+      "inputNamespaceMap": {
+        "relatedEntity": "global"
       }
     },
     {
@@ -160,13 +172,17 @@
     },
     {
       "from": "ApproveGlossaryTerm",
-      "to": "SetGlossaryTermStatusToApproved",
+      "to": "SetGlossaryTermStatusToApprovedAfterApproval",
       "condition": "true"
     },
     {
       "from": "ApproveGlossaryTerm",
       "to": "SetGlossaryTermStatusToRejected",
       "condition": "false"
+    },
+    {
+      "from": "SetGlossaryTermStatusToApprovedAfterApproval",
+      "to": "ApprovedEnd"
     },
     {
       "from": "SetGlossaryTermStatusToApproved",


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->
Changing the default Glossary Approval Workflow to make independent the Approval Task from the Has Reviewers test.
The way we have it until now there is only one node that sets the status to approved and if the users want to change how either one of the sides behaves, he is unable to change the other side.

Only the default workflow is changed. There are no migrations to avoid messing with any workflow that could have been changed so far, but the new instances should spin up with this improved format.

Similar to https://github.com/open-metadata/OpenMetadata/pull/19780, but taking into account the changes already in main

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
