### PR TITLE
Fixes 24332: Enable paginate_es to sort the response

### DIFF
--- a/ingestion/src/metadata/ingestion/ometa/mixins/es_mixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/es_mixin.py
@@ -356,7 +356,27 @@ class ESMixin(Generic[T]):
         sort_field: str = "fullyQualifiedName",
         sort_order: str = "desc",
     ) -> Iterator[ESResponse]:
-        """Paginate through the ES results, ignoring individual errors"""
+        """
+        Paginate through the ES results, ignoring individual errors.
+
+        Args:
+            entity: The entity type to paginate
+            query_filter: Optional ES query filter in JSON format
+            size: Number of results per page (default: 100)
+            include_fields: Optional list of fields to include in ES response (optimization)
+            sort_field: Field to sort by (default: "fullyQualifiedName").
+                       Special field "_score" is supported for relevance sorting.
+            sort_order: Sort order, either "asc" or "desc" (default: "desc")
+
+        Yields:
+            ESResponse objects containing paginated results
+
+        Raises:
+            ValueError: If sort_order is not "asc" or "desc"
+        """
+        if sort_order not in ("asc", "desc"):
+            raise ValueError(f"sort_order must be 'asc' or 'desc', got '{sort_order}'")
+
         after: Optional[str] = None
         error_pages = 0
         query = functools.partial(
@@ -400,6 +420,22 @@ class ESMixin(Generic[T]):
         sort_field: str = "fullyQualifiedName",
         sort_order: str = "desc",
     ) -> Iterator[T]:
+        """
+        Paginate through Elasticsearch results and fetch full entities from the API.
+
+        Args:
+            entity: The entity type to paginate
+            query_filter: Optional ES query filter in JSON format
+            size: Number of results per page (default: 100)
+            fields: Optional list of fields to fetch from the API for each entity
+            sort_field: Field to sort by (default: "fullyQualifiedName").
+                       Must be an indexed ES field. Special field "_score" is supported
+                       for relevance-based sorting.
+            sort_order: Sort order, either "asc" or "desc" (default: "desc")
+
+        Yields:
+            Full entity objects fetched from the OpenMetadata API
+        """
         for response in self._paginate_es_internal(
             entity, query_filter, size, sort_order=sort_order, sort_field=sort_field
         ):


### PR DESCRIPTION
The REST API accepts the parameters `sort_field` and `sort_order`, but they aren't implemented (yet) in the SDK.

EDIT:
As mentioned in the issue: filtering by the `_score` field would break the code, since it'd lead to a deserialization
problem. I fixed the issue as part of this PR.

Testing `sort_field` in tests is tricky, because the sort_field needs to be indexed.

<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes 24332


I worked on enabling the python SDK to pass the sort_field and sort_order parameters to the ES query endpoint.


#
### Type of change:
- [x] Improvement

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->


- [x] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.


- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.


<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
