### PR TITLE
Fix: Resolve asset count mismatch between Teams listing and team Assets tab

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Teams.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Teams.spec.ts
@@ -56,6 +56,7 @@ import {
   searchTeam,
   softDeleteTeam,
   verifyAssetsInTeamsPage,
+  verifyTeamListingAssetCount,
 } from '../../utils/team';
 
 const id = uuid();
@@ -504,7 +505,9 @@ test.describe('Teams Page', () => {
 
       // Should not find the organization team
       await searchTeam(page, 'Organization', { expectNotFound: true });
-      await searchTeam(page, 'OrganizationSearchTest', { expectEmptyResults: true });
+      await searchTeam(page, 'OrganizationSearchTest', {
+        expectEmptyResults: true,
+      });
     } finally {
       await team1.delete(apiContext);
       await team2.delete(apiContext);
@@ -609,6 +612,11 @@ test.describe('Teams Page', () => {
       await verifyAssetsInTeamsPage(page, table2, team2, 1);
       await verifyAssetsInTeamsPage(page, table3, team3, 1);
       await verifyAssetsInTeamsPage(page, table4, team4, 1);
+
+      await verifyTeamListingAssetCount(page, team1, 1);
+      await verifyTeamListingAssetCount(page, team2, 1);
+      await verifyTeamListingAssetCount(page, team3, 1);
+      await verifyTeamListingAssetCount(page, team4, 1);
     } finally {
       await table1.delete(apiContext);
       await table2.delete(apiContext);

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/team.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/team.ts
@@ -29,7 +29,6 @@ import { settingClick } from './sidebar';
 
 const TEAM_TYPES = ['Department', 'Division', 'Group'];
 
-
 interface SearchTeamOptions {
   expectEmptyResults?: boolean;
   expectNotFound?: boolean;
@@ -271,7 +270,6 @@ export const removeOrganizationPolicyAndRole = async (
   });
 };
 
-
 export const searchTeam = async (
   page: Page,
   teamName: string,
@@ -335,6 +333,38 @@ export const verifyAssetsInTeamsPage = async (
   await expect(
     page.getByTestId('assets').getByTestId('filter-count')
   ).toContainText(assetCount.toString());
+};
+
+export const verifyTeamListingAssetCount = async (
+  page: Page,
+  team: TeamClass,
+  expectedCount: number
+) => {
+  const aggregateResponse = page.waitForResponse('/api/v1/search/aggregate*');
+  await settingClick(page, GlobalSettingOptions.TEAMS);
+  await aggregateResponse;
+
+  await searchTeam(page, team.data.displayName);
+
+  await expect(
+    page
+      .locator(`[data-row-key="${team.data.name}"]`)
+      .getByTestId('team-asset-count')
+  ).toHaveText(expectedCount.toString());
+
+  await page
+    .locator(`[data-row-key="${team.data.name}"]`)
+    .getByRole('link')
+    .first()
+    .click();
+
+  const res = page.waitForResponse('/api/v1/search/query?*size=15*');
+  await page.getByTestId('assets').click();
+  await res;
+
+  await expect(
+    page.getByTestId('assets').getByTestId('filter-count')
+  ).toHaveText(expectedCount.toString());
 };
 
 export const addUserInTeam = async (page: Page, user: UserClass) => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamDetails/TeamDetailsV1.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamDetails/TeamDetailsV1.interface.ts
@@ -20,6 +20,7 @@ import { EntityReference } from '../../../../generated/entity/type';
 
 export interface TeamDetailsProp {
   assetsCount: number;
+  teamAssetCounts: Record<string, number>;
   currentTeam: Team;
   teams?: Team[];
   isTeamMemberLoading: number;

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamDetails/TeamDetailsV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamDetails/TeamDetailsV1.tsx
@@ -108,6 +108,7 @@ import { UserTab } from './UserTab/UserTab.component';
 
 const TeamDetailsV1 = ({
   assetsCount,
+  teamAssetCounts,
   currentTeam,
   isTeamMemberLoading,
   childTeams,
@@ -242,11 +243,11 @@ const TeamDetailsV1 = ({
         permissionValue={
           type === ERROR_PLACEHOLDER_TYPE.CREATE
             ? t('label.create-entity', {
-                entity: heading,
-              })
+              entity: heading,
+            })
             : t('label.edit-entity', {
-                entity: heading,
-              })
+              entity: heading,
+            })
         }
         type={type}
         onClick={onClick}>
@@ -451,11 +452,11 @@ const TeamDetailsV1 = ({
       const parents =
         parentTeams && !isOrganization
           ? parentTeams.map((parent) => ({
-              name: getEntityName(parent),
-              url: getTeamsWithFqnPath(
-                parent.fullyQualifiedName ?? parent.name ?? ''
-              ),
-            }))
+            name: getEntityName(parent),
+            url: getTeamsWithFqnPath(
+              parent.fullyQualifiedName ?? parent.name ?? ''
+            ),
+          }))
           : [];
       const breadcrumb = [
         ...parents,
@@ -476,11 +477,11 @@ const TeamDetailsV1 = ({
   const removeUserBodyText = (leave: boolean) => {
     const text = leave
       ? t('message.leave-the-team-team-name', {
-          teamName: currentTeam?.displayName ?? currentTeam?.name,
-        })
+        teamName: currentTeam?.displayName ?? currentTeam?.name,
+      })
       : t('label.remove-entity', {
-          entity: deletingUser.user?.displayName ?? deletingUser.user?.name,
-        });
+        entity: deletingUser.user?.displayName ?? deletingUser.user?.name,
+      });
 
     return t('message.are-you-sure-want-to-text', { text });
   };
@@ -550,52 +551,52 @@ const TeamDetailsV1 = ({
       ...(isGroupType || isTeamDeleted ? [] : IMPORT_EXPORT_MENU_ITEM),
       ...(!currentTeam.parents?.[0]?.deleted && isTeamDeleted
         ? [
-            {
-              label: (
-                <ManageButtonItemLabel
-                  description={t('message.restore-deleted-team')}
-                  icon={IconRestore}
-                  id="restore-team-dropdown"
-                  name={t('label.restore-entity', {
-                    entity: t('label.team'),
-                  })}
-                />
-              ),
-              onClick: handleReactiveTeam,
-              key: 'restore-team-dropdown',
-            },
-          ]
+          {
+            label: (
+              <ManageButtonItemLabel
+                description={t('message.restore-deleted-team')}
+                icon={IconRestore}
+                id="restore-team-dropdown"
+                name={t('label.restore-entity', {
+                  entity: t('label.team'),
+                })}
+              />
+            ),
+            onClick: handleReactiveTeam,
+            key: 'restore-team-dropdown',
+          },
+        ]
         : []),
       ...(isTeamDeleted
         ? []
         : [
-            {
-              label: (
-                <ManageButtonItemLabel
-                  description={t('message.access-to-collaborate')}
-                  icon={IconOpenLock}
-                  id="open-group-dropdown"
-                  name={
-                    <Row>
-                      <Col span={21}>
-                        <Typography.Text
-                          className="font-medium"
-                          data-testid="open-group-label">
-                          {t('label.public-team')}
-                        </Typography.Text>
-                      </Col>
+          {
+            label: (
+              <ManageButtonItemLabel
+                description={t('message.access-to-collaborate')}
+                icon={IconOpenLock}
+                id="open-group-dropdown"
+                name={
+                  <Row>
+                    <Col span={21}>
+                      <Typography.Text
+                        className="font-medium"
+                        data-testid="open-group-label">
+                        {t('label.public-team')}
+                      </Typography.Text>
+                    </Col>
 
-                      <Col span={3}>
-                        <Switch checked={currentTeam.isJoinable} size="small" />
-                      </Col>
-                    </Row>
-                  }
-                />
-              ),
-              onClick: handleOpenToJoinToggle,
-              key: 'open-group-dropdown',
-            },
-          ]),
+                    <Col span={3}>
+                      <Switch checked={currentTeam.isJoinable} size="small" />
+                    </Col>
+                  </Row>
+                }
+              />
+            ),
+            onClick: handleOpenToJoinToggle,
+            key: 'open-group-dropdown',
+          },
+        ]),
     ],
     [
       entityPermissions,
@@ -675,6 +676,7 @@ const TeamDetailsV1 = ({
         isTeamDeleted={isTeamDeleted}
         searchTerm={searchTerm}
         showDeletedTeam={showDeletedTeam}
+        teamAssetCounts={teamAssetCounts}
         onShowDeletedTeamChange={onShowDeletedTeamChange}
         onTeamExpand={onTeamExpand}
       />
@@ -692,6 +694,7 @@ const TeamDetailsV1 = ({
     handleAddTeamButtonClick,
     handleTeamSearch,
     onShowDeletedTeamChange,
+    teamAssetCounts,
   ]);
 
   const userTabRender = useMemo(

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamDetails/TeamHierarchy.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamDetails/TeamHierarchy.tsx
@@ -46,6 +46,7 @@ import './teams.less';
 const TeamHierarchy: FC<TeamHierarchyProps> = ({
   currentTeam,
   data,
+  teamAssetCounts,
   onTeamExpand,
   isFetchingAllTeamAdvancedDetails,
   isSearchLoading,
@@ -133,22 +134,23 @@ const TeamHierarchy: FC<TeamHierarchyProps> = ({
         title: t('label.entity-count', {
           entity: t('label.asset'),
         }),
-        dataIndex: 'owns',
+        key: 'assetCount',
         width: 120,
-        key: 'owns',
-        render: (owns: Team['owns']) =>
+        render: (_: unknown, record: Team) =>
           isFetchingAllTeamAdvancedDetails ? (
             <Skeleton
               active={isFetchingAllTeamAdvancedDetails}
               paragraph={{ rows: 0 }}
             />
           ) : (
-            owns?.length ?? 0
+            <Typography.Text data-testid="team-asset-count">
+              {teamAssetCounts[record.id ?? ''] ?? 0}
+            </Typography.Text>
           ),
       },
       ...descriptionTableObject<Team>({ width: 300 }),
     ];
-  }, [data, isFetchingAllTeamAdvancedDetails, onTeamExpand]);
+  }, [data, isFetchingAllTeamAdvancedDetails, onTeamExpand, teamAssetCounts]);
 
   const handleTableHover = useCallback(
     (value: boolean) => setIsTableHovered(value),
@@ -218,18 +220,18 @@ const TeamHierarchy: FC<TeamHierarchyProps> = ({
   };
 
   const onTableRow = (record: Team, index?: number) =>
-    ({
-      index,
-      handleMoveRow,
-      handleTableHover,
-      record,
-    } as DraggableBodyRowProps<Team>);
+  ({
+    index,
+    handleMoveRow,
+    handleTableHover,
+    record,
+  } as DraggableBodyRowProps<Team>);
 
   const onTableHeader: TableProps<Team>['onHeaderRow'] = () =>
-    ({
-      handleMoveRow,
-      handleTableHover,
-    } as DraggableBodyRowProps<Team>);
+  ({
+    handleMoveRow,
+    handleTableHover,
+  } as DraggableBodyRowProps<Team>);
 
   const onDragConfirmationModalClose = useCallback(() => {
     setIsModalOpen(false);

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamDetails/team.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamDetails/team.interface.ts
@@ -20,6 +20,7 @@ import {
 export interface TeamHierarchyProps {
   currentTeam?: Team;
   data: Team[];
+  teamAssetCounts: Record<string, number>;
   onTeamExpand: (
     loading?: boolean,
     parentTeam?: string,


### PR DESCRIPTION

<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #26099 

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

## Summary

- Fixed an asset count mismatch where the "Asset Count" column in the Teams listing page showed a different number than the count displayed in the Assets tab on the team detail page
- Replaced the stale `owns.length` source with a single ES aggregation query consistent with the Assets tab
- Added Playwright test coverage to catch this mismatch regression

## Root Cause

The mismatch was caused by two different data sources:
- **Listing page**: `owns?.length` from the Teams API (`fields=owns`) — explicit ownership records stored on the Team entity in DB, can drift from ES
- **Assets tab**: `hits.total.value` from an ES query `{"term": {"owners.id": "<teamId>"}}` — the authoritative indexed ownership data

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->


https://github.com/user-attachments/assets/f4890e29-ea2e-4665-bf69-99869de4beed


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **Fixed asset count mismatch:**
  - Replaced stale `owns.length` source with ES aggregation query on `owners.id` field for consistency between Teams listing and Assets tab
  - Removed unnecessary `TabSpecificField.OWNS` from Teams API request
- **New test coverage:**
  - Added `verifyTeamListingAssetCount()` Playwright utility to verify asset counts match between listing table and team detail Assets tab

<sub>This will update automatically on new commits.</sub>