### PR TITLE
Fixes 23166: dbt ingestion pipelines never picks up team names

### DIFF
--- a/ingestion/src/metadata/ingestion/ometa/mixins/user_mixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/user_mixin.py
@@ -181,21 +181,6 @@ class OMetaUserMixin:
         """
         Get a User or Team Entity Reference by searching by its name
         """
-        maybe_user = self._search_by_name(
-            entity=User, name=name, from_count=from_count, size=size, fields=fields
-        )
-        if maybe_user:
-            return EntityReferenceList(
-                root=[
-                    EntityReference(
-                        id=maybe_user.id.root,
-                        type=ENTITY_REFERENCE_TYPE_MAP[User.__name__],
-                        name=maybe_user.name.root,
-                        displayName=maybe_user.displayName,
-                    )
-                ]
-            )
-
         maybe_team = self._search_by_name(
             entity=Team, name=name, from_count=from_count, size=size, fields=fields
         )
@@ -213,5 +198,18 @@ class OMetaUserMixin:
                     )
                 ]
             )
-
+        maybe_user = self._search_by_name(
+            entity=User, name=name, from_count=from_count, size=size, fields=fields
+        )
+        if maybe_user:
+            return EntityReferenceList(
+                root=[
+                    EntityReference(
+                        id=maybe_user.id.root,
+                        type=ENTITY_REFERENCE_TYPE_MAP[User.__name__],
+                        name=maybe_user.name.root,
+                        displayName=maybe_user.displayName,
+                    )
+                ]
+            )
         return None


### PR DESCRIPTION
### Describe your changes:

Fixes #23166

changes are made to `user_mixin.py` to handle fuzzy search for teams before searching for users.

#
### Type of change:
- [x] Bug fix

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`