### PR TITLE
Revert "Fixes #20649: removed memory leak in Redshift ingestion"

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/redshift/utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/redshift/utils.py
@@ -138,13 +138,12 @@ def _get_schema_column_info(
     """
     schema_clause = f"AND schema = '{schema if schema else ''}'"
     all_columns = defaultdict(list)
-    # Ensure the result proxy is closed after using it
-    with connection.execute(
+    result = connection.execute(
         REDSHIFT_GET_SCHEMA_COLUMN_INFO.format(schema_clause=schema_clause)
-    ) as result:
-        for col in result.fetchall():
-            key = RelationKey(col.table_name, col.schema, connection)
-            all_columns[key].append(col)
+    )
+    for col in result:
+        key = RelationKey(col.table_name, col.schema, connection)
+        all_columns[key].append(col)
     return dict(all_columns)
 
 


### PR DESCRIPTION
Reverts open-metadata/OpenMetadata#20650

Since the output of `connection.execute()` is a `LegacyCursorResult` object that does not support context manager methods, it is causing Redshift ingestion to fail.