### PR TITLE
fix: async search and tree lazy loading improvements

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainForm.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainForm.component.tsx
@@ -20,25 +20,25 @@ import { usePermissionProvider } from '../../../context/PermissionProvider/Permi
 import { ResourceEntity } from '../../../context/PermissionProvider/PermissionProvider.interface';
 import { CreateDataProduct } from '../../../generated/api/domains/createDataProduct';
 import {
-  CreateDomain,
-  DomainType,
+    CreateDomain,
+    DomainType
 } from '../../../generated/api/domains/createDomain';
 import { Operation } from '../../../generated/entity/policies/policy';
 import { EntityReference } from '../../../generated/entity/type';
 import {
-  FieldProp,
-  FieldTypes,
-  FormItemLayout,
+    FieldProp,
+    FieldTypes,
+    FormItemLayout
 } from '../../../interface/FormUtils.interface';
 import {
-  domainTypeTooltipDataRender,
-  iconTooltipDataRender,
+    domainTypeTooltipDataRender,
+    iconTooltipDataRender
 } from '../../../utils/DomainUtils';
 import { generateFormFields, getField } from '../../../utils/formUtils';
 import { checkPermission } from '../../../utils/PermissionsUtils';
 import {
-  DEFAULT_DATA_PRODUCT_ICON,
-  DEFAULT_DOMAIN_ICON,
+    DEFAULT_DATA_PRODUCT_ICON,
+    DEFAULT_DOMAIN_ICON
 } from '../../common/IconPicker';
 import '../domain.less';
 import { DomainFormType } from '../DomainPage.interface';
