### PR TITLE
Fix Failing Test AwsCredentialsUtilTest

### DIFF
--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/AwsCredentialsUtilTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/AwsCredentialsUtilTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
@@ -48,6 +49,7 @@ class AwsCredentialsUtilTest {
   void testBuildCredentialsProviderWithNoCredentials() {
     AWSBaseConfig config = new AWSBaseConfig();
     config.setRegion("us-east-1");
+    config.setEnabled(true);
 
     AwsCredentialsProvider provider = AwsCredentialsUtil.buildCredentialsProvider(config);
 
@@ -60,6 +62,7 @@ class AwsCredentialsUtilTest {
     AWSBaseConfig config = new AWSBaseConfig();
     config.setRegion("us-east-1");
     config.setAccessKeyId("AKIAIOSFODNN7EXAMPLE");
+    config.setEnabled(true);
 
     AwsCredentialsProvider provider = AwsCredentialsUtil.buildCredentialsProvider(config);
 
@@ -73,6 +76,7 @@ class AwsCredentialsUtilTest {
     config.setRegion("us-east-1");
     config.setAccessKeyId("");
     config.setSecretAccessKey("");
+    config.setEnabled(true);
 
     AwsCredentialsProvider provider = AwsCredentialsUtil.buildCredentialsProvider(config);
 
@@ -179,5 +183,18 @@ class AwsCredentialsUtilTest {
 
     assertEquals(URI.create("http://localhost:4566"), config.getEndpointUrl());
     assertTrue(AwsCredentialsUtil.isAwsConfigured(config));
+  }
+
+  @Test
+  void testBuildCredentialsProviderThrowsWhenNotConfigured() {
+    AWSBaseConfig config = new AWSBaseConfig();
+    config.setRegion("us-east-1");
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> AwsCredentialsUtil.buildCredentialsProvider(config));
+
+    assertTrue(exception.getMessage().contains("AWS credentials not configured"));
   }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

- Fix Failing Test for AwsCredentialsUtilTest

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

---

## Summary by Gitar

- **Fixed test configuration:**
  - Added `config.setEnabled(true)` to three tests in `AwsCredentialsUtilTest.java` that expect default AWS credential provider
- **New validation test:**
  - `testBuildCredentialsProviderThrowsWhenNotConfigured()` verifies `IllegalArgumentException` when AWS credentials are not configured

<sub>This will update automatically on new commits.</sub>

---