### PR TITLE
Fixes #23868: Ensure consolidated ChangeEvents are reported per TestSuite & DataContract run

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dataContracts/DataContractValidationApp.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dataContracts/DataContractValidationApp.java
@@ -1,7 +1,6 @@
 package org.openmetadata.service.apps.bundles.dataContracts;
 
 import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
-import static org.openmetadata.service.Entity.ADMIN_USER_NAME;
 import static org.openmetadata.service.apps.scheduler.OmAppJobListener.APP_RUN_STATS;
 
 import java.util.HashMap;
@@ -15,13 +14,10 @@ import org.openmetadata.schema.entity.data.DataContract;
 import org.openmetadata.schema.entity.datacontract.DataContractResult;
 import org.openmetadata.schema.system.Stats;
 import org.openmetadata.schema.system.StepStats;
-import org.openmetadata.schema.type.ChangeEvent;
-import org.openmetadata.schema.type.EventType;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.apps.AbstractNativeApplication;
-import org.openmetadata.service.formatter.util.FormatterUtil;
 import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.DataContractRepository;
 import org.openmetadata.service.jdbi3.ListFilter;
@@ -79,11 +75,6 @@ public class DataContractValidationApp extends AbstractNativeApplication {
                 repository.validateContract(dataContract);
             DataContractResult validationResult = validationResponse.getEntity();
 
-            ChangeEvent changeEvent =
-                FormatterUtil.getDataContractResultEvent(
-                    validationResult, ADMIN_USER_NAME, EventType.ENTITY_UPDATED);
-            changeEvent.setEntity(JsonUtils.pojoToMaskedJson(dataContract));
-            Entity.getCollectionDAO().changeEventDAO().insert(JsonUtils.pojoToJson(changeEvent));
             LOG.debug(
                 "Validation completed for {}: Status = {}",
                 dataContract.getFullyQualifiedName(),

--- a/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertUtil.java
@@ -154,8 +154,7 @@ public final class AlertUtil {
 
     // Test Suite
     if (config.getResources().get(0).equals(TEST_SUITE)) {
-      return event.getEntityType().equals(TEST_SUITE)
-          || event.getEntityType().equals(Entity.TEST_CASE);
+      return event.getEntityType().equals(TEST_SUITE);
     }
 
     // Data Contract

--- a/openmetadata-service/src/main/java/org/openmetadata/service/formatter/util/FormatterUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/formatter/util/FormatterUtil.java
@@ -42,6 +42,7 @@ import org.openmetadata.schema.tests.TestCase;
 import org.openmetadata.schema.tests.type.TestCaseResult;
 import org.openmetadata.schema.type.ChangeDescription;
 import org.openmetadata.schema.type.ChangeEvent;
+import org.openmetadata.schema.type.ContractExecutionStatus;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.EventType;
 import org.openmetadata.schema.type.FieldChange;
@@ -51,7 +52,9 @@ import org.openmetadata.service.Entity;
 import org.openmetadata.service.formatter.decorators.MessageDecorator;
 import org.openmetadata.service.formatter.factory.ParserFactory;
 import org.openmetadata.service.formatter.field.DefaultFieldFormatter;
+import org.openmetadata.service.jdbi3.TestCaseRepository;
 import org.openmetadata.service.resources.feeds.MessageParser;
+import org.openmetadata.service.util.EntityUtil;
 import org.openmetadata.service.util.FullyQualifiedName;
 import org.openmetadata.service.util.RestUtil;
 
@@ -320,12 +323,14 @@ public class FormatterUtil {
               .ENTITY_UPDATED; // workaround as adding a test case result is sent as a POST request
       TestCaseResult testCaseResult =
           JsonUtils.readOrConvertValue(entityTimeSeries, TestCaseResult.class);
+      // Load TestCase with all fields including relationships
       TestCase testCase =
-          Entity.getEntityByName(
-              TEST_CASE,
-              testCaseResult.getTestCaseFQN(),
-              TEST_CASE_RESULT + ",testSuites",
-              Include.ALL);
+          Entity.getEntityByName(TEST_CASE, testCaseResult.getTestCaseFQN(), "*", Include.ALL);
+      // Populate inherited fields (owners, tags, domains) for notification templates
+      TestCaseRepository testCaseRepository =
+          (TestCaseRepository) Entity.getEntityRepository(TEST_CASE);
+      testCaseRepository.setInheritedFields(
+          testCase, new EntityUtil.Fields(testCaseRepository.getAllowedFields()));
       ChangeEvent changeEvent =
           getChangeEvent(
               updateBy,
@@ -346,6 +351,11 @@ public class FormatterUtil {
     if (entityTimeSeries instanceof DataContractResult) {
       DataContractResult result =
           JsonUtils.readOrConvertValue(entityTimeSeries, DataContractResult.class);
+      // Don't create ChangeEvent for intermediate "Running" status
+      // Final notification will be sent when DQ validation completes
+      if (result.getContractExecutionStatus() == ContractExecutionStatus.Running) {
+        return null;
+      }
       return getDataContractResultEvent(result, updateBy, eventType);
     }
     return null;
@@ -354,7 +364,16 @@ public class FormatterUtil {
   public static ChangeEvent getDataContractResultEvent(
       DataContractResult result, String updateBy, EventType eventType) {
     DataContract contract =
-        Entity.getEntityByName(Entity.DATA_CONTRACT, result.getDataContractFQN(), "", Include.ALL);
+        Entity.getEntityByName(Entity.DATA_CONTRACT, result.getDataContractFQN(), "*", Include.ALL);
+
+    // Populate the entity reference with complete information (including fullyQualifiedName)
+    if (contract.getEntity() != null) {
+      EntityReference fullEntityRef =
+          Entity.getEntityReferenceById(
+              contract.getEntity().getType(), contract.getEntity().getId(), Include.NON_DELETED);
+      contract.setEntity(fullEntityRef);
+    }
+
     ChangeEvent changeEvent =
         getChangeEvent(updateBy, eventType, contract.getEntityReference().getType(), contract);
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java
@@ -54,6 +54,7 @@ import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.sdk.PipelineServiceClientInterface;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
+import org.openmetadata.service.events.lifecycle.EntityLifecycleEventDispatcher;
 import org.openmetadata.service.logstorage.LogStorageInterface;
 import org.openmetadata.service.resources.services.ingestionpipelines.IngestionPipelineResource;
 import org.openmetadata.service.secrets.SecretsManager;
@@ -384,9 +385,16 @@ public class IngestionPipelineRepository extends EntityRepository<IngestionPipel
         addPipelineStatusChangeDescription(
             ingestionPipeline.getVersion(), pipelineStatus, storedPipelineStatus);
     ingestionPipeline.setPipelineStatuses(pipelineStatus);
+    ingestionPipeline.setChangeDescription(change);
+
+    // Ensure entity reference is set before firing lifecycle event
+    setFullyQualifiedName(ingestionPipeline);
 
     // Update ES Indexes
     searchRepository.updateEntityIndex(ingestionPipeline);
+
+    // Fire lifecycle event for handlers (e.g., TestSuitePipelineStatusHandler)
+    EntityLifecycleEventDispatcher.getInstance().onEntityUpdated(ingestionPipeline, change, null);
 
     ChangeEvent changeEvent =
         getChangeEvent(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseResultRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseResultRepository.java
@@ -231,8 +231,6 @@ public class TestCaseResultRepository extends EntityTimeSeriesRepository<TestCas
             ? testCase.getTestSuites().stream().map(TestSuite::getFullyQualifiedName).toList()
             : null;
     TestSuiteRepository testSuiteRepository = new TestSuiteRepository();
-    DataContractRepository dataContractRepository =
-        (DataContractRepository) Entity.getEntityRepository(Entity.DATA_CONTRACT);
     if (fqns != null) {
       for (String fqn : fqns) {
         TestSuite testSuite = Entity.getEntityByName(TEST_SUITE, fqn, "*", Include.ALL);
@@ -267,10 +265,6 @@ public class TestCaseResultRepository extends EntityTimeSeriesRepository<TestCas
               testSuiteRepository.getUpdater(
                   original, testSuite, EntityRepository.Operation.PATCH, null);
           entityUpdater.update();
-          // Propagate test results to the data contract if it exists
-          if (testSuite.getDataContract() != null) {
-            dataContractRepository.updateContractDQResults(testSuite.getDataContract(), testSuite);
-          }
         }
       }
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestSuiteRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestSuiteRepository.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
@@ -34,6 +35,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.jdbi.v3.sqlobject.transaction.Transaction;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.entity.data.Table;
+import org.openmetadata.schema.entity.services.ingestionPipelines.IngestionPipeline;
+import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineStatusType;
+import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineType;
 import org.openmetadata.schema.tests.DataQualityReport;
 import org.openmetadata.schema.tests.ResultSummary;
 import org.openmetadata.schema.tests.TestCase;
@@ -41,8 +45,11 @@ import org.openmetadata.schema.tests.TestSuite;
 import org.openmetadata.schema.tests.type.ColumnTestSummaryDefinition;
 import org.openmetadata.schema.tests.type.TestCaseResult;
 import org.openmetadata.schema.tests.type.TestSummary;
+import org.openmetadata.schema.type.ChangeDescription;
+import org.openmetadata.schema.type.ChangeEvent;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.EventType;
+import org.openmetadata.schema.type.FieldChange;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.Relationship;
 import org.openmetadata.schema.type.change.ChangeSource;
@@ -50,6 +57,8 @@ import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.search.IndexMapping;
 import org.openmetadata.service.Entity;
+import org.openmetadata.service.events.lifecycle.EntityLifecycleEventDispatcher;
+import org.openmetadata.service.events.lifecycle.EntityLifecycleEventHandler;
 import org.openmetadata.service.resources.dqtests.TestSuiteResource;
 import org.openmetadata.service.resources.feeds.MessageParser;
 import org.openmetadata.service.search.SearchAggregation;
@@ -57,6 +66,7 @@ import org.openmetadata.service.search.SearchClient;
 import org.openmetadata.service.search.SearchIndexUtils;
 import org.openmetadata.service.search.SearchListFilter;
 import org.openmetadata.service.search.indexes.SearchIndex;
+import org.openmetadata.service.security.policyevaluator.SubjectContext;
 import org.openmetadata.service.util.AsyncService;
 import org.openmetadata.service.util.DeleteEntityResponse;
 import org.openmetadata.service.util.EntityUtil;
@@ -117,6 +127,8 @@ public class TestSuiteRepository extends EntityRepository<TestSuite> {
         UPDATE_FIELDS);
     quoteFqn = false;
     supportsSearch = true;
+    EntityLifecycleEventDispatcher.getInstance()
+        .registerHandler(new TestSuitePipelineStatusHandler());
     fieldFetchers.put("summary", this::fetchAndSetTestCaseResultSummary);
     fieldFetchers.put("pipelines", this::fetchAndSetIngestionPipelines);
   }
@@ -646,6 +658,119 @@ public class TestSuiteRepository extends EntityRepository<TestSuite> {
         .withUpdatedBy(testSuite.getUpdatedBy())
         .withUpdatedAt(testSuite.getUpdatedAt())
         .withVersion(testSuite.getVersion());
+  }
+
+  public void onTestSuiteExecutionComplete(IngestionPipeline pipeline) {
+    try {
+      TestSuite testSuite =
+          Entity.getEntity(
+              pipeline.getService().getType(),
+              pipeline.getService().getId(),
+              "*",
+              Include.NON_DELETED);
+
+      PipelineStatusType state = pipeline.getPipelineStatuses().getPipelineState();
+
+      // Create consolidated TestSuite ChangeEvent
+      createTestSuiteCompletionChangeEvent(testSuite, state);
+
+      // Update DataContract if linked (existing logic)
+      if (testSuite.getDataContract() != null) {
+        LOG.info(
+            "Pipeline {} completed with status {}. Updating data contract {}.",
+            pipeline.getFullyQualifiedName(),
+            state,
+            testSuite.getDataContract().getFullyQualifiedName());
+
+        DataContractRepository dataContractRepository =
+            (DataContractRepository) Entity.getEntityRepository(Entity.DATA_CONTRACT);
+        dataContractRepository.updateContractDQResults(testSuite.getDataContract(), testSuite);
+      }
+
+    } catch (Exception e) {
+      LOG.error(
+          "Failed to process test suite completion for pipeline {}: {}",
+          pipeline.getFullyQualifiedName(),
+          e.getMessage(),
+          e);
+    }
+  }
+
+  private void createTestSuiteCompletionChangeEvent(
+      TestSuite testSuite, PipelineStatusType pipelineState) {
+    // Load fresh summary data
+    List<ResultSummary> resultSummary = getResultSummary(testSuite.getId());
+    TestSummary summary = getTestSummary(resultSummary);
+
+    // Create ChangeEvent manually (similar to DataContract pattern)
+    ChangeEvent changeEvent =
+        new ChangeEvent()
+            .withId(UUID.randomUUID())
+            .withEventType(EventType.ENTITY_UPDATED)
+            .withEntityId(testSuite.getId())
+            .withEntityType(Entity.TEST_SUITE)
+            .withEntityFullyQualifiedName(testSuite.getFullyQualifiedName())
+            .withUserName("admin")
+            .withTimestamp(System.currentTimeMillis())
+            .withCurrentVersion(testSuite.getVersion())
+            .withPreviousVersion(testSuite.getVersion())
+            .withChangeDescription(
+                new ChangeDescription()
+                    .withFieldsUpdated(
+                        List.of(
+                            new FieldChange()
+                                .withName("testCaseResultSummary")
+                                .withNewValue(resultSummary))))
+            .withEntity(testSuite);
+
+    // Populate domains if available
+    if (testSuite.getDomains() != null) {
+      changeEvent.withDomains(testSuite.getDomains().stream().map(EntityReference::getId).toList());
+    }
+
+    // Insert directly into change event DAO
+    Entity.getCollectionDAO().changeEventDAO().insert(JsonUtils.pojoToJson(changeEvent));
+
+    LOG.info(
+        "Created consolidated ChangeEvent for TestSuite {} with status: {} (passed: {}/{})",
+        testSuite.getFullyQualifiedName(),
+        pipelineState,
+        summary.getSuccess(),
+        summary.getTotal());
+  }
+
+  private class TestSuitePipelineStatusHandler implements EntityLifecycleEventHandler {
+    @Override
+    public void onEntityUpdated(
+        EntityInterface entity,
+        ChangeDescription changeDescription,
+        SubjectContext subjectContext) {
+      if (!(entity instanceof IngestionPipeline pipeline)) {
+        return;
+      }
+
+      Optional.of(pipeline)
+          .filter(p -> p.getPipelineType() == PipelineType.TEST_SUITE)
+          .filter(p -> p.getPipelineStatuses() != null)
+          .filter(
+              p -> {
+                PipelineStatusType state = p.getPipelineStatuses().getPipelineState();
+                return state == PipelineStatusType.SUCCESS
+                    || state == PipelineStatusType.FAILED
+                    || state == PipelineStatusType.PARTIAL_SUCCESS;
+              })
+          .ifPresent(TestSuiteRepository.this::onTestSuiteExecutionComplete);
+    }
+
+    @Override
+    public String getHandlerName() {
+      return "TestSuitePipelineStatusHandler";
+    }
+
+    @Override
+    public Set<String> getSupportedEntityTypes() {
+      return Set.of(Entity.INGESTION_PIPELINE);
+    }
   }
 
   public class TestSuiteUpdater extends EntityUpdater {


### PR DESCRIPTION
Fixes #23868

* **Fix alert routing:** In `AlertUtil.java`, removed special-casing that matched `testCase` events to `testSuite` subscriptions. Now only `entityType=testSuite` triggers `testSuite` subscriptions.
* **Consolidate results on pipeline completion:** Added `TestSuitePipelineStatusHandler` (in `TestSuiteRepository.java`) that listens to IngestionPipeline lifecycle events and emits a single consolidated `ChangeEvent` (SUCCESS/FAILED/PARTIAL_SUCCESS) for each suite run and DataContract validation.
* **Remove immediate propagation:** In `TestCaseResultRepository.java`, stopped updating DataContracts per individual test result.
* **Defer/Filter DataContract events:** In `DataContractRepository.java` and `FormatterUtil.java`, skip `Running` interim events and emit only the final consolidated status.
* **Improve template context:** In `FormatterUtil.java`, load enriched entity data (`*` fields, owners, tags, domains; FQNs) to fix URL generation and rendering.

Why: test suites and data contracts were spamming users with N notifications (and confusing `entityType=testCase` events) instead of one consolidated `testSuite`/final result.

I worked on backend eventing/notification flow because subscriptions received multiple and misrouted notifications instead of a single, correct, consolidated update.

### Type of change:

* [x] Bug fix
* [ ] Improvement
* [ ] New feature
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation

### Checklist:

* [x] I have read the [**[CONTRIBUTING](https://docs.open-metadata.org/developers/contribute)**](https://docs.open-metadata.org/developers/contribute) document.
* [ ] My PR title is `Fixes <issue-number>: <short explanation>`
* [x] I have commented on my code, particularly in hard-to-understand areas.
* [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Bug fix -->

* [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.