### PR TITLE
fix(airflow): add DriveService to ENTITY_CLASS_MAP

### DIFF
--- a/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/ingestion/common.py
+++ b/openmetadata-airflow-apis/openmetadata_managed_apis/workflows/ingestion/common.py
@@ -11,6 +11,7 @@
 """
 Metadata DAG common functions
 """
+
 import json
 import uuid
 from datetime import datetime, timedelta
@@ -26,6 +27,7 @@ from requests.utils import quote
 from metadata.generated.schema.entity.services.apiService import ApiService
 from metadata.generated.schema.entity.services.dashboardService import DashboardService
 from metadata.generated.schema.entity.services.databaseService import DatabaseService
+from metadata.generated.schema.entity.services.driveService import DriveService
 from metadata.generated.schema.entity.services.messagingService import MessagingService
 from metadata.generated.schema.entity.services.metadataService import MetadataService
 from metadata.generated.schema.entity.services.mlmodelService import MlModelService
@@ -78,6 +80,7 @@ logger = workflow_logger()
 ENTITY_CLASS_MAP = {
     "apiService": ApiService,
     "databaseService": DatabaseService,
+    "driveService": DriveService,
     "pipelineService": PipelineService,
     "dashboardService": DashboardService,
     "messagingService": MessagingService,
@@ -313,12 +316,12 @@ def build_dag_configs(ingestion_pipeline: IngestionPipeline) -> dict:
         dag_kwargs["schedule_interval"] = schedule_interval
 
     if not is_airflow_3_or_higher():
-        dag_kwargs[
-            "default_view"
-        ] = ingestion_pipeline.airflowConfig.workflowDefaultView
-        dag_kwargs[
-            "orientation"
-        ] = ingestion_pipeline.airflowConfig.workflowDefaultViewOrientation
+        dag_kwargs["default_view"] = (
+            ingestion_pipeline.airflowConfig.workflowDefaultView
+        )
+        dag_kwargs["orientation"] = (
+            ingestion_pipeline.airflowConfig.workflowDefaultViewOrientation
+        )
 
     concurrency = ingestion_pipeline.airflowConfig.concurrency
     if concurrency is not None:


### PR DESCRIPTION
## Summary

- Add missing `driveService` entry to `ENTITY_CLASS_MAP` in `common.py`
- Add corresponding `DriveService` import

## Problem

When attempting to deploy ingestion pipelines for `DriveService` entities (used by the new Drive/SharePoint connector), the workflow deployment fails with:

```
InvalidServiceException: Invalid Service Type: driveService
```

This happens because the `ENTITY_CLASS_MAP` dictionary in `openmetadata-airflow-apis/openmetadata_managed_apis/workflows/ingestion/common.py` was missing the `driveService` entry.

## Root Cause

The `build_source` function uses `ENTITY_CLASS_MAP` to look up the entity class for a given service type. When `driveService` is passed (from `ingestion_pipeline.service.type`), the lookup returns `None`, triggering the `InvalidServiceException`.

## Fix

Added the missing entry:
```python
from metadata.generated.schema.entity.services.driveService import DriveService
# ...
ENTITY_CLASS_MAP = {
    # ...
    \"driveService\": DriveService,
    # ...
}
```

## Testing

Tested manually with a custom SharePoint connector ingesting files and directories into OpenMetadata 1.11.8. After applying this fix, the ingestion pipeline deploys and runs successfully.

Fixes #25611"