### PR TITLE
Fixes #23996: Missing Slack notifications for workflow-generated approval tasks

### DIFF
--- a/openmetadata-service/src/test/java/org/openmetadata/service/governance/workflows/GlossaryApprovalWorkflowTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/governance/workflows/GlossaryApprovalWorkflowTest.java
@@ -53,11 +53,14 @@ import org.openmetadata.schema.entity.teams.User;
 import org.openmetadata.schema.governance.workflows.WorkflowDefinition;
 import org.openmetadata.schema.governance.workflows.WorkflowInstance;
 import org.openmetadata.schema.governance.workflows.WorkflowInstanceState;
+import org.openmetadata.schema.type.ChangeEvent;
 import org.openmetadata.schema.type.EntityStatus;
+import org.openmetadata.schema.type.EventType;
 import org.openmetadata.schema.type.ProviderType;
 import org.openmetadata.schema.type.TaskType;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.schema.utils.ResultList;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.OpenMetadataApplicationTest;
 import org.openmetadata.service.resources.events.EventSubscriptionResourceTest;
 import org.openmetadata.service.resources.glossary.GlossaryResourceTest;
@@ -310,6 +313,9 @@ public class GlossaryApprovalWorkflowTest extends OpenMetadataApplicationTest {
             .filter(t -> t.getTask().getId() != null) // Ensure task has valid ID
             .findFirst()
             .orElseThrow(() -> new AssertionError("No open approval task with valid ID found"));
+
+    // Verify ChangeEvent was created for the workflow-generated approval task
+    verifyChangeEventForTask(taskThread);
 
     // Prepare the resolve payload
     ResolveTask resolveTask = new ResolveTask().withNewValue("approved");
@@ -592,6 +598,31 @@ public class GlossaryApprovalWorkflowTest extends OpenMetadataApplicationTest {
         assertFalse(actualDisplayName.trim().isEmpty(), "DisplayName should not be empty");
       }
     }
+  }
+
+  private void verifyChangeEventForTask(Thread taskThread) {
+    long latestOffset = Entity.getCollectionDAO().changeEventDAO().getLatestOffset();
+    List<String> changeEventJsonList =
+        Entity.getCollectionDAO().changeEventDAO().list(100, Math.max(0, latestOffset - 100));
+
+    ChangeEvent matchingEvent =
+        changeEventJsonList.stream()
+            .map(json -> JsonUtils.readValue(json, ChangeEvent.class))
+            .filter(event -> event.getEntityType().equals(Entity.THREAD))
+            .filter(event -> event.getEntityId().equals(taskThread.getId()))
+            .filter(event -> event.getEventType().equals(EventType.THREAD_CREATED))
+            .findFirst()
+            .orElse(null);
+
+    assertNotNull(
+        matchingEvent,
+        String.format(
+            "ChangeEvent with type THREAD_CREATED should exist for task thread ID: %s",
+            taskThread.getId()));
+
+    assertNotNull(matchingEvent.getUserName(), "ChangeEvent userName should not be null");
+    assertNotNull(matchingEvent.getTimestamp(), "ChangeEvent timestamp should not be null");
+    assertNotNull(matchingEvent.getEntity(), "ChangeEvent entity should not be null");
   }
 
   private void manuallyTriggerWorkflowSignal(String entityLink) {


### PR DESCRIPTION
Fixes #23996

I worked on fixing missing Slack notifications for workflow-generated approval tasks because customers reported that when the governance-bot creates approval tasks for glossary terms, the tasks appear in the UI but Slack/email notifications are never sent.

**Root Cause:**
The `CreateApprovalTaskImpl.createApprovalTask()` method creates tasks by calling `feedRepository.create(thread)` directly, bypassing the REST API layer. This means the `ChangeEventHandler` JAX-RS filter never intercepts the operation, so no `ChangeEvent` is inserted into the `change_event` table. Without a `ChangeEvent` in the database, the `AlertPublisher` has nothing to poll, so external notifications (Slack, email, Teams) are never triggered.

**Solution:**
Manually create and insert a `ChangeEvent` after the thread is created in the workflow context, following the same pattern used in `TestSuiteRepository` and `DataContractRepository` for similar scenarios where entities are created outside the REST API flow.

**Changes:**

* Added `ChangeEvent` creation in `CreateApprovalTaskImpl.createApprovalTask()`
* Inserted `ChangeEvent` into the `change_event` table immediately after thread creation
* Added necessary imports: `ChangeEvent`, `EventType`

**Testing:**

* Manual tasks (via REST API): Still generate `ChangeEvent`s via `ChangeEventHandler` – no duplicates
* Workflow tasks (via governance-bot): Now generate `ChangeEvent`s via direct insertion – notifications work
* Verified no code path overlap that could cause duplicate events

### Type of change:

* [x] Bug fix
* [ ] Improvement
* [ ] New feature
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation


### Checklist:

* [x] I have read the [**[CONTRIBUTING](https://docs.open-metadata.org/developers/contribute)**](https://docs.open-metadata.org/developers/contribute) document.
* [x] My PR title is `Fixes <issue-number>: <short explanation>`
* [x] I have commented on my code, particularly in hard-to-understand areas.
* [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

**Bug fix**

* [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.