### PR TITLE
fix: malformed URL generation in QueryBuilder when navigating to explore page

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Form/JSONSchema/JsonSchemaWidgets/QueryBuilderWidget/QueryBuilderWidget.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Form/JSONSchema/JsonSchemaWidgets/QueryBuilderWidget/QueryBuilderWidget.tsx
@@ -48,6 +48,7 @@ import {
 import { elasticSearchFormat } from '../../../../../../utils/QueryBuilderElasticsearchFormatUtils';
 import {
   addEntityTypeFilter,
+  buildExploreUrlParams,
   getEntityTypeAggregationFilter,
   getJsonTreeFromQueryFilter,
   migrateJsonLogic,
@@ -100,13 +101,9 @@ const QueryBuilderWidget: FC<
         config
       ).fixedTree;
 
-      const queryFilterString: Record<string, unknown> = {
-        ...(!isEmpty(tree) && { queryFilter: JSON.stringify(tree) }),
-        ...(!isEmpty(qFilter) &&
-          qFilter.query && { quickFilter: JSON.stringify(qFilter) }),
-      };
+      const extraParameters = buildExploreUrlParams(tree, qFilter);
 
-      setQueryURL(getExplorePath({ extraParameters: queryFilterString }));
+      setQueryURL(getExplorePath({ extraParameters }));
 
       try {
         setIsCountLoading(true);

--- a/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderUtils.test.ts
@@ -18,6 +18,7 @@ import {
 } from '../pages/ExplorePage/ExplorePage.interface';
 import {
   addEntityTypeFilter,
+  buildExploreUrlParams,
   getEntityTypeAggregationFilter,
   getJsonTreeFromQueryFilter,
   jsonLogicToElasticsearch,
@@ -441,5 +442,109 @@ describe('jsonLogicToElasticsearch', () => {
         ],
       },
     });
+  });
+});
+
+describe('buildExploreUrlParams', () => {
+  const mockTree = { id: 'root', type: 'group', children1: {} };
+  const mockQFilter: QueryFilterInterface = {
+    query: {
+      bool: {
+        must: [{ term: { 'owner.displayName.keyword': 'admin' } }],
+      },
+    },
+  };
+
+  it('should return empty object when both tree and qFilter are empty', () => {
+    const result = buildExploreUrlParams({}, undefined);
+
+    expect(result).toEqual({});
+  });
+
+  it('should return only queryFilter when tree is provided but qFilter is empty', () => {
+    const result = buildExploreUrlParams(mockTree, undefined);
+
+    expect(result).toEqual({
+      queryFilter: JSON.stringify(mockTree),
+    });
+    expect(result.quickFilter).toBeUndefined();
+  });
+
+  it('should return only quickFilter when qFilter has query but tree is empty', () => {
+    const result = buildExploreUrlParams({}, mockQFilter);
+
+    expect(result).toEqual({
+      quickFilter: JSON.stringify(mockQFilter),
+    });
+    expect(result.queryFilter).toBeUndefined();
+  });
+
+  it('should return both queryFilter and quickFilter when both are provided', () => {
+    const result = buildExploreUrlParams(mockTree, mockQFilter);
+
+    expect(result).toEqual({
+      queryFilter: JSON.stringify(mockTree),
+      quickFilter: JSON.stringify(mockQFilter),
+    });
+  });
+
+  it('should not include quickFilter when qFilter exists but has no query property', () => {
+    const qFilterWithoutQuery = {
+      someOtherProp: 'value',
+    } as unknown as QueryFilterInterface;
+    const result = buildExploreUrlParams(mockTree, qFilterWithoutQuery);
+
+    expect(result).toEqual({
+      queryFilter: JSON.stringify(mockTree),
+    });
+    expect(result.quickFilter).toBeUndefined();
+  });
+
+  it('should handle null tree gracefully', () => {
+    const result = buildExploreUrlParams(null, mockQFilter);
+
+    expect(result).toEqual({
+      quickFilter: JSON.stringify(mockQFilter),
+    });
+  });
+
+  it('should return valid JSON strings', () => {
+    const result = buildExploreUrlParams(mockTree, mockQFilter);
+
+    expect(() => JSON.parse(result.queryFilter!)).not.toThrow();
+    expect(() => JSON.parse(result.quickFilter!)).not.toThrow();
+  });
+
+  it('should produce params that can be URL encoded with proper separators', () => {
+    const result = buildExploreUrlParams(mockTree, mockQFilter);
+
+    const allParams = { mode: 'edit', ...result };
+    const queryString = new URLSearchParams(allParams).toString();
+
+    expect(queryString).toContain('mode=edit');
+    expect(queryString).toContain('&');
+    expect(queryString).toContain('queryFilter=');
+    expect(queryString).toContain('quickFilter=');
+
+    const decoded = new URLSearchParams(queryString);
+
+    expect(decoded.get('mode')).toBe('edit');
+    expect(JSON.parse(decoded.get('queryFilter')!)).toEqual(mockTree);
+    expect(JSON.parse(decoded.get('quickFilter')!)).toEqual(mockQFilter);
+  });
+
+  it('should work correctly when only queryFilter is present with other params', () => {
+    const result = buildExploreUrlParams(mockTree, undefined);
+
+    const allParams = { mode: 'view', ...result };
+    const queryString = new URLSearchParams(allParams).toString();
+
+    expect(queryString).toContain('mode=view');
+    expect(queryString).toContain('queryFilter=');
+    expect(queryString).not.toContain('quickFilter=');
+
+    const ampersandCount = (queryString.match(/&/g) || []).length;
+
+    expect(ampersandCount).toBe(1);
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderUtils.tsx
@@ -19,7 +19,7 @@ import {
   RenderSettings,
 } from '@react-awesome-query-builder/antd';
 import { Button } from 'antd';
-import { isBoolean, isUndefined } from 'lodash';
+import { isBoolean, isEmpty, isUndefined } from 'lodash';
 import { EntityReferenceFields } from '../enums/AdvancedSearch.enum';
 import { EntityType } from '../enums/entity.enum';
 import {
@@ -935,3 +935,12 @@ export const getFieldsByKeys = (
 
   return filteredFields;
 };
+
+export const buildExploreUrlParams = (
+  tree: unknown,
+  qFilter?: QueryFilterInterface
+): Record<string, string> => ({
+  ...(!isEmpty(tree) && { queryFilter: JSON.stringify(tree) }),
+  ...(!isEmpty(qFilter) &&
+    qFilter?.query && { quickFilter: JSON.stringify(qFilter) }),
+});


### PR DESCRIPTION
When navigating from the workflow asset filter to the Explore page, the generated URL was malformed, resulting in URLs like:
`/explore/?mode=editqueryFilter=%7B"type"%3A"group"...`
Instead of the expected format:
`/explore?mode=edit&queryFilter=...`

This caused:
- Filters are not being applied correctly on the Explore page
- Dropdowns not displaying selected values
- URL parsing errors

### Fix:
Refactored the URL generation; now all query parameters are properly formatted with `&` separators, and used the same URL generation pattern as other parts of the application

https://github.com/user-attachments/assets/9c3eb580-b88f-4adb-86ad-c2d93a4b5ea5

https://github.com/user-attachments/assets/f02dbd67-bb0c-4268-aa1e-f06bb85b0b13



### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Documentation

Testing
[x] Verified that navigating from the workflow page to the Explore page generates the correct URL format
[x] Confirmed filters are properly applied on the Explore page

### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
