### PR TITLE
Fix: User playwright test

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/user.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/user.ts
@@ -575,6 +575,7 @@ export const checkStewardServicesPermissions = async (page: Page) => {
   // Click on the sidebar item for Explore again
   await sidebarClick(page, SidebarItem.EXPLORE);
 
+  await page.waitForResponse('/api/v1/search/query?q=*');
   // Perform search actions
   await page.click('[data-testid="search-dropdown-Data Assets"]');
   await page.locator('[data-testid="table-checkbox"]').scrollIntoViewIfNeeded();

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/user.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/user.ts
@@ -573,9 +573,9 @@ export const checkStewardServicesPermissions = async (page: Page) => {
   }
 
   // Click on the sidebar item for Explore again
+  const queryResponse = page.waitForResponse('/api/v1/search/query?q=*');
   await sidebarClick(page, SidebarItem.EXPLORE);
-
-  await page.waitForResponse('/api/v1/search/query?q=*');
+  await queryResponse;
   // Perform search actions
   await page.click('[data-testid="search-dropdown-Data Assets"]');
   await page.locator('[data-testid="table-checkbox"]').scrollIntoViewIfNeeded();


### PR DESCRIPTION
This PR fixes playwright test  'Check permissions for Data Steward ' of  User.spec
The test was failing because it was not able to find the table checkbox in Assets Filter. The cause of this issue was the aggregate call with size limit 10 happening before the query call sometimes.(which was not having  table in response).
As a fix for this test, have added wait for the query api call.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
