### PR TITLE
feat(search): custom properties are now searchable in any query

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSourceBuilderFactory.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSourceBuilderFactory.java
@@ -80,7 +80,8 @@ public class ElasticSearchSourceBuilderFactory
             .fuzziness(Fuzziness.AUTO)
             .fuzzyMaxExpansions(10)
             .fuzzyPrefixLength(3)
-            .tieBreaker(DEFAULT_TIE_BREAKER);
+            .tieBreaker(DEFAULT_TIE_BREAKER)
+            .lenient(true);
 
     MultiMatchQueryBuilder nonFuzzyQueryBuilder =
         QueryBuilders.multiMatchQuery(query)
@@ -88,7 +89,8 @@ public class ElasticSearchSourceBuilderFactory
             .type(MOST_FIELDS)
             .operator(Operator.AND)
             .tieBreaker(DEFAULT_TIE_BREAKER)
-            .fuzziness(Fuzziness.ZERO);
+            .fuzziness(Fuzziness.ZERO)
+            .lenient(true);
 
     return QueryBuilders.boolQuery()
         .should(fuzzyQueryBuilder)
@@ -262,7 +264,8 @@ public class ElasticSearchSourceBuilderFactory
         .fuzziness(Fuzziness.AUTO)
         .fuzzyMaxExpansions(10)
         .fuzzyPrefixLength(1)
-        .tieBreaker(DEFAULT_TIE_BREAKER);
+        .tieBreaker(DEFAULT_TIE_BREAKER)
+        .lenient(true);
   }
 
   private MultiMatchQueryBuilder createNonFuzzyQueryBuilder(
@@ -272,7 +275,8 @@ public class ElasticSearchSourceBuilderFactory
         .type(MOST_FIELDS)
         .operator(Operator.AND)
         .tieBreaker(DEFAULT_TIE_BREAKER)
-        .fuzziness(Fuzziness.ZERO);
+        .fuzziness(Fuzziness.ZERO)
+        .lenient(true);
   }
 
   private QueryBuilder buildSimpleQuery(String query, AssetTypeConfiguration assetConfig) {
@@ -381,7 +385,8 @@ public class ElasticSearchSourceBuilderFactory
               .prefixLength(1)
               .operator(Operator.OR)
               .minimumShouldMatch(MINIMUM_SHOULD_MATCH)
-              .tieBreaker(DEFAULT_TIE_BREAKER);
+              .tieBreaker(DEFAULT_TIE_BREAKER)
+              .lenient(true);
       fields.forEach(fuzzyQueryBuilder::field);
       combinedQuery.should(fuzzyQueryBuilder.boost(multiplier));
     }
@@ -422,7 +427,8 @@ public class ElasticSearchSourceBuilderFactory
         .prefixLength(1)
         .operator(Operator.OR)
         .minimumShouldMatch(MINIMUM_SHOULD_MATCH)
-        .tieBreaker(DEFAULT_TIE_BREAKER);
+        .tieBreaker(DEFAULT_TIE_BREAKER)
+        .lenient(true);
   }
 
   private MultiMatchQueryBuilder createStandardNonFuzzyQuery(String query) {
@@ -431,7 +437,8 @@ public class ElasticSearchSourceBuilderFactory
         .operator(Operator.OR)
         .minimumShouldMatch(MINIMUM_SHOULD_MATCH)
         .tieBreaker(DEFAULT_TIE_BREAKER)
-        .fuzziness(Fuzziness.ZERO);
+        .fuzziness(Fuzziness.ZERO)
+        .lenient(true);
   }
 
   private QueryBuilder applyFunctionScoring(
@@ -927,7 +934,8 @@ public class ElasticSearchSourceBuilderFactory
             .analyzeWildcard(true)
             .allowLeadingWildcard(true)
             .fuzzyMaxExpansions(50)
-            .tieBreaker(DEFAULT_TIE_BREAKER);
+            .tieBreaker(DEFAULT_TIE_BREAKER)
+            .lenient(true);
 
     return QueryBuilders.boolQuery().must(queryStringBuilder);
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSourceBuilderFactory.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSourceBuilderFactory.java
@@ -85,7 +85,8 @@ public class OpenSearchSourceBuilderFactory
             .fuzziness(Fuzziness.AUTO)
             .fuzzyMaxExpansions(10)
             .fuzzyPrefixLength(3)
-            .tieBreaker(0.5f);
+            .tieBreaker(0.5f)
+            .lenient(true);
 
     MultiMatchQueryBuilder nonFuzzyQueryBuilder =
         QueryBuilders.multiMatchQuery(query)
@@ -93,7 +94,8 @@ public class OpenSearchSourceBuilderFactory
             .type(MOST_FIELDS)
             .operator(Operator.AND)
             .tieBreaker(0.5f)
-            .fuzziness(Fuzziness.ZERO);
+            .fuzziness(Fuzziness.ZERO)
+            .lenient(true);
 
     return QueryBuilders.boolQuery()
         .should(fuzzyQueryBuilder)
@@ -267,7 +269,8 @@ public class OpenSearchSourceBuilderFactory
         .fuzziness(Fuzziness.AUTO)
         .fuzzyMaxExpansions(10)
         .fuzzyPrefixLength(1)
-        .tieBreaker(DEFAULT_TIE_BREAKER);
+        .tieBreaker(DEFAULT_TIE_BREAKER)
+        .lenient(true);
   }
 
   private MultiMatchQueryBuilder createNonFuzzyQueryBuilder(
@@ -277,7 +280,8 @@ public class OpenSearchSourceBuilderFactory
         .type(MOST_FIELDS)
         .operator(Operator.AND)
         .tieBreaker(DEFAULT_TIE_BREAKER)
-        .fuzziness(Fuzziness.ZERO);
+        .fuzziness(Fuzziness.ZERO)
+        .lenient(true);
   }
 
   private QueryBuilder buildSimpleQuery(String query, AssetTypeConfiguration assetConfig) {
@@ -387,7 +391,8 @@ public class OpenSearchSourceBuilderFactory
               .maxExpansions(10)
               .prefixLength(1)
               .operator(Operator.AND)
-              .tieBreaker(DEFAULT_TIE_BREAKER);
+              .tieBreaker(DEFAULT_TIE_BREAKER)
+              .lenient(true);
       fields.forEach(fuzzyQueryBuilder::field);
       combinedQuery.should(fuzzyQueryBuilder.boost(multiplier));
     }
