### PR TITLE
Fix: WorkflowDefinition Test Time consumption and Flaky Test cases

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/WorkflowDefinitionResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/WorkflowDefinitionResourceIT.java
@@ -2336,7 +2336,7 @@ public class WorkflowDefinitionResourceIT {
   }
 
   @Order(29)
-  @RetryingTest(3)
+  @Test
   void test_EntitySpecificFiltering(TestNamespace ns) throws Exception {
     LOG.info("Starting test_EntitySpecificFiltering");
     OpenMetadataClient client = SdkClients.adminClient();
@@ -2558,7 +2558,7 @@ public class WorkflowDefinitionResourceIT {
       // Wait for workflow processing using Awaitility
       LOG.info("Waiting for workflow to process entities...");
       await()
-          .atMost(Duration.ofSeconds(60))
+          .atMost(Duration.ofMinutes(3))  // Increased for CI environment
           .pollDelay(Duration.ofMillis(500))
           .pollInterval(Duration.ofSeconds(1))
           .until(
@@ -5067,7 +5067,7 @@ public class WorkflowDefinitionResourceIT {
   }
 
   @Order(37)
-  @RetryingTest(3)
+  @Test
   void test_AutoApprovalForEntitiesWithoutReviewers(TestNamespace ns) throws Exception {
     LOG.info("Starting test_AutoApprovalForEntitiesWithoutReviewers");
 
@@ -5263,7 +5263,7 @@ public class WorkflowDefinitionResourceIT {
 
       // Wait for workflow to process and auto-approve the dataProduct
       await()
-          .atMost(Duration.ofSeconds(45))
+          .atMost(Duration.ofMinutes(3))  // Increased for CI environment
           .pollInterval(Duration.ofSeconds(2))
           .pollDelay(Duration.ofSeconds(2))
           .ignoreExceptions()


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes WorkflowDefinitionResourceTest

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

---

## Summary by Gitar

- **Added retry mechanism:**
  - `@RetryingTest(3)` annotation on 2 flaky tests for automatic retry on failure
- **Test isolation improvements:**
  - Try-finally blocks with defensive pre-cleanup ensure clean state between test runs
- **New polling helpers:**
  - `waitForEntityUpdate` and `waitForTaskCreation` use Awaitility for event-driven waiting
- **Removed hardcoded delays:**
  - Eliminated 25+ `Thread.sleep()` calls (2-30 seconds each) in `WorkflowDefinitionResourceIT.java`

<sub>This will update automatically on new commits.</sub>

---