### PR TITLE
MINOR: row sampling error

### DIFF
--- a/ingestion/src/metadata/sampler/sqlalchemy/azuresql/sampler.py
+++ b/ingestion/src/metadata/sampler/sqlalchemy/azuresql/sampler.py
@@ -15,7 +15,7 @@ for the profiler
 from typing import List, Optional
 
 from sqlalchemy import Column, Table, text
-from sqlalchemy.orm import Query
+from sqlalchemy.sql.selectable import CTE
 
 from metadata.generated.schema.entity.data.table import TableData, TableType
 from metadata.sampler.sqlalchemy.sampler import ProfileSampleType, SQASampler
@@ -49,14 +49,11 @@ class AzureSQLSampler(SQASampler):
 
         return selectable
 
-    def get_sample_query(self, *, column=None) -> Query:
-        """get query for sample data"""
-        rnd = self._base_sample_query(column).cte(
+    def get_sample_query(self, *, column=None) -> CTE:
+        """Override the base method as ROWS or PERCENT sampling handled through the tablesample clause"""
+        return self._base_sample_query(column).cte(
             f"{self.get_sampler_table_name()}_rnd"
         )
-        with self.get_client() as client:
-            query = client.query(rnd)
-        return query.cte(f"{self.get_sampler_table_name()}_sample")
 
     def fetch_sample_data(self, columns: Optional[List[Column]] = None) -> TableData:
         sqa_columns = []

--- a/ingestion/src/metadata/sampler/sqlalchemy/azuresql/sampler.py
+++ b/ingestion/src/metadata/sampler/sqlalchemy/azuresql/sampler.py
@@ -51,9 +51,11 @@ class AzureSQLSampler(SQASampler):
 
     def get_sample_query(self, *, column=None) -> CTE:
         """Override the base method as ROWS or PERCENT sampling handled through the tablesample clause"""
-        return self._base_sample_query(column).cte(
+        rnd = self._base_sample_query(column).cte(
             f"{self.get_sampler_table_name()}_rnd"
         )
+        query = self.get_client().query(rnd)
+        return query.cte(f"{self.get_sampler_table_name()}_sample")
 
     def fetch_sample_data(self, columns: Optional[List[Column]] = None) -> TableData:
         sqa_columns = []

--- a/ingestion/src/metadata/sampler/sqlalchemy/mssql/sampler.py
+++ b/ingestion/src/metadata/sampler/sqlalchemy/mssql/sampler.py
@@ -44,10 +44,7 @@ class MssqlSampler(SQASampler):
         return selectable
 
     def get_sample_query(self, *, column=None) -> CTE:
-        """get query for sample data"""
-        rnd = self._base_sample_query(column).cte(
+        """Override the base method as ROWS or PERCENT sampling handled through the tablesample clause"""
+        return self._base_sample_query(column).cte(
             f"{self.get_sampler_table_name()}_rnd"
         )
-        with self.get_client() as client:
-            query = client.query(rnd)
-        return query.cte(f"{self.get_sampler_table_name()}_sample")

--- a/ingestion/src/metadata/sampler/sqlalchemy/mssql/sampler.py
+++ b/ingestion/src/metadata/sampler/sqlalchemy/mssql/sampler.py
@@ -45,6 +45,8 @@ class MssqlSampler(SQASampler):
 
     def get_sample_query(self, *, column=None) -> CTE:
         """Override the base method as ROWS or PERCENT sampling handled through the tablesample clause"""
-        return self._base_sample_query(column).cte(
+        rnd = self._base_sample_query(column).cte(
             f"{self.get_sampler_table_name()}_rnd"
         )
+        query = self.get_client().query(rnd)
+        return query.cte(f"{self.get_sampler_table_name()}_sample")

--- a/ingestion/src/metadata/sampler/sqlalchemy/sampler.py
+++ b/ingestion/src/metadata/sampler/sqlalchemy/sampler.py
@@ -136,6 +136,8 @@ class SQASampler(SamplerInterface, SQAInterfaceMixin):
             ).cte(f"{self.get_sampler_table_name()}_sample")
 
         table_query = client.query(self.raw_dataset)
+        if self.partition_details:
+            table_query = self.get_partitioned_query(table_query)
         session_query = self._base_sample_query(
             column,
             (ModuloFn(RandomNumFn(), table_query.count())).label(RANDOM_LABEL)

--- a/ingestion/src/metadata/sampler/sqlalchemy/snowflake/sampler.py
+++ b/ingestion/src/metadata/sampler/sqlalchemy/snowflake/sampler.py
@@ -88,6 +88,8 @@ class SnowflakeSampler(SQASampler):
 
     def get_sample_query(self, *, column=None) -> CTE:
         """Override the base method as ROWS or PERCENT sampling handled through the tablesample clause"""
-        return self._base_sample_query(column).cte(
+        rnd = self._base_sample_query(column).cte(
             f"{self.get_sampler_table_name()}_rnd"
         )
+        query = self.get_client().query(rnd)
+        return query.cte(f"{self.get_sampler_table_name()}_sample")

--- a/ingestion/src/metadata/sampler/sqlalchemy/snowflake/sampler.py
+++ b/ingestion/src/metadata/sampler/sqlalchemy/snowflake/sampler.py
@@ -87,10 +87,7 @@ class SnowflakeSampler(SQASampler):
         )
 
     def get_sample_query(self, *, column=None) -> CTE:
-        """get query for sample data"""
-        rnd = self._base_sample_query(column).cte(
+        """Override the base method as ROWS or PERCENT sampling handled through the tablesample clause"""
+        return self._base_sample_query(column).cte(
             f"{self.get_sampler_table_name()}_rnd"
         )
-        with self.get_client() as client:
-            query = client.query(rnd)
-        return query.cte(f"{self.get_sampler_table_name()}_sample")


### PR DESCRIPTION
### Describe your changes:
Fixes error when running row sampling:

**What**
If user uses randomized row sampled we need to perform a fullscan of the table so we can get `rand n/total_rows`. That full scan did not include the partitioning logic result in partition errors

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

Bug fix
- [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.


<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
