### PR TITLE
Fix # 25704: support new format `DatasetQuery` for metabase >=0.57.0 card response

### DIFF
--- a/ingestion/tests/unit/topology/dashboard/test_metabase.py
+++ b/ingestion/tests/unit/topology/dashboard/test_metabase.py
@@ -429,3 +429,38 @@ class MetabaseUnitTest(TestCase):
             name="test_chart_none_value", id="105", dataset_query=None
         )
         self.assertIsNone(chart_with_none_value.dataset_query)
+
+        # Test 7: New Metabase format with stages array
+        chart_with_stages = MetabaseChart(
+            name="test_chart_stages",
+            id="106",
+            dataset_query={
+                "lib/type": "mbql/query",
+                "database": 2,
+                "stages": [
+                    {
+                        "lib/type": "mbql.stage/native",
+                        "native": "SELECT * FROM new_format_table",
+                    }
+                ],
+            },
+        )
+        self.assertIsNotNone(chart_with_stages.dataset_query)
+        self.assertIsNotNone(chart_with_stages.dataset_query.native)
+        self.assertEqual(
+            chart_with_stages.dataset_query.native.query,
+            "SELECT * FROM new_format_table",
+        )
+
+        # Test 8: New format with stages but no native query
+        chart_with_empty_stages = MetabaseChart(
+            name="test_chart_empty_stages",
+            id="107",
+            dataset_query={
+                "lib/type": "mbql/query",
+                "database": 2,
+                "stages": [{"lib/type": "mbql.stage/mbql"}],
+            },
+        )
+        self.assertIsNotNone(chart_with_empty_stages.dataset_query)
+        self.assertIsNone(chart_with_empty_stages.dataset_query.native)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:


<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

There's a breaking change in Metabase 0.57.0 that completely alter the `/card` response, moving the raw SQL response somewhere else

https://www.metabase.com/docs/latest/developers-guide/api-changelog#metabase-0570

Before
```json
"dataset_query": {
    "database": 2,
    "type": "native",
    "native": {
      "query": "sql content..."
    }
  }
```

after
```json
"dataset_query": {
    "lib/type": "mbql/query",
    "stages": [
      {
        "lib/type": "mbql.stage/native",
        "native": "sql content..."
      }
    ],
    "database": 2,
    "lib.convert/converted?": true
  },
```

This makes openmetadata cannot determine the lineage at all

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

---

## Summary by Gitar

- **Fixed Metabase compatibility:**
  - Added `model_validator` in `DatasetQuery` class to normalize new Metabase 0.57.0 API format to backward-compatible structure
- **Backward compatibility:**
  - Transforms `stages[0].native` to `native.query` format while preserving old format support
- **Test coverage:**
  - Added tests for new stages-based format and edge cases in `test_metabase.py`

<sub>This will update automatically on new commits.</sub>

---

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [X] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [X] My PR title is `Fixes <issue-number>: <short explanation>`
- [X] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

### Bug fix
- [X] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.


<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
