### PR TITLE
Chore(UI): Categorize a test In RightEntityPanelFlow as fixme since it is failing and needs refactoring

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/RightEntityPanelFlow.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/RightEntityPanelFlow.spec.ts
@@ -2161,49 +2161,52 @@ test.describe('Right Entity Panel - Data Consumer User Flow', PLAYWRIGHT_SAMPLE_
     ).toBeVisible();
   });
 
-  test('Data Consumer - Custom Properties Tab - View Custom Properties', async ({
-    dataConsumerPage,
-  }) => {
-    const summaryPanel = dataConsumerPage.locator(
-      '.entity-summary-panel-container'
-    );
-    const cpTab = summaryPanel.getByRole('menuitem', {
-      name: /custom propert/i,
-    });
-
-    if (await cpTab.isVisible()) {
-      await navigateToEntityPanelTab(dataConsumerPage, 'custom property');
-
-      const tabContent = summaryPanel.locator(
-        '.entity-summary-panel-tab-content'
+  // The test is failing and we have unreliable assertions
+  // needs refactoring @harsh-vador
+  test.fixme(
+    'Data Consumer - Custom Properties Tab - View Custom Properties',
+    async ({ dataConsumerPage }) => {
+      const summaryPanel = dataConsumerPage.locator(
+        '.entity-summary-panel-container'
       );
+      const cpTab = summaryPanel.getByRole('menuitem', {
+        name: /custom propert/i,
+      });
 
-      await expect(tabContent).toBeVisible();
+      if (await cpTab.isVisible()) {
+        await navigateToEntityPanelTab(dataConsumerPage, 'custom property');
 
-      // Verify custom properties container is visible (if custom properties exist from Admin test)
-      const customPropertiesContainer =
-        dataConsumerPage.getByTestId('custom_properties');
-
-      // Custom properties should be visible if they were created by Admin
-      if (await customPropertiesContainer.isVisible()) {
-        await expect(customPropertiesContainer).toBeVisible();
-
-        // Verify at least one custom property card is displayed
-        const propertyCards = customPropertiesContainer.locator(
-          '[data-testid^="custom-property-"]'
+        const tabContent = summaryPanel.locator(
+          '.entity-summary-panel-tab-content'
         );
-        const cardCount = await propertyCards.count();
 
-        if (cardCount > 0) {
-          const firstCard = propertyCards.first();
+        await expect(tabContent).toBeVisible();
 
-          await expect(firstCard).toBeVisible();
+        // Verify custom properties container is visible (if custom properties exist from Admin test)
+        const customPropertiesContainer =
+          dataConsumerPage.getByTestId('custom_properties');
 
-          // Verify property name and value elements exist
-          await expect(firstCard.locator('.property-name')).toBeVisible();
-          await expect(firstCard.locator('.property-value')).toBeVisible();
+        // Custom properties should be visible if they were created by Admin
+        if (await customPropertiesContainer.isVisible()) {
+          await expect(customPropertiesContainer).toBeVisible();
+
+          // Verify at least one custom property card is displayed
+          const propertyCards = customPropertiesContainer.locator(
+            '[data-testid^="custom-property-"]'
+          );
+          const cardCount = await propertyCards.count();
+
+          if (cardCount > 0) {
+            const firstCard = propertyCards.first();
+
+            await expect(firstCard).toBeVisible();
+
+            // Verify property name and value elements exist
+            await expect(firstCard.locator('.property-name')).toBeVisible();
+            await expect(firstCard.locator('.property-value')).toBeVisible();
+          }
         }
       }
     }
-  });
+  );
 });


### PR DESCRIPTION
This pull request temporarily disables a failing Playwright test related to viewing custom properties in the Right Entity Panel for Data Consumer users. The test is marked with `test.fixme` and includes a note that it needs refactoring due to unreliable assertions.

cc. @harsh-vador 

Testing changes:

* The test `'Data Consumer - Custom Properties Tab - View Custom Properties'` in `RightEntityPanelFlow.spec.ts` is now marked with `test.fixme` and a comment indicating it needs refactoring because of unreliable assertions. [[1]](diffhunk://#diff-8b0c39545c472fb358668efb538259a8c73dbdd211a0bd660bc0f9fee1f417ecL2164-R2168) [[2]](diffhunk://#diff-8b0c39545c472fb358668efb538259a8c73dbdd211a0bd660bc0f9fee1f417ecL2208-R2211)