### PR TITLE
MINOR - Data Contract fixes and improvements

### DIFF
--- a/bootstrap/sql/migrations/native/1.9.3/mysql/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.9.3/mysql/schemaChanges.sql
@@ -1,0 +1,4 @@
+-- Update the relation between table and dataContract to 0 (CONTAINS)
+UPDATE entity_relationship
+SET relation = 0
+WHERE fromEntity = 'table' AND toEntity = 'dataContract' AND relation = 10;

--- a/bootstrap/sql/migrations/native/1.9.3/postgres/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.9.3/postgres/schemaChanges.sql
@@ -1,0 +1,4 @@
+-- Update the relation between table and dataContract to 0 (CONTAINS)
+UPDATE entity_relationship
+SET relation = 0
+WHERE fromEntity = 'table' AND toEntity = 'dataContract' AND relation = 10;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dataContracts/DataContractValidationApp.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dataContracts/DataContractValidationApp.java
@@ -1,6 +1,7 @@
 package org.openmetadata.service.apps.bundles.dataContracts;
 
 import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
+import static org.openmetadata.service.Entity.ADMIN_USER_NAME;
 import static org.openmetadata.service.apps.scheduler.OmAppJobListener.APP_RUN_STATS;
 
 import java.util.HashMap;
@@ -14,14 +15,18 @@ import org.openmetadata.schema.entity.data.DataContract;
 import org.openmetadata.schema.entity.datacontract.DataContractResult;
 import org.openmetadata.schema.system.Stats;
 import org.openmetadata.schema.system.StepStats;
+import org.openmetadata.schema.type.ChangeEvent;
+import org.openmetadata.schema.type.EventType;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.apps.AbstractNativeApplication;
+import org.openmetadata.service.formatter.util.FormatterUtil;
 import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.DataContractRepository;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.search.SearchRepository;
 import org.openmetadata.service.util.EntityUtil;
+import org.openmetadata.service.util.RestUtil;
 import org.openmetadata.service.util.ResultList;
 import org.quartz.JobExecutionContext;
 
@@ -70,8 +75,15 @@ public class DataContractValidationApp extends AbstractNativeApplication {
         for (DataContract dataContract : contractBatch) {
           try {
             LOG.debug("Validating data contract: {}", dataContract.getFullyQualifiedName());
-            DataContractResult validationResult = repository.validateContract(dataContract);
+            RestUtil.PutResponse<DataContractResult> validationResponse =
+                repository.validateContract(dataContract);
+            DataContractResult validationResult = validationResponse.getEntity();
 
+            ChangeEvent changeEvent =
+                FormatterUtil.getDataContractResultEvent(
+                    validationResult, ADMIN_USER_NAME, EventType.ENTITY_UPDATED);
+            changeEvent.setEntity(JsonUtils.pojoToMaskedJson(dataContract));
+            Entity.getCollectionDAO().changeEventDAO().insert(JsonUtils.pojoToJson(changeEvent));
             LOG.debug(
                 "Validation completed for {}: Status = {}",
                 dataContract.getFullyQualifiedName(),

--- a/openmetadata-service/src/main/java/org/openmetadata/service/formatter/util/FormatterUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/formatter/util/FormatterUtil.java
@@ -346,22 +346,25 @@ public class FormatterUtil {
     if (entityTimeSeries instanceof DataContractResult) {
       DataContractResult result =
           JsonUtils.readOrConvertValue(entityTimeSeries, DataContractResult.class);
-      DataContract contract =
-          Entity.getEntityByName(
-              Entity.DATA_CONTRACT, result.getDataContractFQN(), "", Include.ALL);
-      ChangeEvent changeEvent =
-          getChangeEvent(updateBy, eventType, contract.getEntityReference().getType(), contract);
-
-      return changeEvent
-          .withChangeDescription(
-              new ChangeDescription()
-                  .withFieldsUpdated(
-                      List.of(
-                          new FieldChange().withName(DATA_CONTRACT_RESULT).withNewValue(result))))
-          .withEntity(contract)
-          .withEntityFullyQualifiedName(contract.getFullyQualifiedName());
+      return getDataContractResultEvent(result, updateBy, eventType);
     }
     return null;
+  }
+
+  public static ChangeEvent getDataContractResultEvent(
+      DataContractResult result, String updateBy, EventType eventType) {
+    DataContract contract =
+        Entity.getEntityByName(Entity.DATA_CONTRACT, result.getDataContractFQN(), "", Include.ALL);
+    ChangeEvent changeEvent =
+        getChangeEvent(updateBy, eventType, contract.getEntityReference().getType(), contract);
+
+    return changeEvent
+        .withChangeDescription(
+            new ChangeDescription()
+                .withFieldsUpdated(
+                    List.of(new FieldChange().withName(DATA_CONTRACT_RESULT).withNewValue(result))))
+        .withEntity(contract)
+        .withEntityFullyQualifiedName(contract.getFullyQualifiedName());
   }
 
   private static ChangeEvent getChangeEventForThread(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataContractRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataContractRepository.java
@@ -475,7 +475,7 @@ public class DataContractRepository extends EntityRepository<DataContract> {
     }
   }
 
-  public DataContractResult validateContract(DataContract dataContract) {
+  public RestUtil.PutResponse<DataContractResult> validateContract(DataContract dataContract) {
     // Check if there's a running validation and abort it before starting a new one
     abortRunningValidation(dataContract);
 
@@ -520,8 +520,7 @@ public class DataContractRepository extends EntityRepository<DataContract> {
     }
 
     // Add the result to the data contract and update the time series
-    addContractResult(dataContract, result);
-    return result;
+    return addContractResult(dataContract, result);
   }
 
   public void deployAndTriggerDQValidation(DataContract dataContract) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataContractRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataContractRepository.java
@@ -82,9 +82,9 @@ import org.openmetadata.service.util.RestUtil;
 public class DataContractRepository extends EntityRepository<DataContract> {
 
   private static final String DATA_CONTRACT_UPDATE_FIELDS =
-      "entity,owners,reviewers,status,schema,qualityExpectations,contractUpdates,semantics,latestResult";
+      "entity,owners,reviewers,status,schema,qualityExpectations,contractUpdates,semantics,latestResult,extension";
   private static final String DATA_CONTRACT_PATCH_FIELDS =
-      "entity,owners,reviewers,status,schema,qualityExpectations,contractUpdates,semantics,latestResult";
+      "entity,owners,reviewers,status,schema,qualityExpectations,contractUpdates,semantics,latestResult,extension";
 
   public static final String RESULT_EXTENSION = "dataContract.dataContractResult";
   public static final String RESULT_SCHEMA = "dataContractResult";

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataContractRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataContractRepository.java
@@ -877,7 +877,7 @@ public class DataContractRepository extends EntityRepository<DataContract> {
         dataContract.getId(),
         dataContract.getEntity().getType(),
         Entity.DATA_CONTRACT,
-        Relationship.HAS);
+        Relationship.CONTAINS);
 
     storeOwners(dataContract, dataContract.getOwners());
     storeReviewers(dataContract, dataContract.getReviewers());

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/data/DataContractMapper.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/data/DataContractMapper.java
@@ -43,6 +43,7 @@ public class DataContractMapper {
             .withEffectiveFrom(create.getEffectiveFrom())
             .withEffectiveUntil(create.getEffectiveUntil())
             .withSourceUrl(create.getSourceUrl())
+            .withExtension(create.getExtension())
             .withUpdatedBy(user)
             .withUpdatedAt(System.currentTimeMillis());
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/data/DataContractResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/data/DataContractResource.java
@@ -73,6 +73,7 @@ import org.openmetadata.service.security.Authorizer;
 import org.openmetadata.service.security.policyevaluator.OperationContext;
 import org.openmetadata.service.security.policyevaluator.ResourceContext;
 import org.openmetadata.service.util.EntityUtil.Fields;
+import org.openmetadata.service.util.RestUtil;
 import org.openmetadata.service.util.ResultList;
 
 @Slf4j
@@ -872,8 +873,8 @@ public class DataContractResource extends EntityResource<DataContract, DataContr
         new ResourceContext<>(Entity.DATA_CONTRACT, id, null);
     authorizer.authorize(securityContext, operationContext, resourceContext);
 
-    DataContractResult result = repository.validateContract(dataContract);
-    return Response.ok(result).build();
+    RestUtil.PutResponse<DataContractResult> result = repository.validateContract(dataContract);
+    return result.toResponse();
   }
 
   // Add runId and dataContractFQN to the result if not incoming

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/data/DataContractResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/data/DataContractResource.java
@@ -86,7 +86,7 @@ import org.openmetadata.service.util.ResultList;
 @Collection(name = "dataContracts")
 public class DataContractResource extends EntityResource<DataContract, DataContractRepository> {
   public static final String COLLECTION_PATH = "v1/dataContracts/";
-  static final String FIELDS = "owners,reviewers";
+  static final String FIELDS = "owners,reviewers,extension";
 
   @Override
   public DataContract addHref(UriInfo uriInfo, DataContract dataContract) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/EntityResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/EntityResourceTest.java
@@ -3578,7 +3578,7 @@ public abstract class EntityResourceTest<T extends EntityInterface, K extends Cr
     // PUT and update the entity with extension field intA to a new value
     JsonNode intAValue = mapper.convertValue(2, JsonNode.class);
     jsonNode.set("intA", intAValue);
-    create = createRequest(test).withExtension(jsonNode).withName(entity.getName());
+    create = create.withExtension(jsonNode).withName(entity.getName());
     change = getChangeDescription(entity, MINOR_UPDATE);
     fieldUpdated(
         change,
@@ -3600,7 +3600,7 @@ public abstract class EntityResourceTest<T extends EntityInterface, K extends Cr
     // PUT and remove field intA from the entity extension - *** for BOT this should be ignored ***
     JsonNode oldNode = JsonUtils.valueToTree(entity.getExtension());
     jsonNode.remove("intA");
-    create = createRequest(test).withExtension(jsonNode).withName(entity.getName());
+    create = create.withExtension(jsonNode).withName(entity.getName());
     entity = updateEntity(create, Status.OK, INGESTION_BOT_AUTH_HEADERS);
     assertNotEquals(
         JsonUtils.valueToTree(create.getExtension()), JsonUtils.valueToTree(entity.getExtension()));

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/data/DataContractResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/data/DataContractResourceTest.java
@@ -14,6 +14,7 @@
 package org.openmetadata.service.resources.data;
 
 import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
+import static jakarta.ws.rs.core.Response.Status.OK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -567,7 +568,7 @@ public class DataContractResourceTest extends EntityResourceTest<DataContract, C
       target = target.queryParam("fields", fields);
     }
     Response response = SecurityUtil.addHeaders(target, ADMIN_AUTH_HEADERS).get();
-    return TestUtils.readResponse(response, DataContract.class, Status.OK.getStatusCode());
+    return TestUtils.readResponse(response, DataContract.class, OK.getStatusCode());
   }
 
   private DataContract getDataContractByName(String name, String fields)
@@ -577,7 +578,7 @@ public class DataContractResourceTest extends EntityResourceTest<DataContract, C
       target = target.queryParam("fields", fields);
     }
     Response response = SecurityUtil.addHeaders(target, ADMIN_AUTH_HEADERS).get();
-    return TestUtils.readResponse(response, DataContract.class, Status.OK.getStatusCode());
+    return TestUtils.readResponse(response, DataContract.class, OK.getStatusCode());
   }
 
   private DataContract getDataContractByEntityId(UUID entityId, String entityType)
@@ -596,14 +597,14 @@ public class DataContractResourceTest extends EntityResourceTest<DataContract, C
       target = target.queryParam("fields", fields);
     }
     Response response = SecurityUtil.addHeaders(target, ADMIN_AUTH_HEADERS).get();
-    return TestUtils.readResponse(response, DataContract.class, Status.OK.getStatusCode());
+    return TestUtils.readResponse(response, DataContract.class, OK.getStatusCode());
   }
 
   private DataContract updateDataContract(CreateDataContract create) throws IOException {
     WebTarget target = getCollection();
     Response response =
         SecurityUtil.addHeaders(target, ADMIN_AUTH_HEADERS).put(Entity.json(create));
-    return TestUtils.readResponse(response, DataContract.class, Status.OK.getStatusCode());
+    return TestUtils.readResponse(response, DataContract.class, OK.getStatusCode());
   }
 
   private DataContract patchDataContract(UUID id, String originalJson, DataContract updated)
@@ -624,14 +625,14 @@ public class DataContractResourceTest extends EntityResourceTest<DataContract, C
   private void deleteDataContract(UUID id) throws IOException {
     WebTarget target = getResource(id);
     Response response = SecurityUtil.addHeaders(target, ADMIN_AUTH_HEADERS).delete();
-    TestUtils.readResponse(response, DataContract.class, Status.OK.getStatusCode());
+    TestUtils.readResponse(response, DataContract.class, OK.getStatusCode());
   }
 
   private void deleteDataContract(UUID id, boolean recursive) throws IOException {
     WebTarget target = getResource(id);
     target = target.queryParam("recursive", recursive);
     Response response = SecurityUtil.addHeaders(target, ADMIN_AUTH_HEADERS).delete();
-    TestUtils.readResponse(response, DataContract.class, Status.OK.getStatusCode());
+    TestUtils.readResponse(response, DataContract.class, OK.getStatusCode());
   }
 
   private void deleteTable(UUID id) {
@@ -667,16 +668,14 @@ public class DataContractResourceTest extends EntityResourceTest<DataContract, C
       throws HttpResponseException {
     WebTarget latestTarget = getResource(dataContract.getId()).path("/results/latest");
     Response latestResponse = SecurityUtil.addHeaders(latestTarget, ADMIN_AUTH_HEADERS).get();
-    return TestUtils.readResponse(
-        latestResponse, DataContractResult.class, Status.OK.getStatusCode());
+    return TestUtils.readResponse(latestResponse, DataContractResult.class, OK.getStatusCode());
   }
 
   private DataContractResult runValidate(DataContract dataContract) throws HttpResponseException {
     WebTarget validateTarget = getResource(dataContract.getId()).path("/validate");
     Response validateResponse =
         SecurityUtil.addHeaders(validateTarget, ADMIN_AUTH_HEADERS).post(null);
-    return TestUtils.readResponse(
-        validateResponse, DataContractResult.class, Status.OK.getStatusCode());
+    return TestUtils.readResponse(validateResponse, DataContractResult.class, OK.getStatusCode());
   }
 
   private Response getResultById(UUID dataContractId, UUID resultId) {
@@ -1777,8 +1776,7 @@ public class DataContractResourceTest extends EntityResourceTest<DataContract, C
     WebTarget target = getCollection();
     Response response =
         SecurityUtil.addHeaders(target, ADMIN_AUTH_HEADERS).put(Entity.json(create));
-    DataContract updated =
-        TestUtils.readResponse(response, DataContract.class, Status.OK.getStatusCode());
+    DataContract updated = TestUtils.readResponse(response, DataContract.class, OK.getStatusCode());
 
     assertEquals(ContractStatus.Active, updated.getStatus());
   }
@@ -1798,7 +1796,7 @@ public class DataContractResourceTest extends EntityResourceTest<DataContract, C
         () -> {
           Response response =
               SecurityUtil.addHeaders(target, TEST_AUTH_HEADERS).put(Entity.json(create));
-          TestUtils.readResponse(response, DataContract.class, Status.OK.getStatusCode());
+          TestUtils.readResponse(response, DataContract.class, OK.getStatusCode());
         },
         Status.FORBIDDEN,
         "Principal: CatalogPrincipal{name='test'} operations [EditAll] not allowed");
@@ -1870,7 +1868,7 @@ public class DataContractResourceTest extends EntityResourceTest<DataContract, C
     // Delete as admin should work
     WebTarget target = getResource(created.getId());
     Response response = SecurityUtil.addHeaders(target, ADMIN_AUTH_HEADERS).delete();
-    TestUtils.readResponse(response, DataContract.class, Status.OK.getStatusCode());
+    TestUtils.readResponse(response, DataContract.class, OK.getStatusCode());
 
     // Verify deletion
     assertThrows(HttpResponseException.class, () -> getDataContract(created.getId(), null));
@@ -1889,7 +1887,7 @@ public class DataContractResourceTest extends EntityResourceTest<DataContract, C
     assertResponse(
         () -> {
           Response response = SecurityUtil.addHeaders(target, TEST_AUTH_HEADERS).delete();
-          TestUtils.readResponse(response, DataContract.class, Status.OK.getStatusCode());
+          TestUtils.readResponse(response, DataContract.class, OK.getStatusCode());
         },
         Status.FORBIDDEN,
         "Principal: CatalogPrincipal{name='test'} operations [Delete] not allowed");
@@ -1931,7 +1929,7 @@ public class DataContractResourceTest extends EntityResourceTest<DataContract, C
     WebTarget target = getResource(created.getId());
     Response response = SecurityUtil.addHeaders(target, TEST_AUTH_HEADERS).get();
     DataContract retrieved =
-        TestUtils.readResponse(response, DataContract.class, Status.OK.getStatusCode());
+        TestUtils.readResponse(response, DataContract.class, OK.getStatusCode());
 
     assertEquals(created.getId(), retrieved.getId());
     assertEquals(created.getName(), retrieved.getName());
@@ -1961,7 +1959,7 @@ public class DataContractResourceTest extends EntityResourceTest<DataContract, C
     Map<String, String> authHeaders = SecurityUtil.authHeaders("admin@open-metadata.org");
     WebTarget userTarget = getResource("users").path("name").path("admin");
     Response response = SecurityUtil.addHeaders(userTarget, authHeaders).get();
-    User adminUser = TestUtils.readResponse(response, User.class, Status.OK.getStatusCode());
+    User adminUser = TestUtils.readResponse(response, User.class, OK.getStatusCode());
 
     // Create user references for reviewers using the full entity reference
     List<EntityReference> reviewers = new ArrayList<>();
@@ -1993,7 +1991,7 @@ public class DataContractResourceTest extends EntityResourceTest<DataContract, C
     Map<String, String> authHeaders = SecurityUtil.authHeaders("admin@open-metadata.org");
     WebTarget userTarget = getResource("users").path("name").path("admin");
     Response response = SecurityUtil.addHeaders(userTarget, authHeaders).get();
-    User adminUser = TestUtils.readResponse(response, User.class, Status.OK.getStatusCode());
+    User adminUser = TestUtils.readResponse(response, User.class, OK.getStatusCode());
 
     // Get the full data contract with all fields
     created = getDataContract(created.getId(), "reviewers");
@@ -2020,7 +2018,7 @@ public class DataContractResourceTest extends EntityResourceTest<DataContract, C
     Map<String, String> authHeaders = SecurityUtil.authHeaders("admin@open-metadata.org");
     WebTarget userTarget = getResource("users").path("name").path("admin");
     Response response = SecurityUtil.addHeaders(userTarget, authHeaders).get();
-    User adminUser = TestUtils.readResponse(response, User.class, Status.OK.getStatusCode());
+    User adminUser = TestUtils.readResponse(response, User.class, OK.getStatusCode());
 
     // Create with reviewers
     List<EntityReference> initialReviewers = new ArrayList<>();
@@ -2055,11 +2053,11 @@ public class DataContractResourceTest extends EntityResourceTest<DataContract, C
     Map<String, String> authHeaders = SecurityUtil.authHeaders("admin@open-metadata.org");
     WebTarget userTarget = getResource("users").path("name").path("admin");
     Response response = SecurityUtil.addHeaders(userTarget, authHeaders).get();
-    User adminUser = TestUtils.readResponse(response, User.class, Status.OK.getStatusCode());
+    User adminUser = TestUtils.readResponse(response, User.class, OK.getStatusCode());
 
     userTarget = getResource("users").path("name").path("test");
     response = SecurityUtil.addHeaders(userTarget, authHeaders).get();
-    User testUser = TestUtils.readResponse(response, User.class, Status.OK.getStatusCode());
+    User testUser = TestUtils.readResponse(response, User.class, OK.getStatusCode());
 
     // Create with one reviewer
     List<EntityReference> initialReviewers = new ArrayList<>();
@@ -2110,7 +2108,7 @@ public class DataContractResourceTest extends EntityResourceTest<DataContract, C
     Response response =
         SecurityUtil.addHeaders(resultsTarget, ADMIN_AUTH_HEADERS).put(Entity.json(createResult));
     DataContractResult result =
-        TestUtils.readResponse(response, DataContractResult.class, Status.OK.getStatusCode());
+        TestUtils.readResponse(response, DataContractResult.class, OK.getStatusCode());
 
     assertNotNull(result);
     assertNotNull(result.getId());
@@ -2137,7 +2135,7 @@ public class DataContractResourceTest extends EntityResourceTest<DataContract, C
         getResource(dataContract.getId()).path("/results").path(result.getId().toString());
     Response getResponse = SecurityUtil.addHeaders(getResultTarget, ADMIN_AUTH_HEADERS).get();
     DataContractResult updatedResult =
-        TestUtils.readResponse(getResponse, DataContractResult.class, Status.OK.getStatusCode());
+        TestUtils.readResponse(getResponse, DataContractResult.class, OK.getStatusCode());
 
     assertNotNull(updatedResult);
     assertEquals(dataContract.getFullyQualifiedName(), updatedResult.getDataContractFQN());
@@ -2173,15 +2171,14 @@ public class DataContractResourceTest extends EntityResourceTest<DataContract, C
       WebTarget resultsTarget = getResource(dataContract.getId()).path("/results");
       Response response =
           SecurityUtil.addHeaders(resultsTarget, ADMIN_AUTH_HEADERS).put(Entity.json(createResult));
-      assertEquals(Status.OK.getStatusCode(), response.getStatus());
+      assertEquals(OK.getStatusCode(), response.getStatus());
       response.readEntity(String.class); // Consume response
     }
 
     // List results
     WebTarget listTarget = getResource(dataContract.getId()).path("/results");
     Response listResponse = SecurityUtil.addHeaders(listTarget, ADMIN_AUTH_HEADERS).get();
-    String jsonResponse =
-        TestUtils.readResponse(listResponse, String.class, Status.OK.getStatusCode());
+    String jsonResponse = TestUtils.readResponse(listResponse, String.class, OK.getStatusCode());
     ResultList<DataContractResult> results =
         JsonUtils.readValue(
             jsonResponse,
@@ -2221,7 +2218,7 @@ public class DataContractResourceTest extends EntityResourceTest<DataContract, C
       WebTarget resultsTarget = getResource(dataContract.getId()).path("/results");
       Response response =
           SecurityUtil.addHeaders(resultsTarget, ADMIN_AUTH_HEADERS).put(Entity.json(createResult));
-      assertEquals(Status.OK.getStatusCode(), response.getStatus());
+      assertEquals(OK.getStatusCode(), response.getStatus());
       response.readEntity(String.class); // Consume response
     }
 
@@ -2253,14 +2250,13 @@ public class DataContractResourceTest extends EntityResourceTest<DataContract, C
     WebTarget resultsTarget = getResource(dataContract.getId()).path("/results");
     Response createResponse =
         SecurityUtil.addHeaders(resultsTarget, ADMIN_AUTH_HEADERS).put(Entity.json(createResult));
-    assertEquals(Status.OK.getStatusCode(), createResponse.getStatus());
+    assertEquals(OK.getStatusCode(), createResponse.getStatus());
     createResponse.readEntity(String.class); // Consume response
 
     // Verify result exists
     WebTarget listTarget = getResource(dataContract.getId()).path("/results");
     Response listResponse = SecurityUtil.addHeaders(listTarget, ADMIN_AUTH_HEADERS).get();
-    String jsonResponse =
-        TestUtils.readResponse(listResponse, String.class, Status.OK.getStatusCode());
+    String jsonResponse = TestUtils.readResponse(listResponse, String.class, OK.getStatusCode());
     ResultList<DataContractResult> results =
         JsonUtils.readValue(
             jsonResponse,
@@ -2270,12 +2266,11 @@ public class DataContractResourceTest extends EntityResourceTest<DataContract, C
     // Delete the result
     WebTarget deleteTarget = getResource(dataContract.getId()).path("/results/" + timestamp);
     Response deleteResponse = SecurityUtil.addHeaders(deleteTarget, ADMIN_AUTH_HEADERS).delete();
-    assertEquals(Status.OK.getStatusCode(), deleteResponse.getStatus());
+    assertEquals(OK.getStatusCode(), deleteResponse.getStatus());
 
     // Verify result is deleted
     Response listResponse2 = SecurityUtil.addHeaders(listTarget, ADMIN_AUTH_HEADERS).get();
-    String jsonResponse2 =
-        TestUtils.readResponse(listResponse2, String.class, Status.OK.getStatusCode());
+    String jsonResponse2 = TestUtils.readResponse(listResponse2, String.class, OK.getStatusCode());
     ResultList<DataContractResult> results2 =
         JsonUtils.readValue(
             jsonResponse2,
@@ -2592,7 +2587,7 @@ public class DataContractResourceTest extends EntityResourceTest<DataContract, C
     Response response1 =
         SecurityUtil.addHeaders(resultsTarget, ADMIN_AUTH_HEADERS).put(Entity.json(createResult1));
     DataContractResult result1 =
-        TestUtils.readResponse(response1, DataContractResult.class, Status.OK.getStatusCode());
+        TestUtils.readResponse(response1, DataContractResult.class, OK.getStatusCode());
 
     // Verify first result becomes latestResult
     DataContract contractAfterFirst = getDataContract(dataContract.getId(), "");
@@ -2641,7 +2636,7 @@ public class DataContractResourceTest extends EntityResourceTest<DataContract, C
     Response response3 =
         SecurityUtil.addHeaders(resultsTarget, ADMIN_AUTH_HEADERS).put(Entity.json(createResult3));
     DataContractResult result3 =
-        TestUtils.readResponse(response3, DataContractResult.class, Status.OK.getStatusCode());
+        TestUtils.readResponse(response3, DataContractResult.class, OK.getStatusCode());
 
     // Verify latestResult IS updated to the newest result
     DataContract contractAfterThird = getDataContract(dataContract.getId(), "");
@@ -3029,8 +3024,7 @@ public class DataContractResourceTest extends EntityResourceTest<DataContract, C
     // Finally, verify that we have 2 DataContractResults properly stored
     WebTarget listTarget = getResource(dataContract.getId()).path("/results");
     Response listResponse = SecurityUtil.addHeaders(listTarget, ADMIN_AUTH_HEADERS).get();
-    String jsonResponse =
-        TestUtils.readResponse(listResponse, String.class, Status.OK.getStatusCode());
+    String jsonResponse = TestUtils.readResponse(listResponse, String.class, OK.getStatusCode());
     ResultList<DataContractResult> allResults =
         JsonUtils.readValue(
             jsonResponse,
@@ -3103,8 +3097,7 @@ public class DataContractResourceTest extends EntityResourceTest<DataContract, C
     // Verify we have 2 results: one aborted, one successful
     WebTarget listTarget = getResource(dataContract.getId()).path("/results");
     Response listResponse = SecurityUtil.addHeaders(listTarget, ADMIN_AUTH_HEADERS).get();
-    String jsonResponse =
-        TestUtils.readResponse(listResponse, String.class, Status.OK.getStatusCode());
+    String jsonResponse = TestUtils.readResponse(listResponse, String.class, OK.getStatusCode());
     ResultList<DataContractResult> allResults =
         JsonUtils.readValue(
             jsonResponse,

--- a/openmetadata-spec/src/main/resources/json/schema/api/data/createDataContract.json
+++ b/openmetadata-spec/src/main/resources/json/schema/api/data/createDataContract.json
@@ -76,6 +76,10 @@
     "sourceUrl": {
       "description": "Source URL of the data contract.",
       "$ref": "../../type/basic.json#/definitions/sourceUrl"
+    },
+    "extension": {
+      "description": "Entity extension data with custom attributes added to the entity.",
+      "$ref": "../../type/basic.json#/definitions/entityExtension"
     }
   },
   "required": [

--- a/openmetadata-spec/src/main/resources/json/schema/entity/data/dataContract.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/data/dataContract.json
@@ -197,6 +197,10 @@
         }
       },
       "additionalProperties": false
+    },
+    "extension": {
+      "description": "Entity extension data with custom attributes added to the entity.",
+      "$ref": "../../type/basic.json#/definitions/entityExtension"
     }
   },
   "required": [


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

- Fix Change Event management to trigger alerts on /validate endpoint
- Update relationship to CONTAINS between asset <> contract so deleting an entity properly deletes the contract
- Add support for custom properties

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
