### PR TITLE
Fix nonetype attribute error on cost calculation in usage workflow

### DIFF
--- a/ingestion/src/metadata/ingestion/bulksink/metadata_usage.py
+++ b/ingestion/src/metadata/ingestion/bulksink/metadata_usage.py
@@ -240,7 +240,14 @@ class MetadataUsageBulkSink(BulkSink):
             for usage_record in file_handler.readlines():
                 record = json.loads(usage_record)
                 cost_record = QueryCostWrapper(**record)
-                self.metadata.publish_query_cost(cost_record, self.service_name)
+                try:
+                    self.metadata.publish_query_cost(cost_record, self.service_name)
+                except Exception as exc:
+                    logger.debug(traceback.format_exc())
+                    logger.warning(
+                        f"Failed to publish query cost for "
+                        f"query={cost_record.query[:100]}...: {exc}"
+                    )
 
     # Check here how to properly pick up ES and/or table query data
     def run(self) -> None:

--- a/ingestion/src/metadata/ingestion/ometa/mixins/query_mixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/query_mixin.py
@@ -138,6 +138,11 @@ class OMetaQueryMixin:
 
         masked_query = mask_query(query_cost_data.query, query_cost_data.dialect)
 
+        # mask_query can return None if it fails to parse the query
+        # Fall back to the original query so we can still track cost
+        if masked_query is None:
+            masked_query = query_cost_data.query
+
         query_hash = self._get_query_hash(masked_query)
 
         query = self.__get_query_by_hash(

--- a/ingestion/tests/unit/bulksink/test_metadata_usage.py
+++ b/ingestion/tests/unit/bulksink/test_metadata_usage.py
@@ -11,8 +11,11 @@
 """
 Unit tests for MetadataUsageBulkSink error handling
 """
+import json
+import os
+import tempfile
 from unittest import TestCase
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 from metadata.generated.schema.api.data.createQuery import CreateQueryRequest
@@ -21,12 +24,16 @@ from metadata.generated.schema.type.basic import (
     SqlQuery,
     Timestamp,
 )
-from metadata.generated.schema.type.tableUsageCount import TableUsageCount
+from metadata.generated.schema.type.tableUsageCount import (
+    QueryCostWrapper,
+    TableUsageCount,
+)
 from metadata.ingestion.bulksink.metadata_usage import (
     MetadataUsageBulkSink,
     MetadataUsageSinkConfig,
 )
 from metadata.ingestion.ometa.client import APIError
+from metadata.ingestion.ometa.mixins.query_mixin import OMetaQueryMixin
 
 
 def create_api_error(status_code: int, message: str) -> APIError:
@@ -173,4 +180,206 @@ class TestMetadataUsageBulkSinkErrorHandling(TestCase):
             self.mock_metadata.ingest_entity_queries_data.call_count,
             2,
             "Both tables should be processed",
+        )
+
+
+class TestPublishQueryCostNoneHandling(TestCase):
+    """
+    Test that publish_query_cost handles mask_query returning None
+    without crashing (AttributeError: 'NoneType' has no attribute 'encode').
+
+    This was a customer-facing bug where a 13-hour usage workflow would
+    complete successfully but crash at the very end during query cost
+    publishing when mask_query failed to parse certain SQL queries.
+    """
+
+    def _create_mixin_instance(self):
+        """Create a minimal OMetaQueryMixin instance with mocked dependencies"""
+        obj = OMetaQueryMixin()
+        obj.client = MagicMock()
+        obj.get_by_name = MagicMock(return_value=None)
+        obj.get_suffix = MagicMock(return_value="/api/v1/queries")
+        return obj
+
+    def _create_cost_record(self, query="SELECT * FROM t", dialect="trino"):
+        """Create a QueryCostWrapper for testing"""
+        return QueryCostWrapper(
+            cost=1.5,
+            count=3.0,
+            date="1702000000000",
+            query=query,
+            dialect=dialect,
+            totalDuration=10.0,
+        )
+
+    @patch("metadata.ingestion.ometa.mixins.query_mixin.mask_query")
+    def test_publish_query_cost_mask_query_returns_none(self, mock_mask_query):
+        """
+        When mask_query returns None, publish_query_cost should fall back
+        to the original query instead of crashing on None.encode().
+        """
+        mock_mask_query.return_value = None
+        obj = self._create_mixin_instance()
+        record = self._create_cost_record()
+
+        # Should NOT raise AttributeError: 'NoneType' has no attribute 'encode'
+        result = obj.publish_query_cost(record, "test_service")
+
+        # Returns None because get_by_name returns None (query not found)
+        self.assertIsNone(result)
+        mock_mask_query.assert_called_once_with(record.query, record.dialect)
+
+    @patch("metadata.ingestion.ometa.mixins.query_mixin.mask_query")
+    def test_publish_query_cost_mask_query_returns_none_uses_original_query_hash(
+        self, mock_mask_query
+    ):
+        """
+        When mask_query returns None, the hash should be computed from the
+        original query text, not from None.
+        """
+        mock_mask_query.return_value = None
+        obj = self._create_mixin_instance()
+        record = self._create_cost_record(query="SELECT col FROM my_table")
+
+        obj.publish_query_cost(record, "test_service")
+
+        # Verify get_by_name was called with a hash of the original query
+        expected_hash = obj._get_query_hash("SELECT col FROM my_table")
+        obj.get_by_name.assert_called_once()
+        call_kwargs = obj.get_by_name.call_args
+        self.assertIn(
+            expected_hash,
+            str(call_kwargs),
+            "Should use hash of original query when mask_query returns None",
+        )
+
+    @patch("metadata.ingestion.ometa.mixins.query_mixin.mask_query")
+    def test_publish_query_cost_mask_query_returns_valid_string(self, mock_mask_query):
+        """
+        When mask_query returns a valid masked string, it should be used
+        for hashing (normal path).
+        """
+        mock_mask_query.return_value = "SELECT * FROM t WHERE col = ?"
+        obj = self._create_mixin_instance()
+        record = self._create_cost_record()
+
+        result = obj.publish_query_cost(record, "test_service")
+
+        self.assertIsNone(result)
+        expected_hash = obj._get_query_hash("SELECT * FROM t WHERE col = ?")
+        obj.get_by_name.assert_called_once()
+        call_kwargs = obj.get_by_name.call_args
+        self.assertIn(
+            expected_hash,
+            str(call_kwargs),
+            "Should use hash of masked query",
+        )
+
+
+class TestHandleQueryCostErrorHandling(TestCase):
+    """
+    Test that handle_query_cost in MetadataUsageBulkSink catches exceptions
+    from publish_query_cost so one bad record doesn't crash the entire
+    post-workflow query cost processing.
+    """
+
+    def setUp(self):
+        self.mock_metadata = MagicMock()
+        self.config = MetadataUsageSinkConfig(filename=tempfile.mkdtemp())
+        self.sink = MetadataUsageBulkSink(
+            config=self.config, metadata=self.mock_metadata
+        )
+        self.sink.service_name = "test_service"
+
+    def tearDown(self):
+        import shutil
+
+        if os.path.exists(self.config.filename):
+            shutil.rmtree(self.config.filename)
+
+    def _write_cost_file(self, records):
+        """Write query cost records to a staging file"""
+        filepath = os.path.join(
+            self.config.filename, "test_service_1702000000000_query"
+        )
+        with open(filepath, "w") as f:
+            for record in records:
+                f.write(json.dumps(record) + "\n")
+
+    def test_handle_query_cost_continues_after_exception(self):
+        """
+        If publish_query_cost raises an exception for one record,
+        handle_query_cost should catch it and continue processing
+        remaining records.
+        """
+        records = [
+            {
+                "queryHash": "hash1",
+                "date": "1702000000000",
+                "cost": 1.0,
+                "count": 1.0,
+                "query": "SELECT bad_query",
+                "dialect": "trino",
+                "totalDuration": 5.0,
+            },
+            {
+                "queryHash": "hash2",
+                "date": "1702000000000",
+                "cost": 2.0,
+                "count": 1.0,
+                "query": "SELECT good_query",
+                "dialect": "trino",
+                "totalDuration": 3.0,
+            },
+        ]
+        self._write_cost_file(records)
+
+        call_count = [0]
+
+        def side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise AttributeError("'NoneType' object has no attribute 'encode'")
+            return None
+
+        self.mock_metadata.publish_query_cost.side_effect = side_effect
+
+        # Should NOT raise - exception is caught internally
+        self.sink.handle_query_cost()
+
+        # Both records should have been attempted
+        self.assertEqual(
+            self.mock_metadata.publish_query_cost.call_count,
+            2,
+            "Both cost records should be attempted even if first one fails",
+        )
+
+    def test_handle_query_cost_no_crash_on_empty_dir(self):
+        """handle_query_cost should not crash when there are no cost files"""
+        # Directory exists but has no _query files
+        self.sink.handle_query_cost()
+        self.mock_metadata.publish_query_cost.assert_not_called()
+
+    def test_handle_query_cost_processes_all_records_on_success(self):
+        """All records should be published when there are no errors"""
+        records = [
+            {
+                "queryHash": f"hash{i}",
+                "date": "1702000000000",
+                "cost": float(i),
+                "count": 1.0,
+                "query": f"SELECT col{i} FROM table{i}",
+                "dialect": "trino",
+                "totalDuration": float(i),
+            }
+            for i in range(5)
+        ]
+        self._write_cost_file(records)
+
+        self.sink.handle_query_cost()
+
+        self.assertEqual(
+            self.mock_metadata.publish_query_cost.call_count,
+            5,
+            "All 5 cost records should be published",
         )


### PR DESCRIPTION
### Describe your changes:

Fixes #25308

Usage agent was reporting `AttributeError: 'NoneType' object has no attribute 'encode'` error in usage workflow at step of cost calculation. This PR aims to fix this error and handle it gracefully.

---

## Summary by Gitar

- **Fixed NoneType crash:**
  - Added None check in `query_mixin.py:143` to fall back to original query when `mask_query()` fails
- **Added workflow resilience:**
  - Wrapped `publish_query_cost()` in try-except in `metadata_usage.py:243` to prevent single record failures from crashing entire batch
- **New test coverage:**
  - `TestPublishQueryCostNoneHandling` and `TestHandleQueryCostErrorHandling` classes verify None handling and exception recovery

<sub>This will update automatically on new commits.</sub>

---

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->