### PR TITLE
MINOR: Add data insights migrations to remove stale objects

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v171/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v171/Migration.java
@@ -1,0 +1,21 @@
+package org.openmetadata.service.migration.mysql.v171;
+
+import static org.openmetadata.service.migration.utils.v171.MigrationUtil.removeOldDataInsightsObjects;
+
+import lombok.SneakyThrows;
+import org.openmetadata.service.migration.api.MigrationProcessImpl;
+import org.openmetadata.service.migration.utils.MigrationFile;
+
+public class Migration extends MigrationProcessImpl {
+
+  public Migration(MigrationFile migrationFile) {
+    super(migrationFile);
+  }
+
+  @Override
+  @SneakyThrows
+  public void runDataMigration() {
+    // Data Insights
+    removeOldDataInsightsObjects();
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v171/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v171/Migration.java
@@ -1,0 +1,21 @@
+package org.openmetadata.service.migration.postgres.v171;
+
+import static org.openmetadata.service.migration.utils.v171.MigrationUtil.removeOldDataInsightsObjects;
+
+import lombok.SneakyThrows;
+import org.openmetadata.service.migration.api.MigrationProcessImpl;
+import org.openmetadata.service.migration.utils.MigrationFile;
+
+public class Migration extends MigrationProcessImpl {
+
+  public Migration(MigrationFile migrationFile) {
+    super(migrationFile);
+  }
+
+  @Override
+  @SneakyThrows
+  public void runDataMigration() {
+    // Data Insights
+    removeOldDataInsightsObjects();
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v171/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v171/MigrationUtil.java
@@ -1,0 +1,113 @@
+package org.openmetadata.service.migration.utils.v171;
+
+import java.util.List;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.common.utils.CommonUtil;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.search.SearchClient;
+import org.openmetadata.service.search.SearchRepository;
+
+@Slf4j
+public class MigrationUtil {
+  private static final String DATA_INSIGHTS_PREFIX = "di-data-assets";
+  private static final String INDEX_TEMPLATE_NAME = "di-data-assets";
+  private static final String ILM_POLICY_NAME = "di-data-assets-lifecycle";
+  private static final List<String> COMPONENT_TEMPLATES_NAMES =
+      List.of("di-data-assets-mapping", "di-data-assets-settings");
+  private static String clusterAlias;
+
+  public static void removeOldDataInsightsObjects() {
+    // From 1.6.6 we implemented the support for CLUSTER_ALIAS for Data Insights. The old objects
+    // were not cleaned then.
+    // From 1.7.1 we removed the ILM policy.
+    LOG.info("Starting cleanup of old Data Insights objects");
+    SearchRepository searchRepository = Entity.getSearchRepository();
+    SearchClient searchClient = searchRepository.getSearchClient();
+    clusterAlias = searchRepository.getClusterAlias();
+
+    if (clusterAlias != null && !clusterAlias.isEmpty()) {
+      // Delete data insights objects without cluster alias
+      try {
+        deleteDataInsightsDataStreams(searchClient);
+        deleteIndexTemplate(searchClient);
+        deleteComponentTemplate(searchClient);
+        deleteIlmPolicy(searchClient, clusterAlias);
+        LOG.info("Successfully completed Data Insights objects cleanup");
+      } catch (Exception e) {
+        LOG.error("Error deleting Data Insights objects", e);
+        throw e;
+      }
+    } else {
+      LOG.info("No CLUSTER_ALIAS found, skipping cleanup");
+    }
+
+    deleteIlmPolicy(searchClient, clusterAlias);
+    LOG.info("Successfully completed Data Insights ILM cleanup");
+  }
+
+  private static String getClusteredPrefix(String clusterAlias, String prefix) {
+    if (CommonUtil.nullOrEmpty(clusterAlias)) {
+      return prefix;
+    } else {
+      return String.format("%s-%s", clusterAlias, prefix);
+    }
+  }
+
+  @SneakyThrows
+  private static void deleteDataInsightsDataStreams(SearchClient searchClient) {
+    try {
+      // Get and delete data streams that don't have cluster alias
+      List<String> dataStreams =
+          searchClient.getDataStreams(String.format("%s-*", DATA_INSIGHTS_PREFIX));
+      for (String name : dataStreams) {
+        try {
+          if (!name.startsWith(clusterAlias)) {
+            searchClient.deleteDataStream(name);
+            LOG.info("Successfully deleted data stream: {}", name);
+          }
+        } catch (Exception e) {
+          LOG.error(String.format("Error deleting %s Data Stream", name), e);
+        }
+      }
+    } catch (Exception e) {
+      LOG.error("Error deleting data insights data streams", e);
+      throw e;
+    }
+  }
+
+  @SneakyThrows
+  private static void deleteIlmPolicy(SearchClient searchClient, String clusterAlias) {
+    try {
+      searchClient.deleteILMPolicy(getClusteredPrefix(clusterAlias, ILM_POLICY_NAME));
+      LOG.info(String.format("Successfully deleted %s Policy", ILM_POLICY_NAME));
+    } catch (Exception e) {
+      LOG.error("Error deleting ILM policies", e);
+      throw e;
+    }
+  }
+
+  @SneakyThrows
+  private static void deleteIndexTemplate(SearchClient searchClient) {
+    try {
+      searchClient.deleteIndexTemplate(INDEX_TEMPLATE_NAME);
+      LOG.info("Successfully deleted template: {}", INDEX_TEMPLATE_NAME);
+    } catch (Exception e) {
+      LOG.error("Error deleting index template", e);
+      throw e;
+    }
+  }
+
+  @SneakyThrows
+  private static void deleteComponentTemplate(SearchClient searchClient) {
+    for (String componentName : COMPONENT_TEMPLATES_NAMES) {
+      try {
+        searchClient.deleteComponentTemplate(componentName);
+        LOG.info("Successfully deleted component template: {}", componentName);
+      } catch (Exception e) {
+        LOG.error("Error deleting component template", e);
+        throw e;
+      }
+    }
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v171/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v171/MigrationUtil.java
@@ -78,8 +78,9 @@ public class MigrationUtil {
   @SneakyThrows
   private static void deleteIlmPolicy(SearchClient searchClient, String clusterAlias) {
     try {
-      searchClient.removeILMFromIndexTemplate(
-          getClusteredPrefix(clusterAlias, INDEX_TEMPLATE_NAME));
+      searchClient.removeILMFromComponentTemplate(
+          String.format(
+              "%s-%s", getClusteredPrefix(clusterAlias, INDEX_TEMPLATE_NAME), "settings"));
       searchClient.dettachIlmPolicyFromIndexes(
           String.format("*%s-*", getClusteredPrefix(clusterAlias, DATA_INSIGHTS_PREFIX)));
       searchClient.deleteILMPolicy(getClusteredPrefix(clusterAlias, ILM_POLICY_NAME));

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v171/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v171/MigrationUtil.java
@@ -18,8 +18,8 @@ public class MigrationUtil {
   private static String clusterAlias;
 
   public static void removeOldDataInsightsObjects() {
-    // From 1.6.6 we implemented the support for CLUSTER_ALIAS for Data Insights. The old objects
-    // were not cleaned then.
+    // From 1.6.6 we implemented the support for CLUSTER_ALIAS for Data Insights.
+    // The old objects without CLUSTER_ALIAS were not cleaned then.
     // From 1.7.1 we removed the ILM policy.
     LOG.info("Starting cleanup of old Data Insights objects");
     SearchRepository searchRepository = Entity.getSearchRepository();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchClient.java
@@ -363,4 +363,60 @@ public interface SearchClient {
   SearchHealthStatus getSearchHealthStatus() throws IOException;
 
   QueryCostSearchResult getQueryCostRecords(String serviceName) throws IOException;
+
+  /**
+   * Get a list of data stream names that match the given prefix.
+   *
+   * @param prefix The prefix to match data stream names against
+   * @return List of data stream names that match the prefix
+   * @throws IOException if there is an error communicating with the search engine
+   */
+  default List<String> getDataStreams(String prefix) throws IOException {
+    throw new CustomExceptionMessage(
+        Response.Status.NOT_IMPLEMENTED, NOT_IMPLEMENTED_ERROR_TYPE, NOT_IMPLEMENTED_METHOD);
+  }
+
+  /**
+   * Delete data streams that match the given name or pattern.
+   *
+   * @param dataStreamName The name or pattern of data streams to delete
+   * @throws IOException if there is an error communicating with the search engine
+   */
+  default void deleteDataStream(String dataStreamName) throws IOException {
+    throw new CustomExceptionMessage(
+        Response.Status.NOT_IMPLEMENTED, NOT_IMPLEMENTED_ERROR_TYPE, NOT_IMPLEMENTED_METHOD);
+  }
+
+  /**
+   * Delete an Index Lifecycle Management (ILM) policy.
+   *
+   * @param policyName The name of the ILM policy to delete
+   * @throws IOException if there is an error communicating with the search engine
+   */
+  default void deleteILMPolicy(String policyName) throws IOException {
+    throw new CustomExceptionMessage(
+        Response.Status.NOT_IMPLEMENTED, NOT_IMPLEMENTED_ERROR_TYPE, NOT_IMPLEMENTED_METHOD);
+  }
+
+  /**
+   * Delete an index template.
+   *
+   * @param templateName The name of the index template to delete
+   * @throws IOException if there is an error communicating with the search engine
+   */
+  default void deleteIndexTemplate(String templateName) throws IOException {
+    throw new CustomExceptionMessage(
+        Response.Status.NOT_IMPLEMENTED, NOT_IMPLEMENTED_ERROR_TYPE, NOT_IMPLEMENTED_METHOD);
+  }
+
+  /**
+   * Delete a component template.
+   *
+   * @param componentTemplateName The name of the component template to delete
+   * @throws IOException if there is an error communicating with the search engine
+   */
+  default void deleteComponentTemplate(String componentTemplateName) throws IOException {
+    throw new CustomExceptionMessage(
+        Response.Status.NOT_IMPLEMENTED, NOT_IMPLEMENTED_ERROR_TYPE, NOT_IMPLEMENTED_METHOD);
+  }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchClient.java
@@ -419,4 +419,26 @@ public interface SearchClient {
     throw new CustomExceptionMessage(
         Response.Status.NOT_IMPLEMENTED, NOT_IMPLEMENTED_ERROR_TYPE, NOT_IMPLEMENTED_METHOD);
   }
+
+  /**
+   * Detach an ILM policy from indexes matching the given pattern.
+   *
+   * @param indexPattern The pattern of indexes to detach the ILM policy from
+   * @throws IOException if there is an error communicating with the search engine
+   */
+  default void dettachIlmPolicyFromIndexes(String indexPattern) throws IOException {
+    throw new CustomExceptionMessage(
+        Response.Status.NOT_IMPLEMENTED, NOT_IMPLEMENTED_ERROR_TYPE, NOT_IMPLEMENTED_METHOD);
+  }
+
+  /**
+   * Removes ILM policy from an index template while preserving all other settings.
+   * This is only implemented for Elasticsearch as OpenSearch handles ILM differently.
+   *
+   * @param templateName The name of the index template to update
+   * @throws IOException if there is an error communicating with the search engine
+   */
+  default void removeILMFromIndexTemplate(String templateName) throws IOException {
+    // Default implementation does nothing as this is only needed for Elasticsearch
+  }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchClient.java
@@ -432,13 +432,13 @@ public interface SearchClient {
   }
 
   /**
-   * Removes ILM policy from an index template while preserving all other settings.
+   * Removes ILM policy from a component template while preserving all other settings.
    * This is only implemented for Elasticsearch as OpenSearch handles ILM differently.
    *
-   * @param templateName The name of the index template to update
+   * @param componentTemplateName The name of the component template to update
    * @throws IOException if there is an error communicating with the search engine
    */
-  default void removeILMFromIndexTemplate(String templateName) throws IOException {
+  default void removeILMFromComponentTemplate(String componentTemplateName) throws IOException {
     // Default implementation does nothing as this is only needed for Elasticsearch
   }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

Adding migrations and required methods on the search clients to remove the Stale Data Insights Objects:
- On 1.6.6  we implemented support fo `CLUSTER_ALIAS`, but migrations were missing. This PR aims to delete the Data Streams, ILM Policy, Component Templates and Index Templates without `CLUSTER_ALIAS` if this is present.
- On 1.7.1 we removed the necessity of an ILM. This PR also aims to dettach and delete any ILM.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
