### PR TITLE
FIX: switch dbx to approx_percentile

### DIFF
--- a/ingestion/src/metadata/profiler/orm/functions/median.py
+++ b/ingestion/src/metadata/profiler/orm/functions/median.py
@@ -51,6 +51,14 @@ def _(elements, compiler, **kwargs):
     return "percentile_cont(%s , %s) OVER()" % (col, percentile)
 
 
+@compiles(MedianFn, Dialects.Databricks)
+def _(elements, compiler, **kwargs):
+    col, _, percentile = [
+        compiler.process(element, **kwargs) for element in elements.clauses
+    ]
+    return "percentile_approx(%s , %s)" % (col, percentile)
+
+
 # pylint: disable=unused-argument
 @compiles(MedianFn, Dialects.Cockroach)
 def _(elements, compiler, **kwargs):


### PR DESCRIPTION
## Describe your changes:
- Switched to approx percentile for dbx. Conducting small test, accuracy of approx percentile (even on small dataset ~20K rows) seems to be on part with percentile count
- approx percentile will use t-digest algorithm providing better computational efficiency 


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

Improvement
- [x] I have added tests around the new logic.
- [x] For connector/ingestion changes: I updated the documentation.

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
