### PR TITLE
Fix OpenMetadata default config

### DIFF
--- a/conf/openmetadata.yaml
+++ b/conf/openmetadata.yaml
@@ -432,13 +432,14 @@ elasticsearch:
     embeddingProvider: ${EMBEDDING_PROVIDER:-bedrock}
     providerClass: ${NATURAL_LANGUAGE_SEARCH_PROVIDER_CLASS:-org.openmetadata.service.search.nlq.NoOpNLQService}
     bedrock:
-      region: ${AWS_BEDROCK_REGION:-""}
+      awsConfig:
+        region: ${AWS_BEDROCK_REGION:-""}
+        accessKeyId: ${AWS_BEDROCK_ACCESS_KEY:-""}
+        secretAccessKey: ${AWS_BEDROCK_SECRET_KEY:-""}
+        sessionToken: ${AWS_BEDROCK_SESSION_TOKEN:-""}
       modelId: ${AWS_BEDROCK_MODEL_ID:-""}
       embeddingModelId: ${AWS_BEDROCK_EMBED_MODEL_ID:-""}
       embeddingDimension: ${AWS_BEDROCK_EMBEDDING_DIMENSION:-""}
-      accessKey: ${AWS_BEDROCK_ACCESS_KEY:-""}
-      secretKey: ${AWS_BEDROCK_SECRET_KEY:-""}
-      useIamRole: ${AWS_BEDROCK_USE_IAM:-"false"}
 
 eventMonitoringConfiguration:
   eventMonitor: ${EVENT_MONITOR:-prometheus}  # Possible values are "prometheus", "cloudwatch"


### PR DESCRIPTION
### Describe your changes:

Fixes this:

<img width="1004" height="487" alt="image" src="https://github.com/user-attachments/assets/b81defd1-386f-429a-9b89-d4f6e0468f63" />

#25204 changed the spec for `elasticsearch.naturalLanguageSearch.bedrock`, but did not update the default config file, so the app couldn't be started because of the wrong config.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [X] Bug fix

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.

---

## Summary by Gitar

- **Configuration refactor:**
  - Nested AWS credentials under `awsConfig` to align with standardized `awsBaseConfig.json` schema
- **Standardized field names:**
  - Renamed `accessKey`/`secretKey` to `accessKeyId`/`secretAccessKey` for AWS consistency
- **Added support:**
  - `sessionToken` field enables temporary AWS credentials for Bedrock natural language search

<sub>This will update automatically on new commits.</sub>

---