### PR TITLE
fix(ui): User popover card team redirection issue

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/Task/TaskTabIncidentManagerHeader/TasktabIncidentManagerHeaderNew.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/Task/TaskTabIncidentManagerHeader/TasktabIncidentManagerHeaderNew.tsx
@@ -27,6 +27,7 @@ import { formatDateTime } from '../../../../utils/date-time/DateTimeUtils';
 import { getEntityName } from '../../../../utils/EntityUtils';
 import { useActivityFeedProvider } from '../../../ActivityFeed/ActivityFeedProvider/ActivityFeedProvider';
 
+import { OwnerType } from '../../../../enums/user.enum';
 import { OwnerLabel } from '../../../common/OwnerLabel/OwnerLabel.component';
 import UserPopOverCard from '../../../common/PopOverCard/UserPopOverCard';
 import ProfilePicture from '../../../common/ProfilePicture/ProfilePicture';
@@ -146,7 +147,9 @@ const TaskTabIncidentManagerHeaderNew = ({ thread }: { thread: Thread }) => {
         <Col className="flex items-center gap-2" span={16}>
           {thread?.task?.assignees?.length === 1 ? (
             <div className="d-flex items-center gap-2">
-              <UserPopOverCard userName={thread?.task?.assignees[0].name ?? ''}>
+              <UserPopOverCard
+                type={thread?.task?.assignees[0]?.type as OwnerType}
+                userName={thread?.task?.assignees[0].name ?? ''}>
                 <div className="d-flex items-center">
                   <ProfilePicture
                     name={thread?.task?.assignees[0].name ?? ''}

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/PopOverCard/UserPopOverCard.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/PopOverCard/UserPopOverCard.test.tsx
@@ -249,6 +249,56 @@ describe('Test UserPopOverCard components', () => {
       expect(screen.getByText('testUser')).toBeInTheDocument();
       expect(screen.queryByText('Test User')).not.toBeInTheDocument();
     });
+
+    it('should navigate to team details path when type is TEAM', () => {
+      const mockNavigate = jest.fn();
+      (useNavigate as jest.Mock).mockImplementationOnce(() => mockNavigate);
+      (useUserProfile as jest.Mock).mockImplementation(() => [
+        null,
+        null,
+        { name: 'testTeam', displayName: 'Test Team' },
+      ]);
+
+      render(
+        <PopoverTitle
+          profilePicture={<div>ProfilePicture</div>}
+          type={OwnerType.TEAM}
+          userName="testTeam"
+        />
+      );
+
+      const teamNameButton = screen.getByText('Test Team');
+      teamNameButton.click();
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        '/settings/members/teams/testTeam'
+      );
+
+      expect(mockNavigate).not.toHaveBeenCalledWith('/users/testTeam');
+    });
+
+    it('should navigate to user profile path when type is USER', () => {
+      const mockNavigate = jest.fn();
+      (useNavigate as jest.Mock).mockImplementationOnce(() => mockNavigate);
+      (useUserProfile as jest.Mock).mockImplementation(() => [
+        null,
+        null,
+        { name: 'testUser', displayName: 'Test User' },
+      ]);
+
+      render(
+        <PopoverTitle
+          profilePicture={<div>ProfilePicture</div>}
+          type={OwnerType.USER}
+          userName="testUser"
+        />
+      );
+
+      const userNameButton = screen.getByText('Test User');
+      userNameButton.click();
+
+      expect(mockNavigate).toHaveBeenCalledWith('/users/testUser');
+    });
   });
 
   describe('UserPopOverCard Component', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/PopOverCard/UserPopOverCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/PopOverCard/UserPopOverCard.tsx
@@ -210,7 +210,11 @@ export const PopoverTitle = React.memo(
             type="link"
             onClick={(e) => {
               e.stopPropagation();
-              onTitleClickHandler(getUserPath(name));
+              onTitleClickHandler(
+                type === OwnerType.TEAM
+                  ? getTeamAndUserDetailsPath(name)
+                  : getUserPath(name)
+              );
             }}>
             <span className="font-medium m-r-xs" data-testid="user-name">
               {displayName}


### PR DESCRIPTION
Issue:-
Team redirection not working on User popover card
https://github.com/user-attachments/assets/c1b445c0-1852-4a03-a522-e2cd1f24807c

Fix


https://github.com/user-attachments/assets/41899199-98de-462c-9519-ba5556c88278

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
