### PR TITLE
playwright: fixed incident manager test

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts
@@ -62,10 +62,17 @@ export const acknowledgeTask = async (data: {
 export const addAssigneeFromPopoverWidget = async (data: {
   page: Page;
   user: { name: string; displayName: string };
+  testCaseName?: string;
 }) => {
-  const { page, user } = data;
-  // direct assignment from edit assignee icon
-  await page.click('[data-testid="assignee"] [data-testid="edit-owner"]');
+  const { page, user, testCaseName } = data;
+
+  if (testCaseName) {
+    await page.getByRole('row', { name: testCaseName }).getByTestId('edit-owner').click();
+  } else {
+    // direct assignment from edit assignee icon
+    await page.getByTestId('assignee').getByTestId('edit-owner').click();
+  }
+
   await page.waitForSelector('[data-testid="loader"]', {
     state: 'detached',
   });
@@ -108,7 +115,7 @@ export const assignIncident = async (data: {
   await page.waitForSelector(`[data-testid="test-case-${testCaseName}"]`);
   if (direct) {
     // direct assignment from edit assignee icon
-    await addAssigneeFromPopoverWidget({ page, user });
+    await addAssigneeFromPopoverWidget({ page, user, testCaseName });
   } else {
     await page.click(`[data-testid="${testCaseName}-status"]`);
     await page.getByRole('menuitem', { name: 'Assigned' }).click();


### PR DESCRIPTION
This pull request updates the Playwright utility functions in `incidentManager.ts` to improve how assignees are added to test cases, allowing for more precise UI interactions based on the context. The main change is making the `addAssigneeFromPopoverWidget` function context-aware by introducing an optional `testCaseName` parameter, which enables targeting specific test case rows when assigning users.

**Improvements to test case assignment logic:**

* Updated `addAssigneeFromPopoverWidget` to accept an optional `testCaseName` parameter, allowing the function to assign users to a specific test case row when provided, or default to the general assignee edit icon otherwise.
* Modified `assignIncident` to pass the `testCaseName` to `addAssigneeFromPopoverWidget` for direct assignments, ensuring the correct row is targeted during test case assignment.