### PR TITLE
feat(ui): allow toggle to see both deleted and non-deleted chart on dashboard page

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Dashboards.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Dashboards.spec.ts
@@ -37,7 +37,6 @@ test.describe('Dashboards', () => {
     const dashboardChildren = generateEntityChildren('dashboard', 25);
 
     await dashboardEntity.create(apiContext, dashboardChildren);
-    await dashboard.create(apiContext);
 
     await afterAction();
   });
@@ -46,7 +45,6 @@ test.describe('Dashboards', () => {
     const { afterAction, apiContext } = await performAdminLogin(browser);
 
     await dashboardEntity.delete(apiContext);
-    await dashboard.delete(apiContext);
     await afterAction();
   });
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DashboardChartTable/DashboardChartTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DashboardChartTable/DashboardChartTable.tsx
@@ -11,23 +11,27 @@
  *  limitations under the License.
  */
 
+import { Switch, Typography } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
 import { AxiosError } from 'axios';
 import { compare, Operation } from 'fast-json-patch';
-import { groupBy, isEmpty, isUndefined, uniqBy } from 'lodash';
+import { groupBy, isUndefined, uniqBy } from 'lodash';
 import { EntityTags, TagFilterOptions } from 'Models';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
+import { INITIAL_CHART_FILTERS } from '../../../constants/constants';
 import {
   DEFAULT_DASHBOARD_CHART_VISIBLE_COLUMNS,
   TABLE_COLUMNS_KEYS,
 } from '../../../constants/TableKeys.constants';
 import { usePermissionProvider } from '../../../context/PermissionProvider/PermissionProvider';
 import { ResourceEntity } from '../../../context/PermissionProvider/PermissionProvider.interface';
+import { ERROR_PLACEHOLDER_TYPE } from '../../../enums/common.enum';
 import { EntityType } from '../../../enums/entity.enum';
 import { TagLabel, TagSource } from '../../../generated/entity/data/chart';
 import { Dashboard } from '../../../generated/entity/data/dashboard';
+import { useTableFilters } from '../../../hooks/useTableFilters';
 import { ChartType } from '../../../pages/DashboardDetailsPage/DashboardDetailsPage.component';
 import { updateChart } from '../../../rest/chartAPI';
 import { fetchCharts } from '../../../utils/DashboardDetailsUtils';
