### PR TITLE
MINOR: Accept SecretsManagerProvider instead of using SecretsManagerProvider.DB

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/secrets/SecretsManagerFactory.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/secrets/SecretsManagerFactory.java
@@ -38,9 +38,9 @@ public class SecretsManagerFactory {
     switch (secretsManagerProvider) {
       case DB, AWS_SSM, AWS, AZURE_KV ->
       /*
-      We handle AWS and AWS_SSM as a NoopSecretsManager since we don't
+      We handle AWS, AWS_SSM, and AZURE_KV as a NoopSecretsManager since we don't
       need to WRITE any secrets. We will be just reading them out of the
-      AWS instance on the INGESTION side, but the server does not need
+      external secrets manager on the INGESTION side, but the server does not need
       to do anything here.
 
       If for example we want to set the AWS SSM (non-managed) we configure


### PR DESCRIPTION
This pull request updates the secrets manager instantiation logic to improve flexibility and accuracy in selecting the appropriate provider. The main changes involve passing the `SecretsManagerProvider` explicitly when creating a `DBSecretsManager` instance, ensuring the correct provider is used throughout the codebase.

Secrets manager instantiation improvements:

* Updated the `DBSecretsManager.getInstance` method to accept a `SecretsManagerProvider` parameter instead of always using `SecretsManagerProvider.DB`, allowing for more flexible provider selection.
* Modified the `SecretsManagerFactory.createSecretsManager` method to pass the actual `secretsManagerProvider` to `DBSecretsManager.getInstance`, ensuring that the correct provider is used when initializing the secrets manager.

---

## Summary by Gitar

- **Breaking API change:**
  - Modified `DBSecretsManager.getInstance()` method signature from 1 parameter to 2 parameters (added `SecretsManagerProvider` as first argument)
- **Test compilation failure:**
  - `DBSecretsManagerTest.java:48` calls `getInstance()` with 1 parameter instead of 2, causing build failure in all CI jobs
- **Files affected:**
  - `DBSecretsManager.java` and `SecretsManagerFactory.java` updated to use new signature

<sub>This will update automatically on new commits.</sub>

---