### PR TITLE
Fixes #25278: Add tests to Cockcroach fix handling bytes

### DIFF
--- a/ingestion/tests/integration/cockroach/conftest.py
+++ b/ingestion/tests/integration/cockroach/conftest.py
@@ -62,3 +62,78 @@ def create_service_request(cockroach_container, tmp_path_factory):
             )
         ),
     )
+
+
+@pytest.fixture(scope="module")
+def create_test_data(cockroach_container):
+    engine = create_engine(cockroach_container.get_connection_url())
+
+    setup_statements = [
+        """
+        INSERT INTO user_profiles (user_id, first_name, last_name, email, signup_date, is_active)
+        VALUES (gen_random_uuid(), 'Alice', 'Smith', 'alice.smith@example.com', '2023-01-15 10:00:00', TRUE)
+        """,
+        """
+        INSERT INTO user_profiles (user_id, first_name, last_name, email, signup_date, is_active)
+        VALUES (gen_random_uuid(), 'Bob', 'Jones', 'bob.jones@example.com', '2023-02-20 12:30:00', TRUE)
+        """,
+        """
+        INSERT INTO user_profiles (user_id, first_name, last_name, email, signup_date, is_active)
+        VALUES (gen_random_uuid(), 'Carol', 'Williams', 'carol.williams@example.com', '2023-03-10 09:15:00', FALSE)
+        """,
+        """
+        INSERT INTO user_profiles (user_id, first_name, last_name, email, signup_date, is_active)
+        VALUES (gen_random_uuid(), 'David', 'Brown', 'david.brown@example.com', '2023-04-05 14:45:00', TRUE)
+        """,
+        """
+        INSERT INTO user_profiles (user_id, first_name, last_name, email, signup_date, is_active)
+        VALUES (gen_random_uuid(), 'Eve', 'Davis', 'eve.davis@example.com', '2023-05-22 08:00:00', FALSE)
+        """,
+        """
+        CREATE TABLE kv (
+            k INT8 NOT NULL,
+            v BYTES NOT NULL,
+            CONSTRAINT kv_pkey PRIMARY KEY (k ASC)
+        )
+        """,
+        "INSERT INTO kv (k, v) VALUES (1, b'\\x00\\x01\\x02\\x03')",
+        "INSERT INTO kv (k, v) VALUES (2, b'\\x68\\x65\\x6c\\x6c\\x6f')",
+        "INSERT INTO kv (k, v) VALUES (3, b'\\xde\\xad\\xbe\\xef')",
+        "INSERT INTO kv (k, v) VALUES (4, b'\\xca\\xfe\\xba\\xbe')",
+        "INSERT INTO kv (k, v) VALUES (5, b'\\xff\\x00\\xff\\x00')",
+        """
+        CREATE TABLE employees (
+            employee_id INT8 PRIMARY KEY DEFAULT unique_rowid(),
+            full_name TEXT NOT NULL,
+            email TEXT NOT NULL,
+            phone TEXT,
+            department TEXT,
+            hire_date TIMESTAMP
+        )
+        """,
+        """
+        INSERT INTO employees (full_name, email, phone, department, hire_date)
+        VALUES ('John Doe', 'john.doe@company.com', '555-0101', 'Engineering', '2021-06-01 09:00:00')
+        """,
+        """
+        INSERT INTO employees (full_name, email, phone, department, hire_date)
+        VALUES ('Jane Smith', 'jane.smith@company.com', '555-0102', 'Marketing', '2021-07-15 09:00:00')
+        """,
+        """
+        INSERT INTO employees (full_name, email, phone, department, hire_date)
+        VALUES ('Robert Johnson', 'robert.johnson@company.com', '555-0103', 'Finance', '2022-01-10 09:00:00')
+        """,
+        """
+        INSERT INTO employees (full_name, email, phone, department, hire_date)
+        VALUES ('Maria Garcia', 'maria.garcia@company.com', '555-0104', 'HR', '2022-03-20 09:00:00')
+        """,
+        """
+        INSERT INTO employees (full_name, email, phone, department, hire_date)
+        VALUES ('James Wilson', 'james.wilson@company.com', '555-0105', 'Engineering', '2023-02-14 09:00:00')
+        """,
+    ]
+
+    for stmt in setup_statements:
+        engine.execute(textwrap.dedent(stmt))
+
+    yield

