### PR TITLE
chore: realign main migration with 1.11.1 branch

### DIFF
--- a/bootstrap/sql/migrations/native/1.11.1/mysql/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.11.1/mysql/postDataMigrationSQLScript.sql
@@ -1,15 +1,3 @@
-UPDATE test_definition
-SET json = JSON_SET(
-    json,
-    '$.supportedServices',
-    JSON_ARRAY('Snowflake', 'BigQuery', 'Athena', 'Redshift', 'Postgres', 'MySQL', 'Mssql', 'Oracle', 'Trino', 'SapHana')
-)
-WHERE name = 'tableDiff'
-  AND (
-    JSON_EXTRACT(json, '$.supportedServices') IS NULL
-    OR JSON_LENGTH(JSON_EXTRACT(json, '$.supportedServices')) = 0
-  );
-
 UPDATE
     classification
 SET

--- a/bootstrap/sql/migrations/native/1.11.1/postgres/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.11.1/postgres/postDataMigrationSQLScript.sql
@@ -1,15 +1,3 @@
-UPDATE test_definition
-SET json = jsonb_set(
-    json::jsonb,
-    '{supportedServices}',
-    '["Snowflake", "BigQuery", "Athena", "Redshift", "Postgres", "MySQL", "Mssql", "Oracle", "Trino", "SapHana"]'::jsonb
-)
-WHERE name = 'tableDiff'
-  AND (
-    json->'supportedServices' IS NULL
-    OR json->'supportedServices' = '[]'::jsonb
-  );
-
 UPDATE
     classification
 SET

--- a/bootstrap/sql/migrations/native/1.12.0/mysql/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.12.0/mysql/postDataMigrationSQLScript.sql
@@ -1,0 +1,11 @@
+UPDATE test_definition
+SET json = JSON_SET(
+    json,
+    '$.supportedServices',
+    JSON_ARRAY('Snowflake', 'BigQuery', 'Athena', 'Redshift', 'Postgres', 'MySQL', 'Mssql', 'Oracle', 'Trino', 'SapHana')
+)
+WHERE name = 'tableDiff'
+  AND (
+    JSON_EXTRACT(json, '$.supportedServices') IS NULL
+    OR JSON_LENGTH(JSON_EXTRACT(json, '$.supportedServices')) = 0
+  );

--- a/bootstrap/sql/migrations/native/1.12.0/postgres/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.12.0/postgres/postDataMigrationSQLScript.sql
@@ -1,0 +1,11 @@
+UPDATE test_definition
+SET json = jsonb_set(
+    json::jsonb,
+    '{supportedServices}',
+    '["Snowflake", "BigQuery", "Athena", "Redshift", "Postgres", "MySQL", "Mssql", "Oracle", "Trino", "SapHana"]'::jsonb
+)
+WHERE name = 'tableDiff'
+  AND (
+    json->'supportedServices' IS NULL
+    OR json->'supportedServices' = '[]'::jsonb
+  );


### PR DESCRIPTION
- supportService migration for tableDiff were removed on 1.11.1 branch but not cleaned up on the `main` branch. Moving this migration to 1.12.0

---

## Summary by Gitar

- **Migration realignment:**
  - Removed `tableDiff` supportedServices UPDATE from `1.11.1/mysql/postDataMigrationSQLScript.sql` and `1.11.1/postgres/postDataMigrationSQLScript.sql`
  - Created new migration files in `1.12.0/mysql/postDataMigrationSQLScript.sql` and `1.12.0/postgres/postDataMigrationSQLScript.sql`
- **SQL migration content:**
  - Updates `test_definition` table to set `supportedServices` array with 10 database platforms (Snowflake, BigQuery, Athena, Redshift, Postgres, MySQL, Mssql, Oracle, Trino, SapHana)

<sub>This will update automatically on new commits.</sub>

---