### PR TITLE
Fix lodash prototype pollution vulnerability

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/package.json
+++ b/openmetadata-ui/src/main/resources/ui/package.json
@@ -108,7 +108,7 @@
     "js-yaml": "^4.1.1",
     "jwt-decode": "^3.1.2",
     "katex": "^0.16.21",
-    "lodash": "^4.17.21",
+    "lodash": "^4.17.23",
     "luxon": "^3.2.1",
     "notistack": "^3.0.2",
     "oidc-client": "^1.11.5",
@@ -262,6 +262,7 @@
     "on-headers": "1.1.0",
     "form-data": "3.0.4",
     "tar-fs": "2.1.4",
-    "js-yaml": "4.1.1"
+    "js-yaml": "4.1.1",
+    "lodash": ">=4.17.23"
   }
 }

--- a/openmetadata-ui/src/main/resources/ui/yarn.lock
+++ b/openmetadata-ui/src/main/resources/ui/yarn.lock
@@ -9386,10 +9386,10 @@ lodash.throttle@^4.1.1:
   resolved "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz"
   integrity sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==
 
-lodash@>=4.17.21, lodash@^4.15.0, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4:
-  version "4.17.21"
-  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+lodash@>=4.17.21, lodash@>=4.17.23, lodash@^4.15.0, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.23, lodash@^4.17.4:
+  version "4.17.23"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.23.tgz#f113b0378386103be4f6893388c73d0bde7f2c5a"
+  integrity sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==
 
 log-symbols@^4.0.0:
   version "4.1.0"


### PR DESCRIPTION
## Summary
- Bump `lodash` direct dependency from `^4.17.21` to `^4.17.23` to patch a prototype pollution vulnerability in `_.unset` and `_.omit`
- Add `"lodash": ">=4.17.23"` to yarn `resolutions` to force all 9 transitive dependents (`@ant-design/icons`, `@auth0/auth0-react`, `@deuex-solutions/react-tour`, `@react-awesome-query-builder/antd`, `@rjsf/utils`, `@testing-library/jest-dom`, `antd`, `rapidoc`, `recharts`) to use the patched version

## Test plan
- [ ] Verify `yarn.lock` resolves lodash to `4.17.23`
- [ ] Run `yarn install` successfully
- [ ] Run frontend unit tests (`yarn test`)
- [ ] Run frontend build (`yarn build`)
- [ ] Smoke test the UI to confirm no regressions from the lodash bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)