### PR TITLE
Fix AWS failing Test

### DIFF
--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/AwsCredentialsProviderTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/AwsCredentialsProviderTest.java
@@ -3,6 +3,8 @@ package org.openmetadata.service.search;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 import org.openmetadata.schema.service.configuration.elasticsearch.AwsConfiguration;
@@ -58,6 +60,7 @@ class AwsCredentialsProviderTest {
   void testDefaultCredentialsProviderWhenNoStaticCredentials() {
     AwsConfiguration awsConfig = new AwsConfiguration();
     awsConfig.setRegion("us-east-1");
+    awsConfig.setEnabled(true);
 
     AwsCredentialsProvider provider = AwsCredentialsUtil.buildCredentialsProvider(awsConfig);
 
@@ -66,58 +69,68 @@ class AwsCredentialsProviderTest {
   }
 
   @Test
-  void testDefaultCredentialsProviderWithOnlyAccessKey() {
+  void testThrowsExceptionWithOnlyAccessKey() {
     AwsConfiguration awsConfig = new AwsConfiguration();
     awsConfig.setAccessKeyId("AKIAIOSFODNN7EXAMPLE");
 
-    AwsCredentialsProvider provider = AwsCredentialsUtil.buildCredentialsProvider(awsConfig);
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> AwsCredentialsUtil.buildCredentialsProvider(awsConfig));
 
-    assertNotNull(provider);
-    assertInstanceOf(DefaultCredentialsProvider.class, provider);
+    assertTrue(exception.getMessage().contains("AWS credentials not configured"));
   }
 
   @Test
-  void testDefaultCredentialsProviderWithOnlySecretKey() {
+  void testThrowsExceptionWithOnlySecretKey() {
     AwsConfiguration awsConfig = new AwsConfiguration();
     awsConfig.setSecretAccessKey("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
 
-    AwsCredentialsProvider provider = AwsCredentialsUtil.buildCredentialsProvider(awsConfig);
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> AwsCredentialsUtil.buildCredentialsProvider(awsConfig));
 
-    assertNotNull(provider);
-    assertInstanceOf(DefaultCredentialsProvider.class, provider);
+    assertTrue(exception.getMessage().contains("AWS credentials not configured"));
   }
 
   @Test
-  void testDefaultCredentialsProviderWithEmptyCredentials() {
+  void testThrowsExceptionWithEmptyCredentials() {
     AwsConfiguration awsConfig = new AwsConfiguration();
     awsConfig.setAccessKeyId("");
     awsConfig.setSecretAccessKey("");
 
-    AwsCredentialsProvider provider = AwsCredentialsUtil.buildCredentialsProvider(awsConfig);
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> AwsCredentialsUtil.buildCredentialsProvider(awsConfig));
 
-    assertNotNull(provider);
-    assertInstanceOf(DefaultCredentialsProvider.class, provider);
+    assertTrue(exception.getMessage().contains("AWS credentials not configured"));
   }
 
   @Test
-  void testNullAwsConfig() {
+  void testThrowsExceptionWithEmptyAwsConfig() {
     AwsConfiguration awsConfig = new AwsConfiguration();
 
-    AwsCredentialsProvider provider = AwsCredentialsUtil.buildCredentialsProvider(awsConfig);
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> AwsCredentialsUtil.buildCredentialsProvider(awsConfig));
 
-    assertNotNull(provider);
-    assertInstanceOf(DefaultCredentialsProvider.class, provider);
+    assertTrue(exception.getMessage().contains("AWS credentials not configured"));
   }
 
   @Test
-  void testSessionTokenIgnoredWithoutAccessKeyAndSecret() {
+  void testThrowsExceptionWithOnlySessionToken() {
     AwsConfiguration awsConfig = new AwsConfiguration();
     awsConfig.setSessionToken("FwoGZXIvYXdzEBYaDKTsessiontoken123");
 
-    AwsCredentialsProvider provider = AwsCredentialsUtil.buildCredentialsProvider(awsConfig);
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> AwsCredentialsUtil.buildCredentialsProvider(awsConfig));
 
-    assertNotNull(provider);
-    assertInstanceOf(DefaultCredentialsProvider.class, provider);
+    assertTrue(exception.getMessage().contains("AWS credentials not configured"));
   }
 
   @Test


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

---

## Summary by Gitar

- **Test correctness fix:**
  - Updated 6 test methods in `AwsCredentialsProviderTest.java` to expect `IllegalArgumentException` for invalid AWS credential configurations
- **Test assertion improvements:**
  - Changed from expecting `DefaultCredentialsProvider` fallback to validating exception throwing with proper error messages
- **Test configuration fix:**
  - Added `setEnabled(true)` to `testDefaultCredentialsProviderWhenNoStaticCredentials` to properly test IAM authentication path
- **Test naming refactor:**
  - Renamed test methods to reflect their purpose (e.g., `testThrowsExceptionWithOnlyAccessKey` instead of `testDefaultCredentialsProviderWithOnlyAccessKey`)

<sub>This will update automatically on new commits.</sub>

---