### PR TITLE
Fix the BulkImport spec failure

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkImport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkImport.spec.ts
@@ -30,7 +30,6 @@ import {
 } from '../../utils/common';
 import {
   createColumnRowDetails,
-  createColumnRowDetailsWithEncloseDot,
   createCustomPropertiesForEntity,
   createDatabaseRowDetails,
   createDatabaseSchemaRowDetails,
@@ -536,10 +535,17 @@ test.describe('Bulk Import Export', () => {
         page
       );
 
+      const importProgressCheck = page.waitForSelector(
+        'text=Import is in progress.',
+        {
+          state: 'attached',
+        }
+      );
+
       await page.getByRole('button', { name: 'Next' }).click();
-      await page.waitForSelector('text=Import is in progress.', {
-        state: 'attached',
-      });
+
+      await importProgressCheck;
+
       await page.waitForSelector('text=Import is in progress.', {
         state: 'detached',
       });
@@ -826,7 +832,7 @@ test.describe('Bulk Import Export', () => {
       });
 
       // total column count +2 for newly added columns
-      const rowStatus = Array(
+      const rowStatus = new Array(
         tableEntity.entityLinkColumnsName.length + 2
       ).fill('Entity updated');
 
@@ -1095,7 +1101,7 @@ test.describe('Bulk Import Export', () => {
       });
 
       await test.step('should select all the cells in the column by clicking on column header', async () => {
-        const firstHeaderCell = await page
+        const firstHeaderCell = page
           .locator('.rdg-header-row')
           .first()
           .locator('.rdg-cell')


### PR DESCRIPTION
This pull request makes several improvements to the bulk import/export Playwright test suite, focusing on code clarity, reliability, and consistency. The most important changes include refactoring asynchronous checks for import progress, improving array creation syntax, and enhancing code readability in cell selection logic.

Test reliability and async handling:

* Refactored the sequence for checking import progress by assigning the promise for the progress indicator before clicking the 'Next' button, ensuring more reliable async handling in the bulk import flow.

Code clarity and consistency:

* Changed the array creation syntax for row status from `Array()` to `new Array()` for improved readability and consistency.
* Simplified the assignment of the header cell locator by removing unnecessary `await`, making the code more concise and readable.

Cleanup:

* Removed the unused `createColumnRowDetailsWithEncloseDot` import, reducing clutter in the test utility imports.