### PR TITLE
Fix Lineage Service Issue

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ESLineageGraphBuilder.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ESLineageGraphBuilder.java
@@ -3,8 +3,8 @@ package org.openmetadata.service.search.elasticsearch;
 import static org.openmetadata.common.utils.CommonUtil.collectionOrEmpty;
 import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 import static org.openmetadata.service.Entity.FIELD_FULLY_QUALIFIED_NAME_HASH_KEYWORD;
+import static org.openmetadata.service.search.SearchClient.DATA_ASSET_SEARCH_ALIAS;
 import static org.openmetadata.service.search.SearchClient.FQN_FIELD;
-import static org.openmetadata.service.search.SearchClient.GLOBAL_SEARCH_ALIAS;
 import static org.openmetadata.service.search.SearchUtils.GRAPH_AGGREGATION;
 import static org.openmetadata.service.search.SearchUtils.buildDirectionToFqnSet;
 import static org.openmetadata.service.search.SearchUtils.getLineageDirection;
@@ -129,7 +129,7 @@ public class ESLineageGraphBuilder {
     es.org.elasticsearch.action.search.SearchRequest searchRequest =
         getSearchRequest(
             lineageRequest.getDirection(),
-            GLOBAL_SEARCH_ALIAS,
+            DATA_ASSET_SEARCH_ALIAS,
             lineageRequest.getUpstreamDepth() == remainingDepth
                 ? null
                 : lineageRequest.getQueryFilter(),
@@ -216,7 +216,7 @@ public class ESLineageGraphBuilder {
     es.org.elasticsearch.action.search.SearchRequest searchRequest =
         getSearchRequest(
             lineageRequest.getDirection(),
-            GLOBAL_SEARCH_ALIAS,
+            DATA_ASSET_SEARCH_ALIAS,
             lineageRequest.getQueryFilter(),
             GRAPH_AGGREGATION,
             directionKeyAndValues,
@@ -395,7 +395,7 @@ public class ESLineageGraphBuilder {
     Map<String, Object> rootEntityMap =
         EsUtils.searchEntityByKey(
             null,
-            GLOBAL_SEARCH_ALIAS,
+            DATA_ASSET_SEARCH_ALIAS,
             FIELD_FULLY_QUALIFIED_NAME_HASH_KEYWORD,
             Pair.of(FullyQualifiedName.buildHash(lineageRequest.getFqn()), lineageRequest.getFqn()),
             SOURCE_FIELDS_TO_EXCLUDE);
@@ -423,7 +423,7 @@ public class ESLineageGraphBuilder {
     es.org.elasticsearch.action.search.SearchRequest searchRequest =
         getSearchRequest(
             LineageDirection.DOWNSTREAM,
-            GLOBAL_SEARCH_ALIAS,
+            DATA_ASSET_SEARCH_ALIAS,
             lineageRequest.getQueryFilter(),
             GRAPH_AGGREGATION,
             directionKeyAndValues,
@@ -612,7 +612,7 @@ public class ESLineageGraphBuilder {
       SearchRequest searchRequest =
           EsUtils.getSearchRequest(
               direction,
-              GLOBAL_SEARCH_ALIAS,
+              DATA_ASSET_SEARCH_ALIAS,
               depth == 0 ? null : queryFilter,
               GRAPH_AGGREGATION,
               directionKeyAndValues,
@@ -681,7 +681,7 @@ public class ESLineageGraphBuilder {
       SearchRequest searchRequest =
           EsUtils.getSearchRequest(
               direction,
-              GLOBAL_SEARCH_ALIAS,
+              DATA_ASSET_SEARCH_ALIAS,
               queryFilter,
               GRAPH_AGGREGATION,
               directionKeyAndValues,
@@ -728,7 +728,7 @@ public class ESLineageGraphBuilder {
       Map<String, Object> entityDoc =
           EsUtils.searchEntityByKey(
               null,
-              GLOBAL_SEARCH_ALIAS,
+              DATA_ASSET_SEARCH_ALIAS,
               FIELD_FULLY_QUALIFIED_NAME_HASH_KEYWORD,
               Pair.of(FullyQualifiedName.buildHash(entityFqn), entityFqn),
               SOURCE_FIELDS_TO_EXCLUDE);
@@ -828,7 +828,7 @@ public class ESLineageGraphBuilder {
       SearchRequest searchRequest =
           EsUtils.getSearchRequest(
               request.getDirection(),
-              GLOBAL_SEARCH_ALIAS,
+              DATA_ASSET_SEARCH_ALIAS,
               depth == 0 ? null : request.getQueryFilter(),
               GRAPH_AGGREGATION,
               directionKeyAndValues,

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OSLineageGraphBuilder.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OSLineageGraphBuilder.java
@@ -3,8 +3,8 @@ package org.openmetadata.service.search.opensearch;
 import static org.openmetadata.common.utils.CommonUtil.collectionOrEmpty;
 import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 import static org.openmetadata.service.Entity.FIELD_FULLY_QUALIFIED_NAME_HASH_KEYWORD;
+import static org.openmetadata.service.search.SearchClient.DATA_ASSET_SEARCH_ALIAS;
 import static org.openmetadata.service.search.SearchClient.FQN_FIELD;
-import static org.openmetadata.service.search.SearchClient.GLOBAL_SEARCH_ALIAS;
 import static org.openmetadata.service.search.SearchUtils.GRAPH_AGGREGATION;
 import static org.openmetadata.service.search.SearchUtils.buildDirectionToFqnSet;
 import static org.openmetadata.service.search.SearchUtils.getLineageDirection;
@@ -131,7 +131,7 @@ public class OSLineageGraphBuilder {
     os.org.opensearch.action.search.SearchRequest searchRequest =
         getSearchRequest(
             lineageRequest.getDirection(),
-            GLOBAL_SEARCH_ALIAS,
+            DATA_ASSET_SEARCH_ALIAS,
             lineageRequest.getUpstreamDepth() == remainingDepth
                 ? null
                 : lineageRequest.getQueryFilter(),
@@ -218,7 +218,7 @@ public class OSLineageGraphBuilder {
     os.org.opensearch.action.search.SearchRequest searchRequest =
         getSearchRequest(
             lineageRequest.getDirection(),
-            GLOBAL_SEARCH_ALIAS,
+            DATA_ASSET_SEARCH_ALIAS,
             lineageRequest.getQueryFilter(),
             GRAPH_AGGREGATION,
             directionKeyAndValues,
@@ -399,7 +399,7 @@ public class OSLineageGraphBuilder {
     Map<String, Object> rootEntityMap =
         OsUtils.searchEntityByKey(
             null,
-            GLOBAL_SEARCH_ALIAS,
+            DATA_ASSET_SEARCH_ALIAS,
             FIELD_FULLY_QUALIFIED_NAME_HASH_KEYWORD,
             Pair.of(FullyQualifiedName.buildHash(lineageRequest.getFqn()), lineageRequest.getFqn()),
             SOURCE_FIELDS_TO_EXCLUDE);
@@ -428,7 +428,7 @@ public class OSLineageGraphBuilder {
     os.org.opensearch.action.search.SearchRequest searchRequest =
         getSearchRequest(
             LineageDirection.DOWNSTREAM,
-            GLOBAL_SEARCH_ALIAS,
+            DATA_ASSET_SEARCH_ALIAS,
             lineageRequest.getQueryFilter(),
             GRAPH_AGGREGATION,
             directionKeyAndValues,
@@ -619,7 +619,7 @@ public class OSLineageGraphBuilder {
       os.org.opensearch.action.search.SearchRequest searchRequest =
           getSearchRequest(
               direction,
-              GLOBAL_SEARCH_ALIAS,
+              DATA_ASSET_SEARCH_ALIAS,
               depth == 0 ? null : queryFilter,
               GRAPH_AGGREGATION,
               directionKeyAndValues,
@@ -688,7 +688,7 @@ public class OSLineageGraphBuilder {
       os.org.opensearch.action.search.SearchRequest searchRequest =
           getSearchRequest(
               direction,
-              GLOBAL_SEARCH_ALIAS,
+              DATA_ASSET_SEARCH_ALIAS,
               queryFilter,
               GRAPH_AGGREGATION,
               directionKeyAndValues,
@@ -735,7 +735,7 @@ public class OSLineageGraphBuilder {
       Map<String, Object> entityDoc =
           OsUtils.searchEntityByKey(
               null,
-              GLOBAL_SEARCH_ALIAS,
+              DATA_ASSET_SEARCH_ALIAS,
               FIELD_FULLY_QUALIFIED_NAME_HASH_KEYWORD,
               Pair.of(FullyQualifiedName.buildHash(entityFqn), entityFqn),
               SOURCE_FIELDS_TO_EXCLUDE);
@@ -836,7 +836,7 @@ public class OSLineageGraphBuilder {
       SearchRequest searchRequest =
           getSearchRequest(
               request.getDirection(),
-              GLOBAL_SEARCH_ALIAS,
+              DATA_ASSET_SEARCH_ALIAS,
               depth == 0 ? null : request.getQueryFilter(),
               GRAPH_AGGREGATION,
               directionKeyAndValues,


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

- In data assets services appears dues to lineage search across global alias

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
