### PR TITLE
FIX #21464

### DIFF
--- a/ingestion/src/metadata/pii/algorithms/classifiers.py
+++ b/ingestion/src/metadata/pii/algorithms/classifiers.py
@@ -38,7 +38,11 @@ from metadata.pii.algorithms.feature_extraction import (
     split_column_name,
 )
 from metadata.pii.algorithms.preprocessing import preprocess_values
-from metadata.pii.algorithms.presidio_patches import url_patcher
+from metadata.pii.algorithms.presidio_patches import (
+    combine_patchers,
+    date_time_patcher,
+    url_patcher,
+)
 from metadata.pii.algorithms.presidio_utils import (
     build_analyzer_engine,
     set_presidio_logger_level,
@@ -119,7 +123,7 @@ class HeuristicPIIClassifier(ColumnClassifier[PIITag]):
             self._presidio_analyzer,
             str_values,
             context=context,
-            recognizer_result_patcher=url_patcher,
+            recognizer_result_patcher=combine_patchers(date_time_patcher, url_patcher),
         )
 
         column_name_matches: Set[PIITag] = set()

--- a/ingestion/src/metadata/pii/algorithms/presidio_patches.py
+++ b/ingestion/src/metadata/pii/algorithms/presidio_patches.py
@@ -75,7 +75,7 @@ def date_time_patcher(
         if result.entity_type == "DATE_TIME":
             # try to parse using dateutils, if it fails, skip the result
             try:
-                parse(text[result.start : result.end])
+                _ = parse(text[result.start : result.end])
             except ValueError:
                 # if parsing fails, skip the result
                 continue

--- a/ingestion/src/metadata/pii/algorithms/presidio_patches.py
+++ b/ingestion/src/metadata/pii/algorithms/presidio_patches.py
@@ -30,6 +30,24 @@ class PresidioRecognizerResultPatcher(Protocol):
         ...
 
 
+def combine_patchers(
+    *patchers: PresidioRecognizerResultPatcher,
+) -> PresidioRecognizerResultPatcher:
+    """
+    Combine multiple patchers into one.
+    This allows us to apply multiple patches in sequence.
+    """
+
+    def combined_patcher(
+        recognizer_results: Sequence[RecognizerResult], text: str
+    ) -> Sequence[RecognizerResult]:
+        for patcher in patchers:
+            recognizer_results = patcher(recognizer_results, text)
+        return recognizer_results
+
+    return combined_patcher
+
+
 def url_patcher(
     recognizer_results: Sequence[RecognizerResult], text: str
 ) -> Sequence[RecognizerResult]:

--- a/ingestion/src/metadata/pii/algorithms/presidio_patches.py
+++ b/ingestion/src/metadata/pii/algorithms/presidio_patches.py
@@ -13,6 +13,7 @@ Patch the Presidio recognizer results to make adapt them to specific use cases.
 """
 from typing import List, Protocol, Sequence
 
+from dateutil.parser import parse
 from presidio_analyzer import RecognizerResult
 
 
@@ -40,6 +41,25 @@ def url_patcher(
         if result.entity_type == "URL":
             if text[: result.start].endswith("@"):
                 # probably an email address, skip the URL
+                continue
+        patched_result.append(result)
+    return patched_result
+
+
+def date_time_patcher(
+    recognizer_results: Sequence[RecognizerResult], text: str
+) -> Sequence[RecognizerResult]:
+    """
+    Patch the recognizer result to remove date time false positive with date.
+    """
+    patched_result: List[RecognizerResult] = []
+    for result in recognizer_results:
+        if result.entity_type == "DATE_TIME":
+            # try to parse using dateutils, if it fails, skip the result
+            try:
+                parse(text[result.start : result.end])
+            except ValueError:
+                # if parsing fails, skip the result
                 continue
         patched_result.append(result)
     return patched_result

--- a/ingestion/tests/unit/pii/algorithms/data/pii_samples.py
+++ b/ingestion/tests/unit/pii/algorithms/data/pii_samples.py
@@ -70,6 +70,19 @@ phone_data: LabeledData = {
     "pii_sensitivity": True,
 }
 
+data_time_data: LabeledData = {
+    "column_name": "event_time",
+    "column_data_type": DataType.STRING,
+    "sample_data": [
+        "2023-10-01 12:00:00Z",
+        "2023-10-02 15:30:00Z",
+        "2023-10-03 18:45:00Z",
+        "2023-10-04 21:15:00Z",
+    ],
+    "pii_tags": [PIITag.DATE_TIME],
+    "pii_sensitivity": False,
+}
+
 non_pii_text_data: LabeledData = {
     "column_name": "random_text",
     "column_data_type": DataType.STRING,
@@ -173,7 +186,6 @@ es_nif_data: LabeledData = {
     "sample_data": ["48347544A", "08163649Y", "85738706L", "01922869T", "44729355J"],
     "pii_tags": [
         PIITag.ES_NIF,
-        PIITag.DATE_TIME,
         PIITag.US_DRIVER_LICENSE,  # low score
     ],
     "pii_sensitivity": True,

--- a/ingestion/tests/unit/pii/algorithms/data/pii_samples.py
+++ b/ingestion/tests/unit/pii/algorithms/data/pii_samples.py
@@ -178,3 +178,22 @@ es_nif_data: LabeledData = {
     ],
     "pii_sensitivity": True,
 }
+
+# Sample data for regression tests
+
+# Previously, this data was incorrectly tagged as PII.DATE_TIME
+false_positive_datetime_data: LabeledData = {
+    "column_name": None,
+    "column_data_type": DataType.STRING,
+    "sample_data": [
+        "60001",
+        "60002",
+        "60003",
+        "60004",
+        "60005",
+        "60006",
+        "60007",
+    ],
+    "pii_tags": [],
+    "pii_sensitivity": False,
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

Fixes #21464 

I worked on improving datetime extraction by introducing a patch over Presidio's existing implementation. Presidio's native datetime extraction often produces false positives on datetimes (e.g., 60001 is marked as a datetime, due to its regular expression-based approach). To address this, I added an extra verification layer that attempts to parse detected date strings into actual datetime objects using the `dateutil` library, filtering out invalid or ambiguous extractions.

I tested the changes by running the patched extraction pipeline on a series of sample texts containing valid and invalid date formats. This improved accuracy by reducing false positives, though it does not target or resolve existing false negatives.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Bug fix
- [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->