### PR TITLE
Fix: Short-circuit EmailPublisher when SMTP is disabled to prevent OOM

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/changeEvent/email/EmailPublisher.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/changeEvent/email/EmailPublisher.java
@@ -66,8 +66,13 @@ public class EmailPublisher implements Destination<ChangeEvent> {
   @Override
   public void sendMessage(ChangeEvent event, Set<Recipient> recipients)
       throws EventPublisherException {
+    if (!Boolean.TRUE.equals(EmailUtil.getSmtpSettings().getEnableSmtpServer())) {
+      LOG.debug(
+          "Skipping email notification for subscription [{}]: SMTP is not enabled",
+          eventSubscription.getName());
+      return;
+    }
     try {
-      // Generate message using Handlebars
       NotificationMessage message =
           messageEngine.generateMessage(event, eventSubscription, subscriptionDestination);
       EmailMessage emailMessage = (EmailMessage) message;


### PR DESCRIPTION
## Summary
- When SMTP is not configured, `EmailPublisher.sendMessage()` still performed expensive work (recipient resolution, Handlebars template rendering, JSON deep-copy) before reaching the SMTP check in `EmailUtil`
- Under load with multiple concurrent Quartz workers processing event batches for many recipients, this caused enough memory pressure to OOM-kill the server in AUT environments
- Added an early return at the top of `EmailPublisher.sendMessage()` when SMTP is disabled, skipping all downstream work