### PR TITLE
Add includeAggregates option to the search API

### DIFF
--- a/.github/workflows/ui-core-components-tests.yml
+++ b/.github/workflows/ui-core-components-tests.yml
@@ -1,0 +1,49 @@
+#  Copyright 2025 Collate
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+name: UI Core Components Tests
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "openmetadata-ui-core-components/src/main/resources/ui/**"
+      - ".github/workflows/ui-core-components-tests.yml"
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to run tests on"
+        required: false
+        default: "main"
+        type: string
+      run-coverage:
+        description: "Generate coverage report"
+        required: false
+        default: true
+        type: boolean
+      skip-type-check:
+        description: "Skip TypeScript type check"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  placeholder:
+    name: Placeholder - No Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Placeholder step
+        run: echo "Nothing to test"

--- a/ingestion/src/metadata/ingestion/source/dashboard/powerbi/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/powerbi/metadata.py
@@ -51,6 +51,7 @@ from metadata.generated.schema.type.basic import (
     Markdown,
     SourceUrl,
 )
+from metadata.generated.schema.type.entityLineage import ColumnLineage
 from metadata.generated.schema.type.entityReferenceList import EntityReferenceList
 from metadata.ingestion.api.models import Either
 from metadata.ingestion.api.steps import InvalidSourceException
@@ -1248,6 +1249,70 @@ class PowerbiSource(DashboardServiceSource):
                     )
                 )
 
+    def _get_downstream_data_model_column_fqn(
+        self, data_model_entity: DashboardDataModel, table_name: str, column: str
+    ) -> Optional[str]:
+        """
+        Get the FQN of the column if it exists in the
+        downstream data model entity's table and column.
+        """
+        try:
+            if not data_model_entity:
+                return None
+            for table in data_model_entity.columns:
+                if table.name.root != table_name:
+                    continue
+                for child_column in table.children or []:
+                    if column.lower() == child_column.name.root.lower():
+                        return child_column.fullyQualifiedName.root
+        except Exception as exc:
+            logger.error(
+                f"Error to get downstream data_model_column_fqn for data_model_entity="
+                f"{data_model_entity.name.root}, table_name={table_name}, column={column}: {exc}"
+            )
+            logger.debug(traceback.format_exc())
+        return None
+
+    def _create_dataset_upstream_dataset_column_lineage(
+        self,
+        datamodel_entity: DashboardDataModel,
+        upstream_dataset_entity: DashboardDataModel,
+    ) -> Optional[List[ColumnLineage]]:
+        """
+        Create column lineage between powerbi dataset/datamodel and
+        its upstream dataset/datamodel
+        """
+        try:
+            target_tables = [table.name.root for table in datamodel_entity.columns]
+            if not target_tables:
+                return []
+            column_lineage = []
+            for table in upstream_dataset_entity.columns:
+                if table.name.root not in target_tables:
+                    continue
+                for column in table.children or []:
+                    source_column = column.fullyQualifiedName.root
+                    target_column = self._get_downstream_data_model_column_fqn(
+                        data_model_entity=datamodel_entity,
+                        table_name=table.name.root,
+                        column=column.name.root,
+                    )
+                    if source_column and target_column:
+                        column_lineage.append(
+                            ColumnLineage(
+                                fromColumns=[source_column], toColumn=target_column
+                            )
+                        )
+            return column_lineage
+        except Exception as exc:
+            logger.debug(traceback.format_exc())
+            logger.error(
+                "Error while creating column lineage between dataset = "
+                f"{datamodel_entity.name.root} and upstream dataset = "
+                f"{upstream_dataset_entity.name.root}: {exc}"
+            )
+        return []
+
     def create_dataset_upstream_dataset_lineage(
         self, datamodel: Dataset, datamodel_entity: DashboardDataModel
     ) -> Iterable[Either[AddLineageRequest]]:
@@ -1274,9 +1339,17 @@ class PowerbiSource(DashboardServiceSource):
                     fqn=upstream_dataset_fqn,
                 )
                 if upstream_dataset_entity and datamodel_entity:
