### PR TITLE
fix: add disk space cleanup to maven postgres tests workflow

### DIFF
--- a/.github/workflows/maven-postgres-tests-build.yml
+++ b/.github/workflows/maven-postgres-tests-build.yml
@@ -53,6 +53,16 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft }}
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          swap-storage: true
+          docker-images: false
       - name: Wait for the labeler
         uses: lewagon/wait-on-check-action@v1.3.4
         if: ${{ github.event_name == 'pull_request_target' }}


### PR DESCRIPTION
  Fixes the "No space left on device" error in the Maven PostgreSQL Tests CI workflow.

  I added a disk space cleanup step to `.github/workflows/maven-postgres-tests-build.yml` because the workflow was failing with `System.IO.IOException: No space left on device` errors during test execution. The GitHub Actions runner was running out of disk space, preventing the workflow from completing successfully.

  The fix uses the `jlumbroso/free-disk-space` action to remove unnecessary components

  
  ### Type of change:
  - [x] Bug fix

  ### Checklist:
  - [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
  - [x] My PR title is `Fix: add disk space cleanup to maven postgres tests workflow`
  - [ ] I have commented on my code, particularly in hard-to-understand areas.
  - [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

  <!-- Bug fix -->
  - [x] I have added a fix that resolves the disk space issue in the CI workflow. The workflow itself serves as the test case.
