### PR TITLE
Chore(UI): Fix flakiness in custom property advanced search tests

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/AdvanceSearchFilter/CustomPropertyAdvanceSeach.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/AdvanceSearchFilter/CustomPropertyAdvanceSeach.spec.ts
@@ -605,21 +605,21 @@ test.describe('Custom Property Advanced Search Filter for Dashboard', () => {
     test('Entity Reference CP with all operators', async ({ page }) => {
       test.slow();
       const propertyName = propertyNames['entityReference'];
-      const containsText = topic1.entityResponseData.displayName.substring(
+      const containsText = topic1.entityResponseData.displayName?.substring(
         1,
         5
       );
-      const regexpText = `${topic1.entityResponseData.displayName.substring(
+      const regexpText = `${topic1.entityResponseData.displayName?.substring(
         0,
         2
-      )}.*${topic1.entityResponseData.displayName.substring(5, 7)}.*`;
+      )}.*${topic1.entityResponseData.displayName?.substring(5, 7)}.*`;
 
       await showAdvancedSearchDialog(page);
       await applyCustomPropertyFilter(
         page,
         propertyName,
         'select_equals',
-        topic1.entityResponseData.displayName,
+        topic1.entityResponseData.displayName ?? '',
         'Dashboard',
         'entityReference'
       );
@@ -635,7 +635,7 @@ test.describe('Custom Property Advanced Search Filter for Dashboard', () => {
         page,
         propertyName,
         'select_not_equals',
-        topic1.entityResponseData.displayName,
+        topic1.entityResponseData.displayName ?? '',
         'Dashboard',
         'entityReference'
       );
@@ -647,7 +647,12 @@ test.describe('Custom Property Advanced Search Filter for Dashboard', () => {
       await clearAdvancedSearchFilters(page);
 
       await showAdvancedSearchDialog(page);
-      await applyCustomPropertyFilter(page, propertyName, 'like', containsText);
+      await applyCustomPropertyFilter(
+        page,
+        propertyName,
+        'like',
+        containsText ?? ''
+      );
       await verifySearchResults(
         page,
         dashboard.entityResponseData.fullyQualifiedName,
@@ -661,7 +666,7 @@ test.describe('Custom Property Advanced Search Filter for Dashboard', () => {
         page,
         propertyName,
         'not_like',
-        containsText
+        containsText ?? ''
       );
       await verifySearchResults(
         page,
@@ -703,21 +708,21 @@ test.describe('Custom Property Advanced Search Filter for Dashboard', () => {
     test('Entity Reference List CP with all operators', async ({ page }) => {
       test.slow();
       const propertyName = propertyNames['entityReferenceList'];
-      const containsText = topic1.entityResponseData.displayName.substring(
+      const containsText = topic1.entityResponseData.displayName?.substring(
         1,
         5
       );
-      const regexpText = `${topic1.entityResponseData.displayName.substring(
+      const regexpText = `${topic1.entityResponseData.displayName?.substring(
         0,
         2
-      )}.*${topic1.entityResponseData.displayName.substring(5, 7)}.*`;
+      )}.*${topic1.entityResponseData.displayName?.substring(5, 7)}.*`;
 
       await showAdvancedSearchDialog(page);
       await applyCustomPropertyFilter(
         page,
         propertyName,
         'select_equals',
-        topic1.entityResponseData.displayName,
+        topic1.entityResponseData.displayName ?? '',
         'Dashboard',
         'entityReferenceList'
       );
@@ -733,7 +738,7 @@ test.describe('Custom Property Advanced Search Filter for Dashboard', () => {
         page,
         propertyName,
         'select_equals',
-        topic2.entityResponseData.displayName,
+        topic2.entityResponseData.displayName ?? '',
         'Dashboard',
         'entityReferenceList'
       );
@@ -749,7 +754,7 @@ test.describe('Custom Property Advanced Search Filter for Dashboard', () => {
         page,
         propertyName,
         'select_not_equals',
-        topic2.entityResponseData.displayName,
+        topic2.entityResponseData.displayName ?? '',
         'Dashboard',
         'entityReferenceList'
       );
@@ -761,7 +766,12 @@ test.describe('Custom Property Advanced Search Filter for Dashboard', () => {
       await clearAdvancedSearchFilters(page);
 
       await showAdvancedSearchDialog(page);
-      await applyCustomPropertyFilter(page, propertyName, 'like', containsText);
+      await applyCustomPropertyFilter(
+        page,
+        propertyName,
+        'like',
+        containsText ?? ''
+      );
       await verifySearchResults(
         page,
         dashboard.entityResponseData.fullyQualifiedName,
@@ -775,7 +785,7 @@ test.describe('Custom Property Advanced Search Filter for Dashboard', () => {
         page,
         propertyName,
         'not_like',
-        containsText
+        containsText ?? ''
       );
       await verifySearchResults(
         page,

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/customPropertyAdvancedSearchUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/customPropertyAdvancedSearchUtils.ts
@@ -367,12 +367,27 @@ const handlePropertyValueInput = async (
   propertyType?: string
 ) => {
   const inputElement = ruleLocator.locator('.rule--widget input');
+  const entityRefProperties = ['entityReference', 'entityReferenceList'];
+  const isEntityRefProperty = entityRefProperties.includes(propertyType || '');
+  let apiResponsePromise;
 
   // Fill the input only if it's visible
   if (await inputElement.isVisible()) {
     // Convert object values to JSON strings
     const stringValue = isObject(value) ? JSON.stringify(value) : String(value);
+
+    if (isEntityRefProperty) {
+      apiResponsePromise = page.waitForResponse(
+        '/api/v1/search/aggregate?*value=.%2A*'
+      );
+    }
+
     await inputElement.click();
+
+    if (isEntityRefProperty) {
+      await apiResponsePromise;
+    }
+
     await inputElement.fill(stringValue);
 
     // Press Enter for multiselect operators and date types
@@ -386,10 +401,7 @@ const handlePropertyValueInput = async (
     }
 
     // Handle entity reference selection
-    if (
-      propertyType === 'entityReference' ||
-      propertyType === 'entityReferenceList'
-    ) {
+    if (isEntityRefProperty) {
       await page
         .locator(`.ant-select-dropdown:visible [title*="${value as string}"]`)
         .first()


### PR DESCRIPTION
This pull request improves the robustness of advanced search filter tests for custom properties in dashboards by handling cases where entity display names may be undefined, and by ensuring proper synchronization with backend API responses when interacting with entity reference fields.

Enhancements to test reliability and input handling:

**Graceful handling of undefined display names in tests**
* Updated all usages of `topic1.entityResponseData.displayName` and similar variables to use the optional chaining and nullish coalescing operators (e.g., `displayName?.substring(...)` and `displayName ?? ''`), preventing runtime errors if display names are missing. (`openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/AdvanceSearchFilter/CustomPropertyAdvanceSeach.spec.ts`) [[1]](diffhunk://#diff-ef54c01dbd9be5199555ed49b6ef26c790f1c433963a9778139ad221e43d024bL608-R622) [[2]](diffhunk://#diff-ef54c01dbd9be5199555ed49b6ef26c790f1c433963a9778139ad221e43d024bL638-R638) [[3]](diffhunk://#diff-ef54c01dbd9be5199555ed49b6ef26c790f1c433963a9778139ad221e43d024bL650-R655) [[4]](diffhunk://#diff-ef54c01dbd9be5199555ed49b6ef26c790f1c433963a9778139ad221e43d024bL664-R669) [[5]](diffhunk://#diff-ef54c01dbd9be5199555ed49b6ef26c790f1c433963a9778139ad221e43d024bL706-R725) [[6]](diffhunk://#diff-ef54c01dbd9be5199555ed49b6ef26c790f1c433963a9778139ad221e43d024bL736-R741) [[7]](diffhunk://#diff-ef54c01dbd9be5199555ed49b6ef26c790f1c433963a9778139ad221e43d024bL752-R757) [[8]](diffhunk://#diff-ef54c01dbd9be5199555ed49b6ef26c790f1c433963a9778139ad221e43d024bL764-R774) [[9]](diffhunk://#diff-ef54c01dbd9be5199555ed49b6ef26c790f1c433963a9778139ad221e43d024bL778-R788)

**Synchronization improvements for entity reference property inputs**
* Added logic to wait for the backend API response (`/api/v1/search/aggregate?*value=.%2A*`) before filling input fields for entity reference and entity reference list custom properties, ensuring that dropdowns are populated and selections are reliable. (`openmetadata-ui/src/main/resources/ui/playwright/utils/customPropertyAdvancedSearchUtils.ts`)
* Refactored property type checks to use a single `isEntityRefProperty` variable for cleaner and more maintainable code. (`openmetadata-ui/src/main/resources/ui/playwright/utils/customPropertyAdvancedSearchUtils.ts`) [[1]](diffhunk://#diff-99e1127736f8edc42a8fd93fcea518098d0126af8bb8b5ec7813012176b429c4R370-R390) [[2]](diffhunk://#diff-99e1127736f8edc42a8fd93fcea518098d0126af8bb8b5ec7813012176b429c4L389-R404)