### PR TITLE
Minor :fixed Glossary Label condition

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityVersionUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityVersionUtils.tsx
@@ -334,6 +334,8 @@ const getGlossaryTermApprovalText = (fieldsChanged: FieldChange[]) => {
       status:
         statusFieldDiff.newValue === 'Approved'
           ? t('label.approved')
+          : statusFieldDiff.newValue === 'In Review'
+          ? t('label.in-review')
           : t('label.rejected'),
     });
   }


### PR DESCRIPTION


I worked on glossary inside newly created term when user click on version it was displayed the term has been reject but in actual it was in review

Before

https://github.com/user-attachments/assets/bd9e614d-84be-46da-b7e2-96370a647a21

After
<img width="1337" alt="Screenshot 2025-03-26 at 7 06 02 PM" src="https://github.com/user-attachments/assets/cb7d05b0-3b1c-4040-ba6c-286422be2d6c" />

### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


