### PR TITLE
PLAYWRIGHT: fix delete async alert on other playwright test causing failure

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamsDragAndDrop.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamsDragAndDrop.spec.ts
@@ -101,11 +101,11 @@ test.describe('Teams drag and drop should work properly', () => {
 
   test('Add teams in hierarchy', async ({ page }) => {
     for (const teamDetails of DRAG_AND_DROP_TEAM_DETAILS) {
-      const getOrganizationResponse = page.waitForResponse(
-        '/api/v1/teams/name/*'
-      );
       await addTeamHierarchy(page, teamDetails);
-      await getOrganizationResponse;
+      await page.waitForLoadState('networkidle');
+      await page.waitForSelector('[data-testid="loader"]', {
+        state: 'detached',
+      });
 
       await expect(
         page.locator(`[data-row-key="${teamDetails.name}"]`)

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/Metric.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/Metric.spec.ts
@@ -10,10 +10,12 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
+import { expect, Page, test as base } from '@playwright/test';
 import { SidebarItem } from '../../constant/sidebar';
 import { MetricClass } from '../../support/entity/MetricClass';
-import { createNewPage, redirectToHomePage } from '../../utils/common';
+import { UserClass } from '../../support/user/UserClass';
+import { performAdminLogin } from '../../utils/admin';
+import { redirectToHomePage } from '../../utils/common';
 import {
   addMetric,
   removeGranularity,
@@ -34,13 +36,24 @@ const metric4 = new MetricClass();
 const metric5 = new MetricClass();
 
 // use the admin user to login
-test.use({ storageState: 'playwright/.auth/admin.json' });
+const adminUser = new UserClass();
+
+const test = base.extend<{ page: Page }>({
+  page: async ({ browser }, use) => {
+    const adminPage = await browser.newPage();
+    await adminUser.login(adminPage);
+    await use(adminPage);
+    await adminPage.close();
+  },
+});
 
 test.describe('Metric Entity Special Test Cases', () => {
   test.slow(true);
 
   test.beforeAll('Setup pre-requests', async ({ browser }) => {
-    const { apiContext, afterAction } = await createNewPage(browser);
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+    await adminUser.create(apiContext);
+    await adminUser.setAdminRole(apiContext);
 
     await Promise.all([
       metric1.create(apiContext),
@@ -57,7 +70,8 @@ test.describe('Metric Entity Special Test Cases', () => {
   });
 
   test.afterAll('Cleanup', async ({ browser }) => {
-    const { apiContext, afterAction } = await createNewPage(browser);
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+    await adminUser.delete(apiContext);
 
     await Promise.all([
       metric1.delete(apiContext),
@@ -99,7 +113,9 @@ test.describe('Metric Entity Special Test Cases', () => {
 
 test.describe('Listing page and add Metric flow should work', () => {
   test.beforeAll('Setup pre-requests', async ({ browser }) => {
-    const { apiContext, afterAction } = await createNewPage(browser);
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+    await adminUser.create(apiContext);
+    await adminUser.setAdminRole(apiContext);
 
     await Promise.all([metric4.create(apiContext), metric5.create(apiContext)]);
 
@@ -111,7 +127,8 @@ test.describe('Listing page and add Metric flow should work', () => {
   });
 
   test.afterAll('Cleanup', async ({ browser }) => {
-    const { apiContext, afterAction } = await createNewPage(browser);
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+    await adminUser.delete(apiContext);
 
     await Promise.all([metric4.delete(apiContext), metric5.delete(apiContext)]);
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataInsightReportApplication.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataInsightReportApplication.spec.ts
@@ -33,7 +33,7 @@ test.describe.serial('Data Insight Report Application', () => {
         await apiContext.delete(
           '/api/v1/apps/name/DataInsightsReportApplication?hardDelete=true'
         );
-      } catch (error) {
+      } catch {
         // Do Nothing
       }
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/EntityVersionPages.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/EntityVersionPages.spec.ts
@@ -10,13 +10,14 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import test, { expect } from '@playwright/test';
+import { expect, Page, test as base } from '@playwright/test';
 import { BIG_ENTITY_DELETE_TIMEOUT } from '../../constant/delete';
 import { EntityDataClass } from '../../support/entity/EntityDataClass';
 import { EntityDataClassCreationConfig } from '../../support/entity/EntityDataClass.interface';
 import { TableClass } from '../../support/entity/TableClass';
+import { UserClass } from '../../support/user/UserClass';
+import { performAdminLogin } from '../../utils/admin';
 import {
-  createNewPage,
   descriptionBoxReadOnly,
   redirectToHomePage,
   toastNotification,
@@ -51,13 +52,24 @@ const entities = [
 ];
 
 // use the admin user to login
-test.use({ storageState: 'playwright/.auth/admin.json' });
+const adminUser = new UserClass();
+
+const test = base.extend<{ page: Page }>({
+  page: async ({ browser }, use) => {
+    const adminPage = await browser.newPage();
+    await adminUser.login(adminPage);
+    await use(adminPage);
+    await adminPage.close();
+  },
+});
 
 test.describe('Entity Version pages', () => {
   test.beforeAll('Setup pre-requests', async ({ browser }) => {
     test.slow();
 
-    const { apiContext, afterAction } = await createNewPage(browser);
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+    await adminUser.create(apiContext);
+    await adminUser.setAdminRole(apiContext);
 
     await EntityDataClass.preRequisitesForTests(
       apiContext,
@@ -118,7 +130,9 @@ test.describe('Entity Version pages', () => {
   test.afterAll('Cleanup', async ({ browser }) => {
     test.slow();
 
-    const { apiContext, afterAction } = await createNewPage(browser);
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+    await adminUser.delete(apiContext);
+
     await EntityDataClass.postRequisitesForTests(
       apiContext,
       entityCreationConfig
@@ -177,7 +191,7 @@ test.describe('Entity Version pages', () => {
           type: 'Users',
         });
 
-        const versionDetailResponse = page.waitForResponse(`**/versions/0.2`);
+        const versionDetailResponse = page.waitForResponse(`**/versions/0.3`);
         await page.locator('[data-testid="version-button"]').click();
         await versionDetailResponse;
 
@@ -229,7 +243,7 @@ test.describe('Entity Version pages', () => {
 
         await assignTier(page, 'Tier1', entity.endpoint);
 
-        const versionDetailResponse = page.waitForResponse(`**/versions/0.2`);
+        const versionDetailResponse = page.waitForResponse(`**/versions/0.3`);
         await page.locator('[data-testid="version-button"]').click();
         await versionDetailResponse;
 
@@ -270,7 +284,7 @@ test.describe('Entity Version pages', () => {
 
           await expect(deletedBadge).toHaveText('Deleted');
 
-          const versionDetailResponse = page.waitForResponse(`**/versions/0.3`);
+          const versionDetailResponse = page.waitForResponse(`**/versions/0.4`);
           await page.locator('[data-testid="version-button"]').click();
           await versionDetailResponse;
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/ServiceEntityVersionPage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/ServiceEntityVersionPage.spec.ts
@@ -10,12 +10,13 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import test, { expect } from '@playwright/test';
+import { expect, Page, test as base } from '@playwright/test';
 import { BIG_ENTITY_DELETE_TIMEOUT } from '../../constant/delete';
 import { EntityDataClass } from '../../support/entity/EntityDataClass';
 import { EntityDataClassCreationConfig } from '../../support/entity/EntityDataClass.interface';
+import { UserClass } from '../../support/user/UserClass';
+import { performAdminLogin } from '../../utils/admin';
 import {
-  createNewPage,
   descriptionBoxReadOnly,
   redirectToHomePage,
   toastNotification,
@@ -52,13 +53,25 @@ const entities = [
 ];
 
 // use the admin user to login
-test.use({ storageState: 'playwright/.auth/admin.json' });
+
+const adminUser = new UserClass();
+
+const test = base.extend<{ page: Page }>({
+  page: async ({ browser }, use) => {
+    const adminPage = await browser.newPage();
+    await adminUser.login(adminPage);
+    await use(adminPage);
+    await adminPage.close();
+  },
+});
 
 test.describe('Service Version pages', () => {
   test.beforeAll('Setup pre-requests', async ({ browser }) => {
     test.slow();
 
-    const { apiContext, afterAction } = await createNewPage(browser);
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+    await adminUser.create(apiContext);
+    await adminUser.setAdminRole(apiContext);
 
     await EntityDataClass.preRequisitesForTests(
       apiContext,
@@ -112,7 +125,9 @@ test.describe('Service Version pages', () => {
   test.afterAll('Cleanup', async ({ browser }) => {
     test.slow();
 
-    const { apiContext, afterAction } = await createNewPage(browser);
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+    await adminUser.delete(apiContext);
+
     await EntityDataClass.postRequisitesForTests(
       apiContext,
       entityCreationConfig
@@ -173,7 +188,7 @@ test.describe('Service Version pages', () => {
           type: 'Users',
         });
 
-        const versionDetailResponse = page.waitForResponse(`**/versions/0.2`);
+        const versionDetailResponse = page.waitForResponse(`**/versions/0.3`);
         await page.locator('[data-testid="version-button"]').click();
         await versionDetailResponse;
 
@@ -187,7 +202,7 @@ test.describe('Service Version pages', () => {
 
         await assignTier(page, 'Tier1', entity.endpoint);
 
-        const versionDetailResponse = page.waitForResponse(`**/versions/0.2`);
+        const versionDetailResponse = page.waitForResponse(`**/versions/0.3`);
         await page.locator('[data-testid="version-button"]').click();
         await versionDetailResponse;
 
@@ -228,7 +243,7 @@ test.describe('Service Version pages', () => {
 
           await expect(deletedBadge).toHaveText('Deleted');
 
-          const versionDetailResponse = page.waitForResponse(`**/versions/0.3`);
+          const versionDetailResponse = page.waitForResponse(`**/versions/0.4`);
           await page.locator('[data-testid="version-button"]').click();
           await versionDetailResponse;
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

This pull request focuses on improving Playwright test suites for the OpenMetadata UI by enhancing test reliability, introducing reusable user management utilities, and updating version-related tests. The most significant changes include replacing hardcoded storage states with dynamic admin user login, improving network and UI state checks, and updating version-related assertions.

### Enhancements to Test Reliability:

* [`openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamsDragAndDrop.spec.ts`](diffhunk://#diff-298d80ddbd49d6371cff7c556829ae5b21239fbf0c116204701c3d41c56f0f3fL104-R108): Replaced `waitForResponse` with `waitForLoadState('networkidle')` and added a check for loader detachment to ensure UI stability before proceeding.

### Introduction of Reusable User Management Utilities:

* [`openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/Metric.spec.ts`](diffhunk://#diff-e6833d478c0c70351dcaf2aabd6bf417c8dc89fb35e16cd1355ac9e9ea82b37dL13-R18): Introduced `UserClass` and replaced `test.use` with dynamic admin user login via `performAdminLogin`. Updated pre-request and cleanup logic to use the new admin user utilities.
* [`openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/EntityVersionPages.spec.ts`](diffhunk://#diff-a9254cf62d5116ab08ccadf57e4d7ab4b08af6b912ed396003d411a1576d2a84L13-L19): Similar updates as above, using `UserClass` and `performAdminLogin` for dynamic admin user handling.

### Updates to Version-Related Tests:

* [`openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/EntityVersionPages.spec.ts`](diffhunk://#diff-a9254cf62d5116ab08ccadf57e4d7ab4b08af6b912ed396003d411a1576d2a84L180-R194): Updated version assertions from `**/versions/0.2` to `**/versions/0.3` and `**/versions/0.3` to `**/versions/0.4` where applicable. since the initial changes were done by admin user and on page action by separate user, which lead to version change!!

* [`openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/ServiceEntityVersionPage.spec.ts`](diffhunk://#diff-3cc079899391d67b2ad973f5710a400ddd4ea33a277e4b963942ab9b8410a13dL176-R191): Similar updates to version assertions for service entity version pages. 

### Minor Error Handling Improvement:

* [`openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataInsightReportApplication.spec.ts`](diffhunk://#diff-1d256e9ef8bc7be63a0151f210b02994b147404e8ecf4d06e56dc85ebbe2e130L36-R36): Simplified error handling by removing the `error` parameter in the `catch` block.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
