### PR TITLE
Potential fix for code scanning alert no. 1692: Incomplete string escaping or encoding

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/utils/StringsUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/StringsUtils.ts
@@ -314,7 +314,7 @@ export const jsonToCSV = <T extends JSONRecord>(
         }
         const escaped =
           typeof value === 'string'
-            ? value.replace(/"/g, '\\"')
+            ? value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
             : value.toString(); // handle quotes in content
 
         return `"${escaped}"`; // wrap each field in quotes


### PR DESCRIPTION
Potential fix for [https://github.com/open-metadata/OpenMetadata/security/code-scanning/1692](https://github.com/open-metadata/OpenMetadata/security/code-scanning/1692)

To correctly escape double quotes in a CSV field using backslashes (even though CSV commonly uses double-double-quote to escape quotes), we must first escape all backslashes in the value, turning each `\` into `\\`. Then, we escape all double quotes by turning each `"` into `\"`. This way, any quote preceded by a backslash will not "leak out" because the backslash will itself be escaped. The fix should be implemented in the `jsonToCSV` method, specifically in the mapping/escaping logic beginning at line 316. The escaping logic should be updated so that for string values, all backslashes are first replaced by two backslashes, then all double quotes are replaced by backslash-double-quote. This can be written concisely using chained `.replace` calls. No new imports are necessary, and no other code regions need to be changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
