### PR TITLE
 Fixes #19956: use the correct non english guide in services if it exists

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/ServiceDocPanel/ServiceDocPanel.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/ServiceDocPanel/ServiceDocPanel.tsx
@@ -104,10 +104,10 @@ const ServiceDocPanel: FC<ServiceDocPanelProp> = ({
 
       if (translation.status === 'fulfilled') {
         response = translation.value;
-      }
-
-      if (!isEnglishLanguage && fallbackTranslation.status === 'fulfilled') {
-        response = fallbackTranslation.value;
+      } else {
+        if (fallbackTranslation.status === 'fulfilled') {
+          response = fallbackTranslation.value;
+        }
       }
 
       setMarkdownContent(response);


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #19956

This is a minor fix to the logic that selects the correct markdown document to show to the user.

Right now, even if the non-English document exists, it is **always** overridden by the default English one.

I was adding new Portuguese service guides and they were not presented to the user.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [X] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [X] My PR title is `Fixes <issue-number>: <short explanation>`
