### PR TITLE
remove logging capability from MCP server

### DIFF
--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/McpServer.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/McpServer.java
@@ -84,7 +84,6 @@ public class McpServer implements McpServerProvider {
             .tools(true)
             .prompts(true)
             .resources(true, true)
-            .logging()
             .build();
 
     HttpServletStatelessServerTransport statelessTransport =

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/McpSdkUpgradeTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/McpSdkUpgradeTest.java
@@ -175,6 +175,21 @@ public class McpSdkUpgradeTest {
   }
 
   @Test
+  void testServerCapabilitiesDoNotAdvertiseLogging() {
+    // The stateless MCP server has no handler for logging/setLevel.
+    // Advertising logging capability causes spec-compliant clients (e.g. VSCode)
+    // to call logging/setLevel, which fails with MethodNotFound.
+    McpSchema.ServerCapabilities capabilities =
+        McpSchema.ServerCapabilities.builder()
+            .tools(true)
+            .prompts(true)
+            .resources(true, true)
+            .build();
+
+    assertThat(capabilities.logging()).isNull();
+  }
+
+  @Test
   void testMcpUtilsGetPromptsLoadsPrompts() {
     // Test that McpUtils.getPrompts loads prompts from JSON file
     List<McpSchema.Prompt> prompts = McpUtils.getPrompts("json/data/mcp/prompts.json");


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes https://github.com/open-metadata/OpenMetadata/issues/26152

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

Because we use a stateless HTTP architecture for our MCP server, we physically cannot support MCP's push-based logging notifications (which require a persistent connection like SSE or WebSockets). The underlying Java SDK (McpStatelessAsyncServer) doesn't even have a handler for logging/setLevel in stateless mode, which is exactly why VSCode is throwing that error.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
