### PR TITLE
Fix: Additional permissions call happening in summary components

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssetSummaryPanel/DataAssetSummaryPanel.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssetSummaryPanel/DataAssetSummaryPanel.tsx
@@ -144,7 +144,6 @@ export const DataAssetSummaryPanel = ({
         dataAsset.id
       );
       setEntityPermissions(permissions);
-      fetchEntityBasedDetails();
     } else {
       setEntityPermissions(null);
     }

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssetSummaryPanel/DataAssetSummaryPanel.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssetSummaryPanel/DataAssetSummaryPanel.tsx
@@ -220,7 +220,10 @@ export const DataAssetSummaryPanel = ({
             </Row>
 
             {entityType === EntityType.TABLE && (
-              <TableSummary entityDetails={dataAsset as Table} />
+              <TableSummary
+                entityDetails={dataAsset as Table}
+                permissions={entityPermissions}
+              />
             )}
 
             <SummaryTagsDescription

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/TableSummary/TableSummary.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/TableSummary/TableSummary.component.tsx
@@ -25,11 +25,7 @@ import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { ROUTES } from '../../../../constants/constants';
 import { mockTablePermission } from '../../../../constants/mockTourData.constants';
-import { usePermissionProvider } from '../../../../context/PermissionProvider/PermissionProvider';
-import {
-  OperationPermission,
-  ResourceEntity,
-} from '../../../../context/PermissionProvider/PermissionProvider.interface';
+import { OperationPermission } from '../../../../context/PermissionProvider/PermissionProvider.interface';
 import { EntityTabs, EntityType } from '../../../../enums/entity.enum';
 import { TestSummary } from '../../../../generated/tests/testCase';
 import useCustomLocation from '../../../../hooks/useCustomLocation/useCustomLocation';
@@ -40,21 +36,25 @@ import { TableProfilerTab } from '../../../Database/Profiler/ProfilerDashboard/p
 import './table-summary.less';
 import { TableSummaryProps } from './TableSummary.interface';
 
-function TableSummary({ entityDetails: tableDetails }: TableSummaryProps) {
+function TableSummary({
+  entityDetails: tableDetails,
+  permissions,
+}: Readonly<TableSummaryProps>) {
   const { t } = useTranslation();
   const location = useCustomLocation();
   const history = useHistory();
   const isTourPage = location.pathname.includes(ROUTES.TOUR);
-  const { getEntityPermission } = usePermissionProvider();
 
   const [testSuiteSummary, setTestSuiteSummary] = useState<TestSummary>();
   const [tablePermissions, setTablePermissions] = useState<OperationPermission>(
     DEFAULT_ENTITY_PERMISSION
   );
-
+  useEffect(() => {
+    setTablePermissions(permissions as OperationPermission);
+  }, [permissions]);
   // Since we are showing test cases summary in the table summary panel, we are using ViewTests permission
   const viewTestCasesPermission = useMemo(
-    () => tablePermissions.ViewAll || tablePermissions.ViewTests,
+    () => tablePermissions?.ViewAll || tablePermissions?.ViewTests,
     [tablePermissions]
   );
 
@@ -154,15 +154,10 @@ function TableSummary({ entityDetails: tableDetails }: TableSummaryProps) {
 
   const init = useCallback(async () => {
     if (tableDetails.id && !isTourPage) {
-      const tablePermission = await getEntityPermission(
-        ResourceEntity.TABLE,
-        tableDetails.id
-      );
-      setTablePermissions(tablePermission);
       const shouldFetchTestCaseData =
         !isTableDeleted &&
         tableDetails.service?.type === 'databaseService' &&
-        (tablePermission.ViewAll || tablePermission.ViewTests);
+        (tablePermissions?.ViewAll || tablePermissions?.ViewTests);
 
       if (shouldFetchTestCaseData) {
         fetchAllTests();
@@ -175,7 +170,7 @@ function TableSummary({ entityDetails: tableDetails }: TableSummaryProps) {
     isTourPage,
     isTableDeleted,
     fetchAllTests,
-    getEntityPermission,
+    tablePermissions,
   ]);
 
   useEffect(() => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/TableSummary/TableSummary.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/TableSummary/TableSummary.component.tsx
@@ -157,25 +157,18 @@ function TableSummary({
       const shouldFetchTestCaseData =
         !isTableDeleted &&
         tableDetails.service?.type === 'databaseService' &&
-        (tablePermissions?.ViewAll || tablePermissions?.ViewTests);
-
+        (permissions?.ViewAll || permissions?.ViewTests);
       if (shouldFetchTestCaseData) {
         fetchAllTests();
       }
     } else {
       setTablePermissions(mockTablePermission as OperationPermission);
     }
-  }, [
-    tableDetails,
-    isTourPage,
-    isTableDeleted,
-    fetchAllTests,
-    tablePermissions,
-  ]);
+  }, [tableDetails, isTourPage, isTableDeleted, fetchAllTests, permissions]);
 
   useEffect(() => {
     init();
-  }, [tableDetails.id]);
+  }, [tableDetails.id, permissions]);
 
   return (
     <Row className="p-md border-radius-card summary-panel-card" gutter={[0, 8]}>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/TableSummary/TableSummary.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/TableSummary/TableSummary.interface.ts
@@ -11,10 +11,12 @@
  *  limitations under the License.
  */
 
+import { OperationPermission } from '../../../../context/PermissionProvider/PermissionProvider.interface';
 import { Table } from '../../../../generated/entity/data/table';
 
 export interface TableSummaryProps {
   entityDetails: Table;
+  permissions: OperationPermission | null;
 }
 
 export interface TableProfileDetails {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/TableSummary/TableSummary.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/TableSummary/TableSummary.test.tsx
@@ -14,6 +14,7 @@
 import { act, render, screen } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
+import { OperationPermission } from '../../../../context/PermissionProvider/PermissionProvider.interface';
 import { getTestCaseExecutionSummary } from '../../../../rest/testAPI';
 import { mockTableEntityDetails } from '../mocks/TableSummary.mock';
 import TableSummary from './TableSummary.component';
@@ -69,9 +70,15 @@ jest.mock('../../../../context/PermissionProvider/PermissionProvider', () => ({
 describe('TableSummary component tests', () => {
   it('Component should render properly, when loaded in the Explore page.', async () => {
     await act(async () => {
-      render(<TableSummary entityDetails={mockTableEntityDetails} />, {
-        wrapper: MemoryRouter,
-      });
+      render(
+        <TableSummary
+          entityDetails={mockTableEntityDetails}
+          permissions={mockEntityPermissions as OperationPermission}
+        />,
+        {
+          wrapper: MemoryRouter,
+        }
+      );
     });
 
     const profilerHeader = screen.getByTestId('profiler-header');
@@ -89,9 +96,15 @@ describe('TableSummary component tests', () => {
 
   it('Component should render properly, when loaded in the Lineage page.', async () => {
     await act(async () => {
-      render(<TableSummary entityDetails={mockTableEntityDetails} />, {
-        wrapper: MemoryRouter,
-      });
+      render(
+        <TableSummary
+          entityDetails={mockTableEntityDetails}
+          permissions={mockEntityPermissions as OperationPermission}
+        />,
+        {
+          wrapper: MemoryRouter,
+        }
+      );
     });
 
     const profilerHeader = screen.getByTestId('profiler-header');
@@ -117,9 +130,15 @@ describe('TableSummary component tests', () => {
     );
 
     await act(async () => {
-      render(<TableSummary entityDetails={mockTableEntityDetails} />, {
-        wrapper: MemoryRouter,
-      });
+      render(
+        <TableSummary
+          entityDetails={mockTableEntityDetails}
+          permissions={mockEntityPermissions as OperationPermission}
+        />,
+        {
+          wrapper: MemoryRouter,
+        }
+      );
     });
 
     const testsPassedLabel = screen.getByTestId('test-passed');
@@ -146,9 +165,15 @@ describe('TableSummary component tests', () => {
       })
     );
     await act(async () => {
-      render(<TableSummary entityDetails={mockTableEntityDetails} />, {
-        wrapper: MemoryRouter,
-      });
+      render(
+        <TableSummary
+          entityDetails={mockTableEntityDetails}
+          permissions={mockEntityPermissions as OperationPermission}
+        />,
+        {
+          wrapper: MemoryRouter,
+        }
+      );
     });
     const testsPassedValue = screen.getByTestId('test-passed-value');
     const testsAbortedValue = screen.getByTestId('test-aborted-value');


### PR DESCRIPTION
This PR fixes the additional  permissions api call happening in the Summary Components (Table Summary and DataAssetsSummaryPanel)

Issue:-

https://github.com/user-attachments/assets/b7ad3449-263f-4bf7-8b68-dbbc46e57a80




Fix



https://github.com/user-attachments/assets/bbf47214-50a5-4799-a32c-7237b35ea8e5


<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
