### PR TITLE
Chore(UI): Fix the flatMap property of undefined error

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/AppRouter/AppRouter.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AppRouter/AppRouter.tsx
@@ -116,7 +116,7 @@ const AppRouter = () => {
 
       {/* Render APP position plugin routes (they handle their own layouts) */}
       {isAuthenticated &&
-        plugins.flatMap((plugin) => {
+        plugins?.flatMap((plugin) => {
           const routes = plugin.getRoutes?.() || [];
           // Filter routes with APP position
           const appRoutes = routes.filter(

--- a/openmetadata-ui/src/main/resources/ui/src/components/AppRouter/AuthenticatedAppRouter.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AppRouter/AuthenticatedAppRouter.tsx
@@ -292,7 +292,7 @@ const AuthenticatedAppRouter: FunctionComponent = () => {
 
   // Get all plugin routes that should be in AUTHENTICATED_ROUTE position
   const pluginRoutes = useMemo(() => {
-    return plugins.flatMap((plugin) => {
+    return plugins?.flatMap((plugin) => {
       const routes = plugin.getRoutes?.() || [];
 
       // Filter routes that don't have position or have AUTHENTICATED_ROUTE position


### PR DESCRIPTION
I worked on safeguarding the `plugins` use to avoid the flatMap error. The issue occurs in development mode during the hot reloading. 

**Issue:**

<img width="1434" height="723" alt="Screenshot 2025-10-10 at 3 06 37 PM" src="https://github.com/user-attachments/assets/febd51c4-0d82-435f-887f-697c086b3dd1" />
