### PR TITLE
MINOR: Refactor BigQuery client type hinting in bigquery_utils.py

### DIFF
--- a/ingestion/src/metadata/utils/bigquery_utils.py
+++ b/ingestion/src/metadata/utils/bigquery_utils.py
@@ -16,9 +16,6 @@ Utils module of BigQuery
 from copy import deepcopy
 from typing import TYPE_CHECKING, List, Optional
 
-if TYPE_CHECKING:
-    from google.cloud import bigquery
-
 from metadata.generated.schema.entity.services.connections.database.bigQueryConnection import (
     BigQueryConnection,
 )
@@ -34,6 +31,9 @@ from metadata.utils.credentials import (
     get_gcp_default_credentials,
     get_gcp_impersonate_credentials,
 )
+
+if TYPE_CHECKING:
+    from google.cloud import bigquery
 
 
 def get_bigquery_client(
@@ -66,7 +66,7 @@ def get_bigquery_client(
             scopes=scopes,
             lifetime=lifetime,
         )
-    from google.cloud import bigquery
+    from google.cloud import bigquery  # pylint: disable=import-outside-toplevel
 
     return bigquery.Client(
         credentials=credentials, project=project_id, location=location

--- a/ingestion/src/metadata/utils/bigquery_utils.py
+++ b/ingestion/src/metadata/utils/bigquery_utils.py
@@ -14,9 +14,10 @@ Utils module of BigQuery
 """
 
 from copy import deepcopy
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
-from google.cloud import bigquery
+if TYPE_CHECKING:
+    from google.cloud import bigquery
 
 from metadata.generated.schema.entity.services.connections.database.bigQueryConnection import (
     BigQueryConnection,
@@ -42,7 +43,7 @@ def get_bigquery_client(
     quota_project_id: Optional[str] = None,
     scopes: Optional[List[str]] = None,
     lifetime: Optional[int] = 3600,
-) -> bigquery.Client:
+) -> "bigquery.Client":
     """Get a BigQuery client
 
     Args:
@@ -65,6 +66,8 @@ def get_bigquery_client(
             scopes=scopes,
             lifetime=lifetime,
         )
+    from google.cloud import bigquery
+
     return bigquery.Client(
         credentials=credentials, project=project_id, location=location
     )


### PR DESCRIPTION
Fixes #22619 


This pull request refactors type hinting and import handling in the `bigquery_utils.py` utility module to improve static analysis and avoid unnecessary runtime imports. The main focus is on using `TYPE_CHECKING` for conditional imports and updating type annotations for better compatibility.

Type hinting and import improvements:

* Added a conditional import for `bigquery` using `TYPE_CHECKING` to ensure that the import only occurs during static type checking, reducing runtime overhead.
* Changed the return type annotation of `get_bigquery_client` to use a string literal `"bigquery.Client"` for forward compatibility with type checking.

Runtime import adjustment:

* Moved the import statement for `bigquery` inside the `get_bigquery_client` function to ensure the module is only imported when needed at runtime.