### PR TITLE
Playwright Update: Bulk Import

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkImport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkImport.spec.ts
@@ -37,6 +37,7 @@ import {
   fillRecursiveEntityTypeFQNDetails,
   fillRowDetails,
   fillStoredProcedureCode,
+  firstTimeGridAddRowAction,
   pressKeyXTimes,
   validateImportStatus,
 } from '../../utils/importUtils';
@@ -172,14 +173,7 @@ test.describe('Bulk Import Export', () => {
           page.getByRole('button', { name: 'Previous' })
         ).toBeVisible();
 
-        await page.click('[data-testid="add-row-btn"]');
-
-        // click on last row first cell
-        const rows = await page.$$('.rdg-row');
-        const lastRow = rows[rows.length - 1];
-
-        const firstCell = await lastRow.$('.rdg-cell');
-        await firstCell?.click();
+        await firstTimeGridAddRowAction(page);
 
         // Add first database details
         await fillRowDetails(
@@ -441,17 +435,8 @@ test.describe('Bulk Import Export', () => {
           page.getByRole('button', { name: 'Previous' })
         ).toBeVisible();
 
-        await page.click('[data-testid="add-row-btn"]');
-        await page.waitForTimeout(1000);
+        await firstTimeGridAddRowAction(page);
 
-        // click on last row first cell
-        const rows = await page.$$('.rdg-row');
-        const lastRow = rows[rows.length - 1];
-
-        const firstCell = await lastRow.$('.rdg-cell');
-        await firstCell?.click();
-
-        // Click on first cell and edit
         await fillRowDetails(
           {
             ...databaseSchemaDetails1,
@@ -659,14 +644,7 @@ test.describe('Bulk Import Export', () => {
           page.getByRole('button', { name: 'Previous' })
         ).toBeVisible();
 
-        await page.click('[data-testid="add-row-btn"]');
-
-        // click on last row first cell
-        const rows = await page.$$('.rdg-row');
-        const lastRow = rows[rows.length - 1];
-
-        const firstCell = await lastRow.$('.rdg-cell');
-        await firstCell?.click();
+        await firstTimeGridAddRowAction(page);
 
         // First Table Details with one Column
         await fillRowDetails(
@@ -840,14 +818,7 @@ test.describe('Bulk Import Export', () => {
           page.getByRole('button', { name: 'Previous' })
         ).toBeVisible();
 
-        await page.click('[data-testid="add-row-btn"]');
-
-        // click on last row first cell
-        const rows = await page.$$('.rdg-row');
-        const lastRow = rows[rows.length - 1];
-
-        const firstCell = await lastRow.$('.rdg-cell');
-        await firstCell?.click();
+        await firstTimeGridAddRowAction(page);
 
         // Click on first cell and edit
         await fillColumnDetails(columnDetails1, page);

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/importUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/importUtils.ts
@@ -96,6 +96,10 @@ export const fillOwnerDetails = async (page: Page, owners: string[]) => {
   await userListResponse;
   await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
 
+  await page.waitForSelector('[data-testid="owner-select-users-search-bar"]', {
+    state: 'visible',
+  });
+
   await page.click('[data-testid="owner-select-users-search-bar"]');
 
   for (const owner of owners) {
@@ -921,4 +925,31 @@ export const fillRecursiveColumnDetails = async (
     .press('ArrowRight', { delay: 100 });
 
   await fillTextInputDetails(page, row.dataLength);
+};
+
+export const firstTimeGridAddRowAction = async (page: Page) => {
+  const firstRow = page.locator('.rdg-row').first();
+  if ((await firstRow.count()) > 0) {
+    const firstCell = page
+      .locator('.rdg-row')
+      .first()
+      .locator('.rdg-cell')
+      .first();
+
+    await expect(firstCell).toBeFocused();
+
+    await page.click('[data-testid="add-row-btn"]');
+
+    await expect(firstCell).not.toBeFocused(); // focus should get removed from first cell
+  } else {
+    await page.click('[data-testid="add-row-btn"]');
+  }
+
+  const lastRowFirstCell = page
+    .locator('.rdg-row')
+    .last()
+    .locator('.rdg-cell')
+    .first();
+
+  await expect(lastRowFirstCell).toBeFocused();
 };


### PR DESCRIPTION
Updated the Playwright test for the bulk import feature to improve reliability.
Previously, the test intermittently failed because the first cell of the last row was not focused within the expected time.
This has been addressed by explicitly waiting for the correct focus before proceeding with assertions.