### PR TITLE
Minor improvement around contract security initial data pick

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataContract/ContractSecurityFormTab/ContractSecurityFormTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataContract/ContractSecurityFormTab/ContractSecurityFormTab.tsx
@@ -108,7 +108,7 @@ export const ContractSecurityFormTab: React.FC<{
   };
 
   useEffect(() => {
-    if (!isEmpty(initialValues)) {
+    if (!isEmpty(initialValues?.security)) {
       form.setFieldsValue(initialValues?.security);
     } else {
       form.setFieldsValue({
@@ -128,7 +128,7 @@ export const ContractSecurityFormTab: React.FC<{
       });
     }
     setEditingKey(0);
-  }, [initialValues]);
+  }, [initialValues?.security]);
 
   return (
     <>


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:


<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

- I worked on Minor improvement around contract security initial data pick

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
