### PR TITLE
Fix: ServiceForm playwright test failure in AUT

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ServiceForm.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ServiceForm.spec.ts
@@ -94,10 +94,16 @@ test.describe('Service form functionality', async () => {
         testConnection1.request.connection.config.connection.provider
       ).toEqual(supersetFormDetails1.connection.provider);
 
+      const endTestConnection1 = page.waitForResponse(
+        '/api/v1/automations/workflows/*?hardDelete=true'
+      );
+
       await page
         .getByTestId('test-connection-modal')
-        .getByRole('button', { name: 'OK' })
+        .getByRole('button', { name: 'Cancel' })
         .click();
+
+      await endTestConnection1;
 
       await page.waitForSelector(
         '[data-testid="test-connection-modal"] .ant-modal-mask',
@@ -128,10 +134,16 @@ test.describe('Service form functionality', async () => {
         testConnection2.request.connection.config.connection.provider
       ).toEqual(supersetFormDetails2.connection.provider);
 
+      const endTestConnection2 = page.waitForResponse(
+        '/api/v1/automations/workflows/*?hardDelete=true'
+      );
+
       await page
         .getByTestId('test-connection-modal')
-        .getByRole('button', { name: 'OK' })
+        .getByRole('button', { name: 'Cancel' })
         .click();
+
+      await endTestConnection2;
 
       await page.waitForSelector(
         '[data-testid="test-connection-modal"] .ant-modal-mask',
@@ -168,10 +180,16 @@ test.describe('Service form functionality', async () => {
         testConnection3.request.connection.config.connection.scheme
       ).toEqual(supersetFormDetails3.connection.scheme);
 
+      const endTestConnection3 = page.waitForResponse(
+        '/api/v1/automations/workflows/*?hardDelete=true'
+      );
+
       await page
         .getByTestId('test-connection-modal')
-        .getByRole('button', { name: 'OK' })
+        .getByRole('button', { name: 'Cancel' })
         .click();
+
+      await endTestConnection3;
 
       await page.waitForSelector(
         '[data-testid="test-connection-modal"] .ant-modal-mask',


### PR DESCRIPTION
I worked on fixing the ServiceForm.spec.ts failure in AUTs by removing dependency on test connection to be finished since it's not necessary for the test.

<img width="1382" height="430" alt="Screenshot 2025-12-03 at 2 05 01 PM" src="https://github.com/user-attachments/assets/2e09c9b7-9b70-4e5c-8b95-c4c03ca508f4" />
