### PR TITLE
Minor: Fix Databricks & Unity Catalog, Table or View Not found

### DIFF
--- a/ingestion/src/metadata/profiler/interface/sqlalchemy/databricks/profiler_interface.py
+++ b/ingestion/src/metadata/profiler/interface/sqlalchemy/databricks/profiler_interface.py
@@ -85,10 +85,28 @@ class DatabricksProfilerInterface(SQAProfilerInterface):
             result += "`.`".join(splitted_result)
         return result
 
+    def visit_table(self, *args, **kwargs):
+        result = super(  # pylint: disable=bad-super-call
+            HiveCompiler, self
+        ).visit_table(*args, **kwargs)
+        # Handle table references with hyphens in database/schema names
+        # Format: `database`.`schema`.`table` for Unity Catalog/Databricks
+        if "." in result and not result.startswith("`"):
+            parts = result.split(".")
+            quoted_parts = []
+            for part in parts:
+                if "-" in part and not (part.startswith("`") and part.endswith("`")):
+                    quoted_parts.append(f"`{part}`")
+                else:
+                    quoted_parts.append(part)
+            result = ".".join(quoted_parts)
+        return result
+
     def __init__(self, service_connection_config, **kwargs):
         super().__init__(service_connection_config=service_connection_config, **kwargs)
         self.set_catalog(self.session)
         HiveCompiler.visit_column = DatabricksProfilerInterface.visit_column
+        HiveCompiler.visit_table = DatabricksProfilerInterface.visit_table
 
     def _get_struct_columns(self, columns: List[OMColumn], parent: str):
         """Get struct columns"""

--- a/ingestion/src/metadata/profiler/interface/sqlalchemy/unity_catalog/profiler_interface.py
+++ b/ingestion/src/metadata/profiler/interface/sqlalchemy/unity_catalog/profiler_interface.py
@@ -37,7 +37,9 @@ class UnityCatalogProfilerInterface(DatabricksProfilerInterface):
             connection.execute(
                 "USE CATALOG %(catalog)s;",
                 {"catalog": self.service_connection_config.catalog},
-            )
+            # Safely quote the catalog name to prevent SQL injection
+            quoted_catalog = connection.dialect.identifier_preparer.quote(self.service_connection_config.catalog)
+            connection.execute(f"USE CATALOG {quoted_catalog};")
 
         self.session_factory = scoped_session(session_maker)
         self.session = self.session_factory()

--- a/ingestion/src/metadata/profiler/interface/sqlalchemy/unity_catalog/profiler_interface.py
+++ b/ingestion/src/metadata/profiler/interface/sqlalchemy/unity_catalog/profiler_interface.py
@@ -15,7 +15,8 @@ supporting sqlalchemy abstraction layer
 """
 
 from sqlalchemy import event
-from sqlalchemy.orm import sessionmaker, scoped_session
+from sqlalchemy.orm import scoped_session, sessionmaker
+
 from metadata.ingestion.source.database.databricks.connection import (
     get_connection as databricks_get_connection,
 )
@@ -27,16 +28,16 @@ from metadata.profiler.interface.sqlalchemy.databricks.profiler_interface import
 class UnityCatalogProfilerInterface(DatabricksProfilerInterface):
     def create_session(self):
         self.connection = databricks_get_connection(self.service_connection_config)
-        
+
         # Create custom session factory with after_begin event to set catalog
         session_maker = sessionmaker(bind=self.connection)
-        
+
         @event.listens_for(session_maker, "after_begin")
         def set_catalog(session, transaction, connection):
             connection.execute(
                 "USE CATALOG %(catalog)s;",
-                {"catalog": self.service_connection_config.catalog}
+                {"catalog": self.service_connection_config.catalog},
             )
-        
+
         self.session_factory = scoped_session(session_maker)
         self.session = self.session_factory()

--- a/ingestion/src/metadata/profiler/interface/sqlalchemy/unity_catalog/profiler_interface.py
+++ b/ingestion/src/metadata/profiler/interface/sqlalchemy/unity_catalog/profiler_interface.py
@@ -34,11 +34,10 @@ class UnityCatalogProfilerInterface(DatabricksProfilerInterface):
 
         @event.listens_for(session_maker, "after_begin")
         def set_catalog(session, transaction, connection):
-            connection.execute(
-                "USE CATALOG %(catalog)s;",
-                {"catalog": self.service_connection_config.catalog},
             # Safely quote the catalog name to prevent SQL injection
-            quoted_catalog = connection.dialect.identifier_preparer.quote(self.service_connection_config.catalog)
+            quoted_catalog = connection.dialect.identifier_preparer.quote(
+                self.service_connection_config.catalog
+            )
             connection.execute(f"USE CATALOG {quoted_catalog};")
 
         self.session_factory = scoped_session(session_maker)

--- a/ingestion/src/metadata/profiler/metrics/system/databricks/system.py
+++ b/ingestion/src/metadata/profiler/metrics/system/databricks/system.py
@@ -24,7 +24,7 @@ SYSTEM_QUERY = textwrap.dedent(
         '{database}' AS database,
         '{schema}' AS schema,
         '{table}' AS table
-    FROM (DESCRIBE HISTORY {database}.{schema}.{table})
+    FROM (DESCRIBE HISTORY `{database}`.`{schema}`.`{table}`)
     WHERE operation IN ({operations}) AND timestamp > DATEADD(day, -1, CURRENT_TIMESTAMP())
     """
 )

