### PR TITLE
Add Test to ensure entities have same response when same fields are p…

### DIFF
--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/EntityResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/EntityResourceTest.java
@@ -912,6 +912,78 @@ public abstract class EntityResourceTest<T extends EntityInterface, K extends Cr
 
   @Test
   @Execution(ExecutionMode.CONCURRENT)
+  void test_getAndListReturnSameFieldsData(TestInfo test) throws HttpResponseException {
+    if (!supportsFieldsQueryParam) {
+      return;
+    }
+
+    T entity = createEntity(createRequest(test, 0), ADMIN_AUTH_HEADERS);
+
+    try {
+      String allFields = getAllowedFields();
+      String[] fieldArray = allFields.split(",");
+
+      for (String fields : List.of("", allFields)) {
+        T getEntity = getEntity(entity.getId(), fields, ADMIN_AUTH_HEADERS);
+
+        Map<String, String> params = new HashMap<>();
+        params.put("fields", fields);
+        ResultList<T> listResult = listEntities(params, ADMIN_AUTH_HEADERS);
+
+        T listEntity =
+            listResult.getData().stream()
+                .filter(e -> e.getId().equals(entity.getId()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Created entity not found in list"));
+
+        assertEquals(
+            getEntity.getId(),
+            listEntity.getId(),
+            "Entity ID should match between GET and LIST APIs");
+        assertEquals(
+            getEntity.getFullyQualifiedName(),
+            listEntity.getFullyQualifiedName(),
+            "FQN should match between GET and LIST APIs");
+
+        if (!fields.isEmpty()) {
+          for (String field : fieldArray) {
+            field = field.trim();
+            if (field.equals("owners") && supportsOwners) {
+              assertEquals(
+                  listOrEmpty(getEntity.getOwners()).size(),
+                  listOrEmpty(listEntity.getOwners()).size(),
+                  "Owners count should match between GET and LIST APIs for fields=" + fields);
+            } else if (field.equals("tags") && supportsTags) {
+              assertEquals(
+                  listOrEmpty(getEntity.getTags()).size(),
+                  listOrEmpty(listEntity.getTags()).size(),
+                  "Tags count should match between GET and LIST APIs for fields=" + fields);
+            } else if (field.equals("followers") && supportsFollowers) {
+              assertEquals(
+                  listOrEmpty(getEntity.getFollowers()).size(),
+                  listOrEmpty(listEntity.getFollowers()).size(),
+                  "Followers count should match between GET and LIST APIs for fields=" + fields);
+            } else if (field.equals("domains") && supportsDomains) {
+              assertEquals(
+                  listOrEmpty(getEntity.getDomains()).size(),
+                  listOrEmpty(listEntity.getDomains()).size(),
+                  "Domains count should match between GET and LIST APIs for fields=" + fields);
+            } else if (field.equals("dataProducts") && supportsDataProducts) {
+              assertEquals(
+                  listOrEmpty(getEntity.getDataProducts()).size(),
+                  listOrEmpty(listEntity.getDataProducts()).size(),
+                  "DataProducts count should match between GET and LIST APIs for fields=" + fields);
+            }
+          }
+        }
+      }
+    } finally {
+      deleteEntity(entity.getId(), ADMIN_AUTH_HEADERS);
+    }
+  }
+
+  @Test
+  @Execution(ExecutionMode.CONCURRENT)
   void test_fieldFetchers(TestInfo test) throws HttpResponseException, IOException {
     if (!supportsFieldsQueryParam) {
       return;


### PR DESCRIPTION
…assed

<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
