### PR TITLE
fix: migrate Data Insights workflows from offset to keyset pagination

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/DataInsightsReportApp.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/DataInsightsReportApp.java
@@ -122,8 +122,10 @@ public class DataInsightsReportApp extends AbstractNativeApplication {
       throws SearchIndexException {
     PaginatedEntitiesSource teamReader =
         new PaginatedEntitiesSource(TEAM, 10, List.of("name", "email", "users"));
-    while (!teamReader.isDone().get()) {
-      ResultList<Team> resultList = (ResultList<Team>) teamReader.readNext(null);
+    String keysetCursor = null;
+    while (true) {
+      ResultList<Team> resultList = (ResultList<Team>) teamReader.readNextKeyset(keysetCursor);
+      keysetCursor = resultList.getPaging().getAfter();
       for (Team team : resultList.getData()) {
         Set<String> emails = new HashSet<>();
         String email = team.getEmail();
@@ -167,6 +169,9 @@ public class DataInsightsReportApp extends AbstractNativeApplication {
               team.getName(),
               ex.getMessage());
         }
+      }
+      if (keysetCursor == null) {
+        break;
       }
     }
   }


### PR DESCRIPTION
## Context

A customer incident revealed that Data Insights workflows using OFFSET-based pagination (`ORDER BY name, id LIMIT :limit OFFSET :offset`) cause MySQL `sort_buffer_size` exhaustion on large datasets (3000+ entities). MySQL must sort ALL qualifying rows before applying OFFSET, and with large JSON blobs in entity tables, this exceeds memory limits even at 200MB sort buffer. Keyset pagination (`WHERE (name > :afterName OR (name = :afterName AND id > :afterId))`) scans forward from the cursor position without requiring a full sort.

## Summary

- Migrates all Data Insights workflows (DataAssets, CostAnalysis, DataQuality, WebAnalytics, DataInsightsReport) from OFFSET-based to keyset pagination
- Adds `listAfterKeysetWithRange` to `EntityTimeSeriesDAO` and `EntityTimeSeriesRepository` for time-bounded keyset queries
- Introduces `TimeSeriesCursor` record in `EntityTimeSeriesDAO` for consistent cursor format/parse across the codebase
- Adds `listWebAnalyticEventDataWithKeyset` and `readNextKeyset` for web analytics time series sources

Fixes #26124

## Test plan

- [x] Run Data Insights application on a large dataset (3000+ entities) and verify no sort buffer errors
- [x] Verify DataAssets, CostAnalysis, DataQuality, and WebAnalytics workflows complete successfully
- [x] Verify DataInsightsReport email sends correctly with keyset pagination

----
## Summary by Gitar

- **Keyset pagination implementation:**
  - Workflows now use explicit cursor tracking (`while (true)` with `keysetCursor`) instead of atomic `isDone` flag
  - Overflow detection queries with `LIMIT :limit + 1` to generate next-page cursors efficiently
- **Database layer upgrades:**
  - `KeysetPage` record abstracts cursor extraction and result paging logic
  - Time-bounded queries support backfill workflows with date ranges while maintaining keyset efficiency
- **Bug fixes:**
  - Fixed string format error in `CostAnalysisWorkflow` exception messages
  - Added explicit error exit conditions to prevent infinite loop scenarios in all workflow transitions

<sub>This will update automatically on new commits.</sub>