### PR TITLE
Fix the error in the template yml and add ability to trigger it from specific branch

### DIFF
--- a/.github/workflows/typescript-type-generation.yml
+++ b/.github/workflows/typescript-type-generation.yml
@@ -4,9 +4,17 @@ on:
   pull_request:
     paths:
       - 'openmetadata-spec/src/main/resources/json/schema/**'
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to run the workflow on'
+        required: true
+        default: 'main'
+        type: string
 
 jobs:
   generate-types:
     runs-on: ubuntu-latest
-    # Placeholder for future workflow steps
-    steps: []
+    steps:
+      - name: Placeholder
+        run: echo "Workflow triggered successfully on branch ${{ github.event.inputs.branch || github.ref_name }}"


### PR DESCRIPTION
I fixed the yml error in the template action file and ability to trigger it for a specific branch.

Necessary for testing [Chore: Add github action to generate and commit types based on schema changes](https://github.com/open-metadata/OpenMetadata/pull/21796#top)

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
