### PR TITLE
Revert Playwright CI from 8 shards to 6 shards

### DIFF
--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -47,8 +47,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shardIndex: [1, 2, 3, 4, 5, 6, 7, 8]
-        shardTotal: [8]
+        shardIndex: [1, 2, 3, 4, 5, 6]
+        shardTotal: [6]
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
@@ -133,32 +133,14 @@ jobs:
             npx playwright test \
               --project=ingestion \
 
-          elif [ "${{ matrix.shardIndex }}" -eq "6" ]; then
-            echo "🔹 Running stateful Playwright tests serially on shard 6"
-            npx playwright test \
-              --project=stateful \
-              --workers=1
-
-          elif [ "${{ matrix.shardIndex }}" -eq "7" ]; then
-            echo "🔹 Running graph/right-panel Playwright tests with reduced concurrency on shard 7"
-            npx playwright test \
-              --project=graph \
-              --workers=2
-
-          elif [ "${{ matrix.shardIndex }}" -eq "8" ]; then
-            echo "🔹 Running landing/widget Playwright tests with reduced concurrency on shard 8"
-            npx playwright test \
-              --project=landing \
-              --workers=2
-
           else
-            # Shards 3-5 handle chromium tests (3 shards total)
+            # Shards 3-6 handle chromium tests (4 workers total)
             CHROMIUM_SHARD=$(( ${{ matrix.shardIndex }} - 2 ))
-            echo "🔹 Running all other tests (excluding DataAssetRules/stateful) on chromium shard ${CHROMIUM_SHARD}/3"
+            echo "🔹 Running all other tests (excluding DataAssetRules) on chromium shard ${CHROMIUM_SHARD}/4"
             npx playwright test \
               --project=chromium \
               --grep-invert @dataAssetRules \
-              --shard=${CHROMIUM_SHARD}/3
+              --shard=${CHROMIUM_SHARD}/4
           fi
 
         env:

--- a/openmetadata-ui/src/main/resources/ui/playwright.config.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright.config.ts
@@ -19,32 +19,6 @@ import dotenv from 'dotenv';
  */
 dotenv.config();
 
-const STATEFUL_TEST_FILES = [
-  '**/Pages/LoginConfiguration.spec.ts',
-  '**/Pages/Tag.spec.ts',
-  '**/Pages/TagPageRightPanel.spec.ts',
-  '**/Pages/TeamAssetsRightPanel.spec.ts',
-  '**/Pages/Teams.spec.ts',
-  '**/Pages/UserDetails.spec.ts',
-  '**/Pages/Users.spec.ts',
-  '**/VersionPages/*.spec.ts',
-];
-
-const GRAPH_TEST_FILES = [
-  '**/Features/ImpactAnalysis.spec.ts',
-  '**/Pages/ExplorePageRightPanel.spec.ts',
-  '**/Pages/InputOutputPorts.spec.ts',
-  '**/Pages/Lineage.spec.ts',
-];
-
-const LANDING_TEST_FILES = [
-  '**/Features/ActivityFeed.spec.ts',
-  '**/Features/CustomizeDetailPage.spec.ts',
-  '**/Features/LandingPageWidgets/*.spec.ts',
-  '**/Flow/CustomizeLandingPage.spec.ts',
-  '**/Flow/CustomizeWidgets.spec.ts',
-];
-
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
@@ -115,40 +89,12 @@ export default defineConfig({
         '**/DataAssetRulesDisabled.spec.ts',
         '**/SystemCertificationTags.spec.ts',
         '**/SearchRBAC.spec.ts',
-        ...STATEFUL_TEST_FILES,
-        ...GRAPH_TEST_FILES,
-        ...LANDING_TEST_FILES,
       ],
     },
     {
       name: 'SearchRBAC',
       testMatch: '**/SearchRBAC.spec.ts',
       use: { ...devices['Desktop Chrome'] },
-      teardown: 'entity-data-teardown',
-    },
-    {
-      name: 'landing',
-      use: { ...devices['Desktop Chrome'] },
-      dependencies: ['setup', 'entity-data-setup'],
-      testMatch: LANDING_TEST_FILES,
-      fullyParallel: false,
-      teardown: 'entity-data-teardown',
-    },
-    {
-      name: 'graph',
-      use: { ...devices['Desktop Chrome'] },
-      dependencies: ['setup', 'entity-data-setup'],
-      testMatch: GRAPH_TEST_FILES,
-      fullyParallel: false,
-      teardown: 'entity-data-teardown',
-    },
-    {
-      name: 'stateful',
-      use: { ...devices['Desktop Chrome'] },
-      dependencies: ['setup', 'entity-data-setup'],
-      testMatch: STATEFUL_TEST_FILES,
-      grepInvert: [/@sample-data/],
-      fullyParallel: false,
       teardown: 'entity-data-teardown',
     },
     {
@@ -187,7 +133,6 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] },
       dependencies: ['setup'],
       fullyParallel: true,
-      testIgnore: LANDING_TEST_FILES,
     },
     {
       name: 'ingestion',
@@ -200,7 +145,6 @@ export default defineConfig({
         '**/DataAssetRulesEnabled.spec.ts',
         '**/DataAssetRulesDisabled.spec.ts',
         '**/SystemCertificationTags.spec.ts',
-        ...LANDING_TEST_FILES,
       ],
     },
     // System Certification Tags tests modify global shared state (system tags like Gold, Silver, Bronze)
@@ -216,7 +160,6 @@ export default defineConfig({
 
   // Increase timeout for the test
   timeout: 60000,
-  expect: { timeout: 15_000 },
 
   /* Run your local dev server before starting the tests */
   // webServer: {


### PR DESCRIPTION
## Summary
- Reverts #26417 which split Playwright CI from 6 to 8 shards with dedicated stateful/graph/landing projects
- The 8-shard approach increased infrastructure failure surface (more runners to fail/get killed) without reducing test flakiness
- Restores the simpler 6-shard layout: shard 1 (Basic), shard 2 (Ingestion), shards 3-6 (Chromium split 4 ways)
- Keeps the consolidated PR comment summary from #26418

## Test plan
- [ ] CI runs with 6 shards instead of 8
- [ ] All chromium tests (including former stateful/graph/landing) run via shards 3-6
- [ ] Playwright summary comment still posts correctly on PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)