### PR TITLE
ISSUE #22580: alert display name + url on test case failure

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/formatter/decorators/MessageDecorator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/formatter/decorators/MessageDecorator.java
@@ -98,8 +98,7 @@ public interface MessageDecorator<T> {
       case Entity.TEST_CASE:
         if (entityInterface instanceof TestCase testCase) {
           entityUrl =
-              getEntityUrl(
-                  "incident-manager", testCase.getFullyQualifiedName(), "test-case-results");
+              getEntityUrl("test-case", testCase.getFullyQualifiedName(), "test-case-results");
         }
         break;
 
@@ -136,7 +135,7 @@ public interface MessageDecorator<T> {
       case Entity.TEST_CASE:
         if (entityInterface instanceof TestCase) {
           TestCase testCase = (TestCase) entityInterface;
-          entityUrl = getEntityUrl("incident-manager", testCase.getFullyQualifiedName(), "issues");
+          entityUrl = getEntityUrl("test-case", testCase.getFullyQualifiedName(), "issues");
         }
         break;
 
@@ -590,7 +589,10 @@ public interface MessageDecorator<T> {
     // build TEST_CASE_DETAILS
     builder
         .add(DQ_Template_Section.TEST_CASE_DETAILS, DQ_TestCaseDetailsKeys.ID, testCase.getId())
-        .add(DQ_Template_Section.TEST_CASE_DETAILS, DQ_TestCaseDetailsKeys.NAME, testCase.getName())
+        .add(
+            DQ_Template_Section.TEST_CASE_DETAILS,
+            DQ_TestCaseDetailsKeys.NAME,
+            testCase.getDisplayName() != null ? testCase.getDisplayName() : testCase.getName())
         .add(
             DQ_Template_Section.TEST_CASE_DETAILS,
             DQ_TestCaseDetailsKeys.OWNERS,


### PR DESCRIPTION
Fixes #22580 
**What**
- Fix url prefix for test case results page
- ensure consistency in respect to display name vs name on alert

<img width="853" height="326" alt="Screenshot 2025-07-25 at 11 28 19 AM" src="https://github.com/user-attachments/assets/23d75e5b-1192-449b-a558-68095114c37c" />
<img width="840" height="606" alt="Screenshot 2025-07-25 at 11 28 11 AM" src="https://github.com/user-attachments/assets/c359c4c2-7ac1-45cd-a33c-8a769732f37f" />


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
