### PR TITLE
Support pipeline as node for single sided openlinege ingestion

### DIFF
--- a/ingestion/src/metadata/ingestion/sink/metadata_rest.py
+++ b/ingestion/src/metadata/ingestion/sink/metadata_rest.py
@@ -492,7 +492,7 @@ class MetadataRestSink(Sink):  # pylint: disable=too-many-public-methods
             if (
                 add_lineage.lineage_request.edge.lineageDetails.pipeline
                 and add_lineage.lineage_request.edge.lineageDetails.source
-                == LineageSource.PipelineLineage
+                in (LineageSource.PipelineLineage, LineageSource.OpenLineage)
             ):
                 self.metadata.delete_lineage_by_source(
                     entity_type="pipeline",

--- a/ingestion/src/metadata/ingestion/source/pipeline/openlineage/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/openlineage/metadata.py
@@ -538,6 +538,119 @@ class OpenlineageSource(PipelineServiceSource):
                 stackTrace=traceback.format_exc(),
             )
 
+    def _has_annotated_pipeline_edge(
+        self,
+        dataset_node: LineageNode,
+        pipeline_entity: Pipeline,
+        direction: str,
+    ) -> bool:
+        """
+        Check if a dataset already has a proper both-sided lineage edge where the
+        given pipeline is an annotation (in lineageDetails.pipeline), not a direct
+        endpoint. This prevents creating redundant pipeline-as-node edges when a
+        both-sided event was already processed.
+
+        :param dataset_node: the dataset (table/topic) to check
+        :param pipeline_entity: the pipeline to look for as an annotation
+        :param direction: "upstream" or "downstream" — which edges of the dataset to check
+        :return: True if an annotated edge already exists
+        """
+        entity_class = Table if dataset_node.node_type == "table" else Topic
+        dataset_id = str(dataset_node.uuid)
+        pipeline_id = str(pipeline_entity.id.root)
+        try:
+            lineage_data = self.metadata.get_lineage_by_id(
+                entity=entity_class,
+                entity_id=dataset_id,
+                up_depth=1 if direction == "upstream" else 0,
+                down_depth=1 if direction == "downstream" else 0,
+            )
+            if not lineage_data:
+                return False
+
+            edges_key = (
+                "upstreamEdges" if direction == "upstream" else "downstreamEdges"
+            )
+            for edge_entry in lineage_data.get(edges_key, []):
+                details = edge_entry.get("lineageDetails", {}) or {}
+                pipeline_ref = details.get("pipeline")
+                if pipeline_ref and str(pipeline_ref.get("id")) == pipeline_id:
+                    return True
+        except Exception:
+            logger.debug(traceback.format_exc())
+        return False
+
+    def _cleanup_pipeline_as_node_edges(
+        self,
+        pipeline_entity: Pipeline,
+        event_entity_map: Dict[str, str],
+    ) -> None:
+        """
+        When a pipeline transitions from single-sided (pipeline-as-node) to both-sided
+        lineage, remove stale edges where the pipeline is a direct from/to endpoint
+        paired with a topic or table. Only targets OpenLineage-sourced edges whose
+        other endpoint matches one of the datasets in the current event.
+
+        :param pipeline_entity: the pipeline entity
+        :param event_entity_map: mapping of entity ID -> entity type for datasets
+            resolved from the current event's inputs and outputs
+        """
+        pipeline_id = str(pipeline_entity.id.root)
+        try:
+            lineage_data = self.metadata.get_lineage_by_id(
+                entity=Pipeline,
+                entity_id=pipeline_id,
+                up_depth=1,
+                down_depth=1,
+            )
+            if not lineage_data:
+                return
+
+            for edge_entry in lineage_data.get("upstreamEdges", []):
+                if edge_entry["toEntity"] != pipeline_id:
+                    continue
+                details = edge_entry.get("lineageDetails", {}) or {}
+                if details.get("source") != Source.OpenLineage.value:
+                    continue
+                from_id = edge_entry["fromEntity"]
+                if from_id not in event_entity_map:
+                    continue
+                self.metadata.delete_lineage_edge(
+                    EntitiesEdge(
+                        fromEntity=EntityReference(
+                            id=from_id, type=event_entity_map[from_id]
+                        ),
+                        toEntity=EntityReference(
+                            id=pipeline_id, type="pipeline"
+                        ),
+                    )
+                )
+
+            for edge_entry in lineage_data.get("downstreamEdges", []):
+                if edge_entry["fromEntity"] != pipeline_id:
+                    continue
+                details = edge_entry.get("lineageDetails", {}) or {}
+                if details.get("source") != Source.OpenLineage.value:
+                    continue
+                to_id = edge_entry["toEntity"]
+                if to_id not in event_entity_map:
+                    continue
+                self.metadata.delete_lineage_edge(
+                    EntitiesEdge(
+                        fromEntity=EntityReference(
+                            id=pipeline_id, type="pipeline"
+                        ),
+                        toEntity=EntityReference(
+                            id=to_id, type=event_entity_map[to_id]
+                        ),
+                    )
+                )
+        except Exception as exc:
+            logger.debug(traceback.format_exc())
+            logger.warning(
+                f"Failed to cleanup pipeline-as-node edges for {pipeline_entity.fullyQualifiedName.root}: {exc}"
+            )
+
     def yield_pipeline_lineage_details(
         self, pipeline_details: OpenLineageEvent
     ) -> Iterable[Either[AddLineageRequest]]:
@@ -605,7 +718,54 @@ class OpenlineageSource(PipelineServiceSource):
         )
 
         pipeline_entity = self.metadata.get_by_name(entity=Pipeline, fqn=pipeline_fqn)
+
+        if not pipeline_entity:
+            logger.warning(f"Pipeline entity not found for {pipeline_fqn}, skipping lineage")
+            return
+
+        event_has_no_outputs = not outputs
+        event_has_no_inputs = not inputs
+
+        if event_has_no_outputs and input_edges:
+            pipeline_node = LineageNode(
+                fqn=TableFQN(value=pipeline_fqn),
+                uuid=pipeline_entity.id.root,
+                node_type="pipeline",
+            )
+            for input_node in input_edges:
+                if not self._has_annotated_pipeline_edge(
+                    input_node, pipeline_entity, direction="downstream"
+                ):
+                    edges.append(LineageEdge(from_node=input_node, to_node=pipeline_node))
+                else:
+                    logger.info(f"Skipping pipeline-as-node edge for {input_node.fqn.value}")
+
+        if event_has_no_inputs and output_edges:
+            pipeline_node = LineageNode(
+                fqn=TableFQN(value=pipeline_fqn),
+                uuid=pipeline_entity.id.root,
+                node_type="pipeline",
+            )
+            for output_node in output_edges:
+                if not self._has_annotated_pipeline_edge(
+                    output_node, pipeline_entity, direction="upstream"
+                ):
+                    edges.append(LineageEdge(from_node=pipeline_node, to_node=output_node))
+                else:
+                    logger.info(f"Skipping pipeline-as-node edge for {output_node.fqn.value}")
+
+        if inputs and outputs:
+            event_entity_map = {
+                str(node.uuid): node.node_type
+                for node in input_edges + output_edges
+            }
+            self._cleanup_pipeline_as_node_edges(pipeline_entity, event_entity_map)
+
         for edge in edges:
+            is_pipeline_endpoint = (
+                edge.from_node.node_type == "pipeline"
+                or edge.to_node.node_type == "pipeline"
+            )
             yield Either(
                 right=AddLineageRequest(
                     edge=EntitiesEdge(
@@ -616,7 +776,9 @@ class OpenlineageSource(PipelineServiceSource):
                             id=edge.to_node.uuid, type=edge.to_node.node_type
                         ),
                         lineageDetails=LineageDetails(
-                            pipeline=EntityReference(
+                            pipeline=None
+                            if is_pipeline_endpoint
+                            else EntityReference(
                                 id=pipeline_entity.id.root,
                                 type="pipeline",
                             ),

--- a/ingestion/tests/unit/topology/pipeline/test_openlineage.py
+++ b/ingestion/tests/unit/topology/pipeline/test_openlineage.py
@@ -1480,6 +1480,370 @@ class OpenLineageUnitTest(unittest.TestCase):
             "No lineage edges should be produced when input topic cannot be resolved",
         )
 
+    def test_yield_pipeline_lineage_producer_only_no_inputs(self):
+        """When an event has only outputs (producer), the pipeline itself becomes the
+        fromEntity and each output becomes the toEntity."""
+        output_topic_id = UUID("bbbb2222-2222-2222-2222-222222222222")
+        pipeline_id = UUID("cccc3333-3333-3333-3333-333333333333")
+
+        mock_output_topic = Mock()
+        mock_output_topic.id.root = output_topic_id
+        mock_output_topic.fullyQualifiedName.root = "kafka-service.output-topic"
+
+        mock_pipeline = Mock()
+        mock_pipeline.id.root = pipeline_id
+
+        ol_event = OpenLineageEvent(
+            run_facet={
+                "facets": {
+                    "parent": {
+                        "job": {
+                            "name": "producer-job",
+                            "namespace": "test-namespace",
+                        }
+                    }
+                }
+            },
+            job={"name": "producer-job", "namespace": "test-namespace"},
+            event_type="COMPLETE",
+            inputs=[],
+            outputs=[
+                {
+                    "name": "output-topic",
+                    "namespace": "kafka://kafka-broker:9092",
+                    "facets": {},
+                }
+            ],
+        )
+
+        from metadata.generated.schema.entity.data.topic import Topic
+
+        def get_by_name(entity, fqn, **kwargs):
+            if entity == Topic:
+                return mock_output_topic
+            if entity == Pipeline:
+                return mock_pipeline
+            return None
+
+        lineage_requests = self._run_lineage_with_kafka_broker(ol_event, get_by_name)
+
+        self.assertEqual(len(lineage_requests), 1)
+        edge = lineage_requests[0].edge
+        self.assertEqual(edge.fromEntity.id.root, pipeline_id)
+        self.assertEqual(edge.fromEntity.type, "pipeline")
+        self.assertEqual(edge.toEntity.id.root, output_topic_id)
+        self.assertEqual(edge.toEntity.type, "topic")
+        self.assertIsNone(edge.lineageDetails.pipeline)
+
+    def test_yield_pipeline_lineage_consumer_only_no_outputs(self):
+        """When an event has only inputs (consumer), each input becomes the
+        fromEntity and the pipeline itself becomes the toEntity."""
+        input_topic_id = UUID("aaaa1111-1111-1111-1111-111111111111")
+        pipeline_id = UUID("cccc3333-3333-3333-3333-333333333333")
+
+        mock_input_topic = Mock()
+        mock_input_topic.id.root = input_topic_id
+        mock_input_topic.fullyQualifiedName.root = "kafka-service.input-topic"
+
+        mock_pipeline = Mock()
+        mock_pipeline.id.root = pipeline_id
+
+        ol_event = OpenLineageEvent(
+            run_facet={
+                "facets": {
+                    "parent": {
+                        "job": {
+                            "name": "consumer-job",
+                            "namespace": "test-namespace",
+                        }
+                    }
+                }
+            },
+            job={"name": "consumer-job", "namespace": "test-namespace"},
+            event_type="COMPLETE",
+            inputs=[
+                {
+                    "name": "input-topic",
+                    "namespace": "kafka://kafka-broker:9092",
+                    "facets": {},
+                }
+            ],
+            outputs=[],
+        )
+
+        from metadata.generated.schema.entity.data.topic import Topic
+
+        def get_by_name(entity, fqn, **kwargs):
+            if entity == Topic:
+                return mock_input_topic
+            if entity == Pipeline:
+                return mock_pipeline
+            return None
+
+        lineage_requests = self._run_lineage_with_kafka_broker(ol_event, get_by_name)
+
+        self.assertEqual(len(lineage_requests), 1)
+        edge = lineage_requests[0].edge
+        self.assertEqual(edge.fromEntity.id.root, input_topic_id)
+        self.assertEqual(edge.fromEntity.type, "topic")
+        self.assertEqual(edge.toEntity.id.root, pipeline_id)
+        self.assertEqual(edge.toEntity.type, "pipeline")
+        self.assertIsNone(edge.lineageDetails.pipeline)
+
+    def test_yield_pipeline_lineage_consumer_only_table_input(self):
+        """When an event has only a table input (consumer/batch job), the table
+        becomes the fromEntity and the pipeline becomes the toEntity."""
+        table_id = UUID("aaaa1111-1111-1111-1111-111111111111")
+        pipeline_id = UUID("cccc3333-3333-3333-3333-333333333333")
+
+        mock_table = Mock()
+        mock_table.id.root = table_id
+
+        mock_pipeline = Mock()
+        mock_pipeline.id.root = pipeline_id
+
+        ol_event = OpenLineageEvent(
+            run_facet={
+                "facets": {
+                    "parent": {
+                        "job": {
+                            "name": "batch-consumer-job",
+                            "namespace": "test-namespace",
+                        }
+                    }
+                }
+            },
+            job={"name": "batch-consumer-job", "namespace": "test-namespace"},
+            event_type="COMPLETE",
+            inputs=[
+                {
+                    "name": "public.source_table",
+                    "namespace": "postgres://db:5432",
+                    "facets": {},
+                }
+            ],
+            outputs=[],
+        )
+
+        from metadata.generated.schema.entity.data.table import Table
+
+        def get_by_name(entity, fqn, **kwargs):
+            if entity == Table:
+                return mock_table
+            if entity == Pipeline:
+                return mock_pipeline
+            return None
+
+        extra_patches = [
+            patch.object(
+                self.open_lineage_source,
+                "_get_table_fqn",
+                return_value="db-service.public.source_table",
+            ),
+            patch.object(
+                self.open_lineage_source,
+                "get_create_table_request",
+                return_value=None,
+            ),
+        ]
+
+        lineage_requests = self._run_lineage_with_kafka_broker(
+            ol_event, get_by_name, extra_patches
+        )
+
+        self.assertEqual(len(lineage_requests), 1)
+        edge = lineage_requests[0].edge
+        self.assertEqual(edge.fromEntity.id.root, table_id)
+        self.assertEqual(edge.fromEntity.type, "table")
+        self.assertEqual(edge.toEntity.id.root, pipeline_id)
+        self.assertEqual(edge.toEntity.type, "pipeline")
+        self.assertIsNone(edge.lineageDetails.pipeline)
+
+    def test_yield_pipeline_lineage_producer_only_table_output(self):
+        """When an event has only a table output (producer/batch job), the pipeline
+        becomes the fromEntity and the table becomes the toEntity."""
+        table_id = UUID("bbbb2222-2222-2222-2222-222222222222")
+        pipeline_id = UUID("cccc3333-3333-3333-3333-333333333333")
+
+        mock_table = Mock()
+        mock_table.id.root = table_id
+
+        mock_pipeline = Mock()
+        mock_pipeline.id.root = pipeline_id
+
+        ol_event = OpenLineageEvent(
+            run_facet={
+                "facets": {
+                    "parent": {
+                        "job": {
+                            "name": "batch-producer-job",
+                            "namespace": "test-namespace",
+                        }
+                    }
+                }
+            },
+            job={"name": "batch-producer-job", "namespace": "test-namespace"},
+            event_type="COMPLETE",
+            inputs=[],
+            outputs=[
+                {
+                    "name": "public.target_table",
+                    "namespace": "postgres://db:5432",
+                    "facets": {},
+                }
+            ],
+        )
+
+        from metadata.generated.schema.entity.data.table import Table
+
+        def get_by_name(entity, fqn, **kwargs):
+            if entity == Table:
+                return mock_table
+            if entity == Pipeline:
+                return mock_pipeline
+            return None
+
+        extra_patches = [
+            patch.object(
+                self.open_lineage_source,
+                "_get_table_fqn",
+                return_value="db-service.public.target_table",
+            ),
+            patch.object(
+                self.open_lineage_source,
+                "get_create_table_request",
+                return_value=None,
+            ),
+        ]
+
+        lineage_requests = self._run_lineage_with_kafka_broker(
+            ol_event, get_by_name, extra_patches
+        )
+
+        self.assertEqual(len(lineage_requests), 1)
+        edge = lineage_requests[0].edge
+        self.assertEqual(edge.fromEntity.id.root, pipeline_id)
+        self.assertEqual(edge.fromEntity.type, "pipeline")
+        self.assertEqual(edge.toEntity.id.root, table_id)
+        self.assertEqual(edge.toEntity.type, "table")
+        self.assertIsNone(edge.lineageDetails.pipeline)
+
+    def test_cleanup_only_deletes_edges_matching_current_event_datasets(self):
+        """When a both-sided event arrives, cleanup should only remove
+        pipeline-as-node edges for the datasets in that event, not unrelated ones."""
+        pipeline_id = "cccc3333-3333-3333-3333-333333333333"
+        topic_a_id = "aaaa1111-1111-1111-1111-111111111111"
+        topic_b_id = "bbbb2222-2222-2222-2222-222222222222"
+
+        mock_pipeline = Mock()
+        mock_pipeline.id.root = pipeline_id
+        mock_pipeline.fullyQualifiedName.root = "ol-service.test-pipeline"
+
+        lineage_data = {
+            "upstreamEdges": [
+                {
+                    "fromEntity": topic_a_id,
+                    "toEntity": pipeline_id,
+                    "lineageDetails": {"source": "OpenLineage"},
+                },
+                {
+                    "fromEntity": topic_b_id,
+                    "toEntity": pipeline_id,
+                    "lineageDetails": {"source": "OpenLineage"},
+                },
+            ],
+            "downstreamEdges": [],
+        }
+
+        with patch.object(
+            self.open_lineage_source, "metadata"
+        ) as mock_metadata:
+            mock_metadata.get_lineage_by_id.return_value = lineage_data
+
+            self.open_lineage_source._cleanup_pipeline_as_node_edges(
+                mock_pipeline, event_entity_map={topic_a_id: "topic"}
+            )
+
+            mock_metadata.delete_lineage_edge.assert_called_once()
+            deleted_edge = mock_metadata.delete_lineage_edge.call_args[0][0]
+            self.assertEqual(str(deleted_edge.fromEntity.id.root), topic_a_id)
+            self.assertEqual(deleted_edge.fromEntity.type, "topic")
+            self.assertEqual(str(deleted_edge.toEntity.id.root), pipeline_id)
+
+    def test_cleanup_preserves_non_openlineage_edges(self):
+        """Cleanup should not touch edges that were not sourced from OpenLineage,
+        even if the entity ID matches the current event."""
+        pipeline_id = "cccc3333-3333-3333-3333-333333333333"
+        table_id = "aaaa1111-1111-1111-1111-111111111111"
+
+        mock_pipeline = Mock()
+        mock_pipeline.id.root = pipeline_id
+        mock_pipeline.fullyQualifiedName.root = "ol-service.test-pipeline"
+
+        lineage_data = {
+            "upstreamEdges": [
+                {
+                    "fromEntity": table_id,
+                    "toEntity": pipeline_id,
+                    "lineageDetails": {"source": "Manual"},
+                },
+            ],
+            "downstreamEdges": [],
+        }
+
+        with patch.object(
+            self.open_lineage_source, "metadata"
+        ) as mock_metadata:
+            mock_metadata.get_lineage_by_id.return_value = lineage_data
+
+            self.open_lineage_source._cleanup_pipeline_as_node_edges(
+                mock_pipeline, event_entity_map={table_id: "table"}
+            )
+
+            mock_metadata.delete_lineage_edge.assert_not_called()
+
+    def test_cleanup_handles_downstream_edges_scoped_to_event(self):
+        """Cleanup of downstream edges (pipeline → dataset) should also be
+        scoped to only the current event's datasets."""
+        pipeline_id = "cccc3333-3333-3333-3333-333333333333"
+        table_a_id = "aaaa1111-1111-1111-1111-111111111111"
+        table_b_id = "bbbb2222-2222-2222-2222-222222222222"
+
+        mock_pipeline = Mock()
+        mock_pipeline.id.root = pipeline_id
+        mock_pipeline.fullyQualifiedName.root = "ol-service.test-pipeline"
+
+        lineage_data = {
+            "upstreamEdges": [],
+            "downstreamEdges": [
+                {
+                    "fromEntity": pipeline_id,
+                    "toEntity": table_a_id,
+                    "lineageDetails": {"source": "OpenLineage"},
+                },
+                {
+                    "fromEntity": pipeline_id,
+                    "toEntity": table_b_id,
+                    "lineageDetails": {"source": "OpenLineage"},
+                },
+            ],
+        }
+
+        with patch.object(
+            self.open_lineage_source, "metadata"
+        ) as mock_metadata:
+            mock_metadata.get_lineage_by_id.return_value = lineage_data
+
+            self.open_lineage_source._cleanup_pipeline_as_node_edges(
+                mock_pipeline, event_entity_map={table_b_id: "table"}
+            )
+
+            mock_metadata.delete_lineage_edge.assert_called_once()
+            deleted_edge = mock_metadata.delete_lineage_edge.call_args[0][0]
+            self.assertEqual(str(deleted_edge.fromEntity.id.root), pipeline_id)
+            self.assertEqual(str(deleted_edge.toEntity.id.root), table_b_id)
+            self.assertEqual(deleted_edge.toEntity.type, "table")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/LineageRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/LineageRepository.java
@@ -994,7 +994,8 @@ public class LineageRepository {
   @Transaction
   public void deleteLineageBySource(UUID toId, String toEntity, String source) {
     List<CollectionDAO.EntityRelationshipObject> relations;
-    if (source.equals(LineageDetails.Source.PIPELINE_LINEAGE.value())) {
+    if (source.equals(LineageDetails.Source.PIPELINE_LINEAGE.value())
+        || source.equals(LineageDetails.Source.OPEN_LINEAGE.value())) {
       relations =
           dao.relationshipDAO()
               .findLineageBySourcePipeline(toId, toEntity, source, Relationship.UPSTREAM.ordinal());


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **Pipeline-as-node lineage support:**
  - Added `_has_annotated_pipeline_edge()` to detect existing both-sided edges and prevent redundant pipeline-node connections
  - Added `_cleanup_pipeline_as_node_edges()` to remove stale single-sided edges when transitioning to both-sided lineage
  - Modified `yield_pipeline_lineage_details()` to create pipeline-node edges for producer-only and consumer-only events
- **Lineage cleanup integration:**
  - Updated `MetadataRestSink` to handle `LineageSource.OpenLineage` in deletion logic
  - Updated `LineageRepository.deleteLineageBySource()` to include OpenLineage source in deletion conditions
- **Comprehensive test coverage:**
  - Added 7 new unit tests for producer-only, consumer-only, table input/output scenarios and cleanup edge cases

<sub>This will update automatically on new commits.</sub>