### PR TITLE
MINOR - Fix user update roles

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/UserRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/UserRepository.java
@@ -648,8 +648,8 @@ public class UserRepository extends EntityRepository<User> {
       deleteFrom(original.getId(), USER, Relationship.HAS, Entity.ROLE);
       assignRoles(updated, updated.getRoles());
 
-      List<EntityReference> origRoles = listOrEmpty(original.getRoles());
-      List<EntityReference> updatedRoles = listOrEmpty(updated.getRoles());
+      List<EntityReference> origRoles = listOrEmptyMutable(original.getRoles());
+      List<EntityReference> updatedRoles = listOrEmptyMutable(updated.getRoles());
 
       origRoles.sort(EntityUtil.compareEntityReference);
       updatedRoles.sort(EntityUtil.compareEntityReference);


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

We were getting

```
WARN [2025-02-27 11:23:02,488] [main] o.o.s.r.CollectionRegistry - Encountered exception while initializing resource for class org.openmetadata.service.resources.bots.BotResource
java.lang.reflect.InvocationTargetException: null
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.openmetadata.service.resources.CollectionRegistry.createResource(CollectionRegistry.java:300)
	at org.openmetadata.service.resources.CollectionRegistry.registerResources(CollectionRegistry.java:161)
	at org.openmetadata.service.OpenMetadataApplication.registerResources(OpenMetadataApplication.java:589)
	at org.openmetadata.service.OpenMetadataApplication.run(OpenMetadataApplication.java:237)
	at org.openmetadata.service.OpenMetadataApplication.run(OpenMetadataApplication.java:137)
	at io.dropwizard.cli.EnvironmentCommand.run(EnvironmentCommand.java:67)
	at io.dropwizard.cli.ConfiguredCommand.run(ConfiguredCommand.java:98)
	at io.dropwizard.cli.Cli.run(Cli.java:78)
	at io.dropwizard.Application.run(Application.java:94)
	at org.openmetadata.service.OpenMetadataApplication.main(OpenMetadataApplication.java:636)
Caused by: org.openmetadata.sdk.exception.UserCreationException: User Creation Exception [testsuite-bot] due to [null].
	at org.openmetadata.sdk.exception.UserCreationException.byMessage(UserCreationException.java:33)
	at org.openmetadata.service.util.UserUtil.addOrUpdateUser(UserUtil.java:171)
	at org.openmetadata.service.util.UserUtil.addOrUpdateBotUser(UserUtil.java:209)
	at org.openmetadata.service.resources.bots.BotResource.initialize(BotResource.java:116)
	... 14 common frames omitted
```

when initing the server if any change was required for bots.

This might impact other users too

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
