### PR TITLE
fix(test):

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/AddRoleAndAssignToUser.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/AddRoleAndAssignToUser.spec.ts
@@ -99,13 +99,13 @@ test.describe.serial('Add role and assign it to the user', () => {
     await page.click(`[title="${roleName}"]`);
 
     await clickOutside(page);
-    const userResponse = page.waitForResponse(`/api/v1/users`);
 
     await page.waitForSelector('[data-testid="save-user"]', {
       state: 'visible',
     });
-    await page.click('[data-testid="save-user"]');
 
+    const userResponse = page.waitForResponse('/api/v1/users');
+    await page.click('[data-testid="save-user"]');
     await userResponse;
   });
 


### PR DESCRIPTION
Fixes Create new user and assign new role to him

<img width="954" height="312" alt="Screenshot 2025-09-16 at 12 21 08 PM" src="https://github.com/user-attachments/assets/1a695ff7-af85-49ea-99c9-0ce1ab18dae8" />


Original problem:
  - Setting up the response listener too early (before the button was even visible) could miss the actual API call
  - The response listener might timeout or capture the wrong request

  Why moving it after waitForSelector works:
  1. Ensures UI is ready - First confirms the save button is visible and the form is fully rendered
  2. Sets up listener at the right time - Creates the response listener only when we're about to trigger the action
  3. Prevents premature listening - Avoids catching unrelated API calls that might happen during form loading.
  
 Have  verified the functionality on 1.9.8 and main.


<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
