### PR TITLE
Fix Default Recreate handler

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/DefaultRecreateHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/DefaultRecreateHandler.java
@@ -88,6 +88,15 @@ public class DefaultRecreateHandler implements RecreateIndexHandler {
           }
         }
 
+        // Canonical Indexes needs to be removed before attached that as aliases
+        if (oldIndicesToDelete.contains(canonicalIndex)) {
+          if (searchClient.indexExists(canonicalIndex)) {
+            searchClient.deleteIndexWithBackoff(canonicalIndex);
+            oldIndicesToDelete.remove(canonicalIndex);
+            LOG.info("Cleaned up old index '{}' for entity '{}'.", canonicalIndex, entityType);
+          }
+        }
+
         // Atomically swap aliases from old indices to staged index
         // This ensures zero-downtime: aliases point to new index before old ones are deleted
         if (!aliasesToAttach.isEmpty()) {
@@ -192,6 +201,15 @@ public class DefaultRecreateHandler implements RecreateIndexHandler {
       for (String oldIndex : allEntityIndices) {
         if (!oldIndex.equals(stagedIndex)) {
           oldIndicesToDelete.add(oldIndex);
+        }
+      }
+
+      // Canonical Indexes needs to be removed before attached that as aliases
+      if (oldIndicesToDelete.contains(canonicalIndex)) {
+        if (searchClient.indexExists(canonicalIndex)) {
+          searchClient.deleteIndexWithBackoff(canonicalIndex);
+          oldIndicesToDelete.remove(canonicalIndex);
+          LOG.info("Cleaned up old index '{}' for entity '{}'.", canonicalIndex, entityType);
         }
       }
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

---

## Summary by Gitar

- **Fixed alias name conflict during search index recreation**: Added cleanup logic to delete canonical indices before alias swap operations in `DefaultRecreateHandler`
- **Prevents Elasticsearch/OpenSearch errors**: Canonical index names (e.g., `table_search_index`) must be removed as physical indices before being attached as aliases to timestamped indices
- **Applied to both code paths**: Updated `finalizeReindex()` and `promoteEntityIndex()` methods to ensure consistent behavior during batch and single-entity index recreation
- **Maintains zero-downtime pattern**: Deletion occurs before atomic alias swap, ensuring queries continue to work throughout the recreation process