### PR TITLE
Add smoothness in lineage

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityLineage/CustomNode.utils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityLineage/CustomNode.utils.tsx
@@ -14,7 +14,7 @@ import { Dataflow01, Plus } from '@untitledui/icons';
 import { Button, Col, Row, Skeleton, Typography } from 'antd';
 import classNames from 'classnames';
 import { Fragment, useCallback, useState } from 'react';
-import { Handle, HandleProps, HandleType, Position } from 'reactflow';
+import { Handle, HandleProps, HandleType, Node, Position } from 'reactflow';
 import { ReactComponent as MinusIcon } from '../../../assets/svg/control-minus.svg';
 import { useLineageProvider } from '../../../context/LineageProvider/LineageProvider';
 import { EntityLineageNodeType } from '../../../enums/entity.enum';
@@ -315,3 +315,14 @@ export function getNodeClassNames({
     }
   );
 }
+
+export const getCentroidPositionOfNodes = (nodes: Node[]) => {
+  return {
+    x:
+      nodes.reduce((sum, node) => sum + (node.position?.x ?? 0), 0) /
+      nodes.length,
+    y:
+      nodes.reduce((sum, node) => sum + (node.position?.y ?? 0), 0) /
+      nodes.length,
+  };
+};

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityLineage/CustomNodeV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityLineage/CustomNodeV1.component.tsx
@@ -17,9 +17,11 @@ import { useLineageProvider } from '../../../context/LineageProvider/LineageProv
 import { EntityLineageNodeType } from '../../../enums/entity.enum';
 import { LineageDirection } from '../../../generated/api/lineage/lineageDirection';
 import { LineageLayer } from '../../../generated/configuration/lineageSettings';
