### PR TITLE
feat: Add Unity Catalog data diff module to use DBX connection instead of workspaceclient

### DIFF
--- a/ingestion/src/metadata/data_quality/validations/runtime_param_setter/base_diff_params_setter.py
+++ b/ingestion/src/metadata/data_quality/validations/runtime_param_setter/base_diff_params_setter.py
@@ -143,21 +143,16 @@ class BaseTableParameter:
             # Check if the data diff class is not BaseTableParameter, but an overridden table parameter, then get that
             data_diff_class = service_spec_patch.get_data_diff_class()
             # Check if method is truly overridden (not just different class)
-            if data_diff_class and data_diff_class is not BaseTableParameter:
-                # Compare method objects to ensure it's overridden
-                class_method = getattr(
-                    data_diff_class, "_get_service_connection_config", None
-                )
-                base_method = getattr(
-                    BaseTableParameter, "_get_service_connection_config", None
-                )
-
-                if class_method is not base_method:
-                    # Method is overridden, create instance and call it
-                    instance = data_diff_class()
+            if (
+                data_diff_class
+                and data_diff_class is not BaseTableParameter
+                and data_diff_class is not cls
+            ):
+                
+                    
                     # Call as instance method to avoid recursion
-                    return instance._get_service_connection_config.__func__(
-                        instance, service_connection_config
+                    return data_diff_class()._get_service_connection_config(
+                        service_connection_config
                     )
 
             if not connection_class:

--- a/ingestion/src/metadata/data_quality/validations/runtime_param_setter/base_diff_params_setter.py
+++ b/ingestion/src/metadata/data_quality/validations/runtime_param_setter/base_diff_params_setter.py
@@ -122,13 +122,18 @@ class BaseTableParameter:
             "___SERVICE___", "__DATABASE__", schema, table
         ).replace("___SERVICE___.__DATABASE__.", "")
 
-    @staticmethod
+    @classmethod
     def _get_service_connection_config(
+        cls,
         service_connection_config,
     ) -> Optional[Union[str, dict]]:
         """
         Get the connection dictionary for the service.
+        This is now a classmethod so subclasses can override it properly.
         """
+        if not service_connection_config:
+            return None
+
         service_spec_patch = ServiceSpecPatch(
             ServiceType.Database, service_connection_config.type.value.lower()
         )
@@ -150,8 +155,8 @@ class BaseTableParameter:
                 else None
             )
 
-    @staticmethod
     def get_data_diff_url(
+        self,
         db_service: DatabaseService,
         table_fqn,
         override_url: Optional[Union[str, dict]] = None,
@@ -167,9 +172,7 @@ class BaseTableParameter:
             str: The url for the data diff service
         """
         source_url = (
-            BaseTableParameter._get_service_connection_config(
-                db_service.connection.config
-            )
+            self.__class__._get_service_connection_config(db_service.connection.config)
             if not override_url
             else override_url
         )

--- a/ingestion/src/metadata/data_quality/validations/runtime_param_setter/base_diff_params_setter.py
+++ b/ingestion/src/metadata/data_quality/validations/runtime_param_setter/base_diff_params_setter.py
@@ -140,20 +140,6 @@ class BaseTableParameter:
 
         try:
             connection_class = service_spec_patch.get_connection_class()
-            # Check if the data diff class is not BaseTableParameter, but an overridden table parameter, then get that
-            data_diff_class = service_spec_patch.get_data_diff_class()
-            # Check if method is truly overridden (not just different class)
-            if (
-                data_diff_class
-                and data_diff_class is not BaseTableParameter
-                and data_diff_class is not cls
-            ):
-
-                # Call as instance method to avoid recursion
-                return data_diff_class()._get_service_connection_config(
-                    service_connection_config
-                )
-
             if not connection_class:
                 return (
                     str(get_connection(service_connection_config).url)
@@ -186,7 +172,7 @@ class BaseTableParameter:
             str: The url for the data diff service
         """
         source_url = (
-            self.__class__._get_service_connection_config(db_service.connection.config)
+            self._get_service_connection_config(db_service.connection.config)
             if not override_url
             else override_url
         )

--- a/ingestion/src/metadata/data_quality/validations/runtime_param_setter/base_diff_params_setter.py
+++ b/ingestion/src/metadata/data_quality/validations/runtime_param_setter/base_diff_params_setter.py
@@ -140,6 +140,26 @@ class BaseTableParameter:
 
         try:
             connection_class = service_spec_patch.get_connection_class()
+            # Check if the data diff class is not BaseTableParameter, but an overridden table parameter, then get that
+            data_diff_class = service_spec_patch.get_data_diff_class()
+            # Check if method is truly overridden (not just different class)
+            if data_diff_class and data_diff_class is not BaseTableParameter:
+                # Compare method objects to ensure it's overridden
+                class_method = getattr(
+                    data_diff_class, "_get_service_connection_config", None
+                )
+                base_method = getattr(
+                    BaseTableParameter, "_get_service_connection_config", None
+                )
+
+                if class_method is not base_method:
+                    # Method is overridden, create instance and call it
+                    instance = data_diff_class()
+                    # Call as instance method to avoid recursion
+                    return instance._get_service_connection_config.__func__(
+                        instance, service_connection_config
+                    )
+
             if not connection_class:
                 return (
                     str(get_connection(service_connection_config).url)
@@ -188,7 +208,10 @@ class BaseTableParameter:
         )
         # path needs to include the database AND schema in some of the connectors
         if hasattr(db_service.connection.config, "supportsDatabase"):
-            kwargs["path"] = f"/{database}"
+            if kwargs["scheme"] in {Dialects.UnityCatalog, Dialects.Databricks}:
+                kwargs["query"] = f"catalog={database}"
+            else:
+                kwargs["path"] = f"/{database}"
         if kwargs["scheme"] in {Dialects.MSSQL, Dialects.Snowflake, Dialects.Trino}:
             kwargs["path"] = f"/{database}/{schema}"
         return url._replace(**kwargs).geturl()

--- a/ingestion/src/metadata/data_quality/validations/runtime_param_setter/base_diff_params_setter.py
+++ b/ingestion/src/metadata/data_quality/validations/runtime_param_setter/base_diff_params_setter.py
@@ -148,12 +148,11 @@ class BaseTableParameter:
                 and data_diff_class is not BaseTableParameter
                 and data_diff_class is not cls
             ):
