### PR TITLE
feat: defaults should be None to not rewrite already present topic sc…

### DIFF
--- a/ingestion/src/metadata/ingestion/source/messaging/common_broker_source.py
+++ b/ingestion/src/metadata/ingestion/source/messaging/common_broker_source.py
@@ -146,9 +146,7 @@ class CommonBrokerSource(MessagingServiceSource, ABC):
                     schemaFields=schema_fields if schema_fields is not None else [],
                 )
             else:
-                topic.messageSchema = Topic(
-                    schemaText="", schemaType=SchemaType.Other, schemaFields=[]
-                )
+                topic.messageSchema = Topic()
             yield Either(right=topic)
             self.register_record(topic_request=topic)
 


### PR DESCRIPTION
### Describe your changes:

I worked on software that enriches schemas for Topics metadata already present by/after the provided OpenMetadata Kafka messaging service connector

The issue i was having was with the fact that the versioning for such registered-then-enriched topics didn't correspond to changes to the schema or topic, before setting topic schema to empty strings/lists, it should left already present metadata alone and only supply what it knows (could be configurable to always rewrite with empty or just patch with Kafka metadata without schema)

### Type of change:
- [x] Improvement

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.

----
## Summary by Gitar

- **Improved topic schema handling:** Changed default Topic initialization to use `Topic()` instead of explicitly empty values (`schemaText=""`, `schemaFields=[]`) when no schema is found in the Kafka schema registry, allowing OpenMetadata's patch system to preserve pre-enriched topic metadata instead of overwriting it with empty defaults
- **Fixed version tracking:** Ensures topics maintain correct version history by only patching fields with actual data, enabling multiple data sources to contribute schema information without conflicts

<sub>This will update automatically on new commits.</sub>