### PR TITLE
Update metadata_service_helper.py

### DIFF
--- a/ingestion/src/metadata/utils/metadata_service_helper.py
+++ b/ingestion/src/metadata/utils/metadata_service_helper.py
@@ -83,7 +83,7 @@ SERVICE_TYPE_MAPPER = {
         "connection": {"config": {"awsConfig": "aws_config"}},
     },
     "snowflake": {
-        "service_nmae": "Snowflake",
+        "service_name": "Snowflake",
         "connection": {
             "config": {
                 "username": "randomName",


### PR DESCRIPTION
Fixed typo at line 86 
service_nmae changed to service_name


### Describe your changes:
Fixed typo at line 86 
service_nmae changed to service_name

Fixes issue 21946
