### PR TITLE
Add maxRequestHeaderSize to server.applicationConnectors section in O…

### DIFF
--- a/conf/openmetadata.yaml
+++ b/conf/openmetadata.yaml
@@ -27,6 +27,7 @@ server:
     - type: http
       bindHost: ${SERVER_HOST:-0.0.0.0}
       port: ${SERVER_PORT:-8585}
+      maxRequestHeaderSize: ${MAX_REQUEST_HEADER_SIZE:-8KiB}
   adminConnectors:
     - type: http
       bindHost: ${SERVER_HOST:-0.0.0.0}


### PR DESCRIPTION
Add maxRequestHeaderSize to server.applicationConnectors section in OpenMetaData default config file

### Describe your changes:
Added ability to set maxRequestHeaderSize for web server.

We run OMD in docker. Recently we encountered that if user sets many filters, application throws error "Request Header Fields Too Large". To solve this problem, you can add it with a substitution. Or you need to copy the configuration file, fix it and add it to the image again. Both options are unreliable. It would be great if this parameter could be set out of the box.


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
