### PR TITLE
Minor : Fixed header component Wrapping

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetsHeader/data-asset-header.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetsHeader/data-asset-header.less
@@ -24,8 +24,9 @@
     border-radius: 12px;
     border: 0.5px solid @grey-300;
     padding: 20px;
-    gap: 28px;
+    gap: 16px;
     background-color: @background-color;
+    justify-content: space-evenly;
   }
   .ant-space-item {
     .entity-no-tier {
@@ -83,7 +84,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    width: 148px;
+    max-width: 148px;
   }
 
   .ant-btn-group {
@@ -131,6 +132,6 @@
   }
   .tier-container,
   .extra-info-container {
-    width: 148px;
+    max-width: 148px;
   }
 }

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/RetentionPeriod/RetentionPeriod.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/RetentionPeriod/RetentionPeriod.component.tsx
@@ -132,10 +132,9 @@ const RetentionPeriod = ({
                     entity: t('label.retention-period'),
                   })}>
                   <Button
-                    className="edit-retention-period-button p-0"
+                    className="remove-button-default-styling  flex-center edit-retention-period-button p-0"
                     data-testid="edit-retention-period-button"
-                    icon={<EditIcon color={DE_ACTIVE_COLOR} width="14px" />}
-                    size="small"
+                    icon={<EditIcon color={DE_ACTIVE_COLOR} width="12px" />}
                     type="text"
                     onClick={() => setIsEdit(true)}
                   />

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/RetentionPeriod/retention-period.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/RetentionPeriod/retention-period.less
@@ -12,8 +12,11 @@
  */
 @import url('../../../styles/variables.less');
 
-.ant-btn-icon-only.edit-retention-period-button {
+.ant-btn-icon-only.remove-button-default-styling.edit-retention-period-button {
   border: 1px solid @border-light;
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
 }
 
 span.extra-info-label-heading {
@@ -22,5 +25,5 @@ span.extra-info-label-heading {
 }
 
 .retention-period-container {
-  width: 148px;
+  max-width: 148px;
 }

--- a/openmetadata-ui/src/main/resources/ui/src/components/Metric/MetricHeaderInfo/metric-header-info.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Metric/MetricHeaderInfo/metric-header-info.less
@@ -30,5 +30,5 @@
   }
 }
 .metric-header-info-container {
-  width: 148px;
+  max-width: 148px;
 }

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/DomainLabel/domain-label.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/DomainLabel/domain-label.less
@@ -21,6 +21,6 @@
 }
 .data-assets-header-container {
   .domain-link-container {
-    width: 148px;
+    max-width: 148px;
   }
 }

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/OwnerLabel/owner-label.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/OwnerLabel/owner-label.less
@@ -127,5 +127,5 @@
 }
 
 .owner-label-container {
-  width: 148px;
+  max-width: 148px;
 }


### PR DESCRIPTION

Fixed Data Asset Header wrapping issue and updated styling for the retention period edit button.

Before:
<img width="1354" alt="Screenshot 2025-03-26 at 4 02 44 PM" src="https://github.com/user-attachments/assets/a333efc2-0581-4f78-b0ad-4336b492b250" />

After
<img width="1417" alt="Screenshot 2025-03-26 at 4 03 30 PM" src="https://github.com/user-attachments/assets/896a4db3-f72b-4081-9612-4c78a1c7cf5e" />

<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement


