### PR TITLE
fix: pass additional_client_config_arguments to OpenMetadata correctly

### DIFF
--- a/ingestion/src/airflow_provider_openmetadata/lineage/backend.py
+++ b/ingestion/src/airflow_provider_openmetadata/lineage/backend.py
@@ -86,7 +86,7 @@ class OpenMetadataLineageBackend(LineageBackend):
                     f"Using custom timeout={config.timeout}, retry={config.retry}, retry_wait={config.retry_wait}, retry_codes={config.retry_codes}"
                 )
             metadata = OpenMetadata(
-                config.metadata_config, additional_client_config_arguments
+                config.metadata_config, additional_client_config_arguments=additional_client_config_arguments
             )
 
             runner = AirflowLineageRunner(


### PR DESCRIPTION
This is a follow-up of #22474 and fixes the instantiation of the `OpenMetadata` object used in `backend.py`.

While debugging #23138 we observed that the timeout parameter wasn't passed by `REST._one_request` to  `self._session.request(method, url, **opts)`. 
We traced it back to the instantiation of the `OpenMetadata` object which assigns `additional_client_config_arguments` as second parameter, thereby setting `raw_data` instead of `additional_client_config_arguments`:

<img width="1083" height="131" alt="Screenshot 2025-08-28 at 16 21 29" src="https://github.com/user-attachments/assets/91964a92-e33e-405f-ad12-f04401e9af73" />


We confirmed this leads to the `timeout` parameter being passed to the requests library using the debugger. 

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
