### PR TITLE
Fixes 20036: bump sqlalchemy dep

### DIFF
--- a/ingestion/setup.py
+++ b/ingestion/setup.py
@@ -152,7 +152,7 @@ base_requirements = {
     "PyYAML~=6.0",
     "requests>=2.23",
     "requests-aws4auth~=1.1",  # Only depends on requests as external package. Leaving as base.
-    "sqlalchemy>=1.4.0,<2",
+    "sqlalchemy>=1.4.0,<3",
     "collate-sqllineage~=1.6.0",
     "tabulate==0.9.0",
     "typing-inspect",


### PR DESCRIPTION
### Describe your changes:

Fixes #20036

changed sqlalchemy dependency to allow v2 of the dependency. as noted in the issue, this is a relatively old release, and many other libraries depend on later versions of sqlalchemy.

#
### Type of change:
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
