### PR TITLE
MINOR: Update PySpark and Delta-Spark Versions to use PySpark 3.5.6

### DIFF
--- a/ingestion/setup.py
+++ b/ingestion/setup.py
@@ -238,11 +238,12 @@ plugins: Dict[str, Set[str]] = {
         *COMMONS["datalake"],
     },
     "deltalake": {
-        "delta-spark<=2.3.0",
-        "deltalake~=0.17,<0.20",
+        "delta-spark>=3.0.0,<4.0.0",
+        "deltalake>=0.19.0,<0.20",
+        "pyspark==3.5.6",
     },  # TODO: remove pinning to under 0.20 after https://github.com/open-metadata/OpenMetadata/issues/17909
-    "deltalake-storage": {"deltalake~=0.17"},
-    "deltalake-spark": {"delta-spark<=2.3.0"},
+    "deltalake-storage": {"deltalake>=0.19.0,<0.20"},
+    "deltalake-spark": {"delta-spark>=3.0.0,<4.0.0", "pyspark==3.5.6"},
     "domo": {VERSIONS["pydomo"]},
     "doris": {"pydoris==1.0.2"},
     "druid": {"pydruid>=0.6.5"},

--- a/ingestion/src/metadata/ingestion/source/database/deltalake/clients/pyspark.py
+++ b/ingestion/src/metadata/ingestion/source/database/deltalake/clients/pyspark.py
@@ -79,7 +79,7 @@ class DeltalakePySparkClient(DeltalakeBaseClient):
                 "org.apache.spark.sql.delta.catalog.DeltaCatalog",
             )
             # Download delta-core jars when creating the SparkSession
-            .config("spark.jars.packages", "io.delta:delta-core_2.12:2.0.0")
+            .config("spark.jars.packages", "io.delta:delta-spark_2.12:3.2.0")
         )
 
         # Check that the attribute exists and is properly informed


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

In order to keep moving forward we are upgrading PySpark dependency to use PySpark 3.5.6 and, with it, upgrading Delta-Spark from 2.3 to 3.2.

The ingestion was tested with a local setup for a Hive Metastore.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Improvement

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