-                
-                    
-                    # Call as instance method to avoid recursion
-                    return data_diff_class()._get_service_connection_config(
-                        service_connection_config
-                    )
+
+                # Call as instance method to avoid recursion
+                return data_diff_class()._get_service_connection_config(
+                    service_connection_config
+                )
 
             if not connection_class:
                 return (
@@ -198,9 +197,7 @@ class BaseTableParameter:
         url = urlparse(source_url)
         # remove the driver name from the url because table-diff doesn't support it
         kwargs = {"scheme": url.scheme.split("+")[0]}
-        service, database, schema, table = fqn.split(  # pylint: disable=unused-variable
-            table_fqn
-        )
+        _, database, schema, _ = fqn.split(table_fqn)  # pylint: disable=unused-variable
         # path needs to include the database AND schema in some of the connectors
         if hasattr(db_service.connection.config, "supportsDatabase"):
             if kwargs["scheme"] in {Dialects.UnityCatalog, Dialects.Databricks}:

--- a/ingestion/src/metadata/data_quality/validations/runtime_param_setter/base_diff_params_setter.py
+++ b/ingestion/src/metadata/data_quality/validations/runtime_param_setter/base_diff_params_setter.py
@@ -129,7 +129,6 @@ class BaseTableParameter:
     ) -> Optional[Union[str, dict]]:
         """
         Get the connection dictionary for the service.
-        This is now a classmethod so subclasses can override it properly.
         """
         if not service_connection_config:
             return None

--- a/ingestion/src/metadata/data_quality/validations/runtime_param_setter/table_diff_params_setter.py
+++ b/ingestion/src/metadata/data_quality/validations/runtime_param_setter/table_diff_params_setter.py
@@ -15,7 +15,6 @@ from typing import List, Optional, Set
 from metadata.data_quality.validations import utils
 from metadata.data_quality.validations.models import Column, TableDiffRuntimeParameters
 from metadata.data_quality.validations.runtime_param_setter.base_diff_params_setter import (
-    BaseTableParameter,
     ServiceSpecPatch,
 )
 from metadata.data_quality.validations.runtime_param_setter.param_setter import (
@@ -52,13 +51,16 @@ class TableDiffParamsSetter(RuntimeParameterSetter):
         service_spec_patch = ServiceSpecPatch(
             ServiceType.Database, self.service_connection_config.type.value.lower()
         )
-        cls = service_spec_patch.get_data_diff_class()()
+        data_diff_class = service_spec_patch.get_data_diff_class()
+        cls = data_diff_class()
 
         service1: DatabaseService = self.ometa_client.get_by_id(
             DatabaseService, self.table_entity.service.id, nullable=False
         )
 
-        service1_url = BaseTableParameter._get_service_connection_config(
+        # Use the class method - each connector can override as needed
+        # This is scalable: any connector can override _get_service_connection_config
+        service1_url = data_diff_class._get_service_connection_config(
             self.service_connection_config
         )
 

--- a/ingestion/src/metadata/data_quality/validations/runtime_param_setter/table_diff_params_setter.py
+++ b/ingestion/src/metadata/data_quality/validations/runtime_param_setter/table_diff_params_setter.py
@@ -58,8 +58,6 @@ class TableDiffParamsSetter(RuntimeParameterSetter):
             DatabaseService, self.table_entity.service.id, nullable=False
         )
 
-        # Use the class method - each connector can override as needed
-        # This is scalable: any connector can override _get_service_connection_config
         service1_url = data_diff_class._get_service_connection_config(
             self.service_connection_config
         )

--- a/ingestion/src/metadata/data_quality/validations/runtime_param_setter/table_diff_params_setter.py
+++ b/ingestion/src/metadata/data_quality/validations/runtime_param_setter/table_diff_params_setter.py
@@ -48,33 +48,40 @@ class TableDiffParamsSetter(RuntimeParameterSetter):
         }
 
     def get_parameters(self, test_case) -> TableDiffRuntimeParameters:
-        service_spec_patch = ServiceSpecPatch(
-            ServiceType.Database, self.service_connection_config.type.value.lower()
-        )
-        data_diff_class = service_spec_patch.get_data_diff_class()
-        cls = data_diff_class()
-
         service1: DatabaseService = self.ometa_client.get_by_id(
             DatabaseService, self.table_entity.service.id, nullable=False
-        )
-
-        service1_url = data_diff_class._get_service_connection_config(
-            self.service_connection_config
         )
 
         table2_fqn = self.get_parameter(test_case, "table2")
         if table2_fqn is None:
             raise ValueError("table2 not set")
