### PR TITLE
MINOR: Fix lint / conflict error modify get_by_name to search_in_any_service

### DIFF
--- a/ingestion/src/metadata/ingestion/source/pipeline/kafkaconnect/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/kafkaconnect/metadata.py
@@ -1244,9 +1244,11 @@ class KafkaconnectSource(PipelineServiceSource):
                                 f"Searching for table with pattern: {search_pattern} "
                                 f"(service={db_service_name}, schema={topic_info['database']}, table={topic_info['table']})"
                             )
-                            current_dataset_entity = self.metadata.get_by_name(
-                                entity=Table, fqn=search_pattern
-                                    entity_type=Table, fqn_search_string=search_pattern
+
+                            current_dataset_entity = (
+                                self.metadata.search_in_any_service(
+                                    entity_type=Table,
+                                    fqn_search_string=search_pattern,
                                 )
                             )
                             if current_dataset_entity:
@@ -1278,8 +1280,9 @@ class KafkaconnectSource(PipelineServiceSource):
                                 logger.info(
                                     f"Searching for table with pattern: {search_pattern}"
                                 )
-                                current_dataset_entity = self.metadata.get_by_name(
-                                    entity=Table, fqn=search_pattern
+
+                                current_dataset_entity = (
+                                    self.metadata.search_in_any_service(
                                         entity_type=Table,
                                         fqn_search_string=search_pattern,
                                     )


### PR DESCRIPTION
This pull request updates the logic for retrieving dataset entities in the `yield_pipeline_lineage_details` function within `metadata.py`. The main change is replacing the use of `get_by_name` with `search_in_any_service` for improved flexibility in searching tables across services.

Improvements to dataset entity lookup:

* Replaced `self.metadata.get_by_name` with `self.metadata.search_in_any_service` for retrieving the current dataset entity, allowing searches across any service using `entity_type=Table` and `fqn_search_string=search_pattern`. [[1]](diffhunk://#diff-6599b3e096b170b3873357e8567b937773f3ac686a3afac4cd807e9088e82045L1247-R1251) [[2]](diffhunk://#diff-6599b3e096b170b3873357e8567b937773f3ac686a3afac4cd807e9088e82045L1281-R1285)