### PR TITLE
Fix#22171: The deleted assets showing even when deleted switch is not checked

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ExploreDiscovery.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ExploreDiscovery.spec.ts
@@ -1,0 +1,186 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import test, { expect } from '@playwright/test';
+import { TableClass } from '../../support/entity/TableClass';
+import { createNewPage, redirectToHomePage } from '../../utils/common';
+import { getJsonTreeObject } from '../../utils/exploreDiscovery';
+
+// use the admin user to login
+test.use({ storageState: 'playwright/.auth/admin.json' });
+
+const table = new TableClass();
+
+test.describe('Explore Assets Discovery', () => {
+  test.beforeAll(async ({ browser }) => {
+    const { apiContext, afterAction } = await createNewPage(browser);
+
+    await table.create(apiContext);
+    await table.delete(apiContext, false);
+
+    await afterAction();
+  });
+
+  test.afterAll(async ({ browser }) => {
+    const { apiContext, afterAction } = await createNewPage(browser);
+
+    await table.delete(apiContext);
+
+    await afterAction();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await redirectToHomePage(page);
+  });
+
+  test('Should not display deleted assets when showDeleted is not checked and deleted is not present in queryFilter', async ({
+    page,
+  }) => {
+    const queryFilter = getJsonTreeObject(
+      table.entityResponseData.name,
+      table.schemaResponseData.name,
+      false
+    );
+    await page.goto(
+      `/explore?page=1&size=10&queryFilter=${JSON.stringify(queryFilter)}`
+    );
+
+    await page.waitForLoadState('networkidle');
+    await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
+
+    await expect(
+      page.locator(
+        `[data-testid="table-data-card_${table.entityResponseData.fullyQualifiedName}"]`
+      )
+    ).not.toBeAttached();
+  });
+
+  test('Should display deleted assets when showDeleted is not checked but deleted is true in queryFilter', async ({
+    page,
+  }) => {
+    const queryFilter = getJsonTreeObject(
+      table.entityResponseData.name,
+      table.schemaResponseData.name,
+      true,
+      true
+    );
+    await page.goto(
+      `/explore?page=1&size=10&queryFilter=${JSON.stringify(queryFilter)}`
+    );
+
+    await page.waitForLoadState('networkidle');
+    await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
+
+    await expect(
+      page.locator(
+        `[data-testid="table-data-card_${table.entityResponseData.fullyQualifiedName}"]`
+      )
+    ).toBeAttached();
+  });
+
+  test('Should not display deleted assets when showDeleted is not checked but deleted is false in queryFilter', async ({
+    page,
+  }) => {
+    const queryFilter = getJsonTreeObject(
+      table.entityResponseData.name,
+      table.schemaResponseData.name,
+      true,
+      false
+    );
+    await page.goto(
+      `/explore?page=1&size=10&queryFilter=${JSON.stringify(queryFilter)}`
+    );
+
+    await page.waitForLoadState('networkidle');
+    await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
+
+    await expect(
+      page.locator(
+        `[data-testid="table-data-card_${table.entityResponseData.fullyQualifiedName}"]`
+      )
+    ).not.toBeAttached();
+  });
+
+  test('Should display deleted assets when showDeleted is checked and deleted is not present in queryFilter', async ({
+    page,
+  }) => {
+    const queryFilter = getJsonTreeObject(
+      table.entityResponseData.name,
+      table.schemaResponseData.name,
+      false
+    );
+    await page.goto(
+      `/explore?page=1&size=10&showDeleted=true&queryFilter=${JSON.stringify(
+        queryFilter
+      )}`
+    );
+
+    await page.waitForLoadState('networkidle');
+    await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
+
+    await expect(
+      page.locator(
+        `[data-testid="table-data-card_${table.entityResponseData.fullyQualifiedName}"]`
+      )
+    ).toBeAttached();
+  });
+
+  test('Should display deleted assets when showDeleted is checked and deleted is true in queryFilter', async ({
+    page,
+  }) => {
+    const queryFilter = getJsonTreeObject(
+      table.entityResponseData.name,
+      table.schemaResponseData.name,
+      true,
+      true
+    );
+    await page.goto(
+      `/explore?page=1&size=10&showDeleted=true&queryFilter=${JSON.stringify(
+        queryFilter
+      )}`
+    );
+
+    await page.waitForLoadState('networkidle');
+    await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
+
+    await expect(
+      page.locator(
+        `[data-testid="table-data-card_${table.entityResponseData.fullyQualifiedName}"]`
+      )
+    ).toBeAttached();
+  });
+
+  test('Should not display deleted assets when showDeleted is checked but deleted is false in queryFilter', async ({
+    page,
+  }) => {
+    const queryFilter = getJsonTreeObject(
+      table.entityResponseData.name,
+      table.schemaResponseData.name,
+      true,
+      false
+    );
+    await page.goto(
+      `/explore?page=1&size=10&showDeleted=true&queryFilter=${JSON.stringify(
+        queryFilter
+      )}`
+    );
+
+    await page.waitForLoadState('networkidle');
+    await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
+
+    await expect(
+      page.locator(
+        `[data-testid="table-data-card_${table.entityResponseData.fullyQualifiedName}"]`
+      )
+    ).not.toBeAttached();
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/exploreDiscovery.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/exploreDiscovery.ts
@@ -1,0 +1,103 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+export const getJsonTreeObjectDeletedTerm = (deleted: boolean) => {
+  return {
+    '9a89a899-cdef-4012-b456-7197e8b38b31': {
+      type: 'rule',
+      id: '9a89a899-cdef-4012-b456-7197e8b38b31',
+      properties: {
+        fieldSrc: 'field',
+        field: 'deleted',
+        operator: 'equal',
+        value: [deleted],
+        valueSrc: ['value'],
+        operatorOptions: null,
+        valueType: ['boolean'],
+      },
+      path: [
+        '8baba8ab-89ab-4cde-b012-3197e53630f9',
+        '99a9b98a-4567-489a-bcde-f197e53630f9',
+        '9a89a899-cdef-4012-b456-7197e8b38b31',
+      ],
+    },
+  };
+};
+
+export const getJsonTreeObject = (
+  assetName: string,
+  schemaName: string,
+  includeDeleted: boolean,
+  deleted = false
+) => {
+  return {
+    id: '8baba8ab-89ab-4cde-b012-3197e53630f9',
+    type: 'group',
+    properties: { conjunction: 'AND', not: false },
+    children1: {
+      '99a9b98a-4567-489a-bcde-f197e53630f9': {
+        type: 'group',
+        properties: { conjunction: 'AND', not: false },
+        children1: {
+          '898ba9bb-0123-4456-b89a-b197e53630f9': {
+            type: 'rule',
+            properties: {
+              field: 'name.keyword',
+              operator: 'select_equals',
+              fieldSrc: 'field',
+              value: [assetName],
+              valueSrc: ['value'],
+              operatorOptions: null,
+              valueType: ['select'],
+              valueError: [null],
+              asyncListValues: [{ value: assetName, title: assetName }],
+            },
+            path: [
+              '8baba8ab-89ab-4cde-b012-3197e53630f9',
+              '99a9b98a-4567-489a-bcde-f197e53630f9',
+              '898ba9bb-0123-4456-b89a-b197e53630f9',
+            ],
+            id: '898ba9bb-0123-4456-b89a-b197e53630f9',
+          },
+          '9aaa99ba-89ab-4cde-b012-3197e5458b56': {
+            type: 'rule',
+            id: '9aaa99ba-89ab-4cde-b012-3197e5458b56',
+            properties: {
+              fieldSrc: 'field',
+              value: [schemaName],
+              asyncListValues: [{ value: schemaName, title: schemaName }],
+              valueSrc: ['value'],
+              valueError: [null],
+              valueType: ['select'],
+              operatorOptions: null,
+              operator: 'select_equals',
+              field: 'databaseSchema.displayName.keyword',
+            },
+            path: [
+              '8baba8ab-89ab-4cde-b012-3197e53630f9',
+              '99a9b98a-4567-489a-bcde-f197e53630f9',
+              '9aaa99ba-89ab-4cde-b012-3197e5458b56',
+            ],
+          },
+          ...(includeDeleted ? getJsonTreeObjectDeletedTerm(deleted) : {}),
+        },
+        path: [
+          '8baba8ab-89ab-4cde-b012-3197e53630f9',
+          '99a9b98a-4567-489a-bcde-f197e53630f9',
+        ],
+        id: '99a9b98a-4567-489a-bcde-f197e53630f9',
+      },
+    },
+    path: ['8baba8ab-89ab-4cde-b012-3197e53630f9'],
+  };
+};

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ExplorePage/ExplorePageV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ExplorePage/ExplorePageV1.component.tsx
@@ -102,8 +102,8 @@ const ExplorePageV1: FC<unknown> = () => {
     size,
     showDeleted,
   } = useMemo(() => {
-    return parseSearchParams(location.search);
-  }, [location.search]);
+    return parseSearchParams(location.search, queryFilter);
+  }, [location.search, queryFilter]);
 
   const handlePageChange: ExploreProps['onChangePage'] = (page, size) => {
     navigate({


### PR DESCRIPTION
I worked on fixing the bug where soft-deleted assets were also listed on the explore page when deleted switch is not checked.

https://github.com/user-attachments/assets/9f6e9b04-c44f-4d6e-93d8-bf4c8b5a7112

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
