### PR TITLE
Improvement(UI): Platform info banner logic update

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/AirflowMessageBanner/AirflowMessageBanner.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/AirflowMessageBanner/AirflowMessageBanner.test.tsx
@@ -11,6 +11,7 @@
  *  limitations under the License.
  */
 import { render, screen } from '@testing-library/react';
+import { AIRFLOW_HYBRID } from '../../../constants/constants';
 import { useAirflowStatus } from '../../../context/AirflowStatusProvider/AirflowStatusProvider';
 import AirflowMessageBanner from './AirflowMessageBanner';
 
@@ -20,6 +21,8 @@ jest.mock(
     useAirflowStatus: jest.fn().mockImplementation(() => ({
       reason: 'reason message',
       isAirflowAvailable: false,
+      isFetchingStatus: false,
+      platform: 'unknown',
     })),
   })
 );
@@ -31,15 +34,117 @@ describe('Test Airflow Message Banner', () => {
     expect(screen.getByTestId('no-airflow-placeholder')).toBeInTheDocument();
   });
 
-  it('Should not render the banner if airflow is available', () => {
+  it('Should not render the banner if airflow is available and platform is not hybrid', () => {
     (useAirflowStatus as jest.Mock).mockImplementationOnce(() => ({
       reason: 'reason message',
       isAirflowAvailable: true,
+      isFetchingStatus: false,
+      platform: 'unknown',
     }));
     render(<AirflowMessageBanner />);
 
     expect(
       screen.queryByTestId('no-airflow-placeholder')
     ).not.toBeInTheDocument();
+  });
+
+  describe('Hybrid Runner Scenarios', () => {
+    it('Should render the banner for hybrid runner even when platform is available (status 200)', () => {
+      (useAirflowStatus as jest.Mock).mockImplementationOnce(() => ({
+        reason: 'Hybrid runner is configured correctly',
+        isAirflowAvailable: true,
+        isFetchingStatus: false,
+        platform: AIRFLOW_HYBRID,
+      }));
+      render(<AirflowMessageBanner />);
+
+      expect(screen.getByTestId('no-airflow-placeholder')).toBeInTheDocument();
+      expect(screen.getByTestId('viewer-container')).toBeInTheDocument();
+    });
+
+    it('Should render the banner for hybrid runner when platform is not available', () => {
+      (useAirflowStatus as jest.Mock).mockImplementationOnce(() => ({
+        reason: 'Hybrid runner configuration error',
+        isAirflowAvailable: false,
+        isFetchingStatus: false,
+        platform: AIRFLOW_HYBRID,
+      }));
+      render(<AirflowMessageBanner />);
+
+      expect(screen.getByTestId('no-airflow-placeholder')).toBeInTheDocument();
+      expect(screen.getByTestId('viewer-container')).toBeInTheDocument();
+    });
+
+    it('Should not render the banner for hybrid runner if reason is empty', () => {
+      (useAirflowStatus as jest.Mock).mockImplementationOnce(() => ({
+        reason: '',
+        isAirflowAvailable: true,
+        isFetchingStatus: false,
+        platform: AIRFLOW_HYBRID,
+      }));
+      render(<AirflowMessageBanner />);
+
+      expect(
+        screen.queryByTestId('no-airflow-placeholder')
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Common Scenarios', () => {
+    it('Should not render the banner if fetching status', () => {
+      (useAirflowStatus as jest.Mock).mockImplementationOnce(() => ({
+        reason: 'reason message',
+        isAirflowAvailable: false,
+        isFetchingStatus: true,
+        platform: 'unknown',
+      }));
+      render(<AirflowMessageBanner />);
+
+      expect(
+        screen.queryByTestId('no-airflow-placeholder')
+      ).not.toBeInTheDocument();
+    });
+
+    it('Should not render the banner if reason is empty', () => {
+      (useAirflowStatus as jest.Mock).mockImplementationOnce(() => ({
+        reason: '',
+        isAirflowAvailable: false,
+        isFetchingStatus: false,
+        platform: 'unknown',
+      }));
+      render(<AirflowMessageBanner />);
+
+      expect(
+        screen.queryByTestId('no-airflow-placeholder')
+      ).not.toBeInTheDocument();
+    });
+
+    it('Should not render the banner if reason is null', () => {
+      (useAirflowStatus as jest.Mock).mockImplementationOnce(() => ({
+        reason: null,
+        isAirflowAvailable: false,
+        isFetchingStatus: false,
+        platform: 'unknown',
+      }));
+      render(<AirflowMessageBanner />);
+
+      expect(
+        screen.queryByTestId('no-airflow-placeholder')
+      ).not.toBeInTheDocument();
+    });
+
+    it('Should render the banner if platform is not available and reason is not empty', () => {
+      (useAirflowStatus as jest.Mock).mockImplementationOnce(() => ({
+        reason: 'Some error occurred',
+        isAirflowAvailable: false,
+        isFetchingStatus: false,
+        platform: 'unknown',
+      }));
+      render(<AirflowMessageBanner />);
+
+      expect(
+        screen.queryByTestId('no-airflow-placeholder')
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/AirflowMessageBanner/AirflowMessageBanner.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/AirflowMessageBanner/AirflowMessageBanner.tsx
@@ -15,14 +15,22 @@ import classNames from 'classnames';
 import { isEmpty } from 'lodash';
 import { FC } from 'react';
 import { ReactComponent as IconRetry } from '../../../assets/svg/ic-retry-icon.svg';
+import { AIRFLOW_HYBRID } from '../../../constants/constants';
 import { useAirflowStatus } from '../../../context/AirflowStatusProvider/AirflowStatusProvider';
 import RichTextEditorPreviewerV1 from '../RichTextEditor/RichTextEditorPreviewerV1';
 import './airflow-message-banner.less';
 
 const AirflowMessageBanner: FC<SpaceProps> = ({ className }) => {
-  const { reason, isAirflowAvailable, isFetchingStatus } = useAirflowStatus();
+  const { reason, isAirflowAvailable, isFetchingStatus, platform } =
+    useAirflowStatus();
 
-  if (isAirflowAvailable || isFetchingStatus || isEmpty(reason)) {
+  if (isFetchingStatus || isEmpty(reason)) {
+    return null;
+  }
+
+  // For hybrid runner, always show the banner even if status is 200
+  // For other platforms, only show when Airflow is not available
+  if (platform !== AIRFLOW_HYBRID && isAirflowAvailable) {
     return null;
   }
 


### PR DESCRIPTION
I worked on adding logic to display the platform info banner, even in cases where the status is 200, and the API response contains `reason` for the `Hybrid` platform.
Earlier, we used to show the banner if the platform API status was not 200. This change is to fulfil the requirements of https://github.com/open-metadata/openmetadata-collate/pull/2054

<img width="1440" height="608" alt="Screenshot 2025-09-29 at 6 06 19 PM" src="https://github.com/user-attachments/assets/1c2a8873-7f13-4ddd-8670-35614a98cf73" />
