### PR TITLE
MINOR: Glue pipeline support lineage by parsing code

### DIFF
--- a/ingestion/src/metadata/ingestion/source/pipeline/gluepipeline/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/gluepipeline/metadata.py
@@ -60,7 +60,6 @@ from metadata.ingestion.source.pipeline.gluepipeline.models import (
     S3Target,
 )
 from metadata.ingestion.source.pipeline.gluepipeline.script_parser import (
-    ScriptLineageResult,
     parse_glue_script,
 )
 from metadata.ingestion.source.pipeline.pipeline_service import PipelineServiceSource
@@ -268,9 +267,7 @@ class GluepipelineSource(PipelineServiceSource):
                                 id=container[0].id,
                                 type="container",
                                 name=container[0].name.root,
-                                fullyQualifiedName=container[
-                                    0
-                                ].fullyQualifiedName.root,
+                                fullyQualifiedName=container[0].fullyQualifiedName.root,
                             )
                             if storage_entity:
                                 if key.endswith("Source"):
@@ -279,9 +276,7 @@ class GluepipelineSource(PipelineServiceSource):
                                     lineage_details["targets"].append(storage_entity)
                                 break
 
-    def _extract_script_lineage(
-        self, script_location: str, lineage_details: dict
-    ):
+    def _extract_script_lineage(self, script_location: str, lineage_details: dict):
         script_content = self._download_s3_script(script_location)
         if not script_content:
             return
@@ -373,9 +368,7 @@ class GluepipelineSource(PipelineServiceSource):
                         f"in service {db_service_name}: {exc}"
                     )
 
-    def _resolve_jdbc_entities(
-        self, refs: list, lineage_details: dict, direction: str
-    ):
+    def _resolve_jdbc_entities(self, refs: list, lineage_details: dict, direction: str):
         for ref in refs:
             database_name = ref.database
             table_name = ref.table
@@ -423,9 +416,7 @@ class GluepipelineSource(PipelineServiceSource):
             return self._glue_connection_cache[connection_name]
 
         try:
-            response = self.glue.get_connection(
-                Name=connection_name, HidePassword=True
-            )
+            response = self.glue.get_connection(Name=connection_name, HidePassword=True)
             props = response.get("Connection", {}).get("ConnectionProperties", {})
             jdbc_url = props.get("JDBC_CONNECTION_URL", "")
             result = self._parse_jdbc_url(jdbc_url)
@@ -445,9 +436,7 @@ class GluepipelineSource(PipelineServiceSource):
         # jdbc:redshift://host:port/database
         # jdbc:postgresql://host:port/database
         # jdbc:mysql://host:port/database
-        match = re.match(
-            r"jdbc:\w+://[^/]+/([^?;]+)", jdbc_url
-        )
+        match = re.match(r"jdbc:\w+://[^/]+/([^?;]+)", jdbc_url)
         if match:
             db_name = match.group(1)
             return {"database": db_name, "schema": None}

--- a/ingestion/src/metadata/ingestion/source/pipeline/gluepipeline/models.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/gluepipeline/models.py
@@ -86,9 +86,7 @@ class JobNodes(BaseModel):
     )
     command: Optional[JobCommand] = Field(default=None, alias="Command")
     connections: Optional[JobConnections] = Field(default=None, alias="Connections")
-    default_arguments: Optional[dict] = Field(
-        default=None, alias="DefaultArguments"
-    )
+    default_arguments: Optional[dict] = Field(default=None, alias="DefaultArguments")
 
 
 class JobNodeResponse(BaseModel):

--- a/ingestion/src/metadata/ingestion/source/pipeline/gluepipeline/script_parser.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/gluepipeline/script_parser.py
@@ -208,7 +208,9 @@ def _parse_glue_context_sources(source_code: str, result: ScriptLineageResult):
             database = _extract_kwarg(block, "database")
             table = _extract_kwarg(block, "table_name")
             if database and table:
