### PR TITLE
chore(ui): introduce route position for plugin routes

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/AppRouter/AppRouter.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AppRouter/AppRouter.tsx
@@ -28,7 +28,7 @@ import applicationRoutesClass from '../../utils/ApplicationRoutesClassBase';
 import AppContainer from '../AppContainer/AppContainer';
 import Loader from '../common/Loader/Loader';
 import { useApplicationsProvider } from '../Settings/Applications/ApplicationsProvider/ApplicationsProvider';
-import { PluginPosition } from '../Settings/Applications/plugins/AppPlugin';
+import { RoutePosition } from '../Settings/Applications/plugins/AppPlugin';
 
 const AppRouter = () => {
   const location = useCustomLocation();
@@ -120,7 +120,7 @@ const AppRouter = () => {
           const routes = plugin.getRoutes?.() || [];
           // Filter routes with APP position
           const appRoutes = routes.filter(
-            (route) => route.position === PluginPosition.APP
+            (route) => route.position === RoutePosition.APP
           );
 
           return appRoutes.map((route, idx) => (

--- a/openmetadata-ui/src/main/resources/ui/src/components/AppRouter/AuthenticatedAppRouter.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AppRouter/AuthenticatedAppRouter.tsx
@@ -29,7 +29,7 @@ import PlatformLineage from '../../pages/PlatformLineage/PlatformLineage';
 import TagPage from '../../pages/TagPage/TagPage';
 import { checkPermission, userPermissions } from '../../utils/PermissionsUtils';
 import { useApplicationsProvider } from '../Settings/Applications/ApplicationsProvider/ApplicationsProvider';
-import { PluginPosition } from '../Settings/Applications/plugins/AppPlugin';
+import { RoutePosition } from '../Settings/Applications/plugins/AppPlugin';
 import AdminProtectedRoute from './AdminProtectedRoute';
 import withSuspenseFallback from './withSuspenseFallback';
 
@@ -291,7 +291,7 @@ const AuthenticatedAppRouter: FunctionComponent = () => {
       return routes.filter(
         (route) =>
           !route.position ||
-          route.position === PluginPosition.AUTHENTICATED_ROUTE
+          route.position === RoutePosition.AUTHENTICATED_ROUTE
       );
     });
   }, [plugins]);

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Applications/plugins/AppPlugin.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Applications/plugins/AppPlugin.ts
@@ -23,7 +23,7 @@ export interface LeftSidebarItemExample extends LeftSidebarItem {
 /**
  * Enum defining where plugin routes should be mounted in the app hierarchy
  */
-export enum PluginPosition {
+export enum RoutePosition {
   /**
    * Routes are mounted inside AuthenticatedAppRouter (default)
    * These routes have access to AppContainer layout with navbar and sidebar
@@ -40,13 +40,13 @@ export enum PluginPosition {
 /**
  * Extended RouteProps with position for plugin routes
  */
-export interface PluginRouteProps extends RouteProps {
+export type PluginRouteProps = RouteProps & {
   /**
    * Where this route should be mounted in the app hierarchy
-   * @default PluginPosition.AUTHENTICATED_ROUTE
+   * @default RoutePosition.AUTHENTICATED_ROUTE
    */
-  position?: PluginPosition;
-}
+  position?: RoutePosition;
+};
 
 /**
  * Interface defining the structure and capabilities of an application plugin.


### PR DESCRIPTION
This pull request introduces support for plugin-defined routes with configurable placement within the application's routing hierarchy. Plugins can now specify where their routes should be mounted—either inside the main authenticated app layout or at the top level—allowing for more flexible and customizable plugin integrations. The implementation adds a new `RoutePosition` enum, updates plugin route typing, and adjusts both `AppRouter` and `AuthenticatedAppRouter` to mount plugin routes according to their specified position.

**Plugin Route Positioning Enhancements:**

* Added the `RoutePosition` enum and the `PluginRouteProps` type in `AppPlugin.ts`, allowing plugins to specify where their routes should be mounted (`AUTHENTICATED_ROUTE` or `APP`). (`[openmetadata-ui/src/main/resources/ui/src/components/Settings/Applications/plugins/AppPlugin.tsR23-R50](diffhunk://#diff-1b3b5f66b0df3c99249e71b3d28db6417a05402e9e109ae29db7909feddcd869R23-R50)`)
* Updated the `AppPlugin` interface so that the `getRoutes` method returns an array of `PluginRouteProps`, supporting the new `position` property. (`[openmetadata-ui/src/main/resources/ui/src/components/Settings/Applications/plugins/AppPlugin.tsL56-R87](diffhunk://#diff-1b3b5f66b0df3c99249e71b3d28db6417a05402e9e109ae29db7909feddcd869L56-R87)`)

**AppRouter adjustments:**

* Modified `AppRouter.tsx` to render plugin routes with `RoutePosition.APP` at the top level, outside the default app container layout, enabling plugins to provide their own layouts if desired. (`[[1]](diffhunk://#diff-7c5e3c463fc9dede5f84f40aa8f9fd2458926f18459e2e881aa859bb0c38f1aaR30-R31)`, `[[2]](diffhunk://#diff-7c5e3c463fc9dede5f84f40aa8f9fd2458926f18459e2e881aa859bb0c38f1aaR46)`, `[[3]](diffhunk://#diff-7c5e3c463fc9dede5f84f40aa8f9fd2458926f18459e2e881aa859bb0c38f1aaR116-R131)`)

**AuthenticatedAppRouter adjustments:**

* Updated `AuthenticatedAppRouter.tsx` to filter and render only plugin routes with `RoutePosition.AUTHENTICATED_ROUTE` (or no position specified), ensuring these routes are wrapped with the standard app container layout. (`[[1]](diffhunk://#diff-e6702bfc476b659cbcd339a5d33b79fe2dbb3f6c1eb271098977e843fc84d143R32)`, `[[2]](diffhunk://#diff-e6702bfc476b659cbcd339a5d33b79fe2dbb3f6c1eb271098977e843fc84d143L284-R297)`)