--- a/ingestion/tests/integration/cockroach/test_classifier.py
+++ b/ingestion/tests/integration/cockroach/test_classifier.py
@@ -1,0 +1,113 @@
+import sys
+from copy import deepcopy
+from logging import getLogger
+from time import sleep
+
+import pytest
+
+from metadata.generated.schema.entity.data.table import Table
+from metadata.generated.schema.metadataIngestion.databaseServiceAutoClassificationPipeline import (
+    DatabaseServiceAutoClassificationPipeline,
+)
+from metadata.ingestion.ometa.ometa_api import OpenMetadata
+from metadata.workflow.classification import AutoClassificationWorkflow
+from metadata.workflow.metadata import MetadataWorkflow
+
+if not sys.version_info >= (3, 9):
+    pytest.skip("requires python 3.9+", allow_module_level=True)
+
+logger = getLogger(__name__)
+
+
+@pytest.fixture(scope="module")
+def sampling_only_classifier_config(
+    db_service, sink_config, workflow_config, classifier_config
+):
+    config = deepcopy(classifier_config)
+    config["source"]["sourceConfig"]["config"]["enableAutoClassification"] = False
+    return config
+
+
+def _run_classifier_with_retry(
+    run_workflow,
+    ingestion_config,
+    classifier_config,
+    max_retries=3,
+    delay=30,
+):
+    """Run classifier workflow with retry logic for flaky elasticsearch issues."""
+    last_error = None
+    logger.info("Running CockroachDB metadata ingestion workflow")
+    for attempt in range(max_retries):
+        try:
+            logger.info(
+                "CockroachDB classification workflow attempt %d of %d",
+                attempt + 1,
+                max_retries,
+            )
+            run_workflow(MetadataWorkflow, ingestion_config)
+            run_workflow(AutoClassificationWorkflow, classifier_config)
+            return
+        except Exception as e:
+            last_error = e
+            if attempt < max_retries - 1:
+                sleep(delay)
+
+    raise last_error
+
+
+@pytest.fixture(scope="module")
+def run_classifier(
+    patch_passwords_for_db_services,
+    run_workflow,
+    ingestion_config,
+    sampling_only_classifier_config,
+    create_test_data,
+    request,
+):
+    _run_classifier_with_retry(
+        run_workflow,
+        ingestion_config,
+        sampling_only_classifier_config,
+    )
+    return ingestion_config
+
+
+@pytest.mark.flaky(reruns=3, reruns_delay=30)
+@pytest.mark.parametrize(
+    "table_name",
+    (
+        "{database_service}.roach.public.user_profiles",
+        "{database_service}.roach.public.kv",
+        "{database_service}.roach.public.employees",
+    ),
+)
+def test_auto_classification_workflow(
+    run_classifier,
+    metadata: OpenMetadata,
+    table_name: str,
+    db_service: DatabaseServiceAutoClassificationPipeline,
+):
+    table = metadata.get_by_name(
+        Table, table_name.format(database_service=db_service.fullyQualifiedName.root)
+    )
+    assert metadata.get_sample_data(table) is not None
+
+
+@pytest.mark.flaky(reruns=3, reruns_delay=30)
+def test_bytes_column_sample_data(
+    run_classifier,
+    metadata: OpenMetadata,
+    db_service: DatabaseServiceAutoClassificationPipeline,
+):
+    table = metadata.get_by_name(
+        Table,
+        "{database_service}.roach.public.kv".format(
+            database_service=db_service.fullyQualifiedName.root
+        ),
+    )
+    assert table is not None
+    sample_data = metadata.get_sample_data(table)
+    assert sample_data is not None
+    assert sample_data.sampleData is not None
+    assert len(sample_data.sampleData.rows) > 0

