### PR TITLE
Fixed small typo in comments: changed 'metdata' to 'metadata'

### DIFF
--- a/ingestion/src/metadata/great_expectations/action.py
+++ b/ingestion/src/metadata/great_expectations/action.py
@@ -91,7 +91,7 @@ class OpenMetadataValidationAction(ValidationAction):
         data_context: great expectation data context
         database_service_name: name of the service for the table
         api_version: default to v1
-        config_file_path: path to the open metdata config path
+        config_file_path: path to the open metadata config path
     """
 
     def __init__(

--- a/ingestion/src/metadata/great_expectations/action1xx.py
+++ b/ingestion/src/metadata/great_expectations/action1xx.py
@@ -72,7 +72,7 @@ class OpenMetadataValidationAction1xx(ValidationAction):
         data_context: great expectation data context
         database_service_name: name of the service for the table
         api_version: default to v1
-        config_file_path: path to the open metdata config path
+        config_file_path: path to the open metadata config path
     """
 
     type: Literal["open_metadata_validation_action"] = "open_metadata_validation_action"


### PR DESCRIPTION
### Describe your changes:

Fixes #10734

I fixed a small typo in code comments where "metdata" was misspelled.  
Updated it to "metadata" in the following files:
- ingestion/src/metadata/great_expectations/action.py  
- ingestion/src/metadata/great_expectations/action1xx.py  

This improves code readability and documentation clarity.

#
### Type of change:
- [x] Bug fix

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes #10734: Fixed small typo in comments`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
