### PR TITLE
fix: update OpenMetadata API version to 1.9.8

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/OpenMetadataApplication.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/OpenMetadataApplication.java
@@ -161,7 +161,7 @@ import org.quartz.SchedulerException;
     info =
         @Info(
             title = "OpenMetadata APIs",
-            version = "1.8.0",
+            version = "1.9.8",
             description = "Common types and API definition for OpenMetadata",
             contact =
                 @Contact(


### PR DESCRIPTION
This pull request updates the API version in the OpenMetadata service. The change ensures that the OpenAPI documentation reflects the latest version of the APIs.

* API version updated from `1.8.0` to `1.9.8` in `OpenMetadataApplication.java` to match the current release.