+
         table2: Table = self.ometa_client.get_by_name(
             Table, fqn=table2_fqn, nullable=False
         )
         service2: DatabaseService = self.ometa_client.get_by_id(
             DatabaseService, table2.service.id, nullable=False
         )
+
+        service_spec_patch_table_1 = ServiceSpecPatch(
+            ServiceType.Database, service1.connection.config.type.value.lower()
+        )
+        data_diff_class_1 = service_spec_patch_table_1.get_data_diff_class()()
+        service_spec_patch_table_2 = ServiceSpecPatch(
+            ServiceType.Database, service2.connection.config.type.value.lower()
+        )
+        data_diff_class_2 = service_spec_patch_table_2.get_data_diff_class()()
+
+        service1_url = data_diff_class_1._get_service_connection_config(
+            service1.connection.config
+        )
         service2_url = (
             self.get_parameter(test_case, "service2Url") or service1_url
             if table2.service == self.table_entity.service
-            else None
+            else data_diff_class_2._get_service_connection_config(
+                service2.connection.config
+            )
+            or None
         )
 
         key_columns = self.get_key_columns(test_case)
@@ -93,7 +100,7 @@ class TableDiffParamsSetter(RuntimeParameterSetter):
 
         return TableDiffRuntimeParameters(
             table_profile_config=self.table_entity.tableProfilerConfig,
-            table1=cls.get(
+            table1=data_diff_class_1.get(
                 service1,
                 self.table_entity,
                 key_columns,
@@ -101,7 +108,7 @@ class TableDiffParamsSetter(RuntimeParameterSetter):
                 case_sensitive_columns,
                 service1_url,
             ),
-            table2=cls.get(
+            table2=data_diff_class_2.get(
                 service2,
                 table2,
                 key_columns,

--- a/ingestion/src/metadata/data_quality/validations/table/sqlalchemy/tableDiff.py
+++ b/ingestion/src/metadata/data_quality/validations/table/sqlalchemy/tableDiff.py
@@ -262,15 +262,6 @@ class TableDiffValidator(BaseTestValidator, SQAValidatorMixin):
             List[str]: A list of column names that have incomparable types
         """
 
-        print(
-            f"DEBUG: Connecting to table1 - serviceUrl: {self.runtime_params.table1.serviceUrl}"
-        )
-        print(f"DEBUG: table1.path: {self.runtime_params.table1.path}")
-        print(f"DEBUG: keyColumns: {self.runtime_params.keyColumns}")
-        print(
-            f"DEBUG: Has privateKey: {self.runtime_params.table1.privateKey is not None}"
-        )
-
         table1 = data_diff.connect_to_table(
             self.runtime_params.table1.serviceUrl,
             self.runtime_params.table1.path,

--- a/ingestion/src/metadata/data_quality/validations/table/sqlalchemy/tableDiff.py
+++ b/ingestion/src/metadata/data_quality/validations/table/sqlalchemy/tableDiff.py
@@ -70,6 +70,7 @@ SUPPORTED_DIALECTS = [
     Dialects.Oracle,
     Dialects.Trino,
     SapHanaScheme.hana.value,
+    Dialects.Databricks,
 ]
 
 
@@ -260,6 +261,16 @@ class TableDiffValidator(BaseTestValidator, SQAValidatorMixin):
         Returns:
             List[str]: A list of column names that have incomparable types
         """
+
+        print(
+            f"DEBUG: Connecting to table1 - serviceUrl: {self.runtime_params.table1.serviceUrl}"
+        )
+        print(f"DEBUG: table1.path: {self.runtime_params.table1.path}")
+        print(f"DEBUG: keyColumns: {self.runtime_params.keyColumns}")
+        print(
+            f"DEBUG: Has privateKey: {self.runtime_params.table1.privateKey is not None}"
+        )
+
         table1 = data_diff.connect_to_table(
             self.runtime_params.table1.serviceUrl,
             self.runtime_params.table1.path,

--- a/ingestion/src/metadata/data_quality/validations/table/sqlalchemy/tableDiff.py
+++ b/ingestion/src/metadata/data_quality/validations/table/sqlalchemy/tableDiff.py
@@ -71,6 +71,7 @@ SUPPORTED_DIALECTS = [
     Dialects.Trino,
     SapHanaScheme.hana.value,
     Dialects.Databricks,
+    Dialects.UnityCatalog,
 ]
 
 

--- a/ingestion/src/metadata/ingestion/source/database/common/data_diff/databricks_base.py
+++ b/ingestion/src/metadata/ingestion/source/database/common/data_diff/databricks_base.py
@@ -1,0 +1,42 @@
+"""Base class for Databricks-based data diff implementations"""
+
+from typing import Optional, Union
+
+from metadata.data_quality.validations.runtime_param_setter.base_diff_params_setter import (
+    BaseTableParameter,
+)
+
+
+class DatabricksBaseTableParameter(BaseTableParameter):
+    """Base class for Databricks-based table parameter setters"""
+
+    @classmethod
+    def _get_service_connection_config(
+        cls,
+        service_connection_config,
+    ) -> Optional[Union[str, dict]]:
+        """Build connection URL for Databricks-based connections"""
+        if not service_connection_config:
+            return None
+
+        scheme = getattr(service_connection_config, "scheme", "databricks+connector")
+        # Handle enum values properly
+        if hasattr(scheme, "value"):
+            scheme = scheme.value
+
+        host_port = getattr(service_connection_config, "hostPort", "localhost:443")
+        token = getattr(service_connection_config, "token", "")
+        token_value = (
+            token.get_secret_value()
+            if hasattr(token, "get_secret_value")
+            else str(token)
+        )
+
+        # Include httpPath if available (required for data_diff library)
+        http_path = getattr(service_connection_config, "httpPath", "")
+        if http_path:
+            # Ensure http_path starts with /
+            if not http_path.startswith("/"):
+                http_path = "/" + http_path
+            return f"{scheme}://:{token_value}@{host_port}{http_path}"
+        return f"{scheme}://:{token_value}@{host_port}"

--- a/ingestion/src/metadata/ingestion/source/database/databricks/data_diff/__init__.py
+++ b/ingestion/src/metadata/ingestion/source/database/databricks/data_diff/__init__.py
@@ -1,0 +1,1 @@
+"""Unity Catalog data diff module"""

--- a/ingestion/src/metadata/ingestion/source/database/databricks/data_diff/data_diff.py
+++ b/ingestion/src/metadata/ingestion/source/database/databricks/data_diff/data_diff.py
@@ -1,0 +1,12 @@
+"""Databricks spec for data diff - uses Databricks connection"""
+
+from metadata.ingestion.source.database.common.data_diff.databricks_base import (
+    DatabricksBaseTableParameter,
+)
+
+
+class DatabricksTableParameter(DatabricksBaseTableParameter):
+    """Databricks table parameter setter - uses Databricks connection
+    which is databricks-based for data diff operations"""
+
+    pass

--- a/ingestion/src/metadata/ingestion/source/database/databricks/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/database/databricks/service_spec.py
@@ -1,6 +1,9 @@
 from metadata.data_quality.interface.sqlalchemy.databricks.test_suite_interface import (
     DatabricksTestSuiteInterface,
 )
+from metadata.ingestion.source.database.databricks.data_diff.data_diff import (
+    DatabricksTableParameter,
+)
 from metadata.ingestion.source.database.databricks.lineage import (
     DatabricksLineageSource,
 )
@@ -19,4 +22,5 @@ ServiceSpec = DefaultDatabaseSpec(
     profiler_class=DatabricksProfilerInterface,
     test_suite_class=DatabricksTestSuiteInterface,
     sampler_class=DatabricksSamplerInterface,
+    data_diff=DatabricksTableParameter,
 )

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/data_diff/__init__.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/data_diff/__init__.py
@@ -1,0 +1,1 @@
+"""Unity Catalog data diff module"""

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/data_diff/data_diff.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/data_diff/data_diff.py
@@ -1,20 +1,12 @@
 """Unity Catalog spec for data diff - delegates to Databricks connection"""
 
-from typing import Any, Dict, Optional, Union, cast
+from typing import Optional, Union
 
 from metadata.data_quality.validations.runtime_param_setter.base_diff_params_setter import (
     BaseTableParameter,
 )
-from metadata.generated.schema.entity.services.connections.database.unityCatalogConnection import (
-    UnityCatalogConnection,
-)
-from metadata.generated.schema.entity.services.databaseService import (
-    DatabaseService,
-)
-from metadata.ingestion.source.database.unitycatalog.connection import (
-    
-)from metadata.ingestion.source.database.databricks.connection import (
-    get_connection as databricks_get_connection
+from metadata.ingestion.source.database.databricks.connection import (
+    get_connection as databricks_get_connection,
 )
 
 
@@ -22,12 +14,12 @@ class UnityCatalogTableParameter(BaseTableParameter):
     """Unity Catalog table parameter setter - uses Unity Catalog connection
     which is databricks-based for data diff operations"""
 
-    def _get_service_connection_config(service_connection_config,
-        ) -> Optional[Union[str, dict]]:
-        
+    def _get_service_connection_config(
+        service_connection_config,
+    ) -> Optional[Union[str, dict]]:
+
         return (
-                    str(databricks_get_connection(service_connection_config).url)
-                    if service_connection_config
-                    else None
-                )
-        
+            str(databricks_get_connection(service_connection_config).url)
+            if service_connection_config
+            else None
+        )

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/data_diff/data_diff.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/data_diff/data_diff.py
@@ -1,118 +1,12 @@
 """Unity Catalog spec for data diff - delegates to Databricks connection"""
 
-from typing import Optional, Union
-from urllib.parse import urlparse
-
-from metadata.data_quality.validations.models import TableParameter
-from metadata.data_quality.validations.runtime_param_setter.table_diff_params_setter import (
-    BaseTableParameter,
+from metadata.ingestion.source.database.common.data_diff.databricks_base import (
+    DatabricksBaseTableParameter,
 )
-from metadata.generated.schema.entity.data.table import Table
-from metadata.generated.schema.entity.services.databaseService import DatabaseService
-from metadata.utils import fqn
 
 
-class UnityCatalogTableParameter(BaseTableParameter):
+class UnityCatalogTableParameter(DatabricksBaseTableParameter):
     """Unity Catalog table parameter setter - uses Unity Catalog connection
     which is databricks-based for data diff operations"""
 
-    def get(
-        self,
-        service: DatabaseService,
-        entity: Table,
-        key_columns,
-        extra_columns,
-        case_sensitive_columns,
-        service_url: Optional[Union[str, dict]],
-    ) -> TableParameter:
-        """Getter table parameter for the table diff test.
-
-        Returns:
-            TableParameter
-        """
-        return TableParameter(
-            database_service_type=service.serviceType,
-            path=self.get_data_diff_table_path(
-                entity.fullyQualifiedName.root, service.serviceType
-            ),
-            serviceUrl=self.get_data_diff_url(
-                service,
-                entity.fullyQualifiedName.root,
-                override_url=service_url,
-            ),
-            columns=self.filter_relevant_columns(
-                entity.columns,
-                key_columns,
-                extra_columns,
-                case_sensitive=case_sensitive_columns,
-            ),
-            privateKey=None,
-            passPhrase=None,
-        )
-
-    @classmethod
-    def _get_service_connection_config(
-        cls,
-        service_connection_config,
-    ) -> Optional[Union[str, dict]]:
-        """Build connection URL directly to avoid WorkspaceClient.url AttributeError"""
-        if service_connection_config:
-            scheme = getattr(
-                service_connection_config, "scheme", "databricks+connector"
-            )
-            # Handle enum values properly
-            if hasattr(scheme, "value"):
-                scheme = scheme.value
-            host_port = getattr(service_connection_config, "hostPort", "localhost:443")
-            token = getattr(service_connection_config, "token", "")
-            token_value = (
-                token.get_secret_value()
-                if hasattr(token, "get_secret_value")
-                else str(token)
-            )
-
-            # Include httpPath if available (required for data_diff library)
-            http_path = getattr(service_connection_config, "httpPath", "")
-            if http_path:
-                # Ensure http_path starts with /
-                if not http_path.startswith("/"):
-                    http_path = "/" + http_path
-                return f"{scheme}://:{token_value}@{host_port}{http_path}"
-            return f"{scheme}://:{token_value}@{host_port}"
-        return None
-
-    def get_data_diff_url(
-        self,
-        db_service: DatabaseService,
-        table_fqn,
-        override_url: Optional[Union[str, dict]] = None,
-    ) -> Union[str, dict]:
-        """Get the url for the data diff service.
-
-        Args:
-            db_service (DatabaseService): The database service entity
-            table_fqn (str): The fully qualified name of the table
-            override_url (Optional[str], optional): Override the url. Defaults to None.
-
-        Returns:
-            str: The url for the data diff service
-        """
-        source_url = (
-            self.__class__._get_service_connection_config(db_service.connection.config)
-            if not override_url
-            else override_url
-        )
-        if isinstance(source_url, dict):
-            source_url["driver"] = source_url["driver"].split("+")[0]
-            return source_url
-        url = urlparse(source_url)
-        # remove the driver name from the url because table-diff doesn't support it
-        kwargs = {"scheme": url.scheme.split("+")[0]}
-        service, database, schema, table = fqn.split(  # pylint: disable=unused-variable
-            table_fqn
-        )
-
-        # path needs to include the database AND schema in some of the connectors
-        if hasattr(db_service.connection.config, "supportsDatabase"):
-            kwargs["query"] = f"catalog={database}"
-        return url._replace(**kwargs).geturl()
+    pass

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/data_diff/data_diff.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/data_diff/data_diff.py
@@ -17,9 +17,11 @@ class UnityCatalogTableParameter(BaseTableParameter):
     which is databricks-based for data diff operations"""
 
     def __init__(self):
-        `BaseTableParameter._get_service_connection_config = UnityCatalogTableParameter._get_service_connection_config
+        BaseTableParameter._get_service_connection_config = (
+            UnityCatalogTableParameter._get_service_connection_config
+        )
         super().__init__()
-    
+
     def get(
         self,
         service: DatabaseService,
@@ -122,5 +124,3 @@ class UnityCatalogTableParameter(BaseTableParameter):
         if hasattr(db_service.connection.config, "supportsDatabase"):
             kwargs["query"] = f"catalog={database}"
         return url._replace(**kwargs).geturl()
-
-    

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/data_diff/data_diff.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/data_diff/data_diff.py
@@ -1,7 +1,6 @@
-"""Unity Catalog spec for data diff"""
+"""Unity Catalog spec for data diff - delegates to Databricks connection"""
 
-from typing import Optional, Union, cast
-from urllib.parse import urlparse
+from typing import Any, Dict, Optional, Union, cast
 
 from metadata.data_quality.validations.runtime_param_setter.base_diff_params_setter import (
     BaseTableParameter,
@@ -9,50 +8,26 @@ from metadata.data_quality.validations.runtime_param_setter.base_diff_params_set
 from metadata.generated.schema.entity.services.connections.database.unityCatalogConnection import (
     UnityCatalogConnection,
 )
-from metadata.generated.schema.entity.services.databaseService import DatabaseService
-from metadata.ingestion.source.database.unitycatalog.connection import (
-    get_sqlalchemy_connection,
+from metadata.generated.schema.entity.services.databaseService import (
+    DatabaseService,
 )
-from metadata.profiler.orm.registry import Dialects
-from metadata.utils import fqn
+from metadata.ingestion.source.database.unitycatalog.connection import (
+    
+)from metadata.ingestion.source.database.databricks.connection import (
+    get_connection as databricks_get_connection
+)
 
 
 class UnityCatalogTableParameter(BaseTableParameter):
-    """Unity Catalog table parameter setter for data diff operations"""
+    """Unity Catalog table parameter setter - uses Unity Catalog connection
+    which is databricks-based for data diff operations"""
 
-    @staticmethod
-    def get_data_diff_url(
-        db_service: DatabaseService,
-        table_fqn: str,
-        override_url: Optional[Union[str, dict]] = None,
-    ) -> Union[str, dict]:
-        """Get the connection URL for Unity Catalog data diff operations"""
-
-        if override_url:
-            return override_url
-
-        # Use Unity Catalog's existing SQLAlchemy connection logic
-        connection_config = cast(UnityCatalogConnection, db_service.connection.config)
-        engine = get_sqlalchemy_connection(connection_config)
-        source_url = str(engine.url)
-
-        # Apply the same URL processing as base class
-        url = urlparse(source_url)
-        # Remove the driver name from the URL because data-diff doesn't support it
-        kwargs = {"scheme": url.scheme.split("+")[0]}
-
-        service, database, schema, table = fqn.split(table_fqn)
-
-        # Handle Unity Catalog path requirements
-        # Unity Catalog uses catalog.schema format, similar to Snowflake
-        if hasattr(db_service.connection.config, "supportsDatabase"):
-            kwargs["path"] = f"/{database}"
-
-        # For Unity Catalog (Databricks-based), include both catalog and schema in path
-        if (
-            kwargs["scheme"] in {Dialects.MSSQL, Dialects.Snowflake, Dialects.Trino}
-            or "databricks" in kwargs["scheme"]
-        ):
-            kwargs["path"] = f"/{database}/{schema}"
-
-        return url._replace(**kwargs).geturl()
+    def _get_service_connection_config(service_connection_config,
+        ) -> Optional[Union[str, dict]]:
+        
+        return (
+                    str(databricks_get_connection(service_connection_config).url)
+                    if service_connection_config
+                    else None
+                )
+        

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/data_diff/data_diff.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/data_diff/data_diff.py
@@ -1,25 +1,121 @@
 """Unity Catalog spec for data diff - delegates to Databricks connection"""
 
 from typing import Optional, Union
+from urllib.parse import urlparse
 
-from metadata.data_quality.validations.runtime_param_setter.base_diff_params_setter import (
+from metadata.data_quality.validations.models import TableParameter
+from metadata.data_quality.validations.runtime_param_setter.table_diff_params_setter import (
     BaseTableParameter,
 )
-from metadata.ingestion.source.database.databricks.connection import (
-    get_connection as databricks_get_connection,
-)
+from metadata.generated.schema.entity.data.table import Table
+from metadata.generated.schema.entity.services.databaseService import DatabaseService
+from metadata.utils import fqn
 
 
 class UnityCatalogTableParameter(BaseTableParameter):
     """Unity Catalog table parameter setter - uses Unity Catalog connection
     which is databricks-based for data diff operations"""
 
+    def get(
+        self,
+        service: DatabaseService,
+        entity: Table,
+        key_columns,
+        extra_columns,
+        case_sensitive_columns,
+        service_url: Optional[Union[str, dict]],
+    ) -> TableParameter:
+        """Getter table parameter for the table diff test.
+
+        Returns:
+            TableParameter
+        """
+        return TableParameter(
+            database_service_type=service.serviceType,
+            path=self.get_data_diff_table_path(
+                entity.fullyQualifiedName.root, service.serviceType
+            ),
+            serviceUrl=UnityCatalogTableParameter.get_data_diff_url(
+                db_service=service,
+                table_fqn=entity.fullyQualifiedName.root,
+                override_url=service_url,
+            ),
+            columns=self.filter_relevant_columns(
+                entity.columns,
+                key_columns,
+                extra_columns,
+                case_sensitive=case_sensitive_columns,
+            ),
+            privateKey=None,
+            passPhrase=None,
+        )
+
     def _get_service_connection_config(
         service_connection_config,
     ) -> Optional[Union[str, dict]]:
+        """Build connection URL directly to avoid WorkspaceClient.url AttributeError"""
+        if service_connection_config:
+            scheme = getattr(
+                service_connection_config, "scheme", "databricks+connector"
+            )
+            # Handle enum values properly
+            if hasattr(scheme, "value"):
+                scheme = scheme.value
+            host_port = getattr(service_connection_config, "hostPort", "localhost:443")
+            token = getattr(service_connection_config, "token", "")
+            token_value = (
+                token.get_secret_value()
+                if hasattr(token, "get_secret_value")
+                else str(token)
+            )
 
-        return (
-            str(databricks_get_connection(service_connection_config).url)
-            if service_connection_config
-            else None
+            # Include httpPath if available (required for data_diff library)
+            http_path = getattr(service_connection_config, "httpPath", "")
+            if http_path:
+                # Ensure http_path starts with /
+                if not http_path.startswith("/"):
+                    http_path = "/" + http_path
+                return f"{scheme}://:{token_value}@{host_port}{http_path}"
+            else:
+                return f"{scheme}://:{token_value}@{host_port}"
+        return None
+
+    @staticmethod
+    def get_data_diff_url(
+        db_service: DatabaseService,
+        table_fqn,
+        override_url: Optional[Union[str, dict]] = None,
+    ) -> Union[str, dict]:
+        """Get the url for the data diff service.
+
+        Args:
+            db_service (DatabaseService): The database service entity
+            table_fqn (str): The fully qualified name of the table
+            override_url (Optional[str], optional): Override the url. Defaults to None.
+
+        Returns:
+            str: The url for the data diff service
+        """
+        source_url = (
+            UnityCatalogTableParameter._get_service_connection_config(
+                db_service.connection.config
+            )
+            if not override_url
+            else override_url
         )
+        if isinstance(source_url, dict):
+            source_url["driver"] = source_url["driver"].split("+")[0]
+            return source_url
+        url = urlparse(source_url)
+        # remove the driver name from the url because table-diff doesn't support it
+        kwargs = {"scheme": url.scheme.split("+")[0]}
+        service, database, schema, table = fqn.split(  # pylint: disable=unused-variable
+            table_fqn
+        )
+
+        # path needs to include the database AND schema in some of the connectors
+        if hasattr(db_service.connection.config, "supportsDatabase"):
+            kwargs["query"] = f"catalog={database}"
+        return url._replace(**kwargs).geturl()
+
+    BaseTableParameter._get_service_connection_config = _get_service_connection_config

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/data_diff/data_diff.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/data_diff/data_diff.py
@@ -16,6 +16,10 @@ class UnityCatalogTableParameter(BaseTableParameter):
     """Unity Catalog table parameter setter - uses Unity Catalog connection
     which is databricks-based for data diff operations"""
 
+    def __init__(self):
+        `BaseTableParameter._get_service_connection_config = UnityCatalogTableParameter._get_service_connection_config
+        super().__init__()
+    
     def get(
         self,
         service: DatabaseService,
@@ -30,6 +34,7 @@ class UnityCatalogTableParameter(BaseTableParameter):
         Returns:
             TableParameter
         """
+
         return TableParameter(
             database_service_type=service.serviceType,
             path=self.get_data_diff_table_path(
@@ -77,8 +82,7 @@ class UnityCatalogTableParameter(BaseTableParameter):
                 if not http_path.startswith("/"):
                     http_path = "/" + http_path
                 return f"{scheme}://:{token_value}@{host_port}{http_path}"
-            else:
-                return f"{scheme}://:{token_value}@{host_port}"
+            return f"{scheme}://:{token_value}@{host_port}"
         return None
 
     @staticmethod
@@ -119,4 +123,4 @@ class UnityCatalogTableParameter(BaseTableParameter):
             kwargs["query"] = f"catalog={database}"
         return url._replace(**kwargs).geturl()
 
-    BaseTableParameter._get_service_connection_config = _get_service_connection_config
+    

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/data_diff/data_diff.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/data_diff/data_diff.py
@@ -50,6 +50,7 @@ class UnityCatalogTableParameter(BaseTableParameter):
             passPhrase=None,
         )
 
+    @staticmethod
     def _get_service_connection_config(
         service_connection_config,
     ) -> Optional[Union[str, dict]]:

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/data_diff/data_diff.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/data_diff/data_diff.py
@@ -1,0 +1,58 @@
+"""Unity Catalog spec for data diff"""
+
+from typing import Optional, Union, cast
+from urllib.parse import urlparse
+
+from metadata.data_quality.validations.runtime_param_setter.base_diff_params_setter import (
+    BaseTableParameter,
+)
+from metadata.generated.schema.entity.services.connections.database.unityCatalogConnection import (
+    UnityCatalogConnection,
+)
+from metadata.generated.schema.entity.services.databaseService import DatabaseService
+from metadata.ingestion.source.database.unitycatalog.connection import (
+    get_sqlalchemy_connection,
+)
+from metadata.profiler.orm.registry import Dialects
+from metadata.utils import fqn
+
+
+class UnityCatalogTableParameter(BaseTableParameter):
+    """Unity Catalog table parameter setter for data diff operations"""
+
+    @staticmethod
+    def get_data_diff_url(
+        db_service: DatabaseService,
+        table_fqn: str,
+        override_url: Optional[Union[str, dict]] = None,
+    ) -> Union[str, dict]:
+        """Get the connection URL for Unity Catalog data diff operations"""
+
+        if override_url:
+            return override_url
+
+        # Use Unity Catalog's existing SQLAlchemy connection logic
+        connection_config = cast(UnityCatalogConnection, db_service.connection.config)
+        engine = get_sqlalchemy_connection(connection_config)
+        source_url = str(engine.url)
+
+        # Apply the same URL processing as base class
+        url = urlparse(source_url)
+        # Remove the driver name from the URL because data-diff doesn't support it
+        kwargs = {"scheme": url.scheme.split("+")[0]}
+
+        service, database, schema, table = fqn.split(table_fqn)
+
+        # Handle Unity Catalog path requirements
+        # Unity Catalog uses catalog.schema format, similar to Snowflake
+        if hasattr(db_service.connection.config, "supportsDatabase"):
+            kwargs["path"] = f"/{database}"
+
+        # For Unity Catalog (Databricks-based), include both catalog and schema in path
+        if (
+            kwargs["scheme"] in {Dialects.MSSQL, Dialects.Snowflake, Dialects.Trino}
+            or "databricks" in kwargs["scheme"]
+        ):
+            kwargs["path"] = f"/{database}/{schema}"
+
+        return url._replace(**kwargs).geturl()

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/service_spec.py
@@ -1,6 +1,9 @@
 from metadata.data_quality.interface.sqlalchemy.unity_catalog.test_suite_interface import (
     UnityCatalogTestSuiteInterface,
 )
+from metadata.ingestion.source.database.unitycatalog.data_diff.data_diff import (
+    UnityCatalogTableParameter,
+)
 from metadata.ingestion.source.database.unitycatalog.lineage import (
     UnitycatalogLineageSource,
 )
@@ -23,4 +26,5 @@ ServiceSpec = DefaultDatabaseSpec(
     profiler_class=UnityCatalogProfilerInterface,
     test_suite_class=UnityCatalogTestSuiteInterface,
     sampler_class=UnityCatalogSamplerInterface,
+    data_diff=UnityCatalogTableParameter,
 )

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/service_spec.py
@@ -26,5 +26,5 @@ ServiceSpec = DefaultDatabaseSpec(
     profiler_class=UnityCatalogProfilerInterface,
     test_suite_class=UnityCatalogTestSuiteInterface,
     sampler_class=UnityCatalogSamplerInterface,
-    data_diff=UnityCatalogTableParameter
+    data_diff=UnityCatalogTableParameter,
 )

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/service_spec.py
@@ -26,5 +26,5 @@ ServiceSpec = DefaultDatabaseSpec(
     profiler_class=UnityCatalogProfilerInterface,
     test_suite_class=UnityCatalogTestSuiteInterface,
     sampler_class=UnityCatalogSamplerInterface,
-    data_diff=UnityCatalogTableParameter,
+    data_diff=UnityCatalogTableParameter
 )

--- a/ingestion/src/metadata/profiler/orm/registry.py
+++ b/ingestion/src/metadata/profiler/orm/registry.py
@@ -88,6 +88,7 @@ class PythonDialects(Enum):
     Snowflake = "snowflake"
     Teradata = "teradatasql"
     Trino = "trino"
+    UnityCatalog = "unitycatalog"
     Vertica = "vertica"
 
 

--- a/ingestion/tests/unit/metadata/data_quality/test_table_diff_param_setter.py
+++ b/ingestion/tests/unit/metadata/data_quality/test_table_diff_param_setter.py
@@ -114,7 +114,7 @@ SERVICE_CONNECTION_CONFIG = MysqlConnection(
     ],
 )
 def test_get_data_diff_url(input, expected):
-    assert expected == BaseTableParameter.get_data_diff_url(
+    assert expected == BaseTableParameter().get_data_diff_url(
         input, "service.database.schema.table"
     )
 


### PR DESCRIPTION
This pull request introduces enhanced support for Databricks and Unity Catalog connections in the data diff functionality, refactors connection handling to improve extensibility, and updates the parameter setter logic to accommodate these new connection types. The changes also include codebase improvements for clarity and maintainability.

**Databricks and Unity Catalog support:**

* Added `DatabricksBaseTableParameter` as a shared base class for Databricks-based data diff operations, which builds connection URLs correctly for Databricks and Unity Catalog services. (`ingestion/src/metadata/ingestion/source/database/common/data_diff/databricks_base.py`)
* Implemented `DatabricksTableParameter` and `UnityCatalogTableParameter` classes, delegating connection logic to the shared base class for data diff operations. (`ingestion/src/metadata/ingestion/source/database/databricks/data_diff/data_diff.py`, `ingestion/src/metadata/ingestion/source/database/unitycatalog/data_diff/data_diff.py`) [[1]](diffhunk://#diff-b1339f75c10b13bf40604e4ce1017c2b09db5ac923734171d9fc4735bd7a5c38R1-R12) [[2]](diffhunk://#diff-95b18f165e7f2a396ca7cc88256a5fb9dcd724e4dcff1a20410f97b710752bafR1-R12)
* Registered the new data diff parameter classes in the relevant service spec files for Databricks and Unity Catalog, enabling the framework to use them. (`ingestion/src/metadata/ingestion/source/database/databricks/service_spec.py`, `ingestion/src/metadata/ingestion/source/database/unitycatalog/service_spec.py`) [[1]](diffhunk://#diff-2ded9f2e8011bd1f4edaa4d068a0c35a55ed35a3b8f59d6a7f322ee972eff48dR4-R6) [[2]](diffhunk://#diff-2ded9f2e8011bd1f4edaa4d068a0c35a55ed35a3b8f59d6a7f322ee972eff48dR25) [[3]](diffhunk://#diff-1f8b1df77364899eb738514ad3b741f0df058c14087a1fa72900499e59199ad6R4-R6) [[4]](diffhunk://#diff-1f8b1df77364899eb738514ad3b741f0df058c14087a1fa72900499e59199ad6R29)
* Added module docstrings for the new data diff modules for Databricks and Unity Catalog. (`ingestion/src/metadata/ingestion/source/database/databricks/data_diff/__init__.py`, `ingestion/src/metadata/ingestion/source/database/unitycatalog/data_diff/__init__.py`)

**Refactoring and extensibility improvements:**

* Changed `_get_service_connection_config` in `BaseTableParameter` from a `@staticmethod` to a `@classmethod`, allowing subclasses to override connection logic as needed. (`ingestion/src/metadata/data_quality/validations/runtime_param_setter/base_diff_params_setter.py`)
* Updated usages of `_get_service_connection_config` and related logic in `TableDiffParameterSetter` to leverage the correct class for each service, ensuring proper connection handling for different database types. (`ingestion/src/metadata/data_quality/validations/runtime_param_setter/table_diff_params_setter.py`) [[1]](diffhunk://#diff-83d2d75a663b3b05c524379f9c0d1e3694bdcecfaf48573cc18bc26c1194f5afL52-R84) [[2]](diffhunk://#diff-83d2d75a663b3b05c524379f9c0d1e3694bdcecfaf48573cc18bc26c1194f5afL96-R111)

**Additional updates:**

* Added `UnityCatalog` to the `PythonDialects` enum to support dialect selection for Unity Catalog connections. (`ingestion/src/metadata/profiler/orm/registry.py`)
* Included `Dialects.Databricks` in the list of supported dialects for table diff operations. (`ingestion/src/metadata/data_quality/validations/table/sqlalchemy/tableDiff.py`)
* Minor test update to instantiate `BaseTableParameter` for method calls. (`ingestion/tests/unit/metadata/data_quality/test_table_diff_param_setter.py`)