### PR TITLE
Revert "Fix #25645: MySQL timestamp precision for tag_usage.appliedAt (#25643)"

### DIFF
--- a/bootstrap/sql/migrations/native/1.11.8/mysql/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.11.8/mysql/schemaChanges.sql
@@ -1,4 +1,0 @@
--- Upgrade appliedAt to microsecond precision to match PostgreSQL behavior.
--- Without this, MySQL returns second-precision timestamps which cause spurious
--- diffs in JSON patch operations, leading to deserialization failures.
-ALTER TABLE tag_usage MODIFY appliedAt TIMESTAMP(6) NULL DEFAULT CURRENT_TIMESTAMP(6);

--- a/bootstrap/sql/migrations/native/1.11.8/postgres/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.11.8/postgres/schemaChanges.sql
@@ -1,1 +1,0 @@
--- No changes needed for PostgreSQL - TIMESTAMP already has microsecond precision.

--- a/bootstrap/sql/migrations/native/1.12.0/mysql/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.12.0/mysql/schemaChanges.sql
@@ -111,11 +111,6 @@ CREATE INDEX idx_api_endpoint_entity_updated_at_id ON api_endpoint_entity(update
 -- Add metadata column to tag_usage table
 ALTER TABLE tag_usage ADD metadata JSON NULL;
 
--- Upgrade appliedAt to microsecond precision to match PostgreSQL behavior.
--- Without this, MySQL returns second-precision timestamps which cause spurious
--- diffs in JSON patch operations, leading to deserialization failures.
-ALTER TABLE tag_usage MODIFY appliedAt TIMESTAMP(6) NULL DEFAULT CURRENT_TIMESTAMP(6);
-
 -- Distributed Search Indexing Tables
 
 -- Table to track reindex jobs across distributed servers


### PR DESCRIPTION


This reverts commit e86a0201ab232720a0064927b9ffd9bb752719d5.

<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

---

## Summary by Gitar

- **Reverted database migration:**
  - Removed `TIMESTAMP(6)` precision fix for `tag_usage.appliedAt` column from PR #25643
- **Deleted migration version:**
  - Removed entire `bootstrap/sql/migrations/native/1.11.8/` directory (MySQL and PostgreSQL files)
- **Cleaned duplicate change:**
  - Removed same timestamp modification from `1.12.0/mysql/schemaChanges.sql`

<sub>This will update automatically on new commits.</sub>

---