### PR TITLE
Chore(ui): Increase timeout for delete toast verification

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/constant/delete.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/constant/delete.ts
@@ -67,3 +67,9 @@ export const ENTITIES_WITHOUT_FOLLOWING_BUTTON = [
   'services/searchServices',
   'apiCollections',
 ];
+
+/**
+ * Timeout for deleting big entities
+ * 5 minutes
+ */
+export const BIG_ENTITY_DELETE_TIMEOUT = 5 * 60 * 1000;

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ApiServiceRest.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ApiServiceRest.spec.ts
@@ -11,6 +11,7 @@
  *  limitations under the License.
  */
 import { expect, test } from '@playwright/test';
+import { BIG_ENTITY_DELETE_TIMEOUT } from '../../constant/delete';
 import { GlobalSettingOptions } from '../../constant/settings';
 import {
   descriptionBox,
@@ -102,6 +103,10 @@ test.describe('API service', () => {
 
     await deleteResponse;
 
-    await toastNotification(page, /deleted successfully!/, 5 * 60 * 1000);
+    await toastNotification(
+      page,
+      /deleted successfully!/,
+      BIG_ENTITY_DELETE_TIMEOUT
+    );
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ApiServiceRest.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ApiServiceRest.spec.ts
@@ -102,6 +102,6 @@ test.describe('API service', () => {
 
     await deleteResponse;
 
-    await toastNotification(page, /deleted successfully!/);
+    await toastNotification(page, /deleted successfully!/, 5 * 60 * 1000);
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/EntityVersionPages.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/EntityVersionPages.spec.ts
@@ -11,6 +11,7 @@
  *  limitations under the License.
  */
 import test, { expect } from '@playwright/test';
+import { BIG_ENTITY_DELETE_TIMEOUT } from '../../constant/delete';
 import { EntityDataClass } from '../../support/entity/EntityDataClass';
 import { EntityDataClassCreationConfig } from '../../support/entity/EntityDataClass.interface';
 import { TableClass } from '../../support/entity/TableClass';
@@ -257,7 +258,11 @@ test.describe('Entity Version pages', () => {
 
           await deleteResponse;
 
-          await toastNotification(page, /deleted successfully!/, 5 * 60 * 1000);
+          await toastNotification(
+            page,
+            /deleted successfully!/,
+            BIG_ENTITY_DELETE_TIMEOUT
+          );
 
           await page.reload();
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/EntityVersionPages.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/EntityVersionPages.spec.ts
@@ -257,7 +257,7 @@ test.describe('Entity Version pages', () => {
 
           await deleteResponse;
 
-          await toastNotification(page, /deleted successfully!/);
+          await toastNotification(page, /deleted successfully!/, 5 * 60 * 1000);
 
           await page.reload();
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/ServiceEntityVersionPage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/ServiceEntityVersionPage.spec.ts
@@ -215,7 +215,7 @@ test.describe('Service Version pages', () => {
 
           await deleteResponse;
 
-          await toastNotification(page, /deleted successfully!/);
+          await toastNotification(page, /deleted successfully!/, 5 * 60 * 1000);
 
           await page.reload();
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/ServiceEntityVersionPage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/ServiceEntityVersionPage.spec.ts
@@ -11,6 +11,7 @@
  *  limitations under the License.
  */
 import test, { expect } from '@playwright/test';
+import { BIG_ENTITY_DELETE_TIMEOUT } from '../../constant/delete';
 import { EntityDataClass } from '../../support/entity/EntityDataClass';
 import { EntityDataClassCreationConfig } from '../../support/entity/EntityDataClass.interface';
 import {
@@ -215,7 +216,11 @@ test.describe('Service Version pages', () => {
 
           await deleteResponse;
 
-          await toastNotification(page, /deleted successfully!/, 5 * 60 * 1000);
+          await toastNotification(
+            page,
+            /deleted successfully!/,
+            BIG_ENTITY_DELETE_TIMEOUT
+          );
 
           await page.reload();
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
@@ -13,6 +13,7 @@
 import { expect, Page } from '@playwright/test';
 import { isEmpty, lowerCase } from 'lodash';
 import {
+  BIG_ENTITY_DELETE_TIMEOUT,
   ENTITIES_WITHOUT_FOLLOWING_BUTTON,
   LIST_OF_FIELDS_TO_EDIT_NOT_TO_BE_PRESENT,
   LIST_OF_FIELDS_TO_EDIT_TO_BE_DISABLED,
@@ -1248,7 +1249,11 @@ export const softDeleteEntity = async (
 
   await deleteResponse;
 
-  await toastNotification(page, /deleted successfully!/, 5 * 60 * 1000);
+  await toastNotification(
+    page,
+    /deleted successfully!/,
+    BIG_ENTITY_DELETE_TIMEOUT
+  );
 
   await page.reload();
 
@@ -1313,7 +1318,11 @@ export const hardDeleteEntity = async (
   await page.click('[data-testid="confirm-button"]');
   await deleteResponse;
 
-  await toastNotification(page, /deleted successfully!/, 5 * 60 * 1000);
+  await toastNotification(
+    page,
+    /deleted successfully!/,
+    BIG_ENTITY_DELETE_TIMEOUT
+  );
 };
 
 export const checkDataAssetWidget = async (page: Page, serviceType: string) => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
@@ -1248,7 +1248,7 @@ export const softDeleteEntity = async (
 
   await deleteResponse;
 
-  await toastNotification(page, /deleted successfully!/);
+  await toastNotification(page, /deleted successfully!/, 5 * 60 * 1000);
 
   await page.reload();
 
@@ -1313,7 +1313,7 @@ export const hardDeleteEntity = async (
   await page.click('[data-testid="confirm-button"]');
   await deleteResponse;
 
-  await toastNotification(page, /deleted successfully!/);
+  await toastNotification(page, /deleted successfully!/, 5 * 60 * 1000);
 };
 
 export const checkDataAssetWidget = async (page: Page, serviceType: string) => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/serviceIngestion.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/serviceIngestion.ts
@@ -12,6 +12,7 @@
  */
 
 import { expect, Page } from '@playwright/test';
+import { BIG_ENTITY_DELETE_TIMEOUT } from '../constant/delete';
 import { GlobalSettingOptions } from '../constant/settings';
 import { EntityTypeEndpoint } from '../support/entity/Entity.interface';
 import { getApiContext, toastNotification } from './common';
@@ -120,7 +121,11 @@ export const deleteService = async (
   await deleteResponse;
 
   // Closing the toast notification
-  await toastNotification(page, /deleted successfully!/, 5 * 60 * 1000); // Wait for up to 5 minutes for the toast notification to appear
+  await toastNotification(
+    page,
+    /deleted successfully!/,
+    BIG_ENTITY_DELETE_TIMEOUT
+  ); // Wait for up to 5 minutes for the toast notification to appear
 
   await page.reload();
   await page.waitForLoadState('networkidle');


### PR DESCRIPTION
I worked on increasing the timeout for delete toast verification for entities, which might take more time for the delete operation to complete

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
