### PR TITLE
Fix: Replace maven-surefire-plugin with maven-failsafe-plugin for integration tests

### DIFF
--- a/.github/workflows/integration-tests-mysql-elasticsearch.yml
+++ b/.github/workflows/integration-tests-mysql-elasticsearch.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Run Integration Tests (MySQL + Elasticsearch)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn test -pl :openmetadata-integration-tests -Pmysql-elasticsearch
+        run: mvn verify -pl :openmetadata-integration-tests -Pmysql-elasticsearch
 
       - name: Clean Up
         run: |
@@ -127,4 +127,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           fail_on_test_failures: true
-          report_paths: 'openmetadata-integration-tests/target/surefire-reports/TEST-*.xml'
+          report_paths: 'openmetadata-integration-tests/target/failsafe-reports/TEST-*.xml'

--- a/.github/workflows/integration-tests-postgres-opensearch.yml
+++ b/.github/workflows/integration-tests-postgres-opensearch.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Run Integration Tests (PostgreSQL + OpenSearch)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn test -pl :openmetadata-integration-tests -Ppostgres-opensearch
+        run: mvn verify -pl :openmetadata-integration-tests -Ppostgres-opensearch
 
       - name: Clean Up
         run: |
@@ -127,4 +127,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           fail_on_test_failures: true
-          report_paths: 'openmetadata-integration-tests/target/surefire-reports/TEST-*.xml'
+          report_paths: 'openmetadata-integration-tests/target/failsafe-reports/TEST-*.xml'

--- a/openmetadata-integration-tests/pom.xml
+++ b/openmetadata-integration-tests/pom.xml
@@ -11,6 +11,7 @@
   <packaging>jar</packaging>
   <properties>
     <maven.surefire.version>3.1.2</maven.surefire.version>
+    <maven.failsafe.version>3.1.2</maven.failsafe.version>
     <junit.jupiter.version>5.10.2</junit.jupiter.version>
     <junit.platform.version>1.10.2</junit.platform.version>
   </properties>
@@ -151,15 +152,14 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>${maven.surefire.version}</version>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${maven.failsafe.version}</version>
         <executions>
-          <!-- Phase 1: Run TagRecognizerFeedbackIT sequentially, alone -->
+          <!-- Phase 1: Run TagRecognizerFeedbackIT sequentially in integration-test phase -->
           <execution>
             <id>sequential-test</id>
-            <phase>test</phase>
             <goals>
-              <goal>test</goal>
+              <goal>integration-test</goal>
             </goals>
             <configuration>
               <forkCount>1</forkCount>
@@ -177,12 +177,11 @@
               <useFile>true</useFile>
             </configuration>
           </execution>
-          <!-- Phase 2: Run all other tests in parallel -->
+          <!-- Phase 2: Run all other tests in parallel in integration-test phase -->
           <execution>
             <id>parallel-tests</id>
-            <phase>test</phase>
             <goals>
-              <goal>test</goal>
+              <goal>integration-test</goal>
             </goals>
             <configuration>
               <forkCount>1</forkCount>
@@ -204,6 +203,13 @@
               <useFile>true</useFile>
             </configuration>
           </execution>
+          <!-- Verify phase: Fails the build if any tests failed -->
+          <execution>
+            <id>verify</id>
+            <goals>
+              <goal>verify</goal>
+            </goals>
+          </execution>
         </executions>
       </plugin>
     </plugins>
@@ -219,15 +225,14 @@
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <version>${maven.surefire.version}</version>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <version>${maven.failsafe.version}</version>
             <executions>
-              <!-- Phase 1: Run TagRecognizerFeedbackIT sequentially, alone -->
+              <!-- Phase 1: Run TagRecognizerFeedbackIT sequentially in integration-test phase -->
               <execution>
                 <id>sequential-test</id>
-                <phase>test</phase>
                 <goals>
-                  <goal>test</goal>
+                  <goal>integration-test</goal>
                 </goals>
                 <configuration>
                   <forkCount>1</forkCount>
@@ -245,12 +250,11 @@
                   <useFile>true</useFile>
                 </configuration>
               </execution>
-              <!-- Phase 2: Run all other tests in parallel -->
+              <!-- Phase 2: Run all other tests in parallel in integration-test phase -->
               <execution>
                 <id>parallel-tests</id>
-                <phase>test</phase>
                 <goals>
-                  <goal>test</goal>
+                  <goal>integration-test</goal>
                 </goals>
                 <configuration>
                   <forkCount>1</forkCount>
@@ -271,6 +275,13 @@
                   <reportFormat>plain</reportFormat>
                   <useFile>true</useFile>
                 </configuration>
