### PR TITLE
Fix(ui) : Persona customization widgets style issues

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericWidget/generic-widget.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericWidget/generic-widget.less
@@ -15,6 +15,8 @@
 
 .generic-widget-card {
   height: 100%;
+  overflow-y: hidden;
+  padding-bottom: 16px !important;
 
   .ant-card-head {
     background-color: @grey-100;

--- a/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericWidget/generic-widget.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericWidget/generic-widget.less
@@ -15,8 +15,7 @@
 
 .generic-widget-card {
   height: 100%;
-  overflow-y: hidden;
-  padding-bottom: 16px !important;
+  padding-bottom: @size-md !important;
 
   .ant-card-head {
     background-color: @grey-100;

--- a/openmetadata-ui/src/main/resources/ui/src/pages/CustomizeDetailsPage/customize-details-page.less
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/CustomizeDetailsPage/customize-details-page.less
@@ -10,6 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+@import (reference) url('../../styles/variables.less');
 .customize-details-page {
   box-shadow: 0px 4px 6px -2px #0a0d1208;
   box-shadow: 0px 12px 16px -4px #0a0d1214;
@@ -21,6 +22,7 @@
 
   .ant-card-head {
     border: none;
+    border-radius: @size-sm;
   }
 
   .customize-page-header {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/FrequentlyJoinedTables/FrequentlyJoinedTables.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/FrequentlyJoinedTables/FrequentlyJoinedTables.component.tsx
@@ -29,7 +29,11 @@ export type Joined = JoinedWith & {
   name: string;
 };
 
-export const FrequentlyJoinedTables = () => {
+export const FrequentlyJoinedTables = ({
+  renderAsExpandableCard = true,
+}: {
+  renderAsExpandableCard?: boolean;
+}) => {
   const { t } = useTranslation();
   const { data, filterWidgets } = useGenericContext<Table>();
 
@@ -64,7 +68,7 @@ export const FrequentlyJoinedTables = () => {
     </Space>
   ));
 
-  return (
+  return renderAsExpandableCard ? (
     <ExpandableCard
       cardProps={{
         title: t('label.frequently-joined-table-plural'),
@@ -73,5 +77,7 @@ export const FrequentlyJoinedTables = () => {
       isExpandDisabled={isEmpty(joinedTables)}>
       {content}
     </ExpandableCard>
+  ) : (
+    <>{content}</>
   );
 };

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/PartitionedKeys/PartitionedKeys.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/PartitionedKeys/PartitionedKeys.component.tsx
@@ -23,7 +23,11 @@ import {
   Table as TableType,
 } from '../../../generated/entity/data/table';
 
-export const PartitionedKeys = () => {
+export const PartitionedKeys = ({
+  renderAsExpandableCard = true,
+}: {
+  renderAsExpandableCard?: boolean;
+}) => {
   const { data, filterWidgets } = useGenericContext<TableType>();
 
   const partitionColumnDetails = useMemo(
@@ -80,7 +84,7 @@ export const PartitionedKeys = () => {
     />
   );
 
-  return (
+  return renderAsExpandableCard ? (
     <ExpandableCard
       cardProps={{
         title: t('label.table-partition-plural'),
@@ -88,5 +92,7 @@ export const PartitionedKeys = () => {
       isExpandDisabled={isEmpty(partitionColumnDetails)}>
       {content}
     </ExpandableCard>
+  ) : (
+    content
   );
 };

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableConstraints/TableConstraints.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableConstraints/TableConstraints.tsx
@@ -32,7 +32,11 @@ import ForeignKeyConstraint from './ForeignKeyConstraint';
 import './table-constraints.less';
 import TableConstraintsModal from './TableConstraintsModal/TableConstraintsModal.component';
 
-const TableConstraints = () => {
+const TableConstraints = ({
+  renderAsExpandableCard = true,
+}: {
+  renderAsExpandableCard?: boolean;
+}) => {
   const { t } = useTranslation();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { data, permissions, onUpdate } = useGenericContext<Table>();
@@ -168,13 +172,17 @@ const TableConstraints = () => {
 
   return (
     <>
-      <ExpandableCard
-        cardProps={{
-          title: header,
-        }}
-        isExpandDisabled={isEmpty(data?.tableConstraints)}>
-        {content}
-      </ExpandableCard>
+      {renderAsExpandableCard ? (
+        <ExpandableCard
+          cardProps={{
+            title: header,
+          }}
+          isExpandDisabled={isEmpty(data?.tableConstraints)}>
+          {content}
+        </ExpandableCard>
+      ) : (
+        content
+      )}
       {isModalOpen && (
         <TableConstraintsModal
           constraint={data?.tableConstraints}

--- a/openmetadata-ui/src/main/resources/ui/src/utils/GenericWidget/GenericWidgetUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/GenericWidget/GenericWidgetUtils.tsx
@@ -121,7 +121,7 @@ export const WIDGET_COMPONENTS = {
   ),
   [DetailPageWidgetKeys.TABLE_SCHEMA]: () => <SchemaTable />,
   [DetailPageWidgetKeys.FREQUENTLY_JOINED_TABLES]: () => (
-    <FrequentlyJoinedTables />
+    <FrequentlyJoinedTables renderAsExpandableCard={false} />
   ),
   [DetailPageWidgetKeys.DATA_PRODUCTS]: () => (
     <DataProductsContainer
@@ -133,7 +133,9 @@ export const WIDGET_COMPONENTS = {
   [GlossaryTermDetailPageWidgetKeys.TERMS_TABLE]: () => (
     <GlossaryTermTab isGlossary />
   ),
-  [DetailPageWidgetKeys.TABLE_CONSTRAINTS]: () => <TableConstraints />,
+  [DetailPageWidgetKeys.TABLE_CONSTRAINTS]: () => (
+    <TableConstraints renderAsExpandableCard={false} />
+  ),
   [DetailPageWidgetKeys.TOPIC_SCHEMA]: () => <TopicSchemaFields />,
   [DetailPageWidgetKeys.DATA_MODEL]: () => <ModelTab />,
   [DetailPageWidgetKeys.CONTAINER_CHILDREN]: () => (
@@ -163,5 +165,7 @@ export const WIDGET_COMPONENTS = {
   [DetailPageWidgetKeys.STORED_PROCEDURE_CODE]: () => (
     <StoredProcedureCodeCard />
   ),
-  [DetailPageWidgetKeys.PARTITIONED_KEYS]: () => <PartitionedKeys />,
+  [DetailPageWidgetKeys.PARTITIONED_KEYS]: () => (
+    <PartitionedKeys renderAsExpandableCard={false} />
+  ),
 } as const;

--- a/openmetadata-ui/src/main/resources/ui/src/utils/GenericWidget/GenericWidgetUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/GenericWidget/GenericWidgetUtils.tsx
@@ -125,7 +125,6 @@ export const WIDGET_COMPONENTS = {
   ),
   [DetailPageWidgetKeys.DATA_PRODUCTS]: () => (
     <DataProductsContainer
-      newLook
       dataProducts={tableClassBase.getDummyData().dataProducts ?? []}
       hasPermission={false}
       showHeader={false}


### PR DESCRIPTION
Fixes #21405


1. Overflow issue for widgets 

Issue
<img width="498" alt="Screenshot 2025-05-27 at 3 40 23 PM" src="https://github.com/user-attachments/assets/ea4089fd-660d-439b-bded-7910e9209cdd" />

Fix:


https://github.com/user-attachments/assets/bbc9fc6a-6835-4be5-b5d7-36a68bd20772






2. Border issue for the widgets header cards

Issue:
<img width="366" alt="Screenshot 2025-05-27 at 3 42 57 PM" src="https://github.com/user-attachments/assets/223248e0-c476-4933-972f-334431f7fc75" />

Fix:
<img width="366" alt="Screenshot 2025-05-27 at 3 44 28 PM" src="https://github.com/user-attachments/assets/db03b31f-7d3d-47f1-9cdd-1af956c37124" />
<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->


3. Removed expand collapse nested card for widgets which had nested expand collapse cards
1.Data Products widget

Current Data Products widget
<img width="339" alt="Screenshot 2025-05-27 at 4 51 17 PM" src="https://github.com/user-attachments/assets/6d6e3628-5bf3-40bc-b057-ac3c0f96c8ec" />

Fix:-
<img width="374" alt="Screenshot 2025-05-27 at 4 53 03 PM" src="https://github.com/user-attachments/assets/7ca23bb3-35bd-4292-9ae7-9512b773a347" />

2. Frequently Joined Tables Widget
issue
<img width="339" alt="Screenshot 2025-05-28 at 1 02 33 PM" src="https://github.com/user-attachments/assets/35db5245-c95e-4677-b731-8e456dcfd6e2" />

Fix
<img width="339" alt="Screenshot 2025-05-28 at 1 01 55 PM" src="https://github.com/user-attachments/assets/7763e4c2-1647-4e3a-9384-87ee3646d61b" />

3. Partioned Keys and Table Constraints
<img width="339" alt="Screenshot 2025-05-28 at 1 02 57 PM" src="https://github.com/user-attachments/assets/251abfe7-d6bd-4543-b719-e6fc60a18829" />

Fix

https://github.com/user-attachments/assets/0e7cf160-5eb5-4637-aa7f-9ab8b51d8cf0









https://github.com/user-attachments/assets/63a9a9e9-7278-43be-a9f1-3e7208204eb0



Entity Page and Version Page rendering the widgets as per expand collapse card (unaffected)


https://github.com/user-attachments/assets/3b6333cf-edb3-4f88-b757-bde8bd5eb116


Impacted areas:-
GenericTabWidgets in CustomizeDetailsPage, CustomizeDomainPage and CustomizeGlossaryTermDetailPage


#


### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
