### PR TITLE
Fix #21703 add Mentions destination category to Tasks and Announcements notifications

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/utils/Alerts/AlertsUtil.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Alerts/AlertsUtil.test.tsx
@@ -29,8 +29,6 @@ import {
 } from '../../generated/events/eventSubscription';
 import {
   mockExternalDestinationOptions,
-  mockNonTaskInternalDestinationOptions,
-  mockTaskInternalDestinationOptions,
   mockTypedEvent1,
   mockTypedEvent2,
   mockTypedEvent3,
@@ -228,18 +226,70 @@ describe('AlertsUtil tests', () => {
       'task'
     );
 
-    expect(resultTask).toHaveLength(2);
+    expect(resultTask).toHaveLength(3);
 
-    resultTask.map((result) =>
-      expect(
-        mockTaskInternalDestinationOptions.includes(
-          result.value as SubscriptionCategory
-        )
-      ).toBeTruthy()
+    const taskCategories = resultTask.map(
+      (result) => result.value as SubscriptionCategory
+    );
+
+    expect(taskCategories).toContain(SubscriptionCategory.Owners);
+    expect(taskCategories).toContain(SubscriptionCategory.Assignees);
+    expect(taskCategories).toContain(SubscriptionCategory.Mentions);
+    expect(taskCategories).not.toContain(SubscriptionCategory.Followers);
+    expect(taskCategories).not.toContain(SubscriptionCategory.Admins);
+    expect(taskCategories).not.toContain(SubscriptionCategory.Users);
+    expect(taskCategories).not.toContain(SubscriptionCategory.Teams);
+  });
+
+  it('getFilteredDestinationOptions should return correct internal options for "conversation" source', () => {
+    const resultConversation = getFilteredDestinationOptions(
+      DESTINATION_DROPDOWN_TABS.internal,
+      'conversation'
+    );
+
+    expect(resultConversation).toHaveLength(2);
+
+    const conversationCategories = resultConversation.map(
+      (result) => result.value as SubscriptionCategory
+    );
+
+    expect(conversationCategories).toContain(SubscriptionCategory.Owners);
+    expect(conversationCategories).toContain(SubscriptionCategory.Mentions);
+    expect(conversationCategories).not.toContain(
+      SubscriptionCategory.Followers
+    );
+    expect(conversationCategories).not.toContain(SubscriptionCategory.Admins);
+    expect(conversationCategories).not.toContain(SubscriptionCategory.Users);
+    expect(conversationCategories).not.toContain(SubscriptionCategory.Teams);
+    expect(conversationCategories).not.toContain(
+      SubscriptionCategory.Assignees
     );
   });
 
-  it('getFilteredDestinationOptions should return correct internal options for non "task" source', () => {
+  it('getFilteredDestinationOptions should return correct internal options for "announcement" source', () => {
+    const resultAnnouncement = getFilteredDestinationOptions(
+      DESTINATION_DROPDOWN_TABS.internal,
+      'announcement'
+    );
+
+    expect(resultAnnouncement).toHaveLength(6);
+
+    const announcementCategories = resultAnnouncement.map(
+      (result) => result.value as SubscriptionCategory
+    );
+
+    expect(announcementCategories).toContain(SubscriptionCategory.Owners);
+    expect(announcementCategories).toContain(SubscriptionCategory.Followers);
+    expect(announcementCategories).toContain(SubscriptionCategory.Admins);
+    expect(announcementCategories).toContain(SubscriptionCategory.Users);
+    expect(announcementCategories).toContain(SubscriptionCategory.Teams);
+    expect(announcementCategories).toContain(SubscriptionCategory.Mentions);
+    expect(announcementCategories).not.toContain(
+      SubscriptionCategory.Assignees
+    );
+  });
+
+  it('getFilteredDestinationOptions should return correct internal options for default/other sources', () => {
     const resultContainer = getFilteredDestinationOptions(
       DESTINATION_DROPDOWN_TABS.internal,
       'container'
@@ -252,16 +302,17 @@ describe('AlertsUtil tests', () => {
     [resultContainer, resultTestSuite].forEach((results) => {
       expect(results).toHaveLength(5);
 
-      results.map((result) =>
-        expect(
-          mockNonTaskInternalDestinationOptions.includes(
-            result.value as Exclude<
-              SubscriptionCategory,
-              SubscriptionCategory.External | SubscriptionCategory.Assignees
-            >
-          )
-        ).toBeTruthy()
+      const defaultCategories = results.map(
+        (result) => result.value as SubscriptionCategory
       );
+
+      expect(defaultCategories).toContain(SubscriptionCategory.Owners);
+      expect(defaultCategories).toContain(SubscriptionCategory.Followers);
+      expect(defaultCategories).toContain(SubscriptionCategory.Admins);
+      expect(defaultCategories).toContain(SubscriptionCategory.Users);
+      expect(defaultCategories).toContain(SubscriptionCategory.Teams);
+      expect(defaultCategories).not.toContain(SubscriptionCategory.Assignees);
+      expect(defaultCategories).not.toContain(SubscriptionCategory.Mentions);
     });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Alerts/AlertsUtil.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Alerts/AlertsUtil.tsx
@@ -1233,49 +1233,49 @@ export const getFormattedDestinations = (
   return formattedDestinations;
 };
 
+// Destination category exclusions by entity type
+const DESTINATION_CATEGORY_EXCLUDES: Record<string, SubscriptionCategory[]> = {
+  // Default: exclude Assignees and Mentions for all non-thread entities
+  __default__: [SubscriptionCategory.Assignees, SubscriptionCategory.Mentions],
+  // Thread-specific exclusions
+  task: [
+    SubscriptionCategory.Followers,
+    SubscriptionCategory.Admins,
+    SubscriptionCategory.Users,
+    SubscriptionCategory.Teams,
+  ],
+  conversation: [
+    SubscriptionCategory.Followers,
+    SubscriptionCategory.Admins,
+    SubscriptionCategory.Users,
+    SubscriptionCategory.Teams,
+    SubscriptionCategory.Assignees,
+  ],
+  announcement: [SubscriptionCategory.Assignees],
+};
+
 export const getFilteredDestinationOptions = (
   key: keyof typeof DESTINATION_SOURCE_ITEMS,
   selectedSource: string
 ) => {
-  // Get options based on destination type key ("Internal" OR "External").
-  const newOptions = DESTINATION_SOURCE_ITEMS[key];
+  const options = DESTINATION_SOURCE_ITEMS[key];
+  const isExternalDestination = !isEqual(
+    key,
+    DESTINATION_DROPDOWN_TABS.internal
+  );
 
-  const isInternalOptions = isEqual(key, DESTINATION_DROPDOWN_TABS.internal);
+  if (isExternalDestination) {
+    return options;
+  }
 
-  // Logic to filter the options based on destination type and selected source.
-  const filteredOptions = newOptions.filter((option) => {
-    // If the destination type is external, always show all options.
-    if (!isInternalOptions) {
-      return true;
-    }
+  const excludedCategories =
+    DESTINATION_CATEGORY_EXCLUDES[selectedSource] ||
+    DESTINATION_CATEGORY_EXCLUDES.__default__;
 
-    // Logic to filter options for destination type "Internal"
-
-    // Show all options except "Assignees" and "Mentions" for all sources.
-    let shouldShowOption =
-      option.value !== SubscriptionCategory.Assignees &&
-      option.value !== SubscriptionCategory.Mentions;
-
-    // Only show "Owners" and "Assignees" options for "Task" source.
-    if (selectedSource === 'task') {
-      shouldShowOption = [
-        SubscriptionCategory.Owners,
-        SubscriptionCategory.Assignees,
-      ].includes(option.value as SubscriptionCategory);
-    }
-
-    // Only show "Owners" and "Mentions" options for "Conversation" source.
-    if (selectedSource === 'conversation') {
-      shouldShowOption = [
-        SubscriptionCategory.Owners,
-        SubscriptionCategory.Mentions,
-      ].includes(option.value as SubscriptionCategory);
-    }
-
-    return shouldShowOption;
-  });
-
-  return filteredOptions;
+  return options.filter(
+    (option) =>
+      !excludedCategories.includes(option.value as SubscriptionCategory)
+  );
 };
 
 export const getSourceOptionsFromResourceList = (


### PR DESCRIPTION
  Fixes #21703

  This PR refactors the destination category filtering logic in `AlertsUtil.tsx` to make it more maintainable and extensible while adding support for Mentions category in
  Tasks and Announcements.

  **What changed:**
  - Extracted hardcoded filtering logic into a centralized `DESTINATION_CATEGORY_EXCLUDES` lookup table that defines which destination categories should be excluded for
  each entity type
  - Simplified the `getFilteredDestinationOptions` function to use this configuration-driven approach instead of inline conditional logic
  - **Added Mentions as an allowed destination category for Task sources** (previously excluded)
  - **Added Mentions as an allowed destination category for Announcement sources** (previously excluded by default)

  **Behavioral changes:**
  - **Task notifications**: Now support Mentions in addition to Owners and Assignees
  - **Announcement notifications**: Now support Mentions in addition to Owners (Assignees remains excluded)
  - Conversation notifications: No change (already supported Mentions)
  - All other entity types: No change (continue to default exclusion rules)

  **Why:**
  - Resolves issue #21703 by enabling Mentions as a destination category for Tasks and Announcements
  - The previous implementation had complex nested conditionals that were difficult to maintain and extend
  - Adding new rules required modifying function logic rather than configuration
  - The new approach clearly documents the exclusion rules by entity type in one place
  - Improves code maintainability for future destination category additions
