### PR TITLE
Refactor DatabaseServiceTablesProcessor and simplify getLatestTableProfile logic

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
@@ -769,12 +769,6 @@ public class TableRepository extends EntityRepository<Table> {
         t -> PIIMasker.getTableProfile(fqn, t.getColumns(), authorizer, securityContext));
   }
 
-  public Table getLatestTableProfile(
-      String fqn, boolean authorizePII, boolean includeColumnProfile) {
-    return getLatestTableProfileInternal(
-        fqn, includeColumnProfile, t -> PIIMasker.getTableProfile(t.getColumns(), authorizePII));
-  }
-
   private Table getLatestTableProfileInternal(
       String fqn, boolean includeColumnProfile, Function<Table, List<Column>> maskFn) {
     Table table = findByName(fqn, ALL);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/mask/PIIMasker.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/mask/PIIMasker.java
@@ -136,11 +136,6 @@ public class PIIMasker {
     Table table = Entity.getEntityByName(Entity.TABLE, fqn, "owners", Include.ALL);
     List<EntityReference> owners = table.getOwners();
     boolean authorizePII = authorizer.authorizePII(securityContext, owners);
-    return maskColumnsIfNotAuthorized(columns, authorizePII);
-  }
-
-  private static List<Column> maskColumnsIfNotAuthorized(
-      List<Column> columns, boolean authorizePII) {
     if (authorizePII) return columns;
     for (Column c : listOrEmpty(columns)) {
       if (hasPiiSensitiveTag(c)) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/mask/PIIMasker.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/mask/PIIMasker.java
@@ -139,10 +139,6 @@ public class PIIMasker {
     return maskColumnsIfNotAuthorized(columns, authorizePII);
   }
 
-  public static List<Column> getTableProfile(List<Column> columns, boolean authorizePII) {
-    return maskColumnsIfNotAuthorized(columns, authorizePII);
-  }
-
   private static List<Column> maskColumnsIfNotAuthorized(
       List<Column> columns, boolean authorizePII) {
     if (authorizePII) return columns;


### PR DESCRIPTION

* **DatabaseServiceTablesProcessor**
  Replaced the call to `TableRepository#getLatestTableProfile` with a direct DAO call (`profilerDataTimeSeriesDao#getLatestExtension`). This avoids relying on overloaded repository methods and removes the need for a `SecurityContext` in the processor.

* **TableRepository**
  Inlined `getLatestTableProfileInternal` into a single method. The logic is now self-contained: it fetches the latest profile JSON, attaches it to the table, populates tags, applies column profiling (if requested), and applies masking through `PIIMasker`.

* **PIIMasker**
  Inlined `maskColumnsIfNotAuthorized` into `getTableProfile`. Masking is now handled directly in the main method for clarity and simplicity.

This refactor reduces indirection, simplifies the call chain, and removes the now-unnecessary overloaded `getLatestTableProfile` method.

Tested locally by running DataInsights workflow and verifying profile data is fetched and masking is applied as before.

#

### Type of change:

* [x] Improvement


### Checklist:

* [x] I have read the [**[CONTRIBUTING](https://docs.open-metadata.org/developers/contribute)**](https://docs.open-metadata.org/developers/contribute) document.
* [ ] My PR title is `Fixes <issue-number>: <short explanation>`
* [ ] I have commented on my code, particularly in hard-to-understand areas.
* [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.