### PR TITLE
Cherry-pick: Remove unused domains API call on every page load (#26485)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
@@ -42,7 +42,6 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { UN_AUTHORIZED_EXCLUDED_PATHS } from '../../../constants/Auth.constants';
 import {
-  ES_MAX_PAGE_SIZE,
   REDIRECT_PATHNAME,
   ROUTES,
 } from '../../../constants/constants';
@@ -56,9 +55,7 @@ import { User } from '../../../generated/entity/teams/user';
 import { AuthProvider as AuthProviderEnum } from '../../../generated/settings/settings';
 import { useApplicationStore } from '../../../hooks/useApplicationStore';
 import useCustomLocation from '../../../hooks/useCustomLocation/useCustomLocation';
-import { useDomainStore } from '../../../hooks/useDomainStore';
 import axiosClient from '../../../rest';
-import { getDomainList } from '../../../rest/domainAPI';
 import {
   fetchAuthenticationConfig,
   fetchAuthorizerConfig,
@@ -150,7 +147,6 @@ export const AuthProvider = ({
     isAuthenticating,
     initializeAuthState,
   } = useApplicationStore();
-  const { updateDomains, updateDomainLoading } = useDomainStore();
   const tokenService = useRef<TokenService>(TokenService.getInstance());
 
   const location = useCustomLocation();
@@ -207,21 +203,6 @@ export const AuthProvider = ({
     navigate(ROUTES.SIGNIN);
   }, [timeoutId]);
 
-  const fetchDomainList = useCallback(async () => {
-    try {
-      updateDomainLoading(true);
-      const { data } = await getDomainList({
-        limit: ES_MAX_PAGE_SIZE,
-        fields: 'parent',
-      });
-      updateDomains(data);
-    } catch (error) {
-      // silent fail
-    } finally {
-      updateDomainLoading(false);
-    }
-  }, []);
-
   const handledVerifiedUser = () => {
     if (!applicationRoutesClass.isProtectedRoute(location.pathname)) {
       // Check if provider uses OidcAuthenticator which has routing logic
@@ -276,8 +257,6 @@ export const AuthProvider = ({
       if (res) {
         setCurrentUser(res);
         setIsAuthenticated(true);
-        // Fetch domains at the start
-        await fetchDomainList();
       } else {
         resetUserDetails();
       }
@@ -379,9 +358,6 @@ export const AuthProvider = ({
         if (res) {
           const userDetails = await checkIfUpdateRequired(res, newUser);
           setCurrentUser(userDetails);
-
-          // Fetch domains at the start
-          await fetchDomainList();
 
           handledVerifiedUser();
           // Start expiry timer on successful login

--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetailPage/DomainDetailPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetailPage/DomainDetailPage.component.tsx
@@ -24,7 +24,6 @@ import { TabSpecificField } from '../../../enums/entity.enum';
 import { Domain } from '../../../generated/entity/domains/domain';
 import { Operation } from '../../../generated/entity/policies/policy';
 import { useApplicationStore } from '../../../hooks/useApplicationStore';
-import { useDomainStore } from '../../../hooks/useDomainStore';
 import { useFqn } from '../../../hooks/useFqn';
 import {
   addFollower,
@@ -51,7 +50,6 @@ const DomainDetailPage = () => {
   const { currentUser } = useApplicationStore();
   const currentUserId = currentUser?.id ?? '';
   const { permissions } = usePermissionProvider();
-  const { updateDomains } = useDomainStore();
   const [isMainContentLoading, setIsMainContentLoading] = useState(false);
   const [activeDomain, setActiveDomain] = useState<Domain>();
   const [isFollowingLoading, setIsFollowingLoading] = useState<boolean>(false);
@@ -78,7 +76,6 @@ const DomainDetailPage = () => {
         const response = await patchDomains(activeDomain.id, jsonPatch);
 
         setActiveDomain(response);
-        updateDomains([response], false);
 
         if (activeDomain?.name !== updatedData.name) {
           navigate(getDomainPath(response.fullyQualifiedName));

--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetailPage/DomainDetailPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetailPage/DomainDetailPage.test.tsx
@@ -38,11 +38,6 @@ jest.mock('react-helmet-async', () => ({
 }));
 
 jest.mock('../../../rest/domainAPI');
-jest.mock('../../../hooks/useDomainStore', () => ({
-  useDomainStore: () => ({
-    updateDomains: jest.fn(),
-  }),
-}));
 jest.mock('../../../hooks/useApplicationStore', () => ({
   useApplicationStore: () => ({
     currentUser: { id: '1' },

--- a/openmetadata-ui/src/main/resources/ui/src/components/NavBar/NavBar.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/NavBar/NavBar.test.tsx
@@ -82,7 +82,6 @@ jest.mock('../../utils/FeedUtils', () => ({
 
 jest.mock('../../hooks/useDomainStore', () => ({
   useDomainStore: jest.fn().mockImplementation(() => ({
-    domainOptions: jest.fn().mockReturnValue('domainOptions'),
     activeDomain: jest.fn().mockReturnValue('activeDomain'),
     updateActiveDomain: jest.fn(),
   })),

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useDomainStore.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useDomainStore.ts
@@ -16,55 +16,19 @@ import {
   DEFAULT_DOMAIN_VALUE,
   DOMAIN_STORAGE_KEY,
 } from '../constants/constants';
-import { Domain } from '../generated/entity/domains/domain';
 import { EntityReference } from '../generated/entity/type';
 import { DomainStore } from '../interface/store.interface';
-import { getDomainOptions } from '../utils/DomainUtils';
-import { useApplicationStore } from './useApplicationStore';
 
 export const useDomainStore = create<DomainStore>()(
   persist(
     (set) => ({
-      domains: [],
       userDomains: [],
-      domainLoading: false,
       activeDomain: DEFAULT_DOMAIN_VALUE, // Set default value here
       activeDomainEntityRef: undefined,
-      domainOptions: [],
-      updateDomains: (data: Domain[]) => {
-        const currentUser = useApplicationStore.getState().currentUser;
-        const { isAdmin = false, domains = [] } = currentUser ?? {};
-        const userDomainsObj = isAdmin ? [] : domains;
-        const userDomainFqn =
-          userDomainsObj.map((item) => item.fullyQualifiedName) ?? [];
-
-        let filteredDomains: Domain[] = data;
-        if (domains.length > 0 && !isAdmin) {
-          filteredDomains = data.filter((domain) =>
-            userDomainFqn.includes(domain.fullyQualifiedName)
-          );
-        }
-
-        set({
-          domains: filteredDomains,
-          domainOptions: getDomainOptions(
-            isAdmin ? filteredDomains : userDomainsObj
-          ),
-        });
-      },
       updateActiveDomain: (domain?: EntityReference) => {
         set({
           activeDomain: domain?.fullyQualifiedName ?? DEFAULT_DOMAIN_VALUE,
           activeDomainEntityRef: domain,
-        });
-      },
-      updateDomainLoading: (loading: boolean) => {
-        set({ domainLoading: loading });
-      },
-      setDomains: (domainsArr: Domain[]) => {
-        set({
-          domains: domainsArr,
-          domainOptions: getDomainOptions(domainsArr),
         });
       },
       setUserDomains: (userDomainsArr: EntityReference[]) => {

--- a/openmetadata-ui/src/main/resources/ui/src/interface/store.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/interface/store.interface.ts
@@ -10,7 +10,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { ItemType } from 'antd/lib/menu/hooks/useItems';
 import {
   AuthenticationConfigurationWithScope,
   IAuthContext,
@@ -27,7 +26,6 @@ import { LoginConfiguration } from '../generated/configuration/loginConfiguratio
 import { LogoConfiguration } from '../generated/configuration/logoConfiguration';
 import { SearchSettings } from '../generated/configuration/searchSettings';
 import { UIThemePreference } from '../generated/configuration/uiThemePreference';
-import { Domain } from '../generated/entity/domains/domain';
 import { User } from '../generated/entity/teams/user';
 import { EntityReference } from '../generated/entity/type';
 
@@ -81,15 +79,9 @@ export interface ApplicationStore
 }
 
 export interface DomainStore {
-  domains: Domain[];
   userDomains: EntityReference[];
-  domainLoading: boolean;
   activeDomain: string;
   activeDomainEntityRef?: EntityReference;
-  domainOptions: ItemType[];
-  updateDomains: (domainsArr: Domain[], selectDefault?: boolean) => void;
   updateActiveDomain: (domain: EntityReference) => void;
-  setDomains: (domains: Domain[]) => void;
   setUserDomains: (userDomainsArr: EntityReference[]) => void;
-  updateDomainLoading: (loading: boolean) => void;
 }

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DomainUtils.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DomainUtils.test.tsx
@@ -17,7 +17,6 @@ import { SearchIndex } from '../enums/search.enum';
 import { Domain, DomainType } from '../generated/entity/domains/domain';
 import { useDomainStore } from '../hooks/useDomainStore';
 import {
-  getDomainOptions,
   getQueryFilterToIncludeDomain,
   isDomainExist,
   withDomainFilter,
@@ -26,30 +25,6 @@ import { getPathNameFromWindowLocation } from './RouterUtils';
 
 jest.mock('../hooks/useDomainStore');
 jest.mock('./RouterUtils');
-
-describe('getDomainOptions function', () => {
-  const domains = [
-    {
-      id: '1',
-      name: 'Domain 1',
-      fullyQualifiedName: 'domain1',
-      description: 'test',
-      domainType: DomainType.Aggregate,
-    },
-  ];
-
-  it('should return an array of ItemType objects', () => {
-    const result = getDomainOptions(domains);
-
-    expect(Array.isArray(result)).toBeTruthy();
-    expect(result).toHaveLength(2);
-
-    result.forEach((item) => {
-      expect(item).toHaveProperty('label');
-      expect(item).toHaveProperty('key');
-    });
-  });
-});
 
 describe('isDomainExist', () => {
   it('should return true if domain fqn matches directly', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DomainUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DomainUtils.tsx
@@ -373,39 +373,6 @@ export const iconTooltipDataRender = () => (
   </MUITooltip>
 );
 
-export const getDomainOptions = (domains: Domain[] | EntityReference[]) => {
-  const domainOptions: ItemType[] = [
-    {
-      label: t('label.all-domain-plural'),
-      key: DEFAULT_DOMAIN_VALUE,
-    },
-  ];
-
-  for (const domain of domains) {
-    domainOptions.push({
-      label: getEntityName(domain),
-      key: domain.fullyQualifiedName ?? '',
-      icon: get(domain, 'parent') ? (
-        <SubDomainIcon
-          color={DE_ACTIVE_COLOR}
-          height={20}
-          name="subdomain"
-          width={20}
-        />
-      ) : (
-        <DomainIcon
-          color={DE_ACTIVE_COLOR}
-          height={20}
-          name="domain"
-          width={20}
-        />
-      ),
-    });
-  }
-
-  return domainOptions;
-};
-
 export const renderDomainLink = (
   domain: EntityReference,
   domainDisplayName: ReactNode,


### PR DESCRIPTION
## Summary
- Cherry-pick of #26485 from `main` into `1.12.2`
- Removes the unused `/api/v1/domains?limit=10000&fields=parent` call that fires on every page load, reducing unnecessary network requests

## Test plan
- [ ] Verify no regression in domain-related functionality (domain selector, domain filtering)
- [ ] Confirm the `/api/v1/domains?limit=10000&fields=parent` call no longer fires on page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)