### PR TITLE
MINOR: Allow extension to metadata namespace in env

### DIFF
--- a/ingestion/src/metadata/__init__.py
+++ b/ingestion/src/metadata/__init__.py
@@ -11,6 +11,10 @@
 """
 OpenMetadata package initialization.
 """
+from pkgutil import extend_path
+
+__path__ = extend_path(__path__, __name__)
+
 from typing import Type
 
 from metadata.profiler.api.models import ProfilerProcessorConfig


### PR DESCRIPTION
This pull request introduces a minor update to the `ingestion/src/metadata/__init__.py` file to improve package initialization and support for namespace packages.

* Added usage of `pkgutil.extend_path` to `__init__.py` to enable the `metadata` package to function as a namespace package, allowing it to be extended across multiple directories.

---

## Summary by Gitar

- **Namespace package support:**
  - Added `pkgutil.extend_path(__path__, __name__)` to enable the `metadata` package to span multiple directories
- **Plugin extensibility:**
  - Allows third-party packages to extend the `metadata` namespace without modifying core code
- **Configuration alignment:**
  - Runtime behavior now matches the `namespaces = true` setting in `pyproject.toml`

<sub>This will update automatically on new commits.</sub>

---