### PR TITLE
Fix searchbar getting removed in lineage node when no columns are mat…

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityLineage/CustomNodeV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityLineage/CustomNodeV1.test.tsx
@@ -191,6 +191,36 @@ describe('CustomNodeV1', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('should render searchbar when column layer is applied and node has children', () => {
+    isColumnLayerActive = true;
+
+    render(
+      <ReactFlowProvider>
+        <CustomNodeV1Component {...mockNodeDataProps} />
+      </ReactFlowProvider>
+    );
+
+    expect(screen.getByTestId('search-column-input')).toBeInTheDocument();
+  });
+
+  it('should not remove searchbar from node when no columns are matched while searching', () => {
+    isColumnLayerActive = true;
+
+    render(
+      <ReactFlowProvider>
+        <CustomNodeV1Component {...mockNodeDataProps} />
+      </ReactFlowProvider>
+    );
+
+    const searchInput = screen.getByTestId(
+      'search-column-input'
+    ) as HTMLInputElement;
+
+    fireEvent.change(searchInput, { target: { value: 'nonExistingColumn' } });
+
+    expect(screen.getByTestId('search-column-input')).toBeInTheDocument();
+  });
+
   it('should render NodeChildren when column layer is applied and there are no columns', () => {
     isColumnLayerActive = true;
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityLineage/NodeChildren/NodeChildren.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityLineage/NodeChildren/NodeChildren.component.tsx
@@ -311,6 +311,7 @@ const NodeChildren = ({
         <div className="column-container" data-testid="column-container">
           <div className="search-box">
             <Input
+              data-testid="search-column-input"
               placeholder={t('label.search-entity', {
                 entity: childrenHeading,
               })}


### PR DESCRIPTION
…ched

<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:
Previously, when columns were searched using the searchbar in a lineage node, `renderedColumns` would be empty if nothing matched. However, the searchbar was also conditionally rendered using `!isEmpty(renderedColumns)`, which caused the searchbar to be removed from the DOM entirely. This PR fixes the issue by checking if the node has columns (or children to be specific) and rendering the searchbar based on that instead.

Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
