### PR TITLE
fix(ui): mentions in notification box

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityFeed.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityFeed.spec.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
+import { expect, Page, test as base } from '@playwright/test';
 import { TableClass } from '../../support/entity/TableClass';
 import { PersonaClass } from '../../support/persona/PersonaClass';
 import { UserClass } from '../../support/user/UserClass';
@@ -21,6 +21,8 @@ import {
   navigateToCustomizeLandingPage,
   setUserDefaultPersona,
 } from '../../utils/customizeLandingPage';
+
+const test = base;
 
 const adminUser = new UserClass();
 const user1 = new UserClass();
@@ -381,6 +383,24 @@ test.describe('Mention notifications in Notification Box', () => {
   const user1 = new UserClass();
   const entity = new TableClass();
 
+  const test = base.extend<{
+    adminPage: Page;
+    user1Page: Page;
+  }>({
+    adminPage: async ({ browser }, use) => {
+      const page = await browser.newPage();
+      await adminUser.login(page);
+      await use(page);
+      await page.close();
+    },
+    user1Page: async ({ browser }, use) => {
+      const page = await browser.newPage();
+      await user1.login(page);
+      await use(page);
+      await page.close();
+    },
+  });
+
   test.beforeAll('Setup entities and users', async ({ browser }) => {
     const { apiContext, afterAction } = await performAdminLogin(browser);
 
@@ -395,169 +415,156 @@ test.describe('Mention notifications in Notification Box', () => {
   });
 
   test('Mention notification shows correct user details in Notification box', async ({
-    browser,
+    adminPage,
+    user1Page,
   }) => {
-    const adminPage = await browser.newPage();
-    await adminUser.login(adminPage);
+    await test.step(
+      'Admin user creates a conversation on an entity',
+      async () => {
+        await entity.visitEntityPage(adminPage);
 
-    const user1Page = await browser.newPage();
-    await user1.login(user1Page);
+        await adminPage.getByTestId('activity_feed').click();
+        await adminPage.waitForLoadState('networkidle');
 
-    try {
-      await test.step(
-        'Admin user creates a conversation on an entity',
-        async () => {
-          await entity.visitEntityPage(adminPage);
-
-          await adminPage.getByTestId('activity_feed').click();
-          await adminPage.waitForLoadState('networkidle');
-
-          await adminPage.waitForSelector('[data-testid="loader"]', {
-            state: 'detached',
-          });
-
-          await adminPage.getByTestId('comments-input-field').click();
-
-          await adminPage
-            .locator(
-              '[data-testid="editor-wrapper"] [contenteditable="true"].ql-editor'
-            )
-            .fill('Initial conversation thread for mention test');
-
-          await expect(
-            adminPage.locator('[data-testid="send-button"]')
-          ).toBeVisible();
-          await expect(
-            adminPage.locator('[data-testid="send-button"]')
-          ).not.toBeDisabled();
-
-          const postConversation = adminPage.waitForResponse(
-            (response) =>
-              response.url().includes('/api/v1/feed') &&
-              response.request().method() === 'POST' &&
-              response.url().includes('/posts')
-          );
-          await adminPage.locator('[data-testid="send-button"]').click();
-          await postConversation;
-        }
-      );
-
-      await test.step('User1 mentions admin user in a reply', async () => {
-        await entity.visitEntityPage(user1Page);
-
-        await user1Page.getByTestId('activity_feed').click();
-        await user1Page.waitForLoadState('networkidle');
-
-        await user1Page.waitForSelector('[data-testid="loader"]', {
+        await adminPage.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
 
-        await user1Page.getByTestId('comments-input-field').click();
+        await adminPage.getByTestId('comments-input-field').click();
 
-        const editorLocator = user1Page.locator(
-          '[data-testid="editor-wrapper"] [contenteditable="true"].ql-editor'
-        );
-
-        await editorLocator.fill('Hey ');
-
-        const userSuggestionsResponse = user1Page.waitForResponse(
-          `/api/v1/search/query?q=*${adminUser.responseData.name}***`
-        );
-
-        await editorLocator.pressSequentially(
-          `@${adminUser.responseData.name}`
-        );
-        await userSuggestionsResponse;
-
-        await user1Page
-          .locator(`[data-value="@${adminUser.responseData.name}"]`)
-          .first()
-          .click();
-
-        await editorLocator.type(', can you check this?');
+        await adminPage
+          .locator(
+            '[data-testid="editor-wrapper"] [contenteditable="true"].ql-editor'
+          )
+          .fill('Initial conversation thread for mention test');
 
         await expect(
-          user1Page.locator('[data-testid="send-button"]')
+          adminPage.locator('[data-testid="send-button"]')
         ).toBeVisible();
         await expect(
-          user1Page.locator('[data-testid="send-button"]')
+          adminPage.locator('[data-testid="send-button"]')
         ).not.toBeDisabled();
 
-        const postMentionResponse = user1Page.waitForResponse(
-          '/api/v1/feed/*/posts'
+        const postConversation = adminPage.waitForResponse(
+          (response) =>
+            response.url().includes('/api/v1/feed') &&
+            response.request().method() === 'POST' &&
+            response.url().includes('/posts')
         );
-        await user1Page.locator('[data-testid="send-button"]').click();
-        await postMentionResponse;
+        await adminPage.locator('[data-testid="send-button"]').click();
+        await postConversation;
+      }
+    );
+
+    await test.step('User1 mentions admin user in a reply', async () => {
+      await entity.visitEntityPage(user1Page);
+
+      await user1Page.getByTestId('activity_feed').click();
+      await user1Page.waitForLoadState('networkidle');
+
+      await user1Page.waitForSelector('[data-testid="loader"]', {
+        state: 'detached',
       });
 
-      await test.step(
-        'Admin user checks notification for correct user and timestamp',
-        async () => {
-          await adminPage.reload();
-          await adminPage.waitForLoadState('networkidle');
-          const notificationBell = adminPage.getByTestId('task-notifications');
+      await user1Page.getByTestId('comments-input-field').click();
 
-          await expect(notificationBell).toBeVisible();
-
-          const feedResponseForNotifications =
-            adminPage.waitForResponse(`api/v1/feed?userId=*`);
-
-          await notificationBell.click();
-          await feedResponseForNotifications;
-          const notificationBox = adminPage.locator('.notification-box');
-
-          await expect(notificationBox).toBeVisible();
-
-          const mentionsTab = adminPage
-            .locator('.notification-box')
-            .getByText('Mentions');
-
-          const mentionsFeedResponse = adminPage.waitForResponse(
-            (response) =>
-              response.url().includes('/api/v1/feed') &&
-              response.url().includes('filterType=MENTIONS') &&
-              response.url().includes('type=Conversation')
-          );
-
-          await mentionsTab.click();
-          await mentionsFeedResponse;
-
-          const mentionsList = adminPage
-            .getByRole('tabpanel', { name: 'Mentions' })
-            .getByRole('list');
-
-          await expect(mentionsList).toBeVisible();
-
-          const firstNotificationItem = mentionsList
-            .locator('li.ant-list-item.notification-dropdown-list-btn')
-            .first();
-
-          const firstNotificationText =
-            await firstNotificationItem.textContent();
-
-          expect(firstNotificationText?.toLowerCase()).toContain(
-            user1.responseData.name.toLowerCase()
-          );
-          expect(firstNotificationText?.toLowerCase()).not.toContain(
-            adminUser.responseData.name.toLowerCase()
-          );
-
-          const mentionNotificationLink = firstNotificationItem.locator(
-            '[data-testid^="notification-link-"]'
-          );
-
-          const navigationPromise = adminPage.waitForURL(/activity_feed/);
-          await mentionNotificationLink.click();
-          await navigationPromise;
-          await adminPage.waitForLoadState('networkidle');
-
-          expect(adminPage.url()).toContain('activity_feed');
-          expect(adminPage.url()).toContain('/all');
-        }
+      const editorLocator = user1Page.locator(
+        '[data-testid="editor-wrapper"] [contenteditable="true"].ql-editor'
       );
-    } finally {
-      await user1Page.close();
-      await adminPage.close();
-    }
+
+      await editorLocator.fill('Hey ');
+
+      const userSuggestionsResponse = user1Page.waitForResponse(
+        `/api/v1/search/query?q=*${adminUser.responseData.name}***`
+      );
+
+      await editorLocator.pressSequentially(`@${adminUser.responseData.name}`);
+      await userSuggestionsResponse;
+
+      await user1Page
+        .locator(`[data-value="@${adminUser.responseData.name}"]`)
+        .first()
+        .click();
+
+      await editorLocator.type(', can you check this?');
+
+      await expect(
+        user1Page.locator('[data-testid="send-button"]')
+      ).toBeVisible();
+      await expect(
+        user1Page.locator('[data-testid="send-button"]')
+      ).not.toBeDisabled();
+
+      const postMentionResponse = user1Page.waitForResponse(
+        '/api/v1/feed/*/posts'
+      );
+      await user1Page.locator('[data-testid="send-button"]').click();
+      await postMentionResponse;
+    });
+
+    await test.step(
+      'Admin user checks notification for correct user and timestamp',
+      async () => {
+        await adminPage.reload();
+        await adminPage.waitForLoadState('networkidle');
+        const notificationBell = adminPage.getByTestId('task-notifications');
+
+        await expect(notificationBell).toBeVisible();
+
+        const feedResponseForNotifications =
+          adminPage.waitForResponse(`api/v1/feed?userId=*`);
+
+        await notificationBell.click();
+        await feedResponseForNotifications;
+        const notificationBox = adminPage.locator('.notification-box');
+
+        await expect(notificationBox).toBeVisible();
+
+        const mentionsTab = adminPage
+          .locator('.notification-box')
+          .getByText('Mentions');
+
+        const mentionsFeedResponse = adminPage.waitForResponse(
+          (response) =>
+            response.url().includes('/api/v1/feed') &&
+            response.url().includes('filterType=MENTIONS') &&
+            response.url().includes('type=Conversation')
+        );
+
+        await mentionsTab.click();
+        await mentionsFeedResponse;
+
+        const mentionsList = adminPage
+          .getByRole('tabpanel', { name: 'Mentions' })
+          .getByRole('list');
+
+        await expect(mentionsList).toBeVisible();
+
+        const firstNotificationItem = mentionsList
+          .locator('li.ant-list-item.notification-dropdown-list-btn')
+          .first();
+
+        const firstNotificationText = await firstNotificationItem.textContent();
+
+        expect(firstNotificationText?.toLowerCase()).toContain(
+          user1.responseData.name.toLowerCase()
+        );
+        expect(firstNotificationText?.toLowerCase()).not.toContain(
+          adminUser.responseData.name.toLowerCase()
+        );
+
+        const mentionNotificationLink = firstNotificationItem.locator(
+          '[data-testid^="notification-link-"]'
+        );
+
+        const navigationPromise = adminPage.waitForURL(/activity_feed/);
+        await mentionNotificationLink.click();
+        await navigationPromise;
+        await adminPage.waitForLoadState('networkidle');
+
+        expect(adminPage.url()).toContain('activity_feed');
+        expect(adminPage.url()).toContain('/all');
+      }
+    );
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/NotificationBox/NotificationBox.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/NotificationBox/NotificationBox.component.tsx
@@ -68,15 +68,38 @@ const NotificationBox = ({
       const entityType = getEntityType(feed.about);
       const entityFQN = getEntityFQN(feed.about);
 
+      // For mention notifications, get the actual user who made the mention from posts
+      let actualUser = mainFeed.from;
+      let actualTimestamp = mainFeed.postTs;
+
+      if (
+        feed.type === ThreadType.Conversation &&
+        feed.posts &&
+        feed.posts.length > 0
+      ) {
+        // Find the most recent post that contains a mention
+        const mentionPost = feed.posts
+          .filter(
+            (post) =>
+              post.message.includes('<#E::user::') && post.postTs !== undefined
+          )
+          .sort((a, b) => (b.postTs ?? 0) - (a.postTs ?? 0))[0];
+
+        if (mentionPost && mentionPost.postTs !== undefined) {
+          actualUser = mentionPost.from;
+          actualTimestamp = mentionPost.postTs;
+        }
+      }
+
       return (
         <NotificationFeedCard
-          createdBy={mainFeed.from}
+          createdBy={actualUser}
           entityFQN={entityFQN as string}
           entityType={entityType as string}
           feedType={feed.type || ThreadType.Conversation}
-          key={`${mainFeed.from} ${mainFeed.id}`}
+          key={`${actualUser} ${mainFeed.id}`}
           task={feed}
-          timestamp={mainFeed.postTs}
+          timestamp={actualTimestamp}
         />
       );
     });

--- a/openmetadata-ui/src/main/resources/ui/src/components/NotificationBox/NotificationFeedCard.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/NotificationBox/NotificationFeedCard.component.tsx
@@ -25,6 +25,7 @@ import { getEntityLinkFromType, getEntityName } from '../../utils/EntityUtils';
 import { entityDisplayName, prepareFeedLink } from '../../utils/FeedUtils';
 import Fqn from '../../utils/Fqn';
 import { getTaskDetailPath } from '../../utils/TasksUtils';
+import { ActivityFeedTabs } from '../ActivityFeed/ActivityFeedTab/ActivityFeedTab.interface';
 import ProfilePicture from '../common/ProfilePicture/ProfilePicture';
 import { SourceType } from '../SearchedData/SearchedData.interface';
 import { NotificationFeedProp } from './NotificationFeedCard.interface';
@@ -95,7 +96,7 @@ const NotificationFeedCard: FC<NotificationFeedProp> = ({
       className="no-underline"
       to={
         feedType === ThreadType.Conversation
-          ? prepareFeedLink(entityType, entityFQN)
+          ? prepareFeedLink(entityType, entityFQN, ActivityFeedTabs.ALL)
           : getTaskDetailPath(task)
       }>
       <List.Item.Meta
@@ -117,7 +118,11 @@ const NotificationFeedCard: FC<NotificationFeedProp> = ({
                   <Link
                     className="truncate"
                     data-testid={`notification-link-${entityName}`}
-                    to={prepareFeedLink(entityType, entityFQN)}>
+                    to={prepareFeedLink(
+                      entityType,
+                      entityFQN,
+                      ActivityFeedTabs.ALL
+                    )}>
                     {entityName}
                   </Link>
                 </>

--- a/openmetadata-ui/src/main/resources/ui/src/components/NotificationBox/NotificationFeedCard.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/NotificationBox/NotificationFeedCard.test.tsx
@@ -20,12 +20,16 @@ jest.mock('../../utils/date-time/DateTimeUtils', () => ({
   formatDateTime: jest.fn().mockImplementation((date) => date),
   getRelativeTime: jest.fn().mockImplementation((date) => date),
 }));
+
+const mockPrepareFeedLink = jest.fn();
+const mockGetTaskDetailPath = jest.fn();
+
 jest.mock('../../utils/FeedUtils', () => ({
   entityDisplayName: jest.fn().mockReturnValue('database.schema.table'),
-  prepareFeedLink: jest.fn().mockReturnValue('entity-link'),
+  prepareFeedLink: (...args: any[]) => mockPrepareFeedLink(...args),
 }));
 jest.mock('../../utils/TasksUtils', () => ({
-  getTaskDetailPath: jest.fn().mockReturnValue('/'),
+  getTaskDetailPath: (...args: any[]) => mockGetTaskDetailPath(...args),
 }));
 jest.mock('../common/ProfilePicture/ProfilePicture', () => {
   return jest
@@ -35,9 +39,13 @@ jest.mock('../common/ProfilePicture/ProfilePicture', () => {
 jest.mock('react-router-dom', () => ({
   Link: jest
     .fn()
-    .mockImplementation(({ children }: { children: React.ReactNode }) => (
-      <p data-testid="link">{children}</p>
-    )),
+    .mockImplementation(
+      ({ children, to }: { children: React.ReactNode; to: string }) => (
+        <p data-testid="link" data-to={to}>
+          {children}
+        </p>
+      )
+    ),
 }));
 jest.mock('../../utils/EntityUtils', () => ({
   getEntityLinkFromType: jest.fn().mockReturnValue('/mock-entity-link'),
@@ -180,5 +188,81 @@ describe('Test NotificationFeedCard Component', () => {
     });
 
     expect(screen.getByText('1692612000000')).toBeInTheDocument();
+  });
+
+  describe('Navigation URL Tests', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should navigate to tasks subtab for task notifications', async () => {
+      const taskUrl = '/database/test.entity/activity_feed/tasks';
+      mockGetTaskDetailPath.mockReturnValue(taskUrl);
+
+      const taskProps = {
+        ...mockProps,
+        feedType: ThreadType.Task,
+      };
+
+      await act(async () => {
+        render(<NotificationFeedCard {...taskProps} />);
+      });
+
+      // Verify getTaskDetailPath was called with the task
+      expect(mockGetTaskDetailPath).toHaveBeenCalledWith(mockThread);
+
+      // Verify Link component has the correct URL
+      const linkElement = screen.getAllByTestId('link')[0]; // Main link
+
+      expect(linkElement).toHaveAttribute('data-to', taskUrl);
+    });
+
+    it('should navigate to all subtab for conversation notifications', async () => {
+      const conversationUrl = '/database/test.entity/activity_feed/all';
+      mockPrepareFeedLink.mockReturnValue(conversationUrl);
+
+      const conversationProps = {
+        ...mockProps,
+        feedType: ThreadType.Conversation,
+      };
+
+      await act(async () => {
+        render(<NotificationFeedCard {...conversationProps} />);
+      });
+
+      // Verify prepareFeedLink was called with ActivityFeedTabs.ALL
+      expect(mockPrepareFeedLink).toHaveBeenCalledWith(
+        mockProps.entityType,
+        mockProps.entityFQN,
+        'all' // ActivityFeedTabs.ALL value
+      );
+
+      // Verify Link component has the correct URL
+      const linkElement = screen.getAllByTestId('link')[0]; // Main link
+
+      expect(linkElement).toHaveAttribute('data-to', conversationUrl);
+    });
+
+    it('should call prepareFeedLink with ALL subtab for entity links in conversation notifications', async () => {
+      const entityLinkUrl = '/database/test.entity/activity_feed/all';
+      mockPrepareFeedLink.mockReturnValue(entityLinkUrl);
+
+      const conversationProps = {
+        ...mockProps,
+        feedType: ThreadType.Conversation,
+      };
+
+      await act(async () => {
+        render(<NotificationFeedCard {...conversationProps} />);
+      });
+
+      // Should be called twice - once for main link, once for entity name link
+      expect(mockPrepareFeedLink).toHaveBeenCalledTimes(2);
+      expect(mockPrepareFeedLink).toHaveBeenCalledWith(
+        mockProps.entityType,
+        mockProps.entityFQN,
+        'all' // ActivityFeedTabs.ALL value
+      );
+    });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/FeedUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/FeedUtils.tsx
@@ -502,7 +502,11 @@ export const updateThreadData = async (
   }
 };
 
-export const prepareFeedLink = (entityType: string, entityFQN: string) => {
+export const prepareFeedLink = (
+  entityType: string,
+  entityFQN: string,
+  subTab?: string
+) => {
   const withoutFeedEntities = [
     EntityType.WEBHOOK,
     EntityType.TYPE,
@@ -512,7 +516,9 @@ export const prepareFeedLink = (entityType: string, entityFQN: string) => {
   const entityLink = entityUtilClassBase.getEntityLink(entityType, entityFQN);
 
   if (!withoutFeedEntities.includes(entityType as EntityType)) {
-    return `${entityLink}/${TabSpecificField.ACTIVITY_FEED}`;
+    const activityFeedLink = `${entityLink}/${TabSpecificField.ACTIVITY_FEED}`;
+
+    return subTab ? `${activityFeedLink}/${subTab}` : activityFeedLink;
   } else {
     return entityLink;
   }


### PR DESCRIPTION
Fixes #23223 and #23042

Fix NotificationFeedCard to show actual mentioning user and timestamp and redirection glitch on Activity Feed for notification feeds.

  Problem

  The NotificationFeedCard component was incorrectly displaying the thread creator (createdBy) and thread creation timestamp
  instead of the actual user who made the mention and when the mention occurred. This caused confusion in notification feeds
  where users would see outdated information like "admin mentioned you 15 days ago" when it was actually "stevegreen" who
  mentioned them "just now".

  Root Cause

  In NotificationBox.component.tsx, the notification dropdown logic was using:
  - feed.createdBy (original thread creator) instead of the actual mentioning user
  - feed.threadTs (thread creation time) instead of when the mention was posted

  For mention notifications, we need to extract both the user and timestamp from the specific post in the posts array where the
   mention occurred.

  Solution

  Modified the notificationDropDownList logic in NotificationBox.component.tsx to:

  1. Detect mention notifications: Check if feed.type === ThreadType.Conversation and posts exist
  2. Find mention posts: Filter posts containing user mentions (<#E::user:: pattern) with valid timestamps
  3. Get most recent mention: Sort by timestamp and take the latest mention post
  4. Extract correct data: Use mentionPost.from (actual mentioning user) and mentionPost.postTs (when mention occurred)
  5. Maintain accuracy: Show both who mentioned and when it actually happened

  Changes

  File: openmetadata-ui/src/main/resources/ui/src/components/NotificationBox/NotificationBox.component.tsx

  Key modifications:
  - Added mention detection logic (lines 71-92)
  - Extract actualUser from mentionPost.from instead of feed.createdBy
  - Extract actualTimestamp from mentionPost.postTs instead of feed.threadTs
  - Added TypeScript safety with null checks and nullish coalescing for undefined postTs

  Before vs After

 


Before;-

https://github.com/user-attachments/assets/22346165-d0ab-436b-a113-2f2a8c8e7adf


After fix:-


https://github.com/user-attachments/assets/fabce612-a723-4f0b-9069-dd42074a41f4


<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
