### PR TITLE
MINOR: PBI dataset expressions empty value fix

### DIFF
--- a/ingestion/src/metadata/ingestion/source/dashboard/powerbi/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/powerbi/metadata.py
@@ -706,6 +706,12 @@ class PowerbiSource(DashboardServiceSource):
                 if dataset and dataset.expressions:
                     # find keyword from dataset expressions
                     for dexpression in dataset.expressions:
+                        if not dexpression.expression:
+                            logger.debug(
+                                f"No expression value found inside dataset"
+                                f"({dataset.name}) expressions' name={dexpression.name}"
+                            )
+                            continue
                         if dexpression.name == match.group(2):
                             pattern = r'DefaultValue="([^"]+)"'
                             kw_match = re.search(pattern, dexpression.expression)
@@ -784,7 +790,9 @@ class PowerbiSource(DashboardServiceSource):
             if not isinstance(table.source, list):
                 return {}
             source_expression = table.source[0].expression
-
+            if not source_expression:
+                logger.debug(f"No source expression found for table: {table.name}")
+                return {}
             # parse snowflake source
             table_info = self._parse_snowflake_source(
                 source_expression, datamodel_entity

--- a/ingestion/src/metadata/ingestion/source/dashboard/powerbi/models.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/powerbi/models.py
@@ -143,7 +143,7 @@ class PowerBITableSource(BaseModel):
     PowerBI Table Source
     """
 
-    expression: str
+    expression: Optional[str] = None
 
 
 class PowerBiTable(BaseModel):
@@ -171,7 +171,7 @@ class TablesResponse(BaseModel):
 
 class DatasetExpression(BaseModel):
     name: str
-    expression: str
+    expression: Optional[str] = None
 
 
 class Dataset(BaseModel):

--- a/ingestion/tests/unit/topology/dashboard/test_powerbi.py
+++ b/ingestion/tests/unit/topology/dashboard/test_powerbi.py
@@ -15,7 +15,12 @@ from metadata.generated.schema.type.entityReference import EntityReference
 from metadata.generated.schema.type.entityReferenceList import EntityReferenceList
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.dashboard.powerbi.metadata import PowerbiSource
-from metadata.ingestion.source.dashboard.powerbi.models import Dataset, PowerBIDashboard
+from metadata.ingestion.source.dashboard.powerbi.models import (
+    Dataset,
+    PowerBIDashboard,
+    PowerBiTable,
+    PowerBITableSource,
+)
 
 MOCK_REDSHIFT_EXP = """
 let
@@ -167,6 +172,19 @@ MOCK_DATASET_FROM_WORKSPACE = Dataset(
         },
     ],
 )
+MOCK_DATASET_FROM_WORKSPACE_V2 = Dataset(
+    id="testdataset",
+    name="Test Dataset",
+    tables=[],
+    expressions=[
+        {
+            "name": "DB",
+        },
+        {
+            "name": "Schema",
+        },
+    ],
+)
 MOCK_DASHBOARD_DATA_MODEL = DashboardDataModel(
     name="dummy_datamodel",
     id=uuid.uuid4(),
@@ -292,3 +310,50 @@ class PowerBIUnitTest(TestCase):
 
         # Verify get_reference_by_email was not called when there are no owners
         self.powerbi.metadata.get_reference_by_email.assert_not_called()
+
+    @pytest.mark.order(3)
+    def test_parse_table_info_from_source_exp(self):
+        table = PowerBiTable(
+            name="test_table",
+            source=[PowerBITableSource(expression=MOCK_REDSHIFT_EXP)],
+        )
+        result = self.powerbi._parse_table_info_from_source_exp(
+            table, MOCK_DASHBOARD_DATA_MODEL
+        )
+        self.assertEqual(result, EXPECTED_REDSHIFT_RESULT)
+
+        # no source expression
+        table = PowerBiTable(
+            name="test_table",
+            source=[PowerBITableSource(expression=None)],
+        )
+        result = self.powerbi._parse_table_info_from_source_exp(
+            table, MOCK_DASHBOARD_DATA_MODEL
+        )
+        self.assertEqual(result, {})
+
+        # no source
+        table = PowerBiTable(
+            name="test_table",
+            source=[],
+        )
+        result = self.powerbi._parse_table_info_from_source_exp(
+            table, MOCK_DASHBOARD_DATA_MODEL
+        )
+        self.assertEqual(result, {})
+
+    @pytest.mark.order(4)
+    @patch.object(
+        PowerbiSource,
+        "_fetch_dataset_from_workspace",
+        return_value=MOCK_DATASET_FROM_WORKSPACE_V2,
+    )
+    def test_parse_dataset_expressions(self, *_):
+        # test with valid snowflake source but no
+        # dataset expression value
+        result = self.powerbi._parse_snowflake_source(
+            MOCK_SNOWFLAKE_EXP_V2, MOCK_DASHBOARD_DATA_MODEL
+        )
+        self.assertEqual(result["database"] is None, True)
+        self.assertEqual(result["schema"] is None, True)
+        self.assertEqual(result["table"], "CUSTOMER_TABLE")


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes: dataset expressions empty value, table source expression empty value handled
```
workspaces.26.datasets.6.expressions.1.expression
  Field required [type=missing, input_value={'name': 'something'}, input_type=dict]
```
<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->


<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
