### PR TITLE
Fixes #24869: Add opt-in SSO auto-redirect on Sign In

### DIFF
--- a/conf/openmetadata.yaml
+++ b/conf/openmetadata.yaml
@@ -291,6 +291,7 @@ authenticationConfiguration:
   jwtPrincipalClaims: ${AUTHENTICATION_JWT_PRINCIPAL_CLAIMS:-[email,preferred_username,sub]}
   jwtPrincipalClaimsMapping: ${AUTHENTICATION_JWT_PRINCIPAL_CLAIMS_MAPPING:-[]}
   enableSelfSignup : ${AUTHENTICATION_ENABLE_SELF_SIGNUP:-true}
+  enableAutoRedirect: ${AUTHENTICATION_ENABLE_AUTO_REDIRECT:-false}
   # Force secure flag on session cookies even when not using HTTPS directly.
   # Enable this when running behind a proxy/load balancer that handles SSL termination.
   # Default: false (secure flag only set when HTTPS is detected)

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/system/ConfigResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/system/ConfigResource.java
@@ -97,6 +97,7 @@ public class ConfigResource {
       responseAuthConfig.setProviderName(yamlConfig.getProviderName());
       responseAuthConfig.setClientType(yamlConfig.getClientType());
       responseAuthConfig.setEnableSelfSignup(yamlConfig.getEnableSelfSignup());
+      responseAuthConfig.setEnableAutoRedirect(yamlConfig.getEnableAutoRedirect());
       responseAuthConfig.setJwtPrincipalClaims(yamlConfig.getJwtPrincipalClaims());
       responseAuthConfig.setJwtPrincipalClaimsMapping(yamlConfig.getJwtPrincipalClaimsMapping());
       responseAuthConfig.setClientId(yamlConfig.getClientId());

--- a/openmetadata-spec/src/main/resources/json/schema/configuration/authenticationConfiguration.json
+++ b/openmetadata-spec/src/main/resources/json/schema/configuration/authenticationConfiguration.json
@@ -112,6 +112,12 @@
       "description": "Force secure flag on session cookies even when not using HTTPS directly. Enable this when running behind a proxy/load balancer that handles SSL termination.",
       "type": "boolean",
       "default": false
+    },
+    "enableAutoRedirect": {
+      "title": "Enable Auto Redirect",
+      "description": "Enable automatic redirect from the sign-in page to the configured SSO provider.",
+      "type": "boolean",
+      "default": false
     }
   },
   "required": ["provider", "providerName", "publicKeyUrls", "authority", "callbackUrl", "clientId", "jwtPrincipalClaims"],

--- a/openmetadata-ui/src/main/resources/ui/src/constants/SSO.constant.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/SSO.constant.ts
@@ -483,6 +483,7 @@ export const COMMON_FIELD_TITLES = {
       'Enter username:claim_name (e.g. username:preferred_username,email:email) and press ENTER.',
   },
   enableSelfSignup: { 'ui:title': 'Enable Self Signup' },