-                result.catalog_sources.append(CatalogRef(database=database, table=table))
+                result.catalog_sources.append(
+                    CatalogRef(database=database, table=table)
+                )
                 logger.debug(f"Found catalog source: {database}.{table}")
         except Exception as exc:
             logger.debug(f"Failed to parse from_catalog block: {exc}")
@@ -222,13 +224,19 @@ def _parse_glue_context_sources(source_code: str, result: ScriptLineageResult):
                 result.s3_sources.extend(paths)
                 for p in paths:
                     logger.debug(f"Found S3 source: {p}")
-            elif conn_type and conn_type.lower() in ("jdbc", "mysql", "postgresql", "oracle", "redshift"):
+            elif conn_type and conn_type.lower() in (
+                "jdbc",
+                "mysql",
+                "postgresql",
+                "oracle",
+                "redshift",
+            ):
                 table = _extract_dict_value(block, "dbtable") or _extract_dict_value(
                     block, "dynamodb.input.tableName"
                 )
-                connection_name = _extract_kwarg(block, "catalog_connection") or _extract_kwarg(
-                    block, "connection_name"
-                )
+                connection_name = _extract_kwarg(
+                    block, "catalog_connection"
+                ) or _extract_kwarg(block, "connection_name")
                 if table:
                     result.jdbc_sources.append(
                         JDBCRef(connection_name=connection_name, table=table)
@@ -284,7 +292,9 @@ def _parse_glue_context_targets(source_code: str, result: ScriptLineageResult):
             database = _extract_kwarg(block, "database")
             table = _extract_kwarg(block, "table_name")
             if database and table:
-                result.catalog_targets.append(CatalogRef(database=database, table=table))
+                result.catalog_targets.append(
+                    CatalogRef(database=database, table=table)
+                )
                 logger.debug(f"Found catalog target: {database}.{table}")
         except Exception as exc:
             logger.debug(f"Failed to parse write_catalog block: {exc}")
@@ -295,7 +305,9 @@ def _parse_glue_context_targets(source_code: str, result: ScriptLineageResult):
             database = _extract_kwarg(block, "database")
             table = _extract_kwarg(block, "table_name")
             if database and table:
-                result.catalog_targets.append(CatalogRef(database=database, table=table))
+                result.catalog_targets.append(
+                    CatalogRef(database=database, table=table)
+                )
                 logger.debug(f"Found purge_table target: {database}.{table}")
         except Exception as exc:
             logger.debug(f"Failed to parse purge_table block: {exc}")
@@ -331,7 +343,9 @@ def _parse_spark_read(source_code: str, result: ScriptLineageResult):
         if len(parts) == 2:
             result.catalog_sources.append(CatalogRef(database=parts[0], table=parts[1]))
         else:
-            result.catalog_sources.append(CatalogRef(database="default", table=table_ref))
+            result.catalog_sources.append(
+                CatalogRef(database="default", table=table_ref)
+            )
         logger.debug(f"Found Spark read.table source: {table_ref}")
 
 
@@ -355,7 +369,9 @@ def _parse_spark_write(source_code: str, result: ScriptLineageResult):
             jdbc_url = match.group(1).strip()
             table = match.group(2).strip()
             result.jdbc_targets.append(JDBCRef(jdbc_url=jdbc_url, table=table))
-            logger.debug(f"Found Spark write.jdbc target: url={jdbc_url}, table={table}")
+            logger.debug(
+                f"Found Spark write.jdbc target: url={jdbc_url}, table={table}"
+            )
         except Exception as exc:
             logger.debug(f"Failed to parse df.write.jdbc: {exc}")
 

--- a/ingestion/tests/unit/topology/pipeline/test_glue_script_parser.py
+++ b/ingestion/tests/unit/topology/pipeline/test_glue_script_parser.py
@@ -14,8 +14,6 @@ Tests for Glue PySpark/GlueContext script lineage parser
 from unittest import TestCase
 
 from metadata.ingestion.source.pipeline.gluepipeline.script_parser import (
-    CatalogRef,
-    JDBCRef,
     parse_glue_script,
 )
 
@@ -30,7 +28,7 @@ class TestGlueScriptParser(TestCase):
         self.assertFalse(result.has_lineage)
 
     def test_from_options_s3_source(self):
-        script = '''
+        script = """
 s3_df = glueContext.create_dynamic_frame.from_options(
     connection_type="s3",
     format="parquet",
@@ -40,7 +38,7 @@ s3_df = glueContext.create_dynamic_frame.from_options(
     },
     transformation_ctx="s3_df"
 )
-'''
+"""
         result = parse_glue_script(script)
         self.assertTrue(result.has_lineage)
         self.assertIn(
@@ -49,7 +47,7 @@ s3_df = glueContext.create_dynamic_frame.from_options(
         )
 
     def test_write_jdbc_conf_target(self):
-        script = '''
+        script = """
 glueContext.write_dynamic_frame.from_jdbc_conf(
     frame=s3_df,
     catalog_connection="Redshift - Jdbc connection",
@@ -60,16 +58,18 @@ glueContext.write_dynamic_frame.from_jdbc_conf(
     redshift_tmp_dir="s3://collate-glue-connector-test/temp/",
     transformation_ctx="jdbc_sink"
 )
-'''
+"""
         result = parse_glue_script(script)
         self.assertTrue(result.has_lineage)
         self.assertEqual(len(result.jdbc_targets), 1)
-        self.assertEqual(result.jdbc_targets[0].connection_name, "Redshift - Jdbc connection")
+        self.assertEqual(
+            result.jdbc_targets[0].connection_name, "Redshift - Jdbc connection"
+        )
         self.assertEqual(result.jdbc_targets[0].table, "customer_sample")
         self.assertEqual(result.jdbc_targets[0].database, "dev")
 
     def test_full_user_script(self):
-        script = '''
+        script = """
 import sys
 from awsglue.transforms import *
 from awsglue.utils import getResolvedOptions
@@ -110,7 +110,7 @@ glueContext.write_dynamic_frame.from_jdbc_conf(
 )
 
 job.commit()
-'''
+"""
         result = parse_glue_script(script)
         self.assertTrue(result.has_lineage)
         self.assertIn(
@@ -118,18 +118,20 @@ job.commit()
             result.s3_sources,
         )
         self.assertEqual(len(result.jdbc_targets), 1)
-        self.assertEqual(result.jdbc_targets[0].connection_name, "Redshift - Jdbc connection")
+        self.assertEqual(
+            result.jdbc_targets[0].connection_name, "Redshift - Jdbc connection"
+        )
         self.assertEqual(result.jdbc_targets[0].table, "customer_sample")
         self.assertEqual(result.jdbc_targets[0].database, "dev")
 
     def test_from_catalog_source(self):
-        script = '''
+        script = """
 datasource = glueContext.create_dynamic_frame.from_catalog(
     database="my_database",
     table_name="my_table",
     transformation_ctx="datasource"
 )
-'''
+"""
         result = parse_glue_script(script)
         self.assertTrue(result.has_lineage)
         self.assertEqual(len(result.catalog_sources), 1)
@@ -137,14 +139,14 @@ datasource = glueContext.create_dynamic_frame.from_catalog(
         self.assertEqual(result.catalog_sources[0].table, "my_table")
 
     def test_write_catalog_target(self):
-        script = '''
+        script = """
 glueContext.write_dynamic_frame.from_catalog(
     frame=output_df,
     database="output_db",
     table_name="output_table",
     transformation_ctx="sink"
 )
-'''
+"""
         result = parse_glue_script(script)
         self.assertTrue(result.has_lineage)
         self.assertEqual(len(result.catalog_targets), 1)
@@ -152,7 +154,7 @@ glueContext.write_dynamic_frame.from_catalog(
         self.assertEqual(result.catalog_targets[0].table, "output_table")
 
     def test_write_options_s3_target(self):
-        script = '''
+        script = """
 glueContext.write_dynamic_frame.from_options(
     frame=output_df,
     connection_type="s3",
@@ -160,41 +162,43 @@ glueContext.write_dynamic_frame.from_options(
     connection_options={"path": "s3://my-bucket/output/data/"},
     transformation_ctx="s3_sink"
 )
-'''
+"""
         result = parse_glue_script(script)
         self.assertTrue(result.has_lineage)
         self.assertIn("s3://my-bucket/output/data/", result.s3_targets)
 
     def test_spark_read_parquet(self):
-        script = '''
+        script = """
 df = spark.read.parquet("s3://my-bucket/input/data/")
-'''
+"""
         result = parse_glue_script(script)
         self.assertTrue(result.has_lineage)
         self.assertIn("s3://my-bucket/input/data/", result.s3_sources)
 
     def test_spark_read_format_load(self):
-        script = '''
+        script = """
 df = spark.read.format("parquet").load("s3://my-bucket/input/data/")
-'''
+"""
         result = parse_glue_script(script)
         self.assertTrue(result.has_lineage)
         self.assertIn("s3://my-bucket/input/data/", result.s3_sources)
 
     def test_spark_read_jdbc(self):
-        script = '''
+        script = """
 df = spark.read.jdbc("jdbc:postgresql://myhost:5432/mydb", "public.users")
-'''
+"""
         result = parse_glue_script(script)
         self.assertTrue(result.has_lineage)
         self.assertEqual(len(result.jdbc_sources), 1)
-        self.assertEqual(result.jdbc_sources[0].jdbc_url, "jdbc:postgresql://myhost:5432/mydb")
+        self.assertEqual(
+            result.jdbc_sources[0].jdbc_url, "jdbc:postgresql://myhost:5432/mydb"
+        )
         self.assertEqual(result.jdbc_sources[0].table, "public.users")
 
     def test_spark_read_table(self):
-        script = '''
+        script = """
 df = spark.read.table("my_database.my_table")
-'''
+"""
         result = parse_glue_script(script)
         self.assertTrue(result.has_lineage)
         self.assertEqual(len(result.catalog_sources), 1)
@@ -202,25 +206,25 @@ df = spark.read.table("my_database.my_table")
         self.assertEqual(result.catalog_sources[0].table, "my_table")
 
     def test_spark_write_parquet(self):
-        script = '''
+        script = """
 df.write.parquet("s3://my-bucket/output/")
-'''
+"""
         result = parse_glue_script(script)
         self.assertTrue(result.has_lineage)
         self.assertIn("s3://my-bucket/output/", result.s3_targets)
 
     def test_spark_write_format_save(self):
-        script = '''
+        script = """
 df.write.format("csv").save("s3://my-bucket/output/csv/")
-'''
+"""
         result = parse_glue_script(script)
         self.assertTrue(result.has_lineage)
         self.assertIn("s3://my-bucket/output/csv/", result.s3_targets)
 
     def test_spark_write_jdbc(self):
-        script = '''
+        script = """
 df.write.jdbc("jdbc:mysql://host:3306/mydb", "orders")
-'''
+"""
         result = parse_glue_script(script)
         self.assertTrue(result.has_lineage)
         self.assertEqual(len(result.jdbc_targets), 1)
@@ -228,9 +232,9 @@ df.write.jdbc("jdbc:mysql://host:3306/mydb", "orders")
         self.assertEqual(result.jdbc_targets[0].table, "orders")
 
     def test_spark_save_as_table(self):
-        script = '''
+        script = """
 df.write.saveAsTable("analytics.user_summary")
-'''
+"""
         result = parse_glue_script(script)
         self.assertTrue(result.has_lineage)
         self.assertEqual(len(result.catalog_targets), 1)
@@ -238,9 +242,9 @@ df.write.saveAsTable("analytics.user_summary")
         self.assertEqual(result.catalog_targets[0].table, "user_summary")
 
     def test_spark_insert_into(self):
-        script = '''
+        script = """
 df.write.insertInto("warehouse.events")
-'''
+"""
         result = parse_glue_script(script)
         self.assertTrue(result.has_lineage)
         self.assertEqual(len(result.catalog_targets), 1)
@@ -248,7 +252,7 @@ df.write.insertInto("warehouse.events")
         self.assertEqual(result.catalog_targets[0].table, "events")
 
     def test_multiple_sources_and_targets(self):
-        script = '''
+        script = """
 source1 = glueContext.create_dynamic_frame.from_catalog(
     database="raw_db",
     table_name="orders",
@@ -258,7 +262,7 @@ source2 = spark.read.parquet("s3://data-lake/customers/")
 
 output_df = some_transform(source1, source2)
 output_df.write.saveAsTable("analytics.order_summary")
-'''
+"""
         result = parse_glue_script(script)
         self.assertTrue(result.has_lineage)
         self.assertEqual(len(result.catalog_sources), 1)
@@ -268,22 +272,22 @@ output_df.write.saveAsTable("analytics.order_summary")
         self.assertEqual(result.catalog_targets[0].table, "order_summary")
 
     def test_no_lineage_script(self):
-        script = '''
+        script = """
 import sys
 print("Hello World")
 x = 42
-'''
+"""
         result = parse_glue_script(script)
         self.assertFalse(result.has_lineage)
 
     def test_purge_table_target(self):
-        script = '''
+        script = """
 glueContext.purge_table(
     database="temp_db",
     table_name="staging_data",
     options={"retentionPeriod": 1}
 )
-'''
+"""
         result = parse_glue_script(script)
         self.assertTrue(result.has_lineage)
         self.assertEqual(len(result.catalog_targets), 1)
@@ -291,19 +295,19 @@ glueContext.purge_table(
         self.assertEqual(result.catalog_targets[0].table, "staging_data")
 
     def test_spark_table_single_name(self):
-        script = '''
+        script = """
 df = spark.read.table("my_table")
-'''
+"""
         result = parse_glue_script(script)
         self.assertTrue(result.has_lineage)
         self.assertEqual(result.catalog_sources[0].database, "default")
         self.assertEqual(result.catalog_sources[0].table, "my_table")
 
     def test_s3a_and_s3n_paths(self):
-        script = '''
+        script = """
 df1 = spark.read.parquet("s3a://bucket1/path/")
 df2 = spark.read.json("s3n://bucket2/path/")
-'''
+"""
         result = parse_glue_script(script)
         self.assertIn("s3a://bucket1/path/", result.s3_sources)
         self.assertIn("s3n://bucket2/path/", result.s3_sources)
@@ -337,9 +341,7 @@ class TestParseJdbcUrl(TestCase):
             GluepipelineSource,
         )
 
-        result = GluepipelineSource._parse_jdbc_url(
-            "jdbc:mysql://myhost:3306/salesdb"
-        )
+        result = GluepipelineSource._parse_jdbc_url("jdbc:mysql://myhost:3306/salesdb")
         self.assertIsNotNone(result)
         self.assertEqual(result["database"], "salesdb")
 

--- a/ingestion/tests/unit/topology/pipeline/test_gluepipeline.py
+++ b/ingestion/tests/unit/topology/pipeline/test_gluepipeline.py
@@ -375,9 +375,7 @@ class GluePipelineUnitTest(TestCase):
             database="dev",
             table="customer_sample",
         )
-        self.gluepipeline._resolve_jdbc_entities(
-            [jdbc_ref], lineage_details, "targets"
-        )
+        self.gluepipeline._resolve_jdbc_entities([jdbc_ref], lineage_details, "targets")
 
         assert len(lineage_details["targets"]) == 1
         assert lineage_details["targets"][0].name == "customer_sample"


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **New script lineage parser:**
  - Created `script_parser.py` with regex-based parsing for GlueContext and Spark DataFrame APIs to extract S3, Catalog, and JDBC lineage from Glue job scripts
  - Supports `create_dynamic_frame.from_catalog/from_options`, `write_dynamic_frame.from_jdbc_conf/from_options/from_catalog`, and Spark read/write operations
- **Lineage extraction improvements:**
  - Extended `get_lineage_details()` to fall back to script parsing when Visual ETL CodeGenConfigurationNodes unavailable
  - Added S3 path normalization with trailing slash fallback, JDBC connection resolution with caching, and comprehensive test coverage

<sub>This will update automatically on new commits.</sub>