### PR TITLE
Fix: Update block editor url to open when clicked

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/index.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/index.ts
@@ -81,7 +81,7 @@ export const extensions = [
   }),
   LinkExtension.configure({
     autolink: false,
-    openOnClick: false,
+    openOnClick: true,
     linkOnPaste: true,
     HTMLAttributes: {
       rel: 'noopener noreferrer nofollow',


### PR DESCRIPTION
Updated the URL config for Editor so that clicking on URL will directly navigate to the assigned link.

**Before:**

https://github.com/user-attachments/assets/b2fabd4e-6b89-40f1-bc84-b40a0c3e6fa4


**After:**

https://github.com/user-attachments/assets/90e2bd36-eeba-4330-abb0-114abc1a6a80



<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
