### PR TITLE
Fixes #26340: Enable gzip compression on AWS IAM OpenSearch transport

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchClient.java
@@ -78,6 +78,8 @@ import software.amazon.awssdk.regions.Region;
 @Slf4j
 // Not tagged with Repository annotation as it is programmatically initialized
 public class OpenSearchClient implements SearchClient {
+  private static final int REQUEST_COMPRESSION_THRESHOLD_BYTES = 8 * 1024;
+
   private final boolean isClientAvailable;
   private final RBACConditionEvaluator rbacConditionEvaluator;
 
@@ -718,6 +720,8 @@ public class OpenSearchClient implements SearchClient {
           AwsSdk2TransportOptions.builder()
               .setCredentials(buildCredentialsProvider(awsConfig))
               .setMapper(new JacksonJsonpMapper())
+              .setRequestCompressionSize(REQUEST_COMPRESSION_THRESHOLD_BYTES)
+              .setResponseCompression(true)
               .build();
 
       LOG.info(


### PR DESCRIPTION
Fixes #26340

The DataAssetsWorkflow fails on AWS-managed OpenSearch with `413 Request Entity Too Large` when bulk payloads exceed the server’s 10MB limit.

Root cause: The OpenSearch client has two transport paths—one for regular connections (`ApacheHttpClient5Transport`) and one for AWS IAM authentication (`AwsSdk2Transport`). The regular path already has gzip compression enabled, so a 10MB payload becomes ~1–2MB on the wire. The AWS IAM path was never configured with compression, so payloads were sent as raw uncompressed JSON and hit the server limit.

Fix:
- Added `setRequestCompressionSize(REQUEST_COMPRESSION_THRESHOLD_BYTES)` (8KB threshold) and `setResponseCompression(true)` to `AwsSdk2TransportOptions`.
- This brings the AWS transport path to parity with the existing non-AWS configuration and prevents oversized bulk requests from exceeding the server limit.

I worked on this because workflows indexing large batches of entities could fail entirely on AWS-managed OpenSearch due to uncompressed bulk payloads exceeding the 10MB limit.

### Type of change:
- [x] Bug fix

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Bug fix -->
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.