### PR TITLE
Improve timestamp sorting logic in IngestionRecentRuns component

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionRecentRun/IngestionRecentRun.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionRecentRun/IngestionRecentRun.test.tsx
@@ -319,4 +319,185 @@ describe('Test IngestionRecentRun component', () => {
     expect(getRunHistoryForPipeline).toHaveBeenCalledTimes(2);
     expect(mockHandlePipelineIdToFetchStatus).toHaveBeenCalled();
   });
+
+  describe('Timestamp Sorting Logic', () => {
+    it('should sort runs by timestamp in ascending order and show last 5 runs', async () => {
+      const unorderedRuns = [
+        {
+          runId: 'run-3',
+          pipelineState: 'success',
+          startDate: 1667307000,
+          timestamp: 1667307000,
+          endDate: 1667307003,
+        },
+        {
+          runId: 'run-1',
+          pipelineState: 'failed',
+          startDate: 1667301000,
+          timestamp: 1667301000,
+          endDate: 1667301003,
+        },
+        {
+          runId: 'run-5',
+          pipelineState: 'success',
+          startDate: 1667309000,
+          timestamp: 1667309000,
+          endDate: 1667309003,
+        },
+        {
+          runId: 'run-2',
+          pipelineState: 'partialSuccess',
+          startDate: 1667304000,
+          timestamp: 1667304000,
+          endDate: 1667304003,
+        },
+        {
+          runId: 'run-4',
+          pipelineState: 'running',
+          startDate: 1667308000,
+          timestamp: 1667308000,
+          endDate: 1667308003,
+        },
+        {
+          runId: 'run-6',
+          pipelineState: 'queued',
+          startDate: 1667310000,
+          timestamp: 1667310000,
+          endDate: 1667310003,
+        },
+        {
+          runId: 'run-7',
+          pipelineState: 'success',
+          startDate: 1667311000,
+          timestamp: 1667311000,
+          endDate: 1667311003,
+        },
+      ];
+
+      (getRunHistoryForPipeline as jest.Mock).mockResolvedValueOnce({
+        data: unorderedRuns,
+        paging: { total: 7 },
+      });
+
+      await act(async () => {
+        render(<IngestionRecentRuns ingestion={mockIngestion} />);
+      });
+
+      const runs = await screen.findAllByTestId('pipeline-status');
+
+      expect(runs).toHaveLength(5);
+
+      const latestRun = await screen.findByText(/Success/);
+
+      expect(latestRun).toBeInTheDocument();
+    });
+
+    it('should handle runs with missing timestamps gracefully by treating them as 0', async () => {
+      const runsWithMissingTimestamps = [
+        {
+          runId: 'run-with-timestamp',
+          pipelineState: 'success',
+          startDate: 1667307000,
+          timestamp: 1667307000,
+          endDate: 1667307003,
+        },
+        {
+          runId: 'run-without-timestamp',
+          pipelineState: 'failed',
+          startDate: 1667301000,
+          endDate: 1667301003,
+        },
+        {
+          runId: 'run-with-null-timestamp',
+          pipelineState: 'partialSuccess',
+          startDate: 1667304000,
+          timestamp: null,
+          endDate: 1667304003,
+        },
+      ];
+
+      (getRunHistoryForPipeline as jest.Mock).mockResolvedValueOnce({
+        data: runsWithMissingTimestamps,
+        paging: { total: 3 },
+      });
+
+      await act(async () => {
+        render(<IngestionRecentRuns ingestion={mockIngestion} />);
+      });
+
+      const runs = await screen.findAllByTestId('pipeline-status');
+
+      expect(runs).toHaveLength(3);
+
+      const latestRun = await screen.findByText(/Success/);
+
+      expect(latestRun).toBeInTheDocument();
+    });
+
+    it('should sort appRuns by timestamp when provided', async () => {
+      const unorderedAppRuns = [
+        {
+          runId: 'app-run-2',
+          status: 'Success',
+          startTime: 1667307000,
+          timestamp: 1667307000,
+          endTime: 1667307003,
+          appId: 'app-2',
+        },
+        {
+          runId: 'app-run-1',
+          status: 'Failed',
+          startTime: 1667301000,
+          timestamp: 1667301000,
+          endTime: 1667301003,
+          appId: 'app-1',
+        },
+        {
+          runId: 'app-run-3',
+          status: 'Running',
+          startTime: 1667309000,
+          timestamp: 1667309000,
+          endTime: 1667309003,
+          appId: 'app-3',
+        },
+      ];
+
+      await act(async () => {
+        render(
+          <IngestionRecentRuns appRuns={unorderedAppRuns} fetchStatus={false} />
+        );
+      });
+
+      const runs = await screen.findAllByTestId('pipeline-status');
+
+      expect(runs).toHaveLength(3);
+
+      const latestRun = await screen.findByText(/Running/);
+
+      expect(latestRun).toBeInTheDocument();
+    });
+
+    it('should limit results to maximum 5 runs after sorting', async () => {
+      const manyRuns = Array.from({ length: 10 }, (_, i) => ({
+        runId: `run-${i}`,
+        pipelineState: 'success',
+        startDate: 1667300000 + i * 1000,
+        timestamp: 1667300000 + i * 1000,
+        endDate: 1667300003 + i * 1000,
+      }));
+
+      (getRunHistoryForPipeline as jest.Mock).mockResolvedValueOnce({
+        data: manyRuns,
+        paging: { total: 10 },
+      });
+
+      await act(async () => {
+        render(<IngestionRecentRuns ingestion={mockIngestion} />);
+      });
+
+      const runs = await screen.findAllByTestId('pipeline-status');
+
+      expect(runs).toHaveLength(5);
+    });
+  });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionRecentRun/IngestionRecentRuns.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionRecentRun/IngestionRecentRuns.component.tsx
@@ -65,7 +65,10 @@ export const IngestionRecentRuns = <
           queryParams
         );
 
