### PR TITLE
Fix: Handle NULL created_at

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/life_cycle_query_mixin.py
+++ b/ingestion/src/metadata/ingestion/source/database/life_cycle_query_mixin.py
@@ -99,17 +99,19 @@ class LifeCycleQueryMixin:
         Get the life cycle data
         """
         try:
-            life_cycle_data = self.life_cycle_query_dict(query=query).get(entity_name)
+            life_cycle_data = self.life_cycle_query_dict(query=query).get(entity_name)            
             if life_cycle_data:
+                if life_cycle_data.created_at:
+                    timestamp_value = datetime_to_timestamp(life_cycle_data.created_at, milliseconds=True)
+                else:
+                    timestamp_value = datetime_to_timestamp(datetime.min, milliseconds=True)  # Using minimum date
+
                 life_cycle = LifeCycle(
                     created=AccessDetails(
-                        timestamp=Timestamp(
-                            datetime_to_timestamp(
-                                life_cycle_data.created_at, milliseconds=True
-                            )
-                        )
+                        timestamp=Timestamp(timestamp_value)
                     )
                 )
+            
                 yield Either(
                     right=OMetaLifeCycleData(
                         entity=entity, entity_fqn=entity_fqn, life_cycle=life_cycle

--- a/ingestion/src/metadata/ingestion/source/database/life_cycle_query_mixin.py
+++ b/ingestion/src/metadata/ingestion/source/database/life_cycle_query_mixin.py
@@ -99,19 +99,21 @@ class LifeCycleQueryMixin:
         Get the life cycle data
         """
         try:
-            life_cycle_data = self.life_cycle_query_dict(query=query).get(entity_name)            
+            life_cycle_data = self.life_cycle_query_dict(query=query).get(entity_name)
             if life_cycle_data:
                 if life_cycle_data.created_at:
-                    timestamp_value = datetime_to_timestamp(life_cycle_data.created_at, milliseconds=True)
+                    timestamp_value = datetime_to_timestamp(
+                        life_cycle_data.created_at, milliseconds=True
+                    )
                 else:
-                    timestamp_value = datetime_to_timestamp(datetime.min, milliseconds=True)  # Using minimum date
+                    timestamp_value = datetime_to_timestamp(
+                        datetime.min, milliseconds=True
+                    )  # Using minimum date
 
                 life_cycle = LifeCycle(
-                    created=AccessDetails(
-                        timestamp=Timestamp(timestamp_value)
-                    )
+                    created=AccessDetails(timestamp=Timestamp(timestamp_value))
                 )
-            
+
                 yield Either(
                     right=OMetaLifeCycleData(
                         entity=entity, entity_fqn=entity_fqn, life_cycle=life_cycle


### PR DESCRIPTION
I worked on handling cases where `created_at` is `None`. This caused an error when OpenMetadata tried to call `.timestamp()` on `None`.  

To fix this, I added a check before calling `datetime_to_timestamp`, and if `created_at` is `None`,  
it falls back to `datetime.min`. This ensures ingestion does not fail due to missing creation timestamps.

Changes were tested by running metadata ingestion on tables with and without a valid `create_time`.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.