### PR TITLE
Fixes 25534: Add search_query parameter to paginate_es

### DIFF
--- a/ingestion/src/metadata/ingestion/ometa/mixins/es_mixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/es_mixin.py
@@ -384,7 +384,7 @@ class ESMixin(Generic[T]):
         query = functools.partial(
             self.paginate_query.format,
             index=ES_INDEX_MAP[entity.__name__],
-            search_query=search_query,
+            search_query=quote_plus(search_query) if search_query else "",
             filter="&query_filter=" + quote_plus(query_filter) if query_filter else "",
             size=size,
             include_fields=self._get_include_fields_query(include_fields),

--- a/ingestion/tests/integration/ometa/test_ometa_es_api.py
+++ b/ingestion/tests/integration/ometa/test_ometa_es_api.py
@@ -543,19 +543,19 @@ class TestOMetaESAPI:
                 )
             )
 
-    def test_search(self):
+    def test_search(self, metadata, es_service, es_schema):
         for name in [f"Table {i}" for i in range(5)]:
-            self.metadata.create_or_update(
+            metadata.create_or_update(
                 data=get_create_entity(
                     entity=Table,
                     name=EntityName(name),
-                    reference=self.create_schema_entity.fullyQualifiedName,
+                    reference=es_schema.fullyQualifiedName,
                 )
             )
 
         # Searching by an almost exact match has the highest rank.
         assets = list(
-            self.metadata.paginate_es(
+            metadata.paginate_es(
                 entity=Table, search_query="table 2", sort_field="_score"
             )
         )
@@ -566,7 +566,7 @@ class TestOMetaESAPI:
 
         # Searching by a value that doesn't exist returns an empty set of results.
         assets = list(
-            self.metadata.paginate_es(
+            metadata.paginate_es(
                 entity=Table, search_query="N0NExistent", sort_field="_score"
             )
         )


### PR DESCRIPTION
# Fixes 25534: Add search_query parameter to paginate_es



<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes 25534

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on lightly refactoring `paginate_es` and the other methods it calls, in order to enable the SDK
user to search entities. Otherwise, there's no ability to search entities by any of the indexed fields.
In other words, the `q` parameter in the interpolated query string was missing.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [x] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

---

----
## Summary by Gitar

- **New search parameter:**
  - Added `search_query` parameter to `paginate_es()` and `_paginate_es_internal()` enabling full-text search on indexed entity fields
  - Search queries are URL-encoded using `quote_plus()` and integrated into the ES `/search/query` endpoint
- **Test coverage:**
  - Added integration test validating search functionality with relevance scoring and non-existent query handling

<sub>This will update automatically on new commits.</sub>