### PR TITLE
chore(ui): update alert props

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/alert/alert.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/alert/alert.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import type { FC, ReactNode } from "react";
+import type { FC, HTMLAttributes, ReactNode } from "react";
 import {
   AlertCircle,
   AlertTriangle,
@@ -61,7 +61,7 @@ const variantStyles: Record<
   },
 };
 
-export interface AlertProps {
+export interface AlertProps extends Omit<HTMLAttributes<HTMLDivElement>, "title"> {
   /** success, warning, error, brand or gray */
   variant: AlertVariant;
   /** Bold heading text */
@@ -74,7 +74,6 @@ export interface AlertProps {
   closable?: boolean;
   /** Called when the × close button is clicked. */
   onClose?: () => void;
-  className?: string;
 }
 
 export const Alert = ({
@@ -85,12 +84,14 @@ export const Alert = ({
   closable = false,
   onClose,
   className,
+  ...props
 }: AlertProps) => {
   const styles = variantStyles[variant];
   const Icon = icon ?? styles.defaultIcon;
 
   return (
     <div
+      {...props}
       role="alert"
       className={cx(
         "tw:flex tw:w-full tw:gap-3 tw:rounded-xl tw:border tw:px-4",


### PR DESCRIPTION
----
## Summary by Gitar

- **Props enhancement:**
  - Extended `AlertProps` to inherit from `HTMLAttributes<HTMLDivElement>` (excluding `title`), enabling standard HTML div attributes
  - Removed explicit `className` prop definition, now included via `HTMLAttributes` inheritance
  - Added spread operator `...props` to pass inherited attributes to the rendered `<div>` element

<sub>This will update automatically on new commits.</sub>