@@ -428,7 +433,8 @@ public class OpenSearchSourceBuilderFactory
         .prefixLength(1)
         .operator(Operator.OR)
         .minimumShouldMatch(MINIMUM_SHOULD_MATCH)
-        .tieBreaker(DEFAULT_TIE_BREAKER);
+        .tieBreaker(DEFAULT_TIE_BREAKER)
+        .lenient(true);
   }
 
   private MultiMatchQueryBuilder createStandardNonFuzzyQuery(String query) {
@@ -436,7 +442,8 @@ public class OpenSearchSourceBuilderFactory
         .type(MOST_FIELDS)
         .operator(Operator.AND)
         .tieBreaker(DEFAULT_TIE_BREAKER)
-        .fuzziness(Fuzziness.ZERO);
+        .fuzziness(Fuzziness.ZERO)
+        .lenient(true);
   }
 
   private QueryBuilder applyFunctionScoring(
@@ -941,7 +948,8 @@ public class OpenSearchSourceBuilderFactory
             .analyzeWildcard(true)
             .allowLeadingWildcard(true)
             .fuzzyMaxExpansions(50)
-            .tieBreaker(0.5f);
+            .tieBreaker(0.5f)
+            .lenient(true);
 
     return QueryBuilders.boolQuery().must(queryStringBuilder);
   }

--- a/openmetadata-service/src/main/resources/json/data/settings/searchSettings.json
+++ b/openmetadata-service/src/main/resources/json/data/settings/searchSettings.json
@@ -162,6 +162,11 @@
           "field": "fqnParts",
           "boost": 5.0,
           "matchType": "standard"
+        },
+        {
+          "field": "extension*",
+          "boost": 2.0,
+          "matchType": "standard"
         }
       ],
       "highlightFields": [
@@ -234,6 +239,11 @@
         {
           "field": "fqnParts",
           "boost": 5.0,
+          "matchType": "standard"
+        },
+        {
+          "field": "extension*",
+          "boost": 2.0,
           "matchType": "standard"
         }
       ],
@@ -322,6 +332,11 @@
         {
           "field": "columnNamesFuzzy",
           "boost": 1.5,
+          "matchType": "standard"
+        },
+        {
+          "field": "extension*",
+          "boost": 2.0,
           "matchType": "standard"
         }
       ],
@@ -416,6 +431,11 @@
           "field": "fqnParts",
           "boost": 5.0,
           "matchType": "standard"
+        },
+        {
+          "field": "extension*",
+          "boost": 2.0,
+          "matchType": "standard"
         }
       ],
       "aggregations": [
@@ -505,6 +525,11 @@
           "field": "queryText.ngram",
           "boost": 1.0,
           "matchType": "fuzzy"
+        },
+        {
+          "field": "extension*",
+          "boost": 2.0,
+          "matchType": "standard"
         }
       ],
       "aggregations": [
@@ -593,6 +618,11 @@
         {
           "field": "fieldNamesFuzzy",
           "boost": 1.5,
+          "matchType": "standard"
+        },
+        {
+          "field": "extension*",
+          "boost": 2.0,
           "matchType": "standard"
         }
       ],
@@ -687,6 +717,11 @@
         {
           "field": "messageSchema.schemaFields.description",
           "boost": 1.0,
+          "matchType": "standard"
+        },
+        {
+          "field": "extension*",
+          "boost": 2.0,
           "matchType": "standard"
         }
       ],
@@ -813,6 +848,11 @@
           "field": "columnNamesFuzzy",
           "boost": 1.5,
           "matchType": "standard"
