### PR TITLE
Fix(ui): Close emoji feed editor on outside click

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/FeedEditor/FeedEditor.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/FeedEditor/FeedEditor.tsx
@@ -90,6 +90,32 @@ export const FeedEditor = forwardRef<editorRef, FeedEditorProp>(
 
     const { userProfilePics } = useApplicationStore();
 
+    // handle click outside of emoji container
+    useEffect(() => {
+      const handleClickOutside = (event: MouseEvent) => {
+        const emojiContainer = document.querySelector(
+          '#om-quill-editor #textarea-emoji'
+        ) as HTMLElement;
+        const emojiToggleButton = document.querySelector(
+          '#om-quill-editor .textarea-emoji-control.ql-list'
+        ) as HTMLElement;
+
+        if (
+          emojiContainer &&
+          !emojiContainer.contains(event.target as Node) &&
+          emojiToggleButton &&
+          !emojiToggleButton.contains(event.target as Node)
+        ) {
+          emojiToggleButton.click(); // Simulates a click to close the emoji container
+        }
+      };
+
+      document.addEventListener('mousedown', handleClickOutside);
+
+      return () => {
+        document.removeEventListener('mousedown', handleClickOutside);
+      };
+    }, []);
     const userSuggestionRenderer = async (
       searchTerm: string,
       renderList: (matches: MentionSuggestionsItem[], search: string) => void,


### PR DESCRIPTION
### Fix Emoji Picker Click-Outside Behavior in Feed Editor

#### Problem Statement
The `@windmillcode/quill-emoji` library doesn't provide built-in click-outside handling for the emoji picker. While the library handles emoji selection and toggle behavior, it lacks the functionality to automatically close the picker when clicking outside, requiring a custom implementation.



### Library Limitation
The library only provides:
- Emoji picker UI rendering
- Toggle behaviour through the emoji button
- Emoji selection and insertion

It does not provide:
- Click-outside handling
- Automatic picker closure

## Changes
- Checks if click target is outside both the emoji container and toggle button
- If outside, simulates a click on the toggle button to properly close the picker
- Uses the library's built-in toggle mechanism instead of manual CSS manipulation




#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
