### PR TITLE
MINOR: Fix databricks default schema issue

### DIFF
--- a/ingestion/tests/unit/topology/database/test_databricks.py
+++ b/ingestion/tests/unit/topology/database/test_databricks.py
@@ -14,7 +14,7 @@ Test databricks using the topology
 """
 
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from metadata.generated.schema.api.data.createDatabaseSchema import (
     CreateDatabaseSchemaRequest,
@@ -366,3 +366,452 @@ class DatabricksUnitTest(TestCase):
 
         for _, (expected, original) in enumerate(zip(EXPTECTED_TABLE_2, table_list)):
             self.assertEqual(expected, original)
+
+
+class DatabricksConnectionTest(TestCase):
+    """
+    Unit tests for Databricks connection functionality
+    """
+
+    def setUp(self):
+        """Set up test fixtures"""
+        from metadata.generated.schema.entity.services.connections.database.databricksConnection import (
+            DatabricksConnection,
+            DatabricksScheme,
+        )
+        from metadata.ingestion.source.database.databricks.connection import (
+            DatabricksEngineWrapper,
+            get_connection,
+            get_connection_url,
+            test_connection,
+        )
+
+        self.DatabricksEngineWrapper = DatabricksEngineWrapper
+        self.get_connection_url = get_connection_url
+        self.get_connection = get_connection
+        self.test_connection = test_connection
+        self.DatabricksConnection = DatabricksConnection
+        self.DatabricksScheme = DatabricksScheme
+
+    def test_get_connection_url(self):
+        """Test get_connection_url function"""
+        connection = self.DatabricksConnection(
+            scheme=self.DatabricksScheme.databricks_connector,
+            hostPort="test-host:443",
+            token="test-token",
+            httpPath="/sql/1.0/warehouses/test",
+        )
+
+        url = self.get_connection_url(connection)
+        expected_url = "databricks+connector://token:test-token@test-host:443"
+        self.assertEqual(url, expected_url)
+
+    @patch(
+        "metadata.ingestion.source.database.databricks.connection.create_generic_db_connection"
+    )
+    def test_get_connection(self, mock_create_connection):
+        """Test get_connection function"""
+        connection = self.DatabricksConnection(
+            scheme=self.DatabricksScheme.databricks_connector,
+            hostPort="test-host:443",
+            token="test-token",
+            httpPath="/sql/1.0/warehouses/test",
+        )
+
+        mock_engine = Mock()
+        mock_create_connection.return_value = mock_engine
+
+        result = self.get_connection(connection)
+
+        self.assertEqual(result, mock_engine)
+        mock_create_connection.assert_called_once()
+
+    def test_databricks_engine_wrapper_initialization(self):
+        """Test DatabricksEngineWrapper initialization"""
+        mock_engine = Mock()
+        mock_inspector = Mock()
+
+        with patch(
+            "metadata.ingestion.source.database.databricks.connection.inspect"
+        ) as mock_inspect:
+            mock_inspect.return_value = mock_inspector
+
+            wrapper = self.DatabricksEngineWrapper(mock_engine)
+
+            self.assertEqual(wrapper.engine, mock_engine)
+            self.assertEqual(wrapper.inspector, mock_inspector)
+            self.assertIsNone(wrapper.schemas)
+            self.assertIsNone(wrapper.first_schema)
+
+    def test_databricks_engine_wrapper_get_schemas_with_non_system_schemas(self):
+        """Test get_schemas with non-system schemas"""
+        mock_engine = Mock()
+        mock_inspector = Mock()
+        mock_inspector.get_schema_names.return_value = [
+            "information_schema",
+            "test_schema",
+            "performance_schema",
+        ]
+
+        with patch(
+            "metadata.ingestion.source.database.databricks.connection.inspect"
+        ) as mock_inspect:
+            mock_inspect.return_value = mock_inspector
+
+            wrapper = self.DatabricksEngineWrapper(mock_engine)
+            schemas = wrapper.get_schemas()
+
+            self.assertEqual(
+                schemas, ["information_schema", "test_schema", "performance_schema"]
+            )
+            self.assertEqual(wrapper.first_schema, "test_schema")
+            self.assertEqual(
+                wrapper.schemas,
+                ["information_schema", "test_schema", "performance_schema"],
+            )
+
+    def test_databricks_engine_wrapper_get_schemas_with_only_system_schemas(self):
+        """Test get_schemas with only system schemas"""
+        mock_engine = Mock()
+        mock_inspector = Mock()
+        mock_inspector.get_schema_names.return_value = [
+            "information_schema",
+            "performance_schema",
+        ]
+
+        with patch(
+            "metadata.ingestion.source.database.databricks.connection.inspect"
+        ) as mock_inspect:
+            mock_inspect.return_value = mock_inspector
+
+            wrapper = self.DatabricksEngineWrapper(mock_engine)
+            schemas = wrapper.get_schemas()
+
+            self.assertEqual(schemas, ["information_schema", "performance_schema"])
+            self.assertEqual(wrapper.first_schema, "information_schema")
+            self.assertEqual(
+                wrapper.schemas, ["information_schema", "performance_schema"]
+            )
+
+    def test_databricks_engine_wrapper_get_schemas_empty(self):
+        """Test get_schemas with empty schema list"""
+        mock_engine = Mock()
+        mock_inspector = Mock()
+        mock_inspector.get_schema_names.return_value = []
+
+        with patch(
+            "metadata.ingestion.source.database.databricks.connection.inspect"
+        ) as mock_inspect:
+            mock_inspect.return_value = mock_inspector
+
+            wrapper = self.DatabricksEngineWrapper(mock_engine)
+            schemas = wrapper.get_schemas()
+
+            self.assertEqual(schemas, [])
+            self.assertIsNone(wrapper.first_schema)
+            self.assertEqual(wrapper.schemas, [])
+
+    def test_databricks_engine_wrapper_get_tables_with_cached_schema(self):
+        """Test get_tables with cached schema"""
+        mock_engine = Mock()
+        mock_inspector = Mock()
+        mock_inspector.get_schema_names.return_value = [
+            "test_schema",
+            "information_schema",
+        ]
+        mock_inspector.get_table_names.return_value = ["table1", "table2"]
+
+        with patch(
+            "metadata.ingestion.source.database.databricks.connection.inspect"
+        ) as mock_inspect:
+            mock_inspect.return_value = mock_inspector
+
+            wrapper = self.DatabricksEngineWrapper(mock_engine)
+            # First call to get_schemas to set first_schema
+            wrapper.get_schemas()
+            # Then call get_tables
+            tables = wrapper.get_tables()
+
+            self.assertEqual(tables, ["table1", "table2"])
+            mock_inspector.get_table_names.assert_called_once_with("test_schema")
+
+    def test_databricks_engine_wrapper_get_tables_without_cached_schema(self):
+        """Test get_tables without cached schema"""
+        mock_engine = Mock()
+        mock_inspector = Mock()
+        mock_inspector.get_schema_names.return_value = [
+            "test_schema",
+            "information_schema",
+        ]
+        mock_inspector.get_table_names.return_value = ["table1", "table2"]
+
+        with patch(
+            "metadata.ingestion.source.database.databricks.connection.inspect"
+        ) as mock_inspect:
+            mock_inspect.return_value = mock_inspector
+
+            wrapper = self.DatabricksEngineWrapper(mock_engine)
+            # Call get_tables directly without calling get_schemas first
+            tables = wrapper.get_tables()
+
+            self.assertEqual(tables, ["table1", "table2"])
+            # Should have called get_schemas internally
+            mock_inspector.get_schema_names.assert_called_once()
+            mock_inspector.get_table_names.assert_called_once_with("test_schema")
+
+    def test_databricks_engine_wrapper_get_tables_no_schemas(self):
+        """Test get_tables when no schemas are available"""
+        mock_engine = Mock()
+        mock_inspector = Mock()
+        mock_inspector.get_schema_names.return_value = []
+
+        with patch(
+            "metadata.ingestion.source.database.databricks.connection.inspect"
+        ) as mock_inspect:
+            mock_inspect.return_value = mock_inspector
+
+            wrapper = self.DatabricksEngineWrapper(mock_engine)
+            tables = wrapper.get_tables()
+
+            self.assertEqual(tables, [])
+            mock_inspector.get_table_names.assert_not_called()
+
+    def test_databricks_engine_wrapper_get_views_with_cached_schema(self):
+        """Test get_views with cached schema"""
+        mock_engine = Mock()
+        mock_inspector = Mock()
+        mock_inspector.get_schema_names.return_value = [
+            "test_schema",
+            "information_schema",
+        ]
+        mock_inspector.get_view_names.return_value = ["view1", "view2"]
+
+        with patch(
+            "metadata.ingestion.source.database.databricks.connection.inspect"
+        ) as mock_inspect:
+            mock_inspect.return_value = mock_inspector
+
+            wrapper = self.DatabricksEngineWrapper(mock_engine)
+            # First call to get_schemas to set first_schema
+            wrapper.get_schemas()
+            # Then call get_views
+            views = wrapper.get_views()
+
+            self.assertEqual(views, ["view1", "view2"])
+            mock_inspector.get_view_names.assert_called_once_with("test_schema")
+
+    def test_databricks_engine_wrapper_get_views_without_cached_schema(self):
+        """Test get_views without cached schema"""
+        mock_engine = Mock()
+        mock_inspector = Mock()
+        mock_inspector.get_schema_names.return_value = [
+            "test_schema",
+            "information_schema",
+        ]
+        mock_inspector.get_view_names.return_value = ["view1", "view2"]
+
+        with patch(
+            "metadata.ingestion.source.database.databricks.connection.inspect"
+        ) as mock_inspect:
+            mock_inspect.return_value = mock_inspector
+
+            wrapper = self.DatabricksEngineWrapper(mock_engine)
+            # Call get_views directly without calling get_schemas first
+            views = wrapper.get_views()
+
+            self.assertEqual(views, ["view1", "view2"])
+            # Should have called get_schemas internally
+            mock_inspector.get_schema_names.assert_called_once()
+            mock_inspector.get_view_names.assert_called_once_with("test_schema")
+
+    def test_databricks_engine_wrapper_get_views_no_schemas(self):
+        """Test get_views when no schemas are available"""
+        mock_engine = Mock()
+        mock_inspector = Mock()
+        mock_inspector.get_schema_names.return_value = []
+
+        with patch(
+            "metadata.ingestion.source.database.databricks.connection.inspect"
+        ) as mock_inspect:
+            mock_inspect.return_value = mock_inspector
+
+            wrapper = self.DatabricksEngineWrapper(mock_engine)
+            views = wrapper.get_views()
+
+            self.assertEqual(views, [])
+            mock_inspector.get_view_names.assert_not_called()
+
+    def test_databricks_engine_wrapper_caching_behavior(self):
+        """Test that schemas are cached and not fetched multiple times"""
+        mock_engine = Mock()
+        mock_inspector = Mock()
+        mock_inspector.get_schema_names.return_value = [
+            "test_schema",
+            "information_schema",
+        ]
+
+        with patch(
+            "metadata.ingestion.source.database.databricks.connection.inspect"
+        ) as mock_inspect:
+            mock_inspect.return_value = mock_inspector
+
+            wrapper = self.DatabricksEngineWrapper(mock_engine)
+
+            # Call get_schemas multiple times
+            schemas1 = wrapper.get_schemas()
+            schemas2 = wrapper.get_schemas()
+            schemas3 = wrapper.get_schemas()
+
+            # All calls should return the same result
+            self.assertEqual(schemas1, schemas2)
+            self.assertEqual(schemas2, schemas3)
+
+            # get_schema_names should only be called once due to caching
+            mock_inspector.get_schema_names.assert_called_once()
+
+    @patch(
+        "metadata.ingestion.source.database.databricks.connection.test_connection_steps"
+    )
+    def test_test_connection_function(self, mock_test_connection_steps):
+        """Test the test_connection function"""
+        from metadata.generated.schema.entity.services.connections.database.databricksConnection import (
+            DatabricksConnection,
+            DatabricksScheme,
+        )
+        from metadata.generated.schema.entity.services.connections.testConnectionResult import (
+            StatusType,
+            TestConnectionResult,
+            TestConnectionStepResult,
+        )
+
+        # Mock the test connection result
+        mock_result = TestConnectionResult(
+            status=StatusType.Successful,
+            steps=[
+                TestConnectionStepResult(
+                    name="CheckAccess",
+                    mandatory=True,
+                    passed=True,
+                ),
+                TestConnectionStepResult(
+                    name="GetSchemas",
+                    mandatory=True,
+                    passed=True,
+                ),
+                TestConnectionStepResult(
+                    name="GetTables",
+                    mandatory=True,
+                    passed=True,
+                ),
+                TestConnectionStepResult(
+                    name="GetViews",
+                    mandatory=False,
+                    passed=True,
+                ),
+            ],
+        )
+        mock_test_connection_steps.return_value = mock_result
+
+        # Create test connection
+        service_connection = DatabricksConnection(
+            scheme=DatabricksScheme.databricks_connector,
+            hostPort="test-host:443",
+            token="test-token",
+            httpPath="/sql/1.0/warehouses/test",
+            queryHistoryTable="test_table",
+        )
+
+        mock_engine = Mock()
+        mock_metadata = Mock()
+
+        # Test the function
+        result = self.test_connection(
+            metadata=mock_metadata,
+            connection=mock_engine,
+            service_connection=service_connection,
+        )
+
+        # Verify the result
+        self.assertEqual(result, mock_result)
+        mock_test_connection_steps.assert_called_once()
+
+        # Verify the test_fn dictionary was created with the correct functions
+        call_args = mock_test_connection_steps.call_args
+        test_fn = call_args[1]["test_fn"]
+
+        # Check that the test_fn contains the expected keys
+        expected_keys = [
+            "CheckAccess",
+            "GetSchemas",
+            "GetTables",
+            "GetViews",
+            "GetDatabases",
+            "GetQueries",
+        ]
+        for key in expected_keys:
+            self.assertIn(key, test_fn)
+            self.assertIsNotNone(test_fn[key])
+
+    def test_databricks_engine_wrapper_system_schema_filtering(self):
+        """Test that system schemas are properly filtered out"""
+        mock_engine = Mock()
+        mock_inspector = Mock()
+        # Test with various system schema names
+        mock_inspector.get_schema_names.return_value = [
+            "information_schema",
+            "performance_schema",
+            "sys",
+            "SYS",
+            "INFORMATION_SCHEMA",
+            "user_schema",
+            "test_schema",
+        ]
+
+        with patch(
+            "metadata.ingestion.source.database.databricks.connection.inspect"
+        ) as mock_inspect:
+            mock_inspect.return_value = mock_inspector
+
+            wrapper = self.DatabricksEngineWrapper(mock_engine)
+            schemas = wrapper.get_schemas()
+
+            # Should return all schemas
+            self.assertEqual(
+                schemas,
+                [
+                    "information_schema",
+                    "performance_schema",
+                    "sys",
+                    "SYS",
+                    "INFORMATION_SCHEMA",
+                    "user_schema",
+                    "test_schema",
+                ],
+            )
+            # Should select the first non-system schema (user_schema)
+            self.assertEqual(wrapper.first_schema, "user_schema")
+
+    def test_databricks_engine_wrapper_all_system_schemas(self):
+        """Test behavior when all schemas are system schemas"""
+        mock_engine = Mock()
+        mock_inspector = Mock()
+        mock_inspector.get_schema_names.return_value = [
+            "information_schema",
+            "performance_schema",
+            "sys",
+        ]
+
+        with patch(
+            "metadata.ingestion.source.database.databricks.connection.inspect"
+        ) as mock_inspect:
+            mock_inspect.return_value = mock_inspector
+
+            wrapper = self.DatabricksEngineWrapper(mock_engine)
+            schemas = wrapper.get_schemas()
+
+            # Should return all schemas
+            self.assertEqual(
+                schemas, ["information_schema", "performance_schema", "sys"]
+            )
+            # Should fall back to the first schema when all are system schemas
+            self.assertEqual(wrapper.first_schema, "information_schema")


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Currently when a catalog in databricks does not contain the `default` schema it fails with the following error 

sqlalchemy.exc.DatabaseError: (databricks.sql.exc.ServerOperationError) [SCHEMA_NOT_FOUND] The schema `demo-test-cat`.`default` cannot be found. Verify the spelling and correctness of the schema and catalog.

this pr tries to fix that

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
