### PR TITLE
Remove unexpected tag in classification

### DIFF
--- a/ingestion/tests/integration/auto_classification/test_tag_processor.py
+++ b/ingestion/tests/integration/auto_classification/test_tag_processor.py
@@ -180,13 +180,7 @@ def test_it_returns_the_expected_classifications(
             ),
         ),
     ]
-    assert timestamp_column.tags == [
-        IsInstance(TagLabel)
-        & HasAttributes(
-            tagFQN=HasAttributes(root="PII.NonSensitive"),
-            reason=Contains("Detected by `SpacyRecognizer`"),
-        ),
-    ]
+    assert timestamp_column.tags == []
     assert version_column.tags == []
     assert order_date_column.tags == [
         IsInstance(TagLabel)


### PR DESCRIPTION
### Describe your changes:

Fixes this test in CI (coming from main):

```text
=========================== short test summary info ============================
FAILED ingestion/tests/integration/auto_classification/test_tag_processor.py::test_it_returns_the_expected_classifications
= 1 failed, 519 passed, 21 skipped, 1 xfailed, 1399 warnings in 4521.94s (1:15:21) =
```

I removed a classification introduced in #25441 that wasn't supposed to be picked up by the classifier

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
- [X] Improvement

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [X] I have fixed tests