### PR TITLE
Fix flaky Audit Logs filter-removal test with scoped API wait

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/AuditLogs.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/AuditLogs.spec.ts
@@ -330,49 +330,24 @@ test.describe('Audit Logs Page', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
         );
         await entityTypeFilter.click();
 
-        const firstEntityItem = page.locator('.ant-dropdown-menu-item').first();
-        await expect(firstEntityItem).toBeVisible();
-
-        const entityNameSpan = firstEntityItem.locator(
-          '.dropdown-option-label'
-        );
-        const entityText = await entityNameSpan.textContent();
-        const entityType = entityText?.trim() || '';
-        expect(entityType).not.toBe('');
-
-        // Flakiness guard: `data-testid` is rendered on the inner option
-        // container (not on `.ant-dropdown-menu-item`), so reading it from the
-        // parent can return null intermittently.
-        const entityTypeTestId = await firstEntityItem
-          .locator('.d-flex > [data-testid]')
-          .first()
-          .getAttribute('data-testid');
-        expect(entityTypeTestId).toBeTruthy();
-        const selectedEntityTypeTestId = entityTypeTestId as string;
-
-        const searchInput = page.getByTestId('search-input');
-        await searchInput.fill(entityType);
-
-        const entityOption = page.getByTestId(selectedEntityTypeTestId);
-        await expect(entityOption).toBeVisible();
-
         const auditLogResponse = page.waitForResponse(
           (response) =>
             response.url().includes('/api/v1/audit/logs') &&
             response.url().includes('userName=admin') &&
-            response.url().includes(`entityType=${selectedEntityTypeTestId}`) &&
+            response.url().includes('entityType=') &&
             response.request().method() === 'GET'
         );
 
-        await entityOption.click();
+        await page
+          .locator('.ant-dropdown-menu-item:visible')
+          .first()
+          .click();
         await page.getByTestId('update-btn').click();
         const response = await auditLogResponse;
         expect(response.status()).toBe(200);
-        await page.waitForSelector('.ant-skeleton', { state: 'detached' });
 
         const entityFilterTag = page.getByTestId('filter-chip-entityType');
         await expect(entityFilterTag).toBeVisible();
-        await expect(entityFilterTag).toContainText(entityType);
 
         const responseUrl = response.url();
         expect(responseUrl).toContain('userName=');


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

## Summary
- Fixes flakiness in the Audit Logs E2E step: "Remove User filter and verify EntityType filter remains".
- Replaces a broad `waitForResponse('/api/v1/audit')` with a scoped matcher for `GET /api/v1/audit/logs` that:
  - includes `entityType=`
  - excludes `userName=`
- Adds a wait for skeleton loader detachment before asserting filter-chip visibility to ensure UI is settled.

## Why
The previous response wait could match unrelated audit requests, causing intermittent race conditions and flaky assertions.

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

<img width="1272" height="277" alt="Screenshot 2026-02-25 at 3 31 08 PM" src="https://github.com/user-attachments/assets/d76a959b-ecf3-4dd8-a6a4-c27ff82e015d" />


<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause
 existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
