### PR TITLE
Fix(ui): Reply count being shown as 0 in task feed card

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityFeed.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityFeed.spec.ts
@@ -413,6 +413,9 @@ test.describe('Activity feed', () => {
 
     expect(descriptionTask).toContain('Request to update description');
 
+    // check initial replies count
+    await expect(page.getByTestId('replies-count')).not.toBeVisible();
+
     for (let i = 0; i < 10; i++) {
       const commentInput = page.locator('[data-testid="comments-input-field"]');
       commentInput.click();
@@ -439,6 +442,9 @@ test.describe('Activity feed', () => {
         page.locator('.right-container [data-testid="feed-replies"]')
       ).toContainText(`Reply message ${i}`);
     }
+
+    // check replies count in feed card
+    await expect(page.getByTestId('replies-count')).toHaveText('10 Replies');
   });
 
   test('Open and Closed Task Tab with approve from Task Feed Card', async ({

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/TaskFeedCard/TaskFeedCardNew.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/TaskFeedCard/TaskFeedCardNew.component.tsx
@@ -335,7 +335,7 @@ const TaskFeedCard = ({
                     width={20}
                     onClick={isForFeedTab ? showReplies : undefined}
                   />
-                  {feed?.postsCount && feed?.postsCount > 0 && (
+                  {(feed?.postsCount ?? 0) > 0 && (
                     <Button
                       className="posts-length m-r-xss p-0 remove-button-default-styling"
                       data-testid="replies-count"

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/TaskFeedCard/TaskFeedCardNew.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/TaskFeedCard/TaskFeedCardNew.component.tsx
@@ -335,7 +335,7 @@ const TaskFeedCard = ({
                     width={20}
                     onClick={isForFeedTab ? showReplies : undefined}
                   />
-                  {!!(feed?.postsCount && feed?.postsCount > 0) && (
+                  {feed?.postsCount && feed?.postsCount > 0 ? (
                     <Button
                       className="posts-length m-r-xss p-0 remove-button-default-styling"
                       data-testid="replies-count"
@@ -348,7 +348,7 @@ const TaskFeedCard = ({
                         { number: feed.postsCount }
                       )}
                     </Button>
-                  )}
+                  ) : null}
                 </Col>
 
                 <Col

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/TaskFeedCard/TaskFeedCardNew.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/TaskFeedCard/TaskFeedCardNew.component.tsx
@@ -335,7 +335,7 @@ const TaskFeedCard = ({
                     width={20}
                     onClick={isForFeedTab ? showReplies : undefined}
                   />
-                  {(feed?.postsCount ?? 0) > 0 && (
+                  {!!(feed?.postsCount && feed?.postsCount > 0) && (
                     <Button
                       className="posts-length m-r-xss p-0 remove-button-default-styling"
                       data-testid="replies-count"


### PR DESCRIPTION
Issue

The condition `feed?.postsCount && feed?.postsCount > 0`  was returning 0 and not false in case of postsCount being 0, due to which the count 0 was been shown as 0.
<img width="656" alt="Screenshot 2025-06-25 at 3 25 55 PM" src="https://github.com/user-attachments/assets/064298c2-656e-4063-8b1b-da0c4ab848ab" />

Fix

https://github.com/user-attachments/assets/8725fa2d-aeb0-4d3b-8754-8bc63f14f8e8


<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->



