### PR TITLE
MINOR: Fix databricks pipeline repeating tasks issue

### DIFF
--- a/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/models.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/models.py
@@ -32,20 +32,14 @@ class PipelineTask(BaseModel):
     full_refresh: Optional[bool] = None
 
 
-class DBJobTask(BaseModel):
-    name: Optional[str] = Field(None, alias="task_key")
-    description: Optional[str] = None
-    depends_on: Optional[List[DependentTask]] = None
-    pipeline_task: Optional[PipelineTask] = None
-    notebook_task: Optional[Dict[str, Any]] = None
-    spark_python_task: Optional[Dict[str, Any]] = None
-
-
 class DBTasks(BaseModel):
     name: Optional[str] = Field(None, alias="task_key")
     description: Optional[str] = None
     depends_on: Optional[List[DependentTask]] = None
     run_page_url: Optional[str] = None
+    pipeline_task: Optional[PipelineTask] = None
+    notebook_task: Optional[Dict[str, Any]] = None
+    spark_python_task: Optional[Dict[str, Any]] = None
 
 
 class DBSettings(BaseModel):
@@ -55,7 +49,7 @@ class DBSettings(BaseModel):
     description: Optional[str] = None
     schedule: Optional[DBRunSchedule] = None
     task_type: Optional[str] = Field(None, alias="format")
-    tasks: Optional[List[DBJobTask]] = None
+    tasks: Optional[List[DBTasks]] = None
 
 
 class DataBrickPipelineDetails(BaseModel):

