### PR TITLE
[DO NOT MERGE ]Replace all network idle to domcontentloaded to check playwright time

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityFeed.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityFeed.spec.ts
@@ -81,12 +81,12 @@ test.describe('FeedWidget on landing page', () => {
           if (await saveButton.isEnabled()) {
             const saveResponse = adminPage.waitForResponse('/api/v1/docStore*');
             await saveButton.click();
-            await adminPage.waitForLoadState('networkidle');
+            await adminPage.waitForLoadState('domcontentloaded');
             await saveResponse;
           }
 
           await redirectToHomePage(adminPage);
-          await adminPage.waitForLoadState('networkidle');
+          await adminPage.waitForLoadState('domcontentloaded');
         } finally {
           await adminPage.close();
         }
@@ -116,7 +116,7 @@ test.describe('FeedWidget on landing page', () => {
   test.beforeEach(async ({ page }) => {
     await adminUser.login(page);
     await redirectToHomePage(page);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
   });
 
   test('renders widget wrapper and header with sort dropdown', async ({
@@ -165,7 +165,7 @@ test.describe('FeedWidget on landing page', () => {
       .getByTestId('widget-header')
       .getByText('Activity Feed');
     await titleLink.click();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // Verify navigation to user activity feed
     await expect(page.url()).toContain('/users/');
@@ -213,7 +213,7 @@ test.describe('FeedWidget on landing page', () => {
 
     const feedResponse = page.waitForResponse('/api/v1/feed*');
     await myDataOption.click();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await feedResponse;
 
     // Switch back to All Activity
@@ -226,7 +226,7 @@ test.describe('FeedWidget on landing page', () => {
     if (await allActivityOption.isVisible()) {
       const feedResponse = page.waitForResponse('/api/v1/feed*');
       await allActivityOption.click();
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await feedResponse;
     }
   });
@@ -243,7 +243,7 @@ test.describe('FeedWidget on landing page', () => {
 
     // Click and verify navigation
     await viewMoreLink.click();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // Should navigate away from home page
     expect(page.url()).not.toMatch(/home|welcome/i);
@@ -344,7 +344,7 @@ test.describe('FeedWidget on landing page', () => {
 
     if (await commentInput.count()) {
       await commentInput.click();
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       // Fill in the editor
       const editorField = page.locator(
@@ -358,7 +358,7 @@ test.describe('FeedWidget on landing page', () => {
       await expect(sendButton).toBeEnabled();
 
       const sendReply = page.waitForResponse('/api/v1/feed/*/posts');
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await sendButton.click();
       await sendReply;
 
@@ -437,13 +437,13 @@ test.describe('Mention notifications in Notification Box', () => {
             // wait for 2s before querying again
             await adminPage.waitForTimeout(2000);
             await adminPage.reload();
-            await adminPage.waitForLoadState('networkidle');
+            await adminPage.waitForLoadState('domcontentloaded');
             await waitForAllLoadersToDisappear(adminPage);
           }
         }
 
         await adminPage.getByTestId('activity_feed').click();
-        await adminPage.waitForLoadState('networkidle');
+        await adminPage.waitForLoadState('domcontentloaded');
 
         await adminPage.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
@@ -479,7 +479,7 @@ test.describe('Mention notifications in Notification Box', () => {
       await entity.visitEntityPage(user1Page);
 
       await user1Page.getByTestId('activity_feed').click();
-      await user1Page.waitForLoadState('networkidle');
+      await user1Page.waitForLoadState('domcontentloaded');
 
       await user1Page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
@@ -525,7 +525,7 @@ test.describe('Mention notifications in Notification Box', () => {
       'Admin user checks notification for correct user and timestamp',
       async () => {
         await adminPage.reload();
-        await adminPage.waitForLoadState('networkidle');
+        await adminPage.waitForLoadState('domcontentloaded');
         const notificationBell = adminPage.getByTestId('task-notifications');
 
         await expect(notificationBell).toBeVisible();
@@ -578,7 +578,7 @@ test.describe('Mention notifications in Notification Box', () => {
         const navigationPromise = adminPage.waitForURL(/activity_feed/);
         await mentionNotificationLink.click();
         await navigationPromise;
-        await adminPage.waitForLoadState('networkidle');
+        await adminPage.waitForLoadState('domcontentloaded');
 
         expect(adminPage.url()).toContain('activity_feed');
         expect(adminPage.url()).toContain('/all');

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AdvancedSearchSuggestions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AdvancedSearchSuggestions.spec.ts
@@ -51,7 +51,7 @@ test.describe('Advanced Search Suggestions', () => {
     test(`Verify suggestions for ${field.label} field`, async ({ page }) => {
       await redirectToHomePage(page);
       await sidebarClick(page, SidebarItem.EXPLORE);
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await waitForAllLoadersToDisappear(page);
       await showAdvancedSearchDialog(page);
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AutoPilot.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/AutoPilot.spec.ts
@@ -110,7 +110,7 @@ services.forEach((ServiceClass) => {
 
         // Wait for the service details page to load
         await page.waitForURL('**/service/**');
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -125,7 +125,7 @@ services.forEach((ServiceClass) => {
 
         if (service.serviceType === 'Mysql') {
           await page.reload();
-          await page.waitForLoadState('networkidle');
+          await page.waitForLoadState('domcontentloaded');
           await page.waitForSelector('[data-testid="loader"]', {
             state: 'detached',
           });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkEditEntity.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkEditEntity.spec.ts
@@ -183,7 +183,7 @@ test.describe('Bulk Edit Entity', () => {
 
       await page.click('[data-testid="databases"]');
 
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       // Verify Details updated
       await expect(page.getByTestId('column-name')).toHaveText(
@@ -341,7 +341,7 @@ test.describe('Bulk Edit Entity', () => {
 
       await page.getByTestId('column-display-name').click();
 
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('loader', { state: 'hidden' });
 
       // Verify Tags
@@ -464,7 +464,7 @@ test.describe('Bulk Edit Entity', () => {
         .getByTestId('column-display-name')
         .getByTestId(table.entity.name)
         .click();
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('loader', { state: 'hidden' });
 
       // Verify Domain

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkImport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkImport.spec.ts
@@ -1014,7 +1014,7 @@ test.describe('Bulk Import Export', () => {
 
     await test.step('should verify the removed value from entity', async () => {
       await page.getByTestId('column-name').first().click();
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       await expect(
         page

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Container.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Container.spec.ts
@@ -126,7 +126,7 @@ test.describe('Container entity specific tests ', () => {
   }) => {
     await page.goto('/container/s3_storage_sample.departments.finance');
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CuratedAssets.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CuratedAssets.spec.ts
@@ -181,7 +181,7 @@ test.describe('Curated Assets Widget', () => {
       await page.locator('[data-testid="saveButton"]').click();
       await queryResponse;
 
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       await waitForAllLoadersToDisappear(page, 'entity-list-skeleton');
 
@@ -196,7 +196,7 @@ test.describe('Curated Assets Widget', () => {
       await redirectToHomePage(page);
       await removeLandingBanner(page);
 
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       await waitForAllLoadersToDisappear(page, 'entity-list-skeleton');
 
@@ -210,7 +210,7 @@ test.describe('Curated Assets Widget', () => {
           .getByText(`${entityType.displayName} - Display Name Filter`)
       ).toBeVisible();
 
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       await waitForAllLoadersToDisappear(page, 'entity-list-skeleton');
 
@@ -290,7 +290,7 @@ test.describe('Curated Assets Widget', () => {
     await page.locator('[data-testid="saveButton"]').click();
     await queryResponse;
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await waitForAllLoadersToDisappear(page);
 
@@ -299,7 +299,7 @@ test.describe('Curated Assets Widget', () => {
       page.locator('[data-testid="KnowledgePanel.CuratedAssets"]')
     ).toBeVisible();
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await expect(
       page
@@ -393,12 +393,12 @@ test.describe('Curated Assets Widget', () => {
     ).toBeVisible();
 
     // Wait for auto-save to complete before navigating
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await redirectToHomePage(page);
     await removeLandingBanner(page);
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await waitForAllLoadersToDisappear(page, 'entity-list-skeleton');
 
@@ -483,7 +483,7 @@ test.describe('Curated Assets Widget', () => {
     await ruleLocator2.locator('.rule--value input').clear();
     await ruleLocator2.locator('.rule--value input').fill('pw');
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     const queryResponse = page.waitForResponse(
       (response) =>
@@ -500,7 +500,7 @@ test.describe('Curated Assets Widget', () => {
     await page.locator('[data-testid="saveButton"]').click();
     await queryResponse;
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await waitForAllLoadersToDisappear(page, 'entity-list-skeleton');
 
@@ -517,13 +517,13 @@ test.describe('Curated Assets Widget', () => {
     ).toBeVisible();
 
     // Wait for auto-save to complete before navigating
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // Navigate to landing page to verify widget
     await redirectToHomePage(page);
     await removeLandingBanner(page);
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await waitForAllLoadersToDisappear(page, 'entity-list-skeleton');
 
@@ -650,7 +650,7 @@ test.describe('Curated Assets Widget', () => {
     await page.locator('[data-testid="saveButton"]').click();
     await queryResponse;
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await waitForAllLoadersToDisappear(page, 'entity-list-skeleton');
 
@@ -667,13 +667,13 @@ test.describe('Curated Assets Widget', () => {
     ).toBeVisible();
 
     // Wait for auto-save to complete before navigating
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // Navigate to landing page to verify widget
     await redirectToHomePage(page);
     await removeLandingBanner(page);
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await waitForAllLoadersToDisappear(page, 'entity-list-skeleton');
 
@@ -712,7 +712,7 @@ test.describe('Curated Assets Widget', () => {
     await expect(page.locator('[data-testid="save-button"]')).toBeEnabled();
 
     await page.locator('[data-testid="save-button"]').click();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await redirectToHomePage(page);
     await removeLandingBanner(page);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CustomMetric.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CustomMetric.spec.ts
@@ -38,7 +38,7 @@ test('Table custom metric', async ({ page }) => {
     );
     await table.visitEntityPage(page);
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', { state: 'hidden' });
 
     await page.click('[data-testid="profiler"]');

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CustomPropertySearchSettings.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CustomPropertySearchSettings.spec.ts
@@ -103,7 +103,7 @@ test.describe.serial('Custom Property Search Settings', () => {
 
         // Verify the custom property was saved by refreshing the page
         await page.reload();
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
 
         const customPropertiesTab = page.getByTestId('custom_properties');
         await customPropertiesTab.click();
@@ -135,7 +135,7 @@ test.describe.serial('Custom Property Search Settings', () => {
           /settings\/preferences\/search-settings\/dashboards$/
         );
 
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -204,7 +204,7 @@ test.describe.serial('Custom Property Search Settings', () => {
           await searchInput.fill(dashboard.entityResponseData.name);
           await searchInput.press('Enter');
 
-          await page.waitForLoadState('networkidle');
+          await page.waitForLoadState('domcontentloaded');
           await page.waitForTimeout(2000);
 
           const searchResults = page.getByTestId('search-results');
@@ -226,7 +226,7 @@ test.describe.serial('Custom Property Search Settings', () => {
             await searchInput.fill(dashboardPropertyValue);
             await searchInput.press('Enter');
 
-            await page.waitForLoadState('networkidle');
+            await page.waitForLoadState('domcontentloaded');
             await page.waitForTimeout(2000);
 
             const searchResults = page.getByTestId('search-results');
@@ -298,7 +298,7 @@ test.describe.serial('Custom Property Search Settings', () => {
           /settings\/preferences\/search-settings\/pipelines$/
         );
 
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -357,7 +357,7 @@ test.describe.serial('Custom Property Search Settings', () => {
         await searchInput.fill(pipelinePropertyValue);
         await searchInput.press('Enter');
 
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForTimeout(2000);
 
         const searchResults = page.getByTestId('search-results');
@@ -384,7 +384,7 @@ test.describe.serial('Custom Property Search Settings', () => {
       );
       await dashboardCard.click();
 
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
@@ -404,7 +404,7 @@ test.describe.serial('Custom Property Search Settings', () => {
       );
       await pipelineCard.click();
 
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CustomizeDetailPage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CustomizeDetailPage.spec.ts
@@ -184,7 +184,7 @@ test.describe('Persona customize UI tab', async () => {
     const personaListResponse = adminPage.waitForResponse(`/api/v1/personas?*`);
     await adminPage.goBack();
     await personaListResponse;
-    await adminPage.waitForLoadState('networkidle');
+    await adminPage.waitForLoadState('domcontentloaded');
     await navigateToPersonaWithPagination(
       adminPage,
       navigationPersona.data.name,
@@ -365,7 +365,7 @@ test.describe('Persona customization', () => {
           );
 
           await adminPage.getByRole('tab', { name: 'Customize UI' }).click();
-          await adminPage.waitForLoadState('networkidle');
+          await adminPage.waitForLoadState('domcontentloaded');
           await adminPage.getByText('Data Assets').click();
           await adminPage.getByText(type, { exact: true }).click();
 
@@ -437,7 +437,7 @@ test.describe('Persona customization', () => {
         await redirectToHomePage(userPage);
 
         await entity?.visitEntityPage(userPage);
-        await userPage.waitForLoadState('networkidle');
+        await userPage.waitForLoadState('domcontentloaded');
         await userPage.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -493,7 +493,7 @@ test.describe('Persona customization', () => {
             true
           );
           await adminPage.getByRole('tab', { name: 'Customize UI' }).click();
-          await adminPage.waitForLoadState('networkidle');
+          await adminPage.waitForLoadState('domcontentloaded');
           await adminPage.getByText('Governance').click();
           await adminPage.getByText(type, { exact: true }).click();
 
@@ -561,7 +561,7 @@ test.describe('Persona customization', () => {
         await redirectToHomePage(userPage);
 
         await entity?.visitEntityPage(userPage);
-        await userPage.waitForLoadState('networkidle');
+        await userPage.waitForLoadState('domcontentloaded');
         await userPage.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -608,7 +608,7 @@ test.describe('Persona customization', () => {
       // Need to find persona card and click as the list might get paginated
       await navigateToPersonaWithPagination(adminPage, persona.data.name, true);
       await adminPage.getByRole('tab', { name: 'Customize UI' }).click();
-      await adminPage.waitForLoadState('networkidle');
+      await adminPage.waitForLoadState('domcontentloaded');
       await adminPage.getByText('Governance').click();
       await adminPage.getByText('Glossary Term', { exact: true }).click();
 
@@ -635,7 +635,7 @@ test.describe('Persona customization', () => {
       await redirectToHomePage(userPage);
 
       await entity?.visitEntityPage(userPage);
-      await userPage.waitForLoadState('networkidle');
+      await userPage.waitForLoadState('domcontentloaded');
       await userPage.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
@@ -691,7 +691,7 @@ test.describe('Persona customization', () => {
       // Need to find persona card and click as the list might get paginated
       await navigateToPersonaWithPagination(adminPage, persona.data.name, true);
       await adminPage.getByRole('tab', { name: 'Customize UI' }).click();
-      await adminPage.waitForLoadState('networkidle');
+      await adminPage.waitForLoadState('domcontentloaded');
       await adminPage.getByText('Data Assets').click();
       await adminPage.getByText('Table', { exact: true }).click();
 
@@ -745,7 +745,7 @@ test.describe('Persona customization', () => {
         await redirectToHomePage(userPage);
 
         await entity?.visitEntityPage(userPage);
-        await userPage.waitForLoadState('networkidle');
+        await userPage.waitForLoadState('domcontentloaded');
         await userPage.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -753,7 +753,7 @@ test.describe('Persona customization', () => {
         // Change language to French
         await userPage.getByRole('button', { name: 'EN' }).click();
         await userPage.getByRole('menuitem', { name: 'Français - FR' }).click();
-        await userPage.waitForLoadState('networkidle');
+        await userPage.waitForLoadState('domcontentloaded');
         await userPage.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Dashboards.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Dashboards.spec.ts
@@ -115,7 +115,7 @@ test.describe('Dashboard and Charts deleted toggle', () => {
     page,
   }) => {
     await dashboard.visitEntityPage(page);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
 
@@ -133,7 +133,7 @@ test.describe('Dashboard and Charts deleted toggle', () => {
     await page.click('[data-testid="confirm-button"]');
 
     await deleteResponse;
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await toastNotification(
       page,
@@ -142,7 +142,7 @@ test.describe('Dashboard and Charts deleted toggle', () => {
     );
 
     await page.reload();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
     // Retry mechanism for checking deleted badge
     let deletedBadge = page.locator('[data-testid="deleted-badge"]');
@@ -158,7 +158,7 @@ test.describe('Dashboard and Charts deleted toggle', () => {
       attempts++;
       if (attempts < maxAttempts) {
         await page.reload();
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -179,7 +179,7 @@ test.describe('Dashboard and Charts deleted toggle', () => {
 
     await restoreEntity(page);
     await page.reload();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
 
     await expect(
@@ -202,7 +202,7 @@ test.describe('Data Model', () => {
       '/dashboardDataModel/sample_superset.model.big_analytics_data_model_with_nested_columns'
     );
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataAssetRulesDisabled.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataAssetRulesDisabled.spec.ts
@@ -373,7 +373,7 @@ test.describe(
 
         await page.click('[data-testid="databases"]');
 
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
 
         // Verify Details updated
         await expect(page.getByTestId('column-name')).toHaveText(
@@ -530,7 +530,7 @@ test.describe(
 
         await page.getByTestId('column-display-name').click();
 
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('loader', { state: 'hidden' });
 
         // Verify Tags
@@ -645,7 +645,7 @@ test.describe(
           .getByTestId('column-display-name')
           .getByTestId(table.entity.name)
           .click();
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('loader', { state: 'hidden' });
 
         // Verify Domain

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/AddTestCaseNewFlow.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/AddTestCaseNewFlow.spec.ts
@@ -168,13 +168,13 @@ test.describe('Add TestCase New Flow', () => {
       state: 'visible',
     });
     await testCaseDoc;
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await waitForAllLoadersToDisappear(page);
   };
 
   const visitDataQualityPage = async (page: Page) => {
     await page.goto('/data-quality/test-cases');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await waitForAllLoadersToDisappear(page);
   };
 
@@ -208,7 +208,7 @@ test.describe('Add TestCase New Flow', () => {
         page,
         ...tableTestCaseDetails,
       });
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
@@ -310,12 +310,12 @@ test.describe('Add TestCase New Flow', () => {
       })
       .click();
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
 
     await page.click('[data-testid="profiler-add-table-test-btn"]');
     await page.getByRole('menuitem', { name: 'Test case' }).click();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await createTestCase({
       page,
@@ -328,7 +328,7 @@ test.describe('Add TestCase New Flow', () => {
       .getByTestId('select-table-card')
       .getByText('Column Level')
       .click();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await selectColumn(page, table.entity.columns[0].name);
 
@@ -373,7 +373,7 @@ test.describe('Add TestCase New Flow', () => {
       .getByTestId('edit-button')
       .click();
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DescriptionSuggestion.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DescriptionSuggestion.spec.ts
@@ -107,7 +107,7 @@ test.describe.serial('Description Suggestions Table Entity', () => {
       await singleResolveResponse;
 
       await page.reload();
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
@@ -142,7 +142,7 @@ test.describe.serial('Description Suggestions Table Entity', () => {
       await singleResolveResponse;
 
       await page.reload();
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/EntitySummaryPanel.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/EntitySummaryPanel.spec.ts
@@ -22,14 +22,14 @@ test.use({ storageState: 'playwright/.auth/admin.json' });
 
 async function openEntitySummaryPanel(page: Page, entityType: EntityType) {
   await selectDataAssetFilter(page, entityType);
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   const firstEntityCard = page
     .locator('[data-testid="table-data-card"]')
     .first();
   if (await firstEntityCard.isVisible()) {
     await firstEntityCard.click();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
   }
 }
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ExploreQuickFilters.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ExploreQuickFilters.spec.ts
@@ -63,7 +63,7 @@ test.afterAll('Cleanup', async ({ browser }) => {
 test.beforeEach(async ({ page }) => {
   await redirectToHomePage(page);
   await sidebarClick(page, SidebarItem.EXPLORE);
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForSelector('[data-testid="loader"]', { state: 'hidden' });
 });
 
@@ -188,7 +188,7 @@ test('should persist quick filter on global search', async ({ page }) => {
   await page.getByTestId('searchBox').click();
   await page.keyboard.down('Enter');
 
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   // expect the quick filter to be persisted
   await expect(

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ExploreSortOrderFilter.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ExploreSortOrderFilter.spec.ts
@@ -28,7 +28,7 @@ test.describe('Explore Sort Order Filter', () => {
       await redirectToHomePage(page);
       await sidebarClick(page, SidebarItem.EXPLORE);
 
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       await page.getByTestId('search-dropdown-Data Assets').click();
       await page.waitForSelector(

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/GlobalPageSize.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/GlobalPageSize.spec.ts
@@ -24,7 +24,7 @@ test.describe('Table & Data Model columns table pagination', () => {
       '/table/sample_data.ecommerce_db.shopify.performance_test_table'
     );
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });
@@ -40,7 +40,7 @@ test.describe('Table & Data Model columns table pagination', () => {
     // Go to Explore Page
     await sidebarClick(page, SidebarItem.EXPLORE);
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });
@@ -54,7 +54,7 @@ test.describe('Table & Data Model columns table pagination', () => {
     // Go to Users Page
     await settingClick(page, GlobalSettingOptions.USERS);
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts
@@ -126,7 +126,7 @@ test.describe('Incident Manager', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
       await redirectToHomePage(adminPage);
 
       await table1.visitEntityPage(adminPage);
-      await adminPage.waitForLoadState('networkidle');
+      await adminPage.waitForLoadState('domcontentloaded');
       await adminPage.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
@@ -219,11 +219,11 @@ test.describe('Incident Manager', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
           .innerText();
         await addMentionCommentInFeed(page, 'admin', true);
 
-        await adminPage.waitForLoadState('networkidle');
+        await adminPage.waitForLoadState('domcontentloaded');
         await waitForAllLoadersToDisappear(adminPage);
         await adminPage.getByRole('button', { name: 'Notifications' }).click();
         await adminPage.getByText('Mentions').click();
-        await adminPage.waitForLoadState('networkidle');
+        await adminPage.waitForLoadState('domcontentloaded');
         await waitForAllLoadersToDisappear(adminPage);
 
         await expect(adminPage.getByLabel('Mentions')).toContainText(

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/LandingPageWidgets/DomainDataProductsWidgets.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/LandingPageWidgets/DomainDataProductsWidgets.spec.ts
@@ -182,7 +182,7 @@ test.describe.serial('Domain and Data Product Asset Counts', () => {
 
     // Check assets count is now 1
     await page.reload();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await checkAssetsCount(page, 1);
 
     await redirectToHomePage(page);
@@ -203,7 +203,7 @@ test.describe.serial('Domain and Data Product Asset Counts', () => {
 
     // Click assets tab - data product should have some assets from previous test
     await page.getByTestId('assets').click();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // Wait for assets to load
     await page
@@ -245,13 +245,13 @@ test.describe.serial('Domain and Data Product Asset Counts', () => {
       await removeRes;
 
       // Wait for search to refresh
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForTimeout(500);
     }
 
     // Refresh and check the assets tab shows 0
     await page.reload();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await checkAssetsCount(page, 0);
 
     await redirectToHomePage(page);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/LargeGlossaryPerformance.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/LargeGlossaryPerformance.spec.ts
@@ -171,7 +171,7 @@ test.describe('Large Glossary Performance Tests', () => {
     // Click to collapse all
     await expandAllButton.click();
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForFunction(() => {
       return (
         document.querySelectorAll(

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/MutuallyExclusiveColumnTags.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/MutuallyExclusiveColumnTags.spec.ts
@@ -36,7 +36,7 @@ test('Should show error toast when adding mutually exclusive tags to column', as
   await redirectToHomePage(page);
   await table.visitEntityPage(page);
 
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
 
   const firstColumnName = table.columnsName[0];

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/NavigationBlocker.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/NavigationBlocker.spec.ts
@@ -135,7 +135,7 @@ test.describe('Navigation Blocker Tests', () => {
     // Modal should disappear and navigate to settings
     await expect(adminPage.locator('.ant-modal')).not.toBeVisible();
 
-    await adminPage.waitForLoadState('networkidle');
+    await adminPage.waitForLoadState('domcontentloaded');
 
     // Should navigate to the settings page
     expect(adminPage.url()).toContain('settings');
@@ -188,7 +188,7 @@ test.describe('Navigation Blocker Tests', () => {
     await expect(adminPage.locator('.ant-modal')).not.toBeVisible();
 
     // Should navigate to the settings page
-    await adminPage.waitForLoadState('networkidle');
+    await adminPage.waitForLoadState('domcontentloaded');
 
     // Verify URL changed from customize page
     expect(adminPage.url()).not.toBe(originalUrl);
@@ -234,7 +234,7 @@ test.describe('Navigation Blocker Tests', () => {
       .click();
 
     // Navigation should happen immediately without modal
-    await adminPage.waitForLoadState('networkidle');
+    await adminPage.waitForLoadState('domcontentloaded');
 
     expect(adminPage.url()).toContain('settings');
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OnlineUsers.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OnlineUsers.spec.ts
@@ -29,7 +29,7 @@ test.describe('Online Users Feature', () => {
     page,
   }) => {
     await settingClick(page, GlobalSettingOptions.ONLINE_USERS);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
@@ -72,13 +72,13 @@ test.describe('Online Users Feature', () => {
   }) => {
     // First, navigate around to generate activity
     await sidebarClick(page, SidebarItem.EXPLORE);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await sidebarClick(page, SidebarItem.DATA_QUALITY);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await settingClick(page, GlobalSettingOptions.ONLINE_USERS);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
@@ -97,7 +97,7 @@ test.describe('Online Users Feature', () => {
 
   test('Should not show bots in online users list', async ({ page }) => {
     await settingClick(page, GlobalSettingOptions.ONLINE_USERS);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // Verify bot users are not shown (ingestion-bot should not be visible)
     const tableRows = page.locator('tbody tr');
@@ -113,7 +113,7 @@ test.describe('Online Users Feature', () => {
 
   test('Should filter users by time window', async ({ page }) => {
     await settingClick(page, GlobalSettingOptions.ONLINE_USERS);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
@@ -160,7 +160,7 @@ test.describe('Online Users Feature', () => {
     await sidebarClick(dataConsumerPage, SidebarItem.SETTINGS);
 
     await dataConsumerPage.getByTestId('members').click();
-    await dataConsumerPage.waitForLoadState('networkidle');
+    await dataConsumerPage.waitForLoadState('domcontentloaded');
 
     await expect(
       dataConsumerPage.getByTestId('members.online-users')
@@ -169,7 +169,7 @@ test.describe('Online Users Feature', () => {
 
   test('Should show correct last activity format', async ({ page }) => {
     await settingClick(page, GlobalSettingOptions.ONLINE_USERS);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Permission.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Permission.spec.ts
@@ -252,7 +252,7 @@ test('Permissions', async ({ userPage, adminPage }) => {
     });
 
     await userPage.getByTestId('profiler').click();
-    await userPage.waitForLoadState('networkidle');
+    await userPage.waitForLoadState('domcontentloaded');
     await userPage.waitForSelector("[data-testid='loader']", {
       state: 'detached',
     });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Permissions/DomainPermissions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Permissions/DomainPermissions.spec.ts
@@ -120,7 +120,7 @@ test('Domain allow operations', async ({ testUserPage, browser }) => {
 
   const manageButtonElements = ['delete-button', 'rename-button'];
 
-  await testUserPage.waitForLoadState('networkidle');
+  await testUserPage.waitForLoadState('domcontentloaded');
 
   // Test direct elements first
   for (const testId of directElements) {
@@ -193,7 +193,7 @@ test('Domain deny operations', async ({ testUserPage, browser }) => {
 
   const manageButtonElements = ['delete-button', 'rename-button'];
 
-  await testUserPage.waitForLoadState('networkidle');
+  await testUserPage.waitForLoadState('domcontentloaded');
 
   for (const testId of directElements) {
     let element;

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Permissions/GlossaryPermissions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Permissions/GlossaryPermissions.spec.ts
@@ -101,7 +101,7 @@ test('Glossary allow operations', async ({ testUserPage, browser }) => {
 
   const manageButtonElements = ['delete-button', 'rename-button'];
 
-  await testUserPage.waitForLoadState('networkidle');
+  await testUserPage.waitForLoadState('domcontentloaded');
 
   for (const testId of directElements) {
     let element;
@@ -165,7 +165,7 @@ test('Glossary deny operations', async ({ testUserPage, browser }) => {
 
   const manageButtonElements = ['delete-button', 'rename-button'];
 
-  await testUserPage.waitForLoadState('networkidle');
+  await testUserPage.waitForLoadState('domcontentloaded');
 
   for (const testId of directElements) {
     let element;

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/QueryEntity.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/QueryEntity.spec.ts
@@ -265,7 +265,7 @@ test('Query Entity', async ({ page }) => {
       .click();
 
     await page.reload();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });
@@ -283,7 +283,7 @@ test('Query Entity', async ({ page }) => {
       .click();
 
     await page.reload();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/RestoreEntityInheritedFields.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/RestoreEntityInheritedFields.spec.ts
@@ -78,7 +78,7 @@ entities.forEach((EntityClass) => {
       test.slow();
 
       await entity.visitEntityPage(page);
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       await expect(page.getByTestId('breadcrumb-link')).toHaveCount(
         ['Table', 'ApiEndpoint', 'Store Procedure'].includes(entity.getType())

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SchemaSearch.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SchemaSearch.spec.ts
@@ -61,7 +61,7 @@ test.describe('Schema search', { tag: '@ingestion' }, () => {
 
     await page.click(`[data-testid="service-name-${serviceName}"]`);
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', { state: 'hidden' });
 
     const headerText = await page.textContent(

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SettingsNavigationPage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SettingsNavigationPage.spec.ts
@@ -50,13 +50,13 @@ base.afterAll('Cleanup', async ({ browser }) => {
 const navigateToPersonaNavigation = async (page: Page) => {
   const getPersonas = page.waitForResponse('/api/v1/personas*');
   await settingClick(page, GlobalSettingOptions.PERSONA);
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await getPersonas;
 
   await navigateToPersonaWithPagination(page, persona.data.name, true);
 
   await page.getByTestId('navigation').click();
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 };
 
 test.describe('Settings Navigation Page Tests', () => {
@@ -145,7 +145,7 @@ test.describe('Settings Navigation Page Tests', () => {
 
     // Test discard changes
     await page.getByTestId('unsaved-changes-modal-discard').click();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // Should navigate away and changes should be discarded
     await expect(page).toHaveURL(/.*settings.*/);
@@ -176,7 +176,7 @@ test.describe('Settings Navigation Page Tests', () => {
     const saveResponse = page.waitForResponse('api/v1/docStore');
     await page.getByTestId('unsaved-changes-modal-save').click();
     await saveResponse;
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // Should navigate to settings page
     await expect(page).toHaveURL(/.*settings.*/);
@@ -241,7 +241,7 @@ test.describe('Settings Navigation Page Tests', () => {
 
     // Test discard changes
     await page.getByTestId('unsaved-changes-modal-save').click();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // Verify reset worked - save button disabled and state reverted
     expect(await domainSwitch.isChecked()).toBeTruthy();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Table.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Table.spec.ts
@@ -63,7 +63,7 @@ test.describe('Table pagination sorting search scenarios ', () => {
     await sidebarClick(page, SidebarItem.DATA_QUALITY);
 
     await page.click('[data-testid="test-cases"]');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });
@@ -72,7 +72,7 @@ test.describe('Table pagination sorting search scenarios ', () => {
 
     await page.getByTestId('next').click();
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });
@@ -98,7 +98,7 @@ test.describe('Table pagination sorting search scenarios ', () => {
   }) => {
     await sidebarClick(page, SidebarItem.DATA_QUALITY);
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.click('[data-testid="test-cases"]');
 
     const listTestCaseResponse = page.waitForResponse(
@@ -156,13 +156,13 @@ test.describe('Table pagination sorting search scenarios ', () => {
     await firstLinkInColumn.click();
 
     await page.waitForURL('**/table/**');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });
 
     await page.goBack({
-      waitUntil: 'networkidle',
+      waitUntil: 'domcontentloaded',
     });
 
     await page.waitForSelector('[data-testid="loader"]', {
@@ -181,13 +181,13 @@ test.describe('Table pagination sorting search scenarios ', () => {
     await secondLinkInColumn.click();
 
     await page.waitForURL('**/table/**');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });
 
     await page.goBack({
-      waitUntil: 'networkidle',
+      waitUntil: 'domcontentloaded',
     });
 
     await page.waitForSelector('[data-testid="loader"]', {
@@ -204,7 +204,7 @@ test.describe('Table pagination sorting search scenarios ', () => {
 
   test('should persist page size', async ({ dataConsumerPage: page }) => {
     await page.goto('/databaseSchema/sample_data.ecommerce_db.shopify');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
@@ -234,13 +234,13 @@ test.describe('Table pagination sorting search scenarios ', () => {
     await linkInColumn.click();
 
     await entityApiResponse;
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });
 
     await page.goBack();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });
@@ -262,7 +262,7 @@ test.describe('Table & Data Model columns table pagination', () => {
       '/table/sample_data.ecommerce_db.shopify.performance_test_table'
     );
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });
@@ -282,7 +282,7 @@ test.describe('Table & Data Model columns table pagination', () => {
       '/dashboardDataModel/sample_superset.model.big_analytics_data_model_with_nested_columns'
     );
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });
@@ -346,7 +346,7 @@ test.describe('Table & Data Model columns table pagination', () => {
   }) => {
     await page.goto('/table/sample_data.ecommerce_db.shopify.dim_customer');
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });
@@ -419,7 +419,7 @@ test.describe('Table & Data Model columns table pagination', () => {
       '/table/sample_data.ecommerce_db.shopify.performance_test_table'
     );
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });
@@ -485,7 +485,7 @@ test.describe(
       await page.goto('/table/sample_data.ecommerce_db.shopify.dim_customer');
 
       // Wait for page to be fully loaded
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
@@ -583,7 +583,7 @@ test.describe(
       await page.goto('/table/sample_data.ecommerce_db.shopify.dim_customer');
 
       // Wait for page to be fully loaded
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
@@ -624,7 +624,7 @@ test.describe(
 
       page.reload();
       // Wait for page to be fully loaded
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TableConstraint.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TableConstraint.spec.ts
@@ -60,7 +60,7 @@ test.describe('Table Constraints', {}, () => {
 
     await test.step('Add Constraints', async () => {
       await table.visitEntityPage(page);
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamsDragAndDrop.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TeamsDragAndDrop.spec.ts
@@ -102,7 +102,7 @@ test.describe('Teams drag and drop should work properly', () => {
   test('Add teams in hierarchy', async ({ page }) => {
     for (const teamDetails of DRAG_AND_DROP_TEAM_DETAILS) {
       await addTeamHierarchy(page, teamDetails);
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TestSuiteMultiPipeline.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TestSuiteMultiPipeline.spec.ts
@@ -55,7 +55,7 @@ test(
       await createTestCaseResponse;
 
       await page.reload();
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/UserProfileOnlineStatus.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/UserProfileOnlineStatus.spec.ts
@@ -49,7 +49,7 @@ test.describe('User Profile Online Status', () => {
 
     await redirectToHomePage(page);
     await visitUserProfilePage(page, activeUser.responseData.name);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // Check for online status badge
     const onlineStatusBadge = page.locator(
@@ -84,7 +84,7 @@ test.describe('User Profile Online Status', () => {
     // Navigate to user profile
     await redirectToHomePage(page);
     await visitUserProfilePage(page, activeUser.responseData.name);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // Simulate that the user was active 30 minutes ago
     // (In real scenario, this would be set by backend based on actual activity)
@@ -104,7 +104,7 @@ test.describe('User Profile Online Status', () => {
     // Navigate to inactive user profile
     await redirectToHomePage(page);
     await visitUserProfilePage(page, inactiveUser.responseData.name);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // Check that online status badge is not visible
     const onlineStatusBadge = page.getByTestId('user-online-status');
@@ -125,7 +125,7 @@ test.describe('User Profile Online Status', () => {
     // Navigate to admin's profile (admin always has activity)
     await redirectToHomePage(page);
     await visitOwnProfilePage(page);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // Verify email element is visible
     const emailElement = page.getByTestId('user-email-value');
@@ -157,7 +157,7 @@ test.describe('User Profile Online Status', () => {
     // First navigate to admin profile
     await redirectToHomePage(page);
     await visitOwnProfilePage(page);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // Admin should always show online status since they're logged in
     const onlineStatusBadge = page.getByTestId('user-online-status');
@@ -167,10 +167,10 @@ test.describe('User Profile Online Status', () => {
 
     // Navigate away and back to verify status persists
     await sidebarClick(page, SidebarItem.EXPLORE);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await visitOwnProfilePage(page);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // Status should still be visible
     await expect(onlineStatusBadge).toBeVisible();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/AddRoleAndAssignToUser.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/AddRoleAndAssignToUser.spec.ts
@@ -48,7 +48,7 @@ test.describe.serial('Add role and assign it to the user', () => {
 
   test('Create role', async ({ page }) => {
     await settingClick(page, GlobalSettingOptions.ROLES);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await page.click('[data-testid="add-role"]');
 
@@ -81,7 +81,7 @@ test.describe.serial('Add role and assign it to the user', () => {
   test('Create new user and assign new role to him', async ({ page }) => {
     await settingClick(page, GlobalSettingOptions.USERS);
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await page.click('[data-testid="add-user"]');
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/AdvanceSearchFilter/CustomPropertyAdvanceSeach.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/AdvanceSearchFilter/CustomPropertyAdvanceSeach.spec.ts
@@ -167,7 +167,7 @@ test('CustomProperty Dashboard Filter', async ({ page }) => {
 
       await applyAdvanceFilter;
 
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ApiDocs.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ApiDocs.spec.ts
@@ -25,7 +25,7 @@ test.describe('API docs should work properly', () => {
     await page.locator('[data-testid="help-icon"]').click();
     await page.getByRole('link', { name: 'API', exact: true }).click();
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page
       .getByTestId('fluid-container')
       .getByTestId('loader')

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/CustomizeLandingPage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/CustomizeLandingPage.spec.ts
@@ -191,7 +191,7 @@ test.describe('Customize Landing Page Flow', () => {
 
       // Navigate to the landing page
       await redirectToHomePage(adminPage);
-      await adminPage.waitForLoadState('networkidle');
+      await adminPage.waitForLoadState('domcontentloaded');
 
       // Check if removed widgets are not present on the landing page
       await expect(
@@ -253,7 +253,7 @@ test.describe('Customize Landing Page Flow', () => {
         await redirectToHomePage(adminPage);
 
         // Ensures the page is fully loaded
-        await adminPage.waitForLoadState('networkidle');
+        await adminPage.waitForLoadState('domcontentloaded');
 
         await checkAllDefaultWidgets(adminPage);
       }

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ExploreDiscovery.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ExploreDiscovery.spec.ts
@@ -83,7 +83,7 @@ test.describe('Explore Assets Discovery', () => {
       `/explore?page=1&size=10&queryFilter=${JSON.stringify(queryFilter)}`
     );
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
 
     await expect(
@@ -106,7 +106,7 @@ test.describe('Explore Assets Discovery', () => {
       `/explore?page=1&size=10&queryFilter=${JSON.stringify(queryFilter)}`
     );
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
 
     await expect(
@@ -129,7 +129,7 @@ test.describe('Explore Assets Discovery', () => {
       `/explore?page=1&size=10&queryFilter=${JSON.stringify(queryFilter)}`
     );
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
 
     await expect(
@@ -153,7 +153,7 @@ test.describe('Explore Assets Discovery', () => {
       )}`
     );
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
 
     await expect(
@@ -178,7 +178,7 @@ test.describe('Explore Assets Discovery', () => {
       )}`
     );
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
 
     await expect(
@@ -203,7 +203,7 @@ test.describe('Explore Assets Discovery', () => {
       )}`
     );
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
 
     await expect(
@@ -217,7 +217,7 @@ test.describe('Explore Assets Discovery', () => {
     page,
   }) => {
     await table1.visitEntityPage(page);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await page.getByTestId('manage-button').click();
     await page.getByTestId('delete-button').click();
@@ -241,14 +241,14 @@ test.describe('Explore Assets Discovery', () => {
     await page.getByTestId('confirm-button').click();
 
     await page.reload();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
 
     await expect(page.getByTestId('deleted-badge')).toBeVisible();
 
     await redirectToHomePage(page);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await page.getByTestId('searchBox').click();
     await page.getByTestId('searchBox').fill(table1.entityResponseData.name);
@@ -262,7 +262,7 @@ test.describe('Explore Assets Discovery', () => {
     page,
   }) => {
     await sidebarClick(page, SidebarItem.EXPLORE);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await waitForAllLoadersToDisappear(page);
 
     // The user should not be visible in the owners filter when the deleted switch is off
@@ -315,13 +315,13 @@ test.describe('Explore Assets Discovery', () => {
     page,
   }) => {
     await sidebarClick(page, SidebarItem.EXPLORE);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await waitForAllLoadersToDisappear(page);
 
     // Click on the show deleted toggle button
     await page.getByTestId('show-deleted').click();
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await waitForAllLoadersToDisappear(page);
 
     // The user should be visible in the owners filter when the deleted switch is on
@@ -352,7 +352,7 @@ test.describe('Explore Assets Discovery', () => {
     await page.getByTestId('update-btn').click();
     await fetchWithOwner;
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await waitForAllLoadersToDisappear(page);
 
     // The domain should be visible in the domains filter when the deleted switch is on
@@ -386,7 +386,7 @@ test.describe('Explore Assets Discovery', () => {
     await page.getByTestId('update-btn').click();
     await fetchWithDomain;
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await waitForAllLoadersToDisappear(page);
 
     // Only the table option should be visible for the data assets filter when the deleted switch is on

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/GlobalSearch.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/GlobalSearch.spec.ts
@@ -26,7 +26,7 @@ test('searching for longer description should work', async ({ page }) => {
   await redirectToHomePage(page);
 
   await sidebarClick(page, SidebarItem.EXPLORE);
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   await page.getByTestId('global-search-selector').click();
   await page.getByTestId('global-search-select-option-Table').click();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/IngestionBot.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/IngestionBot.spec.ts
@@ -50,7 +50,7 @@ const test = base.extend<{
 
     await setToken(page, tokenData.config.JWTToken);
     await redirectToHomePage(page);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('loader', { state: 'hidden' });
 
     await expect(page.getByTestId('nav-user-name')).toHaveText('ingestion-bot');
@@ -96,7 +96,7 @@ test.describe('Ingestion Bot ', () => {
     await test.step('Assign assets to domains', async () => {
       // Add assets to domain 1
       await sidebarClick(page, SidebarItem.DOMAIN);
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
@@ -105,7 +105,7 @@ test.describe('Ingestion Bot ', () => {
 
       // Add assets to domain 2
       await sidebarClick(page, SidebarItem.DOMAIN);
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
@@ -149,7 +149,7 @@ test.describe('Ingestion Bot ', () => {
       // Add assets to domain 1
       await redirectToHomePage(page);
       await sidebarClick(page, SidebarItem.DOMAIN);
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
@@ -159,7 +159,7 @@ test.describe('Ingestion Bot ', () => {
 
       // Add assets to domain 2
       await sidebarClick(page, SidebarItem.DOMAIN);
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/LineageSettings.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/LineageSettings.spec.ts
@@ -269,7 +269,7 @@ test.describe('Lineage Settings Tests', () => {
     );
     await pipeline.visitEntityPage(dataStewardPage);
     await dataStewardPage.getByRole('tab', { name: 'Lineage' }).click();
-    await dataStewardPage.waitForLoadState('networkidle');
+    await dataStewardPage.waitForLoadState('domcontentloaded');
     await waitForAllLoadersToDisappear(dataStewardPage);
     await dataStewardPage.getByTestId('fit-screen').click();
 
@@ -288,7 +288,7 @@ test.describe('Lineage Settings Tests', () => {
     await settingsUpdate;
 
     await dataStewardPage.reload();
-    await dataStewardPage.waitForLoadState('networkidle');
+    await dataStewardPage.waitForLoadState('domcontentloaded');
     await waitForAllLoadersToDisappear(dataStewardPage);
     await dataStewardPage.getByTestId('fit-screen').click();
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/Navbar.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/Navbar.spec.ts
@@ -25,7 +25,7 @@ for (const searchItem of navbarSearchItems) {
   test(`Search Term - ${label}`, async ({ page }) => {
     await redirectToHomePage(page);
     await sidebarClick(page, SidebarItem.EXPLORE);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await selectOption(page, page.getByTestId('global-search-selector'), label);
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/PersonaDeletionUserProfile.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/PersonaDeletionUserProfile.spec.ts
@@ -56,7 +56,7 @@ test.describe.serial('User profile works after persona deletion', () => {
     await test.step('Create persona with user', async () => {
       await redirectToHomePage(page);
       await settingClick(page, GlobalSettingOptions.PERSONA);
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
@@ -111,7 +111,7 @@ test.describe.serial('User profile works after persona deletion', () => {
     await test.step('Verify persona appears on user profile', async () => {
       // Go directly to user profile URL
       await page.goto(`/users/${user.responseData.name}`);
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
@@ -136,7 +136,7 @@ test.describe.serial('User profile works after persona deletion', () => {
     // Step 3: Delete the persona
     await test.step('Delete the persona', async () => {
       await settingClick(page, GlobalSettingOptions.PERSONA);
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
@@ -144,7 +144,7 @@ test.describe.serial('User profile works after persona deletion', () => {
       await page
         .getByTestId(`persona-details-card-${PERSONA_DETAILS.name}`)
         .click();
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       await page.click('[data-testid="manage-button"]');
       await page.click('[data-testid="delete-button-title"]');
@@ -183,7 +183,7 @@ test.describe.serial('User profile works after persona deletion', () => {
       async () => {
         // Go directly to user profile URL again
         await page.goto(`/users/${user.responseData.name}`);
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
 
         // User profile should load without errors
         // Check if the user name is displayed (this means the page loaded)
@@ -227,7 +227,7 @@ test.describe.serial('User profile works after persona deletion', () => {
     await test.step('Create default persona with user', async () => {
       await redirectToHomePage(page);
       await settingClick(page, GlobalSettingOptions.PERSONA);
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
@@ -285,14 +285,14 @@ test.describe.serial('User profile works after persona deletion', () => {
       await page
         .getByTestId(`persona-details-card-${DEFAULT_PERSONA_DETAILS.name}`)
         .click();
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       // Use the helper function to set as default
       await setPersonaAsDefault(page);
 
       // Go back to personas list
       await settingClick(page, GlobalSettingOptions.PERSONA);
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
     });
 
     // Step 2: Navigate directly to user profile and verify default persona is shown
@@ -303,7 +303,7 @@ test.describe.serial('User profile works after persona deletion', () => {
         await page.goto(
           `http://localhost:8585/users/${user.responseData.name}`
         );
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
 
         // Check if persona appears on the user profile
         const personaCard = page.getByTestId('persona-details-card');
@@ -339,7 +339,7 @@ test.describe.serial('User profile works after persona deletion', () => {
     // Step 3: Delete the default persona
     await test.step('Delete the default persona', async () => {
       await settingClick(page, GlobalSettingOptions.PERSONA);
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
@@ -347,7 +347,7 @@ test.describe.serial('User profile works after persona deletion', () => {
       await page
         .getByTestId(`persona-details-card-${DEFAULT_PERSONA_DETAILS.name}`)
         .click();
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       await page.click('[data-testid="manage-button"]');
       await page.click('[data-testid="delete-button-title"]');
@@ -388,7 +388,7 @@ test.describe.serial('User profile works after persona deletion', () => {
         await page.goto(
           `http://localhost:8585/users/${user.responseData.name}`
         );
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
 
         // User profile should load without errors
         // Check if the user name is displayed (this means the page loaded)

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/PersonaFlow.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/PersonaFlow.spec.ts
@@ -96,7 +96,7 @@ test.describe.serial('Persona operations', () => {
     const personaListResponse = page.waitForResponse(`/api/v1/personas?*`);
     await settingClick(page, GlobalSettingOptions.PERSONA);
     await personaListResponse;
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
   });
 
@@ -140,7 +140,7 @@ test.describe.serial('Persona operations', () => {
 
     await page.getByRole('button', { name: 'Create' }).click();
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await navigateToPersonaSettings(page);
 
@@ -394,7 +394,7 @@ test.describe.serial('Default persona setting and removal flow', () => {
 
         await adminPage.getByRole('button', { name: 'Create' }).click();
 
-        await adminPage.waitForLoadState('networkidle');
+        await adminPage.waitForLoadState('domcontentloaded');
 
         await navigateToPersonaSettings(adminPage);
 
@@ -459,7 +459,7 @@ test.describe.serial('Default persona setting and removal flow', () => {
           `persona-details-card-${persona1.responseData.fullyQualifiedName}`
         )
         .click();
-      await adminPage.waitForLoadState('networkidle');
+      await adminPage.waitForLoadState('domcontentloaded');
       await setPersonaAsDefault(adminPage);
     });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/RightEntityPanelFlow.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/RightEntityPanelFlow.spec.ts
@@ -625,7 +625,7 @@ test.describe('Right Entity Panel - Admin User Flow', () => {
       await adminPage.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
-      await adminPage.waitForLoadState('networkidle');
+      await adminPage.waitForLoadState('domcontentloaded');
 
       const tabContent = summaryPanel.locator(
         '.entity-summary-panel-tab-content'
@@ -845,7 +845,7 @@ test.describe('Right Entity Panel - Admin User Flow', () => {
       await adminPage.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
-      await adminPage.waitForLoadState('networkidle');
+      await adminPage.waitForLoadState('domcontentloaded');
 
       const tabContent = summaryPanel.locator('.data-quality-tab-container');
 
@@ -1024,7 +1024,7 @@ test.describe('Right Entity Panel - Admin User Flow', () => {
       await adminPage.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
-      await adminPage.waitForLoadState('networkidle');
+      await adminPage.waitForLoadState('domcontentloaded');
 
       const tabContent = summaryPanel.locator('.data-quality-tab-container');
 
@@ -1140,7 +1140,7 @@ test.describe('Right Entity Panel - Admin User Flow', () => {
       await adminPage.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
-      await adminPage.waitForLoadState('networkidle');
+      await adminPage.waitForLoadState('domcontentloaded');
 
       const tabContent = summaryPanel.locator('.data-quality-tab-container');
 
@@ -1390,7 +1390,7 @@ test.describe('Right Entity Panel - Admin User Flow', () => {
 
     // Click on custom properties tab to set values
     await adminPage.click('[data-testid="custom_properties"]');
-    await adminPage.waitForLoadState('networkidle');
+    await adminPage.waitForLoadState('domcontentloaded');
 
     // Set values for each property type through the UI
     for (const type of propertyTypesToTest) {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/SchemaTable.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/SchemaTable.spec.ts
@@ -107,7 +107,7 @@ test('schema table test', async ({ dataStewardPage, ownerPage, page }) => {
     await redirectToHomePage(page);
 
     await table.visitEntityPage(page);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
 
     await addOwner({
@@ -133,7 +133,7 @@ test('schema table test', async ({ dataStewardPage, ownerPage, page }) => {
       await redirectToHomePage(currentPage);
 
       await table.visitEntityPage(currentPage);
-      await currentPage.waitForLoadState('networkidle');
+      await currentPage.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/SearchRBAC.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/SearchRBAC.spec.ts
@@ -90,7 +90,7 @@ const searchForEntityShouldWork = async (
     .getByTestId('navbar-search-container')
     .getByTestId('cancel-icon')
     .click();
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 };
 
 const searchForEntityShouldWorkShowNoResult = async (
@@ -113,7 +113,7 @@ const searchForEntityShouldWorkShowNoResult = async (
 
   await page.waitForResponse(`api/v1/search/query?**`);
 
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForSelector('loader', { state: 'hidden' });
 
   await expect(page.getByTestId('entity-header-display-name')).not.toHaveText(
@@ -130,7 +130,7 @@ Try adjusting your search or filter to find what you are looking for.`)
     .getByTestId('cancel-icon')
     .click();
 
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 };
 
 test.beforeAll(async ({ browser }) => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ServiceForm.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ServiceForm.spec.ts
@@ -230,7 +230,7 @@ test.describe('Service form functionality', async () => {
       test.slow();
 
       await page.goto('/databaseServices/add-service');
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await waitForAllLoadersToDisappear(page);
 
       await page.getByTestId('BigQuery').click();
@@ -246,33 +246,33 @@ test.describe('Service form functionality', async () => {
       await page.getByTestId('next-button').click();
       await page.getByTestId('submit-btn').click();
       await page.getByTestId('submit-btn').click();
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await waitForAllLoadersToDisappear(page);
 
       await expect(page.getByTestId('entity-header-title')).toBeVisible();
 
       await page.getByRole('link', { name: 'Database Services' }).click();
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await waitForAllLoadersToDisappear(page);
       await page.getByTestId('add-service-button').click();
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await waitForAllLoadersToDisappear(page);
       await page.getByTestId('Databricks').click();
       await page.getByTestId('next-button').click();
 
       await page.getByTestId('service-name').click();
       await page.getByTestId('service-name').fill(`${SERVICE_NAMES.service1}`);
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       await expect(page.locator('#name_help')).toContainText(
         'Name already exists.'
       );
 
       await page.getByRole('link', { name: 'Database Services' }).click();
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await waitForAllLoadersToDisappear(page);
       await page.getByTestId(`service-name-${SERVICE_NAMES.service1}`).click();
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.getByTestId('manage-button').click();
       await page.getByTestId('delete-button-title').click();
       await page.getByTestId('confirmation-text-input').fill('DELETE');
@@ -296,7 +296,7 @@ test.describe('Service form functionality', async () => {
       page,
     }) => {
       await page.goto('/dashboardServices/add-service');
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await waitForAllLoadersToDisappear(page);
 
       await page.getByTestId('Looker').click();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/Tour.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/Tour.spec.ts
@@ -33,7 +33,7 @@ const waitForTourBadgeWithRetry = async (
     } catch (e) {
       if (attempt < maxAttempts) {
         await page.reload();
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -197,7 +197,7 @@ test.describe('Tour should work properly', () => {
 
     if (isWelcomeScreenVisible) {
       await page.getByTestId('welcome-screen-close-btn').click();
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
     }
     await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
     await waitForAllLoadersToDisappear(page, 'entity-list-skeleton');

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataContracts.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataContracts.spec.ts
@@ -363,7 +363,7 @@ test.describe('Data Contracts', () => {
 
         await page.reload();
 
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -473,7 +473,7 @@ test.describe('Data Contracts', () => {
 
             await expect(page.getByRole('dialog')).not.toBeVisible();
 
-            await page.waitForLoadState('networkidle');
+            await page.waitForLoadState('domcontentloaded');
             await page.waitForSelector('[data-testid="loader"]', {
               state: 'detached',
             });
@@ -679,7 +679,7 @@ test.describe('Data Contracts', () => {
         await page.getByTestId('save-contract-btn').click();
         await saveContractResponse;
 
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -748,7 +748,7 @@ test.describe('Data Contracts', () => {
         await redirectToHomePage(page);
         await page.goto(`/table/${entityFQN}`);
 
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -919,7 +919,7 @@ test.describe('Data Contracts', () => {
 
         await saveContractResponse;
 
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -974,7 +974,7 @@ test.describe('Data Contracts', () => {
 
           await saveContractResponse;
 
-          await page.waitForLoadState('networkidle');
+          await page.waitForLoadState('domcontentloaded');
           await page.waitForSelector('[data-testid="loader"]', {
             state: 'detached',
           });
@@ -1001,7 +1001,7 @@ test.describe('Data Contracts', () => {
         await redirectToHomePage(page);
         await page.goto(`/table/${entityFQN}`);
 
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -1219,7 +1219,7 @@ test.describe('Data Contracts', () => {
 
     await page.reload();
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });
@@ -1406,7 +1406,7 @@ test.describe('Data Contracts', () => {
 
     await page.reload();
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });
@@ -1570,7 +1570,7 @@ test.describe('Data Contracts', () => {
 
     await page.reload();
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });
@@ -2135,7 +2135,7 @@ test.describe('Data Contracts', () => {
       await page.getByTestId('save-contract-btn').click();
       await saveContractResponse;
 
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
@@ -2371,7 +2371,7 @@ entitiesWithDataContracts.forEach((EntityClass) => {
             async () => {
               await redirectToHomePage(page);
               await entity.visitEntityPage(page);
-              await page.waitForLoadState('networkidle');
+              await page.waitForLoadState('domcontentloaded');
               await page.waitForSelector('[data-testid="loader"]', {
                 state: 'detached',
               });
@@ -2402,7 +2402,7 @@ entitiesWithDataContracts.forEach((EntityClass) => {
                 'Store Procedure': 'Stored Procedure',
               };
               await settingClick(page, GlobalSettingOptions.PERSONA);
-              await page.waitForLoadState('networkidle');
+              await page.waitForLoadState('domcontentloaded');
               await page.waitForSelector('[data-testid="loader"]', {
                 state: 'detached',
               });
@@ -2412,7 +2412,7 @@ entitiesWithDataContracts.forEach((EntityClass) => {
                 .getByTestId(`persona-details-card-${persona.data.name}`)
                 .click();
               await page.getByRole('tab', { name: 'Customize UI' }).click();
-              await page.waitForLoadState('networkidle');
+              await page.waitForLoadState('domcontentloaded');
 
               // Navigate to Table customization
               await page
@@ -2451,7 +2451,7 @@ entitiesWithDataContracts.forEach((EntityClass) => {
 
               await redirectToHomePage(page);
               await entity.visitEntityPage(page);
-              await page.waitForLoadState('networkidle');
+              await page.waitForLoadState('domcontentloaded');
               await page.waitForSelector('[data-testid="loader"]', {
                 state: 'detached',
               });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataContractsSemanticRules.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataContractsSemanticRules.spec.ts
@@ -157,7 +157,7 @@ test.describe('Data Contracts Semantics Rule Owner', () => {
 
         await page.reload();
 
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -273,7 +273,7 @@ test.describe('Data Contracts Semantics Rule Owner', () => {
 
         await page.reload();
 
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -390,7 +390,7 @@ test.describe('Data Contracts Semantics Rule Owner', () => {
 
         await page.reload();
 
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -505,7 +505,7 @@ test.describe('Data Contracts Semantics Rule Owner', () => {
 
         await page.reload();
 
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -596,7 +596,7 @@ test.describe('Data Contracts Semantics Rule Owner', () => {
 
       await page.reload();
 
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
@@ -684,7 +684,7 @@ test.describe('Data Contracts Semantics Rule Owner', () => {
 
       await page.reload();
 
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
@@ -790,7 +790,7 @@ test.describe('Data Contracts Semantics Rule Description', () => {
 
         await page.reload();
 
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -895,7 +895,7 @@ test.describe('Data Contracts Semantics Rule Description', () => {
 
         await page.reload();
 
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -994,7 +994,7 @@ test.describe('Data Contracts Semantics Rule Description', () => {
 
         await page.reload();
 
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -1096,7 +1096,7 @@ test.describe('Data Contracts Semantics Rule Description', () => {
 
         await page.reload();
 
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -1200,7 +1200,7 @@ test.describe('Data Contracts Semantics Rule Domain', () => {
 
       await page.reload();
 
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
@@ -1291,7 +1291,7 @@ test.describe('Data Contracts Semantics Rule Domain', () => {
 
       await page.reload();
 
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
@@ -1383,7 +1383,7 @@ test.describe('Data Contracts Semantics Rule Domain', () => {
 
       await page.reload();
 
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
@@ -1473,7 +1473,7 @@ test.describe('Data Contracts Semantics Rule Domain', () => {
 
       await page.reload();
 
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
@@ -1556,7 +1556,7 @@ test.describe('Data Contracts Semantics Rule Domain', () => {
 
       await page.reload();
 
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
@@ -1643,7 +1643,7 @@ test.describe('Data Contracts Semantics Rule Domain', () => {
 
         await page.reload();
 
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -1734,7 +1734,7 @@ test.describe('Data Contracts Semantics Rule Version', () => {
 
       await page.reload();
 
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
@@ -1827,7 +1827,7 @@ test.describe('Data Contracts Semantics Rule Version', () => {
 
         await page.reload();
 
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -1921,7 +1921,7 @@ test.describe('Data Contracts Semantics Rule Version', () => {
 
         await page.reload();
 
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -2016,7 +2016,7 @@ test.describe('Data Contracts Semantics Rule Version', () => {
 
         await page.reload();
 
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -2112,7 +2112,7 @@ test.describe('Data Contracts Semantics Rule Version', () => {
 
         await page.reload();
 
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -2209,7 +2209,7 @@ test.describe('Data Contracts Semantics Rule Version', () => {
 
         await page.reload();
 
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -2337,7 +2337,7 @@ test.describe('Data Contracts Semantics Rule DataProduct', () => {
 
       await page.reload();
 
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
@@ -2450,7 +2450,7 @@ test.describe('Data Contracts Semantics Rule DataProduct', () => {
 
         await page.reload();
 
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -2564,7 +2564,7 @@ test.describe('Data Contracts Semantics Rule DataProduct', () => {
 
         await page.reload();
 
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -2676,7 +2676,7 @@ test.describe('Data Contracts Semantics Rule DataProduct', () => {
 
         await page.reload();
 
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -2778,7 +2778,7 @@ test.describe('Data Contracts Semantics Rule DataProduct', () => {
 
       await page.reload();
 
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
@@ -2883,7 +2883,7 @@ test.describe('Data Contracts Semantics Rule DataProduct', () => {
 
           await page.reload();
 
-          await page.waitForLoadState('networkidle');
+          await page.waitForLoadState('domcontentloaded');
           await page.waitForSelector('[data-testid="loader"]', {
             state: 'detached',
           });
@@ -2985,7 +2985,7 @@ test.describe('Data Contracts Semantics Rule DisplayName', () => {
 
       await page.reload();
 
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
@@ -3089,7 +3089,7 @@ test.describe('Data Contracts Semantics Rule DisplayName', () => {
 
         await page.reload();
 
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -3191,7 +3191,7 @@ test.describe('Data Contracts Semantics Rule DisplayName', () => {
 
         await page.reload();
 
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -3295,7 +3295,7 @@ test.describe('Data Contracts Semantics Rule DisplayName', () => {
 
         await page.reload();
 
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -3392,7 +3392,7 @@ test.describe('Data Contracts Semantics Rule DisplayName', () => {
 
         await page.reload();
 
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -3491,7 +3491,7 @@ test.describe('Data Contracts Semantics Rule DisplayName', () => {
 
         await page.reload();
 
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataInsight.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataInsight.spec.ts
@@ -175,7 +175,7 @@ test.describe('Data Insight Page', { tag: '@data-insight' }, () => {
 
     await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     expect(page.locator('[data-testid="kpi-widget"]')).toBeVisible();
   });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataQualityAndProfiler.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataQualityAndProfiler.spec.ts
@@ -762,7 +762,7 @@ test(
     await page.getByRole('tab', { name: 'Data Quality' }).click();
 
     await page.reload();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await test.step('Update profiler setting', async () => {
       await page.click('[data-testid="profiler-setting-btn"]');
@@ -1014,7 +1014,7 @@ test('TestCase filters', PLAYWRIGHT_INGESTION_TAG_OBJ, async ({ page }) => {
     await sidebarClick(page, SidebarItem.DATA_QUALITY);
 
     await page.click('[data-testid="test-cases"]');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });
@@ -1282,7 +1282,7 @@ test('TestCase filters', PLAYWRIGHT_INGESTION_TAG_OBJ, async ({ page }) => {
     await sidebarClick(page, SidebarItem.DATA_QUALITY);
 
     await page.click('[data-testid="test-cases"]');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });
@@ -1341,7 +1341,7 @@ test('Pagination functionality in test cases list', async ({ page }) => {
     await sidebarClick(page, SidebarItem.DATA_QUALITY);
     await page.click('[data-testid="test-cases"]');
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts
@@ -166,7 +166,7 @@ test.describe('Domains', () => {
     await test.step('Create domain', async () => {
       await sidebarClick(page, SidebarItem.DOMAIN);
 
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
@@ -226,7 +226,7 @@ test.describe('Domains', () => {
 
     await test.step('Create DataProducts', async () => {
       await createDataProduct(page, dataProduct1.data);
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await waitForAllLoadersToDisappear(page);
 
       await expect(
@@ -280,7 +280,7 @@ test.describe('Domains', () => {
         await sidebarClick(page, SidebarItem.DATA_PRODUCT);
         await selectDataProduct(page, dataProduct1.data);
         await waitForAllLoadersToDisappear(page);
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
 
         await expect(
           page.getByTestId('KnowledgePanel.Domain').getByTestId('add-domain')
@@ -288,7 +288,7 @@ test.describe('Domains', () => {
 
         await page.getByTestId('assets').getByText('Assets').click();
         await waitForAllLoadersToDisappear(page);
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
 
         await expect(page.getByTestId('no-data-placeholder')).toContainText(
           "Looks like you haven't added any data assets yet."
@@ -297,7 +297,7 @@ test.describe('Domains', () => {
         await page.getByTestId('data-assets-add-button').click();
 
         await waitForAllLoadersToDisappear(page);
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
 
         await expect(page.getByTestId('form-heading')).toContainText(
           'Add Assets'
@@ -326,7 +326,7 @@ test.describe('Domains', () => {
       await removeAssetsFromDataProduct(page, dataProduct1.data, assets);
       await page.reload();
       await waitForAllLoadersToDisappear(page);
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await checkAssetsCount(page, 0);
     });
 
@@ -353,7 +353,7 @@ test.describe('Domains', () => {
     await redirectToHomePage(page);
     await followingSearchResponse;
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // Check that the followed domain is shown in the following widget
     await expect(
@@ -439,7 +439,7 @@ test.describe('Domains', () => {
 
     await redirectToExplorePage(page);
     await waitForAllLoadersToDisappear(page);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     const domainsResponse = page.waitForResponse('api/v1/domains/hierarchy?*');
     await page.getByTestId('domain-dropdown').click();
@@ -457,7 +457,7 @@ test.describe('Domains', () => {
       .click();
     await waitForAllLoadersToDisappear(page);
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await redirectToHomePage(page);
 
@@ -550,7 +550,7 @@ test.describe('Domains', () => {
       );
       await redirectToHomePage(page);
       await followingSearchResponse;
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       // Check that the followed domain is shown in the following widget
       await expect(
@@ -778,7 +778,7 @@ test.describe('Domains', () => {
       await domain.create(apiContext);
       await page.reload();
       await sidebarClick(page, SidebarItem.DOMAIN);
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector(`[data-testid="loader"]`, {
         state: 'hidden',
       });
@@ -791,13 +791,13 @@ test.describe('Domains', () => {
 
       await redirectToHomePage(page);
       await sidebarClick(page, SidebarItem.DOMAIN);
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector(`[data-testid="loader"]`, {
         state: 'hidden',
       });
       await selectDomain(page, domain.data);
 
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       await expect(
         page.locator(
@@ -1381,7 +1381,7 @@ test.describe('Domain Access with hasDomain() Rule', () => {
       const domainTableFqn =
         testResources.domainTable.entityResponseData.fullyQualifiedName;
       await userPage.goto(`/table/${encodeURIComponent(domainTableFqn)}`);
-      await userPage.waitForLoadState('networkidle');
+      await userPage.waitForLoadState('domcontentloaded');
       await userPage.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
@@ -1400,7 +1400,7 @@ test.describe('Domain Access with hasDomain() Rule', () => {
       const subDomainTableFqn =
         testResources.subDomainTable.entityResponseData.fullyQualifiedName;
       await userPage.goto(`/table/${encodeURIComponent(subDomainTableFqn)}`);
-      await userPage.waitForLoadState('networkidle');
+      await userPage.waitForLoadState('domcontentloaded');
 
       // Verify no permission error
       await expect(
@@ -1453,7 +1453,7 @@ test.describe('Domain Access with noDomain() Rule', () => {
         const domainTableFqn =
           testResources.domainTable.entityResponseData.fullyQualifiedName;
         await userPage.goto(`/table/${encodeURIComponent(domainTableFqn)}`);
-        await userPage.waitForLoadState('networkidle');
+        await userPage.waitForLoadState('domcontentloaded');
         await userPage.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -1474,7 +1474,7 @@ test.describe('Domain Access with noDomain() Rule', () => {
         const noDomainTableFqn =
           testResources.noDomainTable.entityResponseData.fullyQualifiedName;
         await userPage.goto(`/table/${encodeURIComponent(noDomainTableFqn)}`);
-        await userPage.waitForLoadState('networkidle');
+        await userPage.waitForLoadState('domcontentloaded');
         await userPage.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -1529,11 +1529,11 @@ test.describe('Domain Tree View Functionality', () => {
     test.slow(true);
 
     await sidebarClick(page, SidebarItem.DOMAIN);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await waitForAllLoadersToDisappear(page);
 
     await page.getByRole('button', { name: 'tree' }).click();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await waitForAllLoadersToDisappear(page);
 
     await page
@@ -1549,7 +1549,7 @@ test.describe('Domain Tree View Functionality', () => {
       .getByRole('textbox', { name: 'Search' })
       .fill(domainDisplayName);
     await searchDomain;
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await waitForAllLoadersToDisappear(page);
 
     await expect(
@@ -1613,7 +1613,7 @@ test.describe('Domain Tree View Functionality', () => {
     ).toContainText('1');
 
     await page.getByTestId('subdomains').getByText('Sub Domains').click();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await waitForAllLoadersToDisappear(page);
 
     await expect(

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Entity.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Entity.spec.ts
@@ -558,7 +558,7 @@ entities.forEach((EntityClass) => {
 
         // Navigate to the table entity page
         await entity.visitEntityPage(page);
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -579,7 +579,7 @@ entities.forEach((EntityClass) => {
           await profilerTab.click();
           await profilerResponse;
 
-          await page.waitForLoadState('networkidle');
+          await page.waitForLoadState('domcontentloaded');
           await page.waitForSelector('[data-testid="loader"]', {
             state: 'detached',
           });
@@ -613,7 +613,7 @@ entities.forEach((EntityClass) => {
           await activityFeedTab.click();
           await activityFeedResponse;
 
-          await page.waitForLoadState('networkidle');
+          await page.waitForLoadState('domcontentloaded');
           await page.waitForSelector('[data-testid="loader"]', {
             state: 'detached',
           });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExploreTree.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExploreTree.spec.ts
@@ -58,7 +58,7 @@ test.beforeEach(async ({ page }) => {
 test.describe('Explore Tree scenarios', () => {
   test('Explore Tree', async ({ page }) => {
     await test.step('Check the explore tree', async () => {
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
@@ -173,7 +173,7 @@ test.describe('Explore Tree scenarios', () => {
       const serviceName2 = get(table2.serviceResponseData, 'name', '');
 
       await sidebarClick(page, SidebarItem.EXPLORE);
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       // Verify first table's database and schema
       await test.step('Verify first table database and schema', async () => {
@@ -218,7 +218,7 @@ test.describe('Explore Tree scenarios', () => {
       'Visit explore page and verify existing values',
       async () => {
         await sidebarClick(page, SidebarItem.EXPLORE);
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
 
         // Verify original database and schema names using utility function
         await verifyDatabaseAndSchemaInExploreTree(
@@ -259,7 +259,7 @@ test.describe('Explore Tree scenarios', () => {
     // Step 3: Verify the changes are reflected in explore page
     await test.step('Verify renamed values in explore page', async () => {
       await sidebarClick(page, SidebarItem.EXPLORE);
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       // Verify updated database and schema names using utility function
       await verifyDatabaseAndSchemaInExploreTree(

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts
@@ -757,7 +757,7 @@ test.describe('Glossary tests', () => {
         );
         await page.getByTestId('assets').click();
         await queryRes;
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -1237,7 +1237,7 @@ test.describe('Glossary tests', () => {
       await selectActiveGlossary(page, glossary1.data.displayName);
       await selectActiveGlossaryTerm(page, glossaryTerm1.data.displayName);
       await page.getByTestId('terms').click();
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
@@ -1285,7 +1285,7 @@ test.describe('Glossary tests', () => {
           await verifyColumnsVisibility(page, checkboxLabels, true);
 
           await page.reload();
-          await page.waitForLoadState('networkidle');
+          await page.waitForLoadState('domcontentloaded');
           await verifyColumnsVisibility(page, checkboxLabels, true);
         }
       );
@@ -1299,7 +1299,7 @@ test.describe('Glossary tests', () => {
           await verifyColumnsVisibility(page, checkboxLabels, false);
 
           await page.reload();
-          await page.waitForLoadState('networkidle');
+          await page.waitForLoadState('domcontentloaded');
           await verifyColumnsVisibility(page, checkboxLabels, false);
         }
       );
@@ -1318,7 +1318,7 @@ test.describe('Glossary tests', () => {
         await verifyAllColumns(page, tableColumns, true);
 
         await page.reload();
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await verifyAllColumns(page, tableColumns, true);
       });
 
@@ -1334,7 +1334,7 @@ test.describe('Glossary tests', () => {
         await verifyAllColumns(page, tableColumns, false);
 
         await page.reload();
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await verifyAllColumns(page, tableColumns, false);
       });
     } finally {
@@ -1478,7 +1478,7 @@ test.describe('Glossary tests', () => {
       await selectActiveGlossaryTerm(page, glossaryTerm1.data.displayName);
       await page.getByTestId('terms').click();
 
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
@@ -1747,7 +1747,7 @@ test.describe('Glossary tests', () => {
 
         await page1.getByTestId(`tag-"${domain.data.name}"`).click();
 
-        await page1.waitForLoadState('networkidle');
+        await page1.waitForLoadState('domcontentloaded');
         await page1.waitForSelector('[data-testid="loader"]', {
           state: 'detached',
         });
@@ -1806,10 +1806,10 @@ test.describe('Glossary tests', () => {
         await redirectToHomePage(page);
         await sidebarClick(page, SidebarItem.GLOSSARY);
         await waitForAllLoadersToDisappear(page);
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await selectActiveGlossary(page, glossary.data.displayName);
         await waitForAllLoadersToDisappear(page);
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
 
         await expect(page.getByTestId('entity-header-display-name')).toHaveText(
           glossary.data.displayName
@@ -1818,7 +1818,7 @@ test.describe('Glossary tests', () => {
 
       await test.step('Change application language to German', async () => {
         await waitForAllLoadersToDisappear(page);
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         const languageDropdown = page
           .locator('.nav-bar-side-items button.ant-dropdown-trigger')
           .filter({ hasText: 'EN' })
@@ -1831,7 +1831,7 @@ test.describe('Glossary tests', () => {
         await germanOption.click();
 
         await waitForAllLoadersToDisappear(page);
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
       });
 
       await test.step(
@@ -1839,10 +1839,10 @@ test.describe('Glossary tests', () => {
         async () => {
           await sidebarClick(page, SidebarItem.GLOSSARY);
           await waitForAllLoadersToDisappear(page);
-          await page.waitForLoadState('networkidle');
+          await page.waitForLoadState('domcontentloaded');
           await selectActiveGlossary(page, glossary.data.displayName);
           await waitForAllLoadersToDisappear(page);
-          await page.waitForLoadState('networkidle');
+          await page.waitForLoadState('domcontentloaded');
 
           await page.getByTestId('manage-button').click();
           await page.getByTestId('delete-button').click();
@@ -1871,7 +1871,7 @@ test.describe('Glossary tests', () => {
 
       await test.step('Change language back to English', async () => {
         await waitForAllLoadersToDisappear(page);
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         const languageDropdown = page
           .locator('.nav-bar-side-items button.ant-dropdown-trigger')
           .filter({ hasText: 'DE' })

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryImportExport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryImportExport.spec.ts
@@ -242,7 +242,7 @@ test.describe('Glossary Bulk Import Export', () => {
       for (const propertyName of Object.values(propertyListName)) {
         await settingClick(page, GlobalSettingOptions.GLOSSARY_TERM, true);
 
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
 
         await page.getByTestId('loader').waitFor({ state: 'detached' });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage.spec.ts
@@ -117,7 +117,7 @@ for (const EntityClass of entities) {
         await page.reload();
         const lineageRes = page.waitForResponse('/api/v1/lineage/getLineage?*');
         await lineageRes;
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.waitForSelector('[data-testid="edit-lineage"]', {
           state: 'visible',
         });
@@ -273,7 +273,7 @@ test('Verify column lineage between table and topic', async ({ browser }) => {
   await redirectToHomePage(page);
   await table.visitEntityPage(page);
   await visitLineageTab(page);
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await verifyColumnLineageInCSV(page, table, topic, sourceCol, targetCol);
 
   // Verify relation in platform lineage
@@ -435,7 +435,7 @@ test('Verify function data in edge drawer', async ({ browser }) => {
     await page.reload();
     await lineageReq1;
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await activateColumnLayer(page);
     await page
@@ -521,7 +521,7 @@ test('Verify table search with special characters as handled', async ({
     await expect(page.locator('[data-testid="lineage-details"]')).toBeVisible();
 
     await page.locator(`[data-testid="lineage-node-${dbFqn}"]`).click();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await expect(
       page.locator('.lineage-entity-panel').getByTestId('entity-header-title')
@@ -576,7 +576,7 @@ test('Verify cycle lineage should be handled properly', async ({ browser }) => {
     await rearrangeNodes(page);
 
     await page.reload();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await performZoomOut(page);
 
     await expect(page.getByTestId(`lineage-node-${tableFqn}`)).toBeVisible();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Login.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Login.spec.ts
@@ -61,7 +61,7 @@ test.describe('Login flow should work properly', () => {
 
   test('Signup and Login with signed up credentials', async ({ page }) => {
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await expect(page).toHaveURL(`/signin`);
 
@@ -100,7 +100,7 @@ test.describe('Login flow should work properly', () => {
     const loginResponse = page.waitForResponse(`/api/v1/auth/login`);
     await page.locator('[data-testid="login"]').click();
     await loginResponse;
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await expect(page).toHaveURL(`/my-data`);
 
@@ -114,7 +114,7 @@ test.describe('Login flow should work properly', () => {
 
   test('Signin using invalid credentials', async ({ page }) => {
     await page.goto(`/signin`);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     // Login with invalid email
     await page.fill('#email', invalidEmail);
     await page.fill('#password', CREDENTIALS.password);
@@ -195,7 +195,7 @@ test.describe('Login flow should work properly', () => {
 
     await redirectToHomePage(page1);
     await page1.getByTestId('dropdown-profile').click();
-    await page1.waitForLoadState('networkidle');
+    await page1.waitForLoadState('domcontentloaded');
     await clickOutside(page1);
 
     await expect(page1.getByTestId('nav-user-name')).toContainText(/admin/i);
@@ -206,7 +206,7 @@ test.describe('Login flow should work properly', () => {
     await redirectToHomePage(page2);
 
     await page2.getByTestId('dropdown-profile').click();
-    await page2.waitForLoadState('networkidle');
+    await page2.waitForLoadState('domcontentloaded');
     await clickOutside(page2);
 
     await expect(page2.getByTestId('nav-user-name')).toContainText(/admin/i);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/LoginConfiguration.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/LoginConfiguration.spec.ts
@@ -54,7 +54,7 @@ test.describe('Login configuration', () => {
     // Wait for the API response to complete
     await settingsResponsePromise;
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // Assert the updated values
     await expect(

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Policies.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Policies.spec.ts
@@ -394,7 +394,7 @@ test.describe('Policy page should work properly', () => {
 
     await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await getElementWithPagination(page, policyLocator);
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Roles.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Roles.spec.ts
@@ -302,7 +302,7 @@ test('Delete role action from manage button options', async ({ page }) => {
 
   await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
 
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   await getElementWithPagination(page, roleLocator);
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchIndexApplication.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchIndexApplication.spec.ts
@@ -127,7 +127,7 @@ test('Search Index Application', async ({ page }) => {
     );
 
     await page.click('[data-testid="configuration"]');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await expect(page.locator('#search-indexing-application')).toContainText(
       'Search Indexing Application'

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchSettings.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchSettings.spec.ts
@@ -163,7 +163,7 @@ test.describe('Search Preview test', () => {
       new RegExp(mockEntitySearchSettings.url + '$')
     );
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });
@@ -187,7 +187,7 @@ test.describe('Search Preview test', () => {
     await searchInput.fill(table1.entity.name);
     await previewResponse;
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ServiceListing.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ServiceListing.spec.ts
@@ -47,7 +47,7 @@ test.describe('Service Listing', () => {
   });
 
   test('should render the service listing page', async ({ page }) => {
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await page.getByTestId('filter-icon').click();
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SubDomainPagination.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SubDomainPagination.spec.ts
@@ -64,7 +64,7 @@ test.describe('SubDomain Pagination', () => {
   test.beforeEach('Navigate to domain page', async ({ page }) => {
     await redirectToHomePage(page);
     await sidebarClick(page, SidebarItem.DOMAIN);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
   });
 
@@ -73,7 +73,7 @@ test.describe('SubDomain Pagination', () => {
   }) => {
     await selectDomain(page, domain.data);
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
 
     await test.step('Verify subdomain count in tab label', async () => {
@@ -126,7 +126,7 @@ test.describe('SubDomain Pagination', () => {
         await redirectToHomePage(page);
 
         await sidebarClick(page, SidebarItem.DOMAIN);
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
 
         await selectDomain(page, domain.data);
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Tag.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Tag.spec.ts
@@ -173,7 +173,7 @@ test.describe('Tag Page with Admin Roles', () => {
     await adminPage.locator('button[type="submit"]').click();
     await updateColor;
 
-    await adminPage.waitForLoadState('networkidle');
+    await adminPage.waitForLoadState('domcontentloaded');
 
     await expect(adminPage.getByText(tag.data.name)).toBeVisible();
   });
@@ -289,7 +289,7 @@ test.describe('Tag Page with Admin Roles', () => {
 
     // Verify in My Data page
     await visitUserProfilePage(adminPage, user1.responseData.name);
-    await adminPage.waitForLoadState('networkidle');
+    await adminPage.waitForLoadState('domcontentloaded');
 
     const myDataRes = adminPage.waitForResponse(
       `/api/v1/search/query?q=*&index=all&*`

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Tags.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Tags.spec.ts
@@ -161,7 +161,7 @@ test('Classification Page', async ({ page }) => {
     await expect(page.getByTestId('add-owner')).not.toBeVisible();
 
     await page.getByTestId(tag.responseData.name).click();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });
@@ -225,7 +225,7 @@ test('Classification Page', async ({ page }) => {
     await expect(page.getByTestId('add-owner')).toBeVisible();
 
     await page.getByTestId(tag.responseData.name).click();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });
@@ -415,7 +415,7 @@ test('Classification Page', async ({ page }) => {
       await page.reload();
       await databaseSchemasPage;
 
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
@@ -477,7 +477,7 @@ test('Classification Page', async ({ page }) => {
 
     // Verify term count is now 0 after deleting the tag
     await page.reload();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
@@ -518,7 +518,7 @@ test('Classification Page', async ({ page }) => {
     await page.click('[data-testid="confirm-button"]');
     await deleteClassification;
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await expect(
       page
@@ -535,7 +535,7 @@ test('Search tag using classification display name should work', async ({
 
   await table.visitEntityPage(page);
 
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   const initialQueryResponse = page.waitForResponse('**/api/v1/search/query?*');
 
@@ -659,7 +659,7 @@ test('Verify Owner Add Delete', async ({ page }) => {
   });
 
   await page.getByTestId(tag1.data.name).click();
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   await expect(
     page.locator(`[data-testid="owner-link"]`).getByTestId(OWNER1)
@@ -667,7 +667,7 @@ test('Verify Owner Add Delete', async ({ page }) => {
 
   await classification1.visitPage(page);
 
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   await removeOwner({
     page,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Teams.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Teams.spec.ts
@@ -144,7 +144,7 @@ test.describe('Teams Page', () => {
   test('Teams Page Flow', async ({ page }) => {
     await test.step('Create a new team', async () => {
       await checkTeamTabCount(page);
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       await page.waitForSelector('[data-testid="add-team"]');
 
@@ -396,7 +396,7 @@ test.describe('Teams Page', () => {
 
     await page.getByRole('link', { name: publicTeam.displayName }).click();
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });
@@ -418,7 +418,7 @@ test.describe('Teams Page', () => {
     await clickOutside(page);
 
     await visitOwnProfilePage(page);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await page.getByTestId('edit-teams-button').click();
     await page.getByTestId('team-select').click();
@@ -443,7 +443,7 @@ test.describe('Teams Page', () => {
       .getByText(publicTeam.displayName)
       .click();
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await hardDeleteTeam(page);
   });
@@ -455,7 +455,7 @@ test.describe('Teams Page', () => {
     const team = new TeamClass();
     await team.create(apiContext);
     await settingClick(page, GlobalSettingOptions.TEAMS);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     const getTeamResponse = page.waitForResponse(`/api/v1/teams/name/*?*`);
     await page
       .getByRole('link', { name: team.responseData?.['displayName'] })
@@ -493,7 +493,7 @@ test.describe('Teams Page', () => {
 
     try {
       await settingClick(page, GlobalSettingOptions.TEAMS);
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       for (const team of [team1, team2, team3]) {
         await searchTeam(page, team.responseData?.['displayName']);
@@ -523,7 +523,7 @@ test.describe('Teams Page', () => {
 
     try {
       await settingClick(page, GlobalSettingOptions.TEAMS);
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       await searchTeam(page, team.responseData?.['displayName']);
 
@@ -532,7 +532,7 @@ test.describe('Teams Page', () => {
         .getByRole('link')
         .click();
 
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       await expect(page.getByTestId('team-heading')).toHaveText(
         team.data.displayName

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/TestCases.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/TestCases.spec.ts
@@ -94,9 +94,9 @@ test('Table difference test case', async ({ page }) => {
       );
       await page.fill(`#testCaseFormV1_params_table2`, testCase.table2);
       await tableSearchResponse;
-      // The 'networkidle' parameter tells Playwright to wait until there are no network connections
+      // The 'domcontentloaded' parameter tells Playwright to wait until there are no network connections
       // for at least 500 ms.
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       await expect(
         page

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/TestSuite.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/TestSuite.spec.ts
@@ -59,7 +59,7 @@ test('Logical TestSuite', async ({ page, ownerPage }) => {
   const testCaseName1 = table.testCasesResponseData?.[0]?.['name'];
   const testCaseName2 = table.testCasesResponseData?.[1]?.['name'];
   await page.goto('/data-quality/test-suites/bundle-suites');
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   const loggedInUserRequest = ownerPage.waitForResponse(
     `/api/v1/users/loggedInUser*`
@@ -92,7 +92,7 @@ test('Logical TestSuite', async ({ page, ownerPage }) => {
     await createTestSuiteResponse;
     await toastNotification(page, 'Test Suite created successfully.');
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });
@@ -131,7 +131,7 @@ test('Logical TestSuite', async ({ page, ownerPage }) => {
 
   await test.step('Add test case to logical test suite by owner', async () => {
     await ownerPage.goto(`test-suites/${NEW_TEST_SUITE.name}`);
-    await ownerPage.waitForLoadState('networkidle');
+    await ownerPage.waitForLoadState('domcontentloaded');
     await ownerPage.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });
@@ -181,7 +181,7 @@ test('Logical TestSuite', async ({ page, ownerPage }) => {
     );
 
     await page.getByTestId('view-service-button').click();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/UserDetails.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/UserDetails.spec.ts
@@ -110,7 +110,7 @@ test.describe('User with different Roles', () => {
     adminPage,
   }) => {
     await redirectToUserPage(adminPage);
-    await adminPage.waitForLoadState('networkidle');
+    await adminPage.waitForLoadState('domcontentloaded');
 
     await expect(adminPage.getByTestId('user-profile-teams')).toBeVisible();
 
@@ -142,7 +142,7 @@ test.describe('User with different Roles', () => {
 
     await adminPage.getByText(team.responseData.displayName).first().click();
 
-    await adminPage.waitForLoadState('networkidle');
+    await adminPage.waitForLoadState('domcontentloaded');
 
     const domainResponse = adminPage.waitForResponse((response) =>
       response.url().includes('/api/v1/domains/hierarchy')
@@ -185,7 +185,7 @@ test.describe('User with different Roles', () => {
 
     await redirectToUserPage(adminPage);
 
-    await adminPage.waitForLoadState('networkidle');
+    await adminPage.waitForLoadState('domcontentloaded');
 
     // Wait for the team to be visible in the teams section
     await adminPage

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Users.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Users.spec.ts
@@ -241,7 +241,7 @@ test.describe('User with Admin Roles', () => {
   }) => {
     await redirectToHomePage(adminPage);
     await settingClick(adminPage, GlobalSettingOptions.USERS);
-    await adminPage.waitForLoadState('networkidle');
+    await adminPage.waitForLoadState('domcontentloaded');
     await adminPage.waitForSelector('.user-list-table [data-testid="loader"]', {
       state: 'detached',
     });
@@ -297,7 +297,7 @@ test.describe('User with Data Consumer Roles', () => {
     // Check CRUD for Glossary
     await sidebarClick(dataConsumerPage, SidebarItem.GLOSSARY);
 
-    await dataConsumerPage.waitForLoadState('networkidle');
+    await dataConsumerPage.waitForLoadState('domcontentloaded');
     await dataConsumerPage.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });
@@ -577,7 +577,7 @@ test.describe('User Profile Feed Interactions', () => {
     );
     await adminPage.getByTestId('user-name').click();
     await userResponse;
-    await adminPage.waitForLoadState('networkidle');
+    await adminPage.waitForLoadState('domcontentloaded');
 
     await expect(
       adminPage.locator('.user-profile-dropdown-overlay')
@@ -826,7 +826,7 @@ test.describe('User Profile Dropdown Persona Interactions', () => {
 
       // Refresh the page
       await adminPage.reload();
-      await adminPage.waitForLoadState('networkidle');
+      await adminPage.waitForLoadState('domcontentloaded');
 
       // Open dropdown again after refresh
       await adminPage.locator('[data-testid="dropdown-profile"]').click();
@@ -1082,7 +1082,7 @@ test.describe('User Profile Persona Interactions', () => {
 
         // Click the persona link to navigate
         await personaLink.click();
-        await adminPage.waitForLoadState('networkidle');
+        await adminPage.waitForLoadState('domcontentloaded');
 
         // Verify we're on the persona page
         await expect(adminPage.url()).toContain('/persona/');
@@ -1159,7 +1159,7 @@ test.describe('User Profile Persona Interactions', () => {
       await adminPage.waitForSelector('.ant-select-dropdown', {
         state: 'visible',
       });
-      await adminPage.waitForLoadState('networkidle');
+      await adminPage.waitForLoadState('domcontentloaded');
 
       // Select specific persona for default - try test ID first, fallback to role selector
       const defaultPersonaOptionTestId = adminPage.getByTitle(
@@ -1204,7 +1204,7 @@ test.describe('User Profile Persona Interactions', () => {
 
         // Click the persona link to navigate
         await personaLink.click();
-        await adminPage.waitForLoadState('networkidle');
+        await adminPage.waitForLoadState('domcontentloaded');
 
         // Verify we're on the persona page
         await expect(adminPage.url()).toContain('/persona/');
@@ -1353,7 +1353,7 @@ base.describe(
 
         for (const entity of entities) {
           await entity.visitEntityPage(page);
-          await page.waitForLoadState('networkidle');
+          await page.waitForLoadState('domcontentloaded');
           await page.waitForSelector('[data-testid="loader"]', {
             state: 'detached',
           });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/EntityVersionPages.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/EntityVersionPages.spec.ts
@@ -34,7 +34,7 @@ import {
   descriptionBoxReadOnly,
   getApiContext,
   redirectToHomePage,
-  reloadAndWaitForNetworkIdle,
+  reloadAndWaitFordomcontentloaded,
   toastNotification,
 } from '../../utils/common';
 import { getEntityDataTypeDisplayPatch } from '../../utils/entity';
@@ -155,7 +155,7 @@ test.describe('Entity Version pages', () => {
       const { apiContext } = await getApiContext(page);
       await entity.visitEntityPage(page);
 
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       const versionDetailResponse = page.waitForResponse(
         (response) =>
           response.url().includes('/versions/0.2') && response.status() === 200
@@ -210,7 +210,7 @@ test.describe('Entity Version pages', () => {
           ],
         });
 
-        await reloadAndWaitForNetworkIdle(page);
+        await reloadAndWaitFordomcontentloaded(page);
 
         const versionDetailResponse = page.waitForResponse(`**/versions/0.3`);
         await page.locator('[data-testid="version-button"]').click();
@@ -278,7 +278,7 @@ test.describe('Entity Version pages', () => {
           ],
         });
 
-        await reloadAndWaitForNetworkIdle(page);
+        await reloadAndWaitFordomcontentloaded(page);
 
         const versionDetailResponse = page.waitForResponse(`**/versions/0.3`);
         await page.locator('[data-testid="version-button"]').click();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/GlossaryVersionPage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/GlossaryVersionPage.spec.ts
@@ -187,7 +187,7 @@ test('GlossaryTerm', async ({ page }) => {
     });
 
     await page.reload();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     const versionPageResponse = page.waitForResponse(
       `/api/v1/glossaryTerms/${term2.responseData.id}/versions/0.2`
     );
@@ -216,7 +216,7 @@ test('GlossaryTerm', async ({ page }) => {
     });
 
     await page.reload();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // Verify the reviewer was actually added before checking version diff
     await expect(
@@ -230,7 +230,7 @@ test('GlossaryTerm', async ({ page }) => {
 
     // Wait for the version dialog to be fully loaded
     await page.waitForSelector('[role="dialog"]', { state: 'visible' });
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await expect(
       page.locator('[data-testid="glossary-reviewer"]')

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/TableVersionPage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/TableVersionPage.spec.ts
@@ -24,7 +24,7 @@ test.describe('Table Version Page', () => {
       '/table/sample_data.ecommerce_db.shopify.performance_test_table/versions/0.1'
     );
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/TestCaseVersionPage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/TestCaseVersionPage.spec.ts
@@ -48,7 +48,7 @@ test.describe('TestCase Version Page', () => {
     await page.goto(
       `/test-case/${encodeURIComponent(testCase.fullyQualifiedName)}`
     );
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', {
       state: 'detached',
     });
@@ -75,14 +75,14 @@ test.describe('TestCase Version Page', () => {
       await expect(page.getByTestId('version-button')).toHaveText('0.2');
 
       await page.getByTestId('version-button').click();
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       await expect(
         page.getByTestId('entity-header-display-name').getByTestId('diff-added')
       ).toHaveText('test-case-version-changed');
 
       await page.getByTestId('version-button').click();
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
@@ -102,7 +102,7 @@ test.describe('TestCase Version Page', () => {
       await expect(page.getByTestId('version-button')).toHaveText('0.3');
 
       await page.getByTestId('version-button').click();
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       await expect(
         page
@@ -112,7 +112,7 @@ test.describe('TestCase Version Page', () => {
       ).toHaveText('test case description changed');
 
       await page.getByTestId('version-button').click();
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
@@ -136,7 +136,7 @@ test.describe('TestCase Version Page', () => {
       await expect(page.getByTestId('version-button')).toHaveText('0.4');
 
       await page.getByTestId('version-button').click();
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       await expect(
         page.getByTestId('minValue').getByTestId('diff-removed')

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/auth.setup.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/auth.setup.ts
@@ -150,37 +150,37 @@ setup('authenticate all users', async ({ browser }) => {
 
     // Save states for each user sequentially to avoid file operation conflicts
     await dataConsumer.login(dataConsumerPage);
-    await dataConsumerPage.waitForLoadState('networkidle');
+    await dataConsumerPage.waitForLoadState('domcontentloaded');
     await dataConsumerPage
       .context()
       .storageState({ path: dataConsumerFile, indexedDB: true });
 
     await dataSteward.login(dataStewardPage);
-    await dataStewardPage.waitForLoadState('networkidle');
+    await dataStewardPage.waitForLoadState('domcontentloaded');
     await dataStewardPage
       .context()
       .storageState({ path: dataStewardFile, indexedDB: true });
 
     await editDescriptionUser.login(editDescriptionPage);
-    await editDescriptionPage.waitForLoadState('networkidle');
+    await editDescriptionPage.waitForLoadState('domcontentloaded');
     await editDescriptionPage
       .context()
       .storageState({ path: editDescriptionFile, indexedDB: true });
 
     await editTagsUser.login(editTagsPage);
-    await editTagsPage.waitForLoadState('networkidle');
+    await editTagsPage.waitForLoadState('domcontentloaded');
     await editTagsPage
       .context()
       .storageState({ path: editTagsFile, indexedDB: true });
 
     await editGlossaryTermUser.login(editGlossaryTermPage);
-    await editGlossaryTermPage.waitForLoadState('networkidle');
+    await editGlossaryTermPage.waitForLoadState('domcontentloaded');
     await editGlossaryTermPage
       .context()
       .storageState({ path: editGlossaryTermFile, indexedDB: true });
 
     await ownerUser.login(ownerPage);
-    await ownerPage.waitForLoadState('networkidle');
+    await ownerPage.waitForLoadState('domcontentloaded');
     await ownerPage
       .context()
       .storageState({ path: ownerFile, indexedDB: true });

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/domain/Domain.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/domain/Domain.ts
@@ -56,7 +56,7 @@ export class Domain extends EntityClass {
 
   async visitEntityPage(page: Page) {
     await sidebarClick(page, SidebarItem.DOMAIN);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await selectDomain(page, this.responseData);
   }
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/DatabaseSchemaClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/DatabaseSchemaClass.ts
@@ -141,7 +141,7 @@ export class DatabaseSchemaClass extends EntityClass {
       false
     );
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // Wait for the database to be visible before clicking
     await page.getByTestId(this.database.name).waitFor({ state: 'visible' });

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/MySqlIngestionClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/MySqlIngestionClass.ts
@@ -132,7 +132,7 @@ class MysqlIngestionClass extends ServiceBaseClass {
       if (await metadataTab.isVisible()) {
         await metadataTab.click();
       }
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.click('[data-testid="add-new-ingestion-button"]');
 
       await page.waitForSelector(
@@ -157,7 +157,7 @@ class MysqlIngestionClass extends ServiceBaseClass {
       if (await metadataTab2.isVisible()) {
         await metadataTab2.click();
       }
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       await page
         .getByLabel('agents')

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/PostgresIngestionClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/PostgresIngestionClass.ts
@@ -121,7 +121,7 @@ class PostgresIngestionClass extends ServiceBaseClass {
         if (await metadataTab.isVisible()) {
           await metadataTab.click();
         }
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page.click('[data-testid="add-new-ingestion-button"]');
         await page.waitForSelector(
           '.ant-dropdown:visible [data-menu-id*="usage"]'
@@ -143,7 +143,7 @@ class PostgresIngestionClass extends ServiceBaseClass {
         if (await metadataTab2.isVisible()) {
           await metadataTab2.click();
         }
-        await page.waitForLoadState('networkidle');
+        await page.waitForLoadState('domcontentloaded');
         await page
           .getByLabel('agents')
           .getByTestId('loader')

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/RedshiftWithDBTIngestionClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/RedshiftWithDBTIngestionClass.ts
@@ -125,7 +125,7 @@ class RedshiftWithDBTIngestionClass extends ServiceBaseClass {
       if (await metadataTab.isVisible()) {
         await metadataTab.click();
       }
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.click('[data-testid="add-new-ingestion-button"]');
       await page.waitForSelector('.ant-dropdown:visible [data-menu-id*="dbt"]');
       await page.click('[data-menu-id*="dbt"]');
@@ -170,7 +170,7 @@ class RedshiftWithDBTIngestionClass extends ServiceBaseClass {
       if (await metadataTab2.isVisible()) {
         await metadataTab2.click();
       }
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page
         .getByLabel('agents')
         .getByTestId('loader')

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/ServiceBaseClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/ServiceBaseClass.ts
@@ -160,7 +160,7 @@ class ServiceBaseClass {
     if (await metadataTab.isVisible()) {
       await metadataTab.click();
     }
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await page.waitForSelector('[data-testid="add-new-ingestion-button"]');
 
@@ -199,7 +199,7 @@ class ServiceBaseClass {
     if (await metadataTab2.isVisible()) {
       await metadataTab2.click();
     }
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page
       .getByLabel('agents')
       .getByTestId('loader')
@@ -211,7 +211,7 @@ class ServiceBaseClass {
     await page.getByTestId('more-actions').first().click();
     await page.getByTestId('run-button').click();
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await toastNotification(page, `Pipeline triggered successfully!`);
 
@@ -389,7 +389,7 @@ class ServiceBaseClass {
     if (await metadataTab2.isVisible()) {
       await metadataTab2.click();
     }
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector(`td:has-text("${ingestionType}")`);
 
     await expect(
@@ -416,7 +416,7 @@ class ServiceBaseClass {
     if (await metadataTab2.isVisible()) {
       await metadataTab2.click();
     }
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // click and edit pipeline schedule for Hours
 
@@ -580,7 +580,7 @@ class ServiceBaseClass {
     if (await metadataTab2.isVisible()) {
       await metadataTab2.click();
     }
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await ingestionResponse;
     await page

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/tag/TagClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/tag/TagClass.ts
@@ -72,7 +72,7 @@ export class TagClass {
     );
     await page.getByTestId(this.data.name).waitFor({ state: 'visible' });
     await page.getByTestId(this.data.name).click();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
   }
 
   async create(apiContext: APIRequestContext) {

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/team/TeamClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/team/TeamClass.ts
@@ -68,7 +68,7 @@ export class TeamClass {
       .getByRole('link')
       .click();
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await expect(page.getByTestId('team-heading')).toHaveText(
       this.data.displayName

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/user/UserClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/user/UserClass.ts
@@ -208,7 +208,7 @@ export class UserClass {
   ) {
     await page.goto('/');
     await page.waitForURL('**/signin');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     const emailInput = page.locator('input[id="email"]');
     await emailInput.waitFor({ state: 'visible' });
     await emailInput.fill(userName);

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/alert.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/alert.ts
@@ -158,7 +158,7 @@ export const findPageWithAlert = async (
   alertDetails: AlertDetails
 ) => {
   const { id } = alertDetails;
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForSelector('[data-testid="loader"]', {
     state: 'detached',
   });

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/autoClassification.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/autoClassification.ts
@@ -39,7 +39,7 @@ export const addAndTriggerAutoClassificationPipeline = async (
   if (await metadataTab.isVisible()) {
     await metadataTab.click();
   }
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   await page.click('[data-testid="add-new-ingestion-button"]');
 
@@ -70,7 +70,7 @@ export const addAndTriggerAutoClassificationPipeline = async (
   if (await metadataTab2.isVisible()) {
     await metadataTab2.click();
   }
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page
     .getByLabel('agents')
     .getByTestId('loader')

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/bot.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/bot.ts
@@ -226,7 +226,7 @@ export const redirectToBotPage = async (page: Page) => {
 
 export const resetTokenFromBotPage = async (page: Page, botName: string) => {
   await page.goto(`/bots/${botName}`);
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
 
   const isRevokeButtonVisible = await page
@@ -243,7 +243,7 @@ export const resetTokenFromBotPage = async (page: Page, botName: string) => {
 
     await page.getByTestId('save-button').click();
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
   } else if (isAuthMechanismVisible) {
     await page.getByTestId('auth-mechanism').click();

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
@@ -58,19 +58,19 @@ export const getAuthContext = async (token: string) => {
 
 export const redirectToHomePage = async (
   page: Page,
-  waitForNetworkIdle = true
+  waitFordomcontentloaded = true
 ) => {
   await page.goto('/');
   await page.waitForURL('**/my-data');
-  if (waitForNetworkIdle) {
-    await page.waitForLoadState('networkidle');
+  if (waitFordomcontentloaded) {
+    await page.waitForLoadState('domcontentloaded');
   }
 };
 
 export const redirectToExplorePage = async (page: Page) => {
   await page.goto('/explore');
   await page.waitForURL('**/explore');
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 };
 
 export const removeLandingBanner = async (page: Page) => {
@@ -497,7 +497,7 @@ export const visitGlossaryPage = async (page: Page, glossaryName: string) => {
   await sidebarClick(page, SidebarItem.GLOSSARY);
   await glossaryResponse;
   await page.getByRole('menuitem', { name: glossaryName }).click();
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
 };
 
@@ -574,9 +574,9 @@ export const closeFirstPopupAlert = async (page: Page) => {
   }
 };
 
-export const reloadAndWaitForNetworkIdle = async (page: Page) => {
+export const reloadAndWaitFordomcontentloaded = async (page: Page) => {
   await page.reload();
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   await page.waitForSelector('[data-testid="loader"]', {
     state: 'detached',
@@ -686,7 +686,7 @@ export const testPaginationNavigation = async (
   page: Page,
   waitForLoadSelector?: string
 ) => {
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   if (waitForLoadSelector) {
     await page.waitForSelector(waitForLoadSelector, { state: 'visible' });
@@ -710,7 +710,7 @@ export const testPaginationNavigation = async (
 
   await nextButton.click();
 
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await waitForAllLoadersToDisappear(page);
 
   const currentUrl = page.url();
@@ -725,7 +725,7 @@ export const testPaginationNavigation = async (
   expect(afterValue).toBeTruthy();
 
   await page.reload();
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   if (waitForLoadSelector) {
     await page.waitForSelector(waitForLoadSelector, { state: 'visible' });
@@ -752,7 +752,7 @@ export const testTableSorting = async (
   columnIndex = 0
 ) => {
   await waitForAllLoadersToDisappear(page);
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   const header = page.locator(`th:has-text("${columnHeader}")`).first();
   const visibleRowSelector = `tbody tr:not([aria-hidden="true"])`;
@@ -795,7 +795,7 @@ export const testTableSearch = async (
   notVisibleText: string
 ) => {
   await waitForAllLoadersToDisappear(page);
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   const waitForSearchResponse = page.waitForResponse(
     `/api/v1/search/query?q=*index=${searchIndex}*`
@@ -804,7 +804,7 @@ export const testTableSearch = async (
   await page.getByTestId('searchbar').fill(searchTerm);
   await waitForSearchResponse;
   await waitForAllLoadersToDisappear(page);
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   await expect(page.getByText(searchTerm).first()).toBeVisible();
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/customProperty.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/customProperty.ts
@@ -736,7 +736,7 @@ export const addCustomPropertiesForEntity = async ({
   await page.waitForSelector('[data-testid="custom-property-form"]', {
     state: 'detached',
   });
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   const response = await createPropertyPromise;
 
   expect(response.status()).toBe(200);
@@ -857,7 +857,7 @@ export const verifyCustomPropertyInAdvancedSearch = async (
   entityType: string
 ) => {
   await sidebarClick(page, SidebarItem.EXPLORE);
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   // Open advanced search dialog
   await showAdvancedSearchDialog(page);

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/customizeLandingPage.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/customizeLandingPage.ts
@@ -156,7 +156,7 @@ export const navigateToCustomizeLandingPage = async (
   await page.getByTestId('LandingPage').click();
   await getCustomPageDataResponse;
 
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 };
 
 export const removeAndCheckWidget = async (
@@ -195,7 +195,7 @@ export const setUserDefaultPersona = async (
   ).toBeVisible();
 
   await page.locator('[data-testid="default-persona-select-list"]').click();
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   const setDefaultPersona = page.waitForResponse('/api/v1/users/*');
 
@@ -256,7 +256,7 @@ export const removeAndVerifyWidget = async (
   });
 
   await page.locator('[data-testid="save-button"]').click();
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   await redirectToHomePage(page);
 
@@ -289,7 +289,7 @@ export const addAndVerifyWidget = async (
   ).toBeVisible();
 
   await page.locator('[data-testid="save-button"]').click();
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   await redirectToHomePage(page);
 
@@ -523,7 +523,7 @@ export const verifyWidgetEntityNavigation = async (
     }
 
     // Wait for navigation
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // Verify we're on the correct page
     const currentUrl = page.url();

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/customizeNavigation.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/customizeNavigation.ts
@@ -124,5 +124,5 @@ export const selectPersona = async (page: Page, persona: PersonaClass) => {
     .getByTestId('persona-label')
     .getByText(persona.data.displayName)
     .click();
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 };

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/dataContracts.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/dataContracts.ts
@@ -52,7 +52,7 @@ export const saveAndTriggerDataContractValidation = async (
 
   await page.reload();
 
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForSelector('[data-testid="loader"]', {
     state: 'detached',
   });
@@ -71,7 +71,7 @@ export const validateDataContractInsideBundleTestSuites = async (
   await page.getByTestId('test-suites').click();
   await testSuiteResponse;
 
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   await page
     .locator('.ant-radio-button-wrapper')
@@ -277,7 +277,7 @@ export const saveSecurityAndSLADetails = async (
   await page.getByTestId('save-contract-btn').click();
   await saveContractResponse;
 
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForSelector('[data-testid="loader"]', {
     state: 'detached',
   });

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/domain.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/domain.ts
@@ -163,7 +163,7 @@ export const selectDomain = async (page: Page, domain: Domain['data']) => {
     page.waitForResponse('/api/v1/domains/name/*'),
   ]);
 
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   await page.waitForSelector('[data-testid="loader"]', {
     state: 'detached',
@@ -186,7 +186,7 @@ export const selectSubDomain = async (
     );
     await menuItem.click();
     await subDomainRes;
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
   }
 
   const subDomainRes = page.waitForResponse(
@@ -200,7 +200,7 @@ export const selectSubDomain = async (
   });
 
   await page.getByTestId(subDomain.name).click();
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 };
 
 export const selectDataProductFromTab = async (
@@ -280,7 +280,7 @@ const goToAssetsTab = async (
     page.waitForResponse('/api/v1/search/query?q=&index=all*'),
   ]);
 
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
 };
 
@@ -483,7 +483,7 @@ export const addAssetsToDomain = async (
 
   await page.reload();
   await waitForAllLoadersToDisappear(page);
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   await checkAssetsCount(page, assets.length);
 };
@@ -571,7 +571,7 @@ export const addAssetsToDataProduct = async (
       )
       .click();
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await expect(
       page
@@ -581,7 +581,7 @@ export const addAssetsToDataProduct = async (
     ).toBeVisible();
 
     await page.goBack();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
   }
 };
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
@@ -58,7 +58,7 @@ export const visitEntityPage = async (data: {
   dataTestId: string;
 }) => {
   const { page, searchTerm, dataTestId } = data;
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   // Unified loader handling
   await waitForAllLoadersToDisappear(page);
@@ -69,7 +69,7 @@ export const visitEntityPage = async (data: {
 
   if (isWelcomeScreenVisible) {
     await page.getByTestId('welcome-screen-close-btn').click();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
   }
 
   const waitForSearchResponse = page.waitForResponse(
@@ -79,7 +79,7 @@ export const visitEntityPage = async (data: {
   await waitForSearchResponse;
 
   await page.getByTestId(dataTestId).getByTestId('data-name').click();
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForSelector('[data-testid="loader"]', {
     state: 'detached',
   });
@@ -1057,7 +1057,7 @@ export const unFollowEntity = async (
   page: Page,
   endpoint: EntityTypeEndpoint
 ) => {
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   const followButton = page.getByTestId('entity-follow-button');
 
@@ -1082,7 +1082,7 @@ export const validateFollowedEntityToWidget = async (
   isFollowing: boolean
 ) => {
   await redirectToHomePage(page);
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForSelector('[data-testid="loader"]', {
     state: 'detached',
   });
@@ -1156,7 +1156,7 @@ export const createAnnouncement = async (
 
   await announcementForm(page, { ...data, startDate, endDate }, hideAlert);
   await page.reload();
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForSelector('[data-testid="loader"]', {
     state: 'detached',
   });
@@ -1246,7 +1246,7 @@ export const deleteAnnouncement = async (page: Page) => {
   await getFeed;
 
   await page.reload();
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.getByTestId('manage-button').click();
   await page.getByTestId('announcement-button').click();
 
@@ -1494,7 +1494,7 @@ export const checkForEditActions = async ({
     if (entityType.startsWith('services/')) {
       await page.getByRole('tab').nth(1).click();
 
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
 
       continue;
     }
@@ -1731,7 +1731,7 @@ export const softDeleteEntity = async (
   await page.click('[data-testid="confirm-button"]');
 
   await deleteResponse;
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   await toastNotification(
     page,
@@ -1740,7 +1740,7 @@ export const softDeleteEntity = async (
   );
 
   await page.reload();
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
   // Retry mechanism for checking deleted badge
   let deletedBadge = page.locator('[data-testid="deleted-badge"]');
@@ -1756,7 +1756,7 @@ export const softDeleteEntity = async (
     attempts++;
     if (attempts < maxAttempts) {
       await page.reload();
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       await page.waitForSelector('[data-testid="loader"]', {
         state: 'detached',
       });
@@ -1792,7 +1792,7 @@ export const softDeleteEntity = async (
 
   await restoreEntity(page);
   await page.reload();
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
   await deletedEntityCommonChecks({
     page,
@@ -1928,7 +1928,7 @@ export const checkItemNotExistsInQuickFilter = async (
   filterValue: string
 ) => {
   await sidebarClick(page, SidebarItem.EXPLORE);
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.click(`[data-testid="search-dropdown-${filterLabel}"]`);
   const testId = filterValue.toLowerCase();
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/entityPanel.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/entityPanel.ts
@@ -25,7 +25,7 @@ export const openEntitySummaryPanel = async (
   await page.waitForSelector('[data-testid="loader"]', {
     state: 'detached',
   });
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   const entityCard = page
     .locator('[data-testid="table-data-card"]')
@@ -33,7 +33,7 @@ export const openEntitySummaryPanel = async (
     .first();
   if (await entityCard.isVisible()) {
     await entityCard.click();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
   }
 };
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/explore.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/explore.ts
@@ -284,7 +284,7 @@ export const verifyEntitiesAreSorted = async (page: Page) => {
   await page.waitForSelector('[data-testid="search-results"]', {
     state: 'visible',
   });
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   const entityNames = await page.$$eval(
     '[data-testid="search-results"] .explore-search-card [data-testid="entity-link"]',

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/glossary.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/glossary.ts
@@ -78,7 +78,7 @@ export const selectActiveGlossary = async (
     }
   }
 
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   await page.waitForSelector('[data-testid="loader"]', {
     state: 'detached',
@@ -91,7 +91,7 @@ export const selectActiveGlossaryTerm = async (
 ) => {
   await page.getByTestId(glossaryTermName).click();
 
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   await page.waitForSelector('[data-testid="loader"]', {
     state: 'detached',
@@ -1224,7 +1224,7 @@ export const approveTagsTask = async (
   await sidebarClick(page, SidebarItem.GLOSSARY);
   await glossaryTermsResponse;
   await selectActiveGlossary(page, entity.data.displayName);
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   const tagVisibility = page.locator(`[data-testid="tag-${value.tag}"]`);
   await tagVisibility.scrollIntoViewIfNeeded();

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/importUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/importUtils.ts
@@ -89,7 +89,7 @@ export const fillOwnerDetails = async (page: Page, owners: string[]) => {
     page.locator('.ant-tabs-tab-active').getByText('Teams')
   ).toBeVisible();
 
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
 
@@ -99,7 +99,7 @@ export const fillOwnerDetails = async (page: Page, owners: string[]) => {
   await page.getByRole('tab', { name: 'Users' }).click();
   await userListResponse;
 
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
 
   await page.waitForSelector('[data-testid="owner-select-users-search-bar"]', {
@@ -115,7 +115,7 @@ export const fillOwnerDetails = async (page: Page, owners: string[]) => {
     await page.locator('[data-testid="owner-select-users-search-bar"]').clear();
     await page.fill('[data-testid="owner-select-users-search-bar"]', owner);
     await searchOwner;
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector(
       '[data-testid="select-owner-tabs"] [data-testid="loader"]',
       { state: 'detached' }
@@ -141,7 +141,7 @@ export const fillTeamOwnerDetails = async (page: Page, owners: string[]) => {
     page.locator('.ant-tabs-tab-active').getByText('Users')
   ).toBeVisible();
 
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
 
@@ -150,7 +150,7 @@ export const fillTeamOwnerDetails = async (page: Page, owners: string[]) => {
     .getByRole('tab', { name: 'Teams' })
     .click();
 
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
 
   await page.waitForSelector('[data-testid="owner-select-teams-search-bar"]', {
@@ -166,7 +166,7 @@ export const fillTeamOwnerDetails = async (page: Page, owners: string[]) => {
     await page.locator('[data-testid="owner-select-teams-search-bar"]').clear();
     await page.fill('[data-testid="owner-select-teams-search-bar"]', owner);
     await searchOwner;
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector(
       '[data-testid="select-owner-tabs"] [data-testid="loader"]',
       { state: 'detached' }

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts
@@ -39,7 +39,7 @@ export const acknowledgeTask = async (data: {
 
   await page.waitForSelector(`[data-testid="${testCase}-status"] >> text=New`);
   await page.click(`[data-testid="${testCase}"] >> text=${testCase}`);
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
   await page.click('[data-testid="edit-resolution-icon"]');
   await page.click('[data-testid="test-case-resolution-status-type"]');
@@ -50,7 +50,7 @@ export const acknowledgeTask = async (data: {
   await page.click('#update-status-button');
   await statusChangeResponse;
   await page.waitForSelector(`[data-testid="${testCase}-status"] >> text=Ack`);
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   await expect(
     page.locator(
@@ -66,7 +66,7 @@ export const assignIncident = async (data: {
 }) => {
   const { testCaseName, page, user } = data;
   await sidebarClick(page, SidebarItem.INCIDENT_MANAGER);
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForSelector(`[data-testid="test-case-${testCaseName}"]`);
   await page.click(`[data-testid="${testCaseName}-status"]`);
   await page.getByRole('menuitem', { name: 'Assigned' }).click();

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/lineage.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/lineage.ts
@@ -210,7 +210,7 @@ export const connectEdgeBetweenNodes = async (
 
   await page.locator('[data-testid="suggestion-node"]').dispatchEvent('click');
 
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   const waitForSearchResponse = page.waitForResponse(
     `/api/v1/search/query?q=*&from=0&size=10&*`
@@ -524,7 +524,7 @@ export const visitLineageTab = async (page: Page) => {
   const lineageRes = page.waitForResponse('/api/v1/lineage/getLineage?*');
   await page.click('[data-testid="lineage"]');
   await lineageRes;
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await waitForAllLoadersToDisappear(page);
 };
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/metric.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/metric.ts
@@ -195,7 +195,7 @@ export const updateRelatedMetric = async (
 
   await metricsResponsePromise1;
 
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
 
   await expect(page.getByTestId('entity-header-display-name')).toContainText(
@@ -212,7 +212,7 @@ export const updateRelatedMetric = async (
   await page.getByRole('button', { name: title, exact: true }).click();
   await metricsResponsePromise2;
 
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
 
   await expect(page.getByTestId('entity-header-display-name')).toContainText(

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/observabilityAlert.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/observabilityAlert.ts
@@ -41,7 +41,7 @@ import { sidebarClick } from './sidebar';
 
 export const visitObservabilityAlertPage = async (page: Page) => {
   await redirectToHomePage(page);
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForSelector('[data-testid="loader"]', {
     state: 'detached',
   });
@@ -53,7 +53,7 @@ export const visitObservabilityAlertPage = async (page: Page) => {
 
   // Set up navigation promise before clicking
   const navigationPromise = page.waitForURL('**/observability/alerts', {
-    waitUntil: 'networkidle',
+    waitUntil: 'domcontentloaded',
   });
 
   await sidebarClick(page, SidebarItem.OBSERVABILITY_ALERT);

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/permission.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/permission.ts
@@ -156,7 +156,7 @@ export const validateViewPermissions = async (
   }
 
   await page.click('[data-testid="sample_data"]');
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForSelector("[data-testid='loader']", { state: 'detached' });
   await checkNoPermissionPlaceholder(
     page,
@@ -164,15 +164,15 @@ export const validateViewPermissions = async (
     permission?.viewSampleData
   );
   await page.click('[data-testid="table_queries"]');
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForSelector("[data-testid='loader']", { state: 'detached' });
   await checkNoPermissionPlaceholder(page, /Queries/, permission?.viewQueries);
 
   await page.click('[data-testid="profiler"]');
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForSelector("[data-testid='loader']", { state: 'detached' });
   await page.getByRole('tab', { name: 'Data Quality' }).click();
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForSelector("[data-testid='loader']", { state: 'detached' });
   await checkNoPermissionPlaceholder(
     page,
@@ -180,13 +180,13 @@ export const validateViewPermissions = async (
     permission?.viewTests
   );
   await page.click('[data-testid="lineage"]');
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForSelector("[data-testid='loader']", { state: 'detached' });
 
   await expect(page.getByTestId('edit-lineage')).not.toBeVisible();
 
   await page.click('[data-testid="custom_properties"]');
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForSelector("[data-testid='loader']", { state: 'detached' });
   await checkNoPermissionPlaceholder(page, /Custom Properties/);
 };

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/persona.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/persona.ts
@@ -45,7 +45,7 @@ export const updatePersonaDisplayName = async ({
 export const navigateToPersonaSettings = async (page: Page) => {
   await redirectToHomePage(page);
   await settingClick(page, GlobalSettingOptions.PERSONA);
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForSelector('[data-testid="loader"]', {
     state: 'detached',
   });
@@ -63,7 +63,7 @@ export const checkPersonaInProfile = async (
     state: 'visible',
   });
   await page.getByTestId('user-name').click();
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   if (expectedPersonaName) {
     // Expect persona to be visible with specific name
@@ -139,7 +139,7 @@ export const navigateToPersonaWithPagination = async (
     await nextBtn.click();
     await getPersonas;
 
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await waitForAllLoadersToDisappear(page, 'skeleton-card-loader');
   }
 };

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/service.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/service.ts
@@ -46,7 +46,7 @@ export const visitServiceDetailsPage = async (
   // Click on created service
   await page.click(`[data-testid="service-name-${service.name}"]`);
 
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForSelector('[data-testid="loader"]', { state: 'hidden' });
 
   if (visitChildrenTab) {
@@ -54,7 +54,7 @@ export const visitServiceDetailsPage = async (
     await page.getByRole('tab').nth(1).click();
   }
 
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   if (verifyHeader) {
     const text = await page.textContent(`[data-testid="entity-header-name"]`);

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/serviceIngestion.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/serviceIngestion.ts
@@ -85,7 +85,7 @@ export const deleteService = async (
       serviceName
     )}?currentPage=1`
   );
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
 
   await expect(page.getByTestId('entity-header-name')).toHaveText(serviceName);
@@ -123,7 +123,7 @@ export const deleteService = async (
   ); // Wait for up to 5 minutes for the toast notification to appear
 
   await page.reload();
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForSelector('[data-testid="loader"]', { state: 'detached' });
 
   const serviceSearchResponse = page.waitForResponse((response) => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/sidebar.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/sidebar.ts
@@ -69,5 +69,5 @@ export const settingClick = async (
     await page.click(`[data-testid="${path}"]`);
   }
 
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 };

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/tag.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/tag.ts
@@ -64,7 +64,7 @@ export const visitClassificationPage = async (
   await sidebarClick(page, SidebarItem.TAGS);
   await classificationResponse;
 
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   await page.waitForSelector(
     '[data-testid="tags-container"] .table-container [data-testid="loader"]',
@@ -81,7 +81,7 @@ export const visitClassificationPage = async (
   );
 
   await fetchTags;
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForSelector(
     '[data-testid="tags-container"] .table-container [data-testid="loader"]',
     { state: 'detached' }
@@ -184,7 +184,7 @@ export const removeAssetsFromTag = async (
   await page.getByTestId('delete-all-button').click();
   await assetsRemoveRes;
 
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.reload();
   await page.waitForSelector(
     '[data-testid="tags-container"] [data-testid="loader"]',

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/team.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/team.ts
@@ -58,7 +58,7 @@ export const createTeam = async (page: Page, isPublic?: boolean) => {
 
   await createTeamResponse;
 
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForSelector('[data-testid="loader"]', {
     state: 'detached',
   });
@@ -395,7 +395,7 @@ export const addEmailTeam = async (page: Page, email: string) => {
   // Reload the page
   await page.reload();
 
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   await page.waitForSelector('[data-testid="loader"]', {
     state: 'detached',
@@ -485,7 +485,7 @@ export const executionOnOwnerTeam = async (
 
   const newTeamData = await createTeam(page);
 
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   await page.waitForSelector('[data-testid="loader"]', {
     state: 'detached',

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/testCases.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/testCases.ts
@@ -51,7 +51,7 @@ export const verifyIncidentBreadcrumbsFromTablePageRedirect = async (
     })
     .click();
 
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForSelector('[data-testid="loader"]', {
     state: 'detached',
   });
@@ -71,7 +71,7 @@ export const verifyIncidentBreadcrumbsFromTablePageRedirect = async (
 
   await page.getByTestId('breadcrumb-link').nth(3).click();
 
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForSelector('[data-testid="loader"]', {
     state: 'detached',
   });

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/user.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/user.ts
@@ -615,7 +615,7 @@ export const checkStewardServicesPermissions = async (page: Page) => {
   // Click on the entity link in the drawer title
   await page.click('.summary-panel-container [data-testid="entity-link"]');
 
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   // Check if the edit tier button is visible
   await expect(page.locator('[data-testid="edit-icon-tier"]')).toBeVisible();

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/widgetFilters.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/widgetFilters.ts
@@ -331,7 +331,7 @@ export const verifyDataAssetsFilters = async (
   await aToZFilter;
 
   // Wait for UI to update
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   // Test Z to A sorting
   const zToAFilter = page.waitForResponse(
@@ -344,7 +344,7 @@ export const verifyDataAssetsFilters = async (
   await zToAFilter;
 
   // Wait for UI to update
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   // Test High to Low sorting
   const highToLowFilter = page.waitForResponse(
@@ -357,7 +357,7 @@ export const verifyDataAssetsFilters = async (
   await highToLowFilter;
 
   // Wait for UI to update
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   // Test Low to High sorting
   const lowToHighFilter = page.waitForResponse(
@@ -370,5 +370,5 @@ export const verifyDataAssetsFilters = async (
   await lowToHighFilter;
 
   // Wait for UI to update
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 };


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
