### PR TITLE
Use recognizer in classification

### DIFF
--- a/ingestion/src/metadata/pii/algorithms/presidio_recognizer_factory.py
+++ b/ingestion/src/metadata/pii/algorithms/presidio_recognizer_factory.py
@@ -27,6 +27,7 @@ from metadata.generated.schema.type.patternRecognizer import PatternRecognizer
 from metadata.generated.schema.type.predefinedRecognizer import PredefinedRecognizer
 from metadata.generated.schema.type.recognizer import Recognizer
 from metadata.generated.schema.type.recognizers.regexFlags import RegexFlags
+from metadata.pii.algorithms.presidio_utils import apply_confidence_threshold
 from metadata.utils.logger import pii_logger
 
 logger = pii_logger()
@@ -53,35 +54,41 @@ class PresidioRecognizerFactory:
         config = recognizer_config.recognizerConfig.root
 
         if isinstance(config, PatternRecognizer):
-            return PresidioRecognizerFactory._create_pattern_recognizer(
+            recognizer = PresidioRecognizerFactory._create_pattern_recognizer(
                 config, recognizer_config
             )
         elif isinstance(config, DenyListRecognizer):
-            return PresidioRecognizerFactory._create_deny_list_recognizer(
+            recognizer = PresidioRecognizerFactory._create_deny_list_recognizer(
                 config, recognizer_config
             )
         elif isinstance(config, ContextRecognizer):
-            return PresidioRecognizerFactory._create_context_recognizer(
+            recognizer = PresidioRecognizerFactory._create_context_recognizer(
                 config, recognizer_config
             )
         elif isinstance(config, CustomRecognizer):
-            return PresidioRecognizerFactory._create_custom_recognizer(
+            recognizer = PresidioRecognizerFactory._create_custom_recognizer(
                 config, recognizer_config
             )
         elif isinstance(
             config, PredefinedRecognizer
         ):  # pyright: ignore[reportUnnecessaryIsInstance]
-            return PresidioRecognizerFactory._create_predefined_recognizer(
+            recognizer = PresidioRecognizerFactory._create_predefined_recognizer(
                 config, recognizer_config
             )
         else:
             logger.warning(f"Unknown recognizer type for {recognizer_config.name}")
             return None
 
+        if recognizer and (threshold := recognizer_config.confidenceThreshold):
+            patch_analyze = apply_confidence_threshold(threshold)
+            recognizer = patch_analyze(recognizer)
+
+        return recognizer
+
     @staticmethod
     def _get_regex_flags(flags: Optional[RegexFlags]) -> Optional[int]:
         if flags is None:
-            return re.IGNORECASE | re.DOTALL | re.MULTILINE
+            return re.IGNORECASE | re.DOTALL | re.UNICODE
 
         re_flags = 0
         if flags.ignoreCase:
@@ -281,7 +288,7 @@ class RecognizerRegistry:
 
     def get_all_recognizers(self) -> List[EntityRecognizer]:
         """Get all registered recognizers across all tags."""
-        all_recognizers: List[EntityRecognizer] = []
+        all_recognizers: list[EntityRecognizer] = []
         for recognizers in self.recognizers.values():
             all_recognizers.extend(recognizers)
         return all_recognizers

--- a/ingestion/src/metadata/pii/algorithms/presidio_recognizer_factory.py
+++ b/ingestion/src/metadata/pii/algorithms/presidio_recognizer_factory.py
@@ -88,7 +88,7 @@ class PresidioRecognizerFactory:
     @staticmethod
     def _get_regex_flags(flags: Optional[RegexFlags]) -> Optional[int]:
         if flags is None:
-            return re.IGNORECASE | re.DOTALL | re.UNICODE
+            return re.IGNORECASE | re.DOTALL | re.MULTILINE
 
         re_flags = 0
         if flags.ignoreCase:

--- a/ingestion/src/metadata/pii/algorithms/presidio_utils.py
+++ b/ingestion/src/metadata/pii/algorithms/presidio_utils.py
@@ -31,6 +31,17 @@ from metadata.utils.logger import pii_logger
 logger = pii_logger()
 
 
+def load_nlp_engine(
+    model_name: str = SPACY_EN_MODEL, supported_language: str = SUPPORTED_LANG
+) -> SpacyNlpEngine:
+    _load_spacy_model(model_name)
+    model = {
+        "lang_code": supported_language,
+        "model_name": model_name,
+    }
+    return SpacyNlpEngine(models=[model])
+
+
 def build_analyzer_engine(
     model_name: str = SPACY_EN_MODEL,
 ) -> AnalyzerEngine:
@@ -39,14 +50,9 @@ def build_analyzer_engine(
 
     If the model is not found locally, it will be downloaded.
     """
-    _load_spacy_model(model_name)
-
-    model = {
-        "lang_code": SUPPORTED_LANG,
-        "model_name": model_name,
-    }
-
-    nlp_engine = SpacyNlpEngine(models=[model])
+    nlp_engine = load_nlp_engine(
+        model_name=model_name, supported_language=SUPPORTED_LANG
+    )
     analyzer_engine = AnalyzerEngine(
         nlp_engine=nlp_engine, supported_languages=[SUPPORTED_LANG]
     )

--- a/ingestion/src/metadata/pii/processor_factory.py
+++ b/ingestion/src/metadata/pii/processor_factory.py
@@ -1,0 +1,28 @@
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false
+from typing import Any
+
+from metadata.generated.schema.metadataIngestion.workflow import (
+    OpenMetadataWorkflowConfig,
+)
+from metadata.ingestion.api.parser import parse_workflow_config_gracefully
+from metadata.ingestion.ometa.ometa_api import OpenMetadata
+from metadata.pii.base_processor import AutoClassificationProcessor
+from metadata.pii.processor import PIIProcessor
+from metadata.pii.tag_processor import TagAnalyzerGenerator, TagProcessor
+
+
+def create_pii_processor(
+    metadata: OpenMetadata[Any, Any], openmetadata_config: OpenMetadataWorkflowConfig
+) -> AutoClassificationProcessor:
+    if getattr(openmetadata_config.processor, "type") == "tag-pii-processor":
+        return TagProcessor(
+            config=parse_workflow_config_gracefully(openmetadata_config.model_dump()),
+            metadata=metadata,
+            generate_tag_analyzers=TagAnalyzerGenerator(
+                metadata=metadata,
+            ),
+        )
+    return PIIProcessor.create(
+        openmetadata_config.model_dump(),
+        metadata,
+    )

--- a/ingestion/src/metadata/pii/tag_analyzer.py
+++ b/ingestion/src/metadata/pii/tag_analyzer.py
@@ -1,0 +1,124 @@
+from typing import Sequence, final
+
+from presidio_analyzer import (
+    AnalyzerEngine,
+    EntityRecognizer,
+    RecognizerRegistry,
+    RecognizerResult,
+)
+from presidio_analyzer.nlp_engine import NlpEngine
+
+from metadata.generated.schema.entity.classification.tag import Tag
+from metadata.generated.schema.entity.data.table import Column, Table
+from metadata.generated.schema.type.recognizer import RecognizerException, Target
+from metadata.pii.algorithms.feature_extraction import split_column_name
+from metadata.pii.algorithms.presidio_recognizer_factory import (
+    PresidioRecognizerFactory,
+)
+from metadata.pii.constants import SUPPORTED_LANG
+from metadata.utils.entity_link import (
+    get_entity_link,  # pyright: ignore[reportUnknownVariableType]
+)
+from metadata.utils.fqn import FQN_SEPARATOR
+
+
+@final
+class TagAnalyzer:
+    """An adapter that allows easy obtention of presidio EntityRecognizers from Tag's configuration"""
+
+    tag: Tag
+
+    def __init__(self, tag: Tag, column: Column, nlp_engine: NlpEngine):
+        self.tag = tag
+        self._column = column
+        self._nlp_engine = nlp_engine
+
+    def should_skip_recognizer(self, exception_list: list[RecognizerException]):
+        blacklisted_entities = {ex.entityLink.root for ex in exception_list}
+
+        (
+            *table_fqn_parts,
+            column_name,
+        ) = self._column.fullyQualifiedName.root.split(  # pyright: ignore[reportOptionalMemberAccess]
+            FQN_SEPARATOR
+        )
+        return (
+            get_entity_link(
+                Table, FQN_SEPARATOR.join(table_fqn_parts), column_name=column_name
+            )
+            in blacklisted_entities
+        )
+
+    def get_recognizers_by(self, target: Target) -> list[EntityRecognizer]:
+        if self.tag.autoClassificationEnabled is False:
+            return []
+
+        recognizers: list[EntityRecognizer] = []
+
+        for recognizer in self.tag.recognizers or []:
+            if recognizer.target is not target or self.should_skip_recognizer(
+                recognizer.exceptionList or []
+            ):
+                continue
+
+            created = PresidioRecognizerFactory.create_recognizer(recognizer)
+            if created is not None:
+                recognizers.append(created)
+
+        return recognizers
+
+    @property
+    def content_recognizers(self) -> list[EntityRecognizer]:
+        return self.get_recognizers_by(Target.content)
+
+    @property
+    def column_recognizers(self) -> list[EntityRecognizer]:
+        return self.get_recognizers_by(Target.column_name)
+
+    @property
+    def _column_name(self) -> str:
+        return self._column.name.root
+
+    def build_analyzer_with(
+        self, recognizers: list[EntityRecognizer]
+    ) -> AnalyzerEngine:
+        recognizer_registry = RecognizerRegistry(recognizers=recognizers)
+        return AnalyzerEngine(
+            registry=recognizer_registry,
+            nlp_engine=self._nlp_engine,
+            supported_languages=[SUPPORTED_LANG],
+        )
+
+    def analyze_content(self, values: Sequence[str]) -> float:
+        recognizers = self.content_recognizers
+
+        if not recognizers:
+            return 0.0
+
+        context = split_column_name(self._column_name)
+        analyzer = self.build_analyzer_with(recognizers)
+
+        results: list[RecognizerResult] = []
+        for value in values:
+            results.extend(
+                analyzer.analyze(value, language=SUPPORTED_LANG, context=context)
+            )
+
+        if not results:
+            return 0.0
+
+        return sum(r.score for r in results) / len(results)
+
+    def analyze_column(self) -> float:
+        recognizers = self.column_recognizers
+
+        if not recognizers:
+            return 0.0
+
+        analyzer = self.build_analyzer_with(recognizers)
+        results = analyzer.analyze(self._column_name, language=SUPPORTED_LANG)
+
+        if not results:
+            return 0.0
+
+        return sum(r.score for r in results) / len(results)

--- a/ingestion/src/metadata/pii/tag_processor.py
+++ b/ingestion/src/metadata/pii/tag_processor.py
@@ -1,0 +1,100 @@
+from typing import Any, Callable, Generator, Iterable, List, Optional, Sequence
+
+from presidio_analyzer.nlp_engine import NlpEngine
+
+from metadata.generated.schema.entity.classification.tag import Tag
+from metadata.generated.schema.entity.data.table import Column
+from metadata.generated.schema.metadataIngestion.workflow import (
+    OpenMetadataWorkflowConfig,
+)
+from metadata.generated.schema.type.tagLabel import (
+    LabelType,
+    State,
+    TagLabel,
+    TagSource,
+)
+from metadata.ingestion.ometa.ometa_api import OpenMetadata
+from metadata.pii.algorithms.classifiers import TagClassifier
+from metadata.pii.algorithms.presidio_utils import load_nlp_engine
+from metadata.pii.algorithms.utils import get_top_classes, normalize_scores
+from metadata.pii.base_processor import AutoClassificationProcessor
+from metadata.pii.constants import PII
+from metadata.pii.tag_analyzer import TagAnalyzer
+
+
+class TagAnalyzerGenerator:
+    def __init__(self, metadata: OpenMetadata, nlp_engine: Optional[NlpEngine] = None):
+        self.metadata = metadata
+        self.nlp_engine = nlp_engine or load_nlp_engine()
+        self._tags: List[Tag] = []
+
+    @property
+    def tags(self) -> List[Tag]:
+        if not self._tags:
+            self._tags = list(
+                self.metadata.list_all_entities(
+                    entity=Tag,
+                    fields=[
+                        "name",
+                        "recognizers",
+                        "fullyQualifiedName",
+                        "provider",
+                    ],
+                )
+            )
+        return self._tags
+
+    def __call__(self, column: Column) -> Generator[TagAnalyzer, None, None]:
+        for tag in self.tags:
+            yield TagAnalyzer(tag=tag, column=column, nlp_engine=self.nlp_engine)
+
+
+class TagProcessor(AutoClassificationProcessor):
+    name = "Tag Classification Processor"
+
+    def __init__(
+        self,
+        config: OpenMetadataWorkflowConfig,
+        metadata: OpenMetadata,
+        generate_tag_analyzers: Callable[[Column], Iterable[TagAnalyzer]],
+        tolerance: float = 0.7,
+    ) -> None:
+        super().__init__(config, metadata)
+        self.confidence_threshold = self.source_config.confidence / 100
+        self._tolerance = tolerance
+        self._generate_tag_analyzers = generate_tag_analyzers
+
+    @staticmethod
+    def build_tag_label(tag_fqn: str) -> TagLabel:
+        tag_label = TagLabel(
+            tagFQN=tag_fqn,
+            source=TagSource.Classification,
+            state=State.Suggested,
+            labelType=LabelType.Generated,
+        )
+
+        return tag_label
+
+    def create_column_tag_labels(
+        self, column: Column, sample_data: Sequence[Any]
+    ) -> Sequence[TagLabel]:
+        for tag in column.tags or []:
+            if PII in tag.tagFQN.root:
+                return []
+
+        classifier = TagClassifier(
+            tag_analyzers=self._generate_tag_analyzers(column),
+        )
+
+        # Get the tags and confidence
+        scores = classifier.predict_scores(
+            sample_data,
+            column_name=column.fullyQualifiedName,
+            column_data_type=column.dataType,
+        )
+
+        scores = normalize_scores(scores, tol=self._tolerance)
+
+        # winner is at most 1 tag
+        winner = get_top_classes(scores, 1, self.confidence_threshold)
+        return [self.build_tag_label(tag) for tag in winner]

--- a/ingestion/src/metadata/workflow/classification.py
+++ b/ingestion/src/metadata/workflow/classification.py
@@ -17,7 +17,7 @@ from metadata.generated.schema.metadataIngestion.databaseServiceAutoClassificati
     DatabaseServiceAutoClassificationPipeline,
 )
 from metadata.ingestion.api.steps import Processor
-from metadata.pii.processor import PIIProcessor
+from metadata.pii.processor_factory import create_pii_processor
 from metadata.sampler.processor import SamplerProcessor
 from metadata.utils.logger import profiler_logger
 from metadata.workflow.profiler import ProfilerWorkflow
@@ -50,7 +50,7 @@ class AutoClassificationWorkflow(ProfilerWorkflow):
             self.steps = (sampler_processor, sink)
 
     def _get_pii_processor(self) -> Processor:
-        return PIIProcessor.create(self.config.model_dump(), self.metadata)
+        return create_pii_processor(self.metadata, self.config)
 
     def _get_sampler_processor(self) -> Processor:
         return SamplerProcessor.create(self.config.model_dump(), self.metadata)

--- a/ingestion/tests/unit/metadata/pii/test_classifiers.py
+++ b/ingestion/tests/unit/metadata/pii/test_classifiers.py
@@ -1,0 +1,440 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Unit tests for PII classifiers
+"""
+import uuid
+from unittest.mock import Mock
+
+import pytest
+from presidio_analyzer.nlp_engine import NlpEngine
+
+from metadata.generated.schema.entity.classification.tag import Tag
+from metadata.generated.schema.entity.data.table import Column, ColumnName, DataType
+from metadata.generated.schema.type.patternRecognizer import PatternRecognizer
+from metadata.generated.schema.type.piiEntity import PIIEntity
+from metadata.generated.schema.type.recognizer import (
+    Recognizer,
+    RecognizerConfig,
+    RecognizerException,
+    Target,
+)
+from metadata.generated.schema.type.recognizers.patterns import Pattern
+from metadata.generated.schema.type.recognizers.regexFlags import RegexFlags
+from metadata.pii.algorithms.classifiers import TagClassifier
+from metadata.pii.tag_analyzer import TagAnalyzer
+
+
+class TestTagClassifier:
+    """Test the TagClassifier with TagAnalyzers"""
+
+    @pytest.fixture
+    def nlp_engine(self):
+        """Create NLP engine for testing"""
+        return Mock(spec=NlpEngine)
+
+    @pytest.fixture
+    def column_to_ignore(self) -> Column:
+        return Column(
+            name=ColumnName(root="ignore_column"),
+            displayName="Ignore this column",
+            dataType=DataType.STRING,
+            fullyQualifiedName="test.table.ignore_column",
+        )
+
+    @pytest.fixture
+    def column_to_analyze(self) -> Column:
+        return Column(
+            name=ColumnName(root="analyze_column"),
+            displayName="Analyze this column",
+            dataType=DataType.STRING,
+            fullyQualifiedName="test.table.analyze_column",
+        )
+
+    @pytest.fixture
+    def email_tag(self, column_to_ignore: Column) -> Tag:
+        """Create email tag for testing"""
+        return Tag(
+            id=uuid.uuid4(),
+            name="EmailTag",
+            fullyQualifiedName="PII.EmailTag",
+            description="Tag for email addresses",
+            autoClassificationEnabled=True,
+            recognizers=[
+                Recognizer(
+                    id=uuid.uuid4(),
+                    name="EmailRecognizer",
+                    description="Recognizes email addresses",
+                    recognizerConfig=RecognizerConfig(
+                        root=PatternRecognizer(
+                            type="pattern",
+                            patterns=[
+                                Pattern(
+                                    name="Email pattern",
+                                    regex="[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}",
+                                    score=0.9,
+                                )
+                            ],
+                            supportedEntity=PIIEntity.EMAIL_ADDRESS,
+                            regexFlags=RegexFlags(),
+                            context=[],
+                            supportedLanguage="en",
+                        ),
+                    ),
+                    confidenceThreshold=0.7,
+                    exceptionList=[
+                        RecognizerException(
+                            entityLink="<#E::table::test.table::columns::ignore_column>",
+                            reason="Not my style",
+                        )
+                    ],
+                    target=Target.content,
+                ),
+                Recognizer(
+                    id=uuid.uuid4(),
+                    name="EmailColumnNameRecognizer",
+                    description="Recognizes email address columns",
+                    recognizerConfig=RecognizerConfig(
+                        root=PatternRecognizer(
+                            type="pattern",
+                            patterns=[
+                                Pattern(
+                                    name="Email pattern",
+                                    regex="^email_address$",
+                                    score=0.9,
+                                )
+                            ],
+                            supportedEntity=PIIEntity.EMAIL_ADDRESS,
+                            regexFlags=RegexFlags(),
+                            context=[],
+                            supportedLanguage="en",
+                        ),
+                    ),
+                    confidenceThreshold=0.7,
+                    exceptionList=[],
+                    target=Target.column_name,
+                ),
+            ],
+        )
+
+    @pytest.fixture
+    def phone_tag(self) -> Tag:
+        """Create phone tag for testing"""
+        return Tag(
+            id=uuid.uuid4(),
+            name="PhoneTag",
+            fullyQualifiedName="PII.PhoneTag",
+            description="Tag for phone numbers",
+            autoClassificationEnabled=True,
+            recognizers=[
+                Recognizer(
+                    id=uuid.uuid4(),
+                    name="PhoneRecognizer",
+                    description="Recognizes phone numbers",
+                    recognizerConfig=RecognizerConfig(
+                        root=PatternRecognizer(
+                            type="pattern",
+                            patterns=[
+                                Pattern(
+                                    name="US Phone pattern",
+                                    regex="\\b\\d{3}[-.]?\\d{3}[-.]?\\d{4}\\b",
+                                    score=0.85,
+                                )
+                            ],
+                            supportedEntity=PIIEntity.PHONE_NUMBER,
+                            regexFlags=RegexFlags(),
+                            context=[],
+                            supportedLanguage="en",
+                        ),
+                    ),
+                    confidenceThreshold=0.6,
+                    exceptionList=[],
+                    target=Target.content,
+                )
+            ],
+        )
+
+    @pytest.fixture
+    def tag_analyzers(self, email_tag, phone_tag, column_to_analyze, nlp_engine):
+        """Create tag analyzers for testing"""
+        return [
+            TagAnalyzer(tag=email_tag, column=column_to_analyze, nlp_engine=nlp_engine),
+            TagAnalyzer(tag=phone_tag, column=column_to_analyze, nlp_engine=nlp_engine),
+        ]
+
+    @pytest.fixture
+    def classifier(self, tag_analyzers):
+        """Create a TagClassifier instance with tag analyzers"""
+        return TagClassifier(
+            tag_analyzers=tag_analyzers,
+            column_name_contribution=0.5,
+            score_cutoff=0.1,
+            relative_cardinality_cutoff=0.01,
+        )
+
+    def test_classify_email_with_tag_analyzer(self, classifier, email_tag):
+        """Test classification with email data using TagAnalyzer"""
+        sample_data = [
+            "john.doe@example.com",
+            "jane.smith@test.org",
+            "bob@company.co.uk",
+        ]
+
+        scores = classifier.predict_scores(sample_data, column_name="customer_email")
+
+        # Should detect emails through tag analyzer
+        assert "PII.EmailTag" in scores
+        assert scores["PII.EmailTag"] > 0.5
+
+    def test_classify_phone_with_tag_analyzer(self, classifier, phone_tag):
+        """Test classification with phone data using TagAnalyzer"""
+        sample_data = ["555-123-4567", "555.987.6543", "5551234567"]
+
+        scores = classifier.predict_scores(sample_data, column_name="contact_phone")
+
+        # Should detect phones through tag analyzer
+        assert "PII.PhoneTag" in scores
+        assert scores["PII.PhoneTag"] > 0.5
+
+    def test_empty_data_returns_empty(self, classifier):
+        """Test that empty data returns empty scores"""
+        scores = classifier.predict_scores([])
+        assert scores == {}
+
+    def test_low_cardinality_returns_empty(self, classifier):
+        """Test that low cardinality data returns empty scores"""
+        sample_data = ["same_value"] * 100
+        scores = classifier.predict_scores(sample_data)
+        assert scores == {}
+
+    def test_mixed_data_detection(self, classifier):
+        """Test detection of mixed PII types"""
+        sample_data = [
+            "Contact John at john@example.com",
+            "Call Jane at 555-123-4567",
+            "Email support@company.org or call 555.987.6543",
+        ]
+
+        scores = classifier.predict_scores(sample_data, column_name="contact_info")
+
+        # Should detect patterns through tag analyzers
+        assert len(scores) > 0
+
+    def test_score_cutoff_filtering(self, tag_analyzers):
+        """Test that scores below cutoff are filtered"""
+        # Create a classifier with high cutoff
+        high_cutoff_classifier = TagClassifier(
+            tag_analyzers=tag_analyzers,
+            column_name_contribution=0.5,
+            score_cutoff=0.95,  # Very high cutoff
+            relative_cardinality_cutoff=0.01,
+        )
+
+        sample_data = ["maybe an email@somewhere", "could be phone 123456"]
+        scores = high_cutoff_classifier.predict_scores(sample_data, column_name="data")
+
+        # With such a high cutoff, weak matches should be filtered
+        assert len(scores) == 0 or all(score >= 0.95 for score in scores.values())
+
+    def test_column_name_contribution(self, classifier):
+        """Test that column name contributes to score"""
+        email_data = ["user1@domain.com", "user2@domain.org"]
+
+        # First without column name match
+        scores_without = classifier.predict_scores(
+            email_data, column_name="random_field"
+        )
+
+        # Then with column name that matches email pattern
+        scores_with = classifier.predict_scores(email_data, column_name="email_address")
+
+        # Email tag should have higher score when column name matches
+        if "PII.EmailTag" in scores_with and "PII.EmailTag" in scores_without:
+            assert scores_with["PII.EmailTag"] >= scores_without["PII.EmailTag"]
+
+
+class TestTagAnalyzer:
+    """Test the TagAnalyzer class"""
+
+    @pytest.fixture
+    def nlp_engine(self):
+        """Create NLP engine for testing"""
+        return Mock(spec=NlpEngine)
+
+    @pytest.fixture
+    def column(self) -> Column:
+        return Column(
+            name=ColumnName(root="test_column"),
+            displayName="Test Column",
+            dataType=DataType.STRING,
+            fullyQualifiedName="test.table.test_column",
+        )
+
+    @pytest.fixture
+    def email_tag(self) -> Tag:
+        """Create email tag for testing"""
+        return Tag(
+            id=uuid.uuid4(),
+            name="EmailTag",
+            fullyQualifiedName="PII.EmailTag",
+            description="Tag for email addresses",
+            autoClassificationEnabled=True,
+            recognizers=[
+                Recognizer(
+                    id=uuid.uuid4(),
+                    name="EmailRecognizer",
+                    description="Recognizes email addresses",
+                    recognizerConfig=RecognizerConfig(
+                        root=PatternRecognizer(
+                            type="pattern",
+                            patterns=[
+                                Pattern(
+                                    name="Email pattern",
+                                    regex="[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}",
+                                    score=0.9,
+                                )
+                            ],
+                            supportedEntity=PIIEntity.EMAIL_ADDRESS,
+                            regexFlags=RegexFlags(),
+                            context=[],
+                            supportedLanguage="en",
+                        ),
+                    ),
+                    confidenceThreshold=0.7,
+                    exceptionList=[],
+                    target=Target.content,
+                )
+            ],
+        )
+
+    @pytest.fixture
+    def tag_analyzer(self, email_tag, column, nlp_engine):
+        """Create a TagAnalyzer instance"""
+        return TagAnalyzer(tag=email_tag, column=column, nlp_engine=nlp_engine)
+
+    def test_analyze_content_with_emails(self, tag_analyzer):
+        """Test content analysis with email data"""
+        values = ["john@example.com", "jane@test.org", "bob@company.co.uk"]
+        score = tag_analyzer.analyze_content(values)
+        assert score > 0.8
+
+    def test_analyze_content_no_match(self, tag_analyzer):
+        """Test content analysis with non-matching data"""
+        values = ["random text", "no patterns here", "just words"]
+        score = tag_analyzer.analyze_content(values)
+        assert score == 0.0
+
+    def test_analyze_column_name(self, email_tag, nlp_engine):
+        """Test column name analysis"""
+        # Create column with email-related name
+        column = Column(
+            name=ColumnName(root="email_address"),
+            displayName="Email Address",
+            dataType=DataType.STRING,
+            fullyQualifiedName="test.table.email_address",
+        )
+
+        # Add column name recognizer to tag
+        email_tag.recognizers.append(
+            Recognizer(
+                id=uuid.uuid4(),
+                name="EmailColumnRecognizer",
+                description="Recognizes email columns",
+                recognizerConfig=RecognizerConfig(
+                    root=PatternRecognizer(
+                        type="pattern",
+                        patterns=[
+                            Pattern(
+                                name="Email column pattern",
+                                regex=".*email.*",
+                                score=0.8,
+                            )
+                        ],
+                        supportedEntity=PIIEntity.EMAIL_ADDRESS,
+                        regexFlags=RegexFlags(ignoreCase=True),
+                        context=[],
+                        supportedLanguage="en",
+                    ),
+                ),
+                confidenceThreshold=0.6,
+                exceptionList=[],
+                target=Target.column_name,
+            )
+        )
+
+        analyzer = TagAnalyzer(tag=email_tag, column=column, nlp_engine=nlp_engine)
+        score = analyzer.analyze_column()
+        assert score > 0.5
+
+    def test_get_recognizers_by_target(self, tag_analyzer, email_tag):
+        """Test getting recognizers by target"""
+        content_recognizers = tag_analyzer.get_recognizers_by(Target.content)
+        assert len(content_recognizers) == 1
+
+        column_recognizers = tag_analyzer.get_recognizers_by(Target.column_name)
+        assert (
+            len(column_recognizers) == 0
+        )  # No column name recognizers in base fixture
+
+    def test_disabled_auto_classification(self, column, nlp_engine):
+        """Test that disabled auto-classification returns no recognizers"""
+        tag = Tag(
+            id=uuid.uuid4(),
+            name="DisabledTag",
+            fullyQualifiedName="Test.DisabledTag",
+            description="Tag with disabled auto-classification",
+            autoClassificationEnabled=False,
+            recognizers=[
+                Recognizer(
+                    id=uuid.uuid4(),
+                    name="TestRecognizer",
+                    description="Should not be used",
+                    recognizerConfig=RecognizerConfig(
+                        root=PatternRecognizer(
+                            type="pattern",
+                            patterns=[Pattern(name="test", regex=".*", score=1.0)],
+                            supportedEntity=PIIEntity.EMAIL_ADDRESS,
+                            regexFlags=RegexFlags(),
+                            context=[],
+                            supportedLanguage="en",
+                        ),
+                    ),
+                    target=Target.content,
+                )
+            ],
+        )
+
+        analyzer = TagAnalyzer(tag=tag, column=column, nlp_engine=nlp_engine)
+        recognizers = analyzer.get_recognizers_by(Target.content)
+        assert len(recognizers) == 0
+
+    def test_exception_list_filtering(self, email_tag, nlp_engine):
+        """Test that columns in exception list are filtered"""
+        column = Column(
+            name=ColumnName(root="ignored_column"),
+            displayName="Ignored Column",
+            dataType=DataType.STRING,
+            fullyQualifiedName="test.table.ignored_column",
+        )
+
+        # Add column to exception list
+        email_tag.recognizers[0].exceptionList = [
+            RecognizerException(
+                entityLink="<#E::table::test.table::columns::ignored_column>",
+                reason="Test exception",
+            )
+        ]
+
+        analyzer = TagAnalyzer(tag=email_tag, column=column, nlp_engine=nlp_engine)
+        assert (
+            analyzer.should_skip_recognizer(email_tag.recognizers[0].exceptionList)
+            is True
+        )

--- a/ingestion/tests/unit/metadata/pii/test_presidio_utils.py
+++ b/ingestion/tests/unit/metadata/pii/test_presidio_utils.py
@@ -1,0 +1,112 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Unit tests for Presidio utilities
+"""
+from unittest.mock import Mock, patch
+
+from presidio_analyzer import AnalyzerEngine
+from presidio_analyzer import PatternRecognizer as PresidioPatternRecognizer
+from presidio_analyzer.nlp_engine import SpacyNlpEngine
+
+from metadata.pii.algorithms.presidio_utils import (
+    build_analyzer_engine,
+    load_nlp_engine,
+)
+from metadata.pii.constants import SPACY_EN_MODEL, SUPPORTED_LANG
+
+
+class TestSpacyModelLoading:
+    """Test spacy model loading functions"""
+
+    @patch("metadata.pii.algorithms.presidio_utils._load_spacy_model")
+    @patch("metadata.pii.algorithms.presidio_utils.SpacyNlpEngine")
+    def test_load_nlp_engine(self, mock_nlp_engine_cls, mock_load_spacy):
+        """Test loading NLP engine"""
+        mock_engine = Mock(spec=SpacyNlpEngine)
+        mock_nlp_engine_cls.return_value = mock_engine
+
+        result = load_nlp_engine(SPACY_EN_MODEL, SUPPORTED_LANG)
+
+        mock_load_spacy.assert_called_once_with(SPACY_EN_MODEL)
+        mock_nlp_engine_cls.assert_called_once_with(
+            models=[{"lang_code": SUPPORTED_LANG, "model": SPACY_EN_MODEL}]
+        )
+        assert result == mock_engine
+
+
+class TestAnalyzerEngine:
+    """Test analyzer engine building"""
+
+    @patch("metadata.pii.algorithms.presidio_utils._get_all_pattern_recognizers")
+    @patch("metadata.pii.algorithms.presidio_utils.load_nlp_engine")
+    def test_build_analyzer_engine(self, mock_load_nlp, mock_get_recognizers):
+        """Test building analyzer engine"""
+        # Mock NLP engine
+        mock_nlp_engine = Mock(spec=SpacyNlpEngine)
+        mock_load_nlp.return_value = mock_nlp_engine
+
+        # Mock recognizers
+        mock_recognizer1 = Mock(spec=PresidioPatternRecognizer)
+        mock_recognizer1.supported_language = "other"
+        mock_recognizer2 = Mock(spec=PresidioPatternRecognizer)
+        mock_recognizer2.supported_language = "other"
+        mock_get_recognizers.return_value = [mock_recognizer1, mock_recognizer2]
+
+        with patch(
+            "metadata.pii.algorithms.presidio_utils.AnalyzerEngine"
+        ) as mock_engine_cls:
+            mock_engine = Mock(spec=AnalyzerEngine)
+            mock_registry = Mock()
+            mock_engine.registry = mock_registry
+            mock_engine_cls.return_value = mock_engine
+
+            result = build_analyzer_engine(SPACY_EN_MODEL)
+
+            # Verify NLP engine was loaded
+            mock_load_nlp.assert_called_once_with(
+                model_name=SPACY_EN_MODEL, supported_language=SUPPORTED_LANG
+            )
+
+            # Verify analyzer engine was created
+            mock_engine_cls.assert_called_once_with(
+                nlp_engine=mock_nlp_engine, supported_languages=[SUPPORTED_LANG]
+            )
+
+            # Verify recognizers were added with correct language
+            assert mock_recognizer1.supported_language == SUPPORTED_LANG
+            assert mock_recognizer2.supported_language == SUPPORTED_LANG
+            assert mock_registry.add_recognizer.call_count == 2
+
+            assert result == mock_engine
+
+    @patch("metadata.pii.algorithms.presidio_utils._get_all_pattern_recognizers")
+    @patch("metadata.pii.algorithms.presidio_utils.load_nlp_engine")
+    def test_build_analyzer_engine_default_model(
+        self, mock_load_nlp, mock_get_recognizers
+    ):
+        """Test building analyzer engine with default model"""
+        mock_nlp_engine = Mock(spec=SpacyNlpEngine)
+        mock_load_nlp.return_value = mock_nlp_engine
+        mock_get_recognizers.return_value = []
+
+        with patch(
+            "metadata.pii.algorithms.presidio_utils.AnalyzerEngine"
+        ) as mock_engine_cls:
+            mock_engine = Mock(spec=AnalyzerEngine)
+            mock_engine.registry = Mock()
+            mock_engine_cls.return_value = mock_engine
+
+            result = build_analyzer_engine()
+
+            mock_load_nlp.assert_called_once_with(
+                model_name=SPACY_EN_MODEL, supported_language=SUPPORTED_LANG
+            )

--- a/ingestion/tests/unit/metadata/pii/test_presidio_utils.py
+++ b/ingestion/tests/unit/metadata/pii/test_presidio_utils.py
@@ -38,7 +38,7 @@ class TestSpacyModelLoading:
 
         mock_load_spacy.assert_called_once_with(SPACY_EN_MODEL)
         mock_nlp_engine_cls.assert_called_once_with(
-            models=[{"lang_code": SUPPORTED_LANG, "model": SPACY_EN_MODEL}]
+            models=[{"lang_code": SUPPORTED_LANG, "model_name": SPACY_EN_MODEL}]
         )
         assert result == mock_engine
 

--- a/ingestion/tests/unit/metadata/pii/test_tag_processor.py
+++ b/ingestion/tests/unit/metadata/pii/test_tag_processor.py
@@ -1,0 +1,632 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Unit tests for Tag Processor
+"""
+import uuid
+from typing import Generator
+from unittest.mock import Mock
+
+import pytest
+from presidio_analyzer.nlp_engine import NlpEngine
+
+from metadata.generated.schema.entity.classification.tag import Tag
+from metadata.generated.schema.entity.data.table import Column, ColumnName, DataType
+from metadata.generated.schema.entity.services.connections.metadata.openMetadataConnection import (
+    OpenMetadataConnection,
+)
+from metadata.generated.schema.metadataIngestion.databaseServiceAutoClassificationPipeline import (
+    DatabaseServiceAutoClassificationPipeline,
+)
+from metadata.generated.schema.metadataIngestion.workflow import (
+    OpenMetadataWorkflowConfig,
+    Source,
+    SourceConfig,
+    WorkflowConfig,
+)
+from metadata.generated.schema.security.client.openMetadataJWTClientConfig import (
+    OpenMetadataJWTClientConfig,
+)
+from metadata.generated.schema.type.patternRecognizer import PatternRecognizer
+from metadata.generated.schema.type.piiEntity import PIIEntity
+from metadata.generated.schema.type.recognizer import (
+    Recognizer,
+    RecognizerConfig,
+    RecognizerException,
+    Target,
+)
+from metadata.generated.schema.type.recognizers.patterns import Pattern
+from metadata.generated.schema.type.recognizers.regexFlags import RegexFlags
+from metadata.generated.schema.type.tagLabel import (
+    LabelType,
+    State,
+    TagLabel,
+    TagSource,
+)
+from metadata.ingestion.ometa.ometa_api import OpenMetadata
+from metadata.pii.algorithms.presidio_utils import load_nlp_engine
+from metadata.pii.tag_analyzer import TagAnalyzer
+from metadata.pii.tag_processor import TagAnalyzerGenerator, TagProcessor
+
+
+class TestTagAnalyzerGenerator:
+    """Test the TagAnalyzerGenerator class"""
+
+    @pytest.fixture
+    def nlp_engine(self):
+        """Create NLP engine for testing"""
+        return load_nlp_engine()
+
+    @pytest.fixture
+    def mock_metadata(self):
+        """Create mock metadata client"""
+        metadata = Mock(spec=OpenMetadata)
+        return metadata
+
+    @pytest.fixture
+    def email_tag(self) -> Tag:
+        """Create email tag for testing"""
+        return Tag(
+            id=uuid.uuid4(),
+            name="EmailTag",
+            fullyQualifiedName="PII.EmailTag",
+            description="Tag for email addresses",
+            autoClassificationEnabled=True,
+            recognizers=[
+                Recognizer(
+                    id=uuid.uuid4(),
+                    name="EmailRecognizer",
+                    description="Recognizes email addresses",
+                    recognizerConfig=RecognizerConfig(
+                        root=PatternRecognizer(
+                            type="pattern",
+                            patterns=[
+                                Pattern(
+                                    name="Email pattern",
+                                    regex="[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}",
+                                    score=0.9,
+                                )
+                            ],
+                            supportedEntity=PIIEntity.EMAIL_ADDRESS,
+                            regexFlags=RegexFlags(),
+                            context=[],
+                            supportedLanguage="en",
+                        ),
+                    ),
+                    confidenceThreshold=0.7,
+                    exceptionList=[],
+                    target=Target.content,
+                )
+            ],
+        )
+
+    @pytest.fixture
+    def generator(self, mock_metadata, nlp_engine, email_tag):
+        """Create TagAnalyzerGenerator instance"""
+        mock_metadata.list_all_entities.return_value = [email_tag]
+        return TagAnalyzerGenerator(metadata=mock_metadata, nlp_engine=nlp_engine)
+
+    def test_tags_property_caching(self, generator, email_tag):
+        """Test that tags are fetched once and cached"""
+        # First access
+        tags1 = generator.tags
+        assert len(tags1) == 1
+        assert tags1[0].fullyQualifiedName == "PII.EmailTag"
+
+        # Second access should use cache
+        tags2 = generator.tags
+        assert tags1 is tags2
+
+        # list_all_entities should only be called once
+        generator.metadata.list_all_entities.assert_called_once()
+
+    def test_call_generates_tag_analyzers(self, generator, email_tag):
+        """Test that calling generator produces TagAnalyzer instances"""
+        column = Column(
+            name=ColumnName(root="test_column"),
+            displayName="Test Column",
+            dataType=DataType.STRING,
+            fullyQualifiedName="test.table.test_column",
+        )
+
+        analyzers = list(generator(column))
+        assert len(analyzers) == 1
+        assert isinstance(analyzers[0], TagAnalyzer)
+        assert analyzers[0].tag.fullyQualifiedName == "PII.EmailTag"
+        assert analyzers[0]._column.name.root == "test_column"
+
+
+class TestTagProcessor:
+    """Test the TagProcessor class"""
+
+    @pytest.fixture
+    def workflow_config(self):
+        """Create workflow configuration"""
+        server_config = OpenMetadataConnection(
+            hostPort="http://localhost:8585/api",
+            authProvider="openmetadata",
+            securityConfig=OpenMetadataJWTClientConfig(jwtToken="test_token"),
+        )
+
+        return OpenMetadataWorkflowConfig(
+            source=Source(
+                type="mysql",
+                serviceName="test",
+                sourceConfig=SourceConfig(
+                    config=DatabaseServiceAutoClassificationPipeline(
+                        confidence=85,
+                        enableAutoClassification=True,
+                    )
+                ),
+            ),
+            workflowConfig=WorkflowConfig(openMetadataServerConfig=server_config),
+        )
+
+    @pytest.fixture
+    def email_tag(self):
+        """Create an email tag for testing"""
+        return Tag(
+            id=uuid.uuid4(),
+            name="EmailTag",
+            fullyQualifiedName="PII.EmailTag",
+            description="Tag for email addresses",
+            autoClassificationEnabled=True,
+            recognizers=[
+                Recognizer(
+                    id=uuid.uuid4(),
+                    name="EmailRecognizer",
+                    description="Recognizes email addresses",
+                    recognizerConfig=RecognizerConfig(
+                        root=PatternRecognizer(
+                            type="pattern",
+                            patterns=[
+                                Pattern(
+                                    name="Email pattern",
+                                    regex="[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}",
+                                    score=0.95,
+                                )
+                            ],
+                            supportedEntity=PIIEntity.EMAIL_ADDRESS,
+                            regexFlags=RegexFlags(),
+                            context=[],
+                            supportedLanguage="en",
+                        ),
+                    ),
+                    confidenceThreshold=0.8,
+                    exceptionList=[],
+                    target=Target.content,
+                ),
+            ],
+        )
+
+    @pytest.fixture
+    def phone_tag(self):
+        """Create a phone tag for testing"""
+        return Tag(
+            id=uuid.uuid4(),
+            name="PhoneTag",
+            fullyQualifiedName="PII.PhoneTag",
+            description="Tag for phone numbers",
+            autoClassificationEnabled=True,
+            recognizers=[
+                Recognizer(
+                    id=uuid.uuid4(),
+                    name="PhoneRecognizer",
+                    description="Recognizes phone numbers",
+                    recognizerConfig=RecognizerConfig(
+                        root=PatternRecognizer(
+                            type="pattern",
+                            patterns=[
+                                Pattern(
+                                    name="US Phone pattern",
+                                    regex="\\b\\d{3}[-.]?\\d{3}[-.]?\\d{4}\\b",
+                                    score=0.85,
+                                )
+                            ],
+                            supportedEntity=PIIEntity.PHONE_NUMBER,
+                            regexFlags=RegexFlags(),
+                            context=[],
+                            supportedLanguage="en",
+                        ),
+                    ),
+                    confidenceThreshold=0.6,
+                    exceptionList=[],
+                    target=Target.content,
+                )
+            ],
+        )
+
+    @pytest.fixture
+    def mock_metadata(self):
+        """Create mock metadata client"""
+        metadata = Mock(spec=OpenMetadata)
+        return metadata
+
+    @pytest.fixture
+    def nlp_engine(self):
+        """Create mock NLP engine client"""
+        nlp_engine = Mock(spec=NlpEngine)
+        return nlp_engine
+
+    @pytest.fixture
+    def tag_analyzer_generator(self, email_tag, phone_tag, mock_metadata, nlp_engine):
+        """Create a function that generates TagAnalyzers"""
+        mock_metadata.list_all_entities.return_value = [email_tag, phone_tag]
+
+        return TagAnalyzerGenerator(
+            metadata=mock_metadata,
+            nlp_engine=nlp_engine,
+        )
+
+    @pytest.fixture
+    def processor(self, workflow_config, mock_metadata, tag_analyzer_generator):
+        """Create TagProcessor instance"""
+        return TagProcessor(
+            config=workflow_config,
+            metadata=mock_metadata,
+            generate_tag_analyzers=tag_analyzer_generator,
+        )
+
+    def test_build_tag_label(self):
+        """Test building a tag label"""
+        tag_label = TagProcessor.build_tag_label("PII.EmailTag")
+
+        assert isinstance(tag_label, TagLabel)
+        assert tag_label.tagFQN.root == "PII.EmailTag"
+        assert tag_label.source is TagSource.Classification
+        assert tag_label.state is State.Suggested
+        assert tag_label.labelType is LabelType.Generated
+
+    def test_skip_column_with_existing_pii_tag(self, processor):
+        """Test that columns with existing PII tags are skipped"""
+        # Create column with existing PII tag
+        column = Column(
+            name=ColumnName(root="customer_email"),
+            dataType=DataType.VARCHAR,
+            tags=[
+                TagLabel(
+                    tagFQN="PII.SomeTag",
+                    state=State.Confirmed,
+                    source=TagSource.Classification,
+                    labelType=LabelType.Manual,
+                )
+            ],
+        )
+
+        sample_data = ["john@example.com", "jane@test.com", "bob@domain.org"]
+
+        # Should return empty list because PII tag exists
+        result = processor.create_column_tag_labels(column, sample_data)
+        assert result == []
+
+    def test_classify_email_column(self, processor, email_tag):
+        """Test classifying an email column"""
+        column = Column(
+            name=ColumnName(root="customer_email"),
+            dataType=DataType.VARCHAR,
+            fullyQualifiedName="test.table.customer_email",
+        )
+
+        # Real email data
+        sample_data = [
+            "john.doe@example.com",
+            "jane.smith@company.org",
+            "bob.wilson@test.net",
+        ]
+
+        result = processor.create_column_tag_labels(column, sample_data)
+
+        # Should detect email tag
+        assert len(result) == 1
+        assert isinstance(result[0], TagLabel)
+        assert result[0].tagFQN.root == "PII.EmailTag"
+        assert result[0].state is State.Suggested
+        assert result[0].labelType is LabelType.Generated
+
+    def test_classify_phone_column(self, processor, phone_tag):
+        """Test classifying a phone number column"""
+        column = Column(
+            name=ColumnName(root="phone_number"),
+            dataType=DataType.VARCHAR,
+            fullyQualifiedName="test.table.phone_number",
+        )
+
+        # Real phone number data
+        sample_data = ["555-123-4567", "555.987.6543", "5551234567"]
+
+        result = processor.create_column_tag_labels(column, sample_data)
+
+        # Should detect phone tag
+        assert len(result) == 1
+        assert result[0].tagFQN.root == "PII.PhoneTag"
+
+    def test_no_classification_for_non_pii_data(self, processor):
+        """Test that non-PII data doesn't get classified"""
+        column = Column(
+            name=ColumnName(root="product_id"),
+            dataType=DataType.VARCHAR,
+            fullyQualifiedName="test.table.product_id",
+        )
+
+        # Non-PII data
+        sample_data = ["PROD-001", "PROD-002", "PROD-003"]
+
+        result = processor.create_column_tag_labels(column, sample_data)
+
+        # Should return empty list - no PII detected
+        assert result == []
+
+    def test_mixed_pii_data_chooses_highest_confidence(
+        self, processor, workflow_config, mock_metadata, nlp_engine
+    ):
+        """Test when data contains multiple PII types, highest confidence wins"""
+        # Create tags for mixed PII
+        mixed_tag = Tag(
+            id=uuid.uuid4(),
+            name="MixedTag",
+            fullyQualifiedName="PII.MixedTag",
+            description="Tag for mixed PII",
+            autoClassificationEnabled=True,
+            recognizers=[
+                Recognizer(
+                    id=uuid.uuid4(),
+                    name="MixedRecognizer",
+                    description="Recognizes multiple PII types",
+                    recognizerConfig=RecognizerConfig(
+                        root=PatternRecognizer(
+                            type="pattern",
+                            patterns=[
+                                Pattern(
+                                    name="Email pattern",
+                                    regex="[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}",
+                                    score=0.95,
+                                ),
+                                Pattern(
+                                    name="Name pattern",
+                                    regex="\\b[A-Z][a-z]+ [A-Z][a-z]+\\b",
+                                    score=0.85,
+                                ),
+                            ],
+                            supportedEntity=PIIEntity.EMAIL_ADDRESS,
+                            regexFlags=RegexFlags(),
+                            context=[],
+                            supportedLanguage="en",
+                        ),
+                    ),
+                    confidenceThreshold=0.7,
+                    exceptionList=[],
+                    target=Target.content,
+                )
+            ],
+        )
+
+        def generate_analyzers(column: Column) -> Generator[TagAnalyzer, None, None]:
+            yield TagAnalyzer(tag=mixed_tag, column=column, nlp_engine=nlp_engine)
+
+        processor_with_mixed = TagProcessor(
+            config=workflow_config,
+            metadata=mock_metadata,
+            generate_tag_analyzers=generate_analyzers,
+        )
+
+        column = Column(
+            name=ColumnName(root="user_info"),
+            dataType=DataType.VARCHAR,
+            fullyQualifiedName="test.table.user_info",
+        )
+
+        # Mixed PII data (emails and names)
+        sample_data = [
+            "John Doe - john@example.com",
+            "Jane Smith - jane@test.org",
+            "Bob Wilson - bob@company.net",
+        ]
+
+        result = processor_with_mixed.create_column_tag_labels(column, sample_data)
+
+        # Should detect mixed PII
+        assert len(result) == 1
+        assert result[0].tagFQN.root == "PII.MixedTag"
+
+    def test_column_with_non_pii_tag_still_gets_pii_classification(self, processor):
+        """Test that columns with non-PII tags can still get PII classification"""
+        # Column already has a data quality tag but contains PII
+        column = Column(
+            name=ColumnName(root="customer_email"),
+            dataType=DataType.VARCHAR,
+            fullyQualifiedName="test.table.customer_email",
+            tags=[
+                TagLabel(
+                    tagFQN="DataQuality.ValidatedEmail",
+                    source=TagSource.Classification,
+                    state=State.Confirmed,
+                    labelType=LabelType.Manual,
+                )
+            ],
+        )
+
+        sample_data = [
+            "customer1@example.com",
+            "customer2@test.org",
+            "customer3@company.net",
+        ]
+
+        result = processor.create_column_tag_labels(column, sample_data)
+
+        # Should add PII tag even though other tags exist
+        assert len(result) == 1
+        assert result[0].tagFQN.root == "PII.EmailTag"
+
+    def test_ssn_classification_with_custom_analyzer(
+        self, workflow_config, mock_metadata, nlp_engine
+    ):
+        """Test SSN classification with a custom tag analyzer"""
+        ssn_tag = Tag(
+            id=uuid.uuid4(),
+            name="SSNTag",
+            fullyQualifiedName="PII.SSNTag",
+            description="Tag for SSN",
+            autoClassificationEnabled=True,
+            recognizers=[
+                Recognizer(
+                    id=uuid.uuid4(),
+                    name="SSNRecognizer",
+                    description="Recognizes SSN",
+                    recognizerConfig=RecognizerConfig(
+                        root=PatternRecognizer(
+                            type="pattern",
+                            patterns=[
+                                Pattern(
+                                    name="SSN pattern",
+                                    regex="\\b\\d{3}-\\d{2}-\\d{4}\\b",
+                                    score=0.98,
+                                )
+                            ],
+                            supportedEntity=PIIEntity.US_SSN,
+                            regexFlags=RegexFlags(),
+                            context=[],
+                            supportedLanguage="en",
+                        ),
+                    ),
+                    confidenceThreshold=0.9,
+                    exceptionList=[],
+                    target=Target.content,
+                )
+            ],
+        )
+
+        def generate_ssn_analyzer(column: Column) -> Generator[TagAnalyzer, None, None]:
+            yield TagAnalyzer(tag=ssn_tag, column=column, nlp_engine=nlp_engine)
+
+        processor_with_ssn = TagProcessor(
+            config=workflow_config,
+            metadata=mock_metadata,
+            generate_tag_analyzers=generate_ssn_analyzer,
+        )
+
+        column = Column(
+            name=ColumnName(root="social_security_number"),
+            dataType=DataType.VARCHAR,
+            fullyQualifiedName="test.table.social_security_number",
+        )
+
+        sample_data = ["123-45-6789", "987-65-4321", "555-12-3456"]
+
+        result = processor_with_ssn.create_column_tag_labels(column, sample_data)
+
+        assert len(result) == 1
+        assert result[0].tagFQN.root == "PII.SSNTag"
+
+    @pytest.mark.parametrize(
+        "confidence,expected_threshold",
+        [
+            (90, 0.90),
+            (75, 0.75),
+            (100, 1.0),
+            (50, 0.50),
+        ],
+    )
+    def test_confidence_threshold_initialization(
+        self,
+        workflow_config,
+        mock_metadata,
+        tag_analyzer_generator,
+        confidence,
+        expected_threshold,
+    ):
+        """Test that confidence threshold is correctly initialized from config"""
+        workflow_config.source.sourceConfig.config.confidence = confidence
+
+        processor = TagProcessor(
+            config=workflow_config,
+            metadata=mock_metadata,
+            generate_tag_analyzers=tag_analyzer_generator,
+        )
+
+        assert processor.confidence_threshold == expected_threshold
+
+    @pytest.fixture
+    def email_tag_with_exception_list(self, email_tag: Tag) -> Tag:
+        return Tag(
+            id=uuid.uuid4(),
+            name="EmailTag",
+            fullyQualifiedName="PII.EmailTag",
+            description="Tag for email addresses",
+            autoClassificationEnabled=True,
+            recognizers=[
+                Recognizer(
+                    id=uuid.uuid4(),
+                    name="EmailRecognizer",
+                    description="Recognizes email addresses",
+                    recognizerConfig=r.recognizerConfig,
+                    confidenceThreshold=0.8,
+                    exceptionList=[
+                        RecognizerException(
+                            entityLink="<#E::table::test_db.test_schema.test_table::columns::test_column>",
+                            reason="It didn't work",
+                        )
+                    ],
+                    target=Target.content,
+                )
+                for r in email_tag.recognizers
+            ],
+        )
+
+    def test_it_skips_recognizers_with_exception_lists(
+        self,
+        workflow_config,
+        mock_metadata,
+        nlp_engine,
+        email_tag: Tag,
+        email_tag_with_exception_list: Tag,
+    ):
+        column = Column(
+            name=ColumnName(root="test_column"),
+            dataType=DataType.VARCHAR,
+            fullyQualifiedName="test_db.test_schema.test_table.test_column",
+        )
+
+        sample_data = [
+            "john@example.com",
+            "jane@test.org",
+            "bob@company.net",
+        ]
+
+        def generate_analyzers(column: Column) -> Generator[TagAnalyzer, None, None]:
+            yield TagAnalyzer(tag=email_tag, column=column, nlp_engine=nlp_engine)
+
+        processor_with_mixed = TagProcessor(
+            config=workflow_config,
+            metadata=mock_metadata,
+            generate_tag_analyzers=generate_analyzers,
+        )
+
+        result = processor_with_mixed.create_column_tag_labels(column, sample_data)
+
+        # Should detect Email PII
+        assert len(result) == 1
+        assert result[0].tagFQN.root == "PII.EmailTag"
+
+        def generate_analyzers(column: Column) -> Generator[TagAnalyzer, None, None]:
+            yield TagAnalyzer(
+                tag=email_tag_with_exception_list, column=column, nlp_engine=nlp_engine
+            )
+
+        processor_with_mixed = TagProcessor(
+            config=workflow_config,
+            metadata=mock_metadata,
+            generate_tag_analyzers=generate_analyzers,
+        )
+
+        result = processor_with_mixed.create_column_tag_labels(column, sample_data)
+
+        # Should not detect Email PII
+        assert len(result) == 0

--- a/ingestion/tests/unit/pii/algorithms/test_presidio_utils.py
+++ b/ingestion/tests/unit/pii/algorithms/test_presidio_utils.py
@@ -8,7 +8,14 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+from unittest.mock import Mock
+
+import pytest
+from presidio_analyzer import EntityRecognizer, RecognizerResult
+from presidio_analyzer.nlp_engine import NlpArtifacts
+
 from metadata.pii.algorithms.presidio_utils import (
+    apply_confidence_threshold,
     build_analyzer_engine,
     set_presidio_logger_level,
 )
@@ -29,3 +36,105 @@ def test_analyzer_supports_all_expected_pii_entities():
         f"Analyzer does not support all expected PII entities. "
         f"{entities - supported_entities}"
     )
+
+
+class TestApplyConfidenceThreshold:
+    """Test the apply_confidence_threshold function"""
+
+    @pytest.fixture
+    def mock_recognizer(self):
+        """Create a mock EntityRecognizer"""
+        recognizer = Mock(spec=EntityRecognizer)
+        recognizer.name = "test_recognizer"
+        recognizer.supported_entities = ["TEST_ENTITY"]
+        return recognizer
+
+    def test_filters_results_below_threshold(self, mock_recognizer):
+        """Test that results below threshold are filtered out"""
+        # Create mock results with varying confidence scores
+        mock_results = [
+            RecognizerResult(entity_type="TEST_ENTITY", start=0, end=5, score=0.9),
+            RecognizerResult(entity_type="TEST_ENTITY", start=10, end=15, score=0.5),
+            RecognizerResult(entity_type="TEST_ENTITY", start=20, end=25, score=0.3),
+        ]
+
+        mock_recognizer.analyze = Mock(return_value=mock_results)
+
+        # Apply threshold of 0.6
+        threshold = 0.6
+        decorator = apply_confidence_threshold(threshold)
+        decorated_recognizer = decorator(mock_recognizer)
+
+        # Test the decorated analyze method
+        nlp_artifacts = Mock(spec=NlpArtifacts)
+        results = decorated_recognizer.analyze(
+            "test text", ["TEST_ENTITY"], nlp_artifacts
+        )
+
+        # Should only return results with score >= 0.6
+        assert len(results) == 1
+        assert results[0].score == 0.9
+
+    def test_returns_all_results_above_threshold(self, mock_recognizer):
+        """Test that all results above threshold are kept"""
+        mock_results = [
+            RecognizerResult(entity_type="TEST_ENTITY", start=0, end=5, score=0.8),
+            RecognizerResult(entity_type="TEST_ENTITY", start=10, end=15, score=0.7),
+            RecognizerResult(entity_type="TEST_ENTITY", start=20, end=25, score=0.9),
+        ]
+
+        mock_recognizer.analyze = Mock(return_value=mock_results)
+
+        threshold = 0.65
+        decorator = apply_confidence_threshold(threshold)
+        decorated_recognizer = decorator(mock_recognizer)
+
+        nlp_artifacts = Mock(spec=NlpArtifacts)
+        results = decorated_recognizer.analyze(
+            "test text", ["TEST_ENTITY"], nlp_artifacts
+        )
+
+        # All results should be above threshold
+        assert len(results) == 3
+        assert all(r.score >= threshold for r in results)
+
+    def test_returns_empty_list_when_no_results_pass_threshold(self, mock_recognizer):
+        """Test that empty list is returned when no results pass threshold"""
+        mock_results = [
+            RecognizerResult(entity_type="TEST_ENTITY", start=0, end=5, score=0.3),
+            RecognizerResult(entity_type="TEST_ENTITY", start=10, end=15, score=0.2),
+        ]
+
+        mock_recognizer.analyze = Mock(return_value=mock_results)
+
+        threshold = 0.5
+        decorator = apply_confidence_threshold(threshold)
+        decorated_recognizer = decorator(mock_recognizer)
+
+        nlp_artifacts = Mock(spec=NlpArtifacts)
+        results = decorated_recognizer.analyze(
+            "test text", ["TEST_ENTITY"], nlp_artifacts
+        )
+
+        assert len(results) == 0
+
+    def test_threshold_of_zero_returns_all_results(self, mock_recognizer):
+        """Test that threshold of 0 returns all results"""
+        mock_results = [
+            RecognizerResult(entity_type="TEST_ENTITY", start=0, end=5, score=0.1),
+            RecognizerResult(entity_type="TEST_ENTITY", start=10, end=15, score=0.01),
+            RecognizerResult(entity_type="TEST_ENTITY", start=20, end=25, score=0.001),
+        ]
+
+        mock_recognizer.analyze = Mock(return_value=mock_results)
+
+        threshold = 0.0
+        decorator = apply_confidence_threshold(threshold)
+        decorated_recognizer = decorator(mock_recognizer)
+
+        nlp_artifacts = Mock(spec=NlpArtifacts)
+        results = decorated_recognizer.analyze(
+            "test text", ["TEST_ENTITY"], nlp_artifacts
+        )
+
+        assert len(results) == 3


### PR DESCRIPTION
### Describe your changes:

**Disclaimer**: publishing this PR as well because it seems like I removed the merge commit of #23446 into #23289 

I've added a new `TagProcessor` and downstream code required to use all tag recognizers from OM a build `presidio` recognizers, somewhat replacing the static configuration used in `PIIProcessor`.

I've added new test cases that describe the use case this PR includes.

This includes testing that PII tags configured with the appropriate recognizers are selected accordingly

#
### Type of change:
- [X] New feature

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [X] I have commented on my code, particularly in hard-to-understand areas.