### PR TITLE
fix the cycle lineage nodes when being collapsed

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage.spec.ts
@@ -446,7 +446,7 @@ test('Verify function data in edge drawer', async ({ browser }) => {
   }
 });
 
-test('Verify table search with special characters as handledd', async ({
+test('Verify table search with special characters as handled', async ({
   browser,
 }) => {
   const { page } = await createNewPage(browser);
@@ -515,6 +515,157 @@ test('Verify table search with special characters as handledd', async ({
   } finally {
     // Cleanup
     await table.delete(apiContext);
+    await afterAction();
+  }
+});
+
+test('Verify cycle lineage should be handled properly', async ({ browser }) => {
+  test.slow();
+
+  const { page } = await createNewPage(browser);
+  const { apiContext, afterAction } = await getApiContext(page);
+  const table = new TableClass();
+  const topic = new TopicClass();
+  const dashboard = new DashboardClass();
+
+  try {
+    await Promise.all([
+      table.create(apiContext),
+      topic.create(apiContext),
+      dashboard.create(apiContext),
+    ]);
+
+    const tableFqn = get(table, 'entityResponseData.fullyQualifiedName');
+    const topicFqn = get(topic, 'entityResponseData.fullyQualifiedName');
+    const dashboardFqn = get(
+      dashboard,
+      'entityResponseData.fullyQualifiedName'
+    );
+
+    await redirectToHomePage(page);
+    await table.visitEntityPageWithCustomSearchBox(page);
+    await visitLineageTab(page);
+    await page.getByTestId('full-screen').click();
+    await editLineage(page);
+    await performZoomOut(page);
+
+    // connect table to topic
+    await connectEdgeBetweenNodes(page, table, topic);
+    await rearrangeNodes(page);
+
+    // connect topic to dashboard
+    await connectEdgeBetweenNodes(page, topic, dashboard);
+    await rearrangeNodes(page);
+
+    // connect dashboard to table
+    await connectEdgeBetweenNodes(page, dashboard, table);
+    await rearrangeNodes(page);
+
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    await page.getByTestId('fit-screen').click();
+
+    await expect(page.getByTestId(`lineage-node-${tableFqn}`)).toBeVisible();
+    await expect(page.getByTestId(`lineage-node-${topicFqn}`)).toBeVisible();
+    await expect(
+      page.getByTestId(`lineage-node-${dashboardFqn}`)
+    ).toBeVisible();
+
+    // Collapse the cycle dashboard lineage downstreamNodeHandler
+    await page
+      .getByTestId(`lineage-node-${dashboardFqn}`)
+      .getByTestId('downstream-collapse-handle')
+      .click();
+
+    await expect(
+      page.getByTestId(`edge-${dashboardFqn}-${tableFqn}`)
+    ).not.toBeVisible();
+
+    await expect(page.getByTestId(`lineage-node-${tableFqn}`)).toBeVisible();
+    await expect(page.getByTestId(`lineage-node-${topicFqn}`)).toBeVisible();
+    await expect(
+      page.getByTestId(`lineage-node-${dashboardFqn}`)
+    ).toBeVisible();
+
+    await expect(
+      page
+        .getByTestId(`lineage-node-${tableFqn}`)
+        .getByTestId('upstream-collapse-handle')
+    ).not.toBeVisible();
+
+    await expect(
+      page.getByTestId(`lineage-node-${dashboardFqn}`).getByTestId('plus-icon')
+    ).toBeVisible();
+
+    // Reclick the plus icon to expand the cycle dashboard lineage downstreamNodeHandler
+    const downstreamResponse = page.waitForResponse(
+      `/api/v1/lineage/getLineage/Downstream?fqn=${dashboardFqn}&type=dashboard**`
+    );
+    await page
+      .getByTestId(`lineage-node-${dashboardFqn}`)
+      .getByTestId('plus-icon')
+      .click();
+
+    await downstreamResponse;
+
+    await expect(
+      page
+        .getByTestId(`lineage-node-${tableFqn}`)
+        .getByTestId('upstream-collapse-handle')
+        .getByTestId('minus-icon')
+    ).toBeVisible();
+
+    // Click the Upstream Node to expand the cycle dashboard lineage
+    await page
+      .getByTestId(`lineage-node-${dashboardFqn}`)
+      .getByTestId('upstream-collapse-handle')
+      .click();
+
+    await expect(page.getByTestId(`lineage-node-${tableFqn}`)).toBeVisible();
+    await expect(
+      page.getByTestId(`lineage-node-${dashboardFqn}`)
+    ).toBeVisible();
+    await expect(
+      page.getByTestId(`lineage-node-${topicFqn}`)
+    ).not.toBeVisible();
+
+    await expect(
+      page.getByTestId(`lineage-node-${dashboardFqn}`).getByTestId('plus-icon')
+    ).toBeVisible();
+
+    // Reclick the plus icon to expand the cycle dashboard lineage upstreamNodeHandler
+    const upStreamResponse2 = page.waitForResponse(
+      `/api/v1/lineage/getLineage/Upstream?fqn=${dashboardFqn}&type=dashboard**`
+    );
+    await page
+      .getByTestId(`lineage-node-${dashboardFqn}`)
+      .getByTestId('plus-icon')
+      .click();
+    await upStreamResponse2;
+
+    await expect(page.getByTestId(`lineage-node-${tableFqn}`)).toBeVisible();
+    await expect(
+      page.getByTestId(`lineage-node-${dashboardFqn}`)
+    ).toBeVisible();
+    await expect(page.getByTestId(`lineage-node-${topicFqn}`)).toBeVisible();
+
+    // Collapse the Node from the Parent Cycle Node
+    await page
+      .getByTestId(`lineage-node-${topicFqn}`)
+      .getByTestId('downstream-collapse-handle')
+      .click();
+
+    await expect(page.getByTestId(`lineage-node-${tableFqn}`)).toBeVisible();
+    await expect(page.getByTestId(`lineage-node-${topicFqn}`)).toBeVisible();
+    await expect(
+      page.getByTestId(`lineage-node-${dashboardFqn}`)
+    ).not.toBeVisible();
+  } finally {
+    await Promise.all([
+      table.delete(apiContext),
+      topic.delete(apiContext),
+      dashboard.delete(apiContext),
+    ]);
     await afterAction();
   }
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageUtils.tsx
@@ -1133,8 +1133,12 @@ export const getConnectedNodesEdges = (
               currentNodeID
             );
 
-      stack.push(...childNodes);
-      outgoers.push(...childNodes);
+      const finalChildNodeRemovingRootNode = childNodes.filter(
+        (item) => !item.data.isRootNode
+      );
+
+      stack.push(...finalChildNodeRemovingRootNode);
+      outgoers.push(...finalChildNodeRemovingRootNode);
       connectedEdges.push(...childEdges);
     }
   }

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageUtils.tsx
@@ -1133,6 +1133,8 @@ export const getConnectedNodesEdges = (
               currentNodeID
             );
 
+      // Removing the Root Node from the Child Nodes here, which comes when a cycle lineage is formed
+      // So while collapsing the cycle lineage, we need to prevent the Root Node not to be removed.
       const finalChildNodeRemovingRootNode = childNodes.filter(
         (item) => !item.data.isRootNode
       );


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

- I worked on fixing the cycle lineage nodes when being collapsed
- Restrict the RootNode to be removed when collapsed is perform on cycle lineage, as when collapsing it drop down to the root node to remove it, which create imbalance on the flow!

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->


https://github.com/user-attachments/assets/329c7015-b2b3-44d4-a4f3-82b2caac4336




#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
