### PR TITLE
fix the entityRightPanel and serviceEntity playwright spec

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkEditEntity.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkEditEntity.spec.ts
@@ -683,6 +683,10 @@ test.describe('Bulk Edit Entity', () => {
         .locator('.inovua-react-toolkit-load-mask__background-layer')
         .waitFor({ state: 'detached' });
 
+      await page.waitForSelector('[data-testid="loader"]', {
+        state: 'detached',
+      });
+
       await toastNotification(
         page,
         `Glossaryterm ${glossary.responseData.fullyQualifiedName} details updated successfully`

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/EntityRightCollapsablePanel.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/EntityRightCollapsablePanel.spec.ts
@@ -53,10 +53,6 @@ test('Show and Hide Right Collapsable Panel', async ({ page }) => {
   ).not.toBeVisible();
 
   await expect(
-    page.locator('[data-testid="KnowledgePanel.CustomProperties"]')
-  ).not.toBeVisible();
-
-  await expect(
     page.locator('[data-testid="KnowledgePanel.TableConstraints"]')
   ).not.toBeVisible();
 
@@ -73,10 +69,6 @@ test('Show and Hide Right Collapsable Panel', async ({ page }) => {
 
   await expect(
     page.locator('[data-testid="KnowledgePanel.GlossaryTerms"]')
-  ).toBeVisible();
-
-  await expect(
-    page.locator('[data-testid="KnowledgePanel.CustomProperties"]')
   ).toBeVisible();
 
   await expect(

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/DatabaseClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/DatabaseClass.ts
@@ -249,7 +249,9 @@ export class DatabaseClass extends EntityClass {
     await expect(
       page
         .getByTestId(`table-data-card_${searchTerm}`)
-        .getByRole('link', { name: owner })
+        .getByTestId('owner-label')
+        .getByTestId('owner-link')
+        .getByTestId(owner)
     ).toBeVisible();
   }
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

Playwright fix: 

- ServiceEntity
- EntityRightCollaspablePanel
- BulkEdit- Table

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
