### PR TITLE
chore(ui): add playwright for circular reference

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryImportExport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryImportExport.spec.ts
@@ -250,4 +250,153 @@ test.describe('Glossary Bulk Import Export', () => {
       }
     });
   });
+
+  test('Check for Circular Reference in Glossary Import', async ({
+    page,
+    browser,
+  }) => {
+    const circularRefGlossary = new Glossary('Test CSV');
+
+    try {
+      await test.step(
+        'Create glossary for circular reference test',
+        async () => {
+          const { apiContext, afterAction } = await createNewPage(browser);
+
+          await circularRefGlossary.create(apiContext);
+          await afterAction();
+        }
+      );
+
+      await test.step('Import initial glossary terms', async () => {
+        await sidebarClick(page, SidebarItem.GLOSSARY);
+        await selectActiveGlossary(page, circularRefGlossary.data.displayName);
+
+        await page.click('[data-testid="manage-button"]');
+        await page.click('[data-testid="import-button-description"]');
+
+        const initialCsvContent = `parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension
+,name1,name1,<p>name1</p>,,,,,,user:admin,Approved,,,
+,parent,parent,<p>parent</p>,,,,,,user:admin,Approved,,,
+${circularRefGlossary.data.name}.parent,child,child,<p>child</p>,,,,,,user:admin,Approved,,,`;
+
+        const initialCsvBlob = new Blob([initialCsvContent], {
+          type: 'text/csv',
+        });
+        const initialCsvFile = new File([initialCsvBlob], 'initial-terms.csv', {
+          type: 'text/csv',
+        });
+
+        const fileInput = page.getByTestId('upload-file-widget');
+
+        await fileInput?.setInputFiles([
+          {
+            name: initialCsvFile.name,
+            mimeType: initialCsvFile.type,
+            buffer: Buffer.from(await initialCsvFile.arrayBuffer()),
+          },
+        ]);
+
+        await page.waitForTimeout(500);
+
+        await expect(page.locator('.rdg-header-row')).toBeVisible();
+
+        await page.getByRole('button', { name: 'Next' }).click();
+
+        const loader = page.locator(
+          '.inovua-react-toolkit-load-mask__background-layer'
+        );
+
+        await loader.waitFor({ state: 'hidden' });
+
+        await validateImportStatus(page, {
+          passed: '4',
+          processed: '4',
+          failed: '0',
+        });
+
+        await page.getByRole('button', { name: 'Update' }).click();
+        await page
+          .locator('.inovua-react-toolkit-load-mask__background-layer')
+          .waitFor({ state: 'detached' });
+
+        await toastNotification(
+          page,
+          `Glossaryterm ${circularRefGlossary.responseData.fullyQualifiedName} details updated successfully`
+        );
+      });
+
+      await test.step(
+        'Import CSV with circular reference and verify error',
+        async () => {
+          await sidebarClick(page, SidebarItem.GLOSSARY);
+          await selectActiveGlossary(
+            page,
+            circularRefGlossary.data.displayName
+          );
+
+          await page.click('[data-testid="manage-button"]');
+          await page.click('[data-testid="import-button-description"]');
+
+          const circularCsvContent = `parent,name*,displayName,description,synonyms,relatedTerms,references,tags,reviewers,owner,glossaryStatus,color,iconURL,extension
+${circularRefGlossary.data.name}.name1,name1,name1,<p>name1</p>,,,,,,user:admin,Approved,,,
+,parent,parent,<p>parent</p>,,,,,,user:admin,Approved,,,
+${circularRefGlossary.data.name}.parent,child,child,<p>child</p>,,,,,,user:admin,Approved,,,`;
+
+          const circularCsvBlob = new Blob([circularCsvContent], {
+            type: 'text/csv',
+          });
+          const circularCsvFile = new File(
+            [circularCsvBlob],
+            'circular-reference.csv',
+            {
+              type: 'text/csv',
+            }
+          );
+
+          const fileInput = page.getByTestId('upload-file-widget');
+
+          await fileInput?.setInputFiles([
+            {
+              name: circularCsvFile.name,
+              mimeType: circularCsvFile.type,
+              buffer: Buffer.from(await circularCsvFile.arrayBuffer()),
+            },
+          ]);
+
+          await page.waitForTimeout(500);
+
+          await expect(page.locator('.rdg-header-row')).toBeVisible();
+
+          await page.getByRole('button', { name: 'Next' }).click();
+
+          const loader = page.locator(
+            '.inovua-react-toolkit-load-mask__background-layer'
+          );
+
+          await loader.waitFor({ state: 'hidden' });
+
+          await validateImportStatus(page, {
+            passed: '3',
+            processed: '4',
+            failed: '1',
+          });
+
+          const rows = await page.$$('.rdg-row');
+          const firstRow = rows[0];
+          const detailsCell = await firstRow.$('.rdg-cell-details');
+          const errorText = await detailsCell?.textContent();
+
+          expect(errorText).toContain(
+            "Invalid hierarchy: Term 'Test CSV.name1' cannot be its own parent"
+          );
+        }
+      );
+    } finally {
+      const { apiContext, afterAction } = await createNewPage(browser);
+
+      await circularRefGlossary.delete(apiContext);
+      await afterAction();
+    }
+  });
 });


### PR DESCRIPTION
This pull request adds a new end-to-end test to the glossary bulk import/export feature, specifically targeting the detection and handling of circular references during glossary term import. The test ensures that the UI correctly identifies and reports an error when a term is set as its own parent in the imported CSV file.

### Glossary Import/Export Testing Enhancements

* Added a test case to `GlossaryImportExport.spec.ts` that creates a glossary, imports initial terms, and then attempts to import a CSV file with a circular reference, verifying that the application detects and displays an appropriate error message for the invalid hierarchy.