### PR TITLE
Fix #21517: Last user not visible || profile config icon miss aligned

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/TaskFeedCard/TaskFeedCardNew.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/TaskFeedCard/TaskFeedCardNew.component.tsx
@@ -37,7 +37,6 @@ import EntityLink from '../../../utils/EntityLink';
 import { getEntityFQN, getEntityType } from '../../../utils/FeedUtils';
 
 import { AxiosError } from 'axios';
-import { ReactComponent as AssigneesIcon } from '../../../assets/svg/ic-assignees.svg';
 import { TaskOperation } from '../../../constants/Feeds.constants';
 import { TASK_TYPES } from '../../../constants/Task.constant';
 import { TaskType } from '../../../generated/api/feed/createThread';
@@ -358,7 +357,6 @@ const TaskFeedCard = ({
                       ? 'task-card-assignee'
                       : ''
                   }`}>
-                  <Icon component={AssigneesIcon} style={{ fontSize: 16 }} />
                   <OwnerLabel
                     isAssignee
                     avatarSize={24}

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/TaskFeedCard/TaskFeedCardNew.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/TaskFeedCard/TaskFeedCardNew.component.tsx
@@ -37,15 +37,18 @@ import EntityLink from '../../../utils/EntityLink';
 import { getEntityFQN, getEntityType } from '../../../utils/FeedUtils';
 
 import { AxiosError } from 'axios';
+import { ReactComponent as AssigneesIcon } from '../../../assets/svg/ic-assignees.svg';
 import { TaskOperation } from '../../../constants/Feeds.constants';
 import { TASK_TYPES } from '../../../constants/Task.constant';
 import { TaskType } from '../../../generated/api/feed/createThread';
 import { ResolveTask } from '../../../generated/api/feed/resolveTask';
 import { useAuth } from '../../../hooks/authHooks';
 import { useApplicationStore } from '../../../hooks/useApplicationStore';
+import { useUserProfile } from '../../../hooks/user-profile/useUserProfile';
 import DescriptionTaskNew from '../../../pages/TasksPage/shared/DescriptionTaskNew';
 import TagsTask from '../../../pages/TasksPage/shared/TagsTask';
 import { updateTask } from '../../../rest/feedsAPI';
+import { getEntityName } from '../../../utils/EntityUtils';
 import { getErrorText } from '../../../utils/StringsUtils';
 import {
   getTaskDetailPath,
@@ -53,9 +56,6 @@ import {
   isTagsTask,
 } from '../../../utils/TasksUtils';
 import { showErrorToast, showSuccessToast } from '../../../utils/ToastUtils';
-
-import { useUserProfile } from '../../../hooks/user-profile/useUserProfile';
-import { getEntityName } from '../../../utils/EntityUtils';
 import { OwnerLabel } from '../../common/OwnerLabel/OwnerLabel.component';
 import { useActivityFeedProvider } from '../ActivityFeedProvider/ActivityFeedProvider';
 import './task-feed-card.less';
@@ -358,6 +358,7 @@ const TaskFeedCard = ({
                       ? 'task-card-assignee'
                       : ''
                   }`}>
+                  <Icon component={AssigneesIcon} style={{ fontSize: 16 }} />
                   <OwnerLabel
                     isAssignee
                     avatarSize={24}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ProfilerSettingsModal/ProfilerSettingsModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ProfilerSettingsModal/ProfilerSettingsModal.tsx
@@ -588,7 +588,7 @@ const ProfilerSettingsModal: React.FC<ProfilerSettingsModalProps> = ({
                         {`${t('label.include')}:`}
                       </p>
                       <Button
-                        className="include-columns-add-button"
+                        className="include-columns-add-button flex-center"
                         icon={<PlusOutlined />}
                         size="small"
                         type="primary"
@@ -873,7 +873,7 @@ const ProfilerSettingsModal: React.FC<ProfilerSettingsModalProps> = ({
                               {`${t('label.value')}:`}
                             </p>
                             <Button
-                              className="include-columns-add-button"
+                              className="include-columns-add-button flex-center"
                               icon={<PlusOutlined />}
                               size="small"
                               type="primary"

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/UserTeamSelectableList/user-team-selectable-list.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/UserTeamSelectableList/user-team-selectable-list.less
@@ -79,7 +79,6 @@
 
   .ant-list-vertical {
     .selectable-list-item {
-      margin-bottom: 4px;
       border-bottom: 0;
       border-radius: 4px;
       padding: 8px;


### PR DESCRIPTION

Fixes [#21517](https://github.com/open-metadata/OpenMetadata/issues/21517#top)

Problem :
<img width="466" alt="Screenshot 2025-06-05 at 4 48 22 PM" src="https://github.com/user-attachments/assets/76363f5e-4f6d-45a3-8467-80a07e411383" />

(misaligned icon)
![image (10)](https://github.com/user-attachments/assets/89965d61-d8c0-4198-a99e-2dba65dbf3ea)



Solution:

https://github.com/user-attachments/assets/c6e735e3-2d52-46d8-a63c-e6f70d5f2068


<img width="431" alt="Screenshot 2025-06-05 at 2 49 55 PM" src="https://github.com/user-attachments/assets/0c9d0e7e-c279-4884-9877-9da733bc6320" />




<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
