### PR TITLE
MINOR: Fix NoOp Trigger Workflow Instance Time Series

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dayOneExperience/DayOneExperienceApp.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dayOneExperience/DayOneExperienceApp.java
@@ -3,6 +3,7 @@ package org.openmetadata.service.apps.bundles.dayOneExperience;
 import static org.openmetadata.service.governance.workflows.Workflow.GLOBAL_NAMESPACE;
 import static org.openmetadata.service.governance.workflows.Workflow.RELATED_ENTITY_VARIABLE;
 import static org.openmetadata.service.governance.workflows.WorkflowVariableHandler.getNamespacedVariableName;
+import static org.openmetadata.service.governance.workflows.elements.TriggerFactory.getTriggerWorkflowId;
 
 import java.io.InputStream;
 import java.util.HashMap;
@@ -81,7 +82,8 @@ public class DayOneExperienceApp extends AbstractNativeApplication {
           runtimeConfig.getEntityLink());
 
       WorkflowHandler.getInstance()
-          .triggerByKey(WORKFLOW_NAME, UUID.randomUUID().toString(), variables);
+          .triggerByKey(
+              getTriggerWorkflowId(WORKFLOW_NAME), UUID.randomUUID().toString(), variables);
     } else {
       LOG.info(
           String.format(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/triggers/NoOpTrigger.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/triggers/NoOpTrigger.java
@@ -1,15 +1,27 @@
 package org.openmetadata.service.governance.workflows.elements.triggers;
 
+import static org.openmetadata.service.governance.workflows.Workflow.EXCEPTION_VARIABLE;
+import static org.openmetadata.service.governance.workflows.Workflow.GLOBAL_NAMESPACE;
+import static org.openmetadata.service.governance.workflows.Workflow.WORKFLOW_RUNTIME_EXCEPTION;
 import static org.openmetadata.service.governance.workflows.Workflow.getFlowableElementId;
+import static org.openmetadata.service.governance.workflows.WorkflowVariableHandler.getNamespacedVariableName;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 import lombok.Getter;
+import org.flowable.bpmn.model.BoundaryEvent;
 import org.flowable.bpmn.model.BpmnModel;
+import org.flowable.bpmn.model.CallActivity;
 import org.flowable.bpmn.model.EndEvent;
+import org.flowable.bpmn.model.ErrorEventDefinition;
+import org.flowable.bpmn.model.IOParameter;
 import org.flowable.bpmn.model.Process;
 import org.flowable.bpmn.model.SequenceFlow;
 import org.flowable.bpmn.model.StartEvent;
 import org.openmetadata.schema.governance.workflows.elements.triggers.NoOpTriggerDefinition;
 import org.openmetadata.service.governance.workflows.elements.TriggerInterface;
+import org.openmetadata.service.governance.workflows.flowable.builders.CallActivityBuilder;
 import org.openmetadata.service.governance.workflows.flowable.builders.EndEventBuilder;
 import org.openmetadata.service.governance.workflows.flowable.builders.StartEventBuilder;
 
@@ -23,19 +35,69 @@ public class NoOpTrigger implements TriggerInterface {
     Process process = new Process();
     process.setId(triggerWorkflowId);
     process.setName(triggerWorkflowId);
+    attachWorkflowInstanceListeners(process);
 
     StartEvent startEvent =
         new StartEventBuilder().id(getFlowableElementId(triggerWorkflowId, "startEvent")).build();
     process.addFlowElement(startEvent);
 
+    CallActivity workflowTrigger =
+        getWorkflowTrigger(triggerWorkflowId, mainWorkflowName, triggerDefinition.getOutput());
+    process.addFlowElement(workflowTrigger);
+
+    ErrorEventDefinition runtimeExceptionDefinition = new ErrorEventDefinition();
+    runtimeExceptionDefinition.setErrorCode(WORKFLOW_RUNTIME_EXCEPTION);
+
+    BoundaryEvent runtimeExceptionBoundaryEvent = new BoundaryEvent();
+    runtimeExceptionBoundaryEvent.setId(
+        getFlowableElementId(workflowTrigger.getId(), "runtimeExceptionBoundaryEvent"));
+    runtimeExceptionBoundaryEvent.addEventDefinition(runtimeExceptionDefinition);
+
+    runtimeExceptionBoundaryEvent.setAttachedToRef(workflowTrigger);
+    process.addFlowElement(runtimeExceptionBoundaryEvent);
+
+    EndEvent errorEndEvent =
+        new EndEventBuilder().id(getFlowableElementId(triggerWorkflowId, "errorEndEvent")).build();
+    process.addFlowElement(errorEndEvent);
     EndEvent endEvent =
         new EndEventBuilder().id(getFlowableElementId(triggerWorkflowId, "endEvent")).build();
     process.addFlowElement(endEvent);
 
-    process.addFlowElement(new SequenceFlow(startEvent.getId(), endEvent.getId()));
+    process.addFlowElement(new SequenceFlow(startEvent.getId(), workflowTrigger.getId()));
+    process.addFlowElement(new SequenceFlow(workflowTrigger.getId(), endEvent.getId()));
+    process.addFlowElement(
+        new SequenceFlow(runtimeExceptionBoundaryEvent.getId(), errorEndEvent.getId()));
 
     this.process = process;
     this.triggerWorkflowId = triggerWorkflowId;
+  }
+
+  private CallActivity getWorkflowTrigger(
+      String triggerWorkflowId, String mainWorkflowName, Set<String> triggerOutputs) {
+    CallActivity workflowTrigger =
+        new CallActivityBuilder()
+            .id(getFlowableElementId(triggerWorkflowId, "workflowTrigger"))
+            .calledElement(mainWorkflowName)
+            .inheritBusinessKey(true)
+            .build();
+
+    List<IOParameter> inputParameters = new ArrayList<>();
+
+    for (String triggerOutput : triggerOutputs) {
+      IOParameter inputParameter = new IOParameter();
+      inputParameter.setSource(getNamespacedVariableName(GLOBAL_NAMESPACE, triggerOutput));
+      inputParameter.setTarget(getNamespacedVariableName(GLOBAL_NAMESPACE, triggerOutput));
+      inputParameters.add(inputParameter);
+    }
+
+    IOParameter outputParameter = new IOParameter();
+    outputParameter.setSource(getNamespacedVariableName(GLOBAL_NAMESPACE, EXCEPTION_VARIABLE));
+    outputParameter.setTarget(getNamespacedVariableName(GLOBAL_NAMESPACE, EXCEPTION_VARIABLE));
+
+    workflowTrigger.setInParameters(inputParameters);
+    workflowTrigger.setOutParameters(List.of(outputParameter));
+
+    return workflowTrigger;
   }
 
   @Override

--- a/openmetadata-service/src/main/resources/applications/DayOneExperienceApplication/openmetadata/DayOneExperienceWorkflow.json
+++ b/openmetadata-service/src/main/resources/applications/DayOneExperienceApplication/openmetadata/DayOneExperienceWorkflow.json
@@ -8,7 +8,10 @@
     "storeStageStatus": true
   },
   "trigger": {
-    "type": "noOp"
+    "type": "noOp",
+    "output": [
+      "relatedEntity"
+    ]
   },
   "nodes": [
     {

--- a/openmetadata-spec/src/main/resources/json/schema/governance/workflows/elements/triggers/noOpTrigger.json
+++ b/openmetadata-spec/src/main/resources/json/schema/governance/workflows/elements/triggers/noOpTrigger.json
@@ -21,8 +21,6 @@
       },
       "default": [],
       "additionalItems": false,
-      "minItems": 0,
-      "maxItems": 0,
       "uniqueItems": true
     }
   },


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

Change how the NoOp Trigger works:
Instead of just doing nothing, it will trigger a workflow, passing all the variables passed to it as GLOBAL variables.
This changes allows NoOp to work similar to other triggers without having to be handled anyway special (We could argue we should change teh name to manual. And eventually imho this should be the raw PeriodicTrigger, but for now it will remain as NoOp)

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
