### PR TITLE
MINOR - Alert rule bug fixes [from PR 23635]

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertsRuleEvaluator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertsRuleEvaluator.java
@@ -228,7 +228,7 @@ public class AlertsRuleEvaluator {
     }
 
     // we need to handle both fields updated and fields added
-    List<FieldChange> fieldChanges = 
+    List<FieldChange> fieldChanges =
         new ArrayList<>(changeEvent.getChangeDescription().getFieldsUpdated());
     if (!changeEvent.getChangeDescription().getFieldsAdded().isEmpty()) {
       fieldChanges.addAll(changeEvent.getChangeDescription().getFieldsAdded());

--- a/openmetadata-service/src/test/java/org/openmetadata/service/events/subscription/AlertsRuleEvaluatorResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/events/subscription/AlertsRuleEvaluatorResourceTest.java
@@ -209,7 +209,7 @@ class AlertsRuleEvaluatorResourceTest extends OpenMetadataApplicationTest {
     assertTrue(evaluateExpression("matchTestResult('Success')", evaluationContext));
     assertFalse(evaluateExpression("matchTestResult('Failed')", evaluationContext));
   }
-  
+
   @Test
   void test_matchTestResult_fieldsNotChanged() {
     ChangeDescription changeDescription = new ChangeDescription();
@@ -218,11 +218,11 @@ class AlertsRuleEvaluatorResourceTest extends OpenMetadataApplicationTest {
             new FieldChange()
                 .withName("testCaseResult")
                 .withNewValue(new TestCaseResult().withTestCaseStatus(TestCaseStatus.Success))));
-    
+
     ChangeEvent changeEvent = new ChangeEvent();
     changeEvent.setEntityType(Entity.TEST_CASE);
     changeEvent.setChangeDescription(changeDescription);
-    
+
     AlertsRuleEvaluator alertsRuleEvaluator = new AlertsRuleEvaluator(changeEvent);
     SimpleEvaluationContext evaluationContext =
         SimpleEvaluationContext.forReadOnlyDataBinding()


### PR DESCRIPTION
reference PR https://github.com/open-metadata/OpenMetadata/pull/23635

----
## Summary by Gitar

- **Fixed bug in alert rule evaluation:**
  - Wrapped `getFieldsUpdated()` in `new ArrayList<>()` to create mutable copy before `addAll()` on fieldsAdded, preventing `UnsupportedOperationException`
- **Added test coverage:**
  - New test `test_matchTestResult_fieldsNotChanged()` validates alert evaluation when change events have fieldsAdded but not fieldsUpdated

<sub>This will update automatically on new commits.</sub>