### PR TITLE
MINOR: use separate quartz scheduler

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/events/scheduled/EventSubscriptionScheduler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/events/scheduled/EventSubscriptionScheduler.java
@@ -16,6 +16,8 @@ package org.openmetadata.service.events.scheduled;
 import static org.openmetadata.service.apps.bundles.changeEvent.AbstractEventConsumer.ALERT_INFO_KEY;
 import static org.openmetadata.service.apps.bundles.changeEvent.AbstractEventConsumer.ALERT_OFFSET_KEY;
 import static org.openmetadata.service.events.subscription.AlertUtil.getStartingOffset;
+import static org.quartz.impl.StdSchedulerFactory.PROP_SCHED_INSTANCE_NAME;
+import static org.quartz.impl.StdSchedulerFactory.PROP_THREAD_POOL_PREFIX;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
@@ -73,11 +75,15 @@ public class EventSubscriptionScheduler {
   private static EventSubscriptionScheduler instance;
   private static volatile boolean initialized = false;
   private static final Scheduler alertsScheduler;
+  private static final String SCHEDULER_NAME = "OpenMetadataEventSubscriptionScheduler";
+  private static final int SCHEDULER_THREAD_COUNT = 5;
 
   static {
     Properties properties = new Properties();
+    properties.setProperty(PROP_SCHED_INSTANCE_NAME, SCHEDULER_NAME);
     properties.setProperty(
-        "org.quartz.scheduler.instanceName", "OpenMetadataEventSubscriptionScheduler");
+        PROP_THREAD_POOL_PREFIX + ".threadCount", String.valueOf(SCHEDULER_THREAD_COUNT));
+
     try {
       StdSchedulerFactory factory = new StdSchedulerFactory();
       factory.initialize(properties);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/events/scheduled/EventSubscriptionScheduler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/events/scheduled/EventSubscriptionScheduler.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.SneakyThrows;
@@ -71,7 +72,19 @@ public class EventSubscriptionScheduler {
   public static final String ALERT_TRIGGER_GROUP = "OMAlertJobGroup";
   private static EventSubscriptionScheduler instance;
   private static volatile boolean initialized = false;
-  private final Scheduler alertsScheduler = new StdSchedulerFactory().getScheduler();
+  private static final Scheduler alertsScheduler;
+
+  static {
+    Properties properties = new Properties();
+    properties.setProperty("org.quartz.scheduler.instanceName", "OpenMetadataEventSubscriptionScheduler");
+    try {
+      StdSchedulerFactory factory = new StdSchedulerFactory();
+      factory.initialize(properties);
+      alertsScheduler = factory.getScheduler();
+    } catch (SchedulerException e) {
+      throw new ExceptionInInitializerError("Failed to initialize scheduler: " + e.getMessage());
+    }
+  }
 
   private record CustomJobFactory(DIContainer di) implements JobFactory {
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/events/scheduled/EventSubscriptionScheduler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/events/scheduled/EventSubscriptionScheduler.java
@@ -76,7 +76,8 @@ public class EventSubscriptionScheduler {
 
   static {
     Properties properties = new Properties();
-    properties.setProperty("org.quartz.scheduler.instanceName", "OpenMetadataEventSubscriptionScheduler");
+    properties.setProperty(
+        "org.quartz.scheduler.instanceName", "OpenMetadataEventSubscriptionScheduler");
     try {
       StdSchedulerFactory factory = new StdSchedulerFactory();
       factory.initialize(properties);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/events/scheduled/ServicesStatusJobHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/events/scheduled/ServicesStatusJobHandler.java
@@ -63,7 +63,7 @@ public class ServicesStatusJobHandler {
     try {
       instance = new ServicesStatusJobHandler(eventMonitorConfiguration, config, clusterName);
     } catch (Exception ex) {
-      LOG.error("Failed to initialize the Pipeline Service Status Handler");
+      throw new RuntimeException("Failed to initialize the Pipeline Service Status Handler", ex);
     }
     return instance;
   }


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

## Describe your changes:

### Before

```java
ERROR [2025-02-24 18:04:43,951] [DefaultQuartzScheduler_QuartzSchedulerThread] o.q.c.ErrorLogger - An error occurred instantiating job to be executed. job= 'status.pipelineServiceStatusJob'
org.quartz.SchedulerException: Failed to create job instance
	at org.openmetadata.service.events.scheduled.EventSubscriptionScheduler$CustomJobFactory.newJob(EventSubscriptionScheduler.java:86)
	at org.quartz.core.JobRunShell.initialize(JobRunShell.java:128)
	at org.quartz.core.QuartzSchedulerThread.run(QuartzSchedulerThread.java:403)
Caused by: java.lang.NoSuchMethodException: org.openmetadata.service.events.scheduled.PipelineServiceStatusJob.<init>(org.openmetadata.service.util.DIContainer)
	at java.base/java.lang.Class.getConstructor0(Class.java:3585)
	at java.base/java.lang.Class.getDeclaredConstructor(Class.java:2754)
	at org.openmetadata.service.events.scheduled.EventSubscriptionScheduler$CustomJobFactory.newJob(EventSubscriptionScheduler.java:83)
	... 2 common frames omitted
ERROR [2025-02-24 18:04:43,951] [DefaultQuartzScheduler_QuartzSchedulerThread] o.q.c.ErrorLogger - An error occurred instantiating job to be executed. job= 'status.databaseAndSearchServiceStatusJob'
org.quartz.SchedulerException: Failed to create job instance
	at org.openmetadata.service.events.scheduled.EventSubscriptionScheduler$CustomJobFactory.newJob(EventSubscriptionScheduler.java:86)
	at org.quartz.core.JobRunShell.initialize(JobRunShell.java:128)
	at org.quartz.core.QuartzSchedulerThread.run(QuartzSchedulerThread.java:403)
Caused by: java.lang.NoSuchMethodException: org.openmetadata.service.events.scheduled.DatabseAndSearchServiceStatusJob.<init>(org.openmetadata.service.util.DIContainer)
	at java.base/java.lang.Class.getConstructor0(Class.java:3585)
	at java.base/java.lang.Class.getDeclaredConstructor(Class.java:2754)
	at org.openmetadata.service.events.scheduled.EventSubscriptionScheduler$CustomJobFactory.newJob(EventSubscriptionScheduler.java:83)
	... 2 common frames omitted
```

### After

```java
DEBUG [2025-02-24 18:22:44,919] [DefaultQuartzScheduler_QuartzSchedulerThread] o.q.c.QuartzSchedulerThread - batch acquisition of 0 triggers
DEBUG [2025-02-24 18:22:44,921] [DefaultQuartzScheduler_QuartzSchedulerThread] o.q.c.QuartzSchedulerThread - batch acquisition of 1 triggers
INFO [2025-02-24 18:22:44,922] [main] i.d.s.ServerFactory - Starting OpenMetadataApplication
DEBUG [2025-02-24 18:22:44,922] [DefaultQuartzScheduler_QuartzSchedulerThread] o.q.s.PropertySettingJobFactory - Producing instance of Job 'status.pipelineServiceStatusJob', class=org.openmetadata.service.events.scheduled.PipelineServiceStatusJob
DEBUG [2025-02-24 18:22:44,926] [DefaultQuartzScheduler_QuartzSchedulerThread] o.q.c.QuartzSchedulerThread - batch acquisition of 1 triggers
DEBUG [2025-02-24 18:22:44,926] [DefaultQuartzScheduler_QuartzSchedulerThread] o.q.s.PropertySettingJobFactory - Producing instance of Job 'status.databaseAndSearchServiceStatusJob', class=org.openmetadata.service.events.scheduled.DatabseAndSearchServiceStatusJob
DEBUG [2025-02-24 18:22:44,926] [DefaultQuartzScheduler_Worker-1] o.q.c.JobRunShell - Calling execute on job status.pipelineServiceStatusJob
```

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
