### PR TITLE
Fix: respect fields parameter for table columns in GET API

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TableResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TableResourceIT.java
@@ -1336,6 +1336,41 @@ public class TableResourceIT extends BaseEntityIT<Table, CreateTable> {
     assertEquals(2, response.getData().size());
   }
 
+  @Test
+  void test_getTableWithoutColumnsInFields_returnsNoColumns(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+
+    CreateTable createRequest = createRequest(ns.prefix("table_fields_columns"), ns);
+    createRequest.setColumns(
+        List.of(
+            ColumnBuilder.of("col1", "VARCHAR").build(),
+            ColumnBuilder.of("col2", "INT").build()));
+    Table table = createEntity(createRequest);
+    assertNotNull(table.getColumns());
+    assertEquals(2, table.getColumns().size());
+
+    Table byIdWithoutColumns =
+        client.tables().get(table.getId().toString(), "owners,tags");
+    assertNull(
+        byIdWithoutColumns.getColumns(),
+        "GET table by id without 'columns' in fields must not return columns");
+
+    Table byNameWithoutColumns =
+        client.tables().getByName(table.getFullyQualifiedName(), "owners,tags");
+    assertNull(
+        byNameWithoutColumns.getColumns(),
+        "GET table by name without 'columns' in fields must not return columns");
+
+    Table byIdWithColumns = client.tables().get(table.getId().toString(), "columns");
+    assertNotNull(byIdWithColumns.getColumns());
+    assertEquals(2, byIdWithColumns.getColumns().size());
+
+    Table byNameWithColumns =
+        client.tables().getByName(table.getFullyQualifiedName(), "columns");
+    assertNotNull(byNameWithColumns.getColumns());
+    assertEquals(2, byNameWithColumns.getColumns().size());
+  }
+
   // ===================================================================
   // SAMPLE DATA OPERATIONS TESTS
   // ===================================================================

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
@@ -311,6 +311,7 @@ public class TableRepository extends EntityRepository<Table> {
 
   @Override
   public void clearFields(Table table, Fields fields) {
+    table.setColumns(fields.contains(COLUMN_FIELD) ? table.getColumns() : null);
     table.setTableConstraints(
         fields.contains("tableConstraints") ? table.getTableConstraints() : null);
     table.setUsageSummary(fields.contains("usageSummary") ? table.getUsageSummary() : null);


### PR DESCRIPTION
In our processes - we would like to be able to get tables without their columns - for performance reasons. 
Apparently - using GET table without "columns" in the fields parameter is not ommiting the columns. 
Changes made:
- TableRepository.clearFields() now clears columns when 'columns' is not in the requested fields, so GET table without fields=columns no longer returns column data.
- Add integration test test_getTableWithoutColumnsInFields_returnsNoColumns to verify behavior for get by id and get by name with/without columns.

