### PR TITLE
fix: cross-platform path resolution for dbt ingestion (on Windows)

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/dbt/dbt_config.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/dbt_config.py
@@ -19,6 +19,7 @@ from functools import singledispatch
 from typing import Dict, Iterable, List, Optional, Tuple
 
 import requests
+
 from metadata.clients.aws_client import AWSClient
 from metadata.clients.azure_client import AzureClient
 from metadata.generated.schema.metadataIngestion.dbtconfig.dbtAzureConfig import (
@@ -78,9 +79,7 @@ def _(config: DbtLocalConfig):
     try:
         blob_grouped_by_directory = defaultdict(list)
 
-        subdirectory = (
-            os.path.dirname(config.dbtManifestFilePath)
-        )
+        subdirectory = os.path.dirname(config.dbtManifestFilePath)
         blob_grouped_by_directory[subdirectory] = [
             config.dbtManifestFilePath,
             config.dbtCatalogFilePath,


### PR DESCRIPTION
### Describe your changes:

The `metadata ingest-dbt` command failed to ingest DBT artifacts into the OpenMetadata service due to missing _.json_ files. The root cause was the use of backslashes (\) in one of the Python scripts, which led to incorrect path resolution for Windows OS.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->
