### PR TITLE
Add PATCH with If-Match header support to ingestion SDK

### DIFF
--- a/ingestion/src/metadata/ingestion/ometa/mixins/patch_mixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/patch_mixin.py
@@ -617,7 +617,11 @@ class OMetaPatchMixin(OMetaPatchMixinBase):
                     return entity(**data)
             elif response:
                 # Fallback if headers not returned
-                return entity(**response)
+                try:
+                    return entity(**response)
+                except Exception as exc:
+                    logger.debug(traceback.format_exc())
+                    logger.warning(f"Error creating entity from response: {exc}")
                 
         except Exception as exc:
             logger.debug(traceback.format_exc())


### PR DESCRIPTION
This PR implements PATCH with If-Match header support for the ingestion SDK, addressing issue #22290.

## Changes
- Enhanced HTTP client to capture ETag headers and support custom headers
- Added If-Match header support for conditional PATCH operations
- Implemented ETag management utilities with in-memory cache
- Added convenience methods for ETag-based operations
- Updated patch_mixin to support conditional PATCH requests

This enables optimistic concurrency control using ETags for PATCH operations in the ingestion SDK.

Closes #22293

Generated with [Claude Code](https://claude.ai/code)