### PR TITLE
chore: Exclude playwright documentation and doc-generator paths from various CI workflow triggers.

### DIFF
--- a/.github/workflows/java-checkstyle.yml
+++ b/.github/workflows/java-checkstyle.yml
@@ -20,11 +20,14 @@ on:
       - "0.[0-9]+.[0-9]+"
   pull_request_target:
     types: [opened, synchronize, reopened, labeled]
+    paths-ignore:
+      - "openmetadata-ui/src/main/resources/ui/playwright/doc-generator/**"
+      - "openmetadata-ui/src/main/resources/ui/playwright/docs/**"
 
 permissions:
   contents: read
 
-concurrency: 
+concurrency:
   group: java-checkstyle-${{ github.head_ref }}
   cancel-in-progress: true
 jobs:
@@ -45,7 +48,7 @@ jobs:
             swap-storage: true
             docker-images: false
       - name: Wait for the labeler
-        uses: lewagon/wait-on-check-action@v1.3.4  
+        uses: lewagon/wait-on-check-action@v1.3.4
         if: ${{ github.event_name == 'pull_request_target' }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/maven-build-collate.yml
+++ b/.github/workflows/maven-build-collate.yml
@@ -19,6 +19,8 @@ on:
     paths:
       - "openmetadata-service/**"
       - "openmetadata-ui/**"
+      - "!openmetadata-ui/src/main/resources/ui/playwright/doc-generator/**"
+      - "!openmetadata-ui/src/main/resources/ui/playwright/docs/**"
       - "openmetadata-spec/src/main/resources/json/schema/**"
       - "openmetadata-dist/**"
       - "openmetadata-clients/**"
@@ -38,7 +40,7 @@ permissions:
   contents: read
   checks: write
 
-concurrency: 
+concurrency:
   group: maven-build-collate-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 jobs:

--- a/.github/workflows/maven-postgres-tests-build.yml
+++ b/.github/workflows/maven-postgres-tests-build.yml
@@ -18,6 +18,8 @@ on:
     paths:
       - "openmetadata-service/**"
       - "openmetadata-ui/**"
+      - "!openmetadata-ui/src/main/resources/ui/playwright/doc-generator/**"
+      - "!openmetadata-ui/src/main/resources/ui/playwright/docs/**"
       - "openmetadata-spec/src/main/resources/json/schema/**"
       - "openmetadata-dist/**"
       - "openmetadata-clients/**"
@@ -45,7 +47,7 @@ permissions:
   contents: read
   checks: write
 
-concurrency: 
+concurrency:
   group: maven-build-postgres-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 jobs:
@@ -94,7 +96,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
- 
+
       - name: Set up JDK 21
         if: steps.cache-output.outputs.exit-code == 0
         uses: actions/setup-java@v4

--- a/.github/workflows/playwright-mysql-e2e-skip.yml
+++ b/.github/workflows/playwright-mysql-e2e-skip.yml
@@ -22,12 +22,13 @@ on:
       - synchronize
       - reopened
     paths:
-      - '.github/**'                            
-      - 'openmetadata-dist/**'
-      - 'docker/**'
-      - '!docker/development/docker-compose.yml'
-      - '!docker/development/docker-compose-postgres.yml'
-
+      - ".github/**"
+      - "openmetadata-dist/**"
+      - "docker/**"
+      - "!docker/development/docker-compose.yml"
+      - "!docker/development/docker-compose-postgres.yml"
+      - "openmetadata-ui/src/main/resources/ui/playwright/doc-generator/**"
+      - "openmetadata-ui/src/main/resources/ui/playwright/docs/**"
 
 jobs:
   playwright-ci-mysql:

--- a/.github/workflows/playwright-mysql-e2e.yml
+++ b/.github/workflows/playwright-mysql-e2e.yml
@@ -23,11 +23,13 @@ on:
       - reopened
       - ready_for_review
     paths-ignore:
-      - '.github/**'
-      - 'openmetadata-dist/**'
-      - 'docker/**'
-      - '!docker/development/docker-compose.yml'
-      - '!docker/development/docker-compose-postgres.yml'  
+      - ".github/**"
+      - "openmetadata-dist/**"
+      - "docker/**"
+      - "!docker/development/docker-compose.yml"
+      - "!docker/development/docker-compose-postgres.yml"
+      - "openmetadata-ui/src/main/resources/ui/playwright/doc-generator/**"
+      - "openmetadata-ui/src/main/resources/ui/playwright/docs/**"
 
 permissions:
   contents: read

--- a/.github/workflows/playwright-postgresql-e2e-skip.yml
+++ b/.github/workflows/playwright-postgresql-e2e-skip.yml
@@ -27,8 +27,8 @@ on:
       - "docker/**"
       - "!docker/development/docker-compose.yml"
       - "!docker/development/docker-compose-postgres.yml"
-      - "OpenMetadata/openmetadata-ui/src/main/resources/ui/playwright/doc-generator/**"
-      - "OpenMetadata/openmetadata-ui/src/main/resources/ui/playwright/docs/**"
+      - "openmetadata-ui/src/main/resources/ui/playwright/doc-generator/**"
+      - "openmetadata-ui/src/main/resources/ui/playwright/docs/**"
 
 jobs:
   playwright-ci-postgresql:

--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -28,8 +28,8 @@ on:
       - "docker/**"
       - "!docker/development/docker-compose.yml"
       - "!docker/development/docker-compose-postgres.yml"
-      - "OpenMetadata/openmetadata-ui/src/main/resources/ui/playwright/doc-generator/**"
-      - "OpenMetadata/openmetadata-ui/src/main/resources/ui/playwright/docs/**"
+      - "openmetadata-ui/src/main/resources/ui/playwright/doc-generator/**"
+      - "openmetadata-ui/src/main/resources/ui/playwright/docs/**"
 
 permissions:
   contents: read

--- a/.github/workflows/py-checkstyle.yml
+++ b/.github/workflows/py-checkstyle.yml
@@ -16,11 +16,14 @@ name: Python Checkstyle
 on:
   pull_request_target:
     types: [labeled, opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - "openmetadata-ui/src/main/resources/ui/playwright/doc-generator/**"
+      - "openmetadata-ui/src/main/resources/ui/playwright/docs/**"
 
 permissions:
   contents: read
 
-concurrency: 
+concurrency:
   group: py-checkstyle-${{ github.head_ref }}
   cancel-in-progress: true
 
@@ -32,7 +35,6 @@ jobs:
       pull-requests: write
 
     steps:
-
       - name: Wait for the labeler
         uses: lewagon/wait-on-check-action@v1.3.4
         if: ${{ github.event_name == 'pull_request_target' }}

--- a/.github/workflows/yarn-coverage.yml
+++ b/.github/workflows/yarn-coverage.yml
@@ -8,6 +8,8 @@ on:
     types: [opened, synchronize, reopened, labeled, ready_for_review]
     paths:
       - openmetadata-ui/src/main/resources/ui/**
+      - "!openmetadata-ui/src/main/resources/ui/playwright/doc-generator/**"
+      - "!openmetadata-ui/src/main/resources/ui/playwright/docs/**"
 
 permissions:
   contents: read
@@ -57,7 +59,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
-      - name: Caching NPM dependencies 
+      - name: Caching NPM dependencies
         uses: actions/cache@v4
         id: yarn-cache
         with:


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to refine which files and directories trigger or are ignored by CI jobs. The main focus is to exclude the `playwright/doc-generator` and `playwright/docs` directories in `openmetadata-ui` from most build, checkstyle, and test workflows, ensuring that changes to documentation-related files do not unnecessarily trigger these jobs. Additionally, it fixes path casing inconsistencies and improves path matching in some workflows.

**Workflow trigger and path matching improvements:**

* Excluded `openmetadata-ui/src/main/resources/ui/playwright/doc-generator/**` and `openmetadata-ui/src/main/resources/ui/playwright/docs/**` from triggering Java and Python checkstyle, Maven build/collate, and yarn coverage workflows using `paths-ignore` or negative patterns, so documentation changes don't run full CI. [[1]](diffhunk://#diff-3dffa7868454d78410309499a0f7c3cc510f61b7cab5db05bc9faacb265bf152R23-R25) [[2]](diffhunk://#diff-a57c79e5b60156a27bdba0dae3e6f988057bca3ebf5e7cce9c0d25d92844eb43R19-R21) [[3]](diffhunk://#diff-e2a5137e996e5f19b9c69252f1fddd939d6876220afe02c8a6e356a820913b00R22-R23) [[4]](diffhunk://#diff-5ab5ec94605882b365430999ad163df0fd832117a833ad14b21a85349d2dba39R21-R22) [[5]](diffhunk://#diff-e29db9aa0ca45f65f2c397c0d6f5ab18d77330679389f74c3177e4c301b20a50R11-R12)
* Updated Playwright E2E workflow triggers to consistently include or ignore the documentation directories, and fixed path casing issues (removed `OpenMetadata/` prefix) for correct matching. [[1]](diffhunk://#diff-4d9f638a223646d6c1bcce06ec1b6c5195e493158e41230ad360c599077f015bL25-R31) [[2]](diffhunk://#diff-37a13e66deb903f6ecd558b6a8a4d8d90e827623ba3305f6afcc5afdd7a2b38aL26-R32) [[3]](diffhunk://#diff-626db3d98fdfca6e38b50f7b11001fa86fd80e8f77a933e4dee5eee15d8e34c0L30-R31) [[4]](diffhunk://#diff-cedb3ebcf1e61268809fb0cffc81c8a2ba9bb192f2a206e94f46dbe01aa6f395L31-R32)

**Other minor changes:**

* Removed an unnecessary blank line in the Python checkstyle workflow's job steps section.