+  enableAutoRedirect: { 'ui:title': 'Enable Auto Redirect' },
   clientType: {
     'ui:title': 'Client Type',
     'ui:widget': 'radio',
@@ -694,6 +695,7 @@ export interface AuthenticationConfiguration {
   jwtPrincipalClaims: string[];
   jwtPrincipalClaimsMapping: string[];
   enableSelfSignup: boolean;
+  enableAutoRedirect?: boolean;
   clientType?: ClientType;
   secret?: string;
   ldapConfiguration?: Record<string, unknown>;

--- a/openmetadata-ui/src/main/resources/ui/src/generated/configuration/authenticationConfiguration.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/configuration/authenticationConfiguration.ts
@@ -35,6 +35,10 @@ export interface AuthenticationConfiguration {
      */
     enableSelfSignup?: boolean;
     /**
+     * Enable automatic redirect from the sign-in page to the configured SSO provider.
+     */
+    enableAutoRedirect?: boolean;
+    /**
      * Force secure flag on session cookies even when not using HTTPS directly. Enable this when
      * running behind a proxy/load balancer that handles SSL termination.
      */

--- a/openmetadata-ui/src/main/resources/ui/src/pages/LoginPage/SignInPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/LoginPage/SignInPage.test.tsx
@@ -20,10 +20,12 @@ import {
 import { MemoryRouter } from 'react-router-dom';
 
 import { CarouselLayout } from '../../components/Layout/CarouselLayout/CarouselLayout';
+import { useAuthProvider } from '../../components/Auth/AuthProviders/AuthProvider';
 import { useApplicationStore } from '../../hooks/useApplicationStore';
 import SignInPage from './SignInPage';
 
 const mockuseApplicationStore = useApplicationStore as unknown as jest.Mock;
+const mockUseAuthProvider = useAuthProvider as unknown as jest.Mock;
 
 jest.mock('../../hooks/useApplicationStore', () => ({
   useApplicationStore: jest.fn().mockImplementation(() => ({
@@ -34,6 +36,25 @@ jest.mock('../../hooks/useApplicationStore', () => ({
       },
     },
     getOidcToken: jest.fn(),
+  })),
+}));
+
+jest.mock('../../components/Auth/AuthProviders/AuthProvider', () => ({
+  useAuthProvider: jest.fn().mockImplementation(() => ({
+    onLoginHandler: jest.fn(),
+  })),
+}));
+
+jest.mock('../../components/Auth/AuthProviders/BasicAuthProvider', () => ({
+  useBasicAuth: jest.fn().mockImplementation(() => ({
+    handleLogin: jest.fn(),
+  })),
+}));
+
+jest.mock('../../hooks/useAlertStore', () => ({
+  useAlertStore: jest.fn().mockImplementation(() => ({
+    alert: null,
+    resetAlert: jest.fn(),
   })),
 }));
 
@@ -53,19 +74,24 @@ jest.mock('../../components/Layout/CarouselLayout/CarouselLayout', () => ({
   CarouselLayout: jest.fn().mockImplementation(({ children }) => children),
 }));
 
+jest.mock('../../components/common/Loader/Loader', () => {
+  return jest.fn().mockReturnValue(<div data-testid="loader">Loading...</div>);
+});
+
 describe('Test SignInPage Component', () => {
   afterEach(() => {
     jest.clearAllMocks();
+    jest.useRealTimers();
   });
 
   afterAll(() => {
     jest.resetAllMocks();
   });
 
-  it('Component should render', async () => {
+  it('Component should render for Basic auth provider', async () => {
     mockuseApplicationStore.mockReturnValue({
       isAuthDisabled: false,
-      authConfig: { provider: 'google' },
+      authConfig: { provider: 'basic' },
       onLoginHandler: jest.fn(),
       onLogoutHandler: jest.fn(),
       getOidcToken: jest.fn(),
@@ -96,7 +122,6 @@ describe('Test SignInPage Component', () => {
     mockuseApplicationStore.mockReturnValue({
       isAuthDisabled: false,
       authConfig: { provider },
-      onLoginHandler: jest.fn(),
       onLogoutHandler: jest.fn(),
       getOidcToken: jest.fn(),
     });
@@ -104,7 +129,6 @@ describe('Test SignInPage Component', () => {
       wrapper: MemoryRouter,
     });
     const isUnknow = provider === 'unknown-provider';
-
     const signinButton = await findByText(
       container,
       isUnknow
@@ -115,10 +139,31 @@ describe('Test SignInPage Component', () => {
     expect(signinButton).toBeInTheDocument();
   });
 
-  it('Sign in button should render correctly with custom provider name', async () => {
+  it('SSO providers should auto-redirect when enableAutoRedirect is true', async () => {
+    const onLoginHandler = jest.fn();
+    mockUseAuthProvider.mockReturnValue({ onLoginHandler });
+
     mockuseApplicationStore.mockReturnValue({
       isAuthDisabled: false,
-      authConfig: { provider: 'custom-oidc', providerName: 'Custom OIDC' },
+      authConfig: { provider: 'google', enableAutoRedirect: true },
+      onLogoutHandler: jest.fn(),
+      getOidcToken: jest.fn(),
+    });
+
+    const { container } = render(<SignInPage />, {
+      wrapper: MemoryRouter,
+    });
+
+    const loader = await findByTestId(container, 'loader');
+    expect(loader).toBeInTheDocument();
+
+    expect(onLoginHandler).toHaveBeenCalled();
+  });
+
+  it('Basic auth provider should show login form', async () => {
+    mockuseApplicationStore.mockReturnValue({
+      isAuthDisabled: false,
+      authConfig: { provider: 'basic' },
       onLoginHandler: jest.fn(),
       onLogoutHandler: jest.fn(),
       getOidcToken: jest.fn(),
@@ -126,15 +171,30 @@ describe('Test SignInPage Component', () => {
     const { container } = render(<SignInPage />, {
       wrapper: MemoryRouter,
     });
-    const signinButton = await findByText(container, /label.sign-in-with-sso/i);
 
-    expect(signinButton).toBeInTheDocument();
+    const emailInput = await findByTestId(container, 'email');
+    expect(emailInput).toBeInTheDocument();
   });
 
-  it('Page should render the correct logo image', async () => {
+  it('Custom OIDC provider should show sign-in button by default', async () => {
     mockuseApplicationStore.mockReturnValue({
       isAuthDisabled: false,
       authConfig: { provider: 'custom-oidc', providerName: 'Custom OIDC' },
+      onLogoutHandler: jest.fn(),
+      getOidcToken: jest.fn(),
+    });
+    const { container } = render(<SignInPage />, {
+      wrapper: MemoryRouter,
+    });
+
+    const signinButton = await findByText(container, /label.sign-in-with-sso/i);
+    expect(signinButton).toBeInTheDocument();
+  });
+
+  it('Page should render the correct logo image for Basic auth', async () => {
+    mockuseApplicationStore.mockReturnValue({
+      isAuthDisabled: false,
+      authConfig: { provider: 'basic' },
       onLoginHandler: jest.fn(),
       onLogoutHandler: jest.fn(),
       getOidcToken: jest.fn(),

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AuthProvider.util.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AuthProvider.util.ts
@@ -85,6 +85,7 @@ export const getAuthConfig = (
     provider,
     providerName,
     enableSelfSignup,
+    enableAutoRedirect,
     samlConfiguration,
     responseType = 'id_token',
     clientType = 'public',
@@ -103,6 +104,7 @@ export const getAuthConfig = (
           provider,
           clientType,
           enableSelfSignup,
+          enableAutoRedirect,
         };
       }
 
@@ -119,6 +121,7 @@ export const getAuthConfig = (
           responseType,
           clientType,
           enableSelfSignup,
+          enableAutoRedirect,
         };
       }
 
@@ -134,6 +137,7 @@ export const getAuthConfig = (
           responseType,
           clientType,
           enableSelfSignup,
+          enableAutoRedirect,
         };
       }
 
@@ -145,6 +149,7 @@ export const getAuthConfig = (
           provider,
           clientType,
           enableSelfSignup,
+          enableAutoRedirect,
         };
       }
 
@@ -160,6 +165,7 @@ export const getAuthConfig = (
           responseType: 'code',
           clientType,
           enableSelfSignup,
+          enableAutoRedirect,
         };
       }
 
@@ -172,6 +178,7 @@ export const getAuthConfig = (
         provider,
         clientType,
         enableSelfSignup,
+        enableAutoRedirect,
       };
 
       break;
@@ -190,6 +197,7 @@ export const getAuthConfig = (
         },
         provider,
         enableSelfSignup,
+        enableAutoRedirect,
         clientType,
       };
 
@@ -210,6 +218,7 @@ export const getAuthConfig = (
           provider,
           clientType,
           enableSelfSignup,
+          enableAutoRedirect,
         } as Configuration;
       }
 


### PR DESCRIPTION
### Describe your changes:

Fixes #24869

This PR adds an opt-in `enableAutoRedirect` flag to automatically redirect from the Sign In page to the configured SSO provider, avoiding briefly rendering the “Sign in with Keycloak” screen.

**What changes did you make?**
- Added `enableAutoRedirect` to authentication configuration (schema + server + UI).
- Updated the Sign In page to render a loader while redirecting / while auth config loads and trigger SSO redirect early to avoid UI flash.
- Updated unit tests for the Sign In page to cover the new behavior.

**Why did you make them?**
- Improve SSO UX, especially in embedded/iframe scenarios, by preventing the intermediate sign-in screen from flashing before redirect.

**How did you test your changes?**
- Updated/added unit tests for SignIn page.
- Manual validation in an SSO setup.

Preview: N/A (behavior change is loader before SSO redirect)

### Type of change:
- [x] Improvement
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
  - No migration needed: additive config schema change with default value; no persisted data affected.