### PR TITLE
Fixes 23881: Added native query lineage extraction for powerbi-databricks

### DIFF
--- a/ingestion/src/metadata/ingestion/source/dashboard/powerbi/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/powerbi/metadata.py
@@ -59,7 +59,9 @@ from metadata.ingestion.lineage.parser import LineageParser
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.ometa.utils import model_str
 from metadata.ingestion.source.dashboard.dashboard_service import DashboardServiceSource
-from metadata.ingestion.source.dashboard.powerbi.databricks_parser import parse_databricks_native_query_source
+from metadata.ingestion.source.dashboard.powerbi.databricks_parser import (
+    parse_databricks_native_query_source,
+)
 from metadata.ingestion.source.dashboard.powerbi.models import (
     Dataflow,
     Dataset,
@@ -961,7 +963,9 @@ class PowerbiSource(DashboardServiceSource):
             logger.debug(traceback.format_exc())
         return None
 
-    def _parse_catalog_table_definition(self, source_expression: str, datamodel_entity: DashboardDataModel) -> Optional[List[dict]]:
+    def _parse_catalog_table_definition(
+        self, source_expression: str, datamodel_entity: DashboardDataModel
+    ) -> Optional[List[dict]]:
         """parse catalog table definition"""
         db_match = re.search(
             r'\[Name=(?:"([^"]+)"|([^,]+)),Kind="Database"\]', source_expression
@@ -994,7 +998,7 @@ class PowerbiSource(DashboardServiceSource):
         return None
 
     def _parse_databricks_source(
-            self, source_expression: str, datamodel_entity: DashboardDataModel
+        self, source_expression: str, datamodel_entity: DashboardDataModel
     ) -> Optional[List[dict]]:
         if "Databricks.Catalogs" not in source_expression:
             return None
@@ -1004,7 +1008,9 @@ class PowerbiSource(DashboardServiceSource):
                 if DATABRICKS_QUERY_EXPRESSION_KW in source_expression:
                     return parse_databricks_native_query_source(source_expression)
                 else:
-                    return self._parse_catalog_table_definition(source_expression, datamodel_entity)
+                    return self._parse_catalog_table_definition(
+                        source_expression, datamodel_entity
+                    )
             except Exception as exc:
                 logger.debug(f"Error to parse databricks table source: {exc}")
                 logger.debug(traceback.format_exc())
@@ -1020,7 +1026,9 @@ class PowerbiSource(DashboardServiceSource):
             if SNOWFLAKE_QUERY_EXPRESSION_KW in source_expression:
                 # snowflake query source identified
                 return self._parse_snowflake_query_source(source_expression)
-            return self._parse_catalog_table_definition(source_expression, datamodel_entity)
+            return self._parse_catalog_table_definition(
+                source_expression, datamodel_entity
+            )
         except Exception as exc:
             logger.debug(f"Error to parse snowflake table source: {exc}")
             logger.debug(traceback.format_exc())

--- a/ingestion/tests/unit/topology/dashboard/test_powerbi.py
+++ b/ingestion/tests/unit/topology/dashboard/test_powerbi.py
@@ -101,11 +101,7 @@ in
     Source"""
 
 EXPECTED_DATABRICKS_RESULT = [
-    {
-        "database": "DEMO_STAGE",
-        "schema": "PUBLIC",
-        "table": "STG_CUSTOMERS"
-    }
+    {"database": "DEMO_STAGE", "schema": "PUBLIC", "table": "STG_CUSTOMERS"}
 ]
 
 mock_config = {


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes [23881](https://github.com/open-metadata/OpenMetadata/issues/23881)

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on implementing the native query parser for databricks within the powerbi lineage because most of the powerbi models in my org are using native queries.
Native queries can be select queries(simple or complex ones), or just a table name. 
when it is table name, the lineage will just take it as it is. 
When it is a query, the parser will extract the query and will use the LineageParser(from metadata.ingestion.lineage.parser) to extract the lineage info. 

The current metadata.py doesn't have a modular approach, snowflake, redshift and databricks logics are all in the same file. 
Within this PR, I refactored some common logic into a generic function  (see _parse_catalog_table_definition) and created a databricks_parser.py which encapsulates the databricks specific logic. 

This code is also addressing https://github.com/open-metadata/OpenMetadata/issues/23638 as it extracts the parameters. 

Note: The code disables enableVersionValidation in the powerbi unit test as the test suite has nothing to do with the openmetadata server and therefore, the version validation was adding unnecessary dependency to a running openmetadata server. 
#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x ] Improvement

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [x] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
