### PR TITLE
feat: enhance Typography component with new variant, weight, and color props for improved styling control and semantic rendering.

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/foundations/typography.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/foundations/typography.tsx
@@ -11,14 +11,15 @@
  *  limitations under the License.
  */
 
-import type { ElementType, HTMLAttributes, ReactNode, Ref } from "react";
+import React from "react";
+import type { ElementType, HTMLAttributes, ReactNode } from "react";
 import { cx } from "@/utils/cx";
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-/** Untitled UI type scale variants */
+/** Untitled UI type scale variants (display-2xl = largest, text-xs = smallest) */
 export type TypographyVariant =
   | "display-2xl"
   | "display-xl"
@@ -53,17 +54,35 @@ export type TypographyQuoteVariant =
   | "minimal-quote";
 
 export interface TypographyProps extends HTMLAttributes<HTMLElement> {
-  ref?: Ref<HTMLElement>;
   children?: ReactNode;
-  /** Untitled UI type scale. Determines font-size, line-height and the default HTML tag. Default: `text-sm` (14px) */
+  /**
+   * Untitled UI type scale. Controls font-size and line-height, and determines
+   * the default rendered HTML element.
+   *
+   * **Default element mapping:**
+   * - `display-2xl` → `<h1>` · `display-xl` → `<h2>` · `display-lg` → `<h3>`
+   * - `display-md` → `<h4>` · `display-sm` → `<h5>` · `display-xs` → `<h6>`
+   * - `text-xl`, `text-lg`, `text-md`, `text-sm` → `<p>`
+   * - `text-xs` → `<span>`
+   *
+   * @default "text-sm" (14px)
+   */
   variant?: TypographyVariant;
-  /** Font weight. Default: `regular` */
+  /** Font weight. @default "regular" */
   weight?: TypographyWeight;
-  /** Semantic text color token. Default: `primary` */
+  /**
+   * Semantic text color backed by `--color-text-*` design tokens from theme.css.
+   * @default "primary"
+   */
   color?: TypographyColor;
-  /** Override the rendered HTML element. By default it is inferred from the variant. */
+  /**
+   * Override the rendered HTML element. By default it is inferred from the variant.
+   *
+   * **Breaking change note:** The previous `Typography` implementation always rendered a `<div>`.
+   * Pass `as="div"` or `as="span"` to preserve that behaviour for existing consumers.
+   */
   as?: ElementType;
-  /** Prose quote style (for rich-text containers). Default: `default` */
+  /** Prose quote style for rich-text containers. @default "default" */
   quoteVariant?: TypographyQuoteVariant;
   className?: string;
 }
