### PR TITLE
Prevent duplicate HA event processing by enabling Quartz JDBC clustering

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/changeEvent/AbstractEventConsumer.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/changeEvent/AbstractEventConsumer.java
@@ -332,9 +332,12 @@ public abstract class AbstractEventConsumer
     jobExecutionContext
         .getJobDetail()
         .getJobDataMap()
-        .put(ALERT_OFFSET_KEY, eventSubscriptionOffset);
+        .put(ALERT_OFFSET_KEY, JsonUtils.pojoToJson(eventSubscriptionOffset));
 
-    jobExecutionContext.getJobDetail().getJobDataMap().put(ALERT_INFO_KEY, eventSubscription);
+    jobExecutionContext
+        .getJobDetail()
+        .getJobDataMap()
+        .put(ALERT_INFO_KEY, JsonUtils.pojoToJson(eventSubscription));
 
     AlertMetrics metrics =
         new AlertMetrics()


### PR DESCRIPTION
Fixes #26194

This PR fixes duplicate event processing in HA deployments.

`EventSubscriptionScheduler` was using Quartz `RAMJobStore`, causing each server instance to independently poll and process the same `change_event` records. I switched it to JDBC-backed `JobStoreTX` with `isClustered=true`, following the same pattern used by `AppScheduler`.

To support `useProperties=true`, I updated:

* `EventSubscriptionScheduler.jobBuilder()` to store `JobDataMap` values as JSON strings.
* `AbstractEventConsumer.commit()` to persist offsets and subscription data as JSON strings.

No schema migrations, no new dependencies, and no changes to event processing logic.

**Testing**

* Verified no duplicate Activity Feed threads in 2-node HA setup.
* Confirmed single-node behavior unchanged.
* Validated clean failover and Quartz `QRTZ_` cluster state separation via `SCHED_NAME`.

---

#

### Type of change:

* [x] Bug fix
* [ ] Improvement
* [ ] New feature
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation

#

### Checklist:

* [x] I have read the [**[CONTRIBUTING](https://docs.open-metadata.org/developers/contribute)**](https://docs.open-metadata.org/developers/contribute) document.
* [x] My PR title is `Fixes <issue-number>: Prevent duplicate event processing in HA by enabling Quartz JDBC clustering`
* [x] I have commented on my code, particularly in hard-to-understand areas.
* [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Bug fix -->

* [x] I have added a test that covers the HA duplicate processing scenario.

----
## Summary by Gitar

- **HA event processing fix:**
  - Switched `EventSubscriptionScheduler` from in-memory `RAMJobStore` to JDBC-backed `JobStoreTX` with clustering enabled for distributed coordination across multiple server instances, eliminating duplicate event processing
  - Added backward-compatible deserialization to handle both old (object-based) and new (JSON string) job data formats during transition


<sub>This will update automatically on new commits.</sub>