### PR TITLE
Fix(UI): Current User store crash 

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/NavBar/NavBar.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/NavBar/NavBar.tsx
@@ -511,7 +511,8 @@ const NavBar = () => {
               <Button
                 className="flex-center gap-2 p-x-xs font-medium"
                 type="text">
-                {upperCase(language.split('-')[0])} <DropDownIcon width={12} />
+                {language ? upperCase(language.split('-')[0]) : ''}{' '}
+                <DropDownIcon width={12} />
               </Button>
             </Dropdown>
             <Dropdown

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/currentUserStore/useCurrentUserStore.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/currentUserStore/useCurrentUserStore.ts
@@ -98,7 +98,9 @@ export const useCurrentUserPreferences = () => {
   }
 
   return {
-    preferences: preferences[currentUser.name] || defaultPreferences,
+    preferences: preferences[currentUser.name]
+      ? { ...defaultPreferences, ...preferences[currentUser.name] }
+      : defaultPreferences,
     setPreference: (newPreferences: Partial<UserPreferences>) =>
       setUserPreference(currentUser.name, newPreferences),
   };


### PR DESCRIPTION
Application was getting crashed because old user didn't had `language` key on their local storage which was introduced in latest changes. Added  its fix for any missing key we'll spread the default values.


https://github.com/user-attachments/assets/3e85a4c7-57b2-44ea-81c9-62e59e06e25a


### Describe your changes:


<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
