### PR TITLE
Add Elasticsearch validation to embedding health check

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SystemRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SystemRepository.java
@@ -48,6 +48,7 @@ import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineServic
 import org.openmetadata.schema.security.client.OidcClientConfig;
 import org.openmetadata.schema.security.client.OpenMetadataJWTClientConfig;
 import org.openmetadata.schema.security.scim.ScimConfiguration;
+import org.openmetadata.schema.service.configuration.elasticsearch.ElasticSearchConfiguration;
 import org.openmetadata.schema.service.configuration.elasticsearch.NaturalLanguageSearchConfiguration;
 import org.openmetadata.schema.service.configuration.slackApp.SlackAppConfiguration;
 import org.openmetadata.schema.services.connections.metadata.AuthProvider;
@@ -563,6 +564,14 @@ public class SystemRepository {
     StepValidation embeddingsValidation = new StepValidation();
     String description = "Embeddings are used to allow Semantic Search";
     SearchRepository searchRepository = Entity.getSearchRepository();
+
+    if (searchRepository.getSearchType() == ElasticSearchConfiguration.SearchType.ELASTICSEARCH) {
+      return embeddingsValidation
+          .withDescription(description)
+          .withMessage(
+              "Elasticsearch is not supported for Semantic Search embeddings. Please use OpenSearch.")
+          .withPassed(false);
+    }
 
     String configMessage = getEmbeddingConfigurationMessage(applicationConfig);
 


### PR DESCRIPTION
## Summary
- Adds an early validation check in the system health endpoint (`/v1/system/status`) that detects when Elasticsearch is configured with semantic search embeddings enabled
- Returns a clear error message: "Elasticsearch is not supported for Semantic Search embeddings. Please use OpenSearch."
- The check runs before any embedding client/config validation, avoiding confusing downstream errors

## Test plan
- [ ] Configure OpenMetadata with Elasticsearch and enable semantic search embeddings → verify the health check returns the new error message with `passed: false`
- [ ] Configure OpenMetadata with OpenSearch and enable semantic search embeddings → verify existing embedding validation runs as before
- [ ] Verify the `/v1/system/status` endpoint response includes the "Semantic Search" validation step with the appropriate message

Closes https://github.com/open-metadata/ai-platform/issues/433