### PR TITLE
Fix #19915: Team filter fix on DataInsights Page

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/DataInsightProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DataInsightPage/DataInsightProvider.tsx
@@ -122,7 +122,9 @@ const DataInsightProvider = ({ children }: DataInsightProviderProps) => {
     }));
     setChartFilter((previous) => ({
       ...previous,
-      team: teams.length ? teams.map((team) => team.key).join(',') : undefined,
+      team: teams.length
+        ? teams.map((team) => team.label).join(',')
+        : undefined,
     }));
   };
 


### PR DESCRIPTION
Fix #19915: Team filter fix on DataInsights Page

I've a team who's name is `mergers & acquisitions` and displayname is `RANDOM` 
![image](https://github.com/user-attachments/assets/f8454fcd-106f-4012-bce7-a47afb50153e)

when I apply the filter on data insight page 
![image](https://github.com/user-attachments/assets/030e3720-cefa-4fe4-a99e-409f2b6a3d97)

before this change 
![image](https://github.com/user-attachments/assets/88caa751-5216-4547-b7ce-874da334a7fa)

after this change
![image](https://github.com/user-attachments/assets/6236a2d4-c411-4896-a7b2-5569b35a7747)

