### PR TITLE
Fix Data Insight System Chart Percentage Issue

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/dataInsightAggregators/ElasticSearchDynamicChartAggregatorInterface.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/dataInsightAggregators/ElasticSearchDynamicChartAggregatorInterface.java
@@ -17,6 +17,7 @@ import es.co.elastic.clients.json.JsonData;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -272,6 +273,36 @@ public interface ElasticSearchDynamicChartAggregatorInterface {
     return finalResult;
   }
 
+  /**
+   * Extracts the numeric index from aggregation key names.
+   * Keys follow patterns like "filter0", "filter1", "id.keyword0", "id.keyword1",
+   * etc.
+   * The index is always the trailing digits in the key name.
+   */
+  private static int extractAggregationIndex(String key) {
+    // Extract trailing digits from the key
+    int i = key.length() - 1;
+    while (i >= 0 && Character.isDigit(key.charAt(i))) {
+      i--;
+    }
+    if (i < key.length() - 1) {
+      return Integer.parseInt(key.substring(i + 1));
+    }
+    return Integer.MAX_VALUE; // Keys without numeric suffix go last
+  }
+
+  /**
+   * Returns a sorted list of aggregation entries by their numeric index.
+   * This ensures consistent ordering regardless of the underlying map
+   * implementation.
+   */
+  private static List<Map.Entry<String, Aggregate>> getSortedAggregationEntries(
+      Map<String, Aggregate> aggregations) {
+    List<Map.Entry<String, Aggregate>> entries = new ArrayList<>(aggregations.entrySet());
+    entries.sort(Comparator.comparingInt(e -> extractAggregationIndex(e.getKey())));
+    return entries;
+  }
+
   private List<List<DataInsightCustomChartResult>> processAggregationsInternal(
       Map<String, Aggregate> aggregations, String group, String metric) {
     List<List<DataInsightCustomChartResult>> results = new ArrayList<>();
@@ -280,7 +311,10 @@ public interface ElasticSearchDynamicChartAggregatorInterface {
       if (agg.isSterms()) {
         for (StringTermsBucket bucket : agg.sterms().buckets().array()) {
           List<DataInsightCustomChartResult> subResults = new ArrayList<>();
-          for (Map.Entry<String, Aggregate> subEntry : bucket.aggregations().entrySet()) {
+          // Sort entries by their numeric index to ensure correct formula substitution
+          // order
+          for (Map.Entry<String, Aggregate> subEntry :
+              getSortedAggregationEntries(bucket.aggregations())) {
             addByAggregationType(
                 subEntry.getValue(), subResults, bucket.key().stringValue(), group, false, metric);
           }
@@ -289,7 +323,10 @@ public interface ElasticSearchDynamicChartAggregatorInterface {
       } else if (agg.isDateHistogram()) {
         for (DateHistogramBucket bucket : agg.dateHistogram().buckets().array()) {
           List<DataInsightCustomChartResult> subResults = new ArrayList<>();
-          for (Map.Entry<String, Aggregate> subEntry : bucket.aggregations().entrySet()) {
+          // Sort entries by their numeric index to ensure correct formula substitution
+          // order
+          for (Map.Entry<String, Aggregate> subEntry :
+              getSortedAggregationEntries(bucket.aggregations())) {
             addByAggregationType(
                 subEntry.getValue(), subResults, String.valueOf(bucket.key()), group, true, metric);
           }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/OpenSearchDynamicChartAggregatorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/OpenSearchDynamicChartAggregatorTest.java
@@ -518,4 +518,121 @@ public class OpenSearchDynamicChartAggregatorTest extends OpenMetadataApplicatio
             "(count(k='id.keyword',q='hasDescription: 1')/count(k='id.keyword'))*100",
             resultListLineFormula));
   }
+
+  /**
+   * Test that verifies the aggregation ordering fix works correctly.
+   * This test uses a response where id.keyword1 (total count) appears BEFORE
+   * filter0 (filtered count)
+   * in the JSON, simulating the HashMap ordering issue that caused the 162300%
+   * bug.
+   *
+   * <p>
+   * The formula is: (count(k='id.keyword',q='hasDescription:
+   * 1')/count(k='id.keyword'))*100
+   * With values: (171/455)*100 = 37.58%
+   *
+   * <p>
+   * Without the sorting fix, if id.keyword1 (455) is processed before filter0
+   * (171),
+   * the result would be calculated as: (455/171)*100 = 266% (WRONG!)
+   */
+  @Test
+  public void testAggregationOrderingWithReversedKeys() {
+    // Response with id.keyword1 appearing BEFORE filter0 in the aggregation keys
+    // This simulates the HashMap ordering issue
+    String responseWithReversedOrder =
+        "{\"took\":15,\"timed_out\":false,\"_shards\":{\"failed\":0.0,\"successful\":17.0,\"total\":17.0,\"skipped\":0.0},"
+            + "\"hits\":{\"total\":{\"relation\":\"eq\",\"value\":720},\"hits\":[],\"max_score\":null},"
+            + "\"aggregations\":{\"sterms#0\":{\"buckets\":["
+            + "{\"date_histogram#metric_1\":{\"buckets\":["
+            + "{\"value_count#id.keyword1\":{\"value\":455.0}," // Total count comes FIRST
+            + "\"filter#filter0\":{\"value_count#id.keyword0\":{\"value\":171.0},\"doc_count\":171}," // Filtered
+            // count comes
+            // SECOND
+            + "\"doc_count\":455,\"key_as_string\":\"2026-01-19T00:00:00.000Z\",\"key\":1768780800000}]},"
+            + "\"doc_count\":455,\"key\":\"table\"},"
+            + "{\"date_histogram#metric_1\":{\"buckets\":["
+            + "{\"value_count#id.keyword1\":{\"value\":90.0}," // Total count comes FIRST
+            + "\"filter#filter0\":{\"value_count#id.keyword0\":{\"value\":20.0},\"doc_count\":20}," // Filtered
+            // count comes
+            // SECOND
+            + "\"doc_count\":90,\"key_as_string\":\"2026-01-19T00:00:00.000Z\",\"key\":1768780800000}]},"
+            + "\"doc_count\":90,\"key\":\"pipeline\"}],"
+            + "\"doc_count_error_upper_bound\":0,\"sum_other_doc_count\":0}}}";
+
+    Map<String, Object> lineChartFormula = new LinkedHashMap<>();
+    lineChartFormula.put("type", "LineChart");
+    Map<String, Object> metricsFormula = new LinkedHashMap<>();
+    metricsFormula.put(
+        "formula", "(count(k='id.keyword',q='hasDescription: 1')/count(k='id.keyword'))*100");
+    lineChartFormula.put("metrics", List.of(metricsFormula));
+    lineChartFormula.put("groupBy", "entityType.keyword");
+
+    // Expected results: (171/455)*100 ≈ 37.58% for table, (20/90)*100 ≈ 22.22% for
+    // pipeline
+    List<DataInsightCustomChartResult> expectedResults = new ArrayList<>();
+    expectedResults.add(
+        new DataInsightCustomChartResult()
+            .withCount(37.582417582417584) // (171/455)*100
+            .withDay(1.7687808E12)
+            .withGroup("table"));
+    expectedResults.add(
+        new DataInsightCustomChartResult()
+            .withCount(22.22222222222222) // (20/90)*100
+            .withDay(1.7687808E12)
+            .withGroup("pipeline"));
+
+    assertTrue(
+        compareResponse(
+            responseWithReversedOrder,
+            lineChartFormula,
+            "(count(k='id.keyword',q='hasDescription: 1')/count(k='id.keyword'))*100",
+            expectedResults));
+  }
+
+  /**
+   * Test that verifies the aggregation ordering fix for a simple division
+   * formula.
+   * Uses response where the total count key appears before the filtered count
+   * key.
+   */
+  @Test
+  public void testAggregationOrderingSimpleDivision() {
+    // Response where id.keyword1 comes before filter0 - this is the ordering that
+    // caused the bug
+    String responseWithReversedOrder =
+        "{\"took\":10,\"timed_out\":false,\"_shards\":{\"total\":1,\"successful\":1,\"skipped\":0,\"failed\":0},"
+            + "\"hits\":{\"total\":{\"value\":100,\"relation\":\"eq\"},\"max_score\":null,\"hits\":[]},"
+            + "\"aggregations\":{\"date_histogram#metric_1\":{\"buckets\":["
+            + "{\"key_as_string\":\"2024-07-20T00:00:00.000Z\",\"key\":1721433600000,\"doc_count\":100,"
+            + "\"value_count#id.keyword1\":{\"value\":1623.0}," // Total count (large number) first
+            + "\"filter#filter0\":{\"doc_count\":1,\"value_count#id.keyword0\":{\"value\":1.0}}}]}}}"; // Filtered
+    // count
+    // (small
+    // number)
+    // second
+
+    Map<String, Object> lineChart = new LinkedHashMap<>();
+    lineChart.put("type", "LineChart");
+    Map<String, Object> metrics = new LinkedHashMap<>();
+    // The formula where the bug manifested: should be (1/1623)*100 = 0.0616% not
+    // (1623/1)*100 = 162300%
+    metrics.put(
+        "formula", "(count(k='id.keyword',q='hasDescription: 1')/count(k='id.keyword'))*100");
+    lineChart.put("metrics", List.of(metrics));
+
+    // Expected: (1/1623)*100 = 0.0616... NOT 162300
+    List<DataInsightCustomChartResult> expectedResults = new ArrayList<>();
+    expectedResults.add(
+        new DataInsightCustomChartResult()
+            .withCount(0.06161429451632779) // (1/1623)*100 - the CORRECT value
+            .withDay(1.7214336E12));
+
+    assertTrue(
+        compareResponse(
+            responseWithReversedOrder,
+            lineChart,
+            "(count(k='id.keyword',q='hasDescription: 1')/count(k='id.keyword'))*100",
+            expectedResults));
+  }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

---

## Summary by Gitar

- **Fixed percentage calculation bug:**
  - Data Insight charts were displaying incorrect percentages (e.g., 162300% instead of 0.0616%) due to HashMap iteration ordering
  - Added `extractAggregationIndex` and `getSortedAggregationEntries` methods to ensure aggregations are processed in correct order
- **Applied fix to both search engines:**
  - Implemented identical sorting logic in `ElasticSearchDynamicChartAggregatorInterface` and `OpenSearchDynamicChartAggregatorInterface`
- **Added regression tests:**
  - Created `testAggregationOrderingWithReversedKeys` and `testAggregationOrderingSimpleDivision` for both ElasticSearch and OpenSearch
  - Tests verify correct percentage calculations when aggregation keys appear in reversed order

<sub>This will update automatically on new commits.</sub>

---