@@ -72,7 +91,12 @@ export interface TypographyProps extends HTMLAttributes<HTMLElement> {
 // Maps
 // ---------------------------------------------------------------------------
 
-/** Tailwind text-size classes per variant (tokens defined in theme.css) */
+/**
+ * Tailwind text-size utility classes per variant.
+ * Tokens are defined in theme.css (@theme static).
+ * These classes are intentionally applied after the `prose` class in cx() so
+ * that in CSS cascade they can override the prose base font-size.
+ */
 const variantClasses: Record<TypographyVariant, string> = {
   "display-2xl": "tw:text-display-2xl",
   "display-xl": "tw:text-display-xl",
@@ -89,23 +113,27 @@ const variantClasses: Record<TypographyVariant, string> = {
 
 /**
  * Default semantic HTML tag per variant.
- * Mirrors MUI Typography's element mapping.
+ *
+ * - `display-*` variants → heading elements (`h1`–`h6`), one per display step,
+ *   so no two display variants produce the same heading level by default.
+ * - `text-*` variants → `<p>` / `<span>` (body text — not headings).
+ *
+ * Use the `as` prop to override when you need a different semantic element.
  */
 const variantTags: Record<TypographyVariant, ElementType> = {
   "display-2xl": "h1",
-  "display-xl": "h1",
-  "display-lg": "h1",
-  "display-md": "h2",
-  "display-sm": "h3",
-  "display-xs": "h4",
-  "text-xl": "h5",
-  "text-lg": "h6",
+  "display-xl": "h2",
+  "display-lg": "h3",
+  "display-md": "h4",
+  "display-sm": "h5",
+  "display-xs": "h6",
+  "text-xl": "p",
+  "text-lg": "p",
   "text-md": "p",
   "text-sm": "p",
   "text-xs": "span",
 };
 
-/** Tailwind font-weight classes */
 const weightClasses: Record<TypographyWeight, string> = {
   regular: "tw:font-normal",
   medium: "tw:font-medium",
@@ -114,8 +142,7 @@ const weightClasses: Record<TypographyWeight, string> = {
 };
 
 /**
- * Semantic text color classes.
- * Backed by --color-text-* design tokens defined in theme.css.
+ * Semantic color classes backed by `--color-text-*` tokens in theme.css.
  */
 const colorClasses: Record<TypographyColor, string> = {
   primary: "tw:text-primary",
@@ -144,43 +171,54 @@ const quoteStyles: Record<TypographyQuoteVariant, string> = {
 /**
  * `Typography` — A MUI-like text primitive built on Untitled UI's design system.
  *
- * - Applies the `prose` class (Untitled UI convention) for rich-text styles.
- * - Adds `variant`, `weight`, and `color` props for granular control.
- * - Auto-selects the correct semantic HTML tag based on `variant`.
- * - Override the tag with the `as` prop.
+ * - Applies the `prose` class (Untitled UI convention) for rich-text child styles
+ *   (links, code, blockquotes, lists).
+ * - `variant` controls size (Untitled UI type scale) and the default HTML tag.
+ * - `weight` and `color` map to design tokens from `theme.css`.
+ * - Use `as` to override the rendered HTML element.
+ * - Supports `ref` forwarding for imperative DOM access.
  *
  * @example
  * <Typography variant="display-sm" weight="semibold">Page Title</Typography>
  * <Typography variant="text-sm" color="secondary">Body text</Typography>
  * <Typography variant="text-xs" as="span" color="tertiary">Label</Typography>
+ * <Typography quoteVariant="centered-quote"><blockquote>…</blockquote></Typography>
  */
-export const Typography = (props: TypographyProps) => {
-  const {
-    as,
-    variant = "text-sm",
-    weight = "regular",
-    color = "primary",
-    quoteVariant = "default",
-    className,
-    children,
-    ...otherProps
-  } = props;
+export const Typography = React.forwardRef<HTMLElement, TypographyProps>(
+  (props, ref) => {
+    const {
+      as,
+      variant = "text-sm",
+      weight = "regular",
+      color = "primary",
+      quoteVariant = "default",
+      className,
+      children,
+      ...otherProps
+    } = props;
 
-  const Component = as ?? variantTags[variant];
+    const Component = as ?? variantTags[variant];
 
-  return (
-    <Component
-      {...otherProps}
-      className={cx(
-        "prose",
-        quoteStyles[quoteVariant],
-        variantClasses[variant],
-        weightClasses[weight],
-        colorClasses[color],
-        className,
-      )}
-    >
-      {children}
-    </Component>
-  );
-};
+    return (
+      <Component
+        ref={ref}
+        {...otherProps}
+        className={cx(
+          // `prose` provides Untitled UI rich-text styles for child elements
+          // (links, code, blockquotes, lists). The variant class is placed
+          // after prose so it overrides prose's root font-size in the cascade.
+          "prose",
+          quoteStyles[quoteVariant],
+          variantClasses[variant],
+          weightClasses[weight],
+          colorClasses[color],
+          className,
+        )}
+      >
+        {children}
+      </Component>
+    );
+  },
+);
+
+Typography.displayName = "Typography";


### PR DESCRIPTION
This pull request refactors and enhances the `Typography` component to align with Untitled UI's design system and provide more granular control over text styling. The changes introduce new props for variant, weight, and color, automatic semantic HTML tag selection, and improved documentation.

Component API and design system alignment:

* Added `variant`, `weight`, and `color` props to `TypographyProps` for granular control over font size, weight, and semantic color, defaulting to "text-sm", "regular", and "primary" respectively.
* Introduced mappings for Tailwind text-size, font-weight, and color classes, as well as default semantic HTML tags per variant, enabling automatic tag selection and consistent styling.

Documentation and usability improvements:

* Added detailed JSDoc comments and usage examples to clarify component behavior and usage.

----
## Summary by Gitar

- **Enhanced Typography component:** Added `variant`, `weight`, and `color` props with 11 type scale variants, 4 font weights, and 11 semantic color tokens aligned with Untitled UI design system
- **Semantic HTML and ref forwarding:** Automatically renders appropriate heading levels (h1-h6) or body text tags based on variant; enabled `React.forwardRef` for imperative DOM access
- **⚠️ Breaking change:** Component now renders semantic tags instead of always rendering `<div>` — pass `as="div"` to preserve old behavior
- **Improved documentation:** Comprehensive JSDoc with design system integration guidance and practical usage examples

<sub>This will update automatically on new commits.</sub>