### PR TITLE
(Docs) Correct URLs and Enable OIDC

### DIFF
--- a/openmetadata-docs/content/v1.7.x/deployment/security/keycloak/kubernetes.md
+++ b/openmetadata-docs/content/v1.7.x/deployment/security/keycloak/kubernetes.md
@@ -34,8 +34,8 @@ openmetadata:
       provider: "custom-oidc"
       publicKeys:
       - "{OMD-server-domain}/api/v1/system/config/jwks" # Update with your Domain and Make sure this "/api/v1/system/config/jwks" is always configured to enable JWT tokens
-      - "{Keycloak-server-URL}/auth/realms/{your-realm-name}/protocol/openid-connect/certs"
-      authority: "{Keycloak-server-URL}/auth/realms/{your-realm-name}"      
+      - "{Keycloak-server-URL}/realms/{your-realm-name}/protocol/openid-connect/certs"
+      authority: "{Keycloak-server-URL}/realms/{your-realm-name}/protocol/openid-connect/auth"
       clientId: "{Client ID}"                                        # Update your Client ID
       callbackUrl: "http://localhost:8585/callback"
 ```
@@ -59,8 +59,8 @@ openmetadata:
       provider: "custom-oidc"
       publicKeys:
       - "{OMD-server-domain}/api/v1/system/config/jwks" # Update with your Domain and Make sure this "/api/v1/system/config/jwks" is always configured to enable JWT tokens
-      - "{Keycloak-server-URL}/auth/realms/{your-realm-name}/protocol/openid-connect/certs"
-      authority: "{Keycloak-server-URL}/auth/realms/{your-realm-name}"      
+      - "{Keycloak-server-URL}/realms/{your-realm-name}/protocol/openid-connect/certs"
+      authority: "{Keycloak-server-URL}/realms/{your-realm-name}/protocol/openid-connect/auth"
       clientId: "{Client ID}"                                        # Update your Client ID
       callbackUrl: "http://localhost:8585/callback"
       oidcConfiguration:

--- a/openmetadata-docs/content/v1.7.x/deployment/security/keycloak/kubernetes.md
+++ b/openmetadata-docs/content/v1.7.x/deployment/security/keycloak/kubernetes.md
@@ -64,6 +64,7 @@ openmetadata:
       clientId: "{Client ID}"                                        # Update your Client ID
       callbackUrl: "http://localhost:8585/callback"
       oidcConfiguration:
+        enabled: true
         oidcType: "Keycloak"  
         clientId:
           secretRef: oidc-secrets

--- a/openmetadata-docs/content/v1.8.x/deployment/security/keycloak/kubernetes.md
+++ b/openmetadata-docs/content/v1.8.x/deployment/security/keycloak/kubernetes.md
@@ -34,8 +34,8 @@ openmetadata:
       provider: "custom-oidc"
       publicKeys:
       - "{OMD-server-domain}/api/v1/system/config/jwks" # Update with your Domain and Make sure this "/api/v1/system/config/jwks" is always configured to enable JWT tokens
-      - "{Keycloak-server-URL}/auth/realms/{your-realm-name}/protocol/openid-connect/certs"
-      authority: "{Keycloak-server-URL}/auth/realms/{your-realm-name}"      
+      - "{Keycloak-server-URL}/realms/{your-realm-name}/protocol/openid-connect/certs"
+      authority: "{Keycloak-server-URL}/realms/{your-realm-name}/protocol/openid-connect/auth"      
       clientId: "{Client ID}"                                        # Update your Client ID
       callbackUrl: "http://localhost:8585/callback"
 ```
@@ -59,11 +59,12 @@ openmetadata:
       provider: "custom-oidc"
       publicKeys:
       - "{OMD-server-domain}/api/v1/system/config/jwks" # Update with your Domain and Make sure this "/api/v1/system/config/jwks" is always configured to enable JWT tokens
-      - "{Keycloak-server-URL}/auth/realms/{your-realm-name}/protocol/openid-connect/certs"
-      authority: "{Keycloak-server-URL}/auth/realms/{your-realm-name}"      
+      - "{Keycloak-server-URL}/realms/{your-realm-name}/protocol/openid-connect/certs"
+      authority: "{Keycloak-server-URL}/realms/{your-realm-name}/protocol/openid-connect/auth"      
       clientId: "{Client ID}"                                        # Update your Client ID
       callbackUrl: "http://localhost:8585/callback"
       oidcConfiguration:
+        enabled: true
         oidcType: "Keycloak"  
         clientId:
           secretRef: oidc-secrets

--- a/openmetadata-docs/content/v1.9.x-SNAPSHOT/deployment/security/keycloak/kubernetes.md
+++ b/openmetadata-docs/content/v1.9.x-SNAPSHOT/deployment/security/keycloak/kubernetes.md
@@ -34,8 +34,8 @@ openmetadata:
       provider: "custom-oidc"
       publicKeys:
       - "{OMD-server-domain}/api/v1/system/config/jwks" # Update with your Domain and Make sure this "/api/v1/system/config/jwks" is always configured to enable JWT tokens
-      - "{Keycloak-server-URL}/auth/realms/{your-realm-name}/protocol/openid-connect/certs"
-      authority: "{Keycloak-server-URL}/auth/realms/{your-realm-name}"      
+      - "{Keycloak-server-URL}/realms/{your-realm-name}/protocol/openid-connect/certs"
+      authority: "{Keycloak-server-URL}/realms/{your-realm-name}/protocol/openid-connect/auth"
       clientId: "{Client ID}"                                        # Update your Client ID
       callbackUrl: "http://localhost:8585/callback"
 ```
@@ -59,8 +59,8 @@ openmetadata:
       provider: "custom-oidc"
       publicKeys:
       - "{OMD-server-domain}/api/v1/system/config/jwks" # Update with your Domain and Make sure this "/api/v1/system/config/jwks" is always configured to enable JWT tokens
-      - "{Keycloak-server-URL}/auth/realms/{your-realm-name}/protocol/openid-connect/certs"
-      authority: "{Keycloak-server-URL}/auth/realms/{your-realm-name}"      
+      - "{Keycloak-server-URL}/realms/{your-realm-name}/protocol/openid-connect/certs"
+      authority: "{Keycloak-server-URL}/realms/{your-realm-name}/protocol/openid-connect/auth"
       clientId: "{Client ID}"                                        # Update your Client ID
       callbackUrl: "http://localhost:8585/callback"
       oidcConfiguration:

--- a/openmetadata-docs/content/v1.9.x-SNAPSHOT/deployment/security/keycloak/kubernetes.md
+++ b/openmetadata-docs/content/v1.9.x-SNAPSHOT/deployment/security/keycloak/kubernetes.md
@@ -64,6 +64,7 @@ openmetadata:
       clientId: "{Client ID}"                                        # Update your Client ID
       callbackUrl: "http://localhost:8585/callback"
       oidcConfiguration:
+        enabled: true
         oidcType: "Keycloak"  
         clientId:
           secretRef: oidc-secrets


### PR DESCRIPTION
The KeyCloak URLs were incorrect for the current version of KeyCloak, and additionally the documentation was missing the required key to enable OIDC.