### PR TITLE
fix(test): Inherited domains test failure

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/UserDetails.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/UserDetails.spec.ts
@@ -179,8 +179,15 @@ test.describe('User with different Roles', () => {
       adminPage.locator('[data-testid="header-domain-container"]')
     ).toContainText(domain.responseData.displayName);
 
+    const teamsListResponse = adminPage.waitForResponse(
+      (response) =>
+        response.url().includes('/api/v1/teams/hierarchy') &&
+        response.request().method() === 'GET'
+    );
+
     await adminPage.getByTestId('edit-teams-button').click();
 
+    await teamsListResponse;
     await adminPage.getByTestId('team-select').click();
 
     await adminPage.waitForSelector('.ant-tree-select-dropdown', {
@@ -189,7 +196,7 @@ test.describe('User with different Roles', () => {
 
     await adminPage
       .locator('[title="' + team.responseData.displayName + '"]')
-      .first()
+      .nth(1)
       .click();
 
     const userProfileResponse = adminPage.waitForResponse((response) =>


### PR DESCRIPTION
Fixes failing 'Create team with domain and verify visibility of inherited domain in user profile after team removal" test in main

The test was failing while clicking on the team in the dropdown. There were race condition while clicking the the team since the team list was not properly loaded sometimes in the dropdown.
Added proper await for the  teams api call in the dropdown.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
