### PR TITLE
fix(ui): Edit and display roles issue for bot page

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/InheritedRolesCard/InheritedRolesCard.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/InheritedRolesCard/InheritedRolesCard.component.tsx
@@ -25,7 +25,7 @@ const InheritedRolesCard = ({ userData }: InheritedRolesCardProps) => {
 
   return (
     <Card
-      className="new-header-border-card"
+      className="bot-page-roles-card-header"
       key="inherited-roles-card-component"
       title={t('label.inherited-role-plural')}>
       <Fragment>

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/RolesCard/RolesCard.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/RolesCard/RolesCard.component.tsx
@@ -82,7 +82,7 @@ const RolesCard = ({
   if (isAdminUser) {
     return (
       <Card
-        className="new-header-border-card"
+        className="bot-page-roles-card-header"
         extra={
           !isRolesEdit && (
             <EditIconButton

--- a/openmetadata-ui/src/main/resources/ui/src/styles/components/card.less
+++ b/openmetadata-ui/src/main/resources/ui/src/styles/components/card.less
@@ -127,3 +127,18 @@
 
   border: 1px solid @grey-15;
 }
+
+.bot-page-roles-card-header {
+  .ant-card-head {
+    background: @grey-50;
+    border-radius: @border-radius-sm;
+    .text-sm();
+    font-weight: 500;
+    border-bottom: none;
+  }
+
+  .ant-card-body {
+    height: auto !important;
+    max-height: none !important;
+  }
+}


### PR DESCRIPTION
Issue:-
The addition of 'new-header-border-card' class was causing this issue, since this class had
` &:not(.expanded) {
    .ant-card-body {
      height: 0 !important;
      overflow: hidden;
      padding: 0;
    }
  }`
Roles are not getting displayed in the roles and inherited  roles widget for bots page.



https://github.com/user-attachments/assets/392a0336-462b-4192-9ebd-b08a6cb1e06c



Fix:-

Fixed it referring the design on sandbox currently


https://github.com/user-attachments/assets/d6b77aa0-403b-4797-b131-34362834f7b3




<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
