### PR TITLE
test: stabilize Settings Navigation Playwright tests

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SettingsNavigationPage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SettingsNavigationPage.spec.ts
@@ -13,13 +13,14 @@
 
 import { test as base, expect, Page } from '@playwright/test';
 import { GlobalSettingOptions } from '../../constant/settings';
+import { SidebarItem } from '../../constant/sidebar';
 import { PersonaClass } from '../../support/persona/PersonaClass';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';
 import { redirectToHomePage } from '../../utils/common';
 import { setUserDefaultPersona } from '../../utils/customizeLandingPage';
 import { navigateToPersonaWithPagination } from '../../utils/persona';
-import { settingClick } from '../../utils/sidebar';
+import { settingClick, sidebarClick } from '../../utils/sidebar';
 
 const adminUser = new UserClass();
 const persona = new PersonaClass();
@@ -248,10 +249,7 @@ test.describe('Settings Navigation Page Tests', () => {
     await expect(page.getByTestId('save-button')).toBeDisabled();
 
     // Verify no navigation blocker when navigating away
-    await page
-      .getByTestId('left-sidebar')
-      .getByTestId('app-bar-item-settings')
-      .click();
+    await sidebarClick(page, SidebarItem.SETTINGS);
     await expect(page).toHaveURL(/.*settings.*/);
     await expect(page.getByTestId('unsaved-changes-modal-title')).not.toBeVisible();
   });


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

This PR resolves flakiness and logic inconsistencies in SettingsNavigationPage.spec.ts to ensure reliable test execution.

### Changes

- Fix Reset Logic Assertion: Updated the "reset functionality" test to correctly expect the Save button to be disabled after a reset, confirming a clean state. Added an explicit wait for the switch UI update (toBeChecked()) and verified that navigating away correctly bypasses the "Unsaved Changes" blocker.
- Fix Stale Navigation State: Added page.reload() to the "hide multiple items" test case. This forces a fresh fetch of the navigation configuration after redirection, preventing false failures caused by stale cached state in the UI.
- Improve Drag & Drop Reliability: Refined the drag-and-drop simulation by increasing mouse movement steps to 20 and targeting the exact bottom edge of the item (y + height). This ensures the "drop to gap" (reorder) action is consistently triggered across different environments.

<img width="1506" height="912" alt="Screenshot 2026-01-16 at 3 20 25 PM" src="https://github.com/user-attachments/assets/39a13ac1-80c8-4a9c-b670-99cbe45ba692" />

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->


<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
