### PR TITLE
MINOR: Improve column validation logic in lineage API

### DIFF
--- a/common/src/main/java/org/openmetadata/common/utils/CommonUtil.java
+++ b/common/src/main/java/org/openmetadata/common/utils/CommonUtil.java
@@ -34,6 +34,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -261,6 +262,24 @@ public final class CommonUtil {
               });
     } catch (Exception e) {
       return false;
+    }
+  }
+
+  public static <T> Set<String> getChildrenNames(
+      List<?> list, String methodName, String parentFqn) {
+    Set<String> result = new HashSet<>();
+    if (list == null || list.isEmpty()) return new HashSet();
+    try {
+      Method getChildren = list.get(0).getClass().getMethod(methodName);
+      Method getFQN = list.get(0).getClass().getMethod("getFullyQualifiedName");
+      for (int i = 0; i < list.size(); i++) {
+        result.add(getFQN.invoke(list.get(i)).toString().replace(parentFqn + ".", ""));
+        result.addAll(
+            getChildrenNames((List<?>) getChildren.invoke(list.get(i)), methodName, parentFqn));
+      }
+      return result;
+    } catch (Exception e) {
+      return result;
     }
   }
 }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/lineage/LineageResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/lineage/LineageResourceTest.java
@@ -401,7 +401,7 @@ public class LineageResourceTest extends OpenMetadataApplicationTest {
     assertResponse(
         () -> addEdge(TOPIC, TABLE_DATA_MODEL_LINEAGE, topicToTable, ADMIN_AUTH_HEADERS),
         BAD_REQUEST,
-        String.format("Invalid field name %s", f3FQN));
+        String.format("Invalid column name %s", f3FQN));
 
     LineageDetails topicToContainer = new LineageDetails();
     String f1c1 = CONTAINER.getDataModel().getColumns().get(0).getFullyQualifiedName();
@@ -418,7 +418,7 @@ public class LineageResourceTest extends OpenMetadataApplicationTest {
     assertResponse(
         () -> addEdge(TOPIC, CONTAINER, topicToContainer, ADMIN_AUTH_HEADERS),
         BAD_REQUEST,
-        String.format("Invalid fully qualified column name %s", f2c3FQN));
+        String.format("Invalid column name %s", f2c3FQN));
 
     LineageDetails containerToTable = new LineageDetails();
     List<ColumnLineage> containerToTableLineage = containerToTable.getColumnsLineage();
@@ -443,7 +443,7 @@ public class LineageResourceTest extends OpenMetadataApplicationTest {
     assertResponse(
         () -> addEdge(TABLE_DATA_MODEL_LINEAGE, ML_MODEL, tableToMlModel, ADMIN_AUTH_HEADERS),
         BAD_REQUEST,
-        String.format("Invalid feature name %s", m3f3));
+        String.format("Invalid column name %s", m3f3));
 
     LineageDetails tableToDashboard = new LineageDetails();
     String c1d1 = DASHBOARD.getCharts().get(0).getFullyQualifiedName();

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/lineage/LineageResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/lineage/LineageResourceTest.java
@@ -342,14 +342,14 @@ public class LineageResourceTest extends OpenMetadataApplicationTest {
     assertResponse(
         () -> addEdge(TABLES.get(0), TABLES.get(1), details, ADMIN_AUTH_HEADERS),
         BAD_REQUEST,
-        "Invalid fully qualified column name invalidColumn");
+        "Invalid column name invalidColumn");
     details
         .getColumnsLineage()
         .add(new ColumnLineage().withFromColumns(List.of(t1c1FQN)).withToColumn("invalidColumn"));
     assertResponse(
         () -> addEdge(TABLES.get(0), TABLES.get(1), details, ADMIN_AUTH_HEADERS),
         BAD_REQUEST,
-        "Invalid fully qualified column name invalidColumn");
+        "Invalid column name invalidColumn");
 
     // Add column level lineage with multiple fromColumns (t1c1 + t3c1) to t2c1
     details.getColumnsLineage().clear();


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

This pr optimises the logic of validating column lineage from O(n^2) to O(n)

Before the fix

![image](https://github.com/user-attachments/assets/24fa5923-7fdb-4d48-b6ac-5624d447d2aa)


After the fix

![image](https://github.com/user-attachments/assets/577113e0-12b3-4824-b18e-4ec89ab0a32a)





#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
