### PR TITLE
Fix required CI checks stuck on PRs touching openmetadata-service

### DIFF
--- a/.github/workflows/maven-postgres-tests-build-skip.yml
+++ b/.github/workflows/maven-postgres-tests-build-skip.yml
@@ -14,17 +14,6 @@ name: Maven Postgres Tests CI
 on:
   pull_request_target:
     types: [labeled, opened, synchronize, reopened]
-    paths-ignore:
-      - "openmetadata-service/**"
-      - "openmetadata-spec/src/main/resources/json/schema/**"
-      - "openmetadata-dist/**"
-      - "openmetadata-clients/**"
-      - "openmetadata-sdk/**"
-      - "common/**"
-      - "pom.xml"
-      - "yarn.lock"
-      - "Makefile"
-      - "bootstrap/**"
 
 permissions:
   contents: read

--- a/.github/workflows/py-tests-postgres.yml
+++ b/.github/workflows/py-tests-postgres.yml
@@ -31,8 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # We'll test postgres and opensearch with a single python version to save time and resources
-        py-version: ['3.10']
+        py-version: ['3.10', '3.11']
     steps:
     - name: Free Disk Space (Ubuntu)
       uses: jlumbroso/free-disk-space@main


### PR DESCRIPTION
## Summary

Two branch protection required checks (`maven-postgresql-ci` and `py-run-tests (3.11)`) were permanently stuck as "Waiting for status to be reported" on PRs modifying `openmetadata-service/**`, blocking merges.

The repo uses a skip/run workflow pattern where a "real" workflow runs on relevant path changes and a "skip" workflow reports a passing no-op status otherwise. The gap:

- **maven-postgresql-ci**: The real workflow was disabled (`workflow_dispatch` only), but the skip workflow still had `paths-ignore` excluding service paths. Neither workflow reported the check. Fix: remove `paths-ignore` so the skip workflow always runs.
- **py-run-tests (3.11)**: The real workflow only had `py-version: ['3.10']` in its matrix, so it never produced a 3.11 check. The skip workflow (which includes 3.11) was excluded by `paths-ignore`. Fix: add `'3.11'` to the real workflow's matrix.