### PR TITLE
Fix batchFetchClassification for tags

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TagRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TagRepository.java
@@ -379,7 +379,8 @@ public class TagRepository extends EntityRepository<Tag> {
     var records =
         daoCollection
             .relationshipDAO()
-            .findToBatch(entityIds, Relationship.CONTAINS.ordinal(), Entity.CLASSIFICATION);
+            .findFromBatch(
+                entityIds, Relationship.CONTAINS.ordinal(), Entity.CLASSIFICATION, NON_DELETED);
 
     if (records.isEmpty()) {
       return Map.of();
@@ -422,7 +423,7 @@ public class TagRepository extends EntityRepository<Tag> {
     var records =
         daoCollection
             .relationshipDAO()
-            .findToBatch(entityIds, Relationship.CONTAINS.ordinal(), TAG);
+            .findFromBatch(entityIds, Relationship.CONTAINS.ordinal(), TAG, NON_DELETED);
 
     if (records.isEmpty()) {
       return Map.of();

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/tags/TagResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/tags/TagResourceTest.java
@@ -793,4 +793,108 @@ public class TagResourceTest extends EntityResourceTest<Tag, CreateTag> {
     return classificationResourceTest.getEntityByName(
         name, classificationResourceTest.getAllowedFields(), ADMIN_AUTH_HEADERS);
   }
+
+  @Test
+  @Order(100) // Run this test later to ensure environment is ready
+  void test_bulkSetFieldsForTags(TestInfo test) throws IOException {
+    // This test verifies that bulk operations (like those used during reindexing)
+    // correctly set classification and parent relationships for tags
+
+    // Create a classification
+    String classificationName =
+        "BulkTestClassification_" + UUID.randomUUID().toString().substring(0, 8);
+    Classification classification = createClassification(classificationName);
+
+    // Create a parent tag
+    String parentTagName = "BulkParentTag_" + UUID.randomUUID().toString().substring(0, 8);
+    CreateTag createParent =
+        createRequest(parentTagName).withClassification(classification.getFullyQualifiedName());
+    Tag parentTag = createEntity(createParent, ADMIN_AUTH_HEADERS);
+
+    // Create multiple child tags
+    List<Tag> childTags = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      String childTagName =
+          "BulkChildTag_" + i + "_" + UUID.randomUUID().toString().substring(0, 8);
+      CreateTag createChild =
+          createRequest(childTagName)
+              .withClassification(classification.getFullyQualifiedName())
+              .withParent(parentTag.getFullyQualifiedName());
+      Tag childTag = createEntity(createChild, ADMIN_AUTH_HEADERS);
+      childTags.add(childTag);
+    }
+
+    // Get TagRepository to test bulk operations
+    org.openmetadata.service.jdbi3.TagRepository tagRepository =
+        (org.openmetadata.service.jdbi3.TagRepository) Entity.getEntityRepository(Entity.TAG);
+
+    // Fetch tags without fields (simulating initial reindexing fetch)
+    // During reindexing, tags are fetched without relationships populated
+    List<Tag> tagsWithoutFields = new ArrayList<>();
+    for (Tag childTag : childTags) {
+      // Create a minimal tag object to simulate what happens during reindexing
+      // when tags are fetched in bulk without relationship fields
+      Tag tagWithoutFields = new Tag();
+      tagWithoutFields.setId(childTag.getId());
+      tagWithoutFields.setName(childTag.getName());
+      tagWithoutFields.setFullyQualifiedName(childTag.getFullyQualifiedName());
+      tagWithoutFields.setDescription(childTag.getDescription());
+      // Classification and parent are intentionally not set - simulating bulk fetch without
+      // relationships
+      tagsWithoutFields.add(tagWithoutFields);
+    }
+
+    // Test setFieldsInBulk method
+    org.openmetadata.service.util.EntityUtil.Fields fields =
+        new org.openmetadata.service.util.EntityUtil.Fields(
+            java.util.Set.of("classification", "parent", "usageCount"));
+    tagRepository.setFieldsInBulk(fields, tagsWithoutFields);
+
+    // Verify all tags now have their classification and parent set correctly
+    for (Tag tag : tagsWithoutFields) {
+      assertNotNull(tag.getClassification(), "Classification should be set after bulk operation");
+      assertEquals(
+          classification.getId(),
+          tag.getClassification().getId(),
+          "Classification ID should match");
+      assertEquals(
+          classification.getFullyQualifiedName(),
+          tag.getClassification().getFullyQualifiedName(),
+          "Classification FQN should match");
+
+      assertNotNull(tag.getParent(), "Parent should be set after bulk operation");
+      assertEquals(parentTag.getId(), tag.getParent().getId(), "Parent ID should match");
+      assertEquals(
+          parentTag.getFullyQualifiedName(),
+          tag.getParent().getFullyQualifiedName(),
+          "Parent FQN should match");
+
+      assertNotNull(tag.getUsageCount(), "Usage count should be set");
+      assertTrue(tag.getUsageCount() >= 0, "Usage count should be non-negative");
+    }
+
+    // Test edge case: empty list
+    List<Tag> emptyList = new ArrayList<>();
+    tagRepository.setFieldsInBulk(fields, emptyList);
+    assertTrue(emptyList.isEmpty(), "Empty list should remain empty");
+
+    // Test with parent tag (which has no parent)
+    List<Tag> parentTagList = new ArrayList<>();
+    Tag parentWithoutFields = new Tag();
+    parentWithoutFields.setId(parentTag.getId());
+    parentWithoutFields.setName(parentTag.getName());
+    parentWithoutFields.setFullyQualifiedName(parentTag.getFullyQualifiedName());
+    parentWithoutFields.setDescription(parentTag.getDescription());
+    parentTagList.add(parentWithoutFields);
+
+    tagRepository.setFieldsInBulk(fields, parentTagList);
+
+    assertNotNull(
+        parentWithoutFields.getClassification(), "Parent tag should have classification set");
+    assertEquals(
+        classification.getId(),
+        parentWithoutFields.getClassification().getId(),
+        "Parent tag classification should match");
+    assertNull(parentWithoutFields.getParent(), "Parent tag should not have a parent");
+  }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fix batchFetchClassification for tags, it was calling the wrong method to fetch Parent, which in turn affected tag_search_index.Once reindex was completed with recreate=True, it will loose the info about its classification

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
