### PR TITLE
Minor: Fix the EntityDataConsumer test flakiness

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/EntityDataConsumer.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/EntityDataConsumer.spec.ts
@@ -75,22 +75,25 @@ entities.forEach((EntityClass) => {
       await entity.visitEntityPage(page);
     });
 
-    test('User as Owner Add, Update and Remove', async ({ page }) => {
-      test.slow(true);
+    // Running following 2 tests serially since they are dependent on each other
+    test.describe.serial('Owner permission tests', () => {
+      test('User as Owner Add, Update and Remove', async ({ page }) => {
+        test.slow(true);
 
-      const OWNER1 = EntityDataClass.user1.getUserName();
-      const OWNER2 = EntityDataClass.user2.getUserName();
-      const OWNER3 = EntityDataClass.user3.getUserName();
-      await entity.owner(page, [OWNER1, OWNER3], [OWNER2], undefined, false);
-    });
-
-    test('No edit owner permission', async ({ page }) => {
-      await page.reload();
-      await page.waitForSelector('[data-testid="loader"]', {
-        state: 'detached',
+        const OWNER1 = EntityDataClass.user1.getUserName();
+        const OWNER2 = EntityDataClass.user2.getUserName();
+        const OWNER3 = EntityDataClass.user3.getUserName();
+        await entity.owner(page, [OWNER1, OWNER3], [OWNER2], undefined, false);
       });
 
-      await expect(page.getByTestId('edit-owner')).not.toBeAttached();
+      test('No edit owner permission', async ({ page }) => {
+        await page.reload();
+        await page.waitForSelector('[data-testid="loader"]', {
+          state: 'detached',
+        });
+
+        await expect(page.getByTestId('edit-owner')).not.toBeAttached();
+      });
     });
 
     test('Tier Add, Update and Remove', async ({ page }) => {


### PR DESCRIPTION
I worked on fixing the playwright flakiness for `EntityDataConsumer.spec.ts`


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
