### PR TITLE
Minor(fix): align Sonar reporting with coverage recording in py-tests workflow

### DIFF
--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -106,7 +106,7 @@ jobs:
         # we have to pass these args values since we are working with the 'pull_request_target' trigger
       - name: Push Results in PR to Sonar
         id: push-to-sonar
-        if: ${{ github.event_name == 'pull_request_target' && matrix.py-version == '3.9' }}
+        if: ${{ github.event_name == 'pull_request_target' && matrix.py-version == '3.10' }}
         continue-on-error: true
         uses: sonarsource/sonarcloud-github-action@v2.3.0
         env:
@@ -124,13 +124,13 @@ jobs:
 
       # next two steps are for retrying "Push Results in PR to Sonar" step in case it fails
       - name: Wait to retry 'Push Results in PR to Sonar'
-        if: ${{ github.event_name == 'pull_request_target' && matrix.py-version == '3.9' && steps.push-to-sonar.outcome != 'success' }}
+        if: ${{ github.event_name == 'pull_request_target' && matrix.py-version == '3.10' && steps.push-to-sonar.outcome != 'success' }}
         run: sleep 20s
         shell: bash
 
       - name: Retry 'Push Results in PR to Sonar'
         uses: sonarsource/sonarcloud-github-action@master
-        if: ${{ github.event_name == 'pull_request_target' && matrix.py-version == '3.9' && steps.push-to-sonar.outcome != 'success' }}
+        if: ${{ github.event_name == 'pull_request_target' && matrix.py-version == '3.10' && steps.push-to-sonar.outcome != 'success' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.INGESTION_SONAR_SECRET }}


### PR DESCRIPTION
  - Fixed mismatch between coverage recording (Python 3.10) and Sonar reporting (Python 3.9)
  - Updated Sonar steps to run on Python 3.10 to ensure coverage data is properly sent to SonarCloud
  - This pull request updates the Python version used in specific conditional checks within the GitHub Actions workflow for SonarCloud integration. The changes ensure compatibility with Python 3.10 instead of 3.9.

  ## Changes
  - Changed Sonar step condition from `matrix.py-version == '3.9'` to `matrix.py-version == '3.10'`
  - Updated retry step condition to match the same Python version

### Workflow updates:

* [`.github/workflows/py-tests.yml`](diffhunk://#diff-f0263b7556185d249b93280d75502de1aa13f467ac1fc078f90eda0ad833ef8bL109-R109): Updated conditional checks in the "Push Results in PR to Sonar" step to use Python 3.10 instead of Python 3.9.
* [`.github/workflows/py-tests.yml`](diffhunk://#diff-f0263b7556185d249b93280d75502de1aa13f467ac1fc078f90eda0ad833ef8bL127-R133): Updated conditional checks in the retry mechanism for the "Push Results in PR to Sonar" step to use Python 3.10 instead of Python 3.9.