### PR TITLE
[Redshift] Speed up test connection using `has_table_privilege` for partition details test

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/redshift/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/redshift/connection.py
@@ -78,6 +78,15 @@ def test_connection(
         )
     )
 
+    def test_partition_details(engine_: Engine):
+        """Check if we have the right permissions to get partition details"""
+        with engine_.connect() as conn:
+            res = conn.execute(REDSHIFT_TEST_PARTITION_DETAILS).fetchone()
+            if not all(res):
+                raise SourceConnectionException(
+                    f"We don't have the right permissions to get partition details - {res}"
+                )
+
     def test_get_queries_permissions(engine_: Engine):
         """Check if we have the right permissions to list queries"""
         with engine_.connect() as conn:
@@ -96,9 +105,7 @@ def test_connection(
         "GetDatabases": partial(
             test_query, statement=REDSHIFT_GET_DATABASE_NAMES, engine=engine
         ),
-        "GetPartitionTableDetails": partial(
-            test_query, statement=REDSHIFT_TEST_PARTITION_DETAILS, engine=engine
-        ),
+        "GetPartitionTableDetails": partial(test_partition_details, engine),
     }
 
     result = test_connection_steps(

--- a/ingestion/src/metadata/ingestion/source/database/redshift/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/redshift/queries.py
@@ -238,7 +238,10 @@ SELECT
 """
 
 
-REDSHIFT_TEST_PARTITION_DETAILS = "select * from SVV_TABLE_INFO limit 1"
+REDSHIFT_TEST_PARTITION_DETAILS = """
+SELECT
+    has_table_privilege('SVV_TABLE_INFO', 'SELECT') as can_access_svv_table_info
+"""
 
 REDSHIFT_GET_ALL_CONSTRAINTS = """
 select 


### PR DESCRIPTION
### Describe your changes:

This will speedup the test connection significantly since `SELECT` takes a good amount time while `has_table_privilege` takes a lot less, also fits to our use-case perfectly.
- It will also fix the concern of high delays on test connection noticed in the AUT runs.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
