### PR TITLE
Fix custom details page test

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CustomizeDetailPage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CustomizeDetailPage.spec.ts
@@ -125,16 +125,16 @@ test.beforeAll('Setup Customize tests', async ({ browser }) => {
   await afterAction();
 });
 
-// test.afterAll('Cleanup Customize tests', async ({ browser }) => {
-//   test.slow();
+test.afterAll('Cleanup Customize tests', async ({ browser }) => {
+  test.slow();
 
-//   const { apiContext, afterAction } = await performAdminLogin(browser);
-//   await adminUser.delete(apiContext);
-//   await user.delete(apiContext);
-//   await persona.delete(apiContext);
-//   await navigationPersona.delete(apiContext);
-//   await afterAction();
-// });
+  const { apiContext, afterAction } = await performAdminLogin(browser);
+  await adminUser.delete(apiContext);
+  await user.delete(apiContext);
+  await persona.delete(apiContext);
+  await navigationPersona.delete(apiContext);
+  await afterAction();
+});
 
 test.describe('Persona customize UI tab', async () => {
   test.beforeEach(async ({ adminPage }) => {


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Replace adminPage.goBack() with settingClick(adminPage, GlobalSettingOptions.PERSONA) in the "customize navigation should work" test
The beforeEach hook navigates through paginated persona list (potentially landing on page 2 or 3). When the test then calls goBack(), it returns to the persona list but retains the stale pagination state. The subsequent navigateToPersonaWithPagination call starts from that advanced page and may click "next" past the last page, causing the test to fail.
Navigating fresh via settingClick ensures pagination always starts from page 1

Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->
<img width="1303" height="276" alt="Screenshot 2026-02-18 at 1 05 15 PM" src="https://github.com/user-attachments/assets/2b20e509-3b25-474b-be0b-e2acbc7b7378" />

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

---

## Summary by Gitar

- **Fixed test failure:**
  - Replaced `goBack()` with `settingClick()` in `CustomizeDetailPage.spec.ts` to prevent stale pagination state from causing "customize navigation should work" test to fail
- **Test reliability improvement:**
  - Ensures pagination always starts from page 1, preventing flaky failures when `navigateToPersonaWithPagination` clicks past the last page

<sub>This will update automatically on new commits.</sub>

---
