### PR TITLE
Fix #24056: Fix autoclassification bot assignment

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataConnectionBuilder.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataConnectionBuilder.java
@@ -88,6 +88,7 @@ public class OpenMetadataConnectionBuilder {
     String botName;
     switch (ingestionPipeline.getPipelineType()) {
       case METADATA, DBT -> botName = Entity.INGESTION_BOT_NAME;
+      case AUTO_CLASSIFICATION -> botName = "autoClassification-bot";
       case APPLICATION -> {
         String type = IngestionPipelineRepository.getPipelineWorkflowType(ingestionPipeline);
         botName = String.format("%sApplicationBot", type);

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/OpenMetadataConnectionBuilderTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/OpenMetadataConnectionBuilderTest.java
@@ -2,16 +2,23 @@ package org.openmetadata.service.util;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.interfaces.DecodedJWT;
+import java.lang.reflect.Method;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.openmetadata.schema.api.configuration.pipelineServiceClient.PipelineServiceClientConfiguration;
+import org.openmetadata.schema.entity.applications.configuration.ApplicationConfig;
+import org.openmetadata.schema.entity.services.ingestionPipelines.IngestionPipeline;
+import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineType;
+import org.openmetadata.schema.metadataIngestion.ApplicationPipeline;
+import org.openmetadata.schema.metadataIngestion.SourceConfig;
 import org.openmetadata.schema.security.secrets.SecretsManagerClientLoader;
 import org.openmetadata.schema.security.secrets.SecretsManagerConfiguration;
 import org.openmetadata.schema.security.secrets.SecretsManagerProvider;
 import org.openmetadata.schema.security.ssl.VerifySSL;
 import org.openmetadata.schema.services.connections.metadata.OpenMetadataConnection;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
 import org.openmetadata.service.OpenMetadataApplicationTest;
 import org.openmetadata.service.secrets.SecretsManagerFactory;
@@ -50,5 +57,101 @@ public class OpenMetadataConnectionBuilderTest extends OpenMetadataApplicationTe
     // The OM Connection passes the right JWT based on the incoming bot
     DecodedJWT jwt = JWT.decode(openMetadataServerConnection.getSecurityConfig().getJwtToken());
     Assertions.assertEquals("autoclassification-bot", jwt.getClaim("sub").asString());
+  }
+
+  @Test
+  void testGetBotFromPipeline_Metadata() throws Exception {
+    IngestionPipeline pipeline = new IngestionPipeline().withPipelineType(PipelineType.METADATA);
+    String botName = invokeBotFromPipeline(pipeline);
+    Assertions.assertEquals(Entity.INGESTION_BOT_NAME, botName);
+  }
+
+  @Test
+  void testGetBotFromPipeline_DBT() throws Exception {
+    IngestionPipeline pipeline = new IngestionPipeline().withPipelineType(PipelineType.DBT);
+    String botName = invokeBotFromPipeline(pipeline);
+    Assertions.assertEquals(Entity.INGESTION_BOT_NAME, botName);
+  }
+
+  @Test
+  void testGetBotFromPipeline_AutoClassification() throws Exception {
+    IngestionPipeline pipeline =
+        new IngestionPipeline().withPipelineType(PipelineType.AUTO_CLASSIFICATION);
+    String botName = invokeBotFromPipeline(pipeline);
+    Assertions.assertEquals("autoClassification-bot", botName);
+  }
+
+  @Test
+  void testGetBotFromPipeline_Profiler() throws Exception {
+    IngestionPipeline pipeline = new IngestionPipeline().withPipelineType(PipelineType.PROFILER);
+    String botName = invokeBotFromPipeline(pipeline);
+    Assertions.assertEquals("profiler-bot", botName);
+  }
+
+  @Test
+  void testGetBotFromPipeline_Lineage() throws Exception {
+    IngestionPipeline pipeline = new IngestionPipeline().withPipelineType(PipelineType.LINEAGE);
+    String botName = invokeBotFromPipeline(pipeline);
+    Assertions.assertEquals("lineage-bot", botName);
+  }
+
+  @Test
+  void testGetBotFromPipeline_Usage() throws Exception {
+    IngestionPipeline pipeline = new IngestionPipeline().withPipelineType(PipelineType.USAGE);
+    String botName = invokeBotFromPipeline(pipeline);
+    Assertions.assertEquals("usage-bot", botName);
+  }
+
+  @Test
+  void testGetBotFromPipeline_TestSuite() throws Exception {
+    IngestionPipeline pipeline = new IngestionPipeline().withPipelineType(PipelineType.TEST_SUITE);
+    String botName = invokeBotFromPipeline(pipeline);
+    Assertions.assertEquals("testsuite-bot", botName);
+  }
+
+  @Test
+  void testGetBotFromPipeline_DataInsight() throws Exception {
+    IngestionPipeline pipeline =
+        new IngestionPipeline().withPipelineType(PipelineType.DATA_INSIGHT);
+    String botName = invokeBotFromPipeline(pipeline);
+    Assertions.assertEquals("datainsight-bot", botName);
+  }
+
+  @Test
+  void testGetBotFromPipeline_Application() throws Exception {
+    ApplicationConfig appConfig = new ApplicationConfig();
+    appConfig.setAdditionalProperty("type", "SearchIndexing");
+    IngestionPipeline pipeline =
+        new IngestionPipeline()
+            .withPipelineType(PipelineType.APPLICATION)
+            .withSourceConfig(
+                new SourceConfig()
+                    .withConfig(
+                        new ApplicationPipeline()
+                            .withType(ApplicationPipeline.ApplicationConfigType.APPLICATION)
+                            .withAppConfig(appConfig)));
+    String botName = invokeBotFromPipeline(pipeline);
+    Assertions.assertEquals("SearchIndexingApplicationBot", botName);
+  }
+
+  private String invokeBotFromPipeline(IngestionPipeline pipeline) throws Exception {
+    OpenMetadataConnectionBuilder builder =
+        new OpenMetadataConnectionBuilder(createTestConfig(), Entity.INGESTION_BOT_NAME);
+    Method method =
+        OpenMetadataConnectionBuilder.class.getDeclaredMethod(
+            "getBotFromPipeline", IngestionPipeline.class);
+    method.setAccessible(true);
+    return (String) method.invoke(builder, pipeline);
+  }
+
+  private OpenMetadataApplicationConfig createTestConfig() {
+    OpenMetadataApplicationConfig config = new OpenMetadataApplicationConfig();
+    config.setClusterName(CLUSTER_NAME);
+    config.setPipelineServiceClientConfiguration(
+        new PipelineServiceClientConfiguration()
+            .withMetadataApiEndpoint("http://localhost:8585/api")
+            .withVerifySSL(VerifySSL.NO_SSL)
+            .withSecretsManagerLoader(SecretsManagerClientLoader.ENV));
+    return config;
   }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

---

## Summary by Gitar

- **Fixed bot assignment:**
  - Added explicit case for `AUTO_CLASSIFICATION` pipeline type in `OpenMetadataConnectionBuilder.getBotFromPipeline()` to return `"autoClassification-bot"` instead of incorrectly generated `"auto_classification-bot"`
- **New test coverage:**
  - Added 9 unit tests in `OpenMetadataConnectionBuilderTest` covering all pipeline types (METADATA, DBT, AUTO_CLASSIFICATION, PROFILER, LINEAGE, USAGE, TEST_SUITE, DATA_INSIGHT, APPLICATION)
- **Bug context:**
  - Default case was lowercasing enum name, causing bot user lookup failures for AUTO_CLASSIFICATION pipelines

<sub>This will update automatically on new commits.</sub>

---