### PR TITLE
fix for code scanning alert no. 1681: Insecure randomness

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/utils/StringsUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/StringsUtils.ts
@@ -258,7 +258,7 @@ export const formatJsonString = (jsonString: string, indent = '') => {
 
 export const replaceCallback = (character: string) => {
   // Generate a random number between 0 and 15
-  const randomNumber = (Math.random() * 16) | 0;
+  const randomNumber = crypto.getRandomValues(new Uint8Array(1))[0] & 0xf;
 
   // If the character in the UUID template is 'x', use the random number.
   // Otherwise, use the random number ANDed with 0x3 (which gives a number between 0 and 3) ORed with 0x8


### PR DESCRIPTION
Potential fix for [https://github.com/open-metadata/OpenMetadata/security/code-scanning/1681](https://github.com/open-metadata/OpenMetadata/security/code-scanning/1681)

To fix the problem, we need to replace the use of `Math.random()` with a cryptographically secure random number generator. In modern browsers, `window.crypto.getRandomValues()` is available and provides secure random values. On Node.js, `require('crypto').randomBytes()` can be used. 

Since the code appears to be intended for browser environments (TypeScript, client utility functions, JSX return types), we will use `window.crypto.getRandomValues()`. We'll modify `replaceCallback` so that instead of generating a random number using `Math.random() * 16 | 0`, we generate a single random byte using `crypto.getRandomValues(new Uint8Array(1))[0]` and mask it to the 0-15 range.

Edit file `openmetadata-ui/src/main/resources/ui/src/utils/StringsUtils.ts`:
- Update `replaceCallback` to use `window.crypto.getRandomValues(new Uint8Array(1))[0] & 0xf`to obtain a cryptographically secure random integer between 0 and 15.
- Ensure compatibility: browsers without `window.crypto` (very old ones) will not work; for environments where `crypto` may not be available, you might want to gracefully fallback or throw.

No external dependencies are required; `window.crypto` is built-in to browser JavaScript.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
