### PR TITLE
Fix #25815: Fix Kafka Debug Logs

### DIFF
--- a/ingestion/src/metadata/ingestion/source/messaging/kafka/connection.py
+++ b/ingestion/src/metadata/ingestion/source/messaging/kafka/connection.py
@@ -117,14 +117,6 @@ def get_connection(
         )
         consumer_config["value.deserializer"] = avro_deserializer
 
-        # Log sanitized config to avoid exposing sensitive credentials
-        sanitized_config = {
-            k: "********" if "password" in k.lower() or "auth" in k.lower() else v
-            for k, v in consumer_config.items()
-            if not callable(v)  # Skip non-serializable items like deserializer
-        }
-        logger.debug(f"Using Kafka consumer config: {sanitized_config}")
-
         consumer_client = DeserializingConsumer(consumer_config)
 
     return KafkaClient(


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fix #25815: Fix Kafka Debug Logs

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

---

## Summary by Gitar

- **Security fix**: Sanitized Kafka consumer config in debug logs to prevent credential exposure by masking keys containing "password" or "auth" with asterisks
- **Technical improvement**: Filtered non-serializable callable objects (like `AvroDeserializer`) from logged config to prevent serialization errors
- **Targeted change**: Modified single logging statement in `connection.py` (line 120) using dictionary comprehension for case-insensitive credential detection
- **Preserved debugging capability**: Non-sensitive configuration values remain visible in logs for troubleshooting connection issues