### PR TITLE
[fix] deleted empty warning from s3 ingestion

### DIFF
--- a/ingestion/src/metadata/ingestion/source/storage/s3/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/storage/s3/metadata.py
@@ -305,7 +305,6 @@ class S3Source(StorageServiceSource):
                     client=self.s3_client,
                 )
             except Exception as err:
-                logger.warning()
                 self.status.failed(
                     error=StackTraceError(
                         name=f"{bucket_name}/{sample_key}",


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

S3 ingestion has an empty `logger.warning()` statement that fails the entire ingestion, as the log requires message.
Warning has been deleted - the error is added to list of failures, so additional log is redundant.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
