### PR TITLE
Chore(UI): Add .codeqlignore in license ignore list

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/.codeqlignore
+++ b/openmetadata-ui/src/main/resources/ui/.codeqlignore
@@ -1,12 +1,1 @@
-#  Copyright 2021 Collate
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#  http://www.apache.org/licenses/LICENSE-2.0
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-
 playwright/**

--- a/openmetadata-ui/src/main/resources/ui/.licenseheaderignore
+++ b/openmetadata-ui/src/main/resources/ui/.licenseheaderignore
@@ -83,3 +83,6 @@ src/generated/antlr
 
 # env
 ".env"
+
+# Code quality ignore
+".codeqlignore"


### PR DESCRIPTION
This pull request updates the configuration for code quality and license header checks in the frontend resources. The most important changes focus on improving the handling of files that should be excluded from automated analysis and license header enforcement.

Configuration improvements:

* Removed the contents of `.codeqlignore`, which previously excluded the `playwright/**` directory from CodeQL analysis.
* Added `.codeqlignore` to `.licenseheaderignore`, ensuring that the CodeQL ignore file itself is excluded from license header checks.