### PR TITLE
MINOR: Fix airflow 2 missing execution logs

### DIFF
--- a/ingestion/tests/unit/airflow/test_airflow_metadata.py
+++ b/ingestion/tests/unit/airflow/test_airflow_metadata.py
@@ -1,0 +1,297 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Test Airflow metadata source for compatibility between Airflow SDK v3.x
+and Airflow 2.x/3.x databases.
+
+The Airflow SDK is always v3.x (which has DagRun.logical_date), but we may
+connect to Airflow 2.x databases (which have execution_date column).
+"""
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, PropertyMock, patch
+from uuid import uuid4
+
+import pytest
+
+try:
+    from airflow.models import DagRun
+except ImportError:
+    pytest.skip("Airflow dependencies not installed", allow_module_level=True)
+
+
+class TestExecutionDateColumnDetection:
+    """Test the execution_date_column property for detecting database schema."""
+
+    @patch(
+        "metadata.ingestion.source.pipeline.airflow.metadata.AirflowSource.session",
+        new_callable=PropertyMock,
+    )
+    @patch(
+        "metadata.ingestion.source.pipeline.airflow.metadata.AirflowSource.__init__",
+        return_value=None,
+    )
+    def test_detects_logical_date_column(self, mock_init, mock_session):
+        """When database has logical_date column, it should be detected."""
+        from metadata.ingestion.source.pipeline.airflow.metadata import AirflowSource
+
+        source = AirflowSource.__new__(AirflowSource)
+        source._execution_date_column = None
+
+        mock_inspector = MagicMock()
+        mock_inspector.get_columns.return_value = [
+            {"name": "dag_id"},
+            {"name": "run_id"},
+            {"name": "logical_date"},
+            {"name": "start_date"},
+            {"name": "state"},
+        ]
+
+        mock_bind = MagicMock()
+        mock_session.return_value.bind = mock_bind
+
+        with patch(
+            "metadata.ingestion.source.pipeline.airflow.metadata.inspect",
+            return_value=mock_inspector,
+        ):
+            result = source.execution_date_column
+
+        assert result == "logical_date"
+
+    @patch(
+        "metadata.ingestion.source.pipeline.airflow.metadata.AirflowSource.session",
+        new_callable=PropertyMock,
+    )
+    @patch(
+        "metadata.ingestion.source.pipeline.airflow.metadata.AirflowSource.__init__",
+        return_value=None,
+    )
+    def test_detects_execution_date_column(self, mock_init, mock_session):
+        """When database has execution_date column (Airflow 2.x), it should be detected."""
+        from metadata.ingestion.source.pipeline.airflow.metadata import AirflowSource
+
+        source = AirflowSource.__new__(AirflowSource)
+        source._execution_date_column = None
+
+        mock_inspector = MagicMock()
+        mock_inspector.get_columns.return_value = [
+            {"name": "dag_id"},
+            {"name": "run_id"},
+            {"name": "execution_date"},
+            {"name": "start_date"},
+            {"name": "state"},
+        ]
+
+        mock_bind = MagicMock()
+        mock_session.return_value.bind = mock_bind
+
+        with patch(
+            "metadata.ingestion.source.pipeline.airflow.metadata.inspect",
+            return_value=mock_inspector,
+        ):
+            result = source.execution_date_column
+
+        assert result == "execution_date"
+
+    @patch(
+        "metadata.ingestion.source.pipeline.airflow.metadata.AirflowSource.session",
+        new_callable=PropertyMock,
+    )
+    @patch(
+        "metadata.ingestion.source.pipeline.airflow.metadata.AirflowSource.__init__",
+        return_value=None,
+    )
+    def test_caches_column_detection(self, mock_init, mock_session):
+        """Column detection should be cached after first call."""
+        from metadata.ingestion.source.pipeline.airflow.metadata import AirflowSource
+
+        source = AirflowSource.__new__(AirflowSource)
+        source._execution_date_column = "logical_date"
+
+        result = source.execution_date_column
+
+        assert result == "logical_date"
+        mock_session.assert_not_called()
+
+    @patch(
+        "metadata.ingestion.source.pipeline.airflow.metadata.AirflowSource.session",
+        new_callable=PropertyMock,
+    )
+    @patch(
+        "metadata.ingestion.source.pipeline.airflow.metadata.AirflowSource.__init__",
+        return_value=None,
+    )
+    def test_fallback_on_inspection_error(self, mock_init, mock_session):
+        """On inspection error, should fallback to execution_date."""
+        from metadata.ingestion.source.pipeline.airflow.metadata import AirflowSource
+
+        source = AirflowSource.__new__(AirflowSource)
+        source._execution_date_column = None
+
+        mock_bind = MagicMock()
+        mock_session.return_value.bind = mock_bind
+
+        with patch(
+            "metadata.ingestion.source.pipeline.airflow.metadata.inspect",
+            side_effect=Exception("Inspection failed"),
+        ):
+            result = source.execution_date_column
+
+        assert result == "execution_date"
+
+
+class TestGetPipelineStatus:
+    """Test get_pipeline_status method for cross-version compatibility."""
+
+    @patch(
+        "metadata.ingestion.source.pipeline.airflow.metadata.AirflowSource.session",
+        new_callable=PropertyMock,
+    )
+    @patch(
+        "metadata.ingestion.source.pipeline.airflow.metadata.AirflowSource.execution_date_column",
+        new_callable=PropertyMock,
+    )
+    @patch(
+        "metadata.ingestion.source.pipeline.airflow.metadata.AirflowSource.__init__",
+        return_value=None,
+    )
+    def test_handles_query_exception(self, mock_init, mock_exec_col, mock_session):
+        """When query fails, should return empty list and log warning."""
+        from metadata.ingestion.source.pipeline.airflow.metadata import AirflowSource
+
+        source = AirflowSource.__new__(AirflowSource)
+        source._execution_date_column = None
+
+        mock_exec_col.return_value = "logical_date"
+
+        mock_config = MagicMock()
+        mock_config.serviceConnection.root.config.numberOfStatus = 10
+        source.config = mock_config
+
+        mock_session.return_value.query.side_effect = Exception("Database error")
+
+        dag_runs = source.get_pipeline_status("test_dag")
+
+        assert dag_runs == []
+
+    @patch(
+        "metadata.ingestion.source.pipeline.airflow.metadata.AirflowSource.session",
+        new_callable=PropertyMock,
+    )
+    @patch(
+        "metadata.ingestion.source.pipeline.airflow.metadata.AirflowSource.execution_date_column",
+        new_callable=PropertyMock,
+    )
+    @patch(
+        "metadata.ingestion.source.pipeline.airflow.metadata.AirflowSource.__init__",
+        return_value=None,
+    )
+    def test_returns_empty_list_for_no_results(
+        self, mock_init, mock_exec_col, mock_session
+    ):
+        """When no dag runs found, should return empty list."""
+        from metadata.ingestion.source.pipeline.airflow.metadata import AirflowSource
+
+        source = AirflowSource.__new__(AirflowSource)
+        source._execution_date_column = None
+
+        mock_exec_col.return_value = "logical_date"
+
+        mock_config = MagicMock()
+        mock_config.serviceConnection.root.config.numberOfStatus = 10
+        source.config = mock_config
+
+        mock_query = MagicMock()
+        mock_query.filter.return_value = mock_query
+        mock_query.order_by.return_value = mock_query
+        mock_query.limit.return_value = mock_query
+        mock_query.all.return_value = []
+
+        mock_session.return_value.query.return_value = mock_query
+
+        dag_runs = source.get_pipeline_status("test_dag")
+
+        assert dag_runs == []
+
+
+class TestDagRunLogicalDateUsage:
+    """Test that DagRun model has expected attributes for SDK v3.x."""
+
+    def test_dagrun_has_logical_date_attribute(self):
+        """Verify DagRun model has logical_date attribute (Airflow SDK 3.x)."""
+        assert hasattr(
+            DagRun, "logical_date"
+        ), "DagRun should have logical_date attribute in Airflow SDK 3.x"
+
+    def test_dagrun_does_not_have_execution_date_attribute(self):
+        """Verify DagRun model does NOT have execution_date attribute (Airflow SDK 3.x).
+
+        This is the core issue - SDK 3.x removed execution_date from the ORM model,
+        so code must use column() to reference the database column directly.
+        """
+        assert not hasattr(DagRun, "execution_date"), (
+            "DagRun should NOT have execution_date attribute in Airflow SDK 3.x. "
+            "The code uses column() to reference the database column directly."
+        )
+
+
+class TestBuildObservabilityFromDagRun:
+    """Test _build_observability_from_dag_run uses logical_date."""
+
+    @patch(
+        "metadata.ingestion.source.pipeline.airflow.metadata.AirflowSource.__init__",
+        return_value=None,
+    )
+    def test_uses_logical_date_from_dag_run(self, mock_init):
+        """Observability should be built using dag_run.logical_date."""
+        from metadata.ingestion.source.pipeline.airflow.metadata import AirflowSource
+
+        source = AirflowSource.__new__(AirflowSource)
+
+        test_date = datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+        start_date = datetime(2024, 1, 15, 10, 25, 0, tzinfo=timezone.utc)
+
+        mock_dag_run = MagicMock()
+        mock_dag_run.logical_date = test_date
+        mock_dag_run.start_date = start_date
+        mock_dag_run.state = "success"
+
+        pipeline_uuid = uuid4()
+        mock_pipeline_entity = MagicMock()
+        mock_pipeline_entity.id.root = pipeline_uuid
+        mock_pipeline_entity.fullyQualifiedName.root = "service.pipeline_name"
+
+        observability = source._build_observability_from_dag_run(
+            dag_run=mock_dag_run,
+            pipeline_entity=mock_pipeline_entity,
+            schedule_interval="@daily",
+        )
+
+        assert observability.scheduleInterval == "@daily"
+        assert observability.lastRunStatus.value == "Successful"
+
+
+class TestColumnFunctionUsage:
+    """Test that the code uses sqlalchemy column() for database queries."""
+
+    def test_column_import_exists(self):
+        """Verify column is imported from sqlalchemy in the metadata module."""
+        from metadata.ingestion.source.pipeline.airflow import metadata
+
+        assert hasattr(
+            metadata, "column"
+        ), "The metadata module should import column from sqlalchemy"
+
+    def test_get_pipeline_status_uses_column_function(self):
+        """Verify get_pipeline_status method exists and can handle both column names."""
+        from metadata.ingestion.source.pipeline.airflow.metadata import AirflowSource
+
+        assert hasattr(AirflowSource, "get_pipeline_status")
+        assert hasattr(AirflowSource, "execution_date_column")


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

---

## Summary by Gitar

- **Fixed cross-version compatibility**: Airflow SDK 3.x removed `DagRun.execution_date` ORM attribute, causing `AttributeError` when connecting to Airflow 2.x databases (which still use `execution_date` column)
- **Solution**: Use SQLAlchemy's `column()` function to query database columns by name instead of ORM attributes, enabling dynamic column references based on detected schema
- **Simplified object construction**: DagRun objects always use `logical_date` parameter (SDK is always 3.x), eliminating conditional branching logic
- **Added comprehensive tests**: 297 lines of pytest-style unit tests covering column detection, query handling, and cross-version compatibility scenarios
- **Enhanced error messages**: Improved lineage ingestion warnings to provide actionable guidance when entities are missing in OpenMetadata