### PR TITLE
Update the typescript type check workflow to work on forked PRs

### DIFF
--- a/.github/workflows/typescript-type-generation.yml
+++ b/.github/workflows/typescript-type-generation.yml
@@ -38,10 +38,11 @@ jobs:
           BASE_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          PR_DATA=$(gh pr view "$PR_NUMBER" --json headRepository,headRefName,headRepositoryOwner --repo "$BASE_REPO")
+          PR_DATA=$(gh pr view "$PR_NUMBER" --json headRepository,headRefName,headRepositoryOwner,headRefOid --repo "$BASE_REPO")
           echo "head_repo=$(echo "$PR_DATA" | jq -r '.headRepository.name')" >> $GITHUB_OUTPUT
           echo "head_owner=$(echo "$PR_DATA" | jq -r '.headRepositoryOwner.login')" >> $GITHUB_OUTPUT
           echo "head_ref=$(echo "$PR_DATA" | jq -r '.headRefName')" >> $GITHUB_OUTPUT
+          echo "head_sha=$(echo "$PR_DATA" | jq -r '.headRefOid')" >> $GITHUB_OUTPUT
           echo "full_repo=$(echo "$PR_DATA" | jq -r '.headRepositoryOwner.login + "/" + .headRepository.name')" >> $GITHUB_OUTPUT
 
       - name: Wait for the labeler
@@ -96,6 +97,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_DETAILS_HEAD_SHA: ${{ steps.pr-details.outputs.head_sha }}
           PR_DETAILS_HEAD_REF: ${{ steps.pr-details.outputs.head_ref }}
           INPUT_BRANCH: ${{ github.event.inputs.branch }}
           GITHUB_REF: ${{ github.ref }}
@@ -104,6 +106,8 @@ jobs:
             echo "ref=$PR_HEAD_SHA" >> $GITHUB_OUTPUT
           elif [ "$EVENT_NAME" == "pull_request_target" ]; then
             echo "ref=$PR_HEAD_REF" >> $GITHUB_OUTPUT
+          elif [ "$IS_FORK" == "true" ] && [ -n "$PR_DETAILS_HEAD_SHA" ]; then
+            echo "ref=$PR_DETAILS_HEAD_SHA" >> $GITHUB_OUTPUT
           elif [ -n "$PR_DETAILS_HEAD_REF" ]; then
             echo "ref=$PR_DETAILS_HEAD_REF" >> $GITHUB_OUTPUT
           elif [ -n "$INPUT_BRANCH" ]; then
@@ -151,7 +155,6 @@ jobs:
       - name: Commit and push changes
         if: steps.git-check.outcome != 'success' && steps.check-fork.outputs.is_fork == 'false'
         run: |
-          git add openmetadata-ui/src/main/resources/ui/src/generated/
           git commit -m "Update generated TypeScript types"
           git push --force-with-lease
 


### PR DESCRIPTION
This pull request updates the TypeScript type generation workflow to improve label handling, automate type updates, and clarify instructions for contributors from forked repositories. The changes enhance automation, enforce label requirements, and improve communication in PRs.

**Workflow automation and label handling:**
* Added steps to wait for the Team Label check and verify that PRs have the required `safe to test` label before proceeding, ensuring proper labeling and safety for PRs.

**TypeScript type update automation and communication:**
* Improved logic for detecting type changes and committing updates, including switching to `git diff-files` and using workflow step outcomes for conditional execution.
* Updated PR comments for auto-updated types and forked repositories with clearer instructions and improved formatting; switched to `peter-evans/create-or-update-comment@v4` for comment creation.
* Added a step to fail the workflow for fork PRs with type changes, enforcing manual updates and preventing out-of-sync types.

**Repository checkout improvement:**
* Changed the checkout step to use the commit SHA instead of branch name for PRs, ensuring the correct source is used during workflow execution.