### PR TITLE
fix: promote vector search index alias after reindex

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/SearchIndexExecutor.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/SearchIndexExecutor.java
@@ -292,6 +292,9 @@ public class SearchIndexExecutor implements AutoCloseable {
 
     reIndexFromStartToEnd(clusterMetrics, entities);
     closeSinkIfNeeded();
+    // Promote anything yet to be promoted such as vector search indexes which is not part of
+    // entities set
+    finalizeReindex();
 
     return buildResult();
   }


### PR DESCRIPTION
## Summary
- **Single-server mode**: `executeSingleServer()` never called `finalizeReindex()` in the success path. Real entities were promoted per-entity during batch processing, but `vectorEmbedding` (a pseudo-entity not in the entities set) was never promoted, leaving orphaned `vector_search_index_rebuild_<ts>` indices.
- **Distributed mode**: `finalizeAllEntityReindex()` used a global success flag. When any entity had partial failures (`ACTIVE_ERROR`), the flag was `false`, causing the staged vector index to be deleted instead of promoted — also leaving orphaned rebuild indices.

### Changes
- Add `finalizeReindex()` call in `SearchIndexExecutor.executeSingleServer()` after sink close to promote vector index in single-server mode
- Separate vector index finalization from the entity loop in `SearchIndexApp.finalizeAllEntityReindex()` with a dedicated `finalizeVectorIndex()` method that promotes on `COMPLETED` or `ACTIVE_ERROR`, and only deletes on `FAILED`/`STOPPED`
- Add 4 unit tests covering: successful promotion, `ACTIVE_ERROR` promotion, `FAILED` deletion, and mixed entity+vector scenarios

## Test plan
- [x] New unit tests pass (`testFinalizeAllEntityReindexPromotesVectorIndexOnCompleted`, `testFinalizeAllEntityReindexPromotesVectorIndexOnActiveError`, `testFinalizeAllEntityReindexDeletesVectorIndexOnFailed`, `testFinalizeAllEntityReindexSkipsAlreadyPromotedEntities`)
- [ ] Run full reindex with `recreateIndex=true` and verify `vector_search_index` alias points to the new rebuild index
- [ ] Run reindex that produces `ACTIVE_ERROR` and verify vector index is still promoted
- [ ] Verify no orphaned `vector_search_index_rebuild_*` indices remain after reindex

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----
## Summary by Gitar

- **Fixed vector index promotion:** Orphaned `vector_search_index_rebuild_*` indices now properly promoted to live `vector_search_index` alias in both single-server and distributed modes
  - Single-server: Added `finalizeReindex()` call in success path to handle pseudo-entity (vector) not in entities set
  - Distributed: Separates vector finalization from entity loop with status-aware logic—promotes on `COMPLETED` or `ACTIVE_ERROR`, deletes only on `FAILED`/`STOPPED`
- **Test coverage:** 4 unit tests validate promotion success paths, `ACTIVE_ERROR` resilience, failure cleanup, and mixed entity scenarios

<sub>This will update automatically on new commits.</sub>