### PR TITLE
Fix : query_cost_record_search_index Search reindexing issue

### DIFF
--- a/openmetadata-service/src/main/resources/elasticsearch/en/query_cost_record_index_mapping.json
+++ b/openmetadata-service/src/main/resources/elasticsearch/en/query_cost_record_index_mapping.json
@@ -201,7 +201,8 @@
           },
           "query": {
             "type": "keyword",
-            "index": false
+            "index": false,
+            "doc_values": false
           },
           "queryDate": {
             "type": "long"

--- a/openmetadata-service/src/main/resources/elasticsearch/jp/query_cost_record_index_mapping.json
+++ b/openmetadata-service/src/main/resources/elasticsearch/jp/query_cost_record_index_mapping.json
@@ -178,7 +178,8 @@
           },
           "query": {
             "type": "keyword",
-            "index": false
+            "index": false,
+            "doc_values": false
           },
           "queryDate": {
             "type": "long"

--- a/openmetadata-service/src/main/resources/elasticsearch/zh/query_cost_record_index_mapping.json
+++ b/openmetadata-service/src/main/resources/elasticsearch/zh/query_cost_record_index_mapping.json
@@ -183,7 +183,8 @@
           },
           "query": {
             "type": "keyword",
-            "index": false
+            "index": false,
+            "doc_values": false
           },
           "queryDate": {
             "type": "long"


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes 
```
[errorSource]: Sink
[message]: Issues in Sink to OpenSearch: [org.openmetadata.schema.system.EntityError@10cfd0b[message=OpenSearchException[OpenSearch exception [type=illegal_argument_exception, reason=DocValuesField "query.query" is too large, must be <= 32766]],entity=update {[query_cost_record_search_index][804181ea-d22e-40d6-aa34-3f9723995c34], doc_as_upsert[true], doc[index {[null][null], source[n/a, actual length: [57.7kb], max length: 2kb]}], scripted_upsert[false], detect_noop[true]}]]
[failedEntities]:
  [0]:
    [message]: OpenSearchException[OpenSearch exception [type=illegal_argument_exception, reason=DocValuesField "query.query" is too large, must be <= 32766]]
    [entity]: update {[query_cost_record_search_index][804181ea-d22e-40d6-aa34-3f9723995c34], doc_as_upsert[true], doc[index {[null][null], source[n/a, actual length: [57.7kb], max length: 2kb]}], scripted_upsert[false], detect_noop[true]}
[submittedCount]: 10
[successCount]: 9
[failedCount]: 1
```

- 	The above changes in pr will make  `query.query`  field  stored in _source only.
- 	It is not searchable, not sortable, and not usable in aggregations, we can use the `query.queryText` field (type:text) for required operations

	
<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
