### PR TITLE
Playwright: Fix the flakiness in service ingestion playwright

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/service.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/service.ts
@@ -11,13 +11,18 @@
  *  limitations under the License.
  */
 import { expect, Page } from '@playwright/test';
+import { escapeESReservedCharacters, getEncodedFqn } from './entity';
 import { settingClick, SettingOptionsType } from './sidebar';
 
 export const searchServiceFromSettingPage = async (
   page: Page,
   service: string
 ) => {
-  const serviceResponse = page.waitForResponse(`/api/v1/search/query?q=*`);
+  const serviceResponse = page.waitForResponse(
+    `/api/v1/search/query?q=**${getEncodedFqn(
+      escapeESReservedCharacters(service)
+    )}**`
+  );
   await page.fill('[data-testid="searchbar"]', service);
 
   await serviceResponse;


### PR DESCRIPTION
This pull request updates the service search functionality in the Playwright test utilities to improve accuracy and reliability when searching for services with special characters. The main change is in how the search query is constructed to handle reserved characters and ensure proper encoding.

Improvements to service search logic:

* Updated `searchServiceFromSettingPage` in `service.ts` to use `escapeESReservedCharacters` and `getEncodedFqn` when constructing the search query, ensuring special characters in service names are properly escaped and encoded.