### PR TITLE
(test) ui: Fix flaky drag and drop test in Settings Navigation Page spec

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SettingsNavigationPage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SettingsNavigationPage.spec.ts
@@ -259,25 +259,25 @@ test.describe.serial('Settings Navigation Page Tests', () => {
     await navigateToPersonaNavigation(page);
 
     const treeItems = page.locator('.ant-tree-node-content-wrapper');
-    
+
     // Wait for the tree to be fully ready
     await expect(treeItems.first()).toBeVisible();
-    
-    const firstItem = treeItems.first();
-    const secondItem = treeItems.nth(1);
 
-    const firstItemText = await firstItem.textContent();
+    const homeItem = treeItems.getByTitle('label.home');
+    const exploreItem = treeItems.getByTitle('label.explore');
+
+    const firstItemText = await homeItem.textContent();
 
     expect(firstItemText).not.toBeNull();
 
-    const firstItemBox = await firstItem.boundingBox();
-    const secondItemBox = await secondItem.boundingBox();
+    const firstItemBox = await homeItem.boundingBox();
+    const secondItemBox = await exploreItem.boundingBox();
 
     expect(firstItemBox).not.toBeNull();
     expect(secondItemBox).not.toBeNull();
 
     if (firstItemBox && secondItemBox) {
-      await firstItem.dragTo(secondItem, {
+      await homeItem.dragTo(exploreItem, {
         sourcePosition: {
           x: firstItemBox.width / 2,
           y: firstItemBox.height / 2,
@@ -294,7 +294,6 @@ test.describe.serial('Settings Navigation Page Tests', () => {
 
       await expect(saveButton).toBeVisible();
       await expect(saveButton).toBeEnabled();
-       
     }
   });
 
@@ -335,9 +334,9 @@ test.describe.serial('Settings Navigation Page Tests', () => {
     await expect(page.getByText('Switch Persona')).toBeVisible();
 
     // Initially should show limited personas (2 by default)
-    const initialPersonaLabels = page.locator(
-      '[data-testid="persona-label"]'
-    ).locator('input[type="radio"]');
+    const initialPersonaLabels = page
+      .locator('[data-testid="persona-label"]')
+      .locator('input[type="radio"]');
     await initialPersonaLabels.first().click();
     await expect(page.getByTestId('app-bar-item-explore')).not.toBeVisible();
     await expect(page.getByTestId('app-bar-item-insights')).not.toBeVisible();


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

The test should support drag and drop reordering of navigation items in `SettingsNavigationPage.spec.ts` was prone to flakiness. Previously, the test grabbed the first and second items in the navigation tree using basic index selectors (.first() and .nth(1)). Index-based selection is fragile in end-to-end tests because it relies on the strict synchronous rendering order of elements, which can occasionally vary or be affected by loading states, causing the drag-and-drop action to fail or target the wrong elements.

### Changes
- Replaced the implicit index-based locators with explicit, deterministic selectors using getByTitle('label.home') and getByTitle('label.explore').
- This ensures that the test predictably targets the "Home" and "Explore" menu items for the drag-and-drop action, regardless of their exact DOM index at the split second the test runs, significantly improving test stability and reducing flakiness.


https://github.com/user-attachments/assets/6432b4b7-4c64-4e3b-997d-4d1ca9341625


<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
