### PR TITLE
Fix #21326: Lifecycle keeps updating the entity minor version everytime usage runs.

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/APICollectionResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/APICollectionResourceIT.java
@@ -40,6 +40,7 @@ public class APICollectionResourceIT extends BaseEntityIT<APICollection, CreateA
   {
     supportsFollowers = false;
     supportsBulkAPI = true;
+    supportsLifeCycle = true;
   }
 
   // ===================================================================

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/APIEndpointResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/APIEndpointResourceIT.java
@@ -47,6 +47,10 @@ import org.openmetadata.sdk.models.ListResponse;
 @Execution(ExecutionMode.CONCURRENT)
 public class APIEndpointResourceIT extends BaseEntityIT<APIEndpoint, CreateAPIEndpoint> {
 
+  {
+    supportsLifeCycle = true;
+  }
+
   // ===================================================================
   // ABSTRACT METHOD IMPLEMENTATIONS (Required by BaseEntityIT)
   // ===================================================================

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ChartResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ChartResourceIT.java
@@ -39,6 +39,10 @@ import org.openmetadata.sdk.models.ListResponse;
 @Execution(ExecutionMode.CONCURRENT)
 public class ChartResourceIT extends BaseEntityIT<Chart, CreateChart> {
 
+  {
+    supportsLifeCycle = true;
+  }
+
   // ===================================================================
   // ABSTRACT METHOD IMPLEMENTATIONS (Required by BaseEntityIT)
   // ===================================================================

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ContainerResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ContainerResourceIT.java
@@ -40,6 +40,10 @@ import org.openmetadata.sdk.models.ListResponse;
 @Execution(ExecutionMode.CONCURRENT)
 public class ContainerResourceIT extends BaseEntityIT<Container, CreateContainer> {
 
+  {
+    supportsLifeCycle = true;
+  }
+
   // ===================================================================
   // ABSTRACT METHOD IMPLEMENTATIONS (Required by BaseEntityIT)
   // ===================================================================

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DashboardDataModelResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DashboardDataModelResourceIT.java
@@ -46,6 +46,10 @@ import org.openmetadata.sdk.models.ListResponse;
 public class DashboardDataModelResourceIT
     extends BaseEntityIT<DashboardDataModel, CreateDashboardDataModel> {
 
+  {
+    supportsLifeCycle = true;
+  }
+
   // ===================================================================
   // ABSTRACT METHOD IMPLEMENTATIONS (Required by BaseEntityIT)
   // ===================================================================

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DashboardResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DashboardResourceIT.java
@@ -42,6 +42,10 @@ import org.openmetadata.sdk.models.ListResponse;
 @Execution(ExecutionMode.CONCURRENT)
 public class DashboardResourceIT extends BaseEntityIT<Dashboard, CreateDashboard> {
 
+  {
+    supportsLifeCycle = true;
+  }
+
   // ===================================================================
   // ABSTRACT METHOD IMPLEMENTATIONS (Required by BaseEntityIT)
   // ===================================================================

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DatabaseResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DatabaseResourceIT.java
@@ -55,9 +55,9 @@ import org.openmetadata.sdk.exceptions.InvalidRequestException;
 @Execution(ExecutionMode.CONCURRENT)
 public class DatabaseResourceIT extends BaseEntityIT<Database, CreateDatabase> {
 
-  // Enable import/export for databases
   {
     supportsImportExport = true;
+    supportsLifeCycle = true;
   }
 
   // Store last created database for import/export tests

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DatabaseSchemaResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DatabaseSchemaResourceIT.java
@@ -36,9 +36,9 @@ import org.openmetadata.sdk.models.ListResponse;
 @Execution(ExecutionMode.CONCURRENT)
 public class DatabaseSchemaResourceIT extends BaseEntityIT<DatabaseSchema, CreateDatabaseSchema> {
 
-  // Enable import/export for database schemas
   {
     supportsImportExport = true;
+    supportsLifeCycle = true;
   }
 
   // Store last created schema for import/export tests

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/MlModelResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/MlModelResourceIT.java
@@ -40,6 +40,10 @@ import org.openmetadata.sdk.models.ListResponse;
 @Execution(ExecutionMode.CONCURRENT)
 public class MlModelResourceIT extends BaseEntityIT<MlModel, CreateMlModel> {
 
+  {
+    supportsLifeCycle = true;
+  }
+
   // ===================================================================
   // ABSTRACT METHOD IMPLEMENTATIONS (Required by BaseEntityIT)
   // ===================================================================

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/PipelineResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/PipelineResourceIT.java
@@ -35,6 +35,10 @@ import org.openmetadata.sdk.models.ListResponse;
 @Execution(ExecutionMode.CONCURRENT)
 public class PipelineResourceIT extends BaseEntityIT<Pipeline, CreatePipeline> {
 
+  {
+    supportsLifeCycle = true;
+  }
+
   // ===================================================================
   // ABSTRACT METHOD IMPLEMENTATIONS (Required by BaseEntityIT)
   // ===================================================================

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/SearchIndexResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/SearchIndexResourceIT.java
@@ -41,8 +41,9 @@ import org.openmetadata.sdk.models.ListResponse;
 public class SearchIndexResourceIT extends BaseEntityIT<SearchIndex, CreateSearchIndex> {
 
   {
-    supportsSearchIndex = false; // SearchIndex entity doesn't have its own search index
-    supportsDomains = false; // SearchIndex doesn't support domains field
+    supportsSearchIndex = false;
+    supportsDomains = false;
+    supportsLifeCycle = true;
   }
 
   // ===================================================================

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/StoredProcedureResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/StoredProcedureResourceIT.java
@@ -37,7 +37,8 @@ public class StoredProcedureResourceIT
     extends BaseEntityIT<StoredProcedure, CreateStoredProcedure> {
 
   {
-    supportsSearchIndex = false; // StoredProcedure doesn't have search index
+    supportsSearchIndex = false;
+    supportsLifeCycle = true;
   }
 
   // ===================================================================

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TableResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TableResourceIT.java
@@ -104,6 +104,7 @@ public class TableResourceIT extends BaseEntityIT<Table, CreateTable> {
     // Table CSV export exports columns from a specific table, not tables from a schema
     // The test framework expects export from a container (schema), but tables use a different API
     supportsImportExport = false;
+    supportsLifeCycle = true;
   }
 
   private DatabaseSchema lastCreatedSchema;

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TopicResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TopicResourceIT.java
@@ -40,6 +40,10 @@ import org.openmetadata.sdk.models.ListResponse;
 @Execution(ExecutionMode.CONCURRENT)
 public class TopicResourceIT extends BaseEntityIT<Topic, CreateTopic> {
 
+  {
+    supportsLifeCycle = true;
+  }
+
   // ===================================================================
   // ABSTRACT METHOD IMPLEMENTATIONS (Required by BaseEntityIT)
   // ===================================================================

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -4804,7 +4804,9 @@ public abstract class EntityRepository<T extends EntityInterface> {
           updatedLifeCycle.setUpdated(origLifeCycle.getUpdated());
         }
       }
-      recordChange(FIELD_LIFE_CYCLE, origLifeCycle, updatedLifeCycle, true);
+      // Use updateVersion=false to prevent version pollution from lifecycle-only changes
+      // See: https://github.com/open-metadata/OpenMetadata/issues/21326
+      recordChange(FIELD_LIFE_CYCLE, origLifeCycle, updatedLifeCycle, true, objectMatch, false);
     }
 
     private void updateCertification() {


### PR DESCRIPTION

<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #21326 

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

---

## Summary by Gitar

- **Fixed version pollution bug:**
  - Lifecycle-only updates (like usage ingestion updating accessed timestamps) no longer increment entity versions
  - Changed `recordChange` in `EntityRepository.java:4809` to pass `updateVersion=false` for lifecycle field updates
- **New test coverage:**
  - `patch_entityLifeCycle_noVersionPollution` in `BaseEntityIT.java` verifies lifecycle-only changes don't increment version (simulates 3 consecutive usage runs)
  - `patch_entityLifeCycleWithOtherChanges_versionIncrements` ensures normal versioning still works when lifecycle changes with real metadata changes
- **Test infrastructure:**
  - Enabled lifecycle testing with `supportsLifeCycle = true` across 14 entity types (Table, Dashboard, Pipeline, Chart, Container, Database, etc.)

<sub>This will update automatically on new commits.</sub>

---