### PR TITLE
fix: Fixed the classification form drawer loader

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/TagsPage/ClassificationFormDrawer.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TagsPage/ClassificationFormDrawer.test.tsx
@@ -98,12 +98,12 @@ describe('ClassificationFormDrawer', () => {
     expect(saveButton).toBeDisabled();
   });
 
-  it('should show "Saving" text when isLoading is true', () => {
+  it('should keep "Save" text visible when isLoading is true', () => {
     render(<ClassificationFormDrawer {...defaultProps} isLoading />);
 
     const saveButton = screen.getByTestId('save-button');
 
-    expect(saveButton).toHaveTextContent('label.saving');
+    expect(saveButton).toHaveTextContent('label.save');
   });
 
   it('should show "Save" text when isLoading is false', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TagsPage/ClassificationFormDrawer.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TagsPage/ClassificationFormDrawer.tsx
@@ -11,7 +11,14 @@
  *  limitations under the License.
  */
 
-import { Box, Button, Drawer, IconButton, Typography } from '@mui/material';
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Drawer,
+  IconButton,
+  Typography,
+} from '@mui/material';
 import { XClose } from '@untitledui/icons';
 import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -97,9 +104,11 @@ const ClassificationFormDrawer: FC<ClassificationFormDrawerProps> = ({
         <Button
           data-testid="save-button"
           disabled={isLoading}
+          loading={isLoading}
+          loadingIndicator={<CircularProgress color="inherit" size={18} />}
           variant="contained"
           onClick={() => formRef.submit()}>
-          {isLoading ? t('label.saving') : t('label.save')}
+          {t('label.save')}
         </Button>
       </Box>
     </Drawer>


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

---

## Summary by Gitar

- **UI improvement:**
  - Replaced text-based loading state with MUI `CircularProgress` spinner in `ClassificationFormDrawer.tsx` save button
- **Loading indicator enhancement:**
  - Button now shows consistent "Save" text with visual spinner instead of toggling to "Saving"
- **Test updates:**
  - Updated `ClassificationFormDrawer.test.tsx` to expect "label.save" instead of "label.saving"

<sub>This will update automatically on new commits.</sub>

---