### PR TITLE
MINOR: remove unnecessary blank line in OpenMetadataApplicationConfig

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/OpenMetadataApplicationConfig.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/OpenMetadataApplicationConfig.java
@@ -176,7 +176,7 @@ public class OpenMetadataApplicationConfig extends Configuration {
     }
     return bulkOperationConfiguration;
   }
-  
+
   public String getApiRootPath() {
     if (!(getServerFactory() instanceof DefaultServerFactory serverFactory)) {
       return "";


### PR DESCRIPTION
To fix the Java Checkstyle GH action workflow failure