### PR TITLE
MINOR: Adding missing fallback value for gx integration

### DIFF
--- a/ingestion/src/metadata/great_expectations/action1xx.py
+++ b/ingestion/src/metadata/great_expectations/action1xx.py
@@ -108,7 +108,7 @@ class OpenMetadataValidationAction1xx(ValidationAction):
                 table_entity = self._get_table_entity(
                     self.database_name,
                     check_point_spec.get("schema_name", self.schema_name),
-                    check_point_spec.get("table_name"),
+                    check_point_spec.get("table_name", self.table_name),
                 )
 
             else:


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

This fix aims to provide a fallback table_name value for when it is missing in the checkpoint results. If the checkpoint results contain more than one table and no table_names, all the results will be pushed to the fallback table_name.

If this is a common pattern for gx, we should think about allowing the users to provide a map instead.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
