### PR TITLE
Fix flakiness in BulkImport spec

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkImport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkImport.spec.ts
@@ -535,16 +535,21 @@ test.describe('Bulk Import Export', () => {
         page
       );
 
-      const importProgressCheck = page.waitForSelector(
-        'text=Import is in progress.',
-        {
-          state: 'attached',
-        }
+      const importApiCall = page.waitForResponse(
+        (resp) =>
+          resp.url().includes('/importAsync?dryRun=true') &&
+          resp.request().method() === 'PUT'
       );
 
       await page.getByRole('button', { name: 'Next' }).click();
+      await importApiCall;
 
-      await importProgressCheck;
+      // Wait directly for final state (results grid)
+      await page.waitForSelector('[data-testid="passed-row"]', {
+        state: 'visible',
+      });
+      // Verify no loading state remains
+      await expect(page.getByText('Import is in progress.')).not.toBeVisible();
 
       await page.waitForSelector('text=Import is in progress.', {
         state: 'detached',


### PR DESCRIPTION
This pull request updates the bulk import test flow to improve reliability and reduce flakiness by synchronizing with API responses instead of UI loading indicators. The test now waits for the actual import API call and directly checks for the final results grid, ensuring the test is more robust and less dependent on intermediate UI states.

Bulk import test improvements:

* Replaced waiting for the "Import is in progress." UI text with waiting for the `/importAsync?dryRun=true` API response, ensuring synchronization with the backend operation.
* Added direct waiting for the results grid (`[data-testid="passed-row"]`) to confirm the import completion, and verified that the loading state is no longer visible.