### PR TITLE
Fixes #24555: Include entityUrl in webhook payloads

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/notifications/template/handlebars/helpers/BuildEntityUrlHelper.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/notifications/template/handlebars/helpers/BuildEntityUrlHelper.java
@@ -133,7 +133,7 @@ public class BuildEntityUrlHelper implements HandlebarsHelper {
    * Builds the entity URL following the same logic as MessageDecorator.buildEntityUrl()
    * Handles special cases for different entity types.
    */
-  private String buildEntityUrl(String entityType, String fqn, Map<String, Object> entityMap) {
+  public String buildEntityUrl(String entityType, String fqn, Map<String, Object> entityMap) {
     String baseUrl = EmailUtil.getOMBaseURL();
     if (nullOrEmpty(baseUrl)) {
       LOG.warn("Base URL is null or empty, cannot build entity URL");


### PR DESCRIPTION
Fixes #24555

I implemented the `entityUrl` field in webhook payloads sent by `GenericPublisher` to provide direct links to entities in the OpenMetadata UI. This eliminates the need for webhook consumers to construct URLs themselves while ensuring consistency with OpenMetadata's official UI routing patterns.

## What changed
1. Made `BuildEntityUrlHelper.buildEntityUrl()` method public to enable reuse outside the Handlebars context
2. Added `enrichWebhookPayload()` method to `GenericPublisher` to support scalable payload enrichment for future enhancements
3. Added `generateEntityUrl()` helper method to handle URL generation with graceful error handling

## Why
- Simplifies webhook consumers by providing pre-computed entity URLs
- Ensures consistent URL generation across all entity types
- Future URL changes in the UI automatically propagate to webhook payloads
- Maintains backward compatibility with existing webhook integrations

---

## Type of change
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

---

## Checklist
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

### New feature
- [x] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
