### PR TITLE
Fix bundle test suite alerts missing testCaseResultSummary in ChangeEvents

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestSuiteRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestSuiteRepository.java
@@ -525,6 +525,8 @@ public class TestSuiteRepository extends EntityRepository<TestSuite> {
     testCaseResultSummaryMap.forEach(
         (id, results) -> testSummaryMap.put(id, computeSimpleSummary(results)));
 
+    setFieldFromMap(
+        true, testSuites, testCaseResultSummaryMap, TestSuite::setTestCaseResultSummary);
     setFieldFromMap(true, testSuites, testSummaryMap, TestSuite::setSummary);
   }
 


### PR DESCRIPTION
Fixes #25732

## Summary

- The bulk path (`fetchAndSetTestCaseResultSummary`) used by `updateRelatedSuites` was setting the `summary` counts but not populating `testCaseResultSummary` on each suite
- This caused ChangeEvents for bundle (logical) test suites to have an empty `testCaseResultSummary`, making `matchTestResult` alert filters unable to detect test failures
- Alerts configured with a bundle test suite as the source and failure as the trigger would never fire when tests were run from the table's pipeline

## Test plan

- [ ] Create a bundle test suite with a failing test case
- [ ] Configure an alert with the bundle suite as source and `Failed` as trigger
- [ ] Run the table's test suite pipeline
- [ ] Verify the alert fires (ChangeEvent for the bundle suite contains populated `testCaseResultSummary`)