### PR TITLE
fix(test): sperate navigation persona to avoid conflict with persona …

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CustomizeDetailPage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CustomizeDetailPage.spec.ts
@@ -27,6 +27,7 @@ import { AdminClass } from '../../support/user/AdminClass';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';
 import {
+  clickOutside,
   getApiContext,
   redirectToHomePage,
   toastNotification,
@@ -180,6 +181,15 @@ test.describe('Persona customize UI tab', async () => {
   test('customize navigation should work', async ({ adminPage, userPage }) => {
     test.slow();
 
+    const personaListResponse = adminPage.waitForResponse(`/api/v1/personas?*`);
+    await adminPage.goBack();
+    await personaListResponse;
+    await adminPage.waitForLoadState('networkidle');
+    await navigateToPersonaWithPagination(
+      adminPage,
+      navigationPersona.data.name,
+      true
+    );
     await adminPage.getByText('Navigation').click();
 
     await test.step(
@@ -222,8 +232,13 @@ test.describe('Persona customize UI tab', async () => {
 
         // Select navigation persona
         await redirectToHomePage(userPage);
-        await userPage.reload();
-        await userPage.waitForLoadState('networkidle');
+        await userPage.getByTestId('dropdown-profile').click();
+        await userPage
+          .getByRole('menuitem', {
+            name: navigationPersona.responseData.displayName,
+          })
+          .click();
+        await clickOutside(userPage);
 
         // Validate changes in navigation tree
         await validateLeftSidebarWithHiddenItems(userPage, [


### PR DESCRIPTION
…tests

<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
