### PR TITLE
Fix query duplicate throwing error in bulk apis

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/QueryResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/QueryResourceIT.java
@@ -22,6 +22,7 @@ import org.openmetadata.schema.entity.data.DatabaseSchema;
 import org.openmetadata.schema.entity.data.Query;
 import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.schema.entity.services.DatabaseService;
+import org.openmetadata.schema.type.ApiStatus;
 import org.openmetadata.schema.type.Column;
 import org.openmetadata.schema.type.ColumnDataType;
 import org.openmetadata.schema.type.EntityHistory;
@@ -1016,6 +1017,20 @@ public class QueryResourceIT extends BaseEntityIT<Query, CreateQuery> {
   // ===================================================================
   // BULK API SUPPORT
   // ===================================================================
+
+  @Test
+  void test_bulkCreate_duplicateQueryHandledGracefully(TestNamespace ns) {
+    CreateQuery request = createRequest(ns.prefix("dup_bulk_q"), ns);
+    Query existing = createEntity(request);
+    assertNotNull(existing);
+
+    BulkOperationResult result = executeBulkCreate(List.of(request));
+
+    assertNotNull(result);
+    assertEquals(1, result.getNumberOfRowsProcessed());
+    assertEquals(0, result.getNumberOfRowsFailed());
+    assertEquals(ApiStatus.SUCCESS, result.getStatus());
+  }
 
   @Override
   protected BulkOperationResult executeBulkCreate(List<CreateQuery> createRequests) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -105,7 +105,7 @@ import jakarta.ws.rs.core.UriInfo;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.net.URI;
-import java.sql.SQLIntegrityConstraintViolationException;
+import java.sql.SQLException;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -238,7 +238,6 @@ import org.openmetadata.service.util.RestUtil;
 import org.openmetadata.service.util.RestUtil.DeleteResponse;
 import org.openmetadata.service.util.RestUtil.PatchResponse;
 import org.openmetadata.service.util.RestUtil.PutResponse;
-import org.postgresql.util.PSQLException;
 import software.amazon.awssdk.utils.Either;
 
 /**
@@ -8131,12 +8130,12 @@ public abstract class EntityRepository<T extends EntityInterface> {
 
   private static boolean isDuplicateKeyException(Exception e) {
     Throwable cause = e.getCause();
-    if (cause instanceof SQLIntegrityConstraintViolationException) {
-      return true;
+    if (cause instanceof SQLException sqlEx) {
+      // MySQL: error code 1062 = ER_DUP_ENTRY
+      // PostgreSQL: SQL state "23505" = unique_violation
+      return sqlEx.getErrorCode() == 1062 || "23505".equals(sqlEx.getSQLState());
     }
-    return cause instanceof PSQLException
-        && cause.getMessage() != null
-        && cause.getMessage().contains("duplicate");
+    return false;
   }
 
   private void recordEntityMetrics(


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

---

## Summary by Gitar

- **Fixed duplicate entity error:**
  - Bulk APIs now treat duplicate key violations as successful operations in `EntityRepository.bulkCreateOrUpdateEntitiesSequential`
- **New exception handler:**
  - `isDuplicateKeyException` detects `SQLIntegrityConstraintViolationException` and PostgreSQL `PSQLException` for cross-database compatibility
- **Test coverage:**
  - `test_bulkCreate_duplicateQueryHandledGracefully` in `QueryResourceIT.java` verifies idempotent duplicate handling

<sub>This will update automatically on new commits.</sub>

---
