### PR TITLE
Fixes-20112: Make domain a required field for Data Product creation

### DIFF
--- a/openmetadata-spec/src/main/resources/json/schema/api/domains/createDataProduct.json
+++ b/openmetadata-spec/src/main/resources/json/schema/api/domains/createDataProduct.json
@@ -66,7 +66,8 @@
   },
   "required": [
     "name",
-    "description"
+    "description",
+    "domain"
   ],
   "additionalProperties": false
 }

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/domains/createDataProduct.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/domains/createDataProduct.ts
@@ -29,7 +29,7 @@ export interface CreateDataProduct {
     /**
      * Fully qualified name of the Domain the DataProduct belongs to.
      */
-    domain?: string;
+    domain: string;
     /**
      * List of user/login names of users who are experts in this DataProduct.
      */


### PR DESCRIPTION
The PR fixes #20112, i.e. Creation of Data Product throwing error on not sending domains, which is expected since Data Product cannot be without a domain


This pull request includes a small change to the `openmetadata-spec/src/main/resources/json/schema/api/domains/createDataProduct.json` file. The change adds the "domain" field to the list of required properties in the JSON schema.

* [`openmetadata-spec/src/main/resources/json/schema/api/domains/createDataProduct.json`](diffhunk://#diff-433db411d2509c1e787472cdaf94dab331881738d74557cfdc94c006916e4776L69-R70): Added "domain" to the list of required properties.


<img width="796" alt="Screenshot 2025-03-11 at 7 45 06 PM" src="https://github.com/user-attachments/assets/0cb0ed0b-6d85-496c-9897-8ae39ca9ff02" />
<img width="432" alt="Screenshot 2025-03-11 at 7 45 11 PM" src="https://github.com/user-attachments/assets/4e760de9-aa8a-40d8-bfe9-4ae562099d64" />