+        },
+        {
+          "field": "extension*",
+          "boost": 2.0,
+          "matchType": "standard"
         }
       ],
       "aggregations": [
@@ -908,6 +948,11 @@
           "field": "tasks.description",
           "boost": 1.0,
           "matchType": "standard"
+        },
+        {
+          "field": "extension*",
+          "boost": 2.0,
+          "matchType": "standard"
         }
       ],
       "aggregations": [
@@ -994,6 +1039,11 @@
           "field": "mlFeatures.description",
           "boost": 1.0,
           "matchType": "standard"
+        },
+        {
+          "field": "extension*",
+          "boost": 2.0,
+          "matchType": "standard"
         }
       ],
       "aggregations": [
@@ -1079,6 +1129,11 @@
         {
           "field": "mlFeatures.description",
           "boost": 1.0,
+          "matchType": "standard"
+        },
+        {
+          "field": "extension*",
+          "boost": 2.0,
           "matchType": "standard"
         }
       ],
@@ -1170,6 +1225,11 @@
         {
           "field": "columnNamesFuzzy",
           "boost": 1.5,
+          "matchType": "standard"
+        },
+        {
+          "field": "extension*",
+          "boost": 2.0,
           "matchType": "standard"
         }
       ],
@@ -1278,6 +1338,11 @@
           "field": "requestSchema.schemaFields.children.keyword",
           "boost": 5.0,
           "matchType": "exact"
+        },
+        {
+          "field": "extension*",
+          "boost": 2.0,
+          "matchType": "standard"
         }
       ],
       "aggregations": [
@@ -1362,6 +1427,11 @@
           "field": "fqnParts",
           "boost": 5.0,
           "matchType": "standard"
+        },
+        {
+          "field": "extension*",
+          "boost": 2.0,
+          "matchType": "standard"
         }
       ],
       "aggregations": [
@@ -1441,6 +1511,11 @@
           "field": "fqnParts",
           "boost": 5.0,
           "matchType": "standard"
+        },
+        {
+          "field": "extension*",
+          "boost": 2.0,
+          "matchType": "standard"
         }
       ],
       "aggregations": [],
@@ -1518,6 +1593,11 @@
         {
           "field": "classification.displayName",
           "boost": 7.0,
+          "matchType": "standard"
+        },
+        {
+          "field": "extension*",
+          "boost": 2.0,
           "matchType": "standard"
         }
       ],
@@ -1607,6 +1687,11 @@
           "field": "glossary.displayName",
           "boost": 5.0,
           "matchType": "standard"
+        },
+        {
+          "field": "extension*",
+          "boost": 2.0,
+          "matchType": "standard"
         }
       ],
       "aggregations": [
@@ -1691,6 +1776,11 @@
           "field": "fqnParts",
           "boost": 5.0,
           "matchType": "standard"
+        },
+        {
+          "field": "extension*",
+          "boost": 2.0,
+          "matchType": "standard"
         }
       ],
       "aggregations": [],
@@ -1763,6 +1853,11 @@
         {
           "field": "path",
           "boost": 3.0,
+          "matchType": "standard"
+        },
+        {
+          "field": "extension*",
+          "boost": 2.0,
           "matchType": "standard"
         }
       ],
@@ -1852,6 +1947,11 @@
         },
         {
           "field": "extension",
+          "boost": 2.0,
+          "matchType": "standard"
+        },
+        {
+          "field": "extension*",
           "boost": 2.0,
           "matchType": "standard"
         }
@@ -1949,6 +2049,11 @@
           "field": "path",
           "boost": 3.0,
           "matchType": "standard"
+        },
+        {
+          "field": "extension*",
+          "boost": 2.0,
+          "matchType": "standard"
         }
       ],
       "aggregations": [
@@ -2043,6 +2148,11 @@
         {
           "field": "columnNamesFuzzy",
           "boost": 1.5,
+          "matchType": "standard"
+        },
+        {
+          "field": "extension*",
+          "boost": 2.0,
           "matchType": "standard"
         }
       ],


### PR DESCRIPTION
### Describe your changes:

Fixes n/a

I worked on the search because i wanted the data assets to be found by custom properties in the global search.

Currently the search (`/api/v1/search/query`) does not include the custom properties fields.
This change aims to make them searchable as they getting index in ElasticSearch.

The configuration was changed to include all custom properties reflected by `"extension*"` as a new field, which matches all custom properties. This was done as the custom properties are registered by the user and not known at compile-time. The boost value of `2.0` was chosen as it should have (imo) a similar priority as the description, as though it could be even higher.
As an alternative it could be considered to edit the `SearchSettings` config(!) at runtime whenever a a custom property is added by the user. This would be more complicated but would allow to get rid off the second change.

The second change is to include `.lenient(true)` in the queries generated to ElasticSearch (or OpenSearch) to circumvent the problem that custom properties could be non-text-searchable types like `datetime-cp`. This ignores fields in a query which are not of the correct type. The question is whether such a change is desired.

I have not added any test already as the current test suite for the search module seem to be broken for me on main. It also seem in not so great shape. For the same reason I cannot confirm that my changes broke any tests, I only tested in manually and it seems to work correctly.
Is there something in work on the tests or can I help with that?

#
### Type of change:
- [X] Improvement

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

#### Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