--- a/ingestion/tests/unit/topology/pipeline/test_databricks_pipeline.py
+++ b/ingestion/tests/unit/topology/pipeline/test_databricks_pipeline.py
@@ -148,24 +148,24 @@ EXPECTED_CREATED_PIPELINES = CreatePipelineRequest(
     description="This job contain multiple tasks that are required to produce the weekly shark sightings report.",
     tasks=[
         Task(
-            name="Orders_Ingest",
-            description="Ingests order data",
-            sourceUrl="https://my-workspace.cloud.databricks.com/#job/11223344/run/123",
-            downstreamTasks=[],
-            taskType="SINGLE_TASK",
-        ),
-        Task(
-            name="Match",
-            description="Matches orders with user sessions",
-            sourceUrl="https://my-workspace.cloud.databricks.com/#job/11223344/run/123",
-            downstreamTasks=["Orders_Ingested", "Sessionize"],
-            taskType="SINGLE_TASK",
-        ),
-        Task(
             name="Sessionize",
             description="Extracts session data from events",
-            sourceUrl="https://my-workspace.cloud.databricks.com/#job/11223344/run/123",
+            sourceUrl="https://localhost:443/#job/11223344",
             downstreamTasks=[],
+            taskType="SINGLE_TASK",
+        ),
+        Task(
+            name="Orders_Ingest",
+            description="Ingests order data",
+            sourceUrl="https://localhost:443/#job/11223344",
+            downstreamTasks=[],
+            taskType="SINGLE_TASK",
+        ),
+        Task(
+            name="Matched_Changed",
+            description="Matches orders with user sessions",
+            sourceUrl="https://localhost:443/#job/11223344",
+            downstreamTasks=["Orders_Ingest", "Sessionize", "Sessionize_duplicated"],
             taskType="SINGLE_TASK",
         ),
     ],
@@ -279,11 +279,7 @@ class DatabricksPipelineTests(TestCase):
         results = list(self.databricks.get_pipelines_list())
         self.assertEqual(PIPELINE_LIST, results)
 
-    @patch(
-        "metadata.ingestion.source.database.databricks.client.DatabricksClient.get_job_runs"
-    )
-    def test_yield_pipeline(self, get_job_runs):
-        get_job_runs.return_value = mock_run_data
+    def test_yield_pipeline(self):
         pipelines = list(self.databricks.yield_pipeline(PIPELINE_LIST[0]))[0].right
         self.assertEqual(pipelines, EXPECTED_CREATED_PIPELINES)
 


### PR DESCRIPTION
## Summary

Fixed a critical bug in the Databricks Pipeline connector where tasks were being duplicated for each job run instead of being extracted from the job definition. This caused pipelines to show N×M tasks (where N = number of tasks, M = number of runs) instead of just N tasks.

## Problem

The previous implementation incorrectly iterated through all job runs (`get_job_runs`) and created task definitions from each run's task execution data. This meant:

- If a job had 3 tasks and 10 historical runs, it would register 30 tasks (3 × 10)
- Tasks were being confused with task executions
- Each "task" had a run-specific URL, which doesn't make sense for task definitions

### Root Cause

```python
# BEFORE: Iterating through runs to get tasks ❌
for run in self.client.get_job_runs(job_id=pipeline_details.job_id):
    run = DBRun(**run)
    task_list.extend([Task(...) for task in run.tasks])
```

## Solution

Tasks should come from the **job definition** (available via `list_jobs` API with `expand_tasks=True`), not from individual job runs. Job runs should only be used for pipeline execution status.

### Changes Made

#### 1. Updated Data Model
**File:** `ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/models.py`

```python
class DBSettings(BaseModel):
    name: Optional[str] = None
    timeout_seconds: Optional[int] = 0
    max_concurrent_runs: Optional[int] = 0
    description: Optional[str] = None
    schedule: Optional[DBRunSchedule] = None
    task_type: Optional[str] = Field(None, alias="format")
    tasks: Optional[List[DBTasks]] = None  # ✅ Added
```

**Rationale:** The Databricks Jobs API returns task definitions in `settings.tasks` when called with `expand_tasks=True`.

#### 2. Fixed Task Extraction Logic
**File:** `ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/metadata.py`

```python
def get_tasks(self, pipeline_details: DataBrickPipelineDetails) -> List[Task]:
    try:
        if not pipeline_details.settings or not pipeline_details.settings.tasks:
            return None

        # Construct job-level URL for tasks
        job_url = f"https://{self.service_connection.hostPort}/#job/{pipeline_details.job_id}"

        return [
            Task(
                name=str(task.name),
                taskType=pipeline_details.settings.task_type,
                sourceUrl=SourceUrl(job_url),  # ✅ Job-level URL
                description=(
                    Markdown(task.description) if task.description else None
                ),
                downstreamTasks=[
                    depend_task.name for depend_task in task.depends_on or []
                ],
            )
            for task in pipeline_details.settings.tasks  # ✅ From job definition
        ]
    except Exception as exc:
        logger.debug(traceback.format_exc())
        logger.warning(f"Failed to get tasks list due to : {exc}")
    return None
```

**Key Changes:**
- Extract tasks from `pipeline_details.settings.tasks` (job definition) ✅
- Removed iteration through `get_job_runs()` ❌
- Added job-level `sourceUrl` that links to the Databricks job page
- Properly handle task dependencies from job definition

#### 3. Updated Tests
**File:** `ingestion/tests/unit/topology/pipeline/test_databricks_pipeline.py`

- Removed `@patch` decorator for `get_job_runs` in `test_yield_pipeline` (no longer needed)
- Updated expected task list to match actual job definition from mock data
- Added `sourceUrl` expectations with correct job URL format
- All 4 tests passing ✅

## Databricks API Usage

### Job Definition (list_jobs with expand_tasks=True)
```json
{
  "job_id": 11223344,
  "settings": {
    "name": "My Job",
    "tasks": [                    // ✅ Task DEFINITIONS
      {
        "task_key": "task1",
        "description": "...",
        "depends_on": [...]
      }
    ]
  }
}
```

### Job Runs (get_job_runs)
```json
{
  "job_id": 11223344,
  "run_id": 123,
  "tasks": [                      // ✅ Task EXECUTIONS (for status)
    {
      "task_key": "task1",
      "state": { "result_state": "SUCCESS" },
      "run_page_url": "..."
    }
  ]
}
```

## Impact

### Before
- ❌ Tasks duplicated per run
- ❌ Incorrect task count in OpenMetadata UI
- ❌ Run-specific URLs on task definitions
- ❌ Confusing user experience

### After
- ✅ One task definition per actual task
- ✅ Correct task count matching Databricks job
- ✅ Job-level URLs for task definitions
- ✅ Task executions tracked via pipeline status (separate concern)

## Testing

All existing tests pass:
```bash
pytest tests/unit/topology/pipeline/test_databricks_pipeline.py -xvs
```

**Test Results:**
- ✅ `test_get_pipelines_list` - Job listing works
- ✅ `test_yield_pipeline` - Tasks extracted correctly from job definition
- ✅ `test_yield_pipeline_status` - Run status still works correctly
- ✅ `test_databricks_pipeline_lineage` - Lineage processing unaffected

## Backward Compatibility

This is a **bug fix** that corrects incorrect behavior. Users will see:
- Reduced task count (correct number instead of duplicates)
- Task URLs pointing to job page instead of specific runs
- No breaking changes to API or configuration

## Files Changed

1. `ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/models.py`
2. `ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/metadata.py`
3. `ingestion/tests/unit/topology/pipeline/test_databricks_pipeline.py`

## Checklist

- [x] Code follows project style guidelines (`make py_format` applied)
- [x] Tests updated and passing
- [x] Bug fix addresses root cause
- [x] No breaking changes to public API
- [x] Databricks API used correctly per documentation
