### PR TITLE
feat: enhance platform insights data formatting methods and add null checks

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/ServiceInsights/PlatformInsightsWidget/PlatformInsightsWidget.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ServiceInsights/PlatformInsightsWidget/PlatformInsightsWidget.interface.ts
@@ -20,7 +20,7 @@ export interface ChartData {
 }
 
 export interface ChartSeriesData {
-  chartType: SystemChartType;
+  chartType?: SystemChartType;
   percentageChange?: number;
   currentPercentage: number;
   isIncreased?: boolean;

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ServiceInsightsTabUtils.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ServiceInsightsTabUtils.test.tsx
@@ -11,7 +11,13 @@
  *  limitations under the License.
  */
 
-import { filterDistributionChartItem } from './ServiceInsightsTabUtils';
+import { SystemChartType } from '../enums/DataInsight.enum';
+import { DataInsightCustomChartResult } from '../rest/DataInsightAPI';
+import {
+  filterDistributionChartItem,
+  getFormattedTotalAssetsDataFromSocketData,
+  getPlatformInsightsChartDataFormattingMethod,
+} from './ServiceInsightsTabUtils';
 
 describe('ServiceInsightsTabUtils', () => {
   describe('filterDistributionChartItem', () => {
@@ -79,6 +85,162 @@ describe('ServiceInsightsTabUtils', () => {
       const result = filterDistributionChartItem(item);
 
       expect(result).toBe(true);
+    });
+  });
+
+  describe('getPlatformInsightsChartDataFormattingMethod', () => {
+    const mockChartsData = {
+      [SystemChartType.TotalDataAssets]: {
+        results: [
+          { day: 1, count: 10, group: 'group1', term: 'term1' },
+          { day: 2, count: 20, group: 'group2', term: 'term2' },
+        ],
+      },
+    } as unknown as Record<SystemChartType, DataInsightCustomChartResult>;
+
+    it('should return default object when chartsData is null', () => {
+      const formatter = getPlatformInsightsChartDataFormattingMethod(
+        null as unknown as Record<SystemChartType, DataInsightCustomChartResult>
+      );
+
+      const result = formatter(SystemChartType.TotalDataAssets);
+
+      expect(result).toEqual({
+        isIncreased: false,
+        percentageChange: 0,
+        currentPercentage: 0,
+        noRecords: true,
+        numberOfDays: 0,
+      });
+    });
+
+    it('should return default object when chartsData is undefined', () => {
+      const formatter = getPlatformInsightsChartDataFormattingMethod(
+        undefined as unknown as Record<
+          SystemChartType,
+          DataInsightCustomChartResult
+        >
+      );
+
+      const result = formatter(SystemChartType.TotalDataAssets);
+
+      expect(result).toEqual({
+        isIncreased: false,
+        percentageChange: 0,
+        currentPercentage: 0,
+        noRecords: true,
+        numberOfDays: 0,
+      });
+    });
+
+    it('should return default object when chartType does not exist in chartsData', () => {
+      const formatter = getPlatformInsightsChartDataFormattingMethod(
+        {} as unknown as Record<SystemChartType, DataInsightCustomChartResult>
+      );
+
+      const result = formatter(SystemChartType.TotalDataAssets);
+
+      expect(result).toEqual({
+        isIncreased: false,
+        percentageChange: 0,
+        currentPercentage: 0,
+        noRecords: true,
+        numberOfDays: 0,
+      });
+    });
+
+    it('should return default object when results array is empty', () => {
+      const emptyResultsData = {
+        [SystemChartType.TotalDataAssets]: {
+          results: [],
+        },
+      } as unknown as Record<SystemChartType, DataInsightCustomChartResult>;
+
+      const formatter =
+        getPlatformInsightsChartDataFormattingMethod(emptyResultsData);
+
+      const result = formatter(SystemChartType.TotalDataAssets);
+
+      expect(result).toEqual({
+        isIncreased: false,
+        percentageChange: 0,
+        currentPercentage: 0,
+        noRecords: true,
+        numberOfDays: 0,
+      });
+    });
+
+    it('should return formatted data when valid chartsData is provided', () => {
+      const formatter =
+        getPlatformInsightsChartDataFormattingMethod(mockChartsData);
+
+      const result = formatter(SystemChartType.TotalDataAssets);
+
+      expect(result.isIncreased).toBe(true);
+      expect(result.percentageChange).toBe(10);
+      expect(result.currentPercentage).toBe(20);
+      expect(result.numberOfDays).toBe(1);
+    });
+  });
+
+  describe('getFormattedTotalAssetsDataFromSocketData', () => {
+    const mockSocketData: DataInsightCustomChartResult = {
+      results: [
+        { count: 10, group: 'table', term: 'term1', day: 1 },
+        { count: 5, group: 'topic', term: 'term2', day: 1 },
+      ],
+    };
+
+    it('should return empty array when socketData is null', () => {
+      const result = getFormattedTotalAssetsDataFromSocketData(
+        null as unknown as DataInsightCustomChartResult,
+        'databaseServices'
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array when socketData is undefined', () => {
+      const result = getFormattedTotalAssetsDataFromSocketData(
+        undefined as unknown as DataInsightCustomChartResult,
+        'databaseServices'
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array when socketData.results is null', () => {
+      const socketDataWithNullResults = {
+        results: null,
+      } as unknown as DataInsightCustomChartResult;
+
+      const result = getFormattedTotalAssetsDataFromSocketData(
+        socketDataWithNullResults,
+        'databaseServices'
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array when socketData.results is undefined', () => {
+      const socketDataWithUndefinedResults = {} as DataInsightCustomChartResult;
+
+      const result = getFormattedTotalAssetsDataFromSocketData(
+        socketDataWithUndefinedResults,
+        'databaseServices'
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return formatted array when valid socketData is provided', () => {
+      const result = getFormattedTotalAssetsDataFromSocketData(
+        mockSocketData,
+        'databaseServices'
+      );
+
+      expect(result).toBeInstanceOf(Array);
+      expect(result.length).toBeGreaterThan(0);
     });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ServiceInsightsTabUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ServiceInsightsTabUtils.tsx
@@ -14,6 +14,7 @@ import { Typography } from 'antd';
 import {
   first,
   isEmpty,
+  isNil,
   isUndefined,
   last,
   round,
@@ -137,6 +138,20 @@ export const getChartTypeForWidget = (chartType: SystemChartType) => {
 export const getPlatformInsightsChartDataFormattingMethod =
   (chartsData: Record<SystemChartType, DataInsightCustomChartResult>) =>
   (chartType: SystemChartType) => {
+    if (
+      isNil(chartsData) ||
+      isNil(chartsData[chartType]) ||
+      isEmpty(chartsData[chartType].results)
+    ) {
+      return {
+        isIncreased: false,
+        percentageChange: 0,
+        currentPercentage: 0,
+        noRecords: true,
+        numberOfDays: 0,
+      };
+    }
+
     const summaryChartData = chartsData[chartType];
     const lastDay = last(summaryChartData?.results)?.day ?? 1;
 
@@ -191,6 +206,10 @@ export const getFormattedTotalAssetsDataFromSocketData = (
   socketData: DataInsightCustomChartResult,
   serviceCategory: ServiceTypes
 ) => {
+  if (isNil(socketData) || isNil(socketData.results)) {
+    return [];
+  }
+
   const assets = getAssetsByServiceType(serviceCategory);
 
   const buckets = assets.reduce((acc, curr) => {
@@ -357,7 +376,7 @@ export const filterDistributionChartItem = (item: {
   }
 
   // clean start and end quotes
-  const tag_name = termParts[1].replace(/(^["']+|["']+$)/g, '');
+  const tag_name = termParts[1].replaceAll(/(^["']+|["']+$)/g, '');
 
   return toLower(tag_name) === toLower(item.group);
 };


### PR DESCRIPTION
This pull request introduces improvements to the `ServiceInsightsTabUtils` utility and its associated test coverage, focusing on robust handling of edge cases and enhancing type safety. The most important changes include adding comprehensive tests for data formatting methods, improving null/undefined checks in utility functions, and making type adjustments for chart data.

**Test coverage enhancements:**

* Added extensive unit tests for `getPlatformInsightsChartDataFormattingMethod` and `getFormattedTotalAssetsDataFromSocketData` to verify their behavior with null, undefined, empty, and valid input scenarios in `ServiceInsightsTabUtils.test.tsx`.

**Robustness and edge case handling:**

* Updated `getPlatformInsightsChartDataFormattingMethod` to return a default object when input data is null, undefined, or empty, using `isNil` and `isEmpty` checks for safer handling.
* Improved `getFormattedTotalAssetsDataFromSocketData` to return an empty array when input data or its results are null/undefined, ensuring graceful failure.

**Type and import changes:**

* Made `chartType` optional in `ChartSeriesData` interface to accommodate cases where chart type may be absent.
* Updated imports in `ServiceInsightsTabUtils.test.tsx` to include new enums and types required for expanded test cases.

**Minor bug fix:**

* Changed `.replace` to `.replaceAll` for tag name cleaning in `filterDistributionChartItem`, improving string sanitization.