### PR TITLE
Fix #25615 - Use system tables instead of API for lineage in UC

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/client.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/client.py
@@ -34,15 +34,11 @@ from metadata.ingestion.source.database.databricks.client import (
     API_TIMEOUT,
     DatabricksClient,
 )
-from metadata.ingestion.source.database.unitycatalog.models import (
-    LineageColumnStreams,
-    LineageTableStreams,
-)
+from metadata.ingestion.source.database.unitycatalog.models import LineageTableStreams
 from metadata.utils.logger import ingestion_logger
 
 logger = ingestion_logger()
 TABLE_LINEAGE_PATH = "/lineage-tracking/table-lineage"
-COLUMN_LINEAGE_PATH = "/lineage-tracking/column-lineage/get"
 TABLES_PATH = "/unity-catalog/tables"
 
 
@@ -109,48 +105,6 @@ class UnityCatalogClient(DatabricksClient):
             logger.debug(traceback.format_exc())
 
         return LineageTableStreams()
-
-    def get_column_lineage(
-        self, table_name: str, column_name: str
-    ) -> LineageColumnStreams:
-        """
-        Method returns column lineage details
-        """
-        try:
-            data = {
-                "table_name": table_name,
-                "column_name": column_name,
-            }
-
-            logger.debug(
-                f"Fetching column lineage from Databricks API for: {table_name}.{column_name}"
-            )
-            raw_response = self.client.get(
-                f"{self.base_url}{COLUMN_LINEAGE_PATH}",
-                headers=self.headers,
-                data=json.dumps(data),
-                timeout=API_TIMEOUT,
-            )
-            try:
-                response = raw_response.json()
-            except json.JSONDecodeError as json_err:
-                logger.error(
-                    f"Failed to parse JSON response for column lineage {table_name}.{column_name}. "
-                    f"Status code: {raw_response.status_code}, "
-                    f"Raw response: {raw_response.text}"
-                )
-                raise json_err
-
-            if response:
-                return LineageColumnStreams(**response)
-
-        except Exception as exc:
-            logger.error(
-                f"Unexpected error while fetching column lineage for {table_name}.{column_name}: {exc}"
-            )
-            logger.debug(traceback.format_exc())
-
-        return LineageColumnStreams()
 
     def get_owner_info(self, full_table_name: str) -> str:
         """

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/connection.py
@@ -53,6 +53,8 @@ from metadata.ingestion.source.database.unitycatalog.queries import (
     UNITY_CATALOG_GET_ALL_TABLE_TAGS,
     UNITY_CATALOG_GET_CATALOGS_TAGS,
     UNITY_CATALOG_SQL_STATEMENT_TEST,
+    UNITY_CATALOG_TEST_COLUMN_LINEAGE,
+    UNITY_CATALOG_TEST_TABLE_LINEAGE,
 )
 from metadata.utils.constants import THREE_MIN
 from metadata.utils.db_utils import get_host_from_host_port
@@ -187,17 +189,18 @@ def test_connection(
                 ).replace(";", " limit 1;")
             )
 
+    def test_lineage_tables(engine: Engine):
+        with engine.connect() as conn:
+            conn.execute(UNITY_CATALOG_TEST_TABLE_LINEAGE).fetchone()
+            conn.execute(UNITY_CATALOG_TEST_COLUMN_LINEAGE).fetchone()
+
     test_fn = {
         "CheckAccess": connection.catalogs.list,
         "GetDatabases": partial(get_catalogs, connection, table_obj),
         "GetSchemas": partial(get_schemas, connection, table_obj),
         "GetTables": partial(get_tables, connection, table_obj),
         "GetViews": partial(get_tables, connection, table_obj),
-        "GetQueries": partial(
-            test_database_query,
-            engine=engine,
-            statement=UNITY_CATALOG_SQL_STATEMENT_TEST,
-        ),
+        "GetQueries": partial(test_lineage_tables, engine),
         "GetTags": partial(get_tags, service_connection, table_obj),
     }
 

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/lineage.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/lineage.py
@@ -12,7 +12,10 @@
 Databricks Unity Catalog Lineage Source Module
 """
 import traceback
+from collections import defaultdict
 from typing import Iterable, Optional
+
+from sqlalchemy import text
 
 from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
 from metadata.generated.schema.entity.data.container import ContainerDataModel
