### PR TITLE
MINOR: Fix LongRunning Steps Retriggering Endlessly

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/nodes/automatedTask/createAndRunIngestionPipeline/CreateAndRunIngestionPipelineTask.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/nodes/automatedTask/createAndRunIngestionPipeline/CreateAndRunIngestionPipelineTask.java
@@ -32,7 +32,7 @@ public class CreateAndRunIngestionPipelineTask implements NodeInterface {
     String subProcessId = nodeDefinition.getName();
 
     SubProcess subProcess =
-        new SubProcessBuilder().id(subProcessId).setAsync(true).exclusive(false).build();
+        new SubProcessBuilder().id(subProcessId).setAsync(true).exclusive(true).build();
 
     StartEvent startEvent =
         new StartEventBuilder().id(getFlowableElementId(subProcessId, "startEvent")).build();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/flowable/sql/SqlMapper.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/flowable/sql/SqlMapper.java
@@ -1,0 +1,13 @@
+package org.openmetadata.service.governance.workflows.flowable.sql;
+
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Update;
+
+public interface SqlMapper {
+  @Update(
+      "UPDATE ACT_RU_EXECUTION SET LOCK_OWNER_ = NULL, LOCK_TIME_ = NULL WHERE ID_ = #{executionId}")
+  void unlockExecution(@Param("executionId") String executionId);
+
+  @Update("UPDATE ACT_RU_JOB SET LOCK_OWNER_ = NULL, LOCK_EXP_TIME_ = NULL WHERE ID_ = #{jobId}")
+  void unlockJob(@Param("jobId") String jobId);
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/flowable/sql/UnlockExecutionSql.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/flowable/sql/UnlockExecutionSql.java
@@ -1,0 +1,23 @@
+package org.openmetadata.service.governance.workflows.flowable.sql;
+
+import org.flowable.common.engine.impl.cmd.CustomSqlExecution;
+
+public class UnlockExecutionSql implements CustomSqlExecution<SqlMapper, Void> {
+
+  private final String executionId;
+
+  public UnlockExecutionSql(String executionId) {
+    this.executionId = executionId;
+  }
+
+  @Override
+  public Class<SqlMapper> getMapperClass() {
+    return SqlMapper.class;
+  }
+
+  @Override
+  public Void execute(SqlMapper mapper) {
+    mapper.unlockExecution(executionId);
+    return null;
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/flowable/sql/UnlockJobSql.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/flowable/sql/UnlockJobSql.java
@@ -1,0 +1,23 @@
+package org.openmetadata.service.governance.workflows.flowable.sql;
+
+import org.flowable.common.engine.impl.cmd.CustomSqlExecution;
+
+public class UnlockJobSql implements CustomSqlExecution<SqlMapper, Void> {
+
+  private final String executionId;
+
+  public UnlockJobSql(String executionId) {
+    this.executionId = executionId;
+  }
+
+  @Override
+  public Class<SqlMapper> getMapperClass() {
+    return SqlMapper.class;
+  }
+
+  @Override
+  public Void execute(SqlMapper mapper) {
+    mapper.unlockJob(executionId);
+    return null;
+  }
+}

--- a/openmetadata-spec/src/main/resources/json/schema/configuration/workflowSettings.json
+++ b/openmetadata-spec/src/main/resources/json/schema/configuration/workflowSettings.json
@@ -31,8 +31,8 @@
         },
         "jobLockTimeInMillis": {
           "type": "integer",
-          "default": 300000,
-          "description": "The amount of time a Job gets locked before being retried."
+          "default": 1296000000,
+          "description": "The amount of time a Job gets locked before being retried. Default: 15 Days. This avoids jobs that takes too long to run being retried while running."
         }
       },
       "additionalProperties": false

--- a/openmetadata-ui/src/main/resources/ui/src/generated/configuration/workflowSettings.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/configuration/workflowSettings.ts
@@ -33,7 +33,8 @@ export interface ExecutorConfiguration {
      */
     corePoolSize?: number;
     /**
-     * The amount of time a Job gets locked before being retried.
+     * The amount of time a Job gets locked before being retried. Default: 15 Days. This avoids
+     * jobs that takes too long to run being retried while running.
      */
     jobLockTimeInMillis?: number;
     /**


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

We had a short `jobLockTimeInMillis` default in order to be able to rapidly retry a Task if the server crashed in the middle of it.
Sadly this does not work as expected as after the lock expires, flowable picks the task again, even if it is indeed running. This was causing long running tasks to endlessly retrigger.

In order to fix this we did the following:
1. Increase the `jobLockTimeInMillis` from 5min to 15 days, to guarantee no tasks would be retried while running.
2. Implemented a `unlockJobsOnStartup()` method that would reset the lock manually on startup, getting any task ready to be picked up by any executor.


<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
