### PR TITLE
readding textToHtmlString function

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/utils/BlockEditorUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/BlockEditorUtils.test.ts
@@ -13,8 +13,70 @@
 import {
   formatValueBasedOnContent,
   getHtmlStringFromMarkdownString,
+  getTextFromHtmlString,
   isHTMLString,
 } from './BlockEditorUtils';
+
+describe('getTextFromHtmlString', () => {
+  it('should return empty string when input is undefined', () => {
+    expect(getTextFromHtmlString(undefined)).toBe('');
+  });
+
+  it('should return empty string when input is empty string', () => {
+    expect(getTextFromHtmlString('')).toBe('');
+  });
+
+  it('should return same text when no HTML tags present', () => {
+    expect(getTextFromHtmlString('Hello World')).toBe('Hello World');
+  });
+
+  it('should remove simple HTML tags', () => {
+    expect(getTextFromHtmlString('<p>Hello World</p>')).toBe('Hello World');
+  });
+
+  it('should remove nested HTML tags', () => {
+    expect(
+      getTextFromHtmlString('<div><p>Hello <span>World</span></p></div>')
+    ).toBe('Hello World');
+  });
+
+  it('should remove HTML tags with attributes', () => {
+    expect(
+      getTextFromHtmlString(
+        '<p class="test" id="123">Hello <a href="#test">World</a></p>'
+      )
+    ).toBe('Hello World');
+  });
+
+  it('should handle multiple spaces and trim result', () => {
+    expect(getTextFromHtmlString('<p>  Hello    World  </p>  ')).toBe(
+      'Hello    World'
+    );
+  });
+
+  it('should preserve special characters', () => {
+    expect(getTextFromHtmlString('<p>Hello & World! @ #$%^</p>')).toBe(
+      'Hello & World! @ #$%^'
+    );
+  });
+
+  it('should handle complex nested structure', () => {
+    const input = `
+        <div class="container">
+          <h1>Title</h1>
+          <p>First <strong>paragraph</strong> with <em>emphasis</em></p>
+          <ul>
+            <li>Item 1</li>
+            <li>Item 2</li>
+          </ul>
+        </div>
+      `;
+
+    const output = getTextFromHtmlString(input);
+
+    expect(getTextFromHtmlString(input)).toBe(output);
+  });
+});
 
 describe('getHtmlStringFromMarkdownString', () => {
   it('should return the same string if input is already HTML', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/BlockEditorUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/BlockEditorUtils.ts
@@ -213,3 +213,16 @@ export const isDescriptionContentEmpty = (content: string) => {
   // Check if the content is empty or has only empty paragraph tags
   return isEmpty(content) || content === '<p></p>';
 };
+
+/**
+ *
+ * @param description HTML string
+ * @returns Text from HTML string
+ */
+export const getTextFromHtmlString = (description?: string): string => {
+  if (!description) {
+    return '';
+  }
+
+  return description.replace(/<[^>]{1,1000}>/g, '').trim();
+};


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

- I worked on readding textToHtmlString function which is used in function

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
