### PR TITLE
Fixes #25638: skip and warn long values in classification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,4 +185,5 @@ hive-mind-prompt-*.txt
 .claude-flow/
 memory
 .claude/agents
+ingestion/.claude/agents
 

--- a/ingestion/src/metadata/pii/algorithms/preprocessing.py
+++ b/ingestion/src/metadata/pii/algorithms/preprocessing.py
@@ -18,6 +18,8 @@ from metadata.utils.logger import pii_logger
 
 logger = pii_logger()
 
+MAX_NLP_TEXT_LENGTH = 1_000_000
+
 
 # pylint: disable=too-many-return-statements
 def convert_to_str(value: Any) -> Optional[Union[List[str], str]]:
@@ -26,6 +28,11 @@ def convert_to_str(value: Any) -> Optional[Union[List[str], str]]:
     tailored to our use case, not a generic one.
     """
     if isinstance(value, str):
+        if len(value) > MAX_NLP_TEXT_LENGTH:
+            logger.warning(
+                f"Skipping text field of length {len(value)} as it exceeds maximum NLP length of {MAX_NLP_TEXT_LENGTH} characters"
+            )
+            return None
         return value
     if isinstance(value, (int, float, datetime.datetime, datetime.date)):
         # Values we want to convert to string out of the box

--- a/ingestion/tests/unit/pii/algorithms/test_preprocessing.py
+++ b/ingestion/tests/unit/pii/algorithms/test_preprocessing.py
@@ -8,9 +8,15 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+from unittest.mock import patch
+
 import pytest
 
-from metadata.pii.algorithms.preprocessing import convert_to_str, preprocess_values
+from metadata.pii.algorithms.preprocessing import (
+    MAX_NLP_TEXT_LENGTH,
+    convert_to_str,
+    preprocess_values,
+)
 
 
 @pytest.mark.parametrize(
@@ -22,7 +28,7 @@ from metadata.pii.algorithms.preprocessing import convert_to_str, preprocess_val
         (b"hello", None),
         (None, None),
         ({"key": "value"}, ["value"]),
-        ({1, 2, 3}, None),  # Sets cannot be converted to JSON
+        ({1, 2, 3}, None),
     ],
 )
 def test_converts_various_types_to_string(input_value, expected):
@@ -40,3 +46,76 @@ def test_converts_various_types_to_string(input_value, expected):
 )
 def test_preprocesses_sequences_correctly(input_values, expected):
     assert preprocess_values(input_values) == expected
+
+
+def test_normal_length_string_processed_correctly():
+    normal_string = "a" * 1000
+    result = convert_to_str(normal_string)
+    assert result == normal_string
+
+
+def test_max_length_string_processed_correctly():
+    max_length_string = "a" * MAX_NLP_TEXT_LENGTH
+    result = convert_to_str(max_length_string)
+    assert result == max_length_string
+
+
+@patch("metadata.pii.algorithms.preprocessing.logger")
+def test_oversized_string_returns_none_and_logs_warning(mock_logger):
+    oversized_string = "a" * (MAX_NLP_TEXT_LENGTH + 1)
+    result = convert_to_str(oversized_string)
+
+    assert result is None
+    mock_logger.warning.assert_called_once()
+    warning_message = mock_logger.warning.call_args[0][0]
+    assert "Skipping text field of length" in warning_message
+    assert str(MAX_NLP_TEXT_LENGTH + 1) in warning_message
+    assert str(MAX_NLP_TEXT_LENGTH) in warning_message
+
+
+@patch("metadata.pii.algorithms.preprocessing.logger")
+def test_very_large_string_returns_none_and_logs_warning(mock_logger):
+    very_large_string = "a" * 2_000_000
+    result = convert_to_str(very_large_string)
+
+    assert result is None
+    mock_logger.warning.assert_called_once()
+    warning_message = mock_logger.warning.call_args[0][0]
+    assert "Skipping text field of length 2000000" in warning_message
+
+
+@patch("metadata.pii.algorithms.preprocessing.logger")
+def test_preprocess_values_with_mixed_size_strings(mock_logger):
+    normal_string = "normal"
+    oversized_string = "a" * (MAX_NLP_TEXT_LENGTH + 1)
+    max_length_string = "b" * MAX_NLP_TEXT_LENGTH
+
+    input_values = [normal_string, oversized_string, max_length_string, "another"]
+    result = preprocess_values(input_values)
+
+    assert result == [normal_string, max_length_string, "another"]
+    mock_logger.warning.assert_called_once()
+
+
+@patch("metadata.pii.algorithms.preprocessing.logger")
+def test_preprocess_values_with_list_containing_oversized_string(mock_logger):
+    normal_string = "normal"
+    oversized_string = "a" * (MAX_NLP_TEXT_LENGTH + 1)
+
+    input_values = [[normal_string, oversized_string, "valid"]]
+    result = preprocess_values(input_values)
+
+    assert result == [normal_string, "valid"]
+    mock_logger.warning.assert_called_once()
+
+
+@patch("metadata.pii.algorithms.preprocessing.logger")
+def test_preprocess_values_all_oversized_returns_empty(mock_logger):
+    oversized_1 = "a" * (MAX_NLP_TEXT_LENGTH + 1)
+    oversized_2 = "b" * (MAX_NLP_TEXT_LENGTH + 100)
+
+    input_values = [oversized_1, oversized_2]
+    result = preprocess_values(input_values)
+
+    assert result == []
+    assert mock_logger.warning.call_count == 2


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #25638 

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

---

## Summary by Gitar

- **New validation logic:**
  - Added `MAX_NLP_TEXT_LENGTH` constant (1M chars) to prevent NLP processor crashes on oversized text fields
- **Fixed classification failures:**
  - `convert_to_str` now skips and logs warnings for text exceeding limits instead of crashing
- **Test coverage:**
  - 7 new test cases covering boundary conditions, mixed inputs, and oversized string handling

<sub>This will update automatically on new commits.</sub>

---