### PR TITLE
MINOR: Add support for Azure Devops clone in Looker

### DIFF
--- a/ingestion/src/metadata/readers/file/credentials.py
+++ b/ingestion/src/metadata/readers/file/credentials.py
@@ -54,6 +54,11 @@ def get_credentials_from_url(
         )
         return original
 
+    # Azure DevOps URLs use the format: {org}/{project}/_git/{repo}
+    if "/_git/" in url:
+        repo_name = url.split("/_git/")[-1].replace(".git", "")
+        return update_repository_name(original=original, name=repo_name)
+
     # Your typical URL is git@bitbucket.org:owner/repo.git
     # or git@github.com:owner/repo.git
     url_repository = url.split(original.repositoryOwner.root + "/")[-1]


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **New Azure DevOps support for Looker connector:**
  - Added `_is_azure_devops_host()` helper to detect Azure DevOps hosts (dev.azure.com and visualstudio.com domains)
  - Enhanced `_clone_repo()` to construct proper Azure DevOps git URLs with format `https://{PAT}@{host}/{org}/{project}/_git/{repo}`
  - Updated credentials parser to extract repository names from Azure DevOps URL format (`/_git/` path segments)
- **Comprehensive test coverage:**
  - Added tests for host detection and cloning with both dev.azure.com (cloud) and visualstudio.com (on-premises) endpoints
  - Verified correct URL construction and PAT token handling for Azure DevOps

<sub>This will update automatically on new commits.</sub>