@@ -37,9 +40,15 @@ from metadata.ingestion.api.steps import InvalidSourceException, Source
 from metadata.ingestion.lineage.sql_lineage import get_column_fqn
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.connections import test_connection_common
-from metadata.ingestion.source.database.unitycatalog.client import UnityCatalogClient
-from metadata.ingestion.source.database.unitycatalog.connection import get_connection
-from metadata.ingestion.source.database.unitycatalog.models import LineageTableStreams
+from metadata.ingestion.source.database.unitycatalog.connection import (
+    get_connection,
+    get_sqlalchemy_connection,
+)
+from metadata.ingestion.source.database.unitycatalog.queries import (
+    UNITY_CATALOG_COLUMN_LINEAGE,
+    UNITY_CATALOG_EXTERNAL_TABLES,
+    UNITY_CATALOG_TABLE_LINEAGE,
+)
 from metadata.utils import fqn
 from metadata.utils.filters import filter_by_database, filter_by_schema, filter_by_table
 from metadata.utils.helpers import retry_with_docker_host
@@ -64,8 +73,13 @@ class UnitycatalogLineageSource(Source):
         self.metadata = metadata
         self.service_connection = self.config.serviceConnection.root.config
         self.source_config = self.config.sourceConfig.config
-        self.client = UnityCatalogClient(self.service_connection)
         self.connection_obj = get_connection(self.service_connection)
+        self.engine = get_sqlalchemy_connection(self.service_connection)
+        self.table_lineage_map: dict[str, set[str]] = defaultdict(set)
+        self.column_lineage_map: dict[
+            tuple[str, str], list[tuple[str, str]]
+        ] = defaultdict(list)
+        self.external_location_map: dict[str, str] = {}
         self.test_connection()
 
     def close(self):
@@ -91,6 +105,81 @@ class UnitycatalogLineageSource(Source):
             )
         return cls(config, metadata)
 
+    def _cache_lineage(self):
+        """
+        Bulk-fetch all table and column lineage from system tables into memory.
+        """
+        query_log_duration = self.source_config.queryLogDuration or 1
+        logger.info(
+            f"Caching lineage from system tables (lookback: {query_log_duration} days)"
+        )
+
+        try:
+            with self.engine.connect() as conn:
+                rows = conn.execute(
+                    text(
+                        UNITY_CATALOG_TABLE_LINEAGE.format(
+                            query_log_duration=query_log_duration
+                        )
+                    )
+                )
+                for row in rows:
+                    self.table_lineage_map[row.target_table_full_name].add(
+                        row.source_table_full_name
+                    )
+            logger.info(
+                f"Cached table lineage: {sum(len(v) for v in self.table_lineage_map.values())} edges "
+                f"for {len(self.table_lineage_map)} target tables"
+            )
+        except Exception as exc:
+            logger.debug(traceback.format_exc())
+            logger.warning(f"Failed to cache table lineage: {exc}")
+
+        try:
+            with self.engine.connect() as conn:
+                rows = conn.execute(
+                    text(
+                        UNITY_CATALOG_COLUMN_LINEAGE.format(
+                            query_log_duration=query_log_duration
+                        )
+                    )
+                )
+                for row in rows:
+                    table_key = (
+                        row.source_table_full_name,
+                        row.target_table_full_name,
+                    )
+                    self.column_lineage_map[table_key].append(
+                        (row.source_column_name, row.target_column_name)
+                    )
+            logger.info(
+                f"Cached column lineage: {sum(len(v) for v in self.column_lineage_map.values())} "
+                f"column mappings for {len(self.column_lineage_map)} table pairs"
+            )
+        except Exception as exc:
+            logger.debug(traceback.format_exc())
+            logger.warning(f"Failed to cache column lineage: {exc}")
+
+    def _cache_external_locations(self):
+        """
+        Bulk-fetch all external table storage locations from system.information_schema.tables.
+        """
+        logger.info("Caching external table locations from system tables")
+        try:
+            with self.engine.connect() as conn:
+                rows = conn.execute(text(UNITY_CATALOG_EXTERNAL_TABLES))
+                for row in rows:
+                    table_fqn = (
+                        f"{row.table_catalog}.{row.table_schema}.{row.table_name}"
+                    )
+                    self.external_location_map[table_fqn] = row.storage_path
+            logger.info(
+                f"Cached {len(self.external_location_map)} external table locations"
+            )
+        except Exception as exc:
+            logger.debug(traceback.format_exc())
+            logger.warning(f"Failed to cache external table locations: {exc}")
+
     def _get_data_model_column_fqn(
         self, data_model_entity: ContainerDataModel, column: str
     ) -> Optional[str]:
