### PR TITLE
i18n: update application-to-improve-data translations

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ar-sa.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ar-sa.json
@@ -1133,8 +1133,6 @@
     "metadata-service": "خدمة البيانات الوصفية",
     "metadata-status": "لديه / بدون بيانات وصفية",
     "metadata-to-es-config-optional": "تكوين البيانات الوصفية إلى ES (اختياري)",
-    "metapilot": "MetaPilot",
-    "metapilot-suggested-description": "وصف مقترح من Metapilot",
     "metric": "مقياس",
     "metric-configuration": "تكوين المقياس",
     "metric-plural": "مقاييس",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/de-de.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/de-de.json
@@ -1133,8 +1133,6 @@
     "metadata-service": "Metadaten-Dienst",
     "metadata-status": "Hat / Fehlende Metadaten",
     "metadata-to-es-config-optional": "Metadaten-zu-ES-Konfiguration (optional)",
-    "metapilot": "MetaPilot",
-    "metapilot-suggested-description": "von Metapilot empfohlene Beschreibung",
     "metric": "Metrik",
     "metric-configuration": "Metrik Konfigurieren",
     "metric-plural": "Metriken",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
@@ -1133,8 +1133,6 @@
     "metadata-service": "Metadata Service",
     "metadata-status": "Has / Missing Metadata",
     "metadata-to-es-config-optional": "Metadata To ES Config (Optional)",
-    "metapilot": "MetaPilot",
-    "metapilot-suggested-description": "Metapilot Suggested Description",
     "metric": "Metric",
     "metric-configuration": "Metric Configuration",
     "metric-plural": "Metrics",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/es-es.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/es-es.json
@@ -1133,8 +1133,6 @@
     "metadata-service": "Servicio de Metadatos",
     "metadata-status": "Tiene / Sin metadatos",
     "metadata-to-es-config-optional": "Configuración de Metadatos a ES (Opcional)",
-    "metapilot": "MetaPilot",
-    "metapilot-suggested-description": "Sugerencia de Metapilot",
     "metric": "Métrica",
     "metric-configuration": "Configuración Métrica",
     "metric-plural": "Métricas",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/fr-fr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/fr-fr.json
@@ -1133,8 +1133,6 @@
     "metadata-service": "Service de Métadonnées",
     "metadata-status": "A / Sans métadonnées",
     "metadata-to-es-config-optional": "Configuration de Métadonnées vers ES (Optionnel)",
-    "metapilot": "MetaPilot",
-    "metapilot-suggested-description": "Description Metapilot Suggérée",
     "metric": "Métrique",
     "metric-configuration": "Configuration de Métrique",
     "metric-plural": "Métriques",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/gl-es.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/gl-es.json
@@ -1133,8 +1133,6 @@
     "metadata-service": "Servizo de Metadatos",
     "metadata-status": "Ten / Sen metadatos",
     "metadata-to-es-config-optional": "Configuración opcional de metadatos para ES",
-    "metapilot": "MetaPilot",
-    "metapilot-suggested-description": "Descrición suxerida por Metapilot",
     "metric": "Métrica",
     "metric-configuration": "Configuración de métricas",
     "metric-plural": "Métricas",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/he-he.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/he-he.json
@@ -1133,8 +1133,6 @@
     "metadata-service": "שירות מטא-נתונים",
     "metadata-status": "יש / חסר מטא-דאטה",
     "metadata-to-es-config-optional": "קונפיגורציית מטא-דאטה ל-Elasticsearch (אופציונלי)",
-    "metapilot": "MetaPilot",
-    "metapilot-suggested-description": "תיאור מוצע על ידי Metapilot",
     "metric": "מדד",
     "metric-configuration": "Metric Configuration",
     "metric-plural": "מדדים",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ja-jp.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ja-jp.json
@@ -1133,8 +1133,6 @@
     "metadata-service": "メタデータサービス",
     "metadata-status": "あり / なし メタデータ",
     "metadata-to-es-config-optional": "MetadataからES設定（オプション）",
-    "metapilot": "MetaPilot",
-    "metapilot-suggested-description": "MetaPilotの提案説明",
     "metric": "メトリクス",
     "metric-configuration": "メトリクス設定",
     "metric-plural": "メトリクス",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ko-kr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ko-kr.json
@@ -1133,8 +1133,6 @@
     "metadata-service": "메타데이터 서비스",
     "metadata-status": "있음 / 없음 메타데이터",
     "metadata-to-es-config-optional": "메타데이터를 ES로 설정 (선택사항)",
-    "metapilot": "메타파일럿",
-    "metapilot-suggested-description": "메타파일럿 제안 설명",
     "metric": "지표",
     "metric-configuration": "지표 구성",
     "metric-plural": "지표",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/mr-in.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/mr-in.json
@@ -1133,8 +1133,6 @@
     "metadata-service": "मेटाडेटा सेवा",
     "metadata-status": "आहे / गहाळ मेटाडेटा",
     "metadata-to-es-config-optional": "मेटाडेटा ते ES कॉन्फिग (पर्यायी)",
-    "metapilot": "मेटापायलट",
-    "metapilot-suggested-description": "मेटापायलट सुचवलेले वर्णन",
     "metric": "मेट्रिक",
     "metric-configuration": "मेट्रिक संरचना",
     "metric-plural": "मेट्रिक्स",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/nl-nl.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/nl-nl.json
