### PR TITLE
Fix #26141: Fix dbt cloud storage ingestion to only process latest ru…

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/dbt/dbt_config.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/dbt_config.py
@@ -414,7 +414,7 @@ def _filter_latest_per_project(
     for directory in blob_grouped_by_directory:
         if _has_date_pattern(directory):
             parent = os.path.dirname(directory)
-            project_to_dated_dirs[parent or directory].append(directory)
+            project_to_dated_dirs[parent].append(directory)
         else:
             filtered[directory] = blob_grouped_by_directory[directory]
 

--- a/ingestion/tests/unit/test_dbt.py
+++ b/ingestion/tests/unit/test_dbt.py
@@ -3104,6 +3104,26 @@ class TestFilterLatestPerProject:
         assert len(result) == 1
         assert "org/team/projectA/run_2025-06-15" in result
 
+    def test_root_level_dated_dirs_filtered_to_latest(self):
+        """Root-level dated dirs (no parent) should be grouped together and filtered."""
+        from metadata.ingestion.source.database.dbt.dbt_config import (
+            _filter_latest_per_project,
+        )
+
+        grouped = {
+            "target_2025-04-18": ["target_2025-04-18/manifest.json"],
+            "target_2025-04-19": ["target_2025-04-19/manifest.json"],
+            "target_2025-04-20": [
+                "target_2025-04-20/manifest.json",
+                "target_2025-04-20/catalog.json",
+            ],
+        }
+        result = _filter_latest_per_project(grouped)
+        assert len(result) == 1
+        assert "target_2025-04-20" in result
+        assert "target_2025-04-18" not in result
+        assert "target_2025-04-19" not in result
+
     def test_has_date_pattern(self):
         from metadata.ingestion.source.database.dbt.dbt_config import _has_date_pattern
 


### PR DESCRIPTION
…n per project

<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **dbt cloud storage filtering:** Added `_filter_latest_per_project()` function to process only the latest timestamped run directory per project across S3, GCS, and Azure storage backends
  - Filters directories with date patterns (YYYY-MM-DD), preserves non-dated directories
  - Applied consistently to `DbtS3Config`, `DbtGcsConfig`, and `DbtAzureConfig` handlers
- **Comprehensive test coverage:** Added 9 unit tests covering edge cases (empty input, single directory, multiple projects, mixed dated/non-dated directories, deeply nested paths)

<sub>This will update automatically on new commits.</sub>