+import { focusToCoordinates } from '../../../utils/EntityLineageUtils';
 import LineageNodeRemoveButton from '../../Lineage/LineageNodeRemoveButton';
 import './custom-node.less';
 import {
+  getCentroidPositionOfNodes,
   getCollapseHandle,
   getExpandHandle,
   getNodeClassNames,
@@ -154,6 +156,10 @@ const CustomNodeV1 = (props: NodeProps) => {
     loadChildNodesHandler,
     activeLayer,
     dataQualityLineage,
+    nodes,
+    newlyLoadedNodeIds,
+    reactFlowInstance,
+    zoomValue,
   } = useLineageProvider();
 
   const {
@@ -170,12 +176,12 @@ const CustomNodeV1 = (props: NodeProps) => {
   const nodeType = isEditMode ? EntityLineageNodeType.DEFAULT : type;
   const isSelected = selectedNode === node;
   const {
-    id,
     fullyQualifiedName,
     upstreamLineage = [],
     upstreamExpandPerformed = false,
     downstreamExpandPerformed = false,
   } = node;
+  const { id } = props;
   const [isTraced, setIsTraced] = useState(false);
 
   const showDqTracing = useMemo(
@@ -201,6 +207,8 @@ const CustomNodeV1 = (props: NodeProps) => {
     setIsOnlyShowColumnsWithLineageFilterActive,
   ] = useState(false);
 
+  const [isNodeExpanded, setIsNodeExpanded] = useState(false);
+
   const toggleOnlyShowColumnsWithLineageFilterActive = useCallback(() => {
     setIsOnlyShowColumnsWithLineageFilterActive((prev) => !prev);
   }, []);
@@ -215,6 +223,33 @@ const CustomNodeV1 = (props: NodeProps) => {
     );
   }, [isColumnLayerEnabled, isEditMode]);
 
+  useEffect(() => {
+    const newlyLoadedNodes = nodes.filter((node) =>
+      newlyLoadedNodeIds.includes(node.id)
+    );
+
+    if (!isNodeExpanded || newlyLoadedNodes.length === 0) {
+      return;
+    }
+
+    /**
+     * When a node expands one level, new nodes load at the same vertical
+     * position—they share the same x-coordinate but have different y-coordinates.
+     * We can focus on the midpoint of all coordinates, which is the centroid.
+     *
+     * Though for a single level, x-coordinates are identical for all points,
+     * but finding their center helps when users click expand-all.
+     * In that case, nodes open to multiple levels.
+     */
+    const newPositionToFocus =
+      newlyLoadedNodes.length > 0
+        ? getCentroidPositionOfNodes(newlyLoadedNodes)
+        : { x: 0, y: 0 };
+
+    focusToCoordinates(newPositionToFocus, reactFlowInstance, zoomValue);
+    setIsNodeExpanded(false);
+  }, [nodes, newlyLoadedNodeIds, isNodeExpanded, reactFlowInstance, zoomValue]);
+
   const containerClass = getNodeClassNames({
     isSelected,
     showDqTracing: showDqTracing ?? false,
@@ -225,7 +260,9 @@ const CustomNodeV1 = (props: NodeProps) => {
 
   const onExpand = useCallback(
     (direction: LineageDirection, depth = 1) => {
-      loadChildNodesHandler(node, direction, depth);
+      loadChildNodesHandler(node, direction, depth).then(() =>
+        setIsNodeExpanded(true)
+      );
     },
     [loadChildNodesHandler, node]
   );
@@ -233,8 +270,13 @@ const CustomNodeV1 = (props: NodeProps) => {
   const onCollapse = useCallback(
     (direction = LineageDirection.Downstream) => {
       onNodeCollapse(props, direction);
+      focusToCoordinates(
+        { x: props.xPos, y: props.yPos },
+        reactFlowInstance,
+        zoomValue
+      );
     },
-    [onNodeCollapse, props]
+    [onNodeCollapse, props, reactFlowInstance, zoomValue]
   );
 
   const nodeLabel = useMemo(() => {
@@ -268,12 +310,15 @@ const CustomNodeV1 = (props: NodeProps) => {
     isEditMode,
     isRootNode,
     isChildrenListExpanded,
+    isOnlyShowColumnsWithLineageFilterActive,
+    node,
     toggleColumnsList,
     toggleOnlyShowColumnsWithLineageFilterActive,
+    isSelected,
+    isEditMode,
+    isRootNode,
     removeNodeHandler,
     props,
-    isOnlyShowColumnsWithLineageFilterActive,
-    isEditMode,
   ]);
 
   const expandCollapseProps = useMemo<ExpandCollapseHandlesProps>(

--- a/openmetadata-ui/src/main/resources/ui/src/context/LineageProvider/LineageProvider.interface.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/context/LineageProvider/LineageProvider.interface.tsx
@@ -122,4 +122,5 @@ export interface LineageContextType {
   useUpdateNodeInternals: () => UpdateNodeInternals;
   columnsInCurrentPages: Record<string, string[]>;
   setColumnsInCurrentPages: Dispatch<SetStateAction<Record<string, string[]>>>;
+  newlyLoadedNodeIds: string[];
 }

--- a/openmetadata-ui/src/main/resources/ui/src/context/LineageProvider/LineageProvider.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/context/LineageProvider/LineageProvider.test.tsx
@@ -50,6 +50,7 @@ const DummyChildrenComponent = () => {
     onColumnClick,
     updateEntityData,
     onLineageEditClick,
+    newlyLoadedNodeIds,
   } = useLineageProvider();
 
   const nodeData = {
@@ -113,6 +114,9 @@ const DummyChildrenComponent = () => {
       <button data-testid="editLineage" onClick={onLineageEditClick}>
         Edit Lineage
       </button>
+      <div data-testid="newly-loaded-node-ids">
+        {newlyLoadedNodeIds.join(',')}
+      </div>
     </div>
   );
 };
@@ -441,5 +445,59 @@ describe('LineageProvider', () => {
     fireEvent.click(columnClick);
 
     expect(edgeDrawer).not.toBeInTheDocument();
+  });
+
+  it('should populate newlyLoadedNodeIds when loading child nodes', async () => {
+    (getLineageDataByFQN as jest.Mock)
+      .mockResolvedValueOnce({
+        nodes: [],
+        edges: [],
+      })
+      .mockResolvedValueOnce({
+        nodes: {
+          'new-node-1': {
+            entity: {
+              id: 'new-node-1',
+              fullyQualifiedName: 'new-node-1',
+              type: 'table',
+            },
+          },
+          'new-node-2': {
+            entity: {
+              id: 'new-node-2',
+              fullyQualifiedName: 'new-node-2',
+              type: 'table',
+            },
+          },
+          'load-more': {
+            entity: {
+              id: 'load-more-node',
+              fullyQualifiedName: 'load-more',
+              type: 'load-more',
+            },
+          },
+        },
+        edges: [],
+        downstreamEdges: {},
+        upstreamEdges: {},
+      });
+
+    render(
+      <LineageProvider>
+        <DummyChildrenComponent />
+      </LineageProvider>
+    );
+
+    const loadButton = screen.getByTestId('load-nodes');
+    const newlyLoadedDisplay = screen.getByTestId('newly-loaded-node-ids');
+
+    expect(newlyLoadedDisplay.textContent).toBe('');
+
+    fireEvent.click(loadButton);
+
+    await screen.findByText('new-node-1,new-node-2');
+
+    expect(newlyLoadedDisplay.textContent).toBe('new-node-1,new-node-2');
+    expect(newlyLoadedDisplay.textContent).not.toContain('load-more-node');
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/context/LineageProvider/LineageProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/context/LineageProvider/LineageProvider.tsx
@@ -235,6 +235,7 @@ const LineageProvider = ({ children }: LineageProviderProps) => {
   const [columnsInCurrentPages, setColumnsInCurrentPages] = useState<
     Record<string, string[]>
   >({});
+  const [newlyLoadedNodeIds, setNewlyLoadedNodeIds] = useState<string[]>([]);
 
   // Add state for entityFqn that can be updated independently of URL params
   const [entityFqn, setEntityFqn] = useState<string>(decodedFqn);
@@ -610,6 +611,7 @@ const LineageProvider = ({ children }: LineageProviderProps) => {
         );
 
         const uniqueNodes = [...(entityLineage.nodes ?? [])];
+        const loadedNodeIds: string[] = [];
         for (const nNode of newNodes ?? []) {
           if (
             !uniqueNodes.some(
@@ -617,6 +619,9 @@ const LineageProvider = ({ children }: LineageProviderProps) => {
             )
           ) {
             uniqueNodes.push(nNode);
+            if (nNode.type !== EntityLineageNodeType.LOAD_MORE) {
+              loadedNodeIds.push(nNode.id);
+            }
           }
         }
 
@@ -668,6 +673,8 @@ const LineageProvider = ({ children }: LineageProviderProps) => {
             upstreamEdges: concatenatedLineageData.upstreamEdges,
           };
         });
+
+        setNewlyLoadedNodeIds(loadedNodeIds);
       } catch (err) {
         showErrorToast(
           err as AxiosError,
@@ -960,8 +967,6 @@ const LineageProvider = ({ children }: LineageProviderProps) => {
           nodes: updatedNodes,
         };
       });
-
-      setNewAddedNode({} as Node);
 
       setColumnsInCurrentPages((prev) => {
         const updated = { ...prev };
@@ -1883,6 +1888,7 @@ const LineageProvider = ({ children }: LineageProviderProps) => {
       useUpdateNodeInternals,
       columnsInCurrentPages,
       setColumnsInCurrentPages,
+      newlyLoadedNodeIds,
     };
   }, [
     dataQualityLineage,
@@ -1945,6 +1951,7 @@ const LineageProvider = ({ children }: LineageProviderProps) => {
     useUpdateNodeInternals,
     columnsInCurrentPages,
     setColumnsInCurrentPages,
+    newlyLoadedNodeIds,
   ]);
 
   useEffect(() => {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageUtils.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageUtils.test.tsx
@@ -11,12 +11,16 @@
  *  limitations under the License.
  */
 
-import { Edge, Node } from 'reactflow';
+import { Edge, Node, ReactFlowInstance } from 'reactflow';
 import {
   EdgeDetails,
   LineageData,
 } from '../components/Lineage/Lineage.interface';
 import { SourceType } from '../components/SearchedData/SearchedData.interface';
+import {
+  ZOOM_TRANSITION_DURATION,
+  ZOOM_VALUE,
+} from '../constants/Lineage.constants';
 import { EntityType } from '../enums/entity.enum';
 import { AddLineage, ColumnLineage } from '../generated/api/lineage/addLineage';
 import { LineageDirection } from '../generated/api/lineage/lineageDirection';
@@ -25,6 +29,7 @@ import { addLineage } from '../rest/miscAPI';
 import {
   addLineageHandler,
   createNewEdge,
+  focusToCoordinates,
   getAllTracedEdges,
   getColumnFunctionValue,
   getColumnLineageData,
@@ -909,6 +914,27 @@ describe('Test EntityLineageUtils utility', () => {
         yMin: -220, // y - padding
         xMax: 160, // rightmost x (100) + width (40) + padding
         yMax: 240, // bottom y (200) + height (20) + padding
+      });
+    });
+  });
+
+  describe('focusToCoordinates', () => {
+    let mockReactFlowInstance: ReactFlowInstance;
+
+    beforeEach(() => {
+      mockReactFlowInstance = {
+        setCenter: jest.fn(),
+      } as unknown as ReactFlowInstance;
+    });
+
+    it('should call setCenter with correct coordinates and default zoom', () => {
+      const position = { x: 100, y: 200 };
+
+      focusToCoordinates(position, mockReactFlowInstance);
+
+      expect(mockReactFlowInstance.setCenter).toHaveBeenCalledWith(100, 245, {
+        zoom: ZOOM_VALUE,
+        duration: ZOOM_TRANSITION_DURATION,
       });
     });
   });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageUtils.tsx
@@ -160,6 +160,17 @@ export const centerNodePosition = (
   );
 };
 
+export const focusToCoordinates = (
+  position: { x: number; y: number },
+  reactFlowInstance?: ReactFlowInstance,
+  zoomValue?: number
+) => {
+  reactFlowInstance?.setCenter(position.x, position.y + NODE_HEIGHT / 2, {
+    zoom: zoomValue ?? ZOOM_VALUE,
+    duration: ZOOM_TRANSITION_DURATION,
+  });
+};
+
 export const onNodeMouseEnter = (_event: ReactMouseEvent, _node: Node) => {
   return;
 };
@@ -243,10 +254,11 @@ export const getLayoutedElements = (
 const layoutOptions = {
   'elk.algorithm': 'layered',
   'elk.direction': 'RIGHT',
-  'elk.spacing.nodeNode': 100,
-  'elk.layered.spacing.nodeNodeBetweenLayers': 50,
+  'elk.spacing.nodeNode': '100',
+  'elk.layered.spacing.nodeNodeBetweenLayers': '50',
   'elk.layered.nodePlacement.strategy': 'SIMPLE',
   'elk.partitioning.activate': 'true',
+  'elk.layered.considerModelOrder.strategy': 'NODES_AND_EDGES',
 };
 
 const elk = new ELK();
@@ -267,6 +279,14 @@ export const getELKLayoutedElements = async (
     const nodeHeight = isExpanded ? childrenHeight + 220 : NODE_HEIGHT;
     const nodeDepth = node.data?.nodeDepth;
 
+    let partition = '0';
+
+    if (node.data.isDownstreamNode) {
+      partition = '2';
+    } else if (node.data.isUpstreamNode) {
+      partition = '1';
+    }
+
     return {
       ...node,
       targetPosition: 'left',
@@ -275,7 +295,7 @@ export const getELKLayoutedElements = async (
       height: nodeHeight,
       ...(nodeDepth !== undefined && {
         layoutOptions: {
-          'elk.partitioning.partition': String(nodeDepth),
+          'elk.partitioning.partition': partition,
         },
       }),
     };


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

---

## Summary by Gitar

- **Viewport auto-focus:**
  - Added smooth viewport transition to newly expanded lineage nodes using `focusToCoordinates` in `EntityLineageUtils.tsx`
  - Implemented centroid calculation via `getCentroidPositionOfNodes` to center viewport on multiple new nodes
- **State tracking:**
  - Added `newlyLoadedNodeIds` to `LineageProvider` context to track freshly loaded nodes (excludes load-more placeholders)
- **Node expansion behavior:**
  - Modified `CustomNodeV1` to trigger viewport focus after expand/collapse operations with proper async handling
- **ELK layout improvements:**
  - Updated graph layout configuration with `considerModelOrder` strategy and string-based spacing values
  - Changed partition logic to separate upstream/downstream nodes (partition 1 and 2)
- **Test coverage:**
  - Added unit tests for focus behavior, centroid calculations, and state management with mock ReactFlow instances

<sub>This will update automatically on new commits.</sub>

---