### PR TITLE
fix(ui): use inline fixtures for Users.spec.ts to support dynamic user testing

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Users.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Users.spec.ts
@@ -116,6 +116,9 @@ const test = base.extend<{
   },
 });
 
+// Configure all tests in this file to run serially to avoid shared state conflicts
+test.describe.configure({ mode: 'serial' });
+
 const entities = [
   EntityDataClass.table1,
   EntityDataClass.topic1,
@@ -611,7 +614,7 @@ test.describe('User Profile Dropdown Persona Interactions', () => {
           value: {
             id: persona1.responseData.id,
             name: persona1.responseData.name,
-            displayName: persona1.responseData.displayName,
+            displayName: persona1.data.displayName,
             fullyQualifiedName: persona1.responseData.fullyQualifiedName,
             type: 'persona',
           },
@@ -620,6 +623,10 @@ test.describe('User Profile Dropdown Persona Interactions', () => {
     });
 
     await afterAction();
+  });
+
+  test.beforeEach(async ({ adminPage }) => {
+    await redirectToHomePage(adminPage);
   });
 
   test('Should display persona dropdown with pagination', async ({
@@ -763,7 +770,7 @@ test.describe('User Profile Dropdown Persona Interactions', () => {
         .allTextContents();
 
       // Verify first one contains the default persona name
-      expect(personaTexts[0]).toContain(persona1.responseData.displayName);
+      expect(personaTexts[0]).toContain(persona1.data.displayName);
     }
   });
 
@@ -935,7 +942,7 @@ test.describe('User Profile Dropdown Persona Interactions', () => {
       .locator('.ant-typography')
       .textContent();
 
-    expect(newDefaultPersonaText).toContain(persona2.responseData.displayName);
+    expect(newDefaultPersonaText).toContain(persona2.data.displayName);
     expect(newDefaultPersonaText).not.toBe(originalDefaultPersonaText);
 
     await expect(
@@ -1153,7 +1160,7 @@ test.describe('User Profile Persona Interactions', () => {
 
       // Select specific persona for default - try test ID first, fallback to role selector
       const defaultPersonaOptionTestId = adminPage.getByTitle(
-        persona1.responseData.displayName
+        persona1.data.displayName
       );
 
       await defaultPersonaOptionTestId.click();
@@ -1170,7 +1177,7 @@ test.describe('User Profile Persona Interactions', () => {
       // Check that success notification appears with correct message
       await toastNotification(
         adminPage,
-        `Your Default Persona changed to ${persona1.responseData.displayName}`
+        `Your Default Persona changed to ${persona1.data.displayName}`
       );
 
       await adminPage.waitForSelector(


### PR DESCRIPTION
### Describe your changes:

This PR updates `Users.spec.ts` to use inline fixture definitions instead of shared fixtures, enabling proper testing with dynamically created users that have specific roles and permissions.

**Problem**
Tests were failing with "Target page, context or browser has been closed" errors because:
- **User mismatch**: Shared fixtures authenticate with pre-created users from `auth.setup.ts`, but these tests create and manage their own users (`adminUser`, `dataConsumerUser`, `dataStewardUser`) in the `beforeAll` hook
- **Permission conflicts**: Fixture users and test users have different IDs and permissions
- **Authentication mismatch**: Tests expected pages authenticated as the dynamically created users, not the stored auth users

**Changes:**
- Import test fixtures from `@playwright/test` for custom extension
- Define inline fixtures for `adminPage`, `dataConsumerPage`, and `dataStewardPage` that authenticate with dynamically created test users
- Update persona tests to use `performUserLogin(browser, adminUser)` and `adminUser.patch()` for consistent user management
- Configure persona creation to associate with `adminUser.responseData.id` (the dynamically created admin user)
- Simplify persona test setup by removing unnecessary cleanup and sequential execution constraints

<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

---

## Summary by Gitar

- **Test isolation enhancement:**
  - Added `test.describe.configure({ mode: 'serial' })` to prevent race conditions from parallel test execution
- **Fixed data structure references:**
  - Corrected 5 instances of `persona.responseData.displayName` to `persona.data.displayName`
- **Test setup improvement:**
  - Added `beforeEach` hook to navigate to home page before persona dropdown tests

<sub>This will update automatically on new commits.</sub>

---