### PR TITLE
Fix : Delete user playwright test 

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/user.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/user.ts
@@ -202,7 +202,7 @@ export const hardDeleteUserProfilePage = async (
   await page.click('[data-testid="confirm-button"]');
 
   await deleteResponse;
-
+  await page.waitForLoadState('networkidle');
   await toastNotification(page, /deleted successfully!/);
 };
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/user.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/user.ts
@@ -196,13 +196,18 @@ export const hardDeleteUserProfilePage = async (
   await page.check('[data-testid="hard-delete"]');
   await page.fill('[data-testid="confirmation-text-input"]', 'DELETE');
 
+  const toastPromises = [
+    page.waitForSelector('[data-testid="alert-bar"]'),
+    page.waitForSelector('[data-testid="alert-icon"]'),
+    page.waitForSelector('[data-testid="alert-icon-close"]'),
+  ];
   const deleteResponse = page.waitForResponse(
     '/api/v1/users/*?hardDelete=true&recursive=true'
   );
   await page.click('[data-testid="confirm-button"]');
 
-  await deleteResponse;
-  await page.waitForLoadState('networkidle');
+  // Wait for both the delete response and all toast elements to appear
+  await Promise.all([deleteResponse, ...toastPromises]);
   await toastNotification(page, /deleted successfully!/);
 };
 


### PR DESCRIPTION
Fixed an issue where the flaky test "Admin soft & hard delete and restore user from profile page"  was failing to locate the alert-icon due to a page redirection causing the alert to close before it was found.

 Fix:-
Updated the  logic to wait for all toast elements (alert-bar, alert-icon, and alert-icon-close) after the delete action. So that the alert elements are detected properly






<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
