### PR TITLE
fix(ui): update message for Glossary Status column

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/de-de.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/de-de.json
@@ -467,6 +467,7 @@
     "domain_access": "Domänenzugriff",
     "down-vote": "Down Vote",
     "downstream-depth": "Nachgelagerte Tiefe",
+    "draft": "Utkast",
     "duplicate": "Duplikat",
     "duration": "Dauer",
     "dynamic-assertion": "Dynamische Assertion",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
@@ -467,6 +467,7 @@
     "domain_access": "Domain Access",
     "down-vote": "Down Vote",
     "downstream-depth": "Downstream Depth",
+    "draft": "Draft",
     "duplicate": "Duplicate",
     "duration": "Duration",
     "dynamic-assertion": "Dynamic Assertion",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/es-es.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/es-es.json
@@ -467,6 +467,7 @@
     "domain_access": "Acceso al Dominio",
     "down-vote": "Voto Negativo",
     "downstream-depth": "Profundidad del flujo",
+    "draft": "Borrador",
     "duplicate": "Duplicar",
     "duration": "Duración",
     "dynamic-assertion": "Dynamic Assertion",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/fr-fr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/fr-fr.json
@@ -467,6 +467,7 @@
     "domain_access": "Accès au Domaine",
     "down-vote": "Down Vote",
     "downstream-depth": "Profondeur en Aval",
+    "draft": "Brouillon",
     "duplicate": "Duplicate",
     "duration": "Durée",
     "dynamic-assertion": "Assertion Dynamique",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/gl-es.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/gl-es.json
@@ -467,6 +467,7 @@
     "domain_access": "Acceso ao dominio",
     "down-vote": "Voto negativo",
     "downstream-depth": "Profundidade descendente",
+    "draft": "Borrador",
     "duplicate": "Duplicar",
     "duration": "Duración",
     "dynamic-assertion": "Aserción dinámica",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/he-he.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/he-he.json
@@ -467,6 +467,7 @@
     "domain_access": "גישה לדומיין",
     "down-vote": "Down Vote",
     "downstream-depth": "דרגות במורד הזרימה",
+    "draft": "טיוטה",
     "duplicate": "שכפל",
     "duration": "משך זמן",
     "dynamic-assertion": "Dynamic Assertion",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ja-jp.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ja-jp.json
@@ -467,6 +467,7 @@
     "domain_access": "ドメインアクセス",
     "down-vote": "Down Vote",
     "downstream-depth": "Downstream Depth",
+    "draft": "下書き",
     "duplicate": "Duplicate",
     "duration": "Duration",
     "dynamic-assertion": "Dynamic Assertion",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ko-kr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ko-kr.json
@@ -467,6 +467,7 @@
     "domain_access": "도메인 접근",
     "down-vote": "비추천",
     "downstream-depth": "다운스트림 깊이",
+    "draft": "초안",
     "duplicate": "복제",
     "duration": "기간",
     "dynamic-assertion": "동적 단언",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/mr-in.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/mr-in.json
@@ -467,6 +467,7 @@
     "domain_access": "डोमेन प्रवेश",
     "down-vote": "खाली मत द्या",
     "downstream-depth": "डाउनस्ट्रीम खोली",
+    "draft": "मसुदा",
     "duplicate": "डुप्लिकेट",
     "duration": "कालावधी",
     "dynamic-assertion": "डायनॅमिक अॅसर्शन",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/nl-nl.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/nl-nl.json
@@ -467,6 +467,7 @@
     "domain_access": "Domeintoegang",
     "down-vote": "Down Vote",
     "downstream-depth": "Stroomafwaartse diepte",
+    "draft": "Concept",
     "duplicate": "Dupliceren",
     "duration": "Duur",
     "dynamic-assertion": "Dynamic Assertion",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pr-pr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pr-pr.json
@@ -467,6 +467,7 @@
     "domain_access": "دسترسی دامنه",
     "down-vote": "رأی منفی",
     "downstream-depth": "عمق پایین‌دست",
+    "draft": "پیش‌نویس",
     "duplicate": "تکراری",
     "duration": "مدت زمان",
     "dynamic-assertion": "ادعای پویا",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-br.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-br.json
@@ -467,6 +467,7 @@
     "domain_access": "Acesso ao Domínio",
     "down-vote": "Voto negativo",
     "downstream-depth": "Profundidade a Jusante",
+    "draft": "Rascunho",
     "duplicate": "Duplicar",
     "duration": "Duração",
     "dynamic-assertion": "Asserção dinâmica",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-pt.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-pt.json
