### PR TITLE
fix(ui): Reduce Data Product icon stroke width in sidebar

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/constants/LeftSidebar.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/LeftSidebar.constants.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { Cube01 as DataProductIcon } from '@untitledui/icons';
+import { Cube01 } from '@untitledui/icons';
 import { ReactComponent as GovernIcon } from '../assets/svg/bank.svg';
 import { ReactComponent as ClassificationIcon } from '../assets/svg/classification.svg';
 import { ReactComponent as ExploreIcon } from '../assets/svg/explore.svg';
@@ -30,7 +30,10 @@ import { ReactComponent as MetricIcon } from '../assets/svg/metric.svg';
 import { LeftSidebarItem } from '../components/MyData/LeftSidebar/LeftSidebar.interface';
 import { SidebarItem } from '../enums/sidebar.enum';
 import { DataInsightTabs } from '../interface/data-insight.interface';
+import { createIconWithStroke } from '../utils/IconUtils';
 import { PLACEHOLDER_ROUTE_TAB, ROUTES } from './constants';
+
+const DataProductIcon = createIconWithStroke(Cube01, 1.2);
 
 export const SIDEBAR_NESTED_KEYS = {
   [ROUTES.OBSERVABILITY_ALERTS]: ROUTES.OBSERVABILITY_ALERTS,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/IconUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/IconUtils.tsx
@@ -104,6 +104,25 @@ export const ICON_MAP: Record<
   Calendar: Calendar,
 };
 
+/**
+ * Creates an icon component with custom stroke width
+ * @param IconComponent - The icon component from @untitledui/icons
+ * @param strokeWidth - Custom stroke width (default icons use 2)
+ * @returns Wrapped icon component with custom stroke width
+ */
+export const createIconWithStroke = (
+  IconComponent: ComponentType<{
+    size?: number;
+    strokeWidth?: number;
+    style?: React.CSSProperties;
+  }>,
+  strokeWidth: number
+) => {
+  return (props: { size?: number; style?: React.CSSProperties }) => (
+    <IconComponent {...props} strokeWidth={strokeWidth} />
+  );
+};
+
 interface RenderIconOptions {
   size?: number;
   className?: string;


### PR DESCRIPTION
- Add createIconWithStroke utility for custom icon stroke widths
- Apply stroke width 1.2 to Data Product icon (down from default 2)
- Matches visual weight with other sidebar icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="3024" height="1374" alt="image" src="https://github.com/user-attachments/assets/4d250802-469b-4578-8dd0-154543c92462" />