+                    # create column lineage between current dataset/datamodel
+                    # and its upstream dataset.
+                    column_lineage = (
+                        self._create_dataset_upstream_dataset_column_lineage(
+                            datamodel_entity, upstream_dataset_entity
+                        )
+                    )
                     yield self._get_add_lineage_request(
                         from_entity=upstream_dataset_entity,
                         to_entity=datamodel_entity,
+                        column_lineage=column_lineage,
                     )
                 else:
                     logger.debug(

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts
@@ -36,6 +36,7 @@ import {
   assignGlossaryTerm,
   assignTag,
   updateDescription,
+  waitForAllLoadersToDisappear,
 } from '../../utils/entity';
 import {
   addAssetToGlossaryTerm,
@@ -1785,6 +1786,105 @@ test.describe('Glossary tests', () => {
     } finally {
       await afterAction();
       await afterActionUser1();
+    }
+  });
+
+  test('Create glossary, change language to Dutch, and delete glossary', async ({
+    browser,
+  }) => {
+    test.slow(true);
+
+    const { page, afterAction, apiContext } = await performAdminLogin(browser);
+    const glossary = new Glossary();
+
+    try {
+      await test.step('Create Glossary via API', async () => {
+        await glossary.create(apiContext);
+      });
+
+      await test.step('Navigate to Glossary page', async () => {
+        await redirectToHomePage(page);
+        await sidebarClick(page, SidebarItem.GLOSSARY);
+        await waitForAllLoadersToDisappear(page);
+        await page.waitForLoadState('networkidle');
+        await selectActiveGlossary(page, glossary.data.displayName);
+        await waitForAllLoadersToDisappear(page);
+        await page.waitForLoadState('networkidle');
+
+        await expect(page.getByTestId('entity-header-display-name')).toHaveText(
+          glossary.data.displayName
+        );
+      });
+
+      await test.step('Change application language to German', async () => {
+        await waitForAllLoadersToDisappear(page);
+        await page.waitForLoadState('networkidle');
+        const languageDropdown = page
+          .locator('.nav-bar-side-items button.ant-dropdown-trigger')
+          .filter({ hasText: 'EN' })
+          .first();
+        await languageDropdown.click();
+
+        const germanOption = page.getByRole('menuitem', {
+          name: 'Deutsch - DE',
+        });
+        await germanOption.click();
+
+        await waitForAllLoadersToDisappear(page);
+        await page.waitForLoadState('networkidle');
+      });
+
+      await test.step(
+        'Open delete modal and verify delete confirmation',
+        async () => {
+          await sidebarClick(page, SidebarItem.GLOSSARY);
+          await waitForAllLoadersToDisappear(page);
+          await page.waitForLoadState('networkidle');
+          await selectActiveGlossary(page, glossary.data.displayName);
+          await waitForAllLoadersToDisappear(page);
+          await page.waitForLoadState('networkidle');
+
+          await page.getByTestId('manage-button').click();
+          await page.getByTestId('delete-button').click();
+
+          await expect(page.locator('[role="dialog"]')).toBeVisible();
+          await expect(page.getByTestId('modal-header')).toContainText(
+            glossary.data.name
+          );
+
+          await expect(page.getByTestId('body-text')).toContainText('DELETE');
+
+          const confirmationInput = page.getByTestId('confirmation-text-input');
+
+          await expect(confirmationInput).toBeVisible();
+
+          await confirmationInput.fill('DELETE');
+
+          await page.getByTestId('confirm-button').click();
+
+          await toastNotification(
+            page,
+            new RegExp(`.*${glossary.data.name}.*`)
+          );
+        }
+      );
+
+      await test.step('Change language back to English', async () => {
+        await waitForAllLoadersToDisappear(page);
+        await page.waitForLoadState('networkidle');
+        const languageDropdown = page
+          .locator('.nav-bar-side-items button.ant-dropdown-trigger')
+          .filter({ hasText: 'DE' })
+          .first();
+        await languageDropdown.click();
+
+        const englishOption = page.getByRole('menuitem', {
+          name: 'English - EN',
+        });
+        await englishOption.click();
+      });
+    } finally {
+      await afterAction();
     }
   });
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/EntityDeleteModal/EntityDeleteModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/EntityDeleteModal/EntityDeleteModal.tsx
@@ -13,7 +13,7 @@
 
 import { Button, Input, InputRef, Modal, Typography } from 'antd';
 import { ChangeEvent, useEffect, useMemo, useRef, useState } from 'react';
-import { Trans, useTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import { Transi18next } from '../../../utils/CommonUtils';
 import { EntityDeleteModalProp } from './EntityDeleteModal.interface';
 
@@ -119,11 +119,10 @@ const EntityDeleteModal = ({
           )}
         </div>
         <Typography className="mb-2">
-          <Trans
-            i18nKey="label.type-to-confirm"
-            values={{ text: t('label.delete-uppercase') }}>
-            <strong />
-          </Trans>
+          <Transi18next
+            i18nKey="message.type-delete-to-confirm"
+            renderElement={<strong />}
+          />
         </Typography>
         <Input
           autoComplete="off"

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/policies/createPolicy.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/policies/createPolicy.ts
@@ -153,6 +153,7 @@ export enum Operation {
     Create = "Create",
     CreateIngestionPipelineAutomator = "CreateIngestionPipelineAutomator",
     CreateScim = "CreateScim",
+    CreateTests = "CreateTests",
     Delete = "Delete",
     DeleteScim = "DeleteScim",
     DeleteTestCaseFailedRowsSample = "DeleteTestCaseFailedRowsSample",

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/policies/accessControl/resourceDescriptor.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/policies/accessControl/resourceDescriptor.ts
@@ -35,6 +35,7 @@ export enum Operation {
     Create = "Create",
     CreateIngestionPipelineAutomator = "CreateIngestionPipelineAutomator",
     CreateScim = "CreateScim",
+    CreateTests = "CreateTests",
     Delete = "Delete",
     DeleteScim = "DeleteScim",
     DeleteTestCaseFailedRowsSample = "DeleteTestCaseFailedRowsSample",

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/policies/accessControl/resourcePermission.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/policies/accessControl/resourcePermission.ts
@@ -77,6 +77,7 @@ export enum Operation {
     Create = "Create",
     CreateIngestionPipelineAutomator = "CreateIngestionPipelineAutomator",
     CreateScim = "CreateScim",
+    CreateTests = "CreateTests",
     Delete = "Delete",
     DeleteScim = "DeleteScim",
     DeleteTestCaseFailedRowsSample = "DeleteTestCaseFailedRowsSample",

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/policies/accessControl/rule.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/policies/accessControl/rule.ts
@@ -60,6 +60,7 @@ export enum Operation {
     Create = "Create",
     CreateIngestionPipelineAutomator = "CreateIngestionPipelineAutomator",
     CreateScim = "CreateScim",
+    CreateTests = "CreateTests",
     Delete = "Delete",
     DeleteScim = "DeleteScim",
     DeleteTestCaseFailedRowsSample = "DeleteTestCaseFailedRowsSample",

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/policies/policy.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/policies/policy.ts
@@ -305,6 +305,7 @@ export enum Operation {
     Create = "Create",
     CreateIngestionPipelineAutomator = "CreateIngestionPipelineAutomator",
     CreateScim = "CreateScim",
+    CreateTests = "CreateTests",
     Delete = "Delete",
     DeleteScim = "DeleteScim",
     DeleteTestCaseFailedRowsSample = "DeleteTestCaseFailedRowsSample",

--- a/openmetadata-ui/src/main/resources/ui/src/generated/search/searchRequest.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/search/searchRequest.ts
@@ -52,6 +52,11 @@ export interface SearchRequest {
      */
     from?: number;
     /**
+     * Include aggregations in the search response. Defaults to true. Set to false to skip
+     * aggregations for faster response times when only search results are needed.
+     */
+    includeAggregations?: boolean;
+    /**
      * Get only selected fields of the document body for each hit. Empty value will return all
      * fields
      */


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

---

## Summary by Gitar

- **New API parameter:**
  - `includeAggregations` (default: `true`) added to search API to control whether aggregations are computed and returned in search responses
  - Enables faster response times and smaller payloads when only search results are needed
- **REST API enhancement:**
  - Added `include_aggregations` query parameter to `/v1/search/query` endpoint in `SearchResource.java`
  - Proper JAX-RS annotations with clear documentation of performance benefit
- **Cross-engine implementation:**
  - Conditional aggregation logic added to both Elasticsearch (`ElasticSearchSourceBuilderFactory.java`) and OpenSearch (`OpenSearchSourceBuilderFactory.java`) implementations
  - Aggregation methods wrapped in conditionals to skip computation when flag is `false`
- **SDK updates:**
  - Python SDK (`search.py`): Added parameter to `search()`, `search_async()`, and `SearchBuilder` class with fluent API support
  - Java SDK (`SearchAPI.java`): Extended with overloaded methods maintaining backward compatibility
- **Comprehensive testing:**
  - New test `testSearchWithIncludeAggregationsParameter()` validates both modes, verifies response size reduction, and confirms identical search results

---