### PR TITLE
Fixes #24769: UnityCatalog Incorrect Circular Lineage

### DIFF
--- a/ingestion/src/metadata/ingestion/lineage/sql_lineage.py
+++ b/ingestion/src/metadata/ingestion/lineage/sql_lineage.py
@@ -66,12 +66,24 @@ CUTOFF_NODES = 20
 
 
 # pylint: disable=too-many-function-args,protected-access
-def get_column_fqn(table_entity: Table, column: str) -> Optional[str]:
+def get_column_fqn(
+    table_entity: Table,
+    column: str,
+    table: Optional[str] = None,
+    schema: Optional[str] = None,
+    database: Optional[str] = None,
+) -> Optional[str]:
     """
     Get fqn of column if exist in table entity
     """
-    if not table_entity:
+    if (
+        (not table_entity)
+        or (table and table != table_entity.name.root)
+        or (schema and schema != table_entity.databaseSchema.name)
+        or (database and database != table_entity.database.name)
+    ):
         return None
+
     for tbl_column in table_entity.columns or []:
         try:
             if column.lower() == tbl_column.name.root.lower():

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/lineage.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/lineage.py
@@ -137,8 +137,15 @@ class UnitycatalogLineageSource(Source):
                 )
                 from_columns = []
                 for col in column_streams.upstream_cols:
-                    col_fqn = get_column_fqn(from_table, col.name)
-                    if col_fqn:
+                    col_fqn = get_column_fqn(
+                        from_table,
+                        col.name,
+                        col.table_name,
+                        col.schema_name,
+                        col.catalog_name,
+                    )
+                    # Check to avoid self column loop
+                    if col_fqn and column.fullyQualifiedName.root != col_fqn:
                         from_columns.append(col_fqn)
 
                 if from_columns:

--- a/ingestion/tests/unit/topology/database/test_unity_catalog_lineage.py
+++ b/ingestion/tests/unit/topology/database/test_unity_catalog_lineage.py
@@ -597,3 +597,208 @@ class TestUnityCatalogLineage(TestCase):
         self.assertIsInstance(results[0], Either)
         self.assertEqual(results[0].right.edge.fromEntity.id, container_entity.id)
         self.assertEqual(results[0].right.edge.toEntity.id, current_table.id)
