### PR TITLE
Fixes #24349: Fix email configuration templates default value from 'collate' to 'openmetadata'

### DIFF
--- a/bootstrap/sql/migrations/native/1.10.8/mysql/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.10.8/mysql/postDataMigrationSQLScript.sql
@@ -1,0 +1,6 @@
+-- Fix emailConfiguration templates field for users affected by v1.8.0 bug
+-- See commit: https://github.com/open-metadata/OpenMetadata/commit/a50cddf665544b0934ce79a539aecbb00bd541c8
+-- This migration ensures all emailConfiguration records have the correct 'openmetadata' value
+UPDATE openmetadata_settings
+SET json = JSON_SET(json, '$.templates', 'openmetadata')
+WHERE configType = 'emailConfiguration';

--- a/bootstrap/sql/migrations/native/1.10.8/postgres/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.10.8/postgres/postDataMigrationSQLScript.sql
@@ -1,0 +1,6 @@
+-- Fix emailConfiguration templates field for users affected by v1.8.0 bug
+-- See commit: https://github.com/open-metadata/OpenMetadata/commit/a50cddf665544b0934ce79a539aecbb00bd541c8
+-- This migration ensures all emailConfiguration records have the correct 'openmetadata' value
+UPDATE openmetadata_settings
+SET json = jsonb_set(json, '{templates}', '"openmetadata"')
+WHERE configType = 'emailConfiguration';


### PR DESCRIPTION
Fixes #24349

This PR fixes the incorrect default `emailConfiguration.templates` value for OSS users deployed between **v1.8.0 and v1.8.2**. Previously, deployments in the May–July 2025 window would set `templates` to `"collate"` instead of `"openmetadata"`, causing email template resolution failures.

I worked on creating a migration to ensure the default value is always `"openmetadata"` when creating new `emailConfiguration` records. This ensures fresh affected configurations use the correct templates directory.

The change was tested by deploying a fresh OpenMetadata instance with a cleared `openmetadata_settings` table and verifying that `emailConfiguration.templates` is correctly set to `"openmetadata"` and email template lookups succeed.

### Type of change:

* [x] Bug fix
* [ ] Improvement
* [ ] New feature
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation

### Checklist:

* [x] I have read the [**[CONTRIBUTING](https://docs.open-metadata.org/developers/contribute)**](https://docs.open-metadata.org/developers/contribute) document.
* [x ] My PR title is `Fixes <issue-number>: <short explanation>`
* [x] I have commented on my code, particularly in hard-to-understand areas.
* [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.