### PR TITLE
Fix: Fields are getting cut in querybuilder option section

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Form/JSONSchema/JsonSchemaWidgets/QueryBuilderWidget/query-builder-widget.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Form/JSONSchema/JsonSchemaWidgets/QueryBuilderWidget/query-builder-widget.less
@@ -75,7 +75,6 @@
 
   .group--field {
     width: 180px;
-    max-width: 220px;
 
     .ant-select {
       width: 100% !important;
@@ -221,7 +220,6 @@
 
 .json-logic-field-select {
   min-width: 280px !important;
-
   .ant-select-item-group {
     padding-left: 8px;
     position: relative;
@@ -229,17 +227,6 @@
     font-size: 14px;
     background-color: @grey-6;
     white-space: nowrap;
-  }
-
-  .ant-select-item-option {
-    white-space: nowrap !important;
-    min-height: 32px;
-    padding: 5px 12px;
-  }
-
-  .ant-select-item-option-content {
-    white-space: nowrap !important;
-    overflow: visible !important;
   }
 
   /* Add vertical line for children */


### PR DESCRIPTION
### Describe your changes:
Fixed an issue in the Query Builder component where field options were getting cut off.

<img width="1511" height="714" alt="Screenshot 2025-11-05 at 2 29 12 PM" src="https://github.com/user-attachments/assets/9c7de5e3-9871-4b6c-b4b0-4ffd70c86427" />

### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.