### PR TITLE
fix(test): permission aut failure

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/permission.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/permission.ts
@@ -171,7 +171,17 @@ export const validateViewPermissions = async (
     .getByTestId('loader')
     .waitFor({ state: 'detached' });
   await page.waitForLoadState('domcontentloaded');
-  await page.getByText('Data Quality').click();
+  await page.waitForSelector('[data-testid="profiler-tab-left-panel"]', {
+    state: 'visible',
+  });
+  await page
+    .getByTestId('profiler-tab-left-panel')
+    .getByText('Data Quality')
+    .waitFor({ state: 'visible' });
+  await page
+    .getByTestId('profiler-tab-left-panel')
+    .getByText('Data Quality')
+    .click();
   await page.waitForLoadState('domcontentloaded');
   await checkNoPermissionPlaceholder(
     page,


### PR DESCRIPTION
The issue was that the test was trying to click on the "Data Quality" menu item before it became visible after clicking the profiler tab. The added waits ensure the sidebar panel and
   menu item are visible before attempting the click.
#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
