### PR TITLE
Minor (ui) : profile redirection issue for DisplayName in Tooltip

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardNew/ActivityFeedcardNew.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardNew/ActivityFeedcardNew.component.tsx
@@ -310,11 +310,11 @@ const ActivityFeedCardNew = ({
           ) : (
             <div className="d-flex gap-2">
               <div>
-                <UserPopOverCard userName={getEntityName(currentUser)}>
+                <UserPopOverCard userName={currentUser?.name ?? ''}>
                   <div className="d-flex items-center">
                     <ProfilePicture
                       key={feed.id}
-                      name={getEntityName(currentUser)}
+                      name={currentUser?.name ?? ''}
                       width="32"
                     />
                   </div>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/Task/TaskTab/TaskTabNew.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/Task/TaskTab/TaskTabNew.component.tsx
@@ -958,20 +958,16 @@ export const TaskTabNew = ({
                 {taskThread?.task?.assignees?.length === 1 ? (
                   <div className="d-flex items-center gap-2">
                     <UserPopOverCard
-                      userName={
-                        taskThread?.task?.assignees[0].displayName ?? ''
-                      }>
+                      userName={taskThread?.task?.assignees[0].name ?? ''}>
                       <div className="d-flex items-center">
                         <ProfilePicture
-                          name={
-                            taskThread?.task?.assignees[0].displayName ?? ''
-                          }
+                          name={taskThread?.task?.assignees[0].name ?? ''}
                           width="24"
                         />
                       </div>
                     </UserPopOverCard>
                     <Typography.Text className="text-grey-body">
-                      {taskThread?.task?.assignees[0].displayName}
+                      {getEntityName(taskThread?.task?.assignees[0])}
                     </Typography.Text>
                   </div>
                 ) : (
@@ -1132,11 +1128,11 @@ export const TaskTabNew = ({
               taskThread?.task?.status === ThreadTaskStatus.Open && (
                 <div className="d-flex gap-2">
                   <div className="profile-picture">
-                    <UserPopOverCard userName={getEntityName(currentUser)}>
+                    <UserPopOverCard userName={currentUser?.name ?? ''}>
                       <div className="d-flex items-center">
                         <ProfilePicture
                           key={taskThread.id}
-                          name={getEntityName(currentUser)}
+                          name={currentUser?.name ?? ''}
                           width="32"
                         />
                       </div>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/Task/TaskTabIncidentManagerHeader/TasktabIncidentManagerHeaderNew.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/Task/TaskTabIncidentManagerHeader/TasktabIncidentManagerHeaderNew.tsx
@@ -145,17 +145,16 @@ const TaskTabIncidentManagerHeaderNew = ({ thread }: { thread: Thread }) => {
         <Col className="flex items-center gap-2" span={16}>
           {thread?.task?.assignees?.length === 1 ? (
             <div className="d-flex items-center gap-2">
-              <UserPopOverCard
-                userName={thread?.task?.assignees[0].displayName ?? ''}>
+              <UserPopOverCard userName={thread?.task?.assignees[0].name ?? ''}>
                 <div className="d-flex items-center">
                   <ProfilePicture
-                    name={thread?.task?.assignees[0].displayName ?? ''}
+                    name={thread?.task?.assignees[0].name ?? ''}
                     width="24"
                   />
                 </div>
               </UserPopOverCard>
               <Typography.Text className="text-grey-body">
-                {thread?.task?.assignees[0].displayName}
+                {getEntityName(thread?.task?.assignees[0])}
               </Typography.Text>
             </div>
           ) : (

--- a/openmetadata-ui/src/main/resources/ui/src/components/ProfileCard/ProfileSectionUserDetailsCard.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ProfileCard/ProfileSectionUserDetailsCard.component.tsx
@@ -239,7 +239,7 @@ const ProfileSectionUserDetailsCard = ({
       </Popover>
 
       <div className="m-t-sm">
-        <UserPopOverCard userName={getEntityName(userData)}>
+        <UserPopOverCard userName={userData?.name}>
           <div className="d-flex items-center">
             <ProfilePicture
               data-testid="replied-user"

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/PopOverCard/UserPopOverCard.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/PopOverCard/UserPopOverCard.test.tsx
@@ -85,6 +85,11 @@ jest.mock('../ProfilePicture/ProfilePicture', () => {
   return jest.fn().mockImplementation(() => <div>ProfilePicture</div>);
 });
 
+const mockPush = jest.fn();
+(useHistory as jest.Mock).mockImplementation(() => ({
+  push: mockPush,
+}));
+
 describe('Test UserPopOverCard components', () => {
   describe('UserTeams Component', () => {
     it('should render teams when teams are available', () => {
@@ -193,6 +198,27 @@ describe('Test UserPopOverCard components', () => {
 
       expect(screen.getByText('Test User')).toBeInTheDocument();
       expect(screen.getByText('testUser')).toBeInTheDocument();
+    });
+
+    it('should navigate using name instead of display name when clicking display name in tooltip', () => {
+      (useUserProfile as jest.Mock).mockImplementation(() => [
+        null,
+        null,
+        mockUserData,
+      ]);
+
+      render(
+        <PopoverTitle
+          profilePicture={<div>ProfilePicture</div>}
+          type={OwnerType.USER}
+          userName="testUser"
+        />
+      );
+
+      const displayNameButton = screen.getByText('Test User');
+      displayNameButton.click();
+
+      expect(mockPush).toHaveBeenCalledWith('/users/testUser');
     });
 
     it('should handle click on user name', () => {


### PR DESCRIPTION
Issue:-
On having display name in the user popover card , and clicking on it , user does not get redirected properly .

Cause :-
Display name was getting passed  instead of  the name in the UserPopoverCard   because of using getEntityName function .
And so the url was getting updated with display name.


https://github.com/user-attachments/assets/2484de5e-aca8-4a41-948e-68551f4daf75

Fix:-

https://github.com/user-attachments/assets/b13a7d65-4a55-4011-9ed3-6a94c9af7517


 
 Also updated places where getEntityName is not required with name to avoid issues while displaying profile pictures , since while fetching profile pictures cached  names are  used.


<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->



