### PR TITLE
FIX - Check ingestion with incoming server version

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/clients/pipeline/MeteredPipelineServiceClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/clients/pipeline/MeteredPipelineServiceClient.java
@@ -151,8 +151,8 @@ public class MeteredPipelineServiceClient implements PipelineServiceClientInterf
   }
 
   @Override
-  public Boolean validServerClientVersions(String clientVersion) {
-    return decoratedClient.validServerClientVersions(clientVersion);
+  public Boolean validServerClientVersions(String clientVersion, String serverVersion) {
+    return decoratedClient.validServerClientVersions(clientVersion, serverVersion);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/clients/pipeline/airflow/AirflowRESTClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/clients/pipeline/airflow/AirflowRESTClient.java
@@ -460,7 +460,7 @@ public class AirflowRESTClient extends PipelineServiceClient {
       if (response.statusCode() == 200) {
         JSONObject responseJSON = new JSONObject(response.body());
         String ingestionVersion = responseJSON.getString("version");
-        return Boolean.TRUE.equals(validServerClientVersions(ingestionVersion))
+        return validServerClientVersions(ingestionVersion, SERVER_VERSION)
             ? buildHealthyStatus(ingestionVersion)
             : buildUnhealthyStatus(
                 buildVersionMismatchErrorMessage(ingestionVersion, SERVER_VERSION));

--- a/openmetadata-spec/src/main/java/org/openmetadata/sdk/PipelineServiceClientInterface.java
+++ b/openmetadata-spec/src/main/java/org/openmetadata/sdk/PipelineServiceClientInterface.java
@@ -71,7 +71,7 @@ public interface PipelineServiceClientInterface {
 
   String getBasicAuthenticationHeader(String username, String password);
 
-  Boolean validServerClientVersions(String clientVersion);
+  Boolean validServerClientVersions(String clientVersion, String serverVersion);
 
   Response getHostIp();
 

--- a/openmetadata-spec/src/main/java/org/openmetadata/service/clients/pipeline/PipelineServiceClient.java
+++ b/openmetadata-spec/src/main/java/org/openmetadata/service/clients/pipeline/PipelineServiceClient.java
@@ -126,9 +126,20 @@ public abstract class PipelineServiceClient implements PipelineServiceClientInte
     }
   }
 
+  private String getMajorMinorVersion(String fullVersion) {
+    String[] versionParts = fullVersion.split("\\.");
+    if (versionParts.length >= 2) {
+      return versionParts[0] + "." + versionParts[1];
+    }
+    return fullVersion;
+  }
+
   @Override
-  public final Boolean validServerClientVersions(String clientVersion) {
-    return getVersionFromString(clientVersion).equals(getVersionFromString(SERVER_VERSION));
+  public final Boolean validServerClientVersions(String clientVersion, String serverVersion) {
+    String clientFullVersion = getVersionFromString(clientVersion);
+    String serverFullVersion = getVersionFromString(serverVersion);
+
+    return getMajorMinorVersion(clientFullVersion).equals(getMajorMinorVersion(serverFullVersion));
   }
 
   public String buildVersionMismatchErrorMessage(String ingestionVersion, String serverVersion) {


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

---

## Summary by Gitar

- **Version validation refactor:**
  - Changed `validServerClientVersions` to accept explicit `serverVersion` parameter instead of using hardcoded constant
  - Now compares only major.minor versions (e.g., `1.5.3` compatible with `1.5.7`) via new `getMajorMinorVersion` helper
- **Interface update:**
  - Updated method signature in `PipelineServiceClientInterface`, `PipelineServiceClient`, `AirflowRESTClient`, and `MeteredPipelineServiceClient`

---