+
+    @patch(
+        "metadata.ingestion.source.database.unitycatalog.lineage.UnitycatalogLineageSource.test_connection"
+    )
+    @patch("metadata.ingestion.ometa.ometa_api.OpenMetadata")
+    def test_transitive_column_lineage(self, mock_metadata, mock_test_connection):
+        """Test transitive column lineage: ABC1.col1 -> ABC.col1 -> ABC.col2
+        Should result in: ABC1.col1 -> ABC.col1 and ABC1.col1 -> ABC.col2
+        No self-referencing lineage ABC.col1 -> ABC.col1 should be created"""
+        mock_test_connection.return_value = None
+
+        from metadata.ingestion.source.database.unitycatalog.models import (
+            DatabricksColumn,
+            LineageColumnStreams,
+        )
+
+        # Create ABC1 table with col1
+        abc1_table = Table(
+            id=uuid4(),
+            name=EntityName(root="ABC1"),
+            database=EntityReference(id=uuid4(), name="demo-test-cat", type="database"),
+            databaseSchema=EntityReference(
+                id=uuid4(), name="test-schema", type="databaseSchema"
+            ),
+            columns=[
+                Column(
+                    name=ColumnName(root="col1"),
+                    dataType=DataType.STRING,
+                    fullyQualifiedName=FullyQualifiedEntityName(
+                        root="local_unitycatalog.demo-test-cat.test-schema.ABC1.col1"
+                    ),
+                )
+            ],
+        )
+
+        # Create ABC table with col1 and col2
+        abc_table = Table(
+            id=uuid4(),
+            name=EntityName(root="ABC"),
+            database=EntityReference(id=uuid4(), name="demo-test-cat", type="database"),
+            databaseSchema=EntityReference(
+                id=uuid4(), name="test-schema", type="databaseSchema"
+            ),
+            columns=[
+                Column(
+                    name=ColumnName(root="col1"),
+                    dataType=DataType.STRING,
+                    fullyQualifiedName=FullyQualifiedEntityName(
+                        root="local_unitycatalog.demo-test-cat.test-schema.ABC.col1"
+                    ),
+                ),
+                Column(
+                    name=ColumnName(root="col2"),
+                    dataType=DataType.STRING,
+                    fullyQualifiedName=FullyQualifiedEntityName(
+                        root="local_unitycatalog.demo-test-cat.test-schema.ABC.col2"
+                    ),
+                ),
+            ],
+        )
+
+        # Set up upstream table info
+        upstream_table_info = DatabricksTable(
+            name="ABC1",
+            catalog_name="demo-test-cat",
+            schema_name="test-schema",
+            table_type="TABLE",
+        )
+
+        table_streams = LineageTableStreams(
+            upstreams=[LineageEntity(tableInfo=upstream_table_info)], downstreams=[]
+        )
+
+        # Mock metadata.get_by_name to return ABC1 table
+        mock_metadata.get_by_name.return_value = abc1_table
+
+        lineage_source = UnitycatalogLineageSource(self.config, mock_metadata)
+        lineage_source.client = Mock()
+
+        # Mock column lineage responses
+        # For ABC.col1: upstream is ABC1.col1
+        col1_lineage = LineageColumnStreams(
+            upstream_cols=[
+                DatabricksColumn(
+                    name="col1",
+                    table_name="ABC1",
+                    schema_name="test-schema",
+                    catalog_name="demo-test-cat",
+                )
+            ]
+        )
+
+        # For ABC.col2: upstream should include both ABC.col1 (self-table) and ABC1.col1 (transitive)
+        col2_lineage = LineageColumnStreams(
+            upstream_cols=[
+                DatabricksColumn(
+                    name="col1",
+                    table_name="ABC",
+                    schema_name="test-schema",
+                    catalog_name="demo-test-cat",
+                ),
+                DatabricksColumn(
+                    name="col1",
+                    table_name="ABC1",
+                    schema_name="test-schema",
+                    catalog_name="demo-test-cat",
+                ),
+            ]
+        )
+
+        # Configure mock to return different lineage based on column name
+        def get_column_lineage_side_effect(table_fqn, column_name):
+            if column_name == "col1":
+                return col1_lineage
+            elif column_name == "col2":
+                return col2_lineage
+            return LineageColumnStreams(upstream_cols=[])
+
+        lineage_source.client.get_column_lineage.side_effect = (
+            get_column_lineage_side_effect
+        )
+
+        # Execute
+        results = list(
+            lineage_source._handle_upstream_table(
+                table_streams, abc_table, "demo-test-cat.test-schema.ABC"
+            )
+        )
+
+        # Verify only one lineage request is created
+        self.assertEqual(len(results), 1)
+        lineage_request = results[0].right
+        self.assertEqual(lineage_request.edge.fromEntity.id, abc1_table.id)
+        self.assertEqual(lineage_request.edge.toEntity.id, abc_table.id)
+
+        # Verify column lineage details
+        lineage_details = lineage_request.edge.lineageDetails
+        self.assertIsNotNone(lineage_details)
+        self.assertIsNotNone(lineage_details.columnsLineage)
+
+        # Check that we have exactly 2 column lineage entries
+        column_lineages = lineage_details.columnsLineage
+        self.assertEqual(
+            len(column_lineages),
+            2,
+            f"Expected exactly 2 column lineage entries, got {len(column_lineages)}",
+        )
+
+        # Track found lineages
+        col1_lineage_found = False
+        col2_transitive_lineage_found = False
+        unexpected_lineages = []
+
+        for col_lineage in column_lineages:
+            to_col = col_lineage.toColumn.root
+            from_cols = [fc.root for fc in col_lineage.fromColumns]
+
+            # Expected: ABC1.col1 -> ABC.col1
+            if to_col == "local_unitycatalog.demo-test-cat.test-schema.ABC.col1":
+                if (
+                    "local_unitycatalog.demo-test-cat.test-schema.ABC1.col1"
+                    in from_cols
+                ):
+                    col1_lineage_found = True
+                    # Verify only ABC1.col1 is in fromColumns, no other columns
+                    self.assertEqual(len(from_cols), 1)
+                else:
+                    unexpected_lineages.append(f"{from_cols} -> {to_col}")
+
+            # Expected: ABC1.col1 -> ABC.col2 (transitive lineage)
+            elif to_col == "local_unitycatalog.demo-test-cat.test-schema.ABC.col2":
+                if (
+                    "local_unitycatalog.demo-test-cat.test-schema.ABC1.col1"
+                    in from_cols
+                ):
+                    col2_transitive_lineage_found = True
+                    # Verify only ABC1.col1 is in fromColumns
+                    # Note: ABC.col1 should be filtered out as it's a self-table reference
+                    self.assertEqual(len(from_cols), 1)
+                    self.assertNotIn(
+                        "local_unitycatalog.demo-test-cat.test-schema.ABC.col1",
+                        from_cols,
+                        "Self-table column lineage ABC.col1 -> ABC.col2 should be handled separately, not in cross-table lineage",
+                    )
+                else:
+                    unexpected_lineages.append(f"{from_cols} -> {to_col}")
+            else:
+                unexpected_lineages.append(f"{from_cols} -> {to_col}")
+
+        # Verify expected lineages were found
+        self.assertTrue(
+            col1_lineage_found,
+            "Expected ABC1.col1 -> ABC.col1 lineage not found",
+        )
+        self.assertTrue(
+            col2_transitive_lineage_found,
+            "Expected transitive lineage ABC1.col1 -> ABC.col2 not found",
+        )
+
+        # Verify no unexpected lineages were created
+        self.assertEqual(
+            len(unexpected_lineages),
+            0,
+            f"Unexpected column lineages found: {unexpected_lineages}",
+        )


### PR DESCRIPTION


<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #24769 

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

- Fixed an incorrect circular lineage issue
- Fixed an issue where self-table referenced lineage caused extra and incorrect table lineage when two tables have the same column names, and one table had an additional column

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
