### PR TITLE
 Fix: Resolve v1.12.0 migration failure due to NULL workflow status

### DIFF
--- a/bootstrap/sql/migrations/native/1.12.0/mysql/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.12.0/mysql/schemaChanges.sql
@@ -252,9 +252,9 @@ SET json = JSON_SET(json, '$.status', 'FINISHED')
 WHERE JSON_EXTRACT(json, '$.status') IS NULL 
   AND JSON_EXTRACT(json, '$.endedAt') IS NOT NULL;
 
--- Set FAILED for incomplete workflow instances where status is null
+-- Set FAILURE for incomplete workflow instances where status is null
 UPDATE workflow_instance_time_series 
-SET json = JSON_SET(json, '$.status', 'FAILED')
+SET json = JSON_SET(json, '$.status', 'FAILURE')
 WHERE JSON_EXTRACT(json, '$.status') IS NULL 
   AND JSON_EXTRACT(json, '$.endedAt') IS NULL;
 
@@ -264,9 +264,9 @@ SET json = JSON_SET(json, '$.status', 'FINISHED')
 WHERE JSON_EXTRACT(json, '$.status') IS NULL
   AND JSON_EXTRACT(json, '$.endedAt') IS NOT NULL;
 
--- Set FAILED for incomplete workflow instance states where status is null
+-- Set FAILURE for incomplete workflow instance states where status is null
 UPDATE workflow_instance_state_time_series
-SET json = JSON_SET(json, '$.status', 'FAILED')
+SET json = JSON_SET(json, '$.status', 'FAILURE')
 WHERE JSON_EXTRACT(json, '$.status') IS NULL
   AND JSON_EXTRACT(json, '$.endedAt') IS NULL;
 

--- a/bootstrap/sql/migrations/native/1.12.0/postgres/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.12.0/postgres/schemaChanges.sql
@@ -268,9 +268,9 @@ SET json = jsonb_set(json, '{status}', '"FINISHED"'::jsonb, true)
 WHERE json->>'status' IS NULL 
   AND json->>'endedAt' IS NOT NULL;
 
--- Set FAILED for incomplete workflow instances where status is null
+-- Set FAILURE for incomplete workflow instances where status is null
 UPDATE workflow_instance_time_series 
-SET json = jsonb_set(json, '{status}', '"FAILED"'::jsonb, true)
+SET json = jsonb_set(json, '{status}', '"FAILURE"'::jsonb, true)
 WHERE json->>'status' IS NULL 
   AND json->>'endedAt' IS NULL;
 
@@ -280,9 +280,9 @@ SET json = jsonb_set(json, '{status}', '"FINISHED"'::jsonb, true)
 WHERE json->>'status' IS NULL
   AND json->>'endedAt' IS NOT NULL;
 
--- Set FAILED for incomplete workflow instance states where status is null
+-- Set FAILURE for incomplete workflow instance states where status is null
 UPDATE workflow_instance_state_time_series
-SET json = jsonb_set(json, '{status}', '"FAILED"'::jsonb, true)
+SET json = jsonb_set(json, '{status}', '"FAILURE"'::jsonb, true)
 WHERE json->>'status' IS NULL
   AND json->>'endedAt' IS NULL;
 


### PR DESCRIPTION
  ## Root Cause Analysis
  - Migration failed when modifying entityLink column in workflow_instance_time_series
  - MySQL's ALTER TABLE MODIFY COLUMN re-validates ALL generated columns for ALL rows
  - Found 184+ workflow instances created between Dec 2024 - Jan 2025 with NULL status
  - These were created with pre-v1.7.0 code that didn't set status field in JSON
  - v1.7.0 added status column as GENERATED NOT NULL but old instances had NULL values
  - v1.12.0 migration triggered constraint validation, causing "Column 'status' cannot be null"

  ## Solution
  - Add UPDATE statements before ALTER TABLE in v1.12.0 migration
  - Set status='FINISHED' for workflows with endedAt (completed)
  - Set status='FAILED' for workflows without endedAt (incomplete)
  - Use two separate queries for better performance vs CASE statements
  - Handle both workflow_instance_time_series and workflow_instance_state_time_series

<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:


<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
