### PR TITLE
MINOR: Modify from Profiler to Auto Classification for sample data

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.component.tsx
@@ -27,7 +27,6 @@ import { isEmpty, lowerCase } from 'lodash';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { ReactComponent as IconDelete } from '../../../assets/svg/ic-delete.svg';
 import { ReactComponent as IconDropdown } from '../../../assets/svg/menu.svg';
-import { WORKFLOWS_PROFILER_DOCS } from '../../../constants/docs.constants';
 import { mockDatasetData } from '../../../constants/mockTourData.constants';
 import { useTourProvider } from '../../../context/TourProvider/TourProvider';
 import { EntityType } from '../../../enums/entity.enum';
@@ -203,14 +202,14 @@ const SampleDataTable = ({
             i18nKey="message.view-sample-data-entity"
             renderElement={
               <a
-                href={WORKFLOWS_PROFILER_DOCS}
+                href={AUTO_CLASSIFICATION_DOCS}
                 rel="noreferrer"
                 style={{ color: theme.primaryColor }}
                 target="_blank"
               />
             }
             values={{
-              entity: t('label.profiler-ingestion'),
+              entity: t('label.auto-classification'),
             }}
           />
         </Typography.Paragraph>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.component.tsx
@@ -27,6 +27,7 @@ import { isEmpty, lowerCase } from 'lodash';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { ReactComponent as IconDelete } from '../../../assets/svg/ic-delete.svg';
 import { ReactComponent as IconDropdown } from '../../../assets/svg/menu.svg';
+import { AUTO_CLASSIFICATION_DOCS } from '../../../constants/docs.constants';
 import { mockDatasetData } from '../../../constants/mockTourData.constants';
 import { useTourProvider } from '../../../context/TourProvider/TourProvider';
 import { EntityType } from '../../../enums/entity.enum';

--- a/openmetadata-ui/src/main/resources/ui/src/constants/docs.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/docs.constants.ts
@@ -40,4 +40,5 @@ export const {
   CUSTOM_PROPERTIES_DOCS,
   DATA_DISCOVERY_DOCS,
   HOW_TO_GUIDE_DOCS,
+  AUTO_CLASSIFICATION_DOCS,
 } = documentationLinksClassBase.getDocsURLS();

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DocumentationLinksClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DocumentationLinksClassBase.ts
@@ -48,6 +48,7 @@ class DocumentationLinksClassBase {
       CUSTOM_PROPERTIES_DOCS: `${this.docsBaseURL}how-to-guides/guide-for-data-users/custom`,
       DATA_DISCOVERY_DOCS: `${this.docsBaseURL}how-to-guides/data-discovery`,
       HOW_TO_GUIDE_DOCS: `${this.docsBaseURL}how-to-guides`,
+      AUTO_CLASSIFICATION_DOCS: `${this.docsBaseURL}how-to-guides/data-governance/classification/auto`,
       OMD_SLACK_LINK:
         'https://join.slack.com/t/openmetadata/shared_invite/zt-1r1kv175f-9qM5eTB39MF6U2DBhZhWow',
       OMD_REPOSITORY_LINK: 'https://star-us.open-metadata.org/',


### PR DESCRIPTION
This pull request includes changes to update documentation links and constants in the `SampleDataTable` component. The most important changes include replacing the `WORKFLOWS_PROFILER_DOCS` link with `AUTO_CLASSIFICATION_DOCS` and updating the `docs.constants.ts` and `DocumentationLinksClassBase.ts` files to include the new documentation link.

Updates to documentation links:

* [`openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.component.tsx`](diffhunk://#diff-42ceb74d00818c3be7fed72fb995ddf6f64b99078c4602bc2e02358c86bef06dL206-R212): Replaced the `WORKFLOWS_PROFILER_DOCS` link with `AUTO_CLASSIFICATION_DOCS` and updated the label from 'profiler-ingestion' to 'auto-classification'.
* [`openmetadata-ui/src/main/resources/ui/src/constants/docs.constants.ts`](diffhunk://#diff-1c35457b23f11e7b294ff00b2db715c0143390b18f6f14b6808d7f37cd123be4R43): Added `AUTO_CLASSIFICATION_DOCS` to the exported documentation links.
* [`openmetadata-ui/src/main/resources/ui/src/utils/DocumentationLinksClassBase.ts`](diffhunk://#diff-67787ef2a2258b9e537146e60925e9112193d7143c47403e739de57fa182bd7aR51): Defined the `AUTO_CLASSIFICATION_DOCS` URL in the `DocumentationLinksClassBase` class.

Code cleanup:

* [`openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.component.tsx`](diffhunk://#diff-42ceb74d00818c3be7fed72fb995ddf6f64b99078c4602bc2e02358c86bef06dL30): Removed unused import `WORKFLOWS_PROFILER_DOCS`.