### PR TITLE
Update the typescript type generation workflow inputs to run on demand on a PR

### DIFF
--- a/.github/workflows/typescript-type-generation.yml
+++ b/.github/workflows/typescript-type-generation.yml
@@ -4,14 +4,18 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened, labeled, ready_for_review]
     paths:
-      - "openmetadata-spec/src/main/resources/json/schema/**"
-      - "openmetadata-ui/src/main/resources/ui/src/generated/**"
+      - 'openmetadata-spec/src/main/resources/json/schema/**'
+      - 'openmetadata-ui/src/main/resources/ui/src/generated/**'
   workflow_dispatch:
     inputs:
       branch:
-        description: "Branch to run the workflow on"
-        required: true
-        default: "main"
+        description: 'Branch to run the workflow on (ignored if pr_number is provided)'
+        required: false
+        default: 'main'
+        type: string
+      pr_number:
+        description: 'PR number to run the workflow for (works for both forked and non-forked PRs)'
+        required: false
         type: string
 
 concurrency:


### PR DESCRIPTION
This pull request updates the workflow configuration in `.github/workflows/typescript-type-generation.yml` to enhance flexibility for triggering the workflow and clarify input options. The changes mainly focus on improving how the workflow can be run for specific branches or pull requests.

Workflow trigger and input improvements:

* Added a new `pr_number` input to allow running the workflow for a specific pull request, supporting both forked and non-forked PRs.
* Updated the `branch` input to clarify its usage and made it optional, since it is ignored if `pr_number` is provided.
* Changed path patterns and descriptions to use single quotes for consistency.