### PR TITLE
fix(test): Close and comment task failure

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityFeed.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityFeed.spec.ts
@@ -366,8 +366,11 @@ test.describe('Activity feed', () => {
     expect(descriptionTask).toContain('Request to update description');
 
     // Close the task from the Button.Group, should throw error when no comment is added.
-    await page.getByRole('button', { name: 'down' }).click();
-    await page.waitForSelector('.ant-dropdown', {
+    await page
+      .getByTestId('edit-accept-task-dropdown')
+      .getByRole('button', { name: 'down' })
+      .click();
+    await page.waitForSelector('.ant-dropdown-menu', {
       state: 'visible',
     });
 
@@ -388,8 +391,11 @@ test.describe('Activity feed', () => {
     const commentWithCloseTask = page.waitForResponse(
       '/api/v1/feed/tasks/*/close'
     );
-    await page.getByRole('button', { name: 'down' }).click();
-    await page.waitForSelector('.ant-dropdown', {
+    await page
+      .getByTestId('edit-accept-task-dropdown')
+      .getByRole('button', { name: 'down' })
+      .click();
+    await page.waitForSelector('.ant-dropdown-menu', {
       state: 'visible',
     });
     await page.getByRole('menuitem', { name: 'close' }).click();


### PR DESCRIPTION
Issue:-

<img width="1018" alt="Screenshot 2025-07-08 at 5 25 22 PM" src="https://github.com/user-attachments/assets/625d2df0-0667-4a3d-b6e2-44d16a7e8d78" />

<img width="1282" alt="Screenshot 2025-07-08 at 4 51 45 PM" src="https://github.com/user-attachments/assets/415c045e-1bed-4f4e-acee-1aeb74ab93f4" />

Fix
<img width="959" alt="Screenshot 2025-07-08 at 5 24 42 PM" src="https://github.com/user-attachments/assets/88dcd88e-c53c-435f-b713-65379da393f0" />



<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
