### PR TITLE
Fix: IncidentManager date filtering and update table column title

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/IncidentManager/IncidentManager.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/IncidentManager/IncidentManager.component.tsx
@@ -59,7 +59,9 @@ import {
 import {
   formatDateTimeLong,
   getCurrentMillis,
+  getEndOfDayInMillis,
   getEpochMillisForPastDays,
+  getStartOfDayInMillis,
 } from '../../utils/date-time/DateTimeUtils';
 import {
   getEntityName,
@@ -115,8 +117,10 @@ const IncidentManager = ({
       isLoading: true,
     });
   const [filters, setFilters] = useState<TestCaseIncidentStatusParams>({
-    startTs: getEpochMillisForPastDays(PROFILER_FILTER_RANGE.last30days.days),
-    endTs: getCurrentMillis(),
+    startTs: getStartOfDayInMillis(
+      getEpochMillisForPastDays(PROFILER_FILTER_RANGE.last30days.days)
+    ),
+    endTs: getEndOfDayInMillis(getCurrentMillis()),
     ...searchParams,
   });
   const [users, setUsers] = useState<{
@@ -464,7 +468,7 @@ const IncidentManager = ({
           ]
         : []),
       {
-        title: t('label.execution-time'),
+        title: t('label.last-updated'),
         dataIndex: 'timestamp',
         key: 'timestamp',
         width: 200,

--- a/openmetadata-ui/src/main/resources/ui/src/components/IncidentManager/IncidentManager.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/IncidentManager/IncidentManager.test.tsx
@@ -78,6 +78,14 @@ jest.mock('../../rest/incidentManagerAPI', () => ({
     .mockImplementation(() => Promise.resolve({ data: [] })),
   updateTestCaseIncidentById: jest.fn(),
 }));
+jest.mock('../../rest/miscAPI', () => ({
+  getUserAndTeamSearch: jest
+    .fn()
+    .mockImplementation(() => Promise.resolve({ data: [] })),
+}));
+jest.mock('../../rest/userAPI', () => ({
+  getUsers: jest.fn().mockImplementation(() => Promise.resolve({ data: [] })),
+}));
 jest.mock('../../rest/searchAPI', () => ({
   searchQuery: jest
     .fn()
@@ -98,12 +106,18 @@ jest.mock('../../utils/date-time/DateTimeUtils', () => {
       .mockImplementation(() => 1709556624254),
     formatDateTime: jest.fn().mockImplementation(() => 'formatted date'),
     getCurrentMillis: jest.fn().mockImplementation(() => 1710161424255),
+    getStartOfDayInMillis: jest
+      .fn()
+      .mockImplementation((timestamp) => timestamp),
+    getEndOfDayInMillis: jest.fn().mockImplementation((timestamp) => timestamp),
   };
 });
 
 describe('IncidentManagerPage', () => {
   it('should render component', async () => {
-    render(<IncidentManager />);
+    await act(async () => {
+      render(<IncidentManager />);
+    });
 
     expect(await screen.findByTestId('status-select')).toBeInTheDocument();
     expect(
@@ -124,11 +138,13 @@ describe('IncidentManagerPage', () => {
   it('Incident should be fetch with updated time', async () => {
     const mockGetListTestCaseIncidentStatus =
       getListTestCaseIncidentStatus as jest.Mock;
-    render(<IncidentManager />);
+    await act(async () => {
+      render(<IncidentManager />);
+    });
 
     const timeFilterButton = await screen.findByTestId('time-filter');
 
-    act(() => {
+    await act(async () => {
       fireEvent.click(timeFilterButton);
     });
 
@@ -140,14 +156,18 @@ describe('IncidentManagerPage', () => {
     });
   });
 
-  it('Should not ender table column if isIncidentManager is false', () => {
-    render(<IncidentManager isIncidentPage={false} />);
+  it('Should not ender table column if isIncidentManager is false', async () => {
+    await act(async () => {
+      render(<IncidentManager isIncidentPage={false} />);
+    });
 
     expect(screen.queryByText('label.table')).not.toBeInTheDocument();
   });
 
-  it('Should render table column if isIncidentManager is true', () => {
-    render(<IncidentManager isIncidentPage />);
+  it('Should render table column if isIncidentManager is true', async () => {
+    await act(async () => {
+      render(<IncidentManager isIncidentPage />);
+    });
 
     expect(screen.getByText('label.table')).toBeInTheDocument();
   });


### PR DESCRIPTION
Enhance IncidentManager date filtering and update table column title

- Updated date filtering logic to use getStartOfDayInMillis and getEndOfDayInMillis for improved accuracy.
- Changed table column title from 'execution-time' to 'last-updated' for better clarity.
- Added additional mocks in tests for user and team search APIs to ensure proper functionality during testing.