### PR TITLE
playwright: remove logging for failed ingestion pipelines in ServiceBaseClass

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/ServiceBaseClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/ServiceBaseClass.ts
@@ -394,21 +394,6 @@ class ServiceBaseClass {
     await page.waitForLoadState('networkidle');
     await page.waitForSelector(`td:has-text("${ingestionType}")`);
 
-    const pipelineStatus = await page
-      .locator(`[data-row-key*="${workflowData.name}"]`)
-      .getByTestId('pipeline-status')
-      .last()
-      .textContent();
-    // add logs to console for failed pipelines
-    if (pipelineStatus?.toLowerCase() === 'failed') {
-      const logsResponse = await apiContext
-        .get(`/api/v1/services/ingestionPipelines/logs/${workflowData.id}/last`)
-        .then((res) => res.json());
-
-      // eslint-disable-next-line no-console
-      console.log(logsResponse);
-    }
-
     await expect(
       page
         .locator(`[data-row-key*="${workflowData.name}"]`)


### PR DESCRIPTION
This pull request makes a small change to the ingestion pipeline test logic by removing the code that checks for failed pipeline statuses and logs their output to the console. This simplifies the test code and eliminates unnecessary logging during test runs.