### PR TITLE
[Lineage/Usage] Wrap filterCondition in parentheses to prevent SQL OR precedence issues

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/mysql/query_parser.py
+++ b/ingestion/src/metadata/ingestion/source/database/mysql/query_parser.py
@@ -73,5 +73,5 @@ class MysqlQueryParserSource(QueryParserSource, ABC):
         else:
             sql_column = "argument"
         if self.source_config.filterCondition:
-            return f"{self.filters.format(sql_column=sql_column)} AND {self.source_config.filterCondition}"
+            return f"{self.filters.format(sql_column=sql_column)} AND ({self.source_config.filterCondition})"
         return self.filters.format(sql_column=sql_column)

--- a/ingestion/src/metadata/ingestion/source/database/postgres/usage.py
+++ b/ingestion/src/metadata/ingestion/source/database/postgres/usage.py
@@ -98,5 +98,5 @@ class PostgresUsageSource(PostgresQueryParserSource, UsageSource):
     def get_filters(self) -> str:
         if filter_condition := self.source_config.filterCondition:
             filter_condition = filter_condition.replace("%", "%%")
-            return f"{self.filters} AND s.{filter_condition}"
+            return f"{self.filters} AND (s.{filter_condition})"
         return self.filters

--- a/ingestion/src/metadata/ingestion/source/database/query_parser_source.py
+++ b/ingestion/src/metadata/ingestion/source/database/query_parser_source.py
@@ -124,7 +124,7 @@ class QueryParserSource(Source, ABC):
 
     def get_filters(self) -> str:
         if self.source_config.filterCondition:
-            return f"{self.filters} AND {self.source_config.filterCondition}"
+            return f"{self.filters} AND ({self.source_config.filterCondition})"
         return self.filters
 
     def get_query_parser_type(self) -> QueryParserType:


### PR DESCRIPTION
### Describe your changes:

This PR wraps user-provided `filterCondition` in parentheses in `get_filters()` to prevent SQL OR precedence from bypassing base query type filters.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
