### PR TITLE
Feat: Enhance filter inputs

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Form/JSONSchema/JSONSchemaTemplate/WorkflowArrayFieldTemplate.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Form/JSONSchema/JSONSchemaTemplate/WorkflowArrayFieldTemplate.test.tsx
@@ -12,7 +12,7 @@
  */
 
 import { FieldProps, IdSchema, Registry } from '@rjsf/utils';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { t } from 'i18next';
 import React from 'react';
 import { MOCK_WORKFLOW_ARRAY_FIELD_TEMPLATE } from '../../../../../mocks/Templates.mock';
@@ -145,5 +145,26 @@ describe('Test WorkflowArrayFieldTemplate Component', () => {
       .querySelector('span.ant-select-selection-placeholder');
 
     expect(placeholderText).toHaveTextContent('');
+  });
+
+  it('Should call onChange with correct value when comma seperated values are entered', async () => {
+    render(
+      <WorkflowArrayFieldTemplate
+        {...mockWorkflowArrayFieldTemplateProps}
+        formData={[]}
+      />
+    );
+
+    const select = screen.getByTestId('workflow-array-field-template');
+    const input = within(select).getByRole('combobox');
+
+    fireEvent.change(input, { target: { value: 'value1,value2,value3' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(mockWorkflowArrayFieldTemplateProps.onChange).toHaveBeenCalledWith([
+      'value1',
+      'value2',
+      'value3',
+    ]);
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Form/JSONSchema/JSONSchemaTemplate/WorkflowArrayFieldTemplate.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Form/JSONSchema/JSONSchemaTemplate/WorkflowArrayFieldTemplate.tsx
@@ -77,6 +77,7 @@ const WorkflowArrayFieldTemplate = (props: FieldProps) => {
           onBlur={() => props.onBlur(id, value)}
           onChange={(value) => props.onChange(value)}
           onFocus={handleFocus}
+          {...(!options && { tokenSeparators: [','] })}
         />
       </Col>
     </Row>


### PR DESCRIPTION

Fixes #15353

Issue:-
Current input for filters does not allow users to enter multiple comma seperated filters by copy pasting.

https://github.com/user-attachments/assets/61aaf6c1-050e-4c80-a386-7e2039a107fc






Fix
Users can now enter multiple conditions at a time by copy pasting 

https://github.com/user-attachments/assets/297157f1-355c-447b-8cff-b0bd53b817d3



#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->