--- a/ingestion/tests/unit/profiler/custom_types/test_custom_hex_byte_string.py
+++ b/ingestion/tests/unit/profiler/custom_types/test_custom_hex_byte_string.py
@@ -1,0 +1,115 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Tests for HexByteString custom SQLAlchemy type.
+
+Covers bytes, bytearray, and memoryview inputs, including values returned by
+CockroachDB/PostgreSQL DBAPI drivers for BYTES/BINARY columns.
+"""
+
+import pytest
+
+from metadata.profiler.orm.types.custom_hex_byte_string import HexByteString
+
+
+@pytest.fixture
+def hex_byte_string():
+    return HexByteString()
+
+
+class TestValidateHappyPath:
+    def test_validate_accepts_bytes(self):
+        HexByteString.validate(b"hello")
+
+    def test_validate_accepts_bytearray(self):
+        HexByteString.validate(bytearray(b"hello"))
+
+    def test_validate_accepts_empty_bytes(self):
+        HexByteString.validate(b"")
+
+    def test_validate_accepts_empty_bytearray(self):
+        HexByteString.validate(bytearray())
+
+
+class TestProcessResultValueHappyPath:
+    def test_none_returns_none(self, hex_byte_string):
+        assert hex_byte_string.process_result_value(None, dialect=None) is None
+
+    def test_bytes_returns_string(self, hex_byte_string):
+        result = hex_byte_string.process_result_value(b"foo", dialect=None)
+        assert isinstance(result, str)
+
+    def test_bytearray_returns_string(self, hex_byte_string):
+        result = hex_byte_string.process_result_value(bytearray(b"foo"), dialect=None)
+        assert isinstance(result, str)
+
+    def test_bytes_content_is_preserved(self, hex_byte_string):
+        result = hex_byte_string.process_result_value(b"hello", dialect=None)
+        assert "hello" in result
+
+    def test_null_byte_is_stripped(self, hex_byte_string):
+        result = hex_byte_string.process_result_value(b"hel\x00lo", dialect=None)
+        assert "\x00" not in result
+
+
+class TestMemoryviewHandling:
+    def test_validate_accepts_memoryview(self):
+        HexByteString.validate(memoryview(b"some binary data"))
+
+    def test_validate_accepts_empty_memoryview(self):
+        HexByteString.validate(memoryview(b""))
+
+    def test_process_result_value_returns_string_for_memoryview(self, hex_byte_string):
+        result = hex_byte_string.process_result_value(memoryview(b"foo"), dialect=None)
+        assert isinstance(result, str)
+
+    def test_process_result_value_preserves_memoryview_content(self, hex_byte_string):
+        result = hex_byte_string.process_result_value(
+            memoryview(b"hello world"), dialect=None
+        )
+        assert "hello world" in result
+
+    def test_process_result_value_memoryview_null_byte_stripped(self, hex_byte_string):
+        result = hex_byte_string.process_result_value(
+            memoryview(b"hel\x00lo"), dialect=None
+        )
+        assert "\x00" not in result
+
+
+class TestValidateErrorCases:
+    def test_validate_rejects_string(self):
+        with pytest.raises(TypeError, match="bytes-like values"):
+            HexByteString.validate("not bytes")
+
+    def test_validate_rejects_int(self):
+        with pytest.raises(TypeError, match="bytes-like values"):
+            HexByteString.validate(123)
+
+    def test_validate_rejects_list(self):
+        with pytest.raises(TypeError, match="bytes-like values"):
+            HexByteString.validate([1, 2, 3])
+
+
+class TestProcessLiteralParam:
+    def test_process_literal_param_accepts_bytes(self, hex_byte_string):
+        value = b"test"
+        result = hex_byte_string.process_literal_param(value, dialect=None)
+        assert result == value
+
+    def test_process_literal_param_accepts_memoryview(self, hex_byte_string):
+        mv = memoryview(b"test")
+        result = hex_byte_string.process_literal_param(mv, dialect=None)
+        assert result == mv
+
+    def test_process_literal_param_rejects_invalid_type(self, hex_byte_string):
+        with pytest.raises(TypeError, match="bytes-like values"):
+            hex_byte_string.process_literal_param("invalid", dialect=None)


### PR DESCRIPTION
### Describe your changes:

Closes #25278 

The actual fix had been advanced in #25798, so this PR makes sure we're covering the bug reported.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [X] Bug fix

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [X] My PR title is `Fixes <issue-number>: <short explanation>`
- [X] I have commented on my code, particularly in hard-to-understand areas. 
- [X] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.

---

## Summary by Gitar

- Adds comprehensive test coverage for CockroachDB `memoryview` bytes handling in `HexByteString` SQLAlchemy type (bug fix from #25798)
- Introduces 115 lines of unit tests covering `bytes`, `bytearray`, and `memoryview` input types with validation, result processing, and error cases
- Adds 113 lines of integration tests with CockroachDB BYTES column to reproduce the real-world failure scenario
- Fixes bug where `value.hex()` failed on `memoryview` objects by changing to `bytes_value.hex()` after conversion
- Updates type annotations to `Union[bytes, bytearray, memoryview]` for improved type safety