### PR TITLE
(test) ui: fix flaky settings navigation spec

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SettingsNavigationPage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SettingsNavigationPage.spec.ts
@@ -59,7 +59,7 @@ const navigateToPersonaNavigation = async (page: Page) => {
   await page.waitForLoadState('networkidle');
 };
 
-test.describe('Settings Navigation Page Tests', () => {
+test.describe.serial('Settings Navigation Page Tests', () => {
   test('should update navigation sidebar', async ({ page }) => {
     // Create and set default persona
     await redirectToHomePage(page);
@@ -166,6 +166,9 @@ test.describe('Settings Navigation Page Tests', () => {
 
     await navigateSwitch.click();
 
+    // Verify save button is enabled to ensure change is registered
+    await expect(page.getByTestId('save-button')).toBeEnabled();
+
     // Try to navigate away
     await page
       .getByTestId('left-sidebar')
@@ -173,7 +176,7 @@ test.describe('Settings Navigation Page Tests', () => {
       .click();
 
     // Click "Save changes" to save and navigate
-    const saveResponse = page.waitForResponse('api/v1/docStore');
+    const saveResponse = page.waitForResponse('**/api/v1/docStore/**');
     await page.getByTestId('unsaved-changes-modal-save').click();
     await saveResponse;
     await page.waitForLoadState('networkidle');
@@ -245,7 +248,7 @@ test.describe('Settings Navigation Page Tests', () => {
 
     // Verify reset worked - save button disabled and state reverted
     expect(await domainSwitch.isChecked()).toBeTruthy();
-    await expect(page.getByTestId('save-button')).toBeEnabled();
+    await expect(page.getByTestId('save-button')).not.toBeEnabled();
   });
 
   test('should support drag and drop reordering of navigation items', async ({
@@ -268,16 +271,17 @@ test.describe('Settings Navigation Page Tests', () => {
     expect(secondItemBox).not.toBeNull();
 
     if (firstItemBox && secondItemBox) {
-      await page.mouse.move(
-        firstItemBox.x + firstItemBox.width / 2,
-        firstItemBox.y + firstItemBox.height / 2
-      );
-      await page.mouse.down();
-      await page.mouse.move(
-        secondItemBox.x + secondItemBox.width / 2,
-        secondItemBox.y + secondItemBox.height / 2 + 10
-      );
-      await page.mouse.up();
+      await firstItem.dragTo(secondItem, {
+        force: true,
+        sourcePosition: {
+          x: firstItemBox.width / 2,
+          y: firstItemBox.height / 2,
+        },
+        targetPosition: {
+          x: secondItemBox.width / 2,
+          y: secondItemBox.height / 2 + 10,
+        },
+      });
 
       // Adding wait so that drop action can complete
       await page.waitForTimeout(500);
@@ -312,12 +316,25 @@ test.describe('Settings Navigation Page Tests', () => {
 
     await expect(page.getByTestId('save-button')).toBeEnabled();
 
-    const saveResponse = page.waitForResponse('api/v1/docStore');
+    const saveResponse = page.waitForResponse('**/api/v1/docStore/**');
     await page.getByTestId('save-button').click();
     await saveResponse;
 
     await redirectToHomePage(page);
 
+    await page.locator('[data-testid="dropdown-profile"]').click();
+    await page.waitForSelector('[role="menu"].profile-dropdown', {
+      state: 'visible',
+    });
+
+    // Verify personas section is visible
+    await expect(page.getByText('Switch Persona')).toBeVisible();
+
+    // Initially should show limited personas (2 by default)
+    const initialPersonaLabels = page.locator(
+      '[data-testid="persona-label"]'
+    ).locator('input[type="radio"]');
+    await initialPersonaLabels.first().click();
     await expect(page.getByTestId('app-bar-item-explore')).not.toBeVisible();
     await expect(page.getByTestId('app-bar-item-insights')).not.toBeVisible();
 
@@ -325,7 +342,7 @@ test.describe('Settings Navigation Page Tests', () => {
     await exploreSwitch.click();
     await insightsSwitch.click();
 
-    const restoreResponse = page.waitForResponse('api/v1/docStore/*');
+    const restoreResponse = page.waitForResponse('**/api/v1/docStore/**');
     await page.getByTestId('save-button').click();
     await restoreResponse;
   });


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

<img width="1506" height="912" alt="Screenshot 2026-01-19 at 4 18 31 PM" src="https://github.com/user-attachments/assets/4e030a2c-93fa-4506-9104-fad5f896ba0e" />

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->


<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

---

## Summary by Gitar

- **Test execution strategy:**
  - Changed to `test.describe.serial()` to prevent parallel execution conflicts with shared persona state
- **API response matching:**
  - Updated all `waitForResponse()` calls to use glob pattern `**/api/v1/docStore/**` for robust URL matching
- **Drag-and-drop reliability:**
  - Replaced manual `page.mouse` operations with Playwright's `dragTo()` method with explicit positioning
- **Assertion corrections:**
  - Fixed reset button test to expect disabled save button after reset (line 251)
  - Added explicit save button state verification before navigation actions
- **Complete user flows:**
  - Added persona dropdown interaction and radio button selection before checking navigation visibility

<sub>This will update automatically on new commits.</sub>

---