### PR TITLE
Increase timeout for QR

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/constants/Services.constant.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/Services.constant.ts
@@ -395,6 +395,8 @@ export const SERVICE_DEFAULT_ERROR_MAP = {
 // Increasing it temporarily while we investigate test connection delays
 // @pmbrull
 export const FETCHING_EXPIRY_TIME = 3 * 60 * 1000;
+// 5 minutes - for Query Runner to accommodate long-running queries (e.g., Trino cold start)
+export const QUERY_RUNNER_FETCHING_EXPIRY_TIME = 5 * 60 * 1000;
 export const FETCH_INTERVAL = 2000;
 export const WORKFLOW_COMPLETE_STATUS = [
   WorkflowStatus.Failed,


### PR DESCRIPTION


---

## Summary by Gitar

- Adds `QUERY_RUNNER_FETCHING_EXPIRY_TIME` constant set to 5 minutes (300,000ms) in `Services.constant.ts`
- Increases timeout from the existing 3-minute `FETCHING_EXPIRY_TIME` to accommodate long-running Query Runner queries
- Specifically addresses scenarios with cold start delays (e.g., Trino cluster initialization)
- Non-breaking change that introduces a dedicated timeout for Query Runner operations without affecting existing test connection timeouts