@@ -1133,8 +1133,6 @@
     "metadata-service": "Metadataservice",
     "metadata-status": "Heeft / Ontbreekt metagegevens",
     "metadata-to-es-config-optional": "Metadata naar ES-configuratie (Optioneel)",
-    "metapilot": "MetaPilot",
-    "metapilot-suggested-description": "Door Metapilot voorgestelde beschrijving",
     "metric": "Metriek",
     "metric-configuration": "Metric Configuration",
     "metric-plural": "Metrieken",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pr-pr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pr-pr.json
@@ -1133,8 +1133,6 @@
     "metadata-service": "سرویس فراداده",
     "metadata-status": "Tiene / Sin metadatos",
     "metadata-to-es-config-optional": "تنظیمات فراداده به ES (اختیاری)",
-    "metapilot": "MetaPilot",
-    "metapilot-suggested-description": "توضیحات پیشنهادی Metapilot",
     "metric": "مقیاس",
     "metric-configuration": "تنظیمات مقیاس",
     "metric-plural": "مقیاس‌ها",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-br.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-br.json
@@ -1133,8 +1133,6 @@
     "metadata-service": "Serviço de Metadados",
     "metadata-status": "Tem / Sem metadados",
     "metadata-to-es-config-optional": "Metadados para Configuração ES (Opcional)",
-    "metapilot": "MetaPilot",
-    "metapilot-suggested-description": "Descrição sugerida do Metapilot",
     "metric": "Métrica",
     "metric-configuration": "Configuração de métrica",
     "metric-plural": "Métricas",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-pt.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-pt.json
@@ -1133,8 +1133,6 @@
     "metadata-service": "Serviço de Metadados",
     "metadata-status": "Tem / Sem metadados",
     "metadata-to-es-config-optional": "Metadados para Configuração ES (Opcional)",
-    "metapilot": "MetaPilot",
-    "metapilot-suggested-description": "Descrição Sugerida pelo Metapilot",
     "metric": "Métrica",
     "metric-configuration": "Configuração de Métricas",
     "metric-plural": "Métricas",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ru-ru.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ru-ru.json
@@ -1133,8 +1133,6 @@
     "metadata-service": "Сервис метаданных",
     "metadata-status": "Есть / Нет метаданных",
     "metadata-to-es-config-optional": "Метаданные для конфигурации ES (необязательно)",
-    "metapilot": "MetaPilot",
-    "metapilot-suggested-description": "Рекомендованные описания Metapilot",
     "metric": "Метрика",
     "metric-configuration": "Настройка метрики",
     "metric-plural": "Метрики",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/th-th.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/th-th.json
@@ -1133,8 +1133,6 @@
     "metadata-service": "บริการข้อมูลเมตา",
     "metadata-status": "มี / ไม่มี เมตาดาต้า",
     "metadata-to-es-config-optional": "ข้อมูลเมตาไปยังการกำหนดค่าของ ES (เลือกได้)",
-    "metapilot": "MetaPilot",
-    "metapilot-suggested-description": "คำอธิบายที่แนะนำโดย Metapilot",
     "metric": "เมตริก",
     "metric-configuration": "การกำหนดค่าเมตริก",
     "metric-plural": "เมตริกหลายรายการ",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/tr-tr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/tr-tr.json
@@ -1133,8 +1133,6 @@
     "metadata-service": "Meta Veri Servisi",
     "metadata-status": "Var / Eksik Metaveri",
     "metadata-to-es-config-optional": "Metadata'dan ES'ye Yapılandırma (İsteğe Bağlı)",
-    "metapilot": "MetaPilot",
-    "metapilot-suggested-description": "Metapilot Tarafından Önerilen Açıklama",
     "metric": "Metrik",
     "metric-configuration": "Metrik Yapılandırması",
     "metric-plural": "Metrikler",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-cn.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-cn.json
@@ -1133,8 +1133,6 @@
     "metadata-service": "元数据服务",
     "metadata-status": "有 / 无 元数据",
     "metadata-to-es-config-optional": "元数据到 ES 配置(可选)",
-    "metapilot": "MetaPilot",
-    "metapilot-suggested-description": "Metapilot 建议说明",
     "metric": "指标",
     "metric-configuration": "指标配置",
     "metric-plural": "指标",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-tw.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-tw.json
@@ -1133,8 +1133,6 @@
     "metadata-service": "元資料服務",
     "metadata-status": "有 / 無 元數據",
     "metadata-to-es-config-optional": "元資料至 ES 組態 (選用)",
-    "metapilot": "MetaPilot",
-    "metapilot-suggested-description": "MetaPilot 建議描述",
     "metric": "指標",
     "metric-configuration": "指標組態",
     "metric-plural": "指標",


### PR DESCRIPTION
----
## Summary by Gitar

- **Updated locale translations:**
  - Removed deprecated `metapilot` and `metapilot-suggested-description` keys across 19 language files
  - Updated `application-to-improve-data` messaging to reference `AskCollate` instead of `MetaPilot`
  - Covers all supported languages: English, Spanish, French, German, Portuguese, Chinese, Japanese, Korean, and 11 others

<sub>This will update automatically on new commits.</sub>