### PR TITLE
fix: enable additional properties for indexingError.json

### DIFF
--- a/openmetadata-spec/src/main/resources/json/schema/system/indexingError.json
+++ b/openmetadata-spec/src/main/resources/json/schema/system/indexingError.json
@@ -2,7 +2,7 @@
   "$id": "https://open-metadata.org/schema/system/indexingError.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "IndexingAppError",
-  "description": "This schema defines Event Publisher Job Error Schema.",
+  "description": "This schema defines Event Publisher Job Error Schema. Additional properties exist for backward compatibility. Don't use it.",
   "type": "object",
   "javaType": "org.openmetadata.schema.system.IndexingError",
   "definitions": {
@@ -43,5 +43,5 @@
       "type": "integer"
     }
   },
-  "additionalProperties": false
+  "additionalProperties": true
 }

--- a/openmetadata-ui/src/main/resources/ui/src/generated/system/indexingError.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/system/indexingError.ts
@@ -11,7 +11,8 @@
  *  limitations under the License.
  */
 /**
- * This schema defines Event Publisher Job Error Schema.
+ * This schema defines Event Publisher Job Error Schema. Additional properties exist for
+ * backward compatibility. Don't use it.
  */
 export interface IndexingError {
     errorSource?:      ErrorSource;
@@ -23,6 +24,7 @@ export interface IndexingError {
     stackTrace?:       string;
     submittedCount?:   number;
     successCount?:     number;
+    [property: string]: any;
 }
 
 export enum ErrorSource {


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Introduced by https://github.com/open-metadata/OpenMetadata/pull/20636

Backward compatibility for failed app run records


https://github.com/open-metadata/OpenMetadata/blob/e2a3eb823a260218cea2dd5773577c210cb90511/openmetadata-service/src/main/java/org/openmetadata/service/apps/scheduler/OmAppJobListener.java#L147

We should remove these entries from the db using migrations.

Followed up by https://github.com/open-metadata/OpenMetadata/issues/20753


```
025-04-10 11:08:04.145	 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 1160] (through reference chain: org.openmetadata.schema.entity.app.AppRunRecord["failureContext"]->org.openmetadata.schema.entity.app.FailureContext["failure"]->org.openmetadata.schema.system.IndexingError["jobStackTrace"])
2025-04-10 11:08:04.145	Caused by: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "jobStackTrace" (class org.openmetadata.schema.system.IndexingError), not marked as ignorable (9 known properties: "failedCount", "errorSource", "reason", "message", "lastFailedCursor", "successCount", "stackTrace", "failedEntities", "submittedCount"])
2025-04-10 11:08:04.145		at java.base/java.lang.Thread.run(Thread.java:840)
2025-04-10 11:08:04.145		at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1034)
2025-04-10 11:08:04.145		at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:883)
2025-04-10 11:08:04.145		at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:409)
2025-04-10 11:08:04.145		at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:131)
2025-04-10 11:08:04.145		at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:173)
2025-04-10 11:08:04.145		at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:315)
2025-04-10 11:08:04.145		at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:338)
2025-04-10 11:08:04.145		at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104)
2025-04-10 11:08:04.145		at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105)
2025-04-10 11:08:04.145		at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
2025-04-10 11:08:04.145		at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:277)
2025-04-10 11:08:04.145		at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:479)
2025-04-10 11:08:04.145		at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:732)
2025-04-10 11:08:04.145		at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:487)
2025-04-10 11:08:04.145		at org.eclipse.jetty.server.Server.handle(Server.java:516)
2025-04-10 11:08:04.145		at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
2025-04-10 11:08:04.145		at org.eclipse.jetty.server.handler.StatisticsHandler.handle(StatisticsHandler.java:181)
2025-04-10 11:08:04.145		at org.eclipse.jetty.server.handler.RequestLogHandler.handle(RequestLogHandler.java:54)
2025-04-10 11:08:04.145		at io.dropwizard.jetty.ZipExceptionHandlingGzipHandler.handle(ZipExceptionHandlingGzipHandler.java:26)
2025-04-10 11:08:04.145		at org.eclipse.jetty.server.handler.gzip.GzipHandler.handle(GzipHandler.java:772)
2025-04-10 11:08:04.145		at io.dropwizard.jetty.RoutingHandler.handle(RoutingHandler.java:52)
2025-04-10 11:08:04.145		at com.codahale.metrics.jetty9.InstrumentedHandler.handle(InstrumentedHandler.java:318)
2025-04-10 11:08:04.145		at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
2025-04-10 11:08:04.145		at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
2025-04-10 11:08:04.145		at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1355)
2025-04-10 11:08:04.145		at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:186)
2025-04-10 11:08:04.145		at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1594)
2025-04-10 11:08:04.145		at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:505)
2025-04-10 11:08:04.145		at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:188)
2025-04-10 11:08:04.145		at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1440)
2025-04-10 11:08:04.145		at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233)
2025-04-10 11:08:04.145		at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1624)
2025-04-10 11:08:04.145		at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233)
2025-04-10 11:08:04.145		at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:552)
2025-04-10 11:08:04.145		at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1626)
2025-04-10 11:08:04.145		at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193)
2025-04-10 11:08:04.145		at org.eclipse.jetty.servlets.HeaderFilter.doFilter(HeaderFilter.java:117)
2025-04-10 11:08:04.145		at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1626)
2025-04-10 11:08:04.145		at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193)
2025-04-10 11:08:04.145		at org.eclipse.jetty.websocket.server.WebSocketUpgradeFilter.doFilter(WebSocketUpgradeFilter.java:292)
2025-04-10 11:08:04.145		at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1626)
2025-04-10 11:08:04.145		at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193)
2025-04-10 11:08:04.145		at io.dropwizard.jersey.filter.AllowedMethodsFilter.doFilter(AllowedMethodsFilter.java:41)
2025-04-10 11:08:04.145		at io.dropwizard.jersey.filter.AllowedMethodsFilter.handle(AllowedMethodsFilter.java:47)
2025-04-10 11:08:04.145		at org.eclipse.jetty.servlet.ServletHandler$Chain.doFilter(ServletHandler.java:1626)
2025-04-10 11:08:04.145		at org.eclipse.jetty.servlet.FilterHolder.doFilter(FilterHolder.java:193)
2025-04-10 11:08:04.145		at io.dropwizard.servlets.ThreadNameFilter.doFilter(ThreadNameFilter.java:35)
2025-04-10 11:08:04.145		at org.eclipse.jetty.servlet.ServletHandler$ChainEnd.doFilter(ServletHandler.java:1656)
2025-04-10 11:08:04.145		at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:799)
2025-04-10 11:08:04.145		at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:205)
2025-04-10 11:08:04.145		at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:311)
2025-04-10 11:08:04.145		at org.glassfish.jersey.servlet.ServletContainer.service(ServletContainer.java:358)
2025-04-10 11:08:04.145		at org.glassfish.jersey.servlet.WebComponent.service(WebComponent.java:346)
2025-04-10 11:08:04.145		at org.glassfish.jersey.servlet.WebComponent.serviceImpl(WebComponent.java:394)
2025-04-10 11:08:04.145		at org.glassfish.jersey.server.ApplicationHandler.handle(ApplicationHandler.java:684)
2025-04-10 11:08:04.145		at org.glassfish.jersey.server.ServerRuntime.process(ServerRuntime.java:235)
2025-04-10 11:08:04.145		at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:265)
2025-04-10 11:08:04.145		at org.glassfish.jersey.internal.Errors.process(Errors.java:244)
2025-04-10 11:08:04.145		at org.glassfish.jersey.internal.Errors.process(Errors.java:274)
2025-04-10 11:08:04.145		at org.glassfish.jersey.internal.Errors.process(Errors.java:292)
2025-04-10 11:08:04.145		at org.glassfish.jersey.internal.Errors$1.call(Errors.java:244)
2025-04-10 11:08:04.145		at org.glassfish.jersey.internal.Errors$1.call(Errors.java:248)
2025-04-10 11:08:04.145		at org.glassfish.jersey.server.ServerRuntime$1.run(ServerRuntime.java:256)
2025-04-10 11:08:04.145		at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:81)
2025-04-10 11:08:04.145		at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:400)
2025-04-10 11:08:04.145		at org.glassfish.jersey.server.model.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:478)
2025-04-10 11:08:04.145		at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.dispatch(AbstractJavaResourceMethodDispatcher.java:93)
2025-04-10 11:08:04.145		at org.glassfish.jersey.server.model.internal.JavaResourceMethodDispatcherProvider$TypeOutInvoker.doDispatch(JavaResourceMethodDispatcherProvider.java:219)
2025-04-10 11:08:04.145		at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.invoke(AbstractJavaResourceMethodDispatcher.java:189)
2025-04-10 11:08:04.145		at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher$1.run(AbstractJavaResourceMethodDispatcher.java:146)
2025-04-10 11:08:04.145		at org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory.lambda$static$0(ResourceMethodInvocationHandlerFactory.java:52)
2025-04-10 11:08:04.145		at java.base/java.lang.reflect.Method.invoke(Method.java:569)
2025-04-10 11:08:04.145		at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
2025-04-10 11:08:04.145		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
2025-04-10 11:08:04.145		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
2025-04-10 11:08:04.145		at org.openmetadata.service.resources.apps.AppResource.listAppRuns(AppResource.java:291)
2025-04-10 11:08:04.145		at org.openmetadata.service.jdbi3.AppRepository.listAppRuns(AppRepository.java:190)
2025-04-10 11:08:04.145		at org.openmetadata.service.jdbi3.AppRepository.listAppExtensionById(AppRepository.java:265)
2025-04-10 11:08:04.145		at org.openmetadata.service.util.JsonUtils.readValue(JsonUtils.java:201)
2025-04-10 11:08:04.145	org.openmetadata.service.exception.UnhandledServerException: An exception with message [Failed to process JSON ] was thrown while processing request.
2025-04-10 11:08:04.144	ERROR [2025-04-10 09:08:04,143] [dw-560 - GET /api/v1/apps/name/CollateAIQualityAgentApplication/status?offset=0&limit=15] o.o.s.e.CatalogGenericExceptionMapper - Error handling a request: 79d92dfec14875fa
```

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
