### PR TITLE
Feat: Add dataflow metadata in powerbi

### DIFF
--- a/ingestion/src/metadata/ingestion/source/dashboard/powerbi/client.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/powerbi/client.py
@@ -30,6 +30,7 @@ from metadata.ingestion.ometa.client import REST, ClientConfig
 from metadata.ingestion.source.dashboard.powerbi.file_client import PowerBiFileClient
 from metadata.ingestion.source.dashboard.powerbi.models import (
     DashboardsResponse,
+    DataflowExportResponse,
     Dataset,
     DatasetResponse,
     Group,
@@ -635,6 +636,33 @@ class PowerBiApiClient:
             poll += 1
 
         return False
+
+    def fetch_dataflow_export(
+        self, dataflow_id: str
+    ) -> Optional[DataflowExportResponse]:
+        """Method to export dataflow definition using admin API
+        API: https://api.powerbi.com/v1.0/myorg/admin/dataflows/{dataflowId}/export
+        API doc: https://learn.microsoft.com/en-us/rest/api/power-bi/admin/dataflows-export-dataflow-as-admin
+        Args:
+            dataflow_id: The ID of the dataflow to export
+        Returns:
+            DataflowExportResponse containing entities and their attributes
+        """
+        try:
+            logger.debug(
+                f"Calling the API({str(self.client._base_url)}/myorg/admin/dataflows/{dataflow_id}/export)"  # pylint: disable=protected-access
+                " to export dataflow definition"
+            )
+            response_data = self.client.get(
+                f"/myorg/admin/dataflows/{dataflow_id}/export"
+            )
+            if response_data:
+                return DataflowExportResponse(**response_data)
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.debug(traceback.format_exc())
+            logger.warning(f"Error exporting dataflow {dataflow_id}: {exc}")
+
+        return None
 
 
 class PowerBiClient(BaseModel):

--- a/ingestion/src/metadata/ingestion/source/dashboard/powerbi/models.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/powerbi/models.py
@@ -322,3 +322,40 @@ class ReportPagesAPIResponse(BaseModel):
 
     odata_context: str = Field(alias="@odata.context")
     value: Optional[List[ReportPage]] = None
+
+
+class DataflowEntityAttribute(BaseModel):
+    """
+    PowerBI Dataflow Entity Attribute Model
+    Represents a column/attribute within a dataflow entity
+    API doc: https://learn.microsoft.com/en-us/rest/api/power-bi/admin/dataflows-export-dataflow-as-admin
+    """
+
+    name: str
+    dataType: Optional[str] = None
+    description: Optional[str] = None
+
+
+class DataflowEntity(BaseModel):
+    """
+    PowerBI Dataflow Entity Model
+    Represents a table/entity within a dataflow
+    API doc: https://learn.microsoft.com/en-us/rest/api/power-bi/admin/dataflows-export-dataflow-as-admin
+    """
+
+    name: str
+    description: Optional[str] = None
+    attributes: Optional[List[DataflowEntityAttribute]] = []
+
+
+class DataflowExportResponse(BaseModel):
+    """
+    PowerBI Dataflow Export API Response Model
+    API: https://api.powerbi.com/v1.0/myorg/admin/dataflows/{dataflowId}/export
+    API doc: https://learn.microsoft.com/en-us/rest/api/power-bi/admin/dataflows-export-dataflow-as-admin
+    """
+
+    name: Optional[str] = None
+    description: Optional[str] = None
+    version: Optional[str] = None
+    entities: Optional[List[DataflowEntity]] = []


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:



<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on adding detailed metadata for the powerbi dataflow entity

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

---

## Summary by Gitar

- **PowerBI Admin API integration:**
  - `fetch_dataflow_export()` calls `/myorg/admin/dataflows/{id}/export` endpoint to retrieve entity and attribute metadata
- **New data models:**
  - `DataflowExportResponse`, `DataflowEntity`, and `DataflowEntityAttribute` Pydantic models for API response deserialization
- **New transformation utility:**
  - `_get_dataflow_column_info()` converts dataflow entities and attributes into hierarchical OpenMetadata Column objects

<sub>This will update automatically on new commits.</sub>

---