--- a/ingestion/src/metadata/sampler/sqlalchemy/databricks/sampler.py
+++ b/ingestion/src/metadata/sampler/sqlalchemy/databricks/sampler.py
@@ -11,7 +11,8 @@
 """
 Helper module to handle data sampling for the profiler
 """
-from sqlalchemy import Column, text
+from sqlalchemy import Column, event, text
+from sqlalchemy.orm import scoped_session, sessionmaker
 
 from metadata.ingestion.source.database.databricks.connection import (
     get_connection as databricks_get_connection,
@@ -25,6 +26,16 @@ class DatabricksSamplerInterface(SQASampler):
         """Initialize with a single Databricks connection"""
         super().__init__(*args, **kwargs)
         self.connection = databricks_get_connection(self.service_connection_config)
+        session_maker = sessionmaker(bind=self.connection)
+
+        @event.listens_for(session_maker, "after_begin")
+        def set_catalog(session, transaction, connection):
+            connection.execute(
+                "USE CATALOG %(catalog)s;",
+                {"catalog": self.service_connection_config.catalog},
+            )
+
+        self.session_factory = scoped_session(session_maker)
 
     def get_client(self):
         """client is the session for SQA"""

--- a/ingestion/src/metadata/sampler/sqlalchemy/databricks/sampler.py
+++ b/ingestion/src/metadata/sampler/sqlalchemy/databricks/sampler.py
@@ -30,10 +30,11 @@ class DatabricksSamplerInterface(SQASampler):
 
         @event.listens_for(session_maker, "after_begin")
         def set_catalog(session, transaction, connection):
-            connection.execute(
-                "USE CATALOG %(catalog)s;",
-                {"catalog": self.service_connection_config.catalog},
+            # Safely quote the catalog name to prevent SQL injection
+            quoted_catalog = connection.dialect.identifier_preparer.quote(
+                self.service_connection_config.catalog
             )
+            connection.execute(f"USE CATALOG {quoted_catalog};")
 
         self.session_factory = scoped_session(session_maker)
 

--- a/ingestion/src/metadata/sampler/sqlalchemy/unitycatalog/sampler.py
+++ b/ingestion/src/metadata/sampler/sqlalchemy/unitycatalog/sampler.py
@@ -14,8 +14,6 @@ Interfaces with database for all database engine
 supporting sqlalchemy abstraction layer
 """
 
-from sqlalchemy import event
-from sqlalchemy.orm import scoped_session, sessionmaker
 
 from metadata.sampler.sqlalchemy.databricks.sampler import DatabricksSamplerInterface
 
@@ -27,15 +25,3 @@ class UnityCatalogSamplerInterface(DatabricksSamplerInterface):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-        # Create custom session with after_begin event to set catalog
-        session_maker = sessionmaker(bind=self.connection)
-
-        @event.listens_for(session_maker, "after_begin")
-        def set_catalog(session, transaction, connection):
-            connection.execute(
-                "USE CATALOG %(catalog)s;",
-                {"catalog": self.service_connection_config.catalog},
-            )
-
-        self.session_factory = scoped_session(session_maker)

--- a/ingestion/src/metadata/sampler/sqlalchemy/unitycatalog/sampler.py
+++ b/ingestion/src/metadata/sampler/sqlalchemy/unitycatalog/sampler.py
@@ -14,47 +14,15 @@ Interfaces with database for all database engine
 supporting sqlalchemy abstraction layer
 """
 
-from sqlalchemy import Column, text
-
-from metadata.ingestion.source.database.databricks.connection import (
-    get_connection as databricks_get_connection,
-)
-from metadata.profiler.orm.types.custom_array import CustomArray
-from metadata.sampler.sqlalchemy.sampler import SQASampler
+from metadata.ingestion.connections.session import create_and_bind_thread_safe_session
+from metadata.sampler.sqlalchemy.databricks.sampler import DatabricksSamplerInterface
 
 
-class UnityCatalogSamplerInterface(SQASampler):
+class UnityCatalogSamplerInterface(DatabricksSamplerInterface):
+    """
+    Unity Catalog Sampler Interface
+    """
+
     def __init__(self, *args, **kwargs):
-        """Initialize with a single Databricks connection"""
         super().__init__(*args, **kwargs)
-        self.connection = databricks_get_connection(self.service_connection_config)
-
-    def get_client(self):
-        """client is the session for SQA"""
-        client = super().get_client()
-        self.set_catalog(client)
-        return client
-
-    def _handle_array_column(self, column: Column) -> bool:
-        """Check if a column is an array type"""
-        return isinstance(column.type, CustomArray)
-
-    def _get_slice_expression(self, column: Column):
-        """Generate SQL expression to slice array elements at query level
-
-        Args:
-            column_name: Name of the column
-            max_elements: Maximum number of elements to extract
-
-        Returns:
-            SQL expression string for array slicing
-        """
-        max_elements = self._get_max_array_elements()
-        return text(
-            f"""
-        CASE 
-            WHEN `{column.name}` IS NULL THEN NULL
-            ELSE slice(`{column.name}`, 1, {max_elements})
-        END AS `{column._label}`
-        """
-        )
+        self.session_factory = create_and_bind_thread_safe_session(self.connection)

--- a/ingestion/src/metadata/sampler/sqlalchemy/unitycatalog/sampler.py
+++ b/ingestion/src/metadata/sampler/sqlalchemy/unitycatalog/sampler.py
@@ -15,7 +15,8 @@ supporting sqlalchemy abstraction layer
 """
 
 from sqlalchemy import event
-from sqlalchemy.orm import sessionmaker, scoped_session
+from sqlalchemy.orm import scoped_session, sessionmaker
+
 from metadata.sampler.sqlalchemy.databricks.sampler import DatabricksSamplerInterface
 
 
@@ -26,15 +27,15 @@ class UnityCatalogSamplerInterface(DatabricksSamplerInterface):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        
+
         # Create custom session with after_begin event to set catalog
         session_maker = sessionmaker(bind=self.connection)
-        
+
         @event.listens_for(session_maker, "after_begin")
         def set_catalog(session, transaction, connection):
             connection.execute(
                 "USE CATALOG %(catalog)s;",
-                {"catalog": self.service_connection_config.catalog}
+                {"catalog": self.service_connection_config.catalog},
             )
-        
+
         self.session_factory = scoped_session(session_maker)

--- a/ingestion/src/metadata/utils/logger.py
+++ b/ingestion/src/metadata/utils/logger.py
@@ -213,6 +213,8 @@ def get_log_name(record: Entity) -> Optional[str]:
     try:
         if hasattr(record, "name"):
             return f"{type(record).__name__} [{getattr(record, 'name').root}]"
+        if hasattr(record, "table") and hasattr(record.table, "name"):
+            return f"{type(record).__name__} [{record.table.name.root}]"
         return f"{type(record).__name__} [{record.entity.name.root}]"
     except Exception:
         return str(record)

--- a/ingestion/tests/unit/sampler/sqlalchemy/test_unitycatalog_sampler.py
+++ b/ingestion/tests/unit/sampler/sqlalchemy/test_unitycatalog_sampler.py
@@ -73,7 +73,7 @@ class UnityCatalogSamplerTest(TestCase):
         )
 
     @patch(
-        "metadata.sampler.sqlalchemy.unitycatalog.sampler.SQASampler.build_table_orm"
+        "metadata.sampler.sqlalchemy.unitycatalog.sampler.UnityCatalogSamplerInterface.build_table_orm"
     )
     def test_handle_array_column(self, mock_build_table_orm):
         """Test array column detection"""


### PR DESCRIPTION
This pull request introduces improvements and bug fixes to the Databricks and Unity Catalog profiler and sampler interfaces, enhancing compatibility with catalog-aware operations and improving the handling of special characters in database identifiers. The most significant changes include correct quoting of table references with hyphens, ensuring the catalog is set for each session, and refactoring the Unity Catalog sampler to inherit from the Databricks sampler for code reuse.

**Databricks/Unity Catalog compatibility and session management:**

* Added `visit_table` method to `DatabricksProfilerInterface` to correctly quote database, schema, and table names containing hyphens, ensuring compatibility with Unity Catalog and Databricks table references.
* Updated session creation in both `UnityCatalogProfilerInterface` and `DatabricksSamplerInterface` to use a custom session factory that sets the catalog via an `after_begin` event, ensuring all queries run in the correct catalog context. [[1]](diffhunk://#diff-363ca7d2c7c0a49f78b28176f6f1f1a9d6a79e10f91cb94b3b806ade7693b410L29-R43) [[2]](diffhunk://#diff-3fd6192598235cb98fc3f3356b8e7760c0a8356af6536df40cdccc86343a8627R29-R38)

**Refactoring for code reuse:**

* Refactored `UnityCatalogSamplerInterface` to inherit from `DatabricksSamplerInterface`, removing redundant code and centralizing catalog/session handling logic.

**Bug fixes and enhancements:**

* Fixed SQL query in Databricks system metrics to properly quote database, schema, and table names in the `DESCRIBE HISTORY` statement.
* Enhanced logging utility to handle cases where the entity name is nested under a `table` attribute, improving robustness of log naming.