### PR TITLE
Format python file causing py-checkstyle job to fail

### DIFF
--- a/ingestion/src/metadata/ingestion/ometa/ometa_api.py
+++ b/ingestion/src/metadata/ingestion/ometa/ometa_api.py
@@ -341,7 +341,7 @@ class OpenMetadata(
         Run a PUT request via create request C.
 
         Note: This method uses PUT operations with server-side business rules that may prevent
-        certain field overwrites across various entity types for data integrity reasons. If you 
+        certain field overwrites across various entity types for data integrity reasons. If you
         need to override existing metadata fields, consider using patch methods instead:
 
         - For descriptions: Use patch_description(force=True)


### PR DESCRIPTION
Python file `ometa_api.py` was commited but wasn't passing py-checkstyle GithubActions CI job, I've ran `make py_format` to fix the issue and unblock other PR CI pipelines.
