### PR TITLE
Fix : Flaky Activity feed playwright test

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityFeed.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityFeed.spec.ts
@@ -714,7 +714,7 @@ base.describe('Activity feed with Data Consumer User', () => {
       await page2.waitForLoadState('networkidle');
       // Count for task should be 1 both open and closed
 
-      checkTaskCountInActivityFeed(page2, 1, 1);
+      await checkTaskCountInActivityFeed(page2, 1, 1);
 
       // Should not see the close button
       expect(page2.locator('[data-testid="close-button"]')).not.toBeVisible();
@@ -730,7 +730,7 @@ base.describe('Activity feed with Data Consumer User', () => {
       await toastNotification(page2, /Task resolved successfully/);
 
       await page2.waitForLoadState('networkidle');
-      checkTaskCountInActivityFeed(page2, 0, 2);
+      await checkTaskCountInActivityFeed(page2, 0, 2);
 
       await afterActionUser2();
     });


### PR DESCRIPTION
This PR fixes flaky test 'Create and Assign Task with Suggestions' in ActivityFeed.spec.ts .
 The test was flaky because it was checking task counts after the page was closed sometimes. Fixed the flakiness by adding missing `await` for task count verification.

Issue
<img width="1060" alt="Screenshot 2025-05-13 at 1 27 26 PM" src="https://github.com/user-attachments/assets/253e50d5-c84f-4c88-b9e6-68c2c699b46e" />


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
