### PR TITLE
Fix dbt testcase creation by bypassing bulk sink and failed request status

### DIFF
--- a/ingestion/src/metadata/ingestion/sink/metadata_rest.py
+++ b/ingestion/src/metadata/ingestion/sink/metadata_rest.py
@@ -36,6 +36,7 @@ from metadata.generated.schema.api.teams.createUser import CreateUserRequest
 from metadata.generated.schema.api.tests.createLogicalTestCases import (
     CreateLogicalTestCases,
 )
+from metadata.generated.schema.api.tests.createTestCase import CreateTestCaseRequest
 from metadata.generated.schema.api.tests.createTestSuite import CreateTestSuiteRequest
 from metadata.generated.schema.dataInsight.kpi.basic import KpiResult
 from metadata.generated.schema.entity.classification.tag import Tag
@@ -204,6 +205,7 @@ class MetadataRestSink(Sink):  # pylint: disable=too-many-public-methods
                     CreateTeamRequest,
                     CreateContainerRequest,
                     CreatePipelineRequest,
+                    CreateTestCaseRequest,
                 ),
             )
         ):
@@ -282,16 +284,14 @@ class MetadataRestSink(Sink):  # pylint: disable=too-many-public-methods
             return Either(right=result, left=None)
 
         self.status.scanned_all(result.successRequest)
-        self.status.failed(
-            [
+        for err in result.failedRequest:
+            self.status.failed(
                 StackTraceError(
                     name="Entity Buffer",
                     error=f"Failed to flush entities to bulk API: {err}",
                     stackTrace=None,
                 )
-                for err in result.failedRequest
-            ]
-        )
+            )
         return Either(
             right=None,
             left=StackTraceError(


### PR DESCRIPTION
### Describe your changes:

Bypass test-case creation from bulk sink, since `add_dbt_test_result` is dependant on each test case creation and fix failed status.

ref:
https://github.com/open-metadata/OpenMetadata/pull/24393
https://github.com/open-metadata/OpenMetadata/pull/24468

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