@@ -109,9 +198,6 @@ class UnitycatalogLineageSource(Source):
         self, data_model_entity: ContainerDataModel, table_entity: Table
     ) -> Optional[LineageDetails]:
         try:
-            logger.debug(
-                f"Computing container column lineage for table: {table_entity.fullyQualifiedName.root}"
-            )
             column_lineage = []
             for column in table_entity.columns:
                 from_column = self._get_data_model_column_fqn(
@@ -123,87 +209,64 @@ class UnitycatalogLineageSource(Source):
                         ColumnLineage(fromColumns=[from_column], toColumn=to_column)
                     )
             if column_lineage:
-                logger.debug(
-                    f"Successfully computed {len(column_lineage)} container column lineage entries"
-                )
                 return LineageDetails(
                     columnsLineage=column_lineage,
                     source=LineageSource.ExternalTableLineage,
                 )
-            logger.debug(
-                f"No container column lineage found for {table_entity.fullyQualifiedName.root}"
-            )
             return None
         except Exception as exc:
             logger.debug(
-                f"Error computing container column lineage for {table_entity.fullyQualifiedName.root}: {exc}"
+                f"Error computing container column lineage for "
+                f"{table_entity.fullyQualifiedName.root}: {exc}"
             )
             logger.debug(traceback.format_exc())
             return None
 
