### PR TITLE
Set `python-version` as string in validate-jsons-yamls.yml

### DIFF
--- a/.github/workflows/validate-jsons-yamls.yml
+++ b/.github/workflows/validate-jsons-yamls.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: '3.10'
 
       - name: Install Ubuntu related dependencies
         run: |


### PR DESCRIPTION
### Describe your changes:

Fixes [this error](https://github.com/open-metadata/OpenMetadata/actions/runs/19235718280/job/54984970524) affecting [all runs](https://github.com/open-metadata/OpenMetadata/actions/workflows/validate-jsons-yamls.yml).

The [`setup-python`](https://github.com/actions/setup-python) action expects `python-version` to be a string. Because of YAML type interpretation, 3.10 was being converted into `3.1`, a python version that can't be installed.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [X] Bug fix

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.