@@ -252,9 +252,6 @@ const AddDomainForm = ({
       multipleUser: true,
       multipleTeam: false,
       label: t('label.owner-plural'),
-      placeholder: t('label.select-field', {
-        field: t('label.user-or-team'),
-      }),
     },
     formItemProps: {
       valuePropName: 'value',
@@ -272,9 +269,6 @@ const AddDomainForm = ({
       userOnly: true,
       multipleUser: true,
       label: t('label.expert-plural'),
-      placeholder: t('label.select-field', {
-        field: t('label.user-plural'),
-      }),
     },
     formItemProps: {
       valuePropName: 'value',

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/MUITagSuggestion/MUITagSuggestion.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/MUITagSuggestion/MUITagSuggestion.tsx
@@ -15,13 +15,13 @@ import { Autocomplete, Box, TextField } from '@mui/material';
 import { debounce, isArray, isEmpty } from 'lodash';
 import { EntityTags } from 'Models';
 import {
-  FC,
-  ReactNode,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
+    FC,
+    ReactNode,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TagSource } from '../../../generated/entity/data/container';
@@ -59,15 +59,12 @@ const MUITagSuggestion: FC<MUITagSuggestionProps> = ({
   const [options, setOptions] = useState<TagOption[]>([]);
   const [loading, setLoading] = useState(false);
   const [inputValue, setInputValue] = useState('');
+  const [open, setOpen] = useState(false);
   const { t } = useTranslation();
 
   const searchDebounced = useRef(
     debounce(async (searchValue: string) => {
-      if (searchValue) {
-        await fetchOptions(searchValue);
-      } else {
-        setOptions([]);
-      }
+      await fetchOptions(searchValue);
     }, 250)
   ).current;
 
@@ -80,10 +77,22 @@ const MUITagSuggestion: FC<MUITagSuggestionProps> = ({
 
   // Handle input changes
   useEffect(() => {
-    if (inputValue.length >= 2) {
+    if (inputValue) {
+      setLoading(true);
       searchDebounced(inputValue);
+    } else {
+      setLoading(true);
+      setOptions([]);
+      searchDebounced('');
     }
   }, [inputValue]);
+
+  // Fetch initial options when dropdown opens
+  useEffect(() => {
+    if (open && options.length === 0 && !inputValue) {
+      searchDebounced('');
+    }
+  }, [open]);
 
   const fetchOptions = async (searchText: string) => {
     setLoading(true);
@@ -113,17 +122,18 @@ const MUITagSuggestion: FC<MUITagSuggestionProps> = ({
   );
 
   const handleChange = useCallback(
-    (event: React.SyntheticEvent, newValue: TagOption[], reason: string) => {
-      if (
-        event.type === 'keydown' &&
-        ((event as React.KeyboardEvent).key === 'Backspace' ||
-          (event as React.KeyboardEvent).key === 'Delete') &&
-        reason === 'removeOption'
-      ) {
-        return;
-      }
+    (
+      event: React.SyntheticEvent,
+      newValue: (TagOption | string)[],
+      reason: string
+    ) => {
       if (isArray(newValue)) {
-        const newTags: EntityTags[] = newValue.map((option) => {
+        // Filter out string values from freeSolo
+        const optionValues = newValue.filter(
+          (v): v is TagOption => typeof v !== 'string'
+        );
+
+        const newTags: EntityTags[] = optionValues.map((option) => {
           const existingTag = value.find((tag) => tag.tagFQN === option.value);
           if (existingTag) {
             return existingTag;
@@ -153,17 +163,30 @@ const MUITagSuggestion: FC<MUITagSuggestionProps> = ({
     }));
   }, [value]);
 
+  const memoizedOptions = useMemo(() => options, [options]);
+
   // Tag autocomplete
   return (
     <Autocomplete
       disableCloseOnSelect
+      freeSolo
       multiple
+      // Force listbox to remount when options change to fix async search not updating dropdown
+      // Using 'as any' because key is not in MUI's ListboxProps type definition
+      ListboxProps={
+        {
+          key: `listbox-${memoizedOptions.length}`,
+        } as any
+      }
       autoFocus={autoFocus}
-      getOptionLabel={(option: TagOption) => option.label}
+      getOptionLabel={(option: TagOption | string) =>
+        typeof option === 'string' ? option : option.label
+      }
       inputValue={inputValue}
       isOptionEqualToValue={(option, value) => option.value === value.value}
       loading={loading}
-      options={options}
+      open={open && (memoizedOptions.length > 0 || loading)}
+      options={memoizedOptions}
       renderInput={(params) => (
         <TextField
           {...params}
@@ -193,9 +216,9 @@ const MUITagSuggestion: FC<MUITagSuggestionProps> = ({
               sx={{ color: option.data?.style?.color || undefined }}>
               {option.label}
             </Box>
-            {option.data?.description && (
+            {(option.data?.displayName || option.data?.name) && (
               <Box color="text.secondary" fontSize="0.875rem">
-                {option.data.description}
+                {option.data?.displayName || option.data?.name}
               </Box>
             )}
           </Box>
@@ -218,7 +241,9 @@ const MUITagSuggestion: FC<MUITagSuggestionProps> = ({
       }
       value={selectedOptions}
       onChange={handleChange}
+      onClose={() => setOpen(false)}
       onInputChange={handleInputChange}
+      onOpen={() => setOpen(true)}
     />
   );
 };

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/MUIUserTeamSelect/MUIUserTeamSelect.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/MUIUserTeamSelect/MUIUserTeamSelect.tsx
@@ -23,12 +23,12 @@ import { SearchIndex } from '../../../enums/search.enum';
 import { EntityReference } from '../../../generated/entity/type';
 import { searchData } from '../../../rest/miscAPI';
 import {
-  formatTeamsResponse,
-  formatUsersResponse,
+    formatTeamsResponse,
+    formatUsersResponse
 } from '../../../utils/APIUtils';
 import {
-  getEntityName,
-  getEntityReferenceFromEntity,
+    getEntityName,
+    getEntityReferenceFromEntity
 } from '../../../utils/EntityUtils';
 import { ProfilePicture } from '../atoms/ProfilePicture';
 
@@ -170,8 +170,10 @@ const MUIUserTeamSelect: FC<MUIUserTeamSelectProps> = ({
     if (inputValue) {
       handleSearch(inputValue);
     } else {
+      setLoading(true);
       setUserOptions([]);
       setTeamOptions([]);
+      handleSearch('');
     }
   }, [inputValue]);
 
@@ -381,7 +383,7 @@ const MUIUserTeamSelect: FC<MUIUserTeamSelectProps> = ({
       isOptionEqualToValue={isOptionEqualToValue}
       loading={loading}
       multiple={isMultiple}
-      open={open && (allOptions.length > 0 || loading || !inputValue)}
+      open={open && (allOptions.length > 0 || loading)}
       options={allOptions}
       renderInput={(params) => (
         <TextField

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/asyncTreeSelect/useAsyncTreeSelect.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/asyncTreeSelect/useAsyncTreeSelect.tsx
@@ -177,29 +177,12 @@ export const useAsyncTreeSelect = <T = unknown,>(
     []
   );
 
-  // Handle node expansion with lazy loading
+  // Handle node expansion
   const handleNodeExpansion = useCallback(
-    async (nodeId: string) => {
-      const wasExpanded = isNodeExpanded(nodeId);
+    (nodeId: string) => {
       toggleExpansion(nodeId);
-      const isExpanding = !wasExpanded;
-
-      if (isExpanding) {
-        const node = findNodeInTree(treeData, nodeId);
-        if (shouldNodeLazyLoad(node, lazyLoad)) {
-          await loadChildrenData(nodeId);
-        }
-      }
     },
-    [
-      toggleExpansion,
-      lazyLoad,
-      isNodeExpanded,
-      loadChildrenData,
-      treeData,
-      findNodeInTree,
-      shouldNodeLazyLoad,
-    ]
+    [toggleExpansion]
   );
 
   // Expand path to highlighted node when search changes


### PR DESCRIPTION
- Add freeSolo prop to MUITagSuggestion for immediate typing without selection
- Add ListboxProps key to force dropdown rerender on options change
- Implement proper loading state management to prevent dropdown flickering
- Handle empty search state by fetching all options on clear
- Remove backspace blocking code to allow tag removal

- Fix MUIUserTeamSelect empty dropdown issue by setting loading state on clear
- Remove duplicate lazy loading logic from useAsyncTreeSelect
- Create single source of truth for node expansion in MUIAsyncTreeSelect
- Fix keyboard navigation (ArrowRight) not triggering lazy load API calls
- Reorder utility functions to fix initialization error

- Remove unnecessary placeholders from AddDomainForm owner and expert fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)


