### PR TITLE
Add IntermediateCatchEvent BPMN builder

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/flowable/builders/IntermediateCatchEventBuilder.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/flowable/builders/IntermediateCatchEventBuilder.java
@@ -2,6 +2,7 @@ package org.openmetadata.service.governance.workflows.flowable.builders;
 
 import org.flowable.bpmn.model.IntermediateCatchEvent;
 import org.flowable.bpmn.model.MessageEventDefinition;
+import org.openmetadata.common.utils.CommonUtil;
 
 public class IntermediateCatchEventBuilder
     extends FlowableElementBuilder<IntermediateCatchEventBuilder> {
@@ -15,7 +16,7 @@ public class IntermediateCatchEventBuilder
 
   @Override
   public IntermediateCatchEvent build() {
-    if (messageExpression == null) {
+    if (CommonUtil.nullOrEmpty(messageExpression)) {
       throw new IllegalStateException(
           "IntermediateCatchEvent requires a messageExpression to be set");
     }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/governance/workflows/flowable/builders/IntermediateCatchEventBuilderTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/governance/workflows/flowable/builders/IntermediateCatchEventBuilderTest.java
@@ -35,4 +35,12 @@ class IntermediateCatchEventBuilderTest {
     IllegalStateException exception = assertThrows(IllegalStateException.class, builder::build);
     assertTrue(exception.getMessage().contains("messageExpression"));
   }
+
+  @Test
+  void testBuildThrowsWhenMessageExpressionIsEmpty() {
+    IntermediateCatchEventBuilder builder =
+        new IntermediateCatchEventBuilder().id("waitForStatus").messageExpression("");
+
+    assertThrows(IllegalStateException.class, builder::build);
+  }
 }


### PR DESCRIPTION
## Summary
- Adds `IntermediateCatchEventBuilder` — a fluent builder for Flowable `IntermediateCatchEvent` with `messageExpression` support (dynamic, per-instance message subscriptions)
- Includes unit tests validating builder behavior and required-field enforcement

Part of Item 1: Task Lifecycle Node

## Context
The governance workflow system needs a way to **pause** execution and wait for external messages (e.g., task status changes). Flowable's `IntermediateCatchEvent` with `messageExpression` enables unique-per-instance subscriptions, where each workflow instance subscribes to a message named after its Task UUID.

This builder follows the existing pattern in `flowable/builders/` (e.g., `ServiceTaskBuilder`, `EndEventBuilder`).

## Test plan
- [x] `IntermediateCatchEventBuilderTest` — validates ID/name/messageExpression are set correctly
- [x] Tests that missing `messageExpression` throws `IllegalStateException`
- [x] Tests that empty string `messageExpression` throws `IllegalStateException`