### PR TITLE
Remove deprecated `defaultTemplateChecksum` field via 1.10.5 migration

### DIFF
--- a/bootstrap/sql/migrations/native/1.10.5/mysql/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.10.5/mysql/postDataMigrationSQLScript.sql
@@ -1,0 +1,4 @@
+-- Remove deprecated defaultTemplateChecksum field from notification_template_entity
+UPDATE notification_template_entity
+SET json = JSON_REMOVE(json, '$.defaultTemplateChecksum')
+WHERE JSON_CONTAINS_PATH(json, 'one', '$.defaultTemplateChecksum');

--- a/bootstrap/sql/migrations/native/1.10.5/mysql/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.10.5/mysql/schemaChanges.sql
@@ -1,0 +1,1 @@
+-- Schema changes for 1.10.5 release

--- a/bootstrap/sql/migrations/native/1.10.5/postgres/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.10.5/postgres/postDataMigrationSQLScript.sql
@@ -1,0 +1,3 @@
+-- Remove deprecated defaultTemplateChecksum field from notification_template_entity
+UPDATE notification_template_entity
+SET json = json::jsonb - 'defaultTemplateChecksum';

--- a/bootstrap/sql/migrations/native/1.10.5/postgres/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.10.5/postgres/schemaChanges.sql
@@ -1,0 +1,1 @@
+-- Schema changes for 1.10.5 release


### PR DESCRIPTION
I added a database migration script in version **1.10.5** to remove the deprecated `defaultTemplateChecksum` field from all existing `notification_template_entity` records.

The `defaultTemplateChecksum` field was previously removed from the `NotificationTemplate` JSON Schema definition, but existing database records still contained this field. This caused Jackson deserialization failures when fetching `NotificationTemplates`, since the schema has `"additionalProperties": false`, which makes it strict about unknown properties.

The migration uses database-native JSON functions to safely remove the field:

* **MySQL:** `JSON_REMOVE(json, '$.defaultTemplateChecksum')`
* **PostgreSQL:** `json::jsonb - 'defaultTemplateChecksum'`

**Testing performed:**

* Verified migration syntax on a local MySQL container
* Confirmed the field is successfully removed from all 12 system notification templates
* Validated that `NotificationTemplate` deserialization works after migration

I worked on this because the deprecated field caused deserialization failures when loading templates, and the migration ensures database consistency with the current schema.

### Type of change:

* [x] Bug fix
* [ ] Improvement
* [ ] New feature
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation

### Checklist:

* [x] I have read the [**[CONTRIBUTING](https://docs.open-metadata.org/developers/contribute)**](https://docs.open-metadata.org/developers/contribute) document.
* [ ] My PR title is `Fixes <issue-number>: Remove deprecated defaultTemplateChecksum field via migration`
* [ ] I have commented on my code, particularly in hard-to-understand areas.
* [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
* [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.