### PR TITLE
MINOR: Modify Documentation for metadata/types api

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/types/TypeResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/types/TypeResource.java
@@ -76,8 +76,10 @@ import org.openmetadata.service.util.SchemaFieldExtractor;
 @Tag(
     name = "Metadata",
     description =
-        "These APIs are for adding new `Types` to OpenMetadata and use those `Types` to "
-            + "extend the metadata of an entity with custom properties.")
+        "These APIs are for managing custom property definitions in OpenMetadata. Use these APIs to "
+            + "create custom properties with predefined data types (String, Integer, Date, etc.) that "
+            + "extend entity metadata. Note: This does not support creating new custom data types - "
+            + "only custom properties using existing OpenMetadata data types.")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 @Collection(name = "types")
@@ -311,12 +313,17 @@ public class TypeResource extends EntityResource<Type, TypeRepository> {
   @POST
   @Operation(
       operationId = "createType",
-      summary = "Create a type",
-      description = "Create a new type.",
+      summary = "Create a custom property definition",
+      description =
+          "Create a new custom property definition that can be applied to entities. "
+              + "This creates a property template using existing OpenMetadata data types "
+              + "(String, Integer, Date, Enum, etc.). The created property can then be used to "
+              + "extend metadata for data assets like tables, dashboards, and pipelines. "
+              + "Note: This does not create new data types - only custom property definitions.",
       responses = {
         @ApiResponse(
             responseCode = "200",
-            description = "The type",
+            description = "The custom property definition",
             content =
                 @Content(
                     mediaType = "application/json",


### PR DESCRIPTION
This pull request updates the documentation and API descriptions for custom property management in OpenMetadata. The changes clarify that the API is intended for creating custom property definitions using existing data types, not for defining new custom data types.

API documentation and description updates:

* Updated the main API tag description in `TypeResource.java` to specify that the APIs are for managing custom property definitions using existing data types, and do not support creating new custom data types.
* Revised the `createType` endpoint summary and description to clarify that it creates custom property definitions (templates) using existing OpenMetadata data types, and updated the response description accordingly.