### PR TITLE
MINOR - Compute Row Level Component

### DIFF
--- a/openmetadata-spec/src/main/resources/json/schema/metadataIngestion/dbtPipeline.json
+++ b/openmetadata-spec/src/main/resources/json/schema/metadataIngestion/dbtPipeline.json
@@ -69,6 +69,12 @@
       "type": "boolean",
       "default": true
     },
+    "overrideLineage":{
+      "title": "Override Lineage",
+      "description": "Set the 'Override Lineage' toggle to control whether to override the existing lineage.",
+      "type": "boolean",
+      "default": false
+    },
     "dbtClassificationName": {
       "title": "DBT Classification Name",
       "description": "Custom OpenMetadata Classification name for dbt tags.",

--- a/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/dbtPipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/dbtPipeline.ts
@@ -39,6 +39,10 @@ export interface DbtPipeline {
      */
     includeTags?: boolean;
     /**
+     * Set the 'Override Lineage' toggle to control whether to override the existing lineage.
+     */
+    overrideLineage?: boolean;
+    /**
      * Configuration to set the timeout for parsing the query in seconds.
      */
     parsingTimeoutLimit?: number;


### PR DESCRIPTION
### Describe your changes:
Fix compute row level component. Added the logic from the UI to present the separation of concern between presentation and retrieval layer.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

Bug fix
- [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

---

## Summary by Gitar

- **Fixed visibility bug:**
  - Compute row count section now only displays when `testDefinition.supportsRowLevelPassedFailed` is `true`
- **New API integration:**
  - Added `getTestDefinitionById` call in `useEffect` to fetch test definition metadata
- **Test coverage:**
  - Added 3 test cases verifying conditional rendering logic for row-level pass/fail support

<sub>This will update automatically on new commits.</sub>

---
