### PR TITLE
[Trino] Fix incomplete view definition extraction

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/trino/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/trino/queries.py
@@ -46,3 +46,7 @@ TRINO_TABLE_COMMENTS = textwrap.dedent(
 TRINO_GET_DATABASE = """
 SHOW CATALOGS
 """
+
+TRINO_VIEW_DEFINITION = """
+SHOW CREATE VIEW {view_name}
+"""


### PR DESCRIPTION
### Describe your changes:

Default implementation of trino sqlalchemy uses `"information_schema"."views"`'s `view_definition` column to get view definition but it returns incomplete definition and that leads to missing column lineage while generating lineage.
<img width="1083" height="271" alt="Screenshot 2025-09-11 at 8 38 41 PM" src="https://github.com/user-attachments/assets/8d8a3984-0976-4747-98d9-14f8b0efa8d1" />

This PR will override that behavior and use `SHOW CREATE VIEW` statement instead, to get complete view definition.
<img width="1070" height="250" alt="Screenshot 2025-09-11 at 8 39 42 PM" src="https://github.com/user-attachments/assets/a402c8d5-2ca8-41bf-8efc-d2bc3964ad56" />


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