+              </execution>
+              <!-- Verify phase: Fails the build if any tests failed -->
+              <execution>
+                <id>verify</id>
+                <goals>
+                  <goal>verify</goal>
+                </goals>
               </execution>
             </executions>
           </plugin>
@@ -284,15 +295,14 @@
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <version>${maven.surefire.version}</version>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <version>${maven.failsafe.version}</version>
             <executions>
-              <!-- Phase 1: Run TagRecognizerFeedbackIT sequentially, alone -->
+              <!-- Phase 1: Run TagRecognizerFeedbackIT sequentially in integration-test phase -->
               <execution>
                 <id>sequential-test</id>
-                <phase>test</phase>
                 <goals>
-                  <goal>test</goal>
+                  <goal>integration-test</goal>
                 </goals>
                 <configuration>
                   <forkCount>1</forkCount>
@@ -310,12 +320,11 @@
                   <useFile>true</useFile>
                 </configuration>
               </execution>
-              <!-- Phase 2: Run all other tests in parallel -->
+              <!-- Phase 2: Run all other tests in parallel in integration-test phase -->
               <execution>
                 <id>parallel-tests</id>
-                <phase>test</phase>
                 <goals>
-                  <goal>test</goal>
+                  <goal>integration-test</goal>
                 </goals>
                 <configuration>
                   <forkCount>1</forkCount>
@@ -336,6 +345,13 @@
                   <reportFormat>plain</reportFormat>
                   <useFile>true</useFile>
                 </configuration>
+              </execution>
+              <!-- Verify phase: Fails the build if any tests failed -->
+              <execution>
+                <id>verify</id>
+                <goals>
+                  <goal>verify</goal>
+                </goals>
               </execution>
             </executions>
           </plugin>
@@ -349,15 +365,14 @@
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <version>${maven.surefire.version}</version>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <version>${maven.failsafe.version}</version>
             <executions>
-              <!-- Phase 1: Run TagRecognizerFeedbackIT sequentially, alone -->
+              <!-- Phase 1: Run TagRecognizerFeedbackIT sequentially in integration-test phase -->
               <execution>
                 <id>sequential-test</id>
-                <phase>test</phase>
                 <goals>
-                  <goal>test</goal>
+                  <goal>integration-test</goal>
                 </goals>
                 <configuration>
                   <forkCount>1</forkCount>
@@ -375,12 +390,11 @@
                   <useFile>true</useFile>
                 </configuration>
               </execution>
-              <!-- Phase 2: Run all other tests in parallel -->
+              <!-- Phase 2: Run all other tests in parallel in integration-test phase -->
               <execution>
                 <id>parallel-tests</id>
-                <phase>test</phase>
                 <goals>
-                  <goal>test</goal>
+                  <goal>integration-test</goal>
                 </goals>
                 <configuration>
                   <forkCount>1</forkCount>
@@ -401,6 +415,13 @@
                   <reportFormat>plain</reportFormat>
                   <useFile>true</useFile>
                 </configuration>
+              </execution>
+              <!-- Verify phase: Fails the build if any tests failed -->
+              <execution>
+                <id>verify</id>
+                <goals>
+                  <goal>verify</goal>
+                </goals>
               </execution>
             </executions>
           </plugin>
@@ -414,15 +435,14 @@
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <version>${maven.surefire.version}</version>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <version>${maven.failsafe.version}</version>
             <executions>
-              <!-- Phase 1: Run TagRecognizerFeedbackIT sequentially, alone -->
+              <!-- Phase 1: Run TagRecognizerFeedbackIT sequentially in integration-test phase -->
               <execution>
                 <id>sequential-test</id>
-                <phase>test</phase>
                 <goals>
-                  <goal>test</goal>
+                  <goal>integration-test</goal>
                 </goals>
                 <configuration>
                   <forkCount>1</forkCount>
@@ -440,12 +460,11 @@
                   <useFile>true</useFile>
                 </configuration>
               </execution>
-              <!-- Phase 2: Run all other tests in parallel -->
+              <!-- Phase 2: Run all other tests in parallel in integration-test phase -->
               <execution>
                 <id>parallel-tests</id>
-                <phase>test</phase>
                 <goals>
-                  <goal>test</goal>
+                  <goal>integration-test</goal>
                 </goals>
                 <configuration>
                   <forkCount>1</forkCount>
@@ -466,6 +485,13 @@
                   <reportFormat>plain</reportFormat>
                   <useFile>true</useFile>
                 </configuration>
