### PR TITLE
Chore(UI): Fix the flakiness in ServiceIngestion.spec

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/ServiceBaseClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/ServiceBaseClass.ts
@@ -25,7 +25,6 @@ import {
   getApiContext,
   INVALID_NAMES,
   NAME_VALIDATION_ERROR,
-  toastNotification,
 } from '../../../utils/common';
 import { visitEntityPage } from '../../../utils/entity';
 import { visitServiceDetailsPage } from '../../../utils/service';
@@ -250,11 +249,19 @@ class ServiceBaseClass {
     await page.waitForTimeout(3000);
 
     await page.getByTestId('more-actions').first().click();
+
+    const triggerPipeline = page.waitForResponse(
+      (response) =>
+        response
+          .url()
+          .includes('/api/v1/services/ingestionPipelines/trigger/') &&
+        response.status() === 200
+    );
     await page.getByTestId('run-button').click();
 
-    await page.waitForLoadState('networkidle');
+    await triggerPipeline;
 
-    await toastNotification(page, `Pipeline triggered successfully!`);
+    await page.waitForLoadState('networkidle');
 
     // need manual wait to make sure we are awaiting on latest run results
     await page.waitForTimeout(2000);
@@ -648,9 +655,17 @@ class ServiceBaseClass {
     await page.waitForTimeout(3000);
 
     await page.getByTestId('more-actions').first().click();
-    await page.getByTestId('run-button').click();
 
-    await toastNotification(page, `Pipeline triggered successfully!`);
+    const triggerPipeline = page.waitForResponse(
+      (response) =>
+        response
+          .url()
+          .includes('/api/v1/services/ingestionPipelines/trigger/') &&
+        response.status() === 200
+    );
+
+    await page.getByTestId('run-button').click();
+    await triggerPipeline;
 
     // need manual wait to make sure we are awaiting on latest run results
     await page.waitForTimeout(2000);


### PR DESCRIPTION
This pull request refactors the pipeline triggering logic in the `ServiceBaseClass` for Playwright tests, improving reliability and removing unnecessary notification code. The main change is to explicitly wait for the pipeline trigger API response instead of relying on toast notifications or generic network idle states.

Improvements to pipeline triggering logic:

* Replaced the use of the `toastNotification` utility with explicit waiting for the `/api/v1/services/ingestionPipelines/trigger/` API response after clicking the `run-button`, ensuring that the pipeline trigger is confirmed by the backend before proceeding. [[1]](diffhunk://#diff-27b613009179a959c1e5cad0edabbe85bc092d0edbbd460b939fac8b3eb2e4d7R252-R264) [[2]](diffhunk://#diff-27b613009179a959c1e5cad0edabbe85bc092d0edbbd460b939fac8b3eb2e4d7L651-R668)
* Removed the import of `toastNotification` from `../../../utils/common` as it is no longer used.