### PR TITLE
feat: extract core-component changes from PR #26064 (Skeleton + Tooltip updates)

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/skeleton/skeleton.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/skeleton/skeleton.tsx
@@ -1,0 +1,103 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { CSSProperties, ReactNode } from "react";
+import { cx } from "@/utils/cx";
+
+export type SkeletonVariant = "text" | "rectangular" | "rounded" | "circular";
+export type SkeletonAnimation = "pulse" | "wave" | false;
+
+export interface SkeletonProps {
+  /**
+   * The shape of the skeleton.
+   * - `text`: Inline text line with slight rounding. Height defaults to `1.2em`.
+   * - `rectangular`: Sharp corners, suitable for card/image placeholders.
+   * - `rounded`: Rounded corners, suitable for button/chip placeholders.
+   * - `circular`: Fully round, suitable for avatar placeholders.
+   * @default "text"
+   */
+  variant?: SkeletonVariant;
+  /**
+   * The animation effect applied to the skeleton.
+   * - `pulse`: Fades opacity in and out.
+   * - `wave`: Horizontal shimmer sweep.
+   * - `false`: No animation.
+   * @default "pulse"
+   */
+  animation?: SkeletonAnimation;
+  /** Width of the skeleton. Numbers are treated as pixels. */
+  width?: number | string;
+  /** Height of the skeleton. Numbers are treated as pixels. */
+  height?: number | string;
+  /** Additional CSS class names. */
+  className?: string;
+  /** Inline styles merged with computed size styles. */
+  style?: CSSProperties;
+  /**
+   * Optional children whose dimensions are inferred to size the skeleton.
+   * Children are rendered invisibly so the skeleton matches their layout.
+   */
+  children?: ReactNode;
+}
+
+const VARIANT_CLASSES: Record<SkeletonVariant, string> = {
+  text: "tw:rounded",
+  rectangular: "",
+  rounded: "tw:rounded-md",
+  circular: "tw:rounded-full",
+};
+
+export const Skeleton = ({
+  variant = "text",
+  animation = "pulse",
+  width,
+  height,
+  className,
+  style,
+  children,
+}: SkeletonProps) => {
+  const computedStyle: CSSProperties = { ...style };
+
+  if (width !== undefined) {
+    computedStyle.width = typeof width === "number" ? `${width}px` : width;
+  }
+
+  if (height !== undefined) {
+    computedStyle.height = typeof height === "number" ? `${height}px` : height;
+  } else if (variant === "text") {
+    computedStyle.height = "1.2em";
+  }
+
+  if (variant === "circular") {
+    if (computedStyle.width && !computedStyle.height) {
+      computedStyle.height = computedStyle.width;
+    } else if (computedStyle.height && !computedStyle.width) {
+      computedStyle.width = computedStyle.height;
+    }
+  }
+
+  return (
+    <span
+      aria-hidden="true"
+      style={computedStyle}
+      className={cx(
+        "tw:block tw:bg-quaternary",
+        VARIANT_CLASSES[variant],
+        animation === "pulse" && "tw:animate-pulse",
+        animation === "wave" && "skeleton-wave",
+        className,
+      )}
+    >
+      {children && <span className="tw:invisible">{children}</span>}
+    </span>
+  );
+};

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/tooltip/tooltip.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/tooltip/tooltip.tsx
@@ -1,107 +1,167 @@
 import type { ReactNode } from "react";
 import type {
-    ButtonProps as AriaButtonProps,
-    TooltipProps as AriaTooltipProps,
-    TooltipTriggerComponentProps as AriaTooltipTriggerComponentProps,
+  ButtonProps as AriaButtonProps,
+  TooltipProps as AriaTooltipProps,
+  TooltipTriggerComponentProps as AriaTooltipTriggerComponentProps,
 } from "react-aria-components";
-import { Button as AriaButton, OverlayArrow as AriaOverlayArrow, Tooltip as AriaTooltip, TooltipTrigger as AriaTooltipTrigger } from "react-aria-components";
+import {
+  Button as AriaButton,
+  OverlayArrow as AriaOverlayArrow,
+  Tooltip as AriaTooltip,
+  TooltipTrigger as AriaTooltipTrigger,
+} from "react-aria-components";
 import { cx } from "@/utils/cx";
 