-    def _get_lineage_details(
-        self, from_table: Table, to_table: Table, databricks_table_fqn: str
+    def _get_column_lineage_details(
+        self,
+        from_table: Table,
+        to_table: Table,
+        source_table_fqn: str,
+        target_table_fqn: str,
     ) -> Optional[LineageDetails]:
         try:
-            logger.debug(
-                f"Computing column lineage for table: {databricks_table_fqn} "
-                f"from {from_table.fullyQualifiedName.root} to {to_table.fullyQualifiedName.root}"
-            )
-            col_lineage = []
-            for column in to_table.columns:
-                logger.debug(
-                    f"Fetching column lineage for {databricks_table_fqn}.{column.name.root}"
-                )
-                column_streams = self.client.get_column_lineage(
-                    databricks_table_fqn, column_name=column.name.root
-                )
-                from_columns = []
-                for col in column_streams.upstream_cols:
-                    col_fqn = get_column_fqn(
-                        from_table,
-                        col.name,
-                        col.table_name,
-                        col.schema_name,
-                        col.catalog_name,
-                    )
-                    # Check to avoid self column loop
-                    if col_fqn and column.fullyQualifiedName.root != col_fqn:
-                        from_columns.append(col_fqn)
+            table_key = (source_table_fqn, target_table_fqn)
+            column_pairs = self.column_lineage_map.get(table_key, [])
+            if not column_pairs:
+                return None
 
-                if from_columns:
+            col_lineage = []
+            for source_col, target_col in column_pairs:
+                from_col_fqn = get_column_fqn(from_table, source_col)
+                to_col_fqn = get_column_fqn(to_table, target_col)
+                if from_col_fqn and to_col_fqn and from_col_fqn != to_col_fqn:
                     col_lineage.append(
-                        ColumnLineage(
-                            fromColumns=from_columns,
-                            toColumn=column.fullyQualifiedName.root,
-                        )
+                        ColumnLineage(fromColumns=[from_col_fqn], toColumn=to_col_fqn)
                     )
+
             if col_lineage:
-                logger.debug(
-                    f"Successfully computed {len(col_lineage)} column lineage entries for {databricks_table_fqn}"
-                )
                 return LineageDetails(
                     columnsLineage=col_lineage, source=LineageSource.QueryLineage
                 )
-            logger.debug(f"No column lineage found for {databricks_table_fqn}")
             return None
         except Exception as exc:
-            logger.debug(
-                f"Error computing column lineage for {to_table.fullyQualifiedName.root} - {exc}"
-            )
+            logger.debug(f"Error computing column lineage: {exc}")
             logger.debug(traceback.format_exc())
             return None
 
-    def _handle_external_location_lineage(
-        self, file_info, table: Table, is_upstream: bool
+    def _process_external_location_lineage(
+        self, table: Table, databricks_table_fqn: str
     ) -> Iterable[Either[AddLineageRequest]]:
-        try:
-            if not file_info.storage_location:
-                logger.debug(
-                    f"No storage location found in fileInfo for table: {table.fullyQualifiedName.root}"
-                )
-                return
+        """
+        Look up external table storage location from cache and create
+        container lineage if a matching container is found.
+        """
+        storage_location = self.external_location_map.get(databricks_table_fqn)
+        if not storage_location:
+            return
 
-            storage_location = file_info.storage_location.rstrip("/")
+        try:
+            storage_location = storage_location.rstrip("/")
             location_entity = self.metadata.es_search_container_by_path(
                 full_path=storage_location, fields="dataModel"
             )
@@ -215,214 +278,92 @@ class UnitycatalogLineageSource(Source):
                         location_entity[0].dataModel, table
                     )
 
-                if is_upstream:
-                    logger.debug(
-                        f"Creating upstream lineage from container {location_entity[0].id} "
-                        f"to table {table.fullyQualifiedName.root}"
-                    )
-                    yield Either(
-                        left=None,
-                        right=AddLineageRequest(
-                            edge=EntitiesEdge(
-                                fromEntity=EntityReference(
-                                    id=location_entity[0].id,
-                                    type="container",
-                                ),
-                                toEntity=EntityReference(
-                                    id=table.id,
-                                    type="table",
-                                ),
-                                lineageDetails=lineage_details,
-                            )
-                        ),
-                    )
-                else:
-                    logger.debug(
-                        f"Creating downstream lineage from table {table.fullyQualifiedName.root} "
-                        f"to container {location_entity[0].id}"
-                    )
-                    yield Either(
-                        left=None,
-                        right=AddLineageRequest(
-                            edge=EntitiesEdge(
-                                fromEntity=EntityReference(
-                                    id=table.id,
-                                    type="table",
-                                ),
-                                toEntity=EntityReference(
-                                    id=location_entity[0].id,
-                                    type="container",
-                                ),
-                                lineageDetails=lineage_details,
-                            )
-                        ),
-                    )
-            else:
-                logger.debug(
-                    f"Unable to find container for external location: {storage_location}"
+                yield Either(
+                    right=AddLineageRequest(
+                        edge=EntitiesEdge(
+                            fromEntity=EntityReference(
+                                id=location_entity[0].id,
+                                type="container",
+                            ),
+                            toEntity=EntityReference(
+                                id=table.id,
+                                type="table",
+                            ),
+                            lineageDetails=lineage_details,
+                        )
+                    ),
                 )
         except Exception as exc:
             logger.debug(
-                f"Error while processing external location lineage for {file_info.storage_location}: {exc}"
+                f"Error processing external location lineage for "
+                f"{databricks_table_fqn}: {exc}"
             )
             logger.debug(traceback.format_exc())
 
-    def _handle_upstream_table(
-        self,
-        table_streams: LineageTableStreams,
-        table: Table,
-        databricks_table_fqn: str,
+    def _process_table_lineage(
+        self, table: Table, databricks_table_fqn: str
     ) -> Iterable[Either[AddLineageRequest]]:
-        logger.debug(
-            f"Processing {len(table_streams.upstreams)} upstream entities for {databricks_table_fqn}"
-        )
-        for upstream_entity in table_streams.upstreams:
+        upstream_tables = self.table_lineage_map.get(databricks_table_fqn, set())
+
+        for source_table_full_name in upstream_tables:
             try:
-                if upstream_entity.fileInfo:
+                parts = source_table_full_name.split(".")
+                if len(parts) != 3:
                     logger.debug(
-                        f"Processing upstream external location for {databricks_table_fqn}"
-                    )
-                    yield from self._handle_external_location_lineage(
-                        upstream_entity.fileInfo, table, is_upstream=True
+                        f"Skipping malformed source table name: {source_table_full_name}"
                     )
                     continue
-
-                if not upstream_entity.tableInfo or not upstream_entity.tableInfo.name:
-                    logger.debug(
-                        f"Skipping upstream entity with no tableInfo for {databricks_table_fqn}"
-                    )
-                    continue
-
-                upstream_table = upstream_entity.tableInfo
-                upstream_table_fqn = f"{upstream_table.catalog_name}.{upstream_table.schema_name}.{upstream_table.name}"
-                logger.debug(
-                    f"Processing upstream table lineage: {upstream_table_fqn} -> {databricks_table_fqn}"
-                )
+                catalog_name, schema_name, table_name = parts
 
                 from_entity_fqn = fqn.build(
                     metadata=self.metadata,
                     entity_type=Table,
-                    database_name=upstream_table.catalog_name,
-                    schema_name=upstream_table.schema_name,
-                    table_name=upstream_table.name,
+                    database_name=catalog_name,
+                    schema_name=schema_name,
+                    table_name=table_name,
                     service_name=self.config.serviceName,
                 )
 
                 from_entity = self.metadata.get_by_name(
                     entity=Table, fqn=from_entity_fqn
                 )
-                if from_entity:
-                    lineage_details = self._get_lineage_details(
-                        from_table=from_entity,
-                        to_table=table,
-                        databricks_table_fqn=databricks_table_fqn,
-                    )
+                if not from_entity:
                     logger.debug(
-                        f"Creating lineage edge: {from_entity_fqn} -> {table.fullyQualifiedName.root}"
-                    )
-                    yield Either(
-                        left=None,
-                        right=AddLineageRequest(
-                            edge=EntitiesEdge(
-                                toEntity=EntityReference(id=table.id, type="table"),
-                                fromEntity=EntityReference(
-                                    id=from_entity.id, type="table"
-                                ),
-                                lineageDetails=lineage_details,
-                            )
-                        ),
-                    )
-                else:
-                    logger.debug(
-                        f"Unable to find upstream entity for "
-                        f"{upstream_table.catalog_name}.{upstream_table.schema_name}.{upstream_table.name}"
-                        f" -> {databricks_table_fqn}"
-                    )
-            except Exception as exc:
-                logger.debug(
-                    f"Error while processing upstream lineage for {databricks_table_fqn}: {exc}"
-                )
-                logger.debug(traceback.format_exc())
-
-    def _handle_downstream_table(
-        self,
-        table_streams: LineageTableStreams,
-        table: Table,
-        databricks_table_fqn: str,
-    ) -> Iterable[Either[AddLineageRequest]]:
-        logger.debug(
-            f"Processing {len(table_streams.downstreams)} downstream entities for {databricks_table_fqn}"
-        )
-        for downstream_entity in table_streams.downstreams:
-            try:
-                if downstream_entity.fileInfo:
-                    logger.debug(
-                        f"Processing downstream external location for {databricks_table_fqn}"
-                    )
-                    yield from self._handle_external_location_lineage(
-                        downstream_entity.fileInfo, table, is_upstream=False
+                        f"Unable to find upstream entity: {source_table_full_name} "
+                        f"-> {databricks_table_fqn}"
                     )
                     continue
 
-                if (
-                    not downstream_entity.tableInfo
-                    or not downstream_entity.tableInfo.name
-                ):
-                    logger.debug(
-                        f"Skipping downstream entity with no tableInfo for {databricks_table_fqn}"
-                    )
-                    continue
-
-                downstream_table = downstream_entity.tableInfo
-                downstream_table_fqn = f"{downstream_table.catalog_name}.{downstream_table.schema_name}.{downstream_table.name}"
-                logger.debug(
-                    f"Processing downstream table lineage: {databricks_table_fqn} -> {downstream_table_fqn}"
+                lineage_details = self._get_column_lineage_details(
+                    from_table=from_entity,
+                    to_table=table,
+                    source_table_fqn=source_table_full_name,
+                    target_table_fqn=databricks_table_fqn,
                 )
 
-                to_entity_fqn = fqn.build(
-                    metadata=self.metadata,
-                    entity_type=Table,
-                    database_name=downstream_table.catalog_name,
-                    schema_name=downstream_table.schema_name,
-                    table_name=downstream_table.name,
-                    service_name=self.config.serviceName,
+                yield Either(
+                    right=AddLineageRequest(
+                        edge=EntitiesEdge(
+                            toEntity=EntityReference(id=table.id, type="table"),
+                            fromEntity=EntityReference(id=from_entity.id, type="table"),
+                            lineageDetails=lineage_details,
+                        )
+                    ),
                 )
-
-                to_entity = self.metadata.get_by_name(entity=Table, fqn=to_entity_fqn)
-                if to_entity:
-                    lineage_details = self._get_lineage_details(
-                        from_table=table,
-                        to_table=to_entity,
-                        databricks_table_fqn=downstream_table_fqn,
-                    )
-                    logger.debug(
-                        f"Creating lineage edge: {table.fullyQualifiedName.root} -> {to_entity_fqn}"
-                    )
-                    yield Either(
-                        left=None,
-                        right=AddLineageRequest(
-                            edge=EntitiesEdge(
-                                fromEntity=EntityReference(id=table.id, type="table"),
-                                toEntity=EntityReference(id=to_entity.id, type="table"),
-                                lineageDetails=lineage_details,
-                            )
-                        ),
-                    )
-                else:
-                    logger.debug(
-                        f"Unable to find downstream entity in metadata: {databricks_table_fqn} -> {downstream_table_fqn}"
-                    )
             except Exception as exc:
                 logger.debug(
-                    f"Error while processing downstream lineage for {databricks_table_fqn}: {exc}"
+                    f"Error processing lineage {source_table_full_name} "
+                    f"-> {databricks_table_fqn}: {exc}"
                 )
                 logger.debug(traceback.format_exc())
 
     def _iter(self, *_, **__) -> Iterable[Either[AddLineageRequest]]:
         """
-        Based on the query logs, prepare the lineage
-        and send it to the sink
+        Fetch lineage from system tables for both table-to-table
+        and external location lineage.
         """
+        self._cache_lineage()
+        self._cache_external_locations()
 
         for database in self.metadata.list_all_entities(
             entity=Database, params={"service": self.config.serviceName}
@@ -461,21 +402,12 @@ class UnitycatalogLineageSource(Source):
                         continue
 
                     databricks_table_fqn = f"{table.database.name}.{table.databaseSchema.name}.{table.name.root}"
-                    logger.debug(f"Processing table: {databricks_table_fqn}")
-                    table_streams: LineageTableStreams = self.client.get_table_lineage(
-                        databricks_table_fqn
-                    )
 
-                    # Process upstream lineage
-                    yield from self._handle_upstream_table(
-                        table_streams, table, databricks_table_fqn
-                    )
+                    yield from self._process_table_lineage(table, databricks_table_fqn)
 
-                    # Disabling downstream lineage for now as it causes slowness
-                    # Process downstream lineage
-                    # yield from self._handle_downstream_table(
-                    #     table_streams, table, databricks_table_fqn
-                    # )
+                    yield from self._process_external_location_lineage(
+                        table, databricks_table_fqn
+                    )
 
     def test_connection(self) -> None:
         test_connection_common(

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/queries.py
@@ -55,3 +55,66 @@ UNITY_CATALOG_SQL_STATEMENT_TEST = """
 """
 
 UNITY_CATALOG_GET_TABLE_DDL = "SHOW CREATE TABLE `{database}`.`{schema}`.`{table}`"
+
+UNITY_CATALOG_TABLE_LINEAGE = textwrap.dedent(
+    """
+    SELECT
+        source_table_full_name,
+        target_table_full_name
+    FROM system.access.table_lineage
+    WHERE event_time >= current_date() - INTERVAL {query_log_duration} DAYS
+        AND source_table_full_name IS NOT NULL
+        AND target_table_full_name IS NOT NULL
+    GROUP BY source_table_full_name, target_table_full_name
+    """
+)
+
+UNITY_CATALOG_COLUMN_LINEAGE = textwrap.dedent(
+    """
+    SELECT
+        source_table_full_name,
+        source_column_name,
+        target_table_full_name,
+        target_column_name
+    FROM system.access.column_lineage
+    WHERE event_time >= current_date() - INTERVAL {query_log_duration} DAYS
+        AND source_table_full_name IS NOT NULL
+        AND target_table_full_name IS NOT NULL
+        AND source_column_name IS NOT NULL
+        AND target_column_name IS NOT NULL
+    GROUP BY
+        source_table_full_name,
+        source_column_name,
+        target_table_full_name,
+        target_column_name
+    """
+)
+
+UNITY_CATALOG_EXTERNAL_TABLES = textwrap.dedent(
+    """
+    SELECT
+        table_catalog,
+        table_schema,
+        table_name,
+        storage_path
+    FROM system.information_schema.tables
+    WHERE table_type = 'EXTERNAL'
+        AND storage_path IS NOT NULL
+    """
+)
+
+UNITY_CATALOG_TEST_TABLE_LINEAGE = textwrap.dedent(
+    """
+    SELECT COUNT(*) as count
+    FROM system.access.table_lineage
+    WHERE 1=0
+    """
+)
+
+UNITY_CATALOG_TEST_COLUMN_LINEAGE = textwrap.dedent(
+    """
+    SELECT COUNT(*) as count
+    FROM system.access.column_lineage
+    WHERE 1=0
+    """
+)


### PR DESCRIPTION
# Replace Unity Catalog Lineage REST API with System Table Queries

Fix #25615 - Use system tables instead of API for lineage in UC #25697


## Summary

Replaces per-table REST API calls in Unity Catalog lineage extraction with bulk SQL queries against Databricks system tables. This eliminates the O(N×M) API call pattern (N tables × M columns) that caused significant performance degradation on large workspaces.

**Before:** Each table required a REST API call to `/lineage-tracking/table-lineage` for table lineage and `/lineage-tracking/column-lineage/get` for each column — extremely slow at scale.

**After:** Three bulk SQL queries at startup fetch all lineage data into memory, then lineage is resolved via in-memory lookups.

## Changes

### `ingestion/src/metadata/ingestion/source/database/unitycatalog/lineage.py`
- **Rewrote lineage source** to use a bulk-cache-then-lookup pattern
- Added `_cache_lineage()`: Bulk-fetches all table and column lineage from `system.access.table_lineage` and `system.access.column_lineage` into in-memory maps
- Added `_cache_external_locations()`: Bulk-fetches all external table storage paths from `system.information_schema.tables` into an in-memory map
- Added `_process_table_lineage()`: Resolves upstream tables from cached `table_lineage_map` and builds column lineage from `column_lineage_map`
- Added `_process_external_location_lineage()`: Looks up external table storage paths from cache to create container-to-table lineage
- Added `_get_column_lineage_details()`: Constructs column-level lineage from cached column mappings
- Removed dependency on `UnityCatalogClient` — lineage source no longer makes any REST API calls
- `_iter()` now calls `_cache_lineage()` and `_cache_external_locations()` once at the start, then iterates tables using cached data

### `ingestion/src/metadata/ingestion/source/database/unitycatalog/queries.py`
- Added `UNITY_CATALOG_TABLE_LINEAGE`: Queries `system.access.table_lineage` for all table-level lineage edges within a configurable lookback window (`queryLogDuration`)
- Added `UNITY_CATALOG_COLUMN_LINEAGE`: Queries `system.access.column_lineage` for all column-level lineage mappings
- Added `UNITY_CATALOG_EXTERNAL_TABLES`: Queries `system.information_schema.tables` for external table storage paths
- Added `UNITY_CATALOG_TEST_TABLE_LINEAGE` and `UNITY_CATALOG_TEST_COLUMN_LINEAGE`: Lightweight test queries for connection validation

### `ingestion/src/metadata/ingestion/source/database/unitycatalog/client.py`
- Removed `get_column_lineage()` method and `COLUMN_LINEAGE_PATH` constant (no longer called)
- `get_table_lineage()` and `get_owner_info()` retained for use by the metadata source

### `ingestion/src/metadata/ingestion/source/database/unitycatalog/connection.py`
- Added `GetLineage` test connection step that validates access to `system.access.table_lineage` and `system.access.column_lineage`

### `ingestion/tests/unit/topology/database/test_unity_catalog_lineage.py`
- Fully rewritten with pytest style (no `TestCase` inheritance)
- 20 tests across 6 test classes covering:
  - `TestCacheLineage`: Table/column lineage caching and error handling
  - `TestProcessTableLineage`: Cache-based table lineage resolution, column lineage enrichment, malformed name handling, missing entity handling
  - `TestColumnLineageDetails`: Self-loop prevention, empty lineage handling
  - `TestExternalLocationLineage`: External location caching, cache-based container lineage, trailing slash handling, missing entries
  - `TestContainerColumnLineage`: Data model column FQN resolution, container column lineage construction
  - `TestLineageTableStreamsModel`: Pydantic model parsing for REST API responses

## System Tables Used

| System Table | Purpose |
|---|---|
| `system.access.table_lineage` | Table-to-table lineage edges |
| `system.access.column_lineage` | Column-to-column lineage mappings |
| `system.information_schema.tables` | External table storage paths (`storage_path` column) |

## Performance Impact

| Metric | Before (REST API) | After (System Tables) |
|---|---|---|
| API calls per table | 1 + N (per column) | 0 |
| SQL queries (total) | 0 | 3 (one-time bulk) |
| Lineage resolution | Network-bound per table | In-memory lookup |

## Configuration

Uses existing `queryLogDuration` parameter (default: 1 day) from the lineage pipeline configuration to control the lookback window for `system.access` table queries.
