### PR TITLE
Potential fix for code scanning alert no. 1685: Incomplete string escaping or encoding

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts
@@ -407,6 +407,7 @@ test.describe('Domains', () => {
     // The domain FQN should be properly escaped in the query
     // The actual format uses escaped hyphens, not URL encoding
     const fqn = (domain.data.fullyQualifiedName ?? '')
+      .replace(/\\/g, '\\\\')
       .replace(/"/g, '\\"')
       .replace(/-/g, '\\-');
 


### PR DESCRIPTION
Potential fix for [https://github.com/open-metadata/OpenMetadata/security/code-scanning/1685](https://github.com/open-metadata/OpenMetadata/security/code-scanning/1685)

To fix the issue, we must ensure that backslashes in `fullyQualifiedName` are escaped before escaping quotes and hyphens. This means:
- Escape all backslashes (`\`) first, replacing each instance with two backslashes (`\\`).
- Then escape double quotes (`"`) and hyphens (`-`) as before.
- The order of operations is important: backslash substitution should be done *before* the others, to prevent double-escaping.

**Implementation:**
- Update the code block on lines 409-411 to include a `.replace(/\\/g, '\\\\')` as the first replacement in the chain, so all backslashes are escaped before any other replacement.
- This is a one-line code fix; no new imports or libraries are required, as this is a straightforward use of standard JavaScript string replacement with regex.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
