### PR TITLE
fix datacontracts specs

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/dataContracts.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/dataContracts.ts
@@ -24,7 +24,7 @@ import { sidebarClick } from './sidebar';
 export const saveAndTriggerDataContractValidation = async (
   page: Page,
   isContractStatusNotVisible?: boolean
-): Promise<string | undefined> => {
+): Promise<object | undefined> => {
   const saveContractResponse = page.waitForResponse('/api/v1/dataContracts/*');
   await page.getByTestId('save-contract-btn').click();
   const response = await saveContractResponse;
@@ -48,7 +48,8 @@ export const saveAndTriggerDataContractValidation = async (
   });
 
   await page.getByTestId('contract-run-now-button').click();
-  await runNowResponse;
+  // Use validate response to get the resultId of the newly triggered execution.
+  const runNowData = await (await runNowResponse).json();
 
   await page.reload();
 
@@ -57,7 +58,8 @@ export const saveAndTriggerDataContractValidation = async (
     state: 'detached',
   });
 
-  return responseData;
+  // Prefer validate response; fall back to save response if latestResult is missing.
+  return 'latestResult' in runNowData ? runNowData : responseData;
 };
 
 export const validateDataContractInsideBundleTestSuites = async (


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **Fixed return handling in `saveAndTriggerDataContractValidation`:**
  - Changed return type from `string | undefined` to `object | undefined` to properly reflect response structure
  - Captured and parsed validate API response (`/api/v1/dataContracts/*/validate`) to extract `latestResult` metadata
  - Implemented smart fallback logic preferring validate response but falling back to save response when needed
  - Added clarifying comments explaining the dual response capture and preference logic

<sub>This will update automatically on new commits.</sub>