### PR TITLE
fix datadiff version

### DIFF
--- a/ingestion/setup.py
+++ b/ingestion/setup.py
@@ -57,6 +57,7 @@ VERSIONS = {
     "giturlparse": "giturlparse",
     "validators": "validators~=0.22.0",
     "teradata": "teradatasqlalchemy>=20.0.0.0",
+    "collate-data-diff": "collate-data-diff<=0.11.3",
 }
 
 COMMONS = {
@@ -94,7 +95,7 @@ COMMONS = {
 }
 
 DATA_DIFF = {
-    driver: f"collate-data-diff[{driver}]"
+    driver: f"collate-data-diff[{driver}]<=0.11.3"
     # data-diff uses different drivers out-of-the-box than OpenMetadata
     # the exrtas are described here:
     # https://github.com/open-metadata/collate-data-diff/blob/main/pyproject.toml#L68
@@ -142,7 +143,7 @@ base_requirements = {
     "typing-inspect",
     "packaging",  # For version parsing
     "shapely",
-    "collate-data-diff",
+    VERSIONS["collate-data-diff"],
 }
 
 plugins: Dict[str, Set[str]] = {


### PR DESCRIPTION
Fix datadiff version in 1.6.4 prior to releasing collate-data-diff==0.11.4