### PR TITLE
Fix: Table.spec AUT failure

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Table.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Table.spec.ts
@@ -140,7 +140,11 @@ test.describe('Table pagination sorting search scenarios ', () => {
 
     await expect(page.getByTestId('databaseSchema-tables')).toBeVisible();
 
+    await page
+      .getByTestId('page-size-selection-dropdown')
+      .scrollIntoViewIfNeeded();
     await page.getByTestId('page-size-selection-dropdown').click();
+    await page.waitForSelector('.ant-dropdown', { state: 'visible' });
 
     await expect(
       page.getByRole('menuitem', { name: '15 / Page' })
@@ -168,6 +172,9 @@ test.describe('Table pagination sorting search scenarios ', () => {
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });
+    await page
+      .getByTestId('page-size-selection-dropdown')
+      .scrollIntoViewIfNeeded();
 
     await expect(page.getByTestId('page-size-selection-dropdown')).toHaveText(
       '15 / Page'


### PR DESCRIPTION
This PR fixes 'should persist page size' playwright test of Table.spec

The test was failing while it was trying find and select the page size in the dropdown sometimes. 
As a fix for it, added scrollIntoView and  proper wait for dropdown to be visible before selecting the page size.


<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
