### PR TITLE
Add default icons for domains and data product

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainForm.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainForm.component.tsx
@@ -36,6 +36,10 @@ import {
 } from '../../../utils/DomainUtils';
 import { generateFormFields, getField } from '../../../utils/formUtils';
 import { checkPermission } from '../../../utils/PermissionsUtils';
+import {
+  DEFAULT_DATA_PRODUCT_ICON,
+  DEFAULT_DOMAIN_ICON,
+} from '../../common/IconPicker';
 import '../domain.less';
 import { DomainFormType } from '../DomainPage.interface';
 import { AddDomainFormProps } from './AddDomainForm.interface';
@@ -74,6 +78,10 @@ const AddDomainForm = ({
       allowUrl: true,
       placeholder: t('label.icon-url'),
       backgroundColor: selectedColor,
+      defaultIcon:
+        type === DomainFormType.DATA_PRODUCT
+          ? DEFAULT_DATA_PRODUCT_ICON
+          : DEFAULT_DOMAIN_ICON,
     },
     formItemLayout: FormItemLayout.HORIZONTAL,
     formItemProps: {

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/IconPicker/IconPicker.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/IconPicker/IconPicker.constants.ts
@@ -56,7 +56,17 @@ import {
 } from '@untitledui/icons';
 import { IconDefinition } from './IconPicker.interface';
 
-export const DEFAULT_ICON = 'Cube01';
+export const DEFAULT_ICON_NAME = 'Cube01';
+export const DEFAULT_DOMAIN_ICON: IconDefinition = {
+  name: 'Globe01',
+  component: Globe01,
+  category: 'default',
+};
+export const DEFAULT_DATA_PRODUCT_ICON: IconDefinition = {
+  name: 'Cube01',
+  component: Cube01,
+  category: 'default',
+};
 
 export const AVAILABLE_ICONS: IconDefinition[] = [
   { name: 'Cube01', component: Cube01, category: 'default' },

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/IconPicker/IconPicker.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/IconPicker/IconPicker.interface.ts
@@ -37,4 +37,5 @@ export interface MUIIconPickerProps {
   allowUrl?: boolean;
   backgroundColor?: string;
   toolTip?: ReactNode;
+  defaultIcon?: IconDefinition;
 }

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/IconPicker/MUIIconPicker.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/IconPicker/MUIIconPicker.tsx
@@ -27,7 +27,7 @@ import { FC, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { renderIcon } from '../../../utils/IconUtils';
 import { useSearch } from '../atoms/navigation/useSearch';
-import { AVAILABLE_ICONS, DEFAULT_ICON } from './IconPicker.constants';
+import { AVAILABLE_ICONS, DEFAULT_ICON_NAME } from './IconPicker.constants';
 import {
   IconPickerTabValue,
   IconPickerValue,
@@ -42,6 +42,7 @@ const MUIIconPicker: FC<MUIIconPickerProps> = ({
   placeholder = 'Enter icon URL',
   value,
   toolTip,
+  defaultIcon,
   onChange,
 }) => {
   const theme = useTheme();
@@ -49,10 +50,11 @@ const MUIIconPicker: FC<MUIIconPickerProps> = ({
   const anchorRef = useRef<HTMLDivElement>(null);
   const [open, setOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
+  const resolvedIconName = defaultIcon?.name || DEFAULT_ICON_NAME;
 
   const parseValue = (val: string | IconPickerValue | undefined) => {
     if (!val) {
-      return { type: 'icons' as IconPickerTabValue, value: DEFAULT_ICON };
+      return { type: 'icons' as IconPickerTabValue, value: resolvedIconName };
     }
     if (typeof val === 'string') {
       if (val.startsWith('http') || val.startsWith('/')) {
@@ -241,7 +243,7 @@ const MUIIconPicker: FC<MUIIconPickerProps> = ({
                   </Box>
 
                   <Box
-                    aria-label={`Select icon ${DEFAULT_ICON}`}
+                    aria-label={`Select icon ${resolvedIconName}`}
                     role="button"
                     sx={{
                       position: 'relative',
@@ -255,7 +257,7 @@ const MUIIconPicker: FC<MUIIconPickerProps> = ({
                       transition: 'all 0.2s',
                       backgroundColor: 'transparent',
                       color:
-                        selectedIcon === DEFAULT_ICON
+                        selectedIcon === resolvedIconName
                           ? theme.palette.primary?.main
                           : theme.palette.grey?.[700],
                       '&:hover': {
@@ -264,14 +266,14 @@ const MUIIconPicker: FC<MUIIconPickerProps> = ({
                       mb: 2,
                     }}
                     tabIndex={0}
-                    onClick={() => handleIconSelect(DEFAULT_ICON)}
+                    onClick={() => handleIconSelect(resolvedIconName)}
                     onKeyDown={(e) => {
                       if (e.key === 'Enter' || e.key === ' ') {
                         e.preventDefault();
-                        handleIconSelect(DEFAULT_ICON);
+                        handleIconSelect(resolvedIconName);
                       }
                     }}>
-                    {AVAILABLE_ICONS[0].component({
+                    {(defaultIcon?.component || AVAILABLE_ICONS[0].component)({
                       size: 20,
                       style: { display: 'block', strokeWidth: 1.25 },
                     })}


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:
Updated default icon for Add domain and data product

|  <img width="642" height="634" alt="Screenshot 2025-09-30 at 5 09 34 PM" src="https://github.com/user-attachments/assets/a2ca8306-bf7e-4f3c-8f8c-1ac2bb632415" /> | <img width="642" height="634" alt="Screenshot 2025-09-30 at 5 09 43 PM" src="https://github.com/user-attachments/assets/22c19dd5-2d75-42c7-806c-c4c3334b3b40" /> |
|---|---|


<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
