### PR TITLE
Fix: Update teams dropdown for admin

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamsSelectable/TeamsSelectable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamsSelectable/TeamsSelectable.tsx
@@ -56,7 +56,13 @@ const TeamsSelectable = ({
     try {
       setIsLoading(true);
       const { data } = await getTeamsHierarchy(filterJoinable);
-      setTeams(data);
+      const sortedData = data.sort((a, b) => {
+        const nameA = a.fullyQualifiedName ?? '';
+        const nameB = b.fullyQualifiedName ?? '';
+
+        return nameA.localeCompare(nameB);
+      });
+      setTeams(sortedData);
       showTeamsAlert && setNoTeam(isEmpty(data));
     } catch (error) {
       showErrorToast(error as AxiosError);

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamsSelectable/TeamsSelectable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamsSelectable/TeamsSelectable.tsx
@@ -56,7 +56,7 @@ const TeamsSelectable = ({
     try {
       setIsLoading(true);
       const { data } = await getTeamsHierarchy(filterJoinable);
-      const sortedData = data.sort((a, b) => {
+      const sortedData = data.toSorted((a, b) => {
         const nameA = a.fullyQualifiedName ?? '';
         const nameB = b.fullyQualifiedName ?? '';
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamsSelectable/TeamsSelectable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamsSelectable/TeamsSelectable.tsx
@@ -56,7 +56,13 @@ const TeamsSelectable = ({
     try {
       setIsLoading(true);
       const { data } = await getTeamsHierarchy(filterJoinable);
-      setTeams(data.sort((a, b) => a.name.localeCompare(b.name)));
+      const sortedData = [...data].sort((a, b) => {
+        const nameA = a.fullyQualifiedName ?? '';
+        const nameB = b.fullyQualifiedName ?? '';
+
+        return nameA.localeCompare(nameB);
+      });
+      setTeams(sortedData);
       showTeamsAlert && setNoTeam(isEmpty(data));
     } catch (error) {
       showErrorToast(error as AxiosError);

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamsSelectable/TeamsSelectable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamsSelectable/TeamsSelectable.tsx
@@ -56,15 +56,7 @@ const TeamsSelectable = ({
     try {
       setIsLoading(true);
       const { data } = await getTeamsHierarchy(filterJoinable);
-      const compareNames = (a: TeamHierarchy, b: TeamHierarchy) => {
-        const nameA = a.fullyQualifiedName ?? '';
-        const nameB = b.fullyQualifiedName ?? '';
-
-        return nameA.localeCompare(nameB);
-      };
-
-      const sortedData = data.sort(compareNames);
-      setTeams(sortedData);
+      setTeams(data.sort((a, b) => a.name.localeCompare(b.name)));
       showTeamsAlert && setNoTeam(isEmpty(data));
     } catch (error) {
       showErrorToast(error as AxiosError);

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamsSelectable/TeamsSelectable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamsSelectable/TeamsSelectable.tsx
@@ -56,12 +56,14 @@ const TeamsSelectable = ({
     try {
       setIsLoading(true);
       const { data } = await getTeamsHierarchy(filterJoinable);
-      const sortedData = data.toSorted((a, b) => {
+      const compareNames = (a: TeamHierarchy, b: TeamHierarchy) => {
         const nameA = a.fullyQualifiedName ?? '';
         const nameB = b.fullyQualifiedName ?? '';
 
         return nameA.localeCompare(nameB);
-      });
+      };
+
+      const sortedData = data.sort(compareNames);
       setTeams(sortedData);
       showTeamsAlert && setNoTeam(isEmpty(data));
     } catch (error) {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UsersProfile/UserProfileTeams/UserProfileTeams.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UsersProfile/UserProfileTeams/UserProfileTeams.component.tsx
@@ -112,7 +112,7 @@ const UserProfileTeams = ({
           onCancel={handleCloseEditTeam}
           onSave={handleTeamsSave}>
           <TeamsSelectable
-            filterJoinable
+            filterJoinable={!isAdminUser}
             maxValueCount={4}
             selectedTeams={selectedTeams}
             onSelectionChange={setSelectedTeams}


### PR DESCRIPTION
**Before:** 
All the teams were not visible for admin.

https://github.com/user-attachments/assets/e148eb73-4f90-4f35-a636-397e97763bb1


**After:** 
Admin can access all the teams to edit in profile page.

https://github.com/user-attachments/assets/7165e140-812a-444f-8d24-f6d7c698d856




<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
