### PR TITLE
Fix Playwright CI build: install antlr4 CLI before Maven

### DIFF
--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -81,6 +81,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
+      - name: Install antlr cli
+        run: sudo make install_antlr_cli
+
       - name: Build with Maven
         run: mvn -DskipTests clean package
 


### PR DESCRIPTION
## Summary
- The build-once job runs `mvn -DskipTests clean package` which builds the UI module
- The UI module's `yarn install` triggers a preinstall script that runs `js-antlr`, requiring the `antlr4` CLI
- The `antlr4` CLI was not installed in the build job, causing exit code 127 (`antlr4: not found`)
- This matches the pattern used in `docker-openmetadata-server.yml` which installs antlr before the Maven build

## Fix
Add `sudo make install_antlr_cli` step before the Maven build, matching the working `docker-openmetadata-server.yml` workflow.

## Test plan
- [ ] Build job completes successfully (antlr4 found, yarn install succeeds, Maven build succeeds)
- [ ] Shards download artifact with UI and auth.setup.ts passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)