### PR TITLE
UI: Increase ingestion test connection timeout to 4 minutes

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/serviceIngestion.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/serviceIngestion.ts
@@ -160,7 +160,7 @@ export const testConnection = async (page: Page) => {
   const warningBadge = page.locator('[data-testid="warning-badge"]');
 
   await expect(successBadge.or(warningBadge)).toBeVisible({
-    timeout: 3.5 * 60 * 1000, // 3 minutes for connection test and 0.5 minute buffer
+    timeout: 4.5 * 60 * 1000, // 4 minutes for connection test and 0.5 minute buffer
   });
 
   await expect(page.getByTestId('messag-text')).toContainText(

--- a/openmetadata-ui/src/main/resources/ui/src/constants/Services.constant.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/Services.constant.ts
@@ -387,10 +387,10 @@ export const STEPS_FOR_EDIT_SERVICE: Array<StepperStepType> = [
 export const SERVICE_DEFAULT_ERROR_MAP = {
   serviceType: false,
 };
-// 3 minutes timeout to wait for test connection status
+// 4 minutes timeout to wait for test connection status
 // Increasing it temporarily while we investigate test connection delays
 // @pmbrull
-export const FETCHING_EXPIRY_TIME = 3 * 60 * 1000;
+export const FETCHING_EXPIRY_TIME = 4 * 60 * 1000;
 export const FETCH_INTERVAL = 2000;
 export const WORKFLOW_COMPLETE_STATUS = [
   WorkflowStatus.Failed,


### PR DESCRIPTION
### Describe your changes:

Increasing the timeout of ingestion test connection to 4 minutes from 3 minutes to validate Redshift ingestion test cases. We saw from the AUT logs that the only reason for this failure is timeout while it's success on the ingestion logs.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
