### PR TITLE
Fix TypeResource to handle inDefinition references

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/SchemaFieldExtractor.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/SchemaFieldExtractor.java
@@ -425,7 +425,16 @@ public class SchemaFieldExtractor {
   }
 
   private static String determineReferenceType(String refUri) {
-    // Pattern to extract the definition name if present
+    // Handle internal schema references first (e.g., #/definitions/column,
+    // #/definitions/tableConstraint, etc.)
+    if (refUri.startsWith("#/definitions/")) {
+      String definitionName = refUri.substring("#/definitions/".length());
+      LOG.debug("Found internal schema reference: {}", definitionName);
+      // Return the definition name as the type - this preserves the actual type name
+      return definitionName;
+    }
+
+    // Pattern to extract the definition name if present from external files
     Pattern definitionPattern = Pattern.compile("^(?:.*/)?basic\\.json#/definitions/([\\w-]+)$");
     Matcher matcher = definitionPattern.matcher(refUri);
     if (matcher.find()) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/metadata/TypeResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/metadata/TypeResourceTest.java
@@ -14,6 +14,7 @@
 package org.openmetadata.service.resources.metadata;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openmetadata.common.utils.CommonUtil.listOrEmpty;
 import static org.openmetadata.service.util.EntityUtil.fieldAdded;
@@ -503,6 +504,54 @@ public class TypeResourceTest extends EntityResourceTest<Type, CreateType> {
     } catch (Exception e) {
       throw new IllegalStateException(e.getMessage());
     }
+  }
+
+  @Test
+  void test_getEntityTypeFields_internalSchemaReferences() throws HttpResponseException {
+    // Test that internal schema references like #/definitions/column are handled correctly
+    WebTarget target = getCollection().path("/fields/table");
+    List<Map<String, Object>> fields = TestUtils.get(target, List.class, ADMIN_AUTH_HEADERS);
+
+    // Find the columns field
+    Map<String, Object> columnsField =
+        fields.stream()
+            .filter(field -> "columns".equals(field.get("name")))
+            .findFirst()
+            .orElse(null);
+
+    // Verify columns field exists and has correct type
+    assertNotNull(columnsField, "columns field should be present");
+    assertEquals(
+        "array<column>",
+        columnsField.get("type"),
+        "columns field should be of type array<column>, not array<string>");
+
+    // Verify that nested column properties are exposed
+    boolean hasColumnName =
+        fields.stream().anyMatch(field -> "columns.name".equals(field.get("name")));
+    boolean hasColumnDescription =
+        fields.stream().anyMatch(field -> "columns.description".equals(field.get("name")));
+    boolean hasColumnDataType =
+        fields.stream().anyMatch(field -> "columns.dataType".equals(field.get("name")));
+
+    assertTrue(hasColumnName, "columns.name field should be exposed");
+    assertTrue(hasColumnDescription, "columns.description field should be exposed");
+    assertTrue(hasColumnDataType, "columns.dataType field should be exposed");
+
+    // Test other internal schema references
+    Map<String, Object> dataModelField =
+        fields.stream()
+            .filter(field -> "dataModel".equals(field.get("name")))
+            .findFirst()
+            .orElse(null);
+
+    assertNotNull(dataModelField, "dataModel field should be present");
+    assertEquals("dataModel", dataModelField.get("type"), "dataModel should be of type object");
+
+    // Verify nested dataModel properties are exposed
+    boolean hasDataModelColumns =
+        fields.stream().anyMatch(field -> "dataModel.columns".equals(field.get("name")));
+    assertTrue(hasDataModelColumns, "dataModel.columns field should be exposed");
   }
 
   @Override


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fix: /metadata/types/fields/{entityType} to check for in definition references as well
Previously for table, we received the below which is wrong
```
{
    "name": "columns",
    "displayName": "columns",
    "type": "array<string>",
    "customPropertyConfig": null
  }
```

After the fix, we receive columns and their nested refs like description, displayName etc etc
```
{
        "name": "columns",
        "displayName": "columns",
        "type": "array<column>",
        "customPropertyConfig": null
    }
```

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
