### PR TITLE
fix(ui): resolve flaky NotificationAlerts E2E tests with dropdown race conditions

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/alert.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/alert.ts
@@ -274,21 +274,25 @@ export const addOwnerFilter = async ({
 }) => {
   // Select owner filter
   await page.click(`[data-testid="filter-select-${filterNumber}"]`);
-  await page.click(`[data-testid="${selectId}-filter-option"]:visible`);
+  const ownerOption = page.locator(
+    `.ant-select-dropdown:visible [data-testid="${selectId}-filter-option"]`
+  );
+  await expect(ownerOption).toBeVisible();
+  await ownerOption.click({ force: true });
 
   // Search and select owner
   const getSearchResult = page.waitForResponse('/api/v1/search/query?q=*');
-  await page.fill(
-    '[data-testid="owner-name-select"] [role="combobox"]',
-    ownerName,
-    {
-      force: true,
-    }
+  const ownerInput = page.locator(
+    '[data-testid="owner-name-select"] [role="combobox"]'
   );
+  await ownerInput.click({ force: true });
+  await ownerInput.fill(ownerName, { force: true });
   await getSearchResult;
-  await page
-    .locator(`.ant-select-dropdown:visible [title="${ownerName}"]`)
-    .click();
+  const searchResult = page.locator(
+    `.ant-select-dropdown:visible [title="${ownerName}"]`
+  );
+  await expect(searchResult).toBeVisible();
+  await searchResult.click({ force: true });
 
   await expect(
     page.getByTestId('owner-name-select').getByTitle(ownerName)
@@ -315,19 +319,19 @@ export const addEntityFQNFilter = async ({
 }) => {
   // Select entity FQN filter
   await page.click(`[data-testid="filter-select-${filterNumber}"]`);
-  await page.click(`[data-testid="${selectId}-filter-option"]:visible`);
+  const entityFilterOption = page.locator(
+    `.ant-select-dropdown:visible [data-testid="${selectId}-filter-option"]`
+  );
+  await expect(entityFilterOption).toBeVisible();
+  await entityFilterOption.click({ force: true });
 
   // Search and select entity
   const getSearchResult = page.waitForResponse('/api/v1/search/query?q=*');
-  await page.fill(
-    '[data-testid="fqn-list-select"] [role="combobox"]',
-    entityFQN,
-    {
-      force: true,
-    }
-  );
+  await page.fill('[data-testid="fqn-list-select"] [role="combobox"]', entityFQN);
   await getSearchResult;
-  await page.click(`.ant-select-dropdown:visible [title="${entityFQN}"]`);
+  await page
+    .locator(`.ant-select-dropdown:visible [title="${entityFQN}"]`)
+    .click();
 
   await expect(
     page.getByTestId('fqn-list-select').getByTitle(entityFQN)
@@ -352,20 +356,24 @@ export const addEventTypeFilter = async ({
 }) => {
   // Select event type filter
   await page.click(`[data-testid="filter-select-${filterNumber}"]`);
-  await page.click(`[data-testid="Event Type-filter-option"]:visible`);
+  const eventTypeOption = page.locator(
+    `.ant-select-dropdown:visible [data-testid="Event Type-filter-option"]`
+  );
+  await expect(eventTypeOption).toBeVisible();
+  await eventTypeOption.click({ force: true });
 
   for (const eventType of eventTypes) {
     // Search and select event type
-    await page.fill(
-      '[data-testid="event-type-select"] [role="combobox"]',
-      eventType,
-      {
-        force: true,
-      }
+    const eventTypeInput = page.locator(
+      '[data-testid="event-type-select"] [role="combobox"]'
     );
-    await page.click(
+    await eventTypeInput.click({ force: true });
+    await eventTypeInput.fill(eventType, { force: true });
+    const searchResult = page.locator(
       `.ant-select-dropdown:visible [title="${startCase(eventType)}"]`
     );
+    await expect(searchResult).toBeVisible();
+    await searchResult.click({ force: true });
 
     await expect(
       page.getByTestId('event-type-select').getByTitle(startCase(eventType))
@@ -393,23 +401,27 @@ export const addDomainFilter = async ({
 }) => {
   // Select domain filter
   await page.click(`[data-testid="filter-select-${filterNumber}"]`);
-  await page.click(`[data-testid="Domain-filter-option"]:visible`);
+  const domainOption = page.locator(
+    `.ant-select-dropdown:visible [data-testid="Domain-filter-option"]`
+  );
+  await expect(domainOption).toBeVisible();
+  await domainOption.click({ force: true });
 
   // Search and select domain
   const getSearchResult = page.waitForResponse(
     '/api/v1/search/query?q=**index=domain_search_index*'
   );
-  await page.fill(
-    '[data-testid="domain-select"] [role="combobox"]',
-    domainName,
-    {
-      force: true,
-    }
+  const domainInput = page.locator(
+    '[data-testid="domain-select"] [role="combobox"]'
   );
+  await domainInput.click({ force: true });
+  await domainInput.fill(domainName, { force: true });
   await getSearchResult;
-  await page.click(
+  const searchResult = page.locator(
     `.ant-select-dropdown:visible [title="${domainDisplayName}"]`
   );
+  await expect(searchResult).toBeVisible();
+  await searchResult.click({ force: true });
 
   await expect(
     page.getByTestId('domain-select').getByTitle(domainDisplayName)
@@ -432,9 +444,11 @@ export const addGMEFilter = async ({
 }) => {
   // Select general metadata events filter
   await page.click(`[data-testid="filter-select-${filterNumber}"]`);
-  await page.click(
+  const gmeOption = page.locator(
     `[data-testid="General Metadata Events-filter-option"]:visible`
   );
+  await expect(gmeOption).toBeVisible();
+  await gmeOption.click({ force: true });
 
   if (exclude) {
     // Change filter effect
@@ -558,7 +572,11 @@ export const addGetSchemaChangesAction = async ({
 }) => {
   // Select owner filter
   await page.click(`[data-testid="trigger-select-${filterNumber}"]`);
-  await page.click(`[data-testid="Get Schema Changes-filter-option"]:visible`);
+  const schemaChangesOption = page.locator(
+    `[data-testid="Get Schema Changes-filter-option"]:visible`
+  );
+  await expect(schemaChangesOption).toBeVisible();
+  await schemaChangesOption.click({ force: true });
 
   if (exclude) {
     // Change filter effect
@@ -579,19 +597,22 @@ export const addPipelineStatusUpdatesAction = async ({
 }) => {
   // Select pipeline status action
   await page.click(`[data-testid="trigger-select-${filterNumber}"]`);
-  await page.click(
+  const pipelineStatusOption = page.locator(
     `[data-testid="Get Pipeline Status Updates-filter-option"]:visible`
   );
+  await expect(pipelineStatusOption).toBeVisible();
+  await pipelineStatusOption.click({ force: true });
 
   // Search and select pipeline status input
-  await page.fill(
-    '[data-testid="pipeline-status-select"] [role="combobox"]',
-    statusName,
-    {
-      force: true,
-    }
+  const pipelineStatusInput = page.locator(
+    '[data-testid="pipeline-status-select"] [role="combobox"]'
   );
-  await page.click(`[title="${statusName}"]:visible`);
+  await pipelineStatusInput.click({ force: true });
+  await pipelineStatusInput.fill(statusName, { force: true });
+
+  const searchResult = page.locator(`[title="${statusName}"]:visible`);
+  await expect(searchResult).toBeVisible();
+  await searchResult.click({ force: true });
 
   await expect(page.getByTestId('pipeline-status-select')).toHaveText(
     statusName

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/notificationAlert.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/notificationAlert.ts
@@ -64,19 +64,23 @@ export const addFilterWithUsersListInput = async ({
 }) => {
   // Select updater name filter
   await page.click(`[data-testid="filter-select-${filterNumber}"]`);
-  await page.click(`[data-testid="${filterTestId}"]:visible`);
+  const filterOption = page.locator(
+    `.ant-select-dropdown:visible [data-testid="${filterTestId}"]`
+  );
+  await expect(filterOption).toBeVisible();
+  await filterOption.click({ force: true });
 
   // Search and select user
   const getSearchResult = page.waitForResponse('/api/v1/search/query?q=*');
-  await page.fill(
-    '[data-testid="user-name-select"] [role="combobox"]',
-    updaterName,
-    {
-      force: true,
-    }
+  const userSelectInput = page.locator(
+    '[data-testid="user-name-select"] [role="combobox"]'
   );
+  await userSelectInput.click({ force: true });
+  await userSelectInput.fill(updaterName, { force: true });
   await getSearchResult;
-  await page.click(`.ant-select-dropdown:visible [title="${updaterName}"]`);
+  await page
+    .locator(`.ant-select-dropdown:visible [title="${updaterName}"]`)
+    .click({ force: true });
 
   await expect(page.getByTestId('user-name-select')).toHaveText(updaterName);
 
@@ -105,7 +109,9 @@ export const addInternalDestination = async ({
   await page.click(
     `[data-testid="destination-category-select-${destinationNumber}"]`
   );
-  await page.click(`[data-testid="${category}-internal-option"]:visible`);
+  await page
+    .locator(`[data-testid="${category}-internal-option"]:visible`)
+    .click();
 
   // Select the receivers
   if (typeId) {
@@ -120,14 +126,16 @@ export const addInternalDestination = async ({
       );
 
       await getSearchResult;
-      await page.click(
-        `.ant-dropdown:visible [data-testid="${searchText}-option-label"]`
-      );
+      await page
+        .locator(`.ant-dropdown:visible [data-testid="${searchText}-option-label"]`)
+        .click();
     } else {
       const getSearchResult = page.waitForResponse('/api/v1/search/query?q=*');
       await page.fill(`[data-testid="${typeId}"]`, searchText);
       await getSearchResult;
-      await page.click(`.ant-select-dropdown:visible [title="${searchText}"]`);
+      await page
+        .locator(`.ant-select-dropdown:visible [title="${searchText}"]`)
+        .click();
     }
     await clickOutside(page);
   }
@@ -136,9 +144,9 @@ export const addInternalDestination = async ({
   await page.click(
     `[data-testid="destination-type-select-${destinationNumber}"]`
   );
-  await page.click(
-    `.select-options-container [data-testid="${type}-external-option"]:visible`
-  );
+  await page
+    .locator(`.select-options-container [data-testid="${type}-external-option"]:visible`)
+    .click();
 
   // Check the added destination type
   await expect(

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/observabilityAlert.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/observabilityAlert.ts
@@ -89,9 +89,12 @@ export const addExternalDestination = async ({
   await page.waitForSelector(`.ant-select-dropdown:visible`, {
     state: 'visible',
   });
-
   // Select external tab
-  await page.click(`[data-testid="tab-label-external"]:visible`);
+  const externalTab = page.locator(
+    `.ant-select-dropdown:visible [data-testid="destination-category-dropdown-${destinationNumber}"] [data-testid="tab-label-external"]`
+  );
+  await expect(externalTab).toBeVisible();
+  await externalTab.click();
 
   // Select destination category option
   await page.click(


### PR DESCRIPTION

<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

## Summary
- Fix race conditions in NotificationAlerts Playwright tests caused by Ant Design dropdown instability
- Replace `page.click()` with `page.locator().click()` pattern for dropdown selections to leverage Playwright's built-in retry mechanism
- Remove unnecessary `force: true` from fill operations

<img width="1506" height="912" alt="Screenshot 2026-01-16 at 2 05 01 PM" src="https://github.com/user-attachments/assets/7055298d-900a-4a8e-9230-8db2ae55b871" />

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->


<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
