### PR TITLE
FIX - Looker local path git converter

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/secrets/converter/LookerConnectionClassConverter.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/secrets/converter/LookerConnectionClassConverter.java
@@ -10,7 +10,11 @@ import org.openmetadata.schema.utils.JsonUtils;
 public class LookerConnectionClassConverter extends ClassConverter {
 
   private static final List<Class<?>> CREDENTIALS_CLASSES =
-      List.of(GitHubCredentials.class, BitBucketCredentials.class, GitlabCredentials.class);
+      List.of(
+          GitHubCredentials.class,
+          BitBucketCredentials.class,
+          GitlabCredentials.class,
+          String.class);
 
   public LookerConnectionClassConverter() {
     super(LookerConnection.class);


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

local repository path converter (string) was missing when trying to run the ingestion from CLI

<img width="1633" height="525" alt="image" src="https://github.com/user-attachments/assets/d3d8b906-2f3e-468e-a576-2028c81902b0" />

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
