### PR TITLE
MINOR - Fix collate app yaml reader with unwanted dropwizard java props

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/ConfigurationReader.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/ConfigurationReader.java
@@ -21,7 +21,7 @@ public class ConfigurationReader {
   private final StringSubstitutor substitutor;
   private final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
   private final YamlConfigurationFactory<Object> factory =
-      new YamlConfigurationFactory<>(Object.class, null, mapper, "dw");
+      new YamlConfigurationFactory<>(Object.class, null, mapper, "app");
 
   public ConfigurationReader(Map<String, String> envMap) {
     // envMap is for custom environment variables (e.g., for testing), defaulting to the system


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

We had a `dw` property prefix reader that during Collate app tests it was adding some unwanted parameters that dropwizard (dw) set during the OM test application init

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