@@ -72,6 +76,9 @@ export const DashboardChartTable = ({
     chart: ChartType;
     index: number;
   }>();
+  const { filters: chartFilters, setFilters } = useTableFilters(
+    INITIAL_CHART_FILTERS
+  );
 
   const fetchChartPermissions = useCallback(async (id: string) => {
     try {
@@ -120,7 +127,10 @@ export const DashboardChartTable = ({
 
   const initializeCharts = useCallback(async () => {
     try {
-      const res = await fetchCharts(listChartIds);
+      const res = await fetchCharts(
+        listChartIds,
+        chartFilters.showDeletedCharts
+      );
       setCharts(res);
     } catch (error) {
       showErrorToast(
@@ -130,7 +140,7 @@ export const DashboardChartTable = ({
         })
       );
     }
-  }, [listChartIds]);
+  }, [listChartIds, chartFilters.showDeletedCharts]);
 
   const handleUpdateChart = (chart: ChartType, index: number) => {
     setEditChart({ chart, index });
@@ -261,6 +271,13 @@ export const DashboardChartTable = ({
     }
   };
 
+  const handleShowDeletedCharts = useCallback(
+    (value: boolean) => {
+      setFilters({ showDeletedCharts: value });
+    },
+    [setFilters, chartFilters]
+  );
+
   const tableColumn: ColumnsType<ChartType> = useMemo(
     () => [
       {
@@ -390,11 +407,14 @@ export const DashboardChartTable = ({
     }
 
     initializeCharts();
-  }, [listChartIds, isCustomizationPage]);
+  }, [listChartIds, isCustomizationPage, initializeCharts]);
 
-  if (isEmpty(charts)) {
-    return <ErrorPlaceHolder className="border-default border-radius-sm" />;
-  }
+  useEffect(() => {
+    setFilters({
+      showDeletedCharts:
+        chartFilters.showDeletedCharts ?? dashboardDetails?.deleted,
+    });
+  }, [dashboardDetails?.deleted, chartFilters.showDeletedCharts, setFilters]);
 
   return (
     <>
@@ -404,6 +424,26 @@ export const DashboardChartTable = ({
         data-testid="charts-table"
         dataSource={charts}
         defaultVisibleColumns={DEFAULT_DASHBOARD_CHART_VISIBLE_COLUMNS}
+        extraTableFilters={
+          <span>
+            <Switch
+              checked={chartFilters.showDeletedCharts}
+              data-testid="show-deleted"
+              onClick={handleShowDeletedCharts}
+            />
+            <Typography.Text className="m-l-xs">
+              {t('label.deleted')}
+            </Typography.Text>
+          </span>
+        }
+        locale={{
+          emptyText: (
+            <ErrorPlaceHolder
+              className="border-none mt-0-important"
+              type={ERROR_PLACEHOLDER_TYPE.NO_DATA}
+            />
+          ),
+        }}
         pagination={false}
         rowKey="fullyQualifiedName"
         scroll={{ x: 1200 }}

--- a/openmetadata-ui/src/main/resources/ui/src/constants/constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/constants.ts
@@ -434,6 +434,10 @@ export const INITIAL_TABLE_FILTERS = {
   showDeletedTables: false,
 };
 
+export const INITIAL_CHART_FILTERS = {
+  showDeletedCharts: false,
+};
+
 export const MAX_VISIBLE_OWNERS_FOR_FEED_TAB = 4;
 export const MAX_VISIBLE_OWNERS_FOR_FEED_CARD = 2;
 

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DashboardDetailsUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DashboardDetailsUtils.tsx
@@ -27,6 +27,7 @@ import { DetailPageWidgetKeys } from '../enums/CustomizeDetailPage.enum';
 import { EntityTabs, EntityType, TabSpecificField } from '../enums/entity.enum';
 import { Dashboard } from '../generated/entity/data/dashboard';
 import { PageType } from '../generated/system/ui/page';
+import { Include } from '../generated/type/include';
 import { WidgetConfig } from '../pages/CustomizablePage/CustomizablePage.interface';
 import { ChartType } from '../pages/DashboardDetailsPage/DashboardDetailsPage.component';
 import { getChartById } from '../rest/chartAPI';
@@ -36,13 +37,19 @@ import { t } from './i18next/LocalUtil';
 // eslint-disable-next-line max-len
 export const defaultFields = `${TabSpecificField.DOMAINS},${TabSpecificField.OWNERS}, ${TabSpecificField.FOLLOWERS}, ${TabSpecificField.TAGS}, ${TabSpecificField.CHARTS},${TabSpecificField.VOTES},${TabSpecificField.DATA_PRODUCTS},${TabSpecificField.EXTENSION}`;
 
-export const fetchCharts = async (charts: Dashboard['charts']) => {
+export const fetchCharts = async (
+  charts: Dashboard['charts'],
+  showDeleted = false
+) => {
   let chartsData: ChartType[] = [];
   let promiseArr: Array<Promise<ChartType>> = [];
   try {
     if (charts?.length) {
       promiseArr = charts.map((chart) =>
-        getChartById(chart.id, { fields: TabSpecificField.TAGS })
+        getChartById(chart.id, {
+          fields: TabSpecificField.TAGS,
+          include: showDeleted ? Include.Deleted : Include.NonDeleted,
+        })
       );
       const res = await Promise.allSettled(promiseArr);
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #22345

**Summary**
Implements a toggle functionality to show both deleted and non-deleted charts on dashboard pages. This feature provides users with the ability to view soft-deleted charts alongside active ones, similar to the functionality available on other entity pages.

**Problem**
Currently, dashboard pages only display non-deleted charts. Users have no way to view soft-deleted charts that were removed when a dashboard was deleted, limiting visibility into the complete chart inventory.

**Solution**
Added a toggle switch in the dashboard chart table that allows users to:
  - Toggle OFF (Default): Show only active/non-deleted charts
  - Toggle ON: Show only soft-deleted charts
  - Auto-default behaviour: When the parent dashboard is deleted, the toggle automatically defaults to showing deleted charts
  
  

https://github.com/user-attachments/assets/2877208b-3f7e-408b-b5ab-84a6d308940c



https://github.com/user-attachments/assets/e75e4ecb-c854-4b91-b231-79c53afab726



<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
