### PR TITLE
Fix locator for tree-select spec

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/domain.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/domain.ts
@@ -663,16 +663,10 @@ export const createDataProductFromListPage = async (
   await fillCommonFormItems(page, dataProduct);
 
   // Fill domain field (required when creating from list page)
-  const domainInput = getByRole('combobox', { name: 'Select domain' })
+  const domainInput = page.getByRole('combobox', { name: 'Select domain' });
   await domainInput.scrollIntoViewIfNeeded();
-  await domainInput.waitFor({ state: 'visible' });
-  await domainInput.click();
 
-  const searchDomain = page.waitForResponse(
-    `/api/v1/search/query?q=*index=domain_search_index*`
-  );
   await domainInput.fill(domain.displayName);
-  await searchDomain;
 
   const domainOption = page.getByText(domain.displayName);
   await domainOption.waitFor({ state: 'visible', timeout: 5000 });


### PR DESCRIPTION
Fix locator for tree-select spec

---

## Summary by Gitar

- **Test selector update:**
  - Changed from `data-testid="domain-select"` to `page.getByRole('combobox', { name: 'Select domain' })` for better accessibility testing
- **Simplified test interactions:**
  - Removed explicit `waitFor`, `click`, and API response waiting, relying on Playwright's auto-waiting
- **Bug fix:**
  - Corrected missing `page` context in original `getByRole` call

<sub>This will update automatically on new commits.</sub>

---