### PR TITLE
fix(ui): fixes 22938 missing input sanitization of suggestions query

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/AppBar/Suggestions.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AppBar/Suggestions.tsx
@@ -53,6 +53,7 @@ import {
   getGroupLabel,
   getSuggestionElement,
 } from '../../utils/SearchUtils';
+import { escapeESReservedCharacters } from '../../utils/StringsUtils';
 import { showErrorToast } from '../../utils/ToastUtils';
 import Loader from '../common/Loader/Loader';
 
@@ -288,7 +289,7 @@ const Suggestions = ({
       setIsLoading(true);
 
       const res = await searchQuery({
-        query: searchText,
+        query: escapeESReservedCharacters(searchText),
         searchIndex: searchCriteria ?? SearchIndex.DATA_ASSET,
         queryFilter: quickFilter,
         pageSize: PAGE_SIZE_BASE,


### PR DESCRIPTION
### Describe your changes:

Fixes #22938 

I worked on input sanitization because I noticed it was broken when testing search queries for custom properties.

The input sanitization was not applied for search queries, when they where issued by the global search bar to recommend suggestions.

I used the code from `src/main/resources/ui/src/utils/StringsUtils.ts` which is used in `src/main/resources/ui/src/utils/ExploreUtils.tsx` called from `src/main/resources/ui/src/pages/ExplorePage/ExplorePageV1.component.tsx`.

I did not add tests as I did not found any for either `ExplorePageV1` nor `ExploreUtils`. It would be good if these were still added. But for that, I need support on where exactly this should happen.

#
### Type of change:
- [X] Bug fix

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [X] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

#### Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