@@ -467,6 +467,7 @@
     "domain_access": "Acesso ao Domínio",
     "down-vote": "Down Vote",
     "downstream-depth": "Profundidade a Jusante",
+    "draft": "Rascunho",
     "duplicate": "Duplicar",
     "duration": "Duração",
     "dynamic-assertion": "Dynamic Assertion",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ru-ru.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ru-ru.json
@@ -467,6 +467,7 @@
     "domain_access": "Доступ к домену",
     "down-vote": "Down Vote",
     "downstream-depth": "Нисходящая линия",
+    "draft": "Черновик",
     "duplicate": "Duplicate",
     "duration": "Длительность",
     "dynamic-assertion": "Dynamic Assertion",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/th-th.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/th-th.json
@@ -467,6 +467,7 @@
     "domain_access": "การเข้าถึงโดเมน",
     "down-vote": "โหวตไม่เห็นด้วย",
     "downstream-depth": "ความลึกของการไหลลง",
+    "draft": "ฉบับร่าง",
     "duplicate": "ซ้ำกัน",
     "duration": "ระยะเวลา",
     "dynamic-assertion": "การยืนยันแบบไดนามิก",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/tr-tr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/tr-tr.json
@@ -467,6 +467,7 @@
     "domain_access": "Alan Adı Erişimi",
     "down-vote": "Aşağı Oy",
     "downstream-depth": "Aşağı Akış Derinliği",
+    "draft": "Taslak",
     "duplicate": "Kopya",
     "duration": "Süre",
     "dynamic-assertion": "Dinamik Beyan",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-cn.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-cn.json
@@ -467,6 +467,7 @@
     "domain_access": "域访问",
     "down-vote": "Down Vote",
     "downstream-depth": "下游深度",
+    "draft": "草稿",
     "duplicate": "Duplicate",
     "duration": "持续时间",
     "dynamic-assertion": "Dynamic Assertion",

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CSV/CSV.utils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CSV/CSV.utils.tsx
@@ -11,6 +11,7 @@
  *  limitations under the License.
  */
 import { TypeColumn } from '@inovua/reactdatagrid-community/types';
+import { Typography } from 'antd';
 import {
   compact,
   get,
@@ -38,7 +39,7 @@ import {
   Type,
 } from '../../generated/entity/type';
 import { Status } from '../../generated/type/csvImportResult';
-import { removeOuterEscapes } from '../CommonUtils';
+import { removeOuterEscapes, Transi18next } from '../CommonUtils';
 import csvUtilsClassBase from './CSVUtilsClassBase';
 
 export interface EditorProps {
@@ -60,21 +61,39 @@ export const COLUMNS_WIDTH: Record<string, number> = {
   status: 70,
 };
 
-const statusRenderer = (value: Status) => {
+const statusRenderer = (value: Status, column?: string) => {
+  const showText = column === 'glossaryStatus';
+
   return value === Status.Failure ? (
-    <FailBadgeIcon
-      className="m-t-xss"
-      data-testid="failure-badge"
-      height={16}
-      width={16}
-    />
+    <div className="flex items-center gap-2">
+      <FailBadgeIcon
+        className="m-t-xss"
+        data-testid="failure-badge"
+        height={16}
+        width={16}
+      />
+      {showText && (
+        <Transi18next
+          i18nKey="label.draft"
+          renderElement={<Typography.Text />}
+        />
+      )}
+    </div>
   ) : (
-    <SuccessBadgeIcon
-      className="m-t-xss"
-      data-testid="success-badge"
-      height={16}
-      width={16}
-    />
+    <div className="flex items-center gap-2">
+      <SuccessBadgeIcon
+        className="m-t-xss"
+        data-testid="success-badge"
+        height={16}
+        width={16}
+      />
+      {showText && (
+        <Transi18next
+          i18nKey="label.approved"
+          renderElement={<Typography.Text />}
+        />
+      )}
+    </div>
   );
 };
 
@@ -89,7 +108,7 @@ const renderColumnDataEditor = (
   switch (column) {
     case 'status':
     case 'glossaryStatus':
-      return statusRenderer(value as Status);
+      return statusRenderer(value as Status, column);
     case 'description':
       return (
         <RichTextEditorPreviewerV1


### PR DESCRIPTION
Before: 

<img width="1017" alt="image" src="https://github.com/user-attachments/assets/362f75b4-1ab2-4078-acc2-29cf249544de" />


After: 

<img width="1315" alt="image" src="https://github.com/user-attachments/assets/4a666245-64f5-424c-95e3-bee815297b2b" />


<img width="1440" alt="image" src="https://github.com/user-attachments/assets/11d4f224-3315-4cdf-b1a7-b9b092689f38" />


<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
