### PR TITLE
Fix Playwright CI: include UI in build-once Maven build

### DIFF
--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -82,7 +82,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Build with Maven
-        run: mvn -DskipTests -DonlyBackend clean package -pl !openmetadata-ui
+        run: mvn -DskipTests clean package
 
       - name: Upload Maven build artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- The build-once optimization (#26423) used `-DonlyBackend -pl !openmetadata-ui` which produces a tar.gz **without** the compiled React app
- The Docker container starts but cannot serve the login page (`/signin`), causing `auth.setup.ts` to timeout on **all 6 shards** waiting for `input[id="email"]` to appear
- This blocks ALL Playwright tests for ALL PRs since `pull_request_target` reads the workflow from main

## Fix
Remove the `-DonlyBackend -pl !openmetadata-ui` flags from the build step so the full distribution (including UI) is built once and shared across shards.

## Test plan
- [ ] Verify build job succeeds with `mvn -DskipTests clean package`
- [ ] Verify auth.setup.ts passes (login page renders)
- [ ] Verify Playwright tests run successfully across all shards

🤖 Generated with [Claude Code](https://claude.com/claude-code)