-        const runs = response.data.splice(0, 5).reverse() ?? [];
+        const runs =
+          response.data
+            .sort((a, b) => (a.timestamp ?? 0) - (b.timestamp ?? 0))
+            .slice(-5) ?? [];
 
         setRecentRunStatus(
           (runs.length === 0 && ingestionPipeline?.pipelineStatuses
@@ -86,7 +89,11 @@ export const IngestionRecentRuns = <
 
   useEffect(() => {
     if (!isEmpty(appRuns)) {
-      setRecentRunStatus(appRuns?.splice(0, 5).reverse() ?? []);
+      setRecentRunStatus(
+        appRuns
+          ?.sort((a, b) => (a.timestamp ?? 0) - (b.timestamp ?? 0))
+          .slice(-5) ?? []
+      );
     }
   }, [appRuns]);
 


### PR DESCRIPTION
This pull request enhances the sorting and display logic for recent ingestion pipeline runs in the `IngestionRecentRuns` component. The main improvement is ensuring that runs are consistently sorted by their `timestamp` (handling missing values gracefully), and only the most recent five runs are shown. Comprehensive tests have been added to validate this behavior.

**Sorting and Display Logic Improvements:**

* Updated the logic in `IngestionRecentRuns.component.tsx` to sort pipeline runs and app runs by their `timestamp` values in ascending order (treating missing timestamps as `0`), then select the last five runs for display. This ensures the most recent runs are always shown, regardless of the original order or missing timestamps. [[1]](diffhunk://#diff-cb0313ad986e25264b2a54a64d7317f7a83339d8b41be3af4040c598cc9e0d55L68-R71) [[2]](diffhunk://#diff-cb0313ad986e25264b2a54a64d7317f7a83339d8b41be3af4040c598cc9e0d55L89-R96)

**Testing Enhancements:**

* Added a new test suite to `IngestionRecentRun.test.tsx` that verifies sorting by timestamp, correct handling of missing timestamps, and limiting the displayed runs to a maximum of five. These tests cover both pipeline runs and app runs scenarios.