### PR TITLE
fix(mcp): guide LLM to use fullyQualifiedName from search results

### DIFF
--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
@@ -305,6 +305,9 @@ public class SearchMetadataTool implements McpTool {
     result.put("totalFound", totalResults);
     result.put("returnedCount", cleanedResults.size());
     result.put("query", query);
+    result.put(
+        "usage",
+        "To get full details for any result, call get_entity_details with the result's exact 'entityType' and 'fullyQualifiedName' values.");
 
     // Handle aggregations based on includeAggregations flag
     if (includeAggregations && searchResponse.containsKey("aggregations")) {

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SemanticSearchTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SemanticSearchTool.java
@@ -103,6 +103,9 @@ public class SemanticSearchTool implements McpTool {
     result.put("results", cleanedResults);
     result.put("returnedCount", cleanedResults.size());
     result.put("totalFound", cleanedResults.size());
+    result.put(
+        "usage",
+        "To get full details for any result, call get_entity_details with the result's exact 'entityType' and 'fullyQualifiedName' values.");
 
     if (cleanedResults.size() >= requestedSize) {
       result.put(

--- a/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
+++ b/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
@@ -2,7 +2,7 @@
   "tools": [
     {
       "name": "search_metadata",
-      "description": "Keyword-based search for data assets in OpenMetadata. Best when you know specific names, owners, tags, tiers, services, or column names. Use this for exact lookups (e.g., 'find table X', 'tables owned by team Y'), filtering by metadata properties, counting assets, and aggregations. Supports pagination and advanced OpenSearch DSL queries. Choose this over semantic_search when the query targets known identifiers or structured attributes.",
+      "description": "Keyword-based search for data assets in OpenMetadata. Best when you know specific names, owners, tags, tiers, services, or column names. Use this for exact lookups (e.g., 'find table X', 'tables owned by team Y'), filtering by metadata properties, counting assets, and aggregations. Supports pagination and advanced OpenSearch DSL queries. Choose this over semantic_search when the query targets known identifiers or structured attributes. Results include 'fullyQualifiedName' and 'entityType' — pass these directly to get_entity_details for full entity information.",
       "parameters": {
         "description": "Use 'query' for keyword search or 'queryFilter' for advanced OpenSearch DSL. Best for exact matches and filtering by metadata properties.",
         "type": "object",
@@ -101,7 +101,7 @@
     },
     {
       "name": "semantic_search",
-      "description": "Meaning-based discovery of data assets using vector embeddings. Best for exploratory or vague queries where you don't know exact names — it finds conceptually related assets even when no keywords match. Use this when the user describes what data they need in plain language (e.g., 'tables about customer spending behavior', 'anything related to revenue forecasting'). Returns entity summaries with name, columns, description, and metadata. Choose this over search_metadata when the query is about meaning or concepts rather than specific identifiers or attributes.",
+      "description": "Meaning-based discovery of data assets using vector embeddings. Best for exploratory or vague queries where you don't know exact names — it finds conceptually related assets even when no keywords match. Use this when the user describes what data they need in plain language (e.g., 'tables about customer spending behavior', 'anything related to revenue forecasting'). Returns entity summaries with name, columns, description, and metadata. Choose this over search_metadata when the query is about meaning or concepts rather than specific identifiers or attributes. Results include 'fullyQualifiedName' and 'entityType' — pass these directly to get_entity_details for full entity information.",
       "parameters": {
         "description": "Use 'query' to describe what you're looking for in plain language. The system finds conceptually similar assets using vector similarity. Optionally filter by entity type, service, or tags.",
         "type": "object",
@@ -162,18 +162,18 @@
     },
     {
       "name": "get_entity_details",
-      "description": "Get detailed information about a specific entity. Response is optimized for LLM context by excluding verbose metadata fields.",
+      "description": "Get detailed information about a specific entity by its fully qualified name. IMPORTANT: Use the 'fullyQualifiedName' and 'entityType' values directly from search_metadata or semantic_search results — do not construct the FQN manually. Response is optimized for LLM context by excluding verbose metadata fields.",
       "parameters": {
-        "description": "Fqn is the fully qualified name of the entity. Entity type could be table, topic etc.",
+        "description": "Use 'fullyQualifiedName' and 'entityType' from search results directly.",
         "type": "object",
         "properties": {
           "entityType": {
             "type": "string",
-            "description": "Type of entity"
+            "description": "Type of entity (e.g., table, dashboard, topic, pipeline). Use the 'entityType' value from search results."
           },
           "fqn": {
             "type": "string",
-            "description": "Fully qualified name of the entity"
+            "description": "Fully qualified name of the entity. IMPORTANT: Use the exact 'fullyQualifiedName' value from search_metadata or semantic_search results. Do not attempt to construct or modify the FQN."
           }
         },
         "required": [


### PR DESCRIPTION
fixes https://github.com/open-metadata/ai-platform/issues/439

<img width="1198" height="1059" alt="image" src="https://github.com/user-attachments/assets/ecb1f141-422a-4feb-9163-24dd65d79a22" />


## Summary

- Updated `get_entity_details` tool description and parameter docs to explicitly instruct LLMs to use `fullyQualifiedName` and `entityType` values directly from `search_metadata` or `semantic_search` results, instead of attempting to manually construct FQNs from component parts (`service`, `database`, `databaseSchema`, `name`)
- Added a `usage` hint field in `search_metadata` and `semantic_search` responses that guides the LLM on how to call `get_entity_details` with the correct parameters
- Updated `search_metadata` and `semantic_search` tool descriptions to note that results include `fullyQualifiedName` and `entityType` for direct use with `get_entity_details`

## Test plan

- [x] Existing `openmetadata-mcp` unit tests pass (`mvn test -pl openmetadata-mcp`)
- [ ] Manual verification: search for an entity via MCP, then call `get_entity_details` — LLM should use `fullyQualifiedName` directly from search results without constructing it manually