### PR TITLE
Fixes ISSUE-21970: make TotalDataAssetsWidget a stacked graph

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/MyData/Widgets/TotalDataAssetsWidget/TotalDataAssetsWidget.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MyData/Widgets/TotalDataAssetsWidget/TotalDataAssetsWidget.component.tsx
@@ -232,6 +232,7 @@ const TotalDataAssetsWidget = ({
                       fill={entityChartColor(i) ?? getRandomHexColor()}
                       key={label}
                       name={label}
+                      stackId="data"
                       stroke={entityChartColor(i) ?? getRandomHexColor()}
                     />
                   ))}


### PR DESCRIPTION
### Describe your changes:

Changed the TotalDataAssetsWidget graph to stacked, as intended.

I worked on ... because ...
before: same as in issue, it's not readable.
<img width="489" alt="image" src="https://github.com/user-attachments/assets/9c1e5388-a006-479b-a4d1-168afdcb7f4a" />


after: it's now stacked, sadly I had only one day of data

<img width="455" alt="image" src="https://github.com/user-attachments/assets/8fe081f6-562d-4985-858d-ac7c9c40ffab" />


#
### Type of change:

- [ x] Improvement

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x ] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [ N/A] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

it's really a minor change, one line of code for a graph format change.
