### PR TITLE
Add check to skip self-referencing lineage for Fivetran source

### DIFF
--- a/ingestion/src/metadata/ingestion/source/pipeline/fivetran/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/fivetran/metadata.py
@@ -253,6 +253,15 @@ class FivetranSource(PipelineServiceSource):
                     )
                     continue
 
+                # Prevent self-lineage loops (table -> same table)
+                if from_entity.id == to_entity.id:
+                    logger.debug(
+                        f"Lineage skipped for pipeline [{pipeline_name}]"
+                        f" - source and destination are the same table [{from_fqn}]."
+                        f" Self-referencing lineage is not allowed."
+                    )
+                    continue
+
                 col_lineage_arr = self.fetch_column_lineage(
                     pipeline_details=pipeline_details,
                     schema_name=schema_name,


### PR DESCRIPTION
This pull request introduces a safeguard to prevent the creation of self-referencing lineage entries in Fivetran pipeline metadata ingestion. It ensures that if a pipeline's source and destination tables are the same (i.e., a table points to itself), no lineage is created for that relationship. A corresponding unit test is also added to verify this behavior.

**Lineage logic improvements:**

* Added a check in `yield_pipeline_lineage_details` (in `metadata.py`) to skip lineage creation when the source and destination tables have the same entity ID, preventing self-referencing lineage loops.

**Testing enhancements:**

* Added a unit test `test_yield_lineage_skips_self_referencing_tables` to `test_fivetran.py` that mocks a scenario where the source and destination tables are the same, and asserts that no lineage is produced for such cases.

---

## Summary by Gitar

- **Fivetran self-referencing lineage prevention:**
  - Entity ID comparison in `yield_pipeline_lineage_details` prevents lineage creation when source and destination tables are identical
  - Debug logging added to track skipped self-referencing lineage entries

<sub>This will update automatically on new commits.</sub>