### PR TITLE
fix: use ConnectionAwareSqlBatch for ChangeEventDAO.insertBatch

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -6410,7 +6410,13 @@ public interface CollectionDAO {
         connectionType = POSTGRES)
     void insert(@Bind("json") String json);
 
-    @SqlBatch("INSERT INTO change_event (json) VALUES (:json)")
+    @Transaction
+    @ConnectionAwareSqlBatch(
+        value = "INSERT INTO change_event (json) VALUES (:json)",
+        connectionType = MYSQL)
+    @ConnectionAwareSqlBatch(
+        value = "INSERT INTO change_event (json) VALUES (:json :: jsonb)",
+        connectionType = POSTGRES)
     void insertBatch(@Bind("json") List<String> jsons);
 
     @SqlUpdate("DELETE FROM change_event WHERE entityType = :entityType")


### PR DESCRIPTION
`ChangeEventDAO.insertBatch` was using a plain `@SqlBatch`, which works correctly with MySQL but fails on PostgreSQL. The failure occurs because the `change_event.json` column is of type `jsonb` in PostgreSQL and requires an explicit cast from `character varying`. As a result, CSV bulk imports (e.g., glossary terms, database schemas, tables, teams, etc.) triggered a `BatchUpdateException` when pending change events were flushed in PostgreSQL deployments.

The single-row `insert()` method already handled this correctly using `@ConnectionAwareSqlUpdate` with a `(:json :: jsonb)` cast for PostgreSQL. However, the batch variant introduced in #25542 did not include the database-specific handling.

I replaced `@SqlBatch` with `@ConnectionAwareSqlBatch` in `insertBatch` and added the explicit `::jsonb` cast for PostgreSQL, aligning it with the existing `insert()` implementation and other batch methods in the codebase.

I validated the change by running CSV bulk imports against a PostgreSQL setup and confirming that change events are now inserted without triggering `BatchUpdateException`.

### Type of change:

* [x] Bug fix
* [ ] Improvement
* [ ] New feature
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation