### PR TITLE
Fixes 1237: Indian entities recognition tests

### DIFF
--- a/ingestion/tests/unit/pii/test_ner_scanner.py
+++ b/ingestion/tests/unit/pii/test_ner_scanner.py
@@ -167,7 +167,7 @@ def test_scan_entities(scanner):
 
 def test_scan_indian_aadhaar(scanner):
     """
-    We can properly validate certain Aadhaar indian IDs.
+    We can properly validate certain Aadhaar Indian IDs.
     Note: These lists are randomly generated and not valid IDs for any actual use,
     but they are valid Aadhaar numbers including the checksum.
     """

--- a/ingestion/tests/unit/pii/test_ner_scanner.py
+++ b/ingestion/tests/unit/pii/test_ner_scanner.py
@@ -163,3 +163,23 @@ def test_scan_entities(scanner):
 
     nif_numbers = ["12345678A", "87654321B", "23456789C", "98765432D", "34567890E"]
     assert scanner.scan(nif_numbers).tag_fqn == "PII.Sensitive"
+
+
+def test_scan_indian_aadhaar(scanner):
+    """
+    We can properly validate certain Aadhaar indian IDs.
+    Note: These lists are randomly generated and not valid IDs for any actual use,
+    but they are valid Aadhaar numbers including the checksum.
+    """
+    aadhaar_numbers = [
+        "466299546357",
+        "967638147560",
+        "988307845186",
+    ]
+    assert scanner.scan(aadhaar_numbers).tag_fqn == "PII.Sensitive"
+
+
+def test_scan_indian_pan(scanner):
+    pan_numbers = ["BAJPC4350M", "DAJPC4150P", "XGZFE7225A", "CTUGE1616I"]
+
+    assert scanner.scan(pan_numbers).tag_fqn == "PII.Sensitive"


### PR DESCRIPTION
### Describe your changes:

Fixes 1237

Check that Indian entities PAN and Aadhaar numbers are correctly detected as PII Sensible type.


### Type of change:
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation


### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
