### PR TITLE
PLAYWRIGHT FIXES: ensure sample data is passed to the right columns

### DIFF
--- a/ingestion/src/metadata/pii/base_processor.py
+++ b/ingestion/src/metadata/pii/base_processor.py
@@ -100,7 +100,8 @@ class AutoClassificationProcessor(Processor, ABC):
 
         column_tags = []
 
-        for idx, column in enumerate(record.table.columns):
+        for idx, column_name in enumerate(record.sample_data.data.columns):
+            column = next(c for c in record.table.columns if c.name == column_name)
             try:
                 tags = self.create_column_tag_labels(
                     column=column,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/nightly/AutoClassification.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/nightly/AutoClassification.spec.ts
@@ -82,17 +82,6 @@ test.describe('Auto Classification', PLAYWRIGHT_INGESTION_TAG_OBJ, async () => {
       )
       .toBeAttached();
 
-    mysqlService.name;
-
-    // Verify the non sensitive tags
-    await test
-      .expect(
-        page.locator(
-          `[data-row-key*="address"] [data-testid="tag-PII.Sensitive"] `
-        )
-      )
-      .toBeAttached();
-
     // Delete the created service
     const { apiContext } = await getApiContext(page);
     await mysqlService.deleteServiceByAPI(apiContext);


### PR DESCRIPTION
### Describe your changes:

Fixes the following [broken test (AutoClassification.spec.ts)](https://github.com/open-metadata/openmetadata-nightly/actions/runs/18283697111/attempts/1#summary-52056461021)

Commit by commit:
- Fixed some ordering issue between table's columns and sample data's columns
- Removed an expectation from the playwright test that no longer made sense

#### Playwright screenshot of fixed test
<img width="998" height="309" alt="image" src="https://github.com/user-attachments/assets/3f333d0c-600b-4f6d-a203-d0b67be314bd" />

#
### Type of change:
- [X] Bug fix

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.