### PR TITLE
Fix #21804 : Admin users cannot see private teams in the "Teams" selection dropdown

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UsersProfile/UserProfileTeams/UserProfileTeams.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UsersProfile/UserProfileTeams/UserProfileTeams.component.tsx
@@ -149,7 +149,6 @@ const UserProfileTeams = ({
                     borderRadius: '5px',
                   }}>
                   <TeamsSelectableNew
-                    filterJoinable
                     handleDropdownChange={handleDropdownChange}
                     maxValueCount={3}
                     ref={teamsSelectableRef}


### PR DESCRIPTION
Fixes <#21804>

Issue:-
Currently admin users cannot see teams in the teams listing dropdown if that particular team has Public Teams options disabled.
This was happening because we were passing isJoinable field as true in the `api/v1/teams/hierarchy` api call

Fix:-


https://github.com/user-attachments/assets/1338713f-9f65-4cc5-81c2-5ba729bcba5f



#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