+              </execution>
+              <!-- Verify phase: Fails the build if any tests failed -->
+              <execution>
+                <id>verify</id>
+                <goals>
+                  <goal>verify</goal>
+                </goals>
               </execution>
             </executions>
           </plugin>
@@ -479,15 +505,14 @@
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <version>${maven.surefire.version}</version>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <version>${maven.failsafe.version}</version>
             <executions>
-              <!-- Phase 1: Run TagRecognizerFeedbackIT sequentially, alone -->
+              <!-- Phase 1: Run TagRecognizerFeedbackIT sequentially in integration-test phase -->
               <execution>
                 <id>sequential-test</id>
-                <phase>test</phase>
                 <goals>
-                  <goal>test</goal>
+                  <goal>integration-test</goal>
                 </goals>
                 <configuration>
                   <forkCount>1</forkCount>
@@ -505,12 +530,11 @@
                   <useFile>true</useFile>
                 </configuration>
               </execution>
-              <!-- Phase 2: Run all other tests in parallel -->
+              <!-- Phase 2: Run all other tests in parallel in integration-test phase -->
               <execution>
                 <id>parallel-tests</id>
-                <phase>test</phase>
                 <goals>
-                  <goal>test</goal>
+                  <goal>integration-test</goal>
                 </goals>
                 <configuration>
                   <forkCount>1</forkCount>
@@ -531,6 +555,13 @@
                   <reportFormat>plain</reportFormat>
                   <useFile>true</useFile>
                 </configuration>
+              </execution>
+              <!-- Verify phase: Fails the build if any tests failed -->
+              <execution>
+                <id>verify</id>
+                <goals>
+                  <goal>verify</goal>
+                </goals>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
## Summary

This PR addresses two critical issues with `TagRecognizerFeedbackIT` and the integration test suite:

1. **Test execution blocking**: Tests would stop running if `TagRecognizerFeedbackIT` failed
2. **Test flakiness**: `TagRecognizerFeedbackIT` was failing intermittently due to race conditions and timing issues

## Changes Made

### 1. Replaced maven-surefire-plugin with maven-failsafe-plugin

**Problem**: When `TagRecognizerFeedbackIT` failed in the sequential-test phase, all remaining tests in the parallel-tests phase would not execute because maven-surefire-plugin stops on first failure.

**Solution**: Migrated to maven-failsafe-plugin, which is designed for integration tests and follows this pattern:
- `integration-test` phase: Runs all tests to completion (even if some fail)
- `verify` phase: Checks results and fails the build if any tests failed

This ensures complete test coverage while still maintaining build integrity.

**Files modified**:
- `openmetadata-integration-tests/pom.xml` - Updated all profiles:
  - mysql-elasticsearch (default)
  - postgres-opensearch
  - postgres-elasticsearch
  - mysql-opensearch
  - postgres-rdf-tests

### 2. Fixed TagRecognizerFeedbackIT Flakiness

**Root causes identified**:
- Race condition: Tests started before the workflow engine was fully initialized
- Tight timeouts: 2-minute timeout was insufficient for CI server load variations
- Poor error handling: Made debugging difficult

**Solutions applied**:
- ✅ Replaced `Thread.sleep(2000)` with Awaitility-based workflow readiness check
- ✅ Increased timeout from 2 to 3 minutes
- ✅ Decreased poll interval from 5 to 3 seconds for faster failure detection
- ✅ Enhanced error handling with detailed exception messages
- ✅ Fixed compilation error by using `WorkflowHandler.isDeployed()` instead of non-existent `getWorkflow()`

**File modified**:
- `openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TagRecognizerFeedbackIT.java`

### 3. Updated GitHub Workflows

Updated CI workflows to work with maven-failsafe-plugin:
- Changed Maven command from `mvn test` to `mvn verify`
- Updated report paths from `target/surefire-reports/` to `target/failsafe-reports/`

**Files modified**:
- `.github/workflows/integration-tests-mysql-elasticsearch.yml`
- `.github/workflows/integration-tests-postgres-opensearch.yml`

## Test Plan

- ✅ Code compiles successfully with `mvn clean compile`
- ✅ Java code formatted with `mvn spotless:apply`
- ✅ Verified maven-failsafe-plugin configuration matches surefire for parallel execution
- ✅ Confirmed failsafe reports are generated in `target/failsafe-reports/`

## Impact

- **Reliability**: All integration tests will now run even if some fail, providing complete test coverage
- **Stability**: TagRecognizerFeedbackIT should be significantly less flaky due to proper workflow initialization checks
- **Debugging**: Better error messages will help diagnose any remaining issues
- **Build integrity**: Builds still fail when tests fail, no hidden failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)