### PR TITLE
[Fix-24269] Data Retention fixes

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dataRetention/DataRetention.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dataRetention/DataRetention.java
@@ -29,6 +29,7 @@ import org.openmetadata.service.jdbi3.FeedRepository;
 import org.openmetadata.service.search.SearchRepository;
 import org.openmetadata.service.socket.WebSocketManager;
 import org.openmetadata.service.util.EntityRelationshipCleanupUtil;
+import org.openmetadata.service.util.TagUsageCleanup;
 import org.quartz.JobExecutionContext;
 
 @Slf4j
@@ -117,6 +118,7 @@ public class DataRetention extends AbstractNativeApplication {
     entityStats.withAdditionalProperty("broken_storage_entities", new StepStats());
     entityStats.withAdditionalProperty("broken_mlmodel_entities", new StepStats());
     entityStats.withAdditionalProperty("broken_search_entities", new StepStats());
+    entityStats.withAdditionalProperty("orphaned_tag_usages", new StepStats());
 
     retentionStats.setEntityStats(entityStats);
   }
@@ -130,6 +132,10 @@ public class DataRetention extends AbstractNativeApplication {
     // Clean up orphaned relationships and broken service hierarchies
     LOG.info("Starting cleanup for orphaned relationships and broken service hierarchies.");
     cleanOrphanedRelationshipsAndHierarchies();
+
+    // Clean up orphaned tag usages
+    LOG.info("Starting cleanup for orphaned tag usages.");
+    cleanOrphanedTagUsages();
 
     int retentionPeriod = config.getChangeEventRetentionPeriod();
     LOG.info("Starting cleanup for change events with retention period: {} days.", retentionPeriod);
@@ -227,6 +233,29 @@ public class DataRetention extends AbstractNativeApplication {
 
     } catch (Exception ex) {
       LOG.error("Failed to clean orphaned relationships and hierarchies", ex);
+      internalStatus = AppRunRecord.Status.ACTIVE_ERROR;
+
+      if (failureDetails == null) {
+        failureDetails = new HashMap<>();
+        failureDetails.put("message", ex.getMessage());
+        failureDetails.put("jobStackTrace", ExceptionUtils.getStackTrace(ex));
+      }
+    }
+  }
+
+  private void cleanOrphanedTagUsages() {
+    LOG.info("Initiating orphaned tag usages cleanup.");
+
+    try {
+      TagUsageCleanup cleanup = new TagUsageCleanup(collectionDAO, false);
+      TagUsageCleanup.TagCleanupResult result = cleanup.performCleanup(BATCH_SIZE);
+
+      updateStats("orphaned_tag_usages", result.getTagUsagesDeleted(), 0);
+
+      LOG.info("Tag usage cleanup completed - Deleted: {}", result.getTagUsagesDeleted());
+
+    } catch (Exception ex) {
+      LOG.error("Failed to clean orphaned tag usages", ex);
       internalStatus = AppRunRecord.Status.ACTIVE_ERROR;
 
       if (failureDetails == null) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -4873,6 +4873,49 @@ public interface CollectionDAO {
         @Bind("source") List<Integer> sources,
         @Bind("tagFQNHash") List<String> tagFQNHashes,
         @Bind("targetFQNHash") List<String> targetFQNHashes);
+
+    @SqlQuery("SELECT COUNT(*) FROM tag_usage")
+    long getTotalTagUsageCount();
+
+    @SqlQuery(
+        "SELECT source, tagFQN, tagFQNHash, targetFQNHash, labelType, state, reason FROM tag_usage ORDER BY source, tagFQNHash LIMIT :limit OFFSET :offset")
+    @RegisterRowMapper(TagUsageObjectMapper.class)
+    List<TagUsageObject> getAllTagUsagesPaginated(
+        @Bind("offset") long offset, @Bind("limit") int limit);
+
+    @SqlUpdate(
+        "DELETE FROM tag_usage WHERE source = :source AND tagFQNHash = :tagFQNHash AND targetFQNHash = :targetFQNHash")
+    int deleteTagUsage(
+        @Bind("source") int source,
+        @Bind("tagFQNHash") String tagFQNHash,
+        @Bind("targetFQNHash") String targetFQNHash);
+  }
+
+  @Getter
+  @Builder
+  class TagUsageObject {
+    private int source;
+    private String tagFQN;
+    private String tagFQNHash;
+    private String targetFQNHash;
+    private int labelType;
+    private int state;
+    private String reason;
+  }
+
+  class TagUsageObjectMapper implements RowMapper<TagUsageObject> {
+    @Override
+    public TagUsageObject map(ResultSet r, StatementContext ctx) throws SQLException {
+      return TagUsageObject.builder()
+          .source(r.getInt("source"))
+          .tagFQN(r.getString("tagFQN"))
+          .tagFQNHash(r.getString("tagFQNHash"))
+          .targetFQNHash(r.getString("targetFQNHash"))
+          .labelType(r.getInt("labelType"))
+          .state(r.getInt("state"))
+          .reason(r.getString("reason"))
+          .build();
+    }
   }
 
   interface RoleDAO extends EntityDAO<Role> {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/TagUsageCleanup.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/TagUsageCleanup.java
@@ -1,0 +1,293 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.util;
+
+import static org.openmetadata.service.util.OpenMetadataOperations.printToAsciiTable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.schema.type.TagLabel;
+import org.openmetadata.service.jdbi3.CollectionDAO;
+import org.openmetadata.service.jdbi3.GlossaryTermRepository;
+import org.openmetadata.service.jdbi3.TagRepository;
+
+@Slf4j
+public class TagUsageCleanup {
+
+  private final CollectionDAO collectionDAO;
+  private final TagRepository tagRepository;
+  private final GlossaryTermRepository glossaryTermRepository;
+  private final boolean dryRun;
+
+  public TagUsageCleanup(CollectionDAO collectionDAO, boolean dryRun) {
+    this.collectionDAO = collectionDAO;
+    this.tagRepository = new TagRepository();
+    this.glossaryTermRepository = new GlossaryTermRepository();
+    this.dryRun = dryRun;
+  }
+
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class OrphanedTagUsage {
+    private String tagFQN;
+    private String tagFQNHash;
+    private String targetFQNHash;
+    private int source;
+    private String sourceName;
+    private String reason;
+  }
+
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class TagCleanupResult {
+    private int totalTagUsagesScanned;
+    private int orphanedTagUsagesFound;
+    private int tagUsagesDeleted;
+    private List<OrphanedTagUsage> orphanedTagUsages;
+    private Map<String, Integer> orphansBySource;
+  }
+
+  public TagCleanupResult performCleanup(int batchSize) {
+    LOG.info("Starting tag usage cleanup. Dry run: {}, Batch size: {}", dryRun, batchSize);
+
+    TagCleanupResult result =
+        TagCleanupResult.builder()
+            .orphanedTagUsages(new ArrayList<>())
+            .orphansBySource(new HashMap<>())
+            .build();
+
+    try {
+      long totalTagUsages = collectionDAO.tagUsageDAO().getTotalTagUsageCount();
+      result.setTotalTagUsagesScanned((int) totalTagUsages);
+
+      LOG.info(
+          "Found {} total tag usages to scan. Processing in batches of {}",
+          totalTagUsages,
+          batchSize);
+
+      long offset = 0;
+      int processedCount = 0;
+      int batchNumber = 1;
+
+      while (offset < totalTagUsages) {
+        LOG.info("Processing batch {} (offset: {}, limit: {})", batchNumber, offset, batchSize);
+
+        List<CollectionDAO.TagUsageObject> tagUsageBatch =
+            collectionDAO.tagUsageDAO().getAllTagUsagesPaginated(offset, batchSize);
+
+        if (tagUsageBatch.isEmpty()) {
+          LOG.info("No more tag usages to process");
+          break;
+        }
+
+        for (CollectionDAO.TagUsageObject tagUsage : tagUsageBatch) {
+          OrphanedTagUsage orphan = validateTagUsage(tagUsage);
+          if (orphan != null) {
+            result.getOrphanedTagUsages().add(orphan);
+            result.getOrphansBySource().merge(orphan.getSourceName(), 1, Integer::sum);
+          }
+          processedCount++;
+        }
+
+        offset += tagUsageBatch.size();
+        batchNumber++;
+
+        if (processedCount % (batchSize * 10) == 0 || offset >= totalTagUsages) {
+          LOG.info(
+              "Progress: {}/{} tag usages processed, {} orphaned tag usages found",
+              processedCount,
+              totalTagUsages,
+              result.getOrphanedTagUsages().size());
+        }
+      }
+
+      result.setOrphanedTagUsagesFound(result.getOrphanedTagUsages().size());
+
+      LOG.info(
+          "Completed scanning {} tag usages. Found {} orphaned tag usages",
+          processedCount,
+          result.getOrphanedTagUsagesFound());
+
+      displayOrphanedTagUsages(result);
+      if (!dryRun && !result.getOrphanedTagUsages().isEmpty()) {
+        result.setTagUsagesDeleted(deleteOrphanedTagUsages(result.getOrphanedTagUsages()));
+      }
+
+      LOG.info(
+          "Tag usage cleanup completed. Scanned: {}, Found: {}, Deleted: {}",
+          processedCount,
+          result.getOrphanedTagUsagesFound(),
+          result.getTagUsagesDeleted());
+
+    } catch (Exception e) {
+      LOG.error("Error during tag usage cleanup", e);
+      throw new RuntimeException("Tag usage cleanup failed", e);
+    }
+
+    return result;
+  }
+
+  private OrphanedTagUsage validateTagUsage(CollectionDAO.TagUsageObject tagUsage) {
+    try {
+      int source = tagUsage.getSource();
+      String tagFQNHash = tagUsage.getTagFQNHash();
+      String tagFQN = tagUsage.getTagFQN();
+
+      boolean tagExists = checkTagExists(source, tagFQN);
+
+      if (tagExists) {
+        return null;
+      }
+
+      return OrphanedTagUsage.builder()
+          .tagFQN(tagFQN)
+          .tagFQNHash(tagFQNHash)
+          .targetFQNHash(tagUsage.getTargetFQNHash())
+          .source(source)
+          .sourceName(getSourceName(source))
+          .reason(
+              String.format(
+                  "%s does not exist in %s table",
+                  tagFQN,
+                  source == TagLabel.TagSource.CLASSIFICATION.ordinal()
+                      ? "tag"
+                      : "glossary_term_entity"))
+          .build();
+
+    } catch (Exception e) {
+      LOG.debug("Error validating tag usage for tag {}: {}", tagUsage.getTagFQN(), e.getMessage());
+      return null;
+    }
+  }
+
+  private boolean checkTagExists(int source, String tagFQNHash) {
+    if (source == TagLabel.TagSource.CLASSIFICATION.ordinal()) {
+      return collectionDAO
+          .tagDAO()
+          .existsByName(
+              collectionDAO.tagDAO().getTableName(),
+              collectionDAO.tagDAO().getNameHashColumn(),
+              tagFQNHash);
+    } else if (source == TagLabel.TagSource.GLOSSARY.ordinal()) {
+      return collectionDAO
+          .glossaryTermDAO()
+          .existsByName(
+              collectionDAO.glossaryTermDAO().getTableName(),
+              collectionDAO.glossaryTermDAO().getNameHashColumn(),
+              tagFQNHash);
+    }
+    LOG.warn("Unknown tag source: {}", source);
+    return true;
+  }
+
+  private int deleteOrphanedTagUsages(List<OrphanedTagUsage> orphanedTagUsages) {
+    LOG.info("Deleting {} orphaned tag usages", orphanedTagUsages.size());
+    int deletedCount = 0;
+
+    for (OrphanedTagUsage orphan : orphanedTagUsages) {
+      try {
+        int deleted =
+            collectionDAO
+                .tagUsageDAO()
+                .deleteTagUsage(
+                    orphan.getSource(), orphan.getTagFQNHash(), orphan.getTargetFQNHash());
+
+        if (deleted > 0) {
+          deletedCount++;
+          LOG.debug(
+              "Deleted orphaned tag usage: {} (source: {}) -> target: {}",
+              orphan.getTagFQN(),
+              orphan.getSourceName(),
+              orphan.getTargetFQNHash());
+        }
+      } catch (Exception e) {
+        LOG.error(
+            "Failed to delete orphaned tag usage: {} (source: {}) -> target: {}: {}",
+            orphan.getTagFQN(),
+            orphan.getSourceName(),
+            orphan.getTargetFQNHash(),
+            e.getMessage());
+      }
+    }
+
+    LOG.info(
+        "Successfully deleted {} out of {} orphaned tag usages",
+        deletedCount,
+        orphanedTagUsages.size());
+    return deletedCount;
+  }
+
+  private void displayOrphanedTagUsages(TagCleanupResult result) {
+    if (result.getOrphanedTagUsages().isEmpty()) {
+      LOG.info("No orphaned tag usages found. All tag usages are valid.");
+      return;
+    }
+
+    LOG.info("Found {} orphaned tag usages", result.getOrphanedTagUsagesFound());
+
+    List<String> columns =
+        Arrays.asList("Tag FQN", "Tag FQN Hash", "Target FQN Hash", "Source", "Reason");
+
+    List<List<String>> rows = new ArrayList<>();
+    for (OrphanedTagUsage orphan : result.getOrphanedTagUsages()) {
+      rows.add(
+          Arrays.asList(
+              orphan.getTagFQN(),
+              orphan.getTagFQNHash(),
+              orphan.getTargetFQNHash(),
+              orphan.getSourceName(),
+              orphan.getReason()));
+    }
+
+    printToAsciiTable(columns, rows, "No orphaned tag usages found");
+
+    displaySummaryStatistics(result);
+  }
+
+  private void displaySummaryStatistics(TagCleanupResult result) {
+    if (!result.getOrphansBySource().isEmpty()) {
+      LOG.info("Orphaned tag usages by source:");
+      List<String> sourceColumns = Arrays.asList("Source", "Count");
+      List<List<String>> sourceRows = new ArrayList<>();
+
+      result.getOrphansBySource().entrySet().stream()
+          .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+          .forEach(
+              entry -> sourceRows.add(Arrays.asList(entry.getKey(), entry.getValue().toString())));
+
+      printToAsciiTable(sourceColumns, sourceRows, "No source statistics");
+    }
+  }
+
+  private String getSourceName(int source) {
+    if (source == TagLabel.TagSource.CLASSIFICATION.ordinal()) {
+      return "Classification";
+    } else if (source == TagLabel.TagSource.GLOSSARY.ordinal()) {
+      return "Glossary";
+    }
+    return "Unknown";
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/relationshipcleanup/DefaultRelationshipValidator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/relationshipcleanup/DefaultRelationshipValidator.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.util.relationshipcleanup;
+
+import java.util.UUID;
+import org.openmetadata.service.jdbi3.CollectionDAO;
+
+public class DefaultRelationshipValidator implements RelationshipValidator {
+
+  @Override
+  public ValidationResult validate(
+      CollectionDAO.EntityRelationshipObject relationship,
+      EntityExistenceChecker existenceChecker) {
+    UUID fromId = UUID.fromString(relationship.getFromId());
+    UUID toId = UUID.fromString(relationship.getToId());
+    String fromEntity = relationship.getFromEntity();
+    String toEntity = relationship.getToEntity();
+
+    boolean fromExists = existenceChecker.exists(fromId, fromEntity);
+    boolean toExists = existenceChecker.exists(toId, toEntity);
+
+    if (fromExists && toExists) {
+      return ValidationResult.valid();
+    }
+
+    if (!fromExists && !toExists) {
+      return ValidationResult.orphaned("Both fromEntity and toEntity do not exist");
+    } else if (!fromExists) {
+      return ValidationResult.orphaned("fromEntity does not exist");
+    } else {
+      return ValidationResult.orphaned("toEntity does not exist");
+    }
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/relationshipcleanup/LineageRelationshipValidator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/relationshipcleanup/LineageRelationshipValidator.java
@@ -1,0 +1,72 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.util.relationshipcleanup;
+
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.type.LineageDetails;
+import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.service.jdbi3.CollectionDAO;
+
+@Slf4j
+public class LineageRelationshipValidator implements RelationshipValidator {
+
+  private final DefaultRelationshipValidator defaultValidator = new DefaultRelationshipValidator();
+
+  @Override
+  public ValidationResult validate(
+      CollectionDAO.EntityRelationshipObject relationship,
+      EntityExistenceChecker existenceChecker) {
+
+    ValidationResult defaultResult = defaultValidator.validate(relationship, existenceChecker);
+    if (defaultResult.isOrphaned()) {
+      return defaultResult;
+    }
+
+    String json = relationship.getJson();
+    if (json == null || json.isBlank()) {
+      return ValidationResult.valid();
+    }
+
+    try {
+      LineageDetails lineageDetails = JsonUtils.readValue(json, LineageDetails.class);
+      EntityReference pipeline = lineageDetails.getPipeline();
+
+      if (pipeline == null) {
+        return ValidationResult.valid();
+      }
+
+      UUID pipelineId = pipeline.getId();
+      if (pipelineId == null) {
+        return ValidationResult.valid();
+      }
+
+      boolean pipelineExists = existenceChecker.exists(pipelineId, pipeline.getType());
+      if (!pipelineExists) {
+        return ValidationResult.orphaned("Pipeline entity referenced in lineage does not exist");
+      }
+
+      return ValidationResult.valid();
+
+    } catch (Exception e) {
+      LOG.debug(
+          "Error parsing lineage details for relationship {}->{}: {}",
+          relationship.getFromId(),
+          relationship.getToId(),
+          e.getMessage());
+      return ValidationResult.valid();
+    }
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/relationshipcleanup/RelationshipValidator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/relationshipcleanup/RelationshipValidator.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.util.relationshipcleanup;
+
+import java.util.UUID;
+import org.openmetadata.service.jdbi3.CollectionDAO;
+
+public interface RelationshipValidator {
+  ValidationResult validate(
+      CollectionDAO.EntityRelationshipObject relationship, EntityExistenceChecker existenceChecker);
+
+  class ValidationResult {
+    private final boolean isOrphaned;
+    private final String reason;
+
+    private ValidationResult(boolean isOrphaned, String reason) {
+      this.isOrphaned = isOrphaned;
+      this.reason = reason;
+    }
+
+    public static ValidationResult valid() {
+      return new ValidationResult(false, null);
+    }
+
+    public static ValidationResult orphaned(String reason) {
+      return new ValidationResult(true, reason);
+    }
+
+    public boolean isOrphaned() {
+      return isOrphaned;
+    }
+
+    public String getReason() {
+      return reason;
+    }
+  }
+
+  @FunctionalInterface
+  interface EntityExistenceChecker {
+    boolean exists(UUID entityId, String entityType);
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/TagUsageCleanupTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/TagUsageCleanupTest.java
@@ -1,0 +1,574 @@
+/*
+ *  Copyright 2025 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.openmetadata.service.util.TestUtils.ADMIN_AUTH_HEADERS;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.openmetadata.schema.api.classification.CreateTag;
+import org.openmetadata.schema.api.data.CreateTable;
+import org.openmetadata.schema.entity.classification.Classification;
+import org.openmetadata.schema.entity.classification.Tag;
+import org.openmetadata.schema.entity.data.GlossaryTerm;
+import org.openmetadata.schema.entity.data.Table;
+import org.openmetadata.schema.type.TagLabel;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.OpenMetadataApplicationTest;
+import org.openmetadata.service.jdbi3.CollectionDAO;
+import org.openmetadata.service.resources.EntityResourceTest;
+import org.openmetadata.service.resources.databases.TableResourceTest;
+import org.openmetadata.service.resources.glossary.GlossaryResourceTest;
+import org.openmetadata.service.resources.glossary.GlossaryTermResourceTest;
+import org.openmetadata.service.resources.tags.ClassificationResourceTest;
+import org.openmetadata.service.resources.tags.TagResourceTest;
+
+@Slf4j
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class TagUsageCleanupTest extends OpenMetadataApplicationTest {
+
+  private static TableResourceTest tableTest;
+  private static TagResourceTest tagResourceTest;
+  private static GlossaryTermResourceTest glossaryTermTest;
+  private static ClassificationResourceTest classificationResourceTest;
+
+  private static List<Table> testTables;
+  private static List<Tag> testTags;
+  private static List<GlossaryTerm> testGlossaryTerms;
+  private static Classification testClassification;
+
+  private static CollectionDAO collectionDAO;
+  private static TagUsageCleanup cleanup;
+
+  @BeforeAll
+  static void setup(TestInfo test) throws IOException, URISyntaxException {
+    tableTest = new TableResourceTest();
+    tagResourceTest = new TagResourceTest();
+    glossaryTermTest = new GlossaryTermResourceTest();
+    classificationResourceTest = new ClassificationResourceTest();
+    GlossaryResourceTest glossaryTest = new GlossaryResourceTest();
+    glossaryTest.setup(test);
+
+    testTables = new ArrayList<>();
+    testTags = new ArrayList<>();
+    testGlossaryTerms = new ArrayList<>();
+
+    collectionDAO = Entity.getCollectionDAO();
+
+    tableTest.setupDatabaseSchemas(test);
+
+    setupTestEntities(test);
+  }
+
+  private static void setupTestEntities(TestInfo test) throws IOException {
+    // Create test classification and tags
+    testClassification =
+        classificationResourceTest.createEntity(
+            classificationResourceTest.createRequest("CleanupTestClassification"),
+            ADMIN_AUTH_HEADERS);
+
+    for (int i = 0; i < 3; i++) {
+      CreateTag createTag =
+          tagResourceTest
+              .createRequest(test, i)
+              .withClassification(testClassification.getFullyQualifiedName());
+      Tag tag = tagResourceTest.createEntity(createTag, ADMIN_AUTH_HEADERS);
+      testTags.add(tag);
+    }
+
+    // Create test glossary terms
+    for (int i = 0; i < 3; i++) {
+      GlossaryTerm term =
+          glossaryTermTest.createEntity(
+              glossaryTermTest.createRequest(test, i), ADMIN_AUTH_HEADERS);
+      testGlossaryTerms.add(term);
+    }
+
+    // Create test tables
+    for (int i = 0; i < 3; i++) {
+      CreateTable createTable =
+          tableTest
+              .createRequest(test, i)
+              .withDatabaseSchema(EntityResourceTest.DATABASE_SCHEMA.getFullyQualifiedName());
+      Table table = tableTest.createEntity(createTable, ADMIN_AUTH_HEADERS);
+      testTables.add(table);
+    }
+
+    LOG.info(
+        "Created test entities: Tags={}, GlossaryTerms={}, Tables={}",
+        testTags.size(),
+        testGlossaryTerms.size(),
+        testTables.size());
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {10, 100, 1000, 10000})
+  void test_cleanupWithDifferentBatchSizes_shouldScanTagUsages(int batchSize) {
+    cleanup = new TagUsageCleanup(collectionDAO, true); // dry-run mode
+    TagUsageCleanup.TagCleanupResult result = cleanup.performCleanup(batchSize);
+    assertNotNull(result, "Cleanup result should not be null for batch size: " + batchSize);
+    assertTrue(
+        result.getTotalTagUsagesScanned() >= 0,
+        "Should scan tag usages with batch size: " + batchSize);
+  }
+
+  @Test
+  void test_cleanupAfterDeletingTag_shouldDetectOrphans() {
+    Tag tagToDelete = testTags.getFirst();
+    String tagFQN = tagToDelete.getFullyQualifiedName();
+
+    // Create a tag usage entry
+    Table targetTable = testTables.getFirst();
+    String targetFQNHash = FullyQualifiedName.buildHash(targetTable.getFullyQualifiedName());
+
+    collectionDAO
+        .tagUsageDAO()
+        .applyTag(
+            TagLabel.TagSource.CLASSIFICATION.ordinal(),
+            tagFQN,
+            tagFQN,
+            targetFQNHash,
+            TagLabel.LabelType.MANUAL.ordinal(),
+            TagLabel.State.CONFIRMED.ordinal(),
+            null);
+
+    // Delete the tag
+    collectionDAO.tagDAO().delete(tagToDelete.getId());
+
+    // Run cleanup
+    cleanup = new TagUsageCleanup(collectionDAO, true);
+    TagUsageCleanup.TagCleanupResult result = cleanup.performCleanup(100);
+
+    assertNotNull(result);
+    assertTrue(
+        result.getOrphanedTagUsagesFound() > 0,
+        "Should find orphaned tag usages after tag deletion");
+
+    boolean foundOrphanedTag =
+        result.getOrphanedTagUsages().stream()
+            .anyMatch(
+                orphan -> FullyQualifiedName.buildHash(tagFQN).equals(orphan.getTagFQNHash()));
+
+    assertTrue(foundOrphanedTag, "Should find orphaned tag usage for deleted tag");
+    assertFalse(result.getOrphansBySource().isEmpty(), "Should have source statistics");
+
+    // Cleanup
+    TagUsageCleanup actualCleanup = new TagUsageCleanup(collectionDAO, false);
+    actualCleanup.performCleanup(100);
+  }
+
+  @Test
+  void test_cleanupAfterDeletingGlossaryTerm_shouldDetectOrphans() {
+    GlossaryTerm termToDelete = testGlossaryTerms.getFirst();
+    String termFQN = termToDelete.getFullyQualifiedName();
+
+    // Create a glossary term usage entry
+    Table targetTable = testTables.get(1);
+    String targetFQNHash = FullyQualifiedName.buildHash(targetTable.getFullyQualifiedName());
+
+    collectionDAO
+        .tagUsageDAO()
+        .applyTag(
+            TagLabel.TagSource.GLOSSARY.ordinal(),
+            termFQN,
+            termFQN,
+            targetFQNHash,
+            TagLabel.LabelType.MANUAL.ordinal(),
+            TagLabel.State.CONFIRMED.ordinal(),
+            null);
+
+    // Delete the glossary term
+    collectionDAO.glossaryTermDAO().delete(termToDelete.getId());
+
+    // Run cleanup
+    cleanup = new TagUsageCleanup(collectionDAO, true);
+    TagUsageCleanup.TagCleanupResult result = cleanup.performCleanup(100);
+
+    assertNotNull(result);
+    assertTrue(
+        result.getOrphanedTagUsagesFound() > 0,
+        "Should find orphaned tag usages after glossary term deletion");
+
+    boolean foundOrphanedTerm =
+        result.getOrphanedTagUsages().stream()
+            .anyMatch(
+                orphan -> FullyQualifiedName.buildHash(termFQN).equals(orphan.getTagFQNHash()));
+
+    assertTrue(foundOrphanedTerm, "Should find orphaned tag usage for deleted glossary term");
+
+    // Cleanup
+    TagUsageCleanup actualCleanup = new TagUsageCleanup(collectionDAO, false);
+    actualCleanup.performCleanup(100);
+  }
+
+  @Test
+  void test_actualCleanup_shouldDeleteOrphanedTagUsages() {
+    // Create orphaned tag usage
+    String orphanTagFQN = "orphanedTag";
+    String orphanTagFQNHash = FullyQualifiedName.buildHash(orphanTagFQN);
+    String targetFQNHash = FullyQualifiedName.buildHash(testTables.get(2).getFullyQualifiedName());
+
+    collectionDAO
+        .tagUsageDAO()
+        .applyTag(
+            TagLabel.TagSource.CLASSIFICATION.ordinal(),
+            orphanTagFQN,
+            orphanTagFQNHash,
+            targetFQNHash,
+            TagLabel.LabelType.MANUAL.ordinal(),
+            TagLabel.State.CONFIRMED.ordinal(),
+            null);
+
+    // Dry run
+    TagUsageCleanup dryRunCleanup = new TagUsageCleanup(collectionDAO, true);
+    TagUsageCleanup.TagCleanupResult dryRunResult = dryRunCleanup.performCleanup(100);
+
+    int orphansFoundInDryRun = dryRunResult.getOrphanedTagUsagesFound();
+
+    if (orphansFoundInDryRun > 0) {
+      // Actual cleanup
+      TagUsageCleanup actualCleanup = new TagUsageCleanup(collectionDAO, false);
+      TagUsageCleanup.TagCleanupResult actualResult = actualCleanup.performCleanup(100);
+
+      assertNotNull(actualResult);
+      assertTrue(actualResult.getTagUsagesDeleted() > 0, "Should have deleted orphaned tag usages");
+
+      // Verify cleanup
+      TagUsageCleanup verificationCleanup = new TagUsageCleanup(collectionDAO, true);
+      TagUsageCleanup.TagCleanupResult verificationResult = verificationCleanup.performCleanup(100);
+
+      boolean stillFoundOrphan =
+          verificationResult.getOrphanedTagUsages().stream()
+              .anyMatch(orphan -> orphanTagFQNHash.equals(orphan.getTagFQNHash()));
+
+      assertFalse(
+          stillFoundOrphan, "Should not find the specific orphaned tag usage after cleanup");
+    }
+  }
+
+  @Test
+  @Order(1)
+  void test_createOrphanedTagUsageScenario() {
+    String nonExistentTagFQN = "NonExistent.Tag";
+
+    collectionDAO
+        .tagUsageDAO()
+        .applyTag(
+            TagLabel.TagSource.CLASSIFICATION.ordinal(),
+            nonExistentTagFQN,
+            nonExistentTagFQN,
+            testTables.getFirst().getFullyQualifiedName(),
+            TagLabel.LabelType.MANUAL.ordinal(),
+            TagLabel.State.CONFIRMED.ordinal(),
+            null);
+
+    cleanup = new TagUsageCleanup(collectionDAO, true);
+    TagUsageCleanup.TagCleanupResult result = cleanup.performCleanup(100);
+
+    assertTrue(
+        result.getOrphanedTagUsagesFound() > 0,
+        "Should detect manually created orphaned tag usage");
+
+    boolean foundSpecificOrphan =
+        result.getOrphanedTagUsages().stream()
+            .anyMatch(
+                orphan ->
+                    FullyQualifiedName.buildHash(nonExistentTagFQN).equals(orphan.getTagFQNHash()));
+
+    assertTrue(foundSpecificOrphan, "Should find the specific orphaned tag usage created");
+
+    TagUsageCleanup actualCleanup = new TagUsageCleanup(collectionDAO, false);
+    TagUsageCleanup.TagCleanupResult cleanupResult = actualCleanup.performCleanup(100);
+
+    assertTrue(cleanupResult.getTagUsagesDeleted() > 0, "Should delete the orphaned tag usage");
+  }
+
+  @Test
+  void test_mixedSourceTypes_shouldHandleBothClassificationAndGlossary() {
+    String orphanTagFQN = "OrphanedClassification.Tag";
+    String orphanTermFQN = "OrphanedGlossary.Term";
+    String targetFQNHash =
+        FullyQualifiedName.buildHash(testTables.getFirst().getFullyQualifiedName());
+
+    // Create orphaned classification tag usage
+    collectionDAO
+        .tagUsageDAO()
+        .applyTag(
+            TagLabel.TagSource.CLASSIFICATION.ordinal(),
+            orphanTagFQN,
+            orphanTagFQN,
+            targetFQNHash,
+            TagLabel.LabelType.MANUAL.ordinal(),
+            TagLabel.State.CONFIRMED.ordinal(),
+            null);
+
+    // Create orphaned glossary term usage
+    collectionDAO
+        .tagUsageDAO()
+        .applyTag(
+            TagLabel.TagSource.GLOSSARY.ordinal(),
+            orphanTermFQN,
+            orphanTermFQN,
+            targetFQNHash,
+            TagLabel.LabelType.MANUAL.ordinal(),
+            TagLabel.State.CONFIRMED.ordinal(),
+            null);
+
+    cleanup = new TagUsageCleanup(collectionDAO, true);
+    TagUsageCleanup.TagCleanupResult result = cleanup.performCleanup(100);
+
+    assertNotNull(result);
+    assertTrue(result.getOrphanedTagUsagesFound() >= 2, "Should find at least 2 orphaned usages");
+
+    boolean foundClassificationOrphan =
+        result.getOrphanedTagUsages().stream()
+            .anyMatch(
+                orphan ->
+                    orphan.getSource() == TagLabel.TagSource.CLASSIFICATION.ordinal()
+                        && FullyQualifiedName.buildHash(orphanTagFQN)
+                            .equals(orphan.getTagFQNHash()));
+
+    boolean foundGlossaryOrphan =
+        result.getOrphanedTagUsages().stream()
+            .anyMatch(
+                orphan ->
+                    orphan.getSource() == TagLabel.TagSource.GLOSSARY.ordinal()
+                        && FullyQualifiedName.buildHash(orphanTermFQN)
+                            .equals(orphan.getTagFQNHash()));
+
+    assertTrue(foundClassificationOrphan, "Should find orphaned classification tag usage");
+    assertTrue(foundGlossaryOrphan, "Should find orphaned glossary term usage");
+
+    assertTrue(
+        result.getOrphansBySource().containsKey("Classification"),
+        "Should have Classification in statistics");
+    assertTrue(
+        result.getOrphansBySource().containsKey("Glossary"), "Should have Glossary in statistics");
+
+    // Cleanup
+    TagUsageCleanup actualCleanup = new TagUsageCleanup(collectionDAO, false);
+    actualCleanup.performCleanup(100);
+  }
+
+  @Test
+  void test_tagUsageCleanupCommand_dryRun() {
+    TagUsageCleanup dryRunCleanup = new TagUsageCleanup(collectionDAO, true);
+    TagUsageCleanup.TagCleanupResult result = dryRunCleanup.performCleanup(500);
+    assertNotNull(result, "Cleanup result should not be null");
+    assertTrue(result.getTotalTagUsagesScanned() >= 0, "Should scan some tag usages");
+  }
+
+  @Test
+  void test_tagUsageCleanupCommand_noOrphanedData() {
+    // First clean up any existing orphaned tag usages from other tests
+    TagUsageCleanup initialCleanup = new TagUsageCleanup(collectionDAO, false);
+    initialCleanup.performCleanup(100);
+
+    // Now run the actual test - there should be no orphaned tag usages
+    TagUsageCleanup cleanup1 = new TagUsageCleanup(collectionDAO, false);
+    TagUsageCleanup.TagCleanupResult result = cleanup1.performCleanup(100);
+    assertNotNull(result, "Cleanup result should not be null");
+    assertEquals(
+        0, result.getTagUsagesDeleted(), "Should not delete any tag usages when none are orphaned");
+  }
+
+  @Test
+  void test_tagUsageCleanupCommand_multipleOrphanedUsages() {
+    for (int i = 0; i < 5; i++) {
+      String orphanTagFQN = "MultipleOrphan.Tag" + i;
+      String targetFQNHash =
+          FullyQualifiedName.buildHash(testTables.getFirst().getFullyQualifiedName());
+
+      collectionDAO
+          .tagUsageDAO()
+          .applyTag(
+              TagLabel.TagSource.CLASSIFICATION.ordinal(),
+              orphanTagFQN,
+              orphanTagFQN,
+              targetFQNHash,
+              TagLabel.LabelType.MANUAL.ordinal(),
+              TagLabel.State.CONFIRMED.ordinal(),
+              null);
+    }
+
+    TagUsageCleanup cleanup1 = new TagUsageCleanup(collectionDAO, false);
+    TagUsageCleanup.TagCleanupResult result = cleanup1.performCleanup(2);
+
+    assertNotNull(result, "Cleanup result should not be null");
+    assertTrue(
+        result.getTagUsagesDeleted() >= 5,
+        "Should delete at least the 5 orphaned tag usages created");
+  }
+
+  @Test
+  void test_commandBehavior_defaultDryRunWithNoOrphans() {
+    // First clean up any existing orphaned tag usages from other tests
+    TagUsageCleanup initialCleanup = new TagUsageCleanup(collectionDAO, false);
+    initialCleanup.performCleanup(100);
+
+    // Now run the actual test
+    TagUsageCleanup dryRunCleanup = new TagUsageCleanup(collectionDAO, true);
+    TagUsageCleanup.TagCleanupResult result = dryRunCleanup.performCleanup(100);
+
+    assertNotNull(result);
+    assertEquals(
+        0, result.getOrphanedTagUsagesFound(), "Should find no orphaned tag usages after cleanup");
+  }
+
+  @Test
+  void test_commandBehavior_defaultDryRunWithOrphans() {
+    String orphanTagFQN = "OrphanForDryRun.Tag";
+    String orphanTagFQNHash = FullyQualifiedName.buildHash(orphanTagFQN);
+    String targetFQNHash =
+        FullyQualifiedName.buildHash(testTables.getFirst().getFullyQualifiedName());
+
+    collectionDAO
+        .tagUsageDAO()
+        .applyTag(
+            TagLabel.TagSource.CLASSIFICATION.ordinal(),
+            orphanTagFQN,
+            orphanTagFQNHash,
+            targetFQNHash,
+            TagLabel.LabelType.MANUAL.ordinal(),
+            TagLabel.State.CONFIRMED.ordinal(),
+            null);
+
+    TagUsageCleanup dryRunCleanup = new TagUsageCleanup(collectionDAO, true);
+    TagUsageCleanup.TagCleanupResult result = dryRunCleanup.performCleanup(100);
+
+    assertNotNull(result);
+    assertTrue(
+        result.getOrphanedTagUsagesFound() > 0, "Should find the orphaned tag usage in dry-run");
+    assertEquals(0, result.getTagUsagesDeleted(), "Should not delete in dry-run mode");
+
+    // Cleanup
+    TagUsageCleanup actualCleanup = new TagUsageCleanup(collectionDAO, false);
+    actualCleanup.performCleanup(100);
+  }
+
+  @Test
+  void test_commandBehavior_explicitDeleteFlag() {
+    String orphanTagFQN = "OrphanForDelete.Tag";
+    String orphanTagFQNHash = FullyQualifiedName.buildHash(orphanTagFQN);
+    String targetFQNHash =
+        FullyQualifiedName.buildHash(testTables.getFirst().getFullyQualifiedName());
+
+    collectionDAO
+        .tagUsageDAO()
+        .applyTag(
+            TagLabel.TagSource.CLASSIFICATION.ordinal(),
+            orphanTagFQN,
+            orphanTagFQNHash,
+            targetFQNHash,
+            TagLabel.LabelType.MANUAL.ordinal(),
+            TagLabel.State.CONFIRMED.ordinal(),
+            null);
+
+    TagUsageCleanup deleteCleanup = new TagUsageCleanup(collectionDAO, false);
+    TagUsageCleanup.TagCleanupResult result = deleteCleanup.performCleanup(100);
+
+    assertNotNull(result);
+    assertTrue(result.getTagUsagesDeleted() > 0, "Should have deleted orphaned tag usages");
+  }
+
+  @Test
+  void test_commandBehavior_batchSizeParameter() {
+    int customBatchSize = 50;
+
+    TagUsageCleanup cleanupRel = new TagUsageCleanup(collectionDAO, true);
+    TagUsageCleanup.TagCleanupResult result = cleanupRel.performCleanup(customBatchSize);
+
+    assertNotNull(result);
+    assertTrue(result.getTotalTagUsagesScanned() >= 0);
+  }
+
+  @Test
+  void test_validTagUsages_shouldNotBeMarkedAsOrphaned() {
+    Tag validTag = testTags.get(1);
+    String validTagFQN = validTag.getFullyQualifiedName();
+    String validTagFQNHash = FullyQualifiedName.buildHash(validTagFQN);
+    String targetFQNHash = FullyQualifiedName.buildHash(testTables.get(1).getFullyQualifiedName());
+
+    // Create a valid tag usage
+    collectionDAO
+        .tagUsageDAO()
+        .applyTag(
+            TagLabel.TagSource.CLASSIFICATION.ordinal(),
+            validTagFQN,
+            validTagFQNHash,
+            targetFQNHash,
+            TagLabel.LabelType.MANUAL.ordinal(),
+            TagLabel.State.CONFIRMED.ordinal(),
+            null);
+
+    cleanup = new TagUsageCleanup(collectionDAO, true);
+    TagUsageCleanup.TagCleanupResult result = cleanup.performCleanup(100);
+
+    assertNotNull(result);
+
+    // Verify that the valid tag usage is not marked as orphaned
+    boolean foundValidTag =
+        result.getOrphanedTagUsages().stream()
+            .anyMatch(orphan -> validTagFQNHash.equals(orphan.getTagFQNHash()));
+
+    assertFalse(foundValidTag, "Valid tag usage should not be marked as orphaned");
+  }
+
+  @Test
+  void test_validGlossaryTermUsages_shouldNotBeMarkedAsOrphaned() {
+    GlossaryTerm validTerm = testGlossaryTerms.get(1);
+    String validTermFQN = validTerm.getFullyQualifiedName();
+    String validTermFQNHash = FullyQualifiedName.buildHash(validTermFQN);
+    String targetFQNHash = FullyQualifiedName.buildHash(testTables.get(1).getFullyQualifiedName());
+
+    // Create a valid glossary term usage
+    collectionDAO
+        .tagUsageDAO()
+        .applyTag(
+            TagLabel.TagSource.GLOSSARY.ordinal(),
+            validTermFQN,
+            validTermFQNHash,
+            targetFQNHash,
+            TagLabel.LabelType.MANUAL.ordinal(),
+            TagLabel.State.CONFIRMED.ordinal(),
+            null);
+
+    cleanup = new TagUsageCleanup(collectionDAO, true);
+    TagUsageCleanup.TagCleanupResult result = cleanup.performCleanup(100);
+
+    assertNotNull(result);
+
+    // Verify that the valid glossary term usage is not marked as orphaned
+    boolean foundValidTerm =
+        result.getOrphanedTagUsages().stream()
+            .anyMatch(orphan -> validTermFQNHash.equals(orphan.getTagFQNHash()));
+
+    assertFalse(foundValidTerm, "Valid glossary term usage should not be marked as orphaned");
+  }
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes [#24269](https://github.com/open-metadata/OpenMetadata/issues/24269)

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
