### PR TITLE
MINOR: Update required Node.js version to 22 in prerequisites script

### DIFF
--- a/scripts/check_prerequisites.sh
+++ b/scripts/check_prerequisites.sh
@@ -50,7 +50,7 @@ jq["required_version"]="any"
 declare -A node
 node["name"]="Node"
 node["version_command"]="node --version"
-node["required_version"]="18"
+node["required_version"]="22"
 
 declare -A yarn
 yarn["name"]="Yarn"


### PR DESCRIPTION
This pull request updates the required Node.js version in the `scripts/check_prerequisites.sh` script to ensure compatibility with newer dependencies and features.

Dependency version update:

* Changed the required Node.js version from `18` to `22` in the `check_prerequisites.sh` script to enforce the use of the latest major release.