### PR TITLE
PLAYWRIGHT: e2e test for checking feeds count for all entities

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Entity.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Entity.spec.ts
@@ -270,6 +270,14 @@ entities.forEach((EntityClass) => {
       await entity.inactiveAnnouncement(page);
     });
 
+    test(`Verify Feed Counts`, async ({ page }) => {
+      const { expectedCount, actualCount } = await entity.verifyFeedCounts(
+        page
+      );
+
+      expect(actualCount).toBe(expectedCount.toString());
+    });
+
     test(`UpVote & DownVote entity`, async ({ page }) => {
       await entity.upVote(page);
       await entity.downVote(page);

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/EntityClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/EntityClass.ts
@@ -228,6 +228,27 @@ export class EntityClass {
       .isVisible();
   }
 
+  async verifyFeedCounts(page: Page) {
+    const responsePromise = page.waitForResponse(
+      '/api/v1/feed/count?entityLink=*'
+    );
+
+    const response = await responsePromise;
+    const data = await response.json();
+
+    const totalCount =
+      data.data[0].conversationCount + data.data[0].totalTaskCount;
+    const displayedCount = await page
+      .getByTestId('activity_feed')
+      .getByTestId('count')
+      .textContent();
+
+    return {
+      expectedCount: totalCount,
+      actualCount: displayedCount,
+    };
+  }
+
   async tagChildren({
     page,
     tag1,


### PR DESCRIPTION
This PR introduces test for verifying the counts call for all the entities.
The test verifies if the count call happens for all the entities and the count of feeds is updated  accordingly.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