-interface TooltipProps extends AriaTooltipTriggerComponentProps, Omit<AriaTooltipProps, "children"> {
-    /**
-     * The title of the tooltip.
-     */
-    title: ReactNode;
-    /**
-     * The description of the tooltip.
-     */
-    description?: ReactNode;
-    /**
-     * Whether to show the arrow on the tooltip.
-     *
-     * @default false
-     */
-    arrow?: boolean;
-    /**
-     * Delay in milliseconds before the tooltip is shown.
-     *
-     * @default 300
-     */
-    delay?: number;
+interface TooltipProps
+  extends AriaTooltipTriggerComponentProps, Omit<AriaTooltipProps, "children"> {
+  /**
+   * The title of the tooltip.
+   */
+  title: ReactNode;
+  /**
+   * The description of the tooltip.
+   */
+  description?: ReactNode;
+  /**
+   * Whether to show the arrow on the tooltip.
+   *
+   * @default false
+   */
+  arrow?: boolean;
+  /**
+   * Delay in milliseconds before the tooltip is shown.
+   *
+   * @default 300
+   */
+  delay?: number;
+  /**
+   * Optional className applied to the tooltip content container div.
+   * Use this to override the default dark background, e.g. for a white tooltip.
+   */
+  containerClassName?: string;
 }
 
 export const Tooltip = ({
-    title,
-    description,
-    children,
-    arrow = false,
-    delay = 300,
-    closeDelay = 0,
-    trigger,
-    isDisabled,
-    isOpen,
-    defaultOpen,
-    offset = 6,
-    crossOffset,
-    placement = "top",
-    onOpenChange,
-    ...tooltipProps
+  title,
+  description,
+  children,
+  arrow = false,
+  delay = 300,
+  closeDelay = 0,
+  trigger,
+  isDisabled,
+  isOpen,
+  defaultOpen,
+  offset = 6,
+  crossOffset,
+  placement = "top",
+  onOpenChange,
+  containerClassName,
+  ...tooltipProps
 }: TooltipProps) => {
-    const isTopOrBottomLeft = ["top left", "top end", "bottom left", "bottom end"].includes(placement);
-    const isTopOrBottomRight = ["top right", "top start", "bottom right", "bottom start"].includes(placement);
-    // Set negative cross offset for left and right placement to visually balance the tooltip.
-    const calculatedCrossOffset = isTopOrBottomLeft ? -12 : isTopOrBottomRight ? 12 : 0;
+  const isTopOrBottomLeft = [
+    "top left",
+    "top end",
+    "bottom left",
+    "bottom end",
+  ].includes(placement);
+  const isTopOrBottomRight = [
+    "top right",
+    "top start",
+    "bottom right",
+    "bottom start",
+  ].includes(placement);
+  // Set negative cross offset for left and right placement to visually balance the tooltip.
+  const calculatedCrossOffset = isTopOrBottomLeft
+    ? -12
+    : isTopOrBottomRight
+      ? 12
+      : 0;
 
-    return (
-        <AriaTooltipTrigger {...{ trigger, delay, closeDelay, isDisabled, isOpen, defaultOpen, onOpenChange }}>
-            {children}
+  return (
+    <AriaTooltipTrigger
+      {...{
+        trigger,
+        delay,
+        closeDelay,
+        isDisabled,
+        isOpen,
+        defaultOpen,
+        onOpenChange,
+      }}
+    >
+      {children}
 
-            <AriaTooltip
-                {...tooltipProps}
-                offset={offset}
-                placement={placement}
-                crossOffset={crossOffset ?? calculatedCrossOffset}
-                className={({ isEntering, isExiting }) => cx(isEntering && "tw:ease-out tw:animate-in", isExiting && "tw:ease-in tw:animate-out")}
-            >
-                {({ isEntering, isExiting }) => (
-                    <div
-                        className={cx(
-                            "tw:z-50 tw:flex tw:max-w-xs tw:origin-(--trigger-anchor-point) tw:flex-col tw:items-start tw:gap-1 tw:rounded-lg tw:bg-primary-solid tw:px-3 tw:shadow-lg tw:will-change-transform",
-                            description ? "tw:py-3" : "tw:py-2",
+      <AriaTooltip
+        {...tooltipProps}
+        offset={offset}
+        placement={placement}
+        crossOffset={crossOffset ?? calculatedCrossOffset}
+        className={({ isEntering, isExiting }) =>
+          cx(
+            isEntering && "tw:ease-out tw:animate-in",
+            isExiting && "tw:ease-in tw:animate-out",
+          )
+        }
+      >
+        {({ isEntering, isExiting }) => (
+          <div
+            className={cx(
+              "tw:z-50 tw:flex tw:max-w-xs tw:origin-(--trigger-anchor-point) tw:flex-col tw:items-start tw:gap-1 tw:rounded-lg tw:bg-primary-solid tw:px-3 tw:shadow-lg tw:will-change-transform",
+              description ? "tw:py-3" : "tw:py-2",
+              containerClassName,
 
-                            isEntering &&
-                                "tw:ease-out tw:animate-in tw:fade-in tw:zoom-in-95 tw:in-placement-left:slide-in-from-right-0.5 tw:in-placement-right:slide-in-from-left-0.5 tw:in-placement-top:slide-in-from-bottom-0.5 tw:in-placement-bottom:slide-in-from-top-0.5",
-                            isExiting &&
-                                "tw:ease-in tw:animate-out tw:fade-out tw:zoom-out-95 tw:in-placement-left:slide-out-to-right-0.5 tw:in-placement-right:slide-out-to-left-0.5 tw:in-placement-top:slide-out-to-bottom-0.5 tw:in-placement-bottom:slide-out-to-top-0.5",
-                        )}
-                    >
-                        <span className="tw:text-xs tw:font-semibold tw:text-white">{title}</span>
+              isEntering &&
+                "tw:ease-out tw:animate-in tw:fade-in tw:zoom-in-95 tw:in-placement-left:slide-in-from-right-0.5 tw:in-placement-right:slide-in-from-left-0.5 tw:in-placement-top:slide-in-from-bottom-0.5 tw:in-placement-bottom:slide-in-from-top-0.5",
+              isExiting &&
+                "tw:ease-in tw:animate-out tw:fade-out tw:zoom-out-95 tw:in-placement-left:slide-out-to-right-0.5 tw:in-placement-right:slide-out-to-left-0.5 tw:in-placement-top:slide-out-to-bottom-0.5 tw:in-placement-bottom:slide-out-to-top-0.5",
+            )}
+          >
+            <span className="tw:text-xs tw:font-semibold tw:text-white">
+              {title}
+            </span>
 
-                        {description && <span className="tw:text-xs tw:font-medium tw:text-tooltip-supporting-text">{description}</span>}
+            {description && (
+              <span className="tw:text-xs tw:font-medium tw:text-tooltip-supporting-text">
+                {description}
+              </span>
+            )}
 
-                        {arrow && (
-                            <AriaOverlayArrow>
-                                <svg
-                                    viewBox="0 0 100 100"
-                                    className="tw:size-2.5 tw:fill-bg-primary-solid tw:in-placement-left:-rotate-90 tw:in-placement-right:rotate-90 tw:in-placement-top:rotate-0 tw:in-placement-bottom:rotate-180"
-                                >
-                                    <path d="M0,0 L35.858,35.858 Q50,50 64.142,35.858 L100,0 Z" />
-                                </svg>
-                            </AriaOverlayArrow>
-                        )}
-                    </div>
-                )}
-            </AriaTooltip>
-        </AriaTooltipTrigger>
-    );
+            {arrow && (
+              <AriaOverlayArrow>
+                <svg
+                  viewBox="0 0 100 100"
+                  className="tw:size-2.5 tw:fill-bg-primary-solid tw:in-placement-left:-rotate-90 tw:in-placement-right:rotate-90 tw:in-placement-top:rotate-0 tw:in-placement-bottom:rotate-180"
+                >
+                  <path d="M0,0 L35.858,35.858 Q50,50 64.142,35.858 L100,0 Z" />
+                </svg>
+              </AriaOverlayArrow>
+            )}
+          </div>
+        )}
+      </AriaTooltip>
+    </AriaTooltipTrigger>
+  );
 };
 
 interface TooltipTriggerProps extends AriaButtonProps {}
 
-export const TooltipTrigger = ({ children, className, ...buttonProps }: TooltipTriggerProps) => {
-    return (
-        <AriaButton {...buttonProps} className={(values) => cx("tw:h-max tw:w-max tw:outline-hidden", typeof className === "function" ? className(values) : className)}>
-            {children}
-        </AriaButton>
-    );
+export const TooltipTrigger = ({
+  children,
+  className,
+  ...buttonProps
+}: TooltipTriggerProps) => {
+  return (
+    <AriaButton
+      {...buttonProps}
+      className={(values) =>
+        cx(
+          "tw:h-max tw:w-max tw:outline-hidden",
+          typeof className === "function" ? className(values) : className,
+        )
+      }
+    >
+      {children}
+    </AriaButton>
+  );
 };

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/index.ts
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/index.ts
@@ -65,6 +65,7 @@ export * from "./base/form/hook-form";
 export * from "./base/progress-indicators/progress-circles";
 export * from "./base/progress-indicators/progress-indicators";
 export * from "./base/progress-indicators/simple-circle";
+export * from "./base/skeleton/skeleton";
 export * from "./base/radio-buttons/radio-buttons";
 export * from "./base/slider/slider";
 export * from "./base/tags/tags";

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/styles/globals.css
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/styles/globals.css
@@ -37,3 +37,24 @@
     display: inline;
   }
 }
