### PR TITLE
Fix: Flaky Workflow Test cross polluted by SystemResource test

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/SystemResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/SystemResourceIT.java
@@ -1027,6 +1027,21 @@ public class SystemResourceIT {
 
     assertEquals("NewCertification", updatedCertificationConfig.getAllowedClassification());
     assertEquals("P60D", updatedCertificationConfig.getValidityPeriod());
+
+    // Reset to original values to avoid cross-test pollution
+    certificationConfig.setAllowedClassification("Certification");
+    certificationConfig.setValidityPeriod("P30D");
+
+    Settings resetSettings =
+        new Settings()
+            .withConfigType(SettingsType.ASSET_CERTIFICATION_SETTINGS)
+            .withConfigValue(certificationConfig);
+
+    String resetJson = MAPPER.writeValueAsString(resetSettings);
+    client
+        .getHttpClient()
+        .executeForString(
+            HttpMethod.PUT, "/v1/system/settings", resetJson, RequestOptions.builder().build());
   }
 
   @Test


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

---

## Summary by Gitar

- **Fixed cross-test pollution:**
  - `test_assetCertificationSettings` in `SystemResourceIT.java` now resets `AssetCertificationSettings` to defaults after test completion
- **Defensive setup:**
  - `setupCertificationTags_SDK` in `WorkflowDefinitionResourceIT.java` ensures `Certification.Gold` tag exists and resets settings before workflow tests
- **Test isolation improvement:**
  - Prevents flaky failures caused by shared state modifications between test classes

<sub>This will update automatically on new commits.</sub>

---