### PR TITLE
FIX - Vector col mapping

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorDocBuilder.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorDocBuilder.java
@@ -359,15 +359,9 @@ public class VectorDocBuilder {
       Map<String, Object> doc, EntityInterface entity, String entityType) {
     if (entity instanceof Table table) {
       if (table.getColumns() != null) {
-        List<Map<String, String>> columns = new ArrayList<>();
-        for (Column col : table.getColumns()) {
-          Map<String, String> colMap = new HashMap<>();
-          colMap.put("name", col.getName());
-          colMap.put("dataType", col.getDataType() != null ? col.getDataType().value() : null);
-          colMap.put("description", col.getDescription());
-          columns.add(colMap);
-        }
-        doc.put("columns", columns);
+        List<String> columnNames =
+            table.getColumns().stream().map(Column::getName).collect(Collectors.toList());
+        doc.put("columns", columnNames);
       }
     } else if (entity instanceof GlossaryTerm glossaryTerm) {
       if (glossaryTerm.getSynonyms() != null) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/VectorDocBuilderTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/VectorDocBuilderTest.java
@@ -122,11 +122,11 @@ class VectorDocBuilderTest {
 
     Map<String, Object> doc = docs.getFirst();
     @SuppressWarnings("unchecked")
-    List<Map<String, String>> columns = (List<Map<String, String>>) doc.get("columns");
+    List<String> columns = (List<String>) doc.get("columns");
     assertNotNull(columns);
     assertEquals(2, columns.size());
-    assertEquals("id", columns.get(0).get("name"));
-    assertEquals("email", columns.get(1).get("name"));
+    assertEquals("id", columns.get(0));
+    assertEquals("email", columns.get(1));
   }
 
   @Test


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Solves 

```
WARN [2026-02-13 09:56:52,266] [virtual-339] o.o.s.s.v.OpenSearchVectorService - Bulk vector indexing error for document [24b60250-1928-4e84-af04-2cd9432650d6-0] in [vector_search_index_rebuild_1770976589707]: type=mapper_parsing_exception, reason=failed to parse field [columns] of type [text] in document with id '24b60250-1928-4e84-af04-2cd9432650d6-0'. Preview of field's value: '{dataType=VARCHAR, name=first_name}'
```

After the SS migration updated some logic mistakenly

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

---

### Summary by Gitar

- Fixed `mapper_parsing_exception` in OpenSearch vector indexing by simplifying the `columns` field from `List<Map<String, String>>` to `List<String>` containing only column names
- Changed `VectorDocBuilder.addEntitySpecificFields()` to use Java Streams for extracting column names, matching the OpenSearch `text` field type expectation
- Updated `VectorDocBuilderTest` to validate the simplified structure with direct column name assertions