### PR TITLE
Fix Consistent masking of PII in table column profiling

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/TableResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/TableResource.java
@@ -1047,8 +1047,7 @@ public class TableResource extends EntityResource<Table, TableRepository> {
             fqn); // get table fqn for the resource context (vs column fqn)
     ResourceContext<?> resourceContext = getResourceContextByName(tableFqn);
     authorizer.authorize(securityContext, operationContext, resourceContext);
-    boolean authorizePII = authorizer.authorizePII(securityContext, resourceContext.getOwners());
-    return repository.getColumnProfiles(fqn, startTs, endTs, authorizePII);
+    return repository.getColumnProfiles(fqn, startTs, endTs, authorizer, securityContext);
   }
 
   @GET

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/TableResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/TableResource.java
@@ -954,12 +954,12 @@ public class TableResource extends EntityResource<Table, TableRepository> {
         new OperationContext(entityType, MetadataOperation.VIEW_DATA_PROFILE);
     ResourceContext<?> resourceContext = getResourceContextByName(fqn);
     authorizer.authorize(securityContext, operationContext, resourceContext);
-    boolean authorizePII = authorizer.authorizePII(securityContext, resourceContext.getOwners());
 
     return Response.status(Response.Status.OK)
         .entity(
             JsonUtils.pojoToJson(
-                repository.getLatestTableProfile(fqn, authorizePII, includeColumnProfile)))
+                repository.getLatestTableProfile(
+                    fqn, includeColumnProfile, authorizer, securityContext)))
         .build();
   }
 
