### PR TITLE
Fix OpenSearch semantic search script field reference

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/SemanticSearchQueryBuilder.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/SemanticSearchQueryBuilder.java
@@ -95,9 +95,9 @@ public class SemanticSearchQueryBuilder {
                                                                 ._types.BuiltinScriptLanguage
                                                                 .Painless))
                                                 .source(
-                                                    "cosineSimilarity(params.query_vector, '"
+                                                    "cosineSimilarity(params.query_vector, doc['"
                                                         + KNN_FIELD
-                                                        + "') + 1.0")
+                                                        + "']) + 1.0")
                                                 .params(convertToJsonDataMap(params)))))));
   }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/SemanticSearchQueryBuilderTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/SemanticSearchQueryBuilderTest.java
@@ -1,0 +1,49 @@
+package org.openmetadata.service.search.opensearch;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.StringWriter;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.openmetadata.schema.search.SearchRequest;
+import org.openmetadata.service.rdf.semantic.EmbeddingService;
+import os.org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import os.org.opensearch.client.opensearch._types.query_dsl.Query;
+
+class SemanticSearchQueryBuilderTest {
+
+  @Test
+  void buildSemanticQueryUsesDocEmbeddingReference() {
+    EmbeddingService embeddingService = mock(EmbeddingService.class);
+    when(embeddingService.generateEmbedding("revenue metrics")).thenReturn(new float[] {0.1f, 0.2f});
+
+    try (MockedStatic<EmbeddingService> mockedStatic = Mockito.mockStatic(EmbeddingService.class)) {
+      mockedStatic.when(EmbeddingService::getInstance).thenReturn(embeddingService);
+
+      SearchRequest request =
+          new SearchRequest()
+              .withQuery("revenue metrics")
+              .withIndex("table")
+              .withSemanticSearch(true);
+
+      SemanticSearchQueryBuilder builder = new SemanticSearchQueryBuilder();
+      Query query = builder.buildSemanticQuery(request);
+
+      assertNotNull(query);
+
+      JacksonJsonpMapper mapper = new JacksonJsonpMapper();
+      StringWriter writer = new StringWriter();
+      var generator = mapper.jsonProvider().createGenerator(writer);
+      query.serialize(generator, mapper);
+      generator.close();
+
+      String json = writer.toString();
+      assertTrue(json.contains("doc['embedding']"), json);
+      assertTrue(!json.contains("'embedding'"), json);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This fixes an OpenSearch semantic search bug in `SemanticSearchQueryBuilder`.

The generated painless script currently uses:

```java
cosineSimilarity(params.query_vector, 'embedding')
```

That passes `'embedding'` as a string literal instead of referencing the document field, which causes OpenSearch semantic queries to fail with `search_phase_execution_exception` / `all shards failed`.

This patch changes it to:

```java
cosineSimilarity(params.query_vector, doc['embedding'])
```

## Changes

- update `SemanticSearchQueryBuilder` to use `doc['embedding']`
- add `SemanticSearchQueryBuilderTest` to verify the serialized query contains the correct field reference

## Why

I reproduced this on an OpenMetadata `1.12.1` deployment with OpenSearch-backed semantic search enabled. After repairing the index state, the remaining failure was the generated query script itself. Direct OpenSearch queries worked with `doc['embedding']`, while the shipped OMD query path failed until this was patched.

## Testing

Added:
- `SemanticSearchQueryBuilderTest`

Suggested verification:

```bash
mvn -pl openmetadata-service -Dtest=SemanticSearchQueryBuilderTest test
```
