### PR TITLE
Fix: Increase notification template body maxLength to 64KB

### DIFF
--- a/openmetadata-spec/src/main/resources/json/schema/api/events/createNotificationTemplate.json
+++ b/openmetadata-spec/src/main/resources/json/schema/api/events/createNotificationTemplate.json
@@ -29,7 +29,7 @@
       "description": "Handlebars template content for rendering notifications",
       "type": "string",
       "minLength": 1,
-      "maxLength": 10240
+      "maxLength": 65536
     },
     "owners": {
       "description": "Owners of this template",

--- a/openmetadata-spec/src/main/resources/json/schema/api/events/notificationTemplateRenderRequest.json
+++ b/openmetadata-spec/src/main/resources/json/schema/api/events/notificationTemplateRenderRequest.json
@@ -16,7 +16,7 @@
       "description": "Handlebars template content for rendering notifications",
       "type": "string",
       "minLength": 1,
-      "maxLength": 10240
+      "maxLength": 65536
     },
     "resource": {
       "type": "string",

--- a/openmetadata-spec/src/main/resources/json/schema/api/events/notificationTemplateValidationRequest.json
+++ b/openmetadata-spec/src/main/resources/json/schema/api/events/notificationTemplateValidationRequest.json
@@ -10,7 +10,7 @@
       "description": "The template body to validate",
       "type": "string",
       "minLength": 1,
-      "maxLength": 10240
+      "maxLength": 65536
     },
     "templateSubject": {
       "description": "The template subject line to validate",

--- a/openmetadata-spec/src/main/resources/json/schema/entity/events/notificationTemplate.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/events/notificationTemplate.json
@@ -60,7 +60,7 @@
       "description": "Handlebars HTML template body with placeholders.",
       "type": "string",
       "minLength": 1,
-      "maxLength": 10240
+      "maxLength": 65536
     },
     "provider": {
       "description": "Provider of the template. System templates are pre-loaded and cannot be deleted. User templates are created by users and can be deleted.",


### PR DESCRIPTION
## Summary
- Increases `templateBody` `maxLength` from 10,240 to 65,536 (64KB) across all notification template schemas
- The `system-notification-entity-updated` template is ~25K chars, exceeding the previous 10KB limit and causing API validation failures on `/validate`, `/render`, `/send`, create, and update endpoints

Closes #26093

## Test plan
- [x] Call `POST /v1/notificationTemplates/validate` with the full `system-notification-entity-updated` template body (>10 KB)— should return 200
- [x] Call `POST /v1/notificationTemplates/render` with a large template body — should render successfully
- [x] Verify create/update of templates with bodies >10KB works without validation errors