@@ -1381,7 +1381,8 @@ public class TableResource extends EntityResource<Table, TableRepository> {
     authorizer.authorize(securityContext, operationContext, getResourceContextById(id));
 
     ResultList<org.openmetadata.schema.type.Column> result =
-        repository.getTableColumns(id, limitParam, offsetParam, fieldsParam, include);
+        repository.getTableColumns(
+            id, limitParam, offsetParam, fieldsParam, include, authorizer, securityContext);
     TableColumnList tableColumnList = new TableColumnList();
     tableColumnList.setData(result.getData());
     tableColumnList.setPaging(result.getPaging());
@@ -1440,7 +1441,8 @@ public class TableResource extends EntityResource<Table, TableRepository> {
     authorizer.authorize(securityContext, operationContext, getResourceContextByName(fqn));
 
     ResultList<org.openmetadata.schema.type.Column> result =
-        repository.getTableColumnsByFQN(fqn, limitParam, offsetParam, fieldsParam, include);
+        repository.getTableColumnsByFQN(
+            fqn, limitParam, offsetParam, fieldsParam, include, authorizer, securityContext);
     TableColumnList tableColumnList = new TableColumnList();
     tableColumnList.setData(result.getData());
     tableColumnList.setPaging(result.getPaging());
@@ -1624,7 +1626,8 @@ public class TableResource extends EntityResource<Table, TableRepository> {
         new OperationContext(entityType, MetadataOperation.VIEW_BASIC);
     authorizer.authorize(securityContext, operationContext, getResourceContextById(id));
     ResultList<Column> result =
-        repository.searchTableColumnsById(id, query, limitParam, offsetParam, fieldsParam, include);
+        repository.searchTableColumnsById(
+            id, query, limitParam, offsetParam, fieldsParam, include, authorizer, securityContext);
     TableColumnList tableColumnList = new TableColumnList();
     tableColumnList.setData(result.getData());
     tableColumnList.setPaging(result.getPaging());
@@ -1685,7 +1688,7 @@ public class TableResource extends EntityResource<Table, TableRepository> {
     authorizer.authorize(securityContext, operationContext, getResourceContextByName(fqn));
     ResultList<org.openmetadata.schema.type.Column> result =
         repository.searchTableColumnsByFQN(
-            fqn, query, limitParam, offsetParam, fieldsParam, include);
+            fqn, query, limitParam, offsetParam, fieldsParam, include, authorizer, securityContext);
     TableColumnList tableColumnList = new TableColumnList();
     tableColumnList.setData(result.getData());
     tableColumnList.setPaging(result.getPaging());

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/mask/PIIMasker.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/mask/PIIMasker.java
@@ -141,16 +141,21 @@ public class PIIMasker {
   }
 
   public static List<ColumnProfile> getColumnProfile(
-      String fqn, List<ColumnProfile> columnProfiles) {
+      String fqn,
+      List<ColumnProfile> columnProfiles,
+      Authorizer authorizer,
+      SecurityContext securityContext) {
     Table table =
         Entity.getEntityByName(
-            Entity.TABLE, FullyQualifiedName.getTableFQN(fqn), "columns,tags", Include.ALL);
+            Entity.TABLE, FullyQualifiedName.getTableFQN(fqn), "columns,tags,owners", Include.ALL);
     Column column =
         table.getColumns().stream()
             .filter(c -> c.getFullyQualifiedName().equals(fqn))
             .findFirst()
             .orElse(null);
-    if (column != null && hasPiiSensitiveTag(column)) {
+    boolean authorizePII = authorizer.authorizePII(securityContext, table.getOwners());
+
+    if (column != null && hasPiiSensitiveTag(column) && !authorizePII) {
       return Collections.nCopies(columnProfiles.size(), new ColumnProfile());
     }
     return columnProfiles;


### PR DESCRIPTION
Fixes https://github.com/open-metadata/openmetadata-collate/issues/1883

This PR fixes inconsistent visibility of **PII-Sensitive** information in the **Data Observability → Column Profile** UI:

* **Unauthorized users** (without PII permission) could view the **column detail** profile, even though the **overview** properly masked it.
* **Authorized users** (admins or owners) could see sensitive column profiles in the **detail** view, but not consistently in the **overview**.

### What Changed
* **Centralized PII authorization logic** by moving the `authorizePII` check into `PIIMasker`, ensuring it uses the latest authorization patterns from the `Authorizer` class.
* **Refactored** `PIIMasker.getTableProfile(...)` to accept the **fully qualified table name (FQN)**, so it can fetch the correct `owners` for the authorization check:

  ```java
  public static List<Column> getTableProfile(
      String fqn, List<Column> columns, Authorizer authorizer, SecurityContext securityContext) {
    Table table = Entity.getEntityByName(Entity.TABLE, fqn, "owners", Include.ALL);
    boolean authorizePII = authorizer.authorizePII(securityContext, table.getOwners());
    return maskColumnsIfNotAuthorized(columns, authorizePII);
  }
  ```

* This ensures the `Authorizer.authorizePII(...)` always gets the actual `owners` list, which was previously null or incomplete from `findByName(fqn, ALL)`.

* **Maintains compatibility** with **system/job executions** (where `SecurityContext` is absent) by **overloading**:

  * A `TableRepository.getLatestTableProfile(...)` variant that accepts `(authorizer, securityContext)` for standard flows, and
  * A `PIIMasker.getTableProfile` overload that accepts a `boolean authorizePII` to bypass masking when needed.
   

  There are jobs that invoke `getLatestTableProfile()` without a `SecurityContext`, overloading it avoids breaking existing workflows and preserves backward compatibility

### Why It Matters

PII masking must respect established roles and owner policies consistently across all views:

* Users **without** PII permissions must **never** see sensitive profiles (neither in detail nor overview).
* Users **with** permission should **always** see them.
  *As specified in this comment:* [[see issue discussion](https://github.com/open-metadata/OpenMetadata/issues/10830#issuecomment-1488798742)](https://github.com/open-metadata/OpenMetadata/issues/10830#issuecomment-1488798742).

### Trade-Offs

* Adds **an extra query** per call to fetch the `owners`, ensuring accurate authorization. This is necessary to unify behavior across overview and detail views.

### Validation

* Tested as **unauthorized user**: PII-Sensitive columns are masked everywhere.
* Tested as **admin/table owner**: full visibility of PII profiles in both overview and detail.
* Verified **non-PII columns** behave as before.

---

### Categories

* [x] Bug fix
* [ ] Improvement
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation

### Checklist:
* [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
* [ ] My PR title is `Fixes <issue-number>: <short explanation>`
* [x] I have commented on my code, particularly in hard-to-understand areas.
* [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
* [x] I have added a test that covers the exact scenario we are fixing.