### PR TITLE
Fixes #26336: Skip version history queries for unchanged entities in Data Insights

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/dataAssets/processors/DataInsightsEntityEnricherProcessor.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/dataAssets/processors/DataInsightsEntityEnricherProcessor.java
@@ -118,13 +118,16 @@ public class DataInsightsEntityEnricherProcessor
     Long startTimestamp = (Long) contextData.get(START_TIMESTAMP_KEY);
 
     // Skip version history queries for entities unchanged during the window (N+1 optimization).
-    Long entityUpdatedDay = TimestampUtils.getStartOfDayTimestamp(entity.getUpdatedAt());
-    if (entityUpdatedDay < startTimestamp) {
-      Map<String, Object> versionMap = new HashMap<>();
-      versionMap.put("endTimestamp", endTimestamp);
-      versionMap.put("startTimestamp", startTimestamp);
-      versionMap.put("versionEntity", entity);
-      return List.of(versionMap);
+    Long updatedAt = entity.getUpdatedAt();
+    if (updatedAt != null) {
+      Long entityUpdatedDay = TimestampUtils.getStartOfDayTimestamp(updatedAt);
+      if (entityUpdatedDay < startTimestamp) {
+        Map<String, Object> versionMap = new HashMap<>();
+        versionMap.put("endTimestamp", endTimestamp);
+        versionMap.put("startTimestamp", startTimestamp);
+        versionMap.put("versionEntity", entity);
+        return List.of(versionMap);
+      }
     }
 
     EntityRepository<?> entityRepository = Entity.getEntityRepository(entityType);


### PR DESCRIPTION
Fixes #26336

* Skip `listVersionsWithOffset` DB queries for entities that haven't changed during the DI time window, using the already-loaded entity directly instead.
* Eliminates 2–3 DB round-trips per entity for the vast majority of entities in daily runs (~99.9% unchanged), addressing the N+1 query bottleneck that accounts for ~81% of `DataAssetsWorkflow` execution time.
