### PR TITLE
Chore(UI): Enable trace for fist failures as well for service ingestion specs

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AutoPilot.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AutoPilot.spec.ts
@@ -49,7 +49,7 @@ if (process.env.PLAYWRIGHT_IS_OSS) {
 // use the admin user to login
 test.use({
   storageState: 'playwright/.auth/admin.json',
-  trace: process.env.PLAYWRIGHT_IS_OSS ? 'off' : 'on-first-retry',
+  trace: process.env.PLAYWRIGHT_IS_OSS ? 'off' : 'retain-on-failure',
   video: process.env.PLAYWRIGHT_IS_OSS ? 'on' : 'off',
 });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/nightly/AutoClassification.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/nightly/AutoClassification.spec.ts
@@ -25,7 +25,7 @@ const mysqlService = new MysqlIngestionClass({
 // use the admin user to login
 test.use({
   storageState: 'playwright/.auth/admin.json',
-  trace: process.env.PLAYWRIGHT_IS_OSS ? 'off' : 'on-first-retry',
+  trace: process.env.PLAYWRIGHT_IS_OSS ? 'off' : 'retain-on-failure',
   video: process.env.PLAYWRIGHT_IS_OSS ? 'on' : 'off',
 });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/nightly/ServiceIngestion.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/nightly/ServiceIngestion.spec.ts
@@ -58,7 +58,7 @@ if (process.env.PLAYWRIGHT_IS_OSS) {
 // use the admin user to login
 test.use({
   storageState: 'playwright/.auth/admin.json',
-  trace: process.env.PLAYWRIGHT_IS_OSS ? 'off' : 'on-first-retry',
+  trace: process.env.PLAYWRIGHT_IS_OSS ? 'off' : 'retain-on-failure',
   video: process.env.PLAYWRIGHT_IS_OSS ? 'on' : 'off',
 });
 


### PR DESCRIPTION
This pull request updates the Playwright test configuration for multiple test suites to improve trace retention behavior. The main change ensures that traces are retained only on test failures, which can help with debugging while reducing unnecessary trace files.

Test configuration updates:

* Changed the `trace` option from `'on-first-retry'` to `'retain-on-failure'` for tests in `AutoPilot.spec.ts`, `AutoClassification.spec.ts`, and `ServiceIngestion.spec.ts`, making traces available only when a test fails. [[1]](diffhunk://#diff-138d979ac1e718e72a39e26a5cd77269d5ae30ffef3df6204e8dca95c364e979L52-R52) [[2]](diffhunk://#diff-adedb514cff99e345d37a0c32406771855ceb9fe080588edf7b8bee5ee96abc2L28-R28) [[3]](diffhunk://#diff-5a1909deaad350482459b183dc59de5b022521d575a3892caa7f99126ec0934bL61-R61)