+
+/* Skeleton wave animation */
+@keyframes skeleton-wave {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}
+
+.skeleton-wave {
+  background: linear-gradient(
+    90deg,
+    var(--color-bg-quaternary) 25%,
+    var(--color-bg-tertiary) 50%,
+    var(--color-bg-quaternary) 75%
+  );
+  background-size: 200% 100%;
+  animation: skeleton-wave 1.5s ease-in-out infinite;
+}


### PR DESCRIPTION
## Summary

Port the core-component changes from [PR #26064](https://github.com/open-metadata/OpenMetadata/pull/26064) (migrate MUI components to UntitledUI).

## Changes (openmetadata-ui-core-components only)

### New Component
- **`Skeleton`** — reusable loading placeholder with:
  - Shape variants: `text`, `rectangular`, `rounded`, `circular`
  - Animation variants: `pulse`, `wave`, `false`
  - Configurable `width`, `height`, `className`, `style`

### Updated Components
- **`Tooltip`** — adds optional `containerClassName` prop to allow overriding the default dark background styling

### Exports & Styles
- `components/index.ts` — exports new `Skeleton` component
- `styles/globals.css` — adds `@keyframes skeleton-wave` + `.skeleton-wave` CSS class for the wave animation

## References
- Source PR: open-metadata/OpenMetadata#26064
- Branch: `migrate-mui-to-ut-for-dq`