### PR TITLE
fix(playwright): resolve flakiness in Entity.spec

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Entity.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Entity.spec.ts
@@ -506,14 +506,14 @@ Object.entries(entities).forEach(([key, EntityClass]) => {
             ).toBeVisible();
 
             // Cleanup: remove tag via panel
-            await openColumnDetailPanel({
+            const cleanupPanelContainer = await openColumnDetailPanel({
               page,
               rowSelector,
               columnId: entity.childrenSelectorId ?? '',
               columnNameTestId,
               entityType: entity.type as EntityType,
             });
-            await panelContainer.getByTestId('edit-icon-tags').click();
+            await cleanupPanelContainer.getByTestId('edit-icon-tags').click();
 
             // Wait for selectable list to be visible and ready
             await page
@@ -540,7 +540,9 @@ Object.entries(entities).forEach(([key, EntityClass]) => {
             await waitForAllLoadersToDisappear(page);
 
             await expect(
-              panelContainer.getByTestId('tag-PersonalData.SpecialCategory')
+              cleanupPanelContainer
+                .locator('.tags-list')
+                .getByTestId('tag-PersonalData.SpecialCategory')
             ).toBeHidden();
 
             await closeColumnDetailPanel(page);


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Resolves flakiness in the Entity.spec Playwright test where `expect(locator).toBeHidden()` sometimes failed after removing the `PersonalData.SpecialCategory` tag in the column detail panel (tag still reported as visible).

## Root cause
1. **Stale panel reference** – After closing the panel and opening it again for cleanup, the test used `panelContainer` from the first open instead of the panel returned by the second `openColumnDetailPanel()` call.
2. **Wrong scope for hidden assertion** – The “tag visible” assertion scopes to `.tags-list`, but the “tag hidden” assertion used the whole panel. The selectable list can also render elements with `data-testid="tag-PersonalData.SpecialCategory"`. After Update, that list may still be in the DOM, so the assertion sometimes matched the tag inside the dropdown, causing the flakiness.

## Changes
- Capture the panel from the second open as `cleanupPanelContainer` and use it for the cleanup steps.
- Scope the “tag hidden” assertion to the panel’s tags list: `cleanupPanelContainer.locator('.tags-list').getByTestId('tag-PersonalData.SpecialCategory')`, so we only assert the tag is gone from the main tags list.

https://github.com/user-attachments/assets/8ac63b89-cac5-4104-86dc-9640e1deba10


<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **Fixed test flakiness:**\n  - Captured correct panel container for tag removal assertion instead of stale reference\n  - Added `.tags-list` locator for improved DOM element specificity and timing reliability

<sub>This will update automatically on new commits.</sub>