### PR TITLE
Fix lineage async export silently dropping edges after encountering a missing entity node

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/LineageBrokenReferenceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/LineageBrokenReferenceIT.java
@@ -3,12 +3,17 @@ package org.openmetadata.it.tests;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.StringReader;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -247,6 +252,72 @@ public class LineageBrokenReferenceIT {
     } finally {
       hardDeleteQuietly(client, mainTable);
       hardDeleteQuietly(client, referencedTable);
+    }
+  }
+
+  /**
+   * Regression test for the writeEdge() bug in exportCsvAsync().
+   *
+   * <p>Fan-in topology: tBad→tFocal and tGood→tFocal. Hard-delete tBad's ES document so it
+   * disappears from entityMap while its lineage edge remains. Before the fix, writeEdge() called
+   * {@code return} on the first missing entity, dropping all subsequent edges (tGood→tFocal would
+   * be lost). After the fix it calls {@code continue}, so tGood→tFocal still appears in the export.
+   */
+  @Test
+  void testAsyncExportSkipsMissingEntityAndContinuesRemainingEdges(TestNamespace ns)
+      throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+
+    Table tFocal = createTable(client, ns, "async_export_focal");
+    Table tBad = createTable(client, ns, "async_export_bad");
+    Table tGood = createTable(client, ns, "async_export_good");
+
+    try {
+      addLineage(client, tBad, tFocal);
+      addLineage(client, tGood, tFocal);
+
+      Awaitility.await("Both upstream lineage edges indexed")
+          .atMost(Duration.ofSeconds(30))
+          .pollInterval(Duration.ofSeconds(2))
+          .ignoreExceptions()
+          .until(
+              () -> {
+                String csv =
+                    Entity.getLineageRepository()
+                        .exportCsv(tFocal.getFullyQualifiedName(), 2, 0, null, false, "table");
+                return parseCsvRecords(csv).size() >= 2;
+              });
+
+      Entity.getSearchRepository().deleteEntityIndex(tBad);
+
+      String[] csvHolder = {null};
+      assertDoesNotThrow(
+          () ->
+              csvHolder[0] =
+                  Entity.getLineageRepository()
+                      .exportCsvAsync(tFocal.getFullyQualifiedName(), 2, 0, null, "table", false),
+          "exportCsvAsync must not throw when a referenced entity is missing from the search index");
+
+      assertNotNull(csvHolder[0]);
+
+      List<CSVRecord> rows = parseCsvRecords(csvHolder[0]);
+      boolean goodEdgePresent =
+          rows.stream().anyMatch(r -> tGood.getFullyQualifiedName().equals(r.get("fromEntityFQN")));
+      assertTrue(
+          goodEdgePresent,
+          "tGood→tFocal edge must appear in the export — exportCsvAsync should continue past the missing tBad node");
+
+    } finally {
+      hardDeleteQuietly(client, tFocal);
+      hardDeleteQuietly(client, tBad);
+      hardDeleteQuietly(client, tGood);
+    }
+  }
+
+  private List<CSVRecord> parseCsvRecords(String csvContent) throws Exception {
+    try (CSVParser parser =
+        CSVFormat.DEFAULT.withFirstRecordAsHeader().parse(new StringReader(csvContent))) {
+      return parser.getRecords();
     }
   }
 

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/LineageResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/LineageResourceIT.java
@@ -6,9 +6,14 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.StringReader;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Disabled;
@@ -1313,5 +1318,179 @@ public class LineageResourceIT {
     } catch (Exception e) {
       // Ignore cleanup errors
     }
+  }
+
+  @Test
+  void testExportLineageBasicChain() throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    TestNamespace namespace = new TestNamespace("LineageResourceIT");
+
+    Table t1 = createTable(client, namespace, "export_chain_t1");
+    Table t2 = createTable(client, namespace, "export_chain_t2");
+    Table t3 = createTable(client, namespace, "export_chain_t3");
+    Table t4 = createTable(client, namespace, "export_chain_t4");
+
+    addLineage(client, t1, t2);
+    addLineage(client, t2, t3);
+    addLineage(client, t3, t4);
+
+    String csvContent =
+        exportLineageWithRetry(client, t2.getFullyQualifiedName(), "table", "2", "2", 3);
+    List<CSVRecord> rows = parseCsvRows(csvContent);
+
+    assertEdgeInCsv(rows, t1.getFullyQualifiedName(), t2.getFullyQualifiedName());
+    assertEdgeInCsv(rows, t2.getFullyQualifiedName(), t3.getFullyQualifiedName());
+    assertEdgeInCsv(rows, t3.getFullyQualifiedName(), t4.getFullyQualifiedName());
+
+    deleteLineage(client, t1.getEntityReference(), t2.getEntityReference());
+    deleteLineage(client, t2.getEntityReference(), t3.getEntityReference());
+    deleteLineage(client, t3.getEntityReference(), t4.getEntityReference());
+
+    cleanupTable(client, t1);
+    cleanupTable(client, t2);
+    cleanupTable(client, t3);
+    cleanupTable(client, t4);
+  }
+
+  @Test
+  void testExportLineageWithColumnLineage() throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    TestNamespace namespace = new TestNamespace("LineageResourceIT");
+
+    Table sourceTable = createTableWithMultipleColumns(client, namespace, "export_col_src");
+    Table targetTable = createTableWithMultipleColumns(client, namespace, "export_col_tgt");
+
+    String srcCol1 = sourceTable.getColumns().get(0).getFullyQualifiedName();
+    String srcCol2 = sourceTable.getColumns().get(1).getFullyQualifiedName();
+    String tgtCol1 = targetTable.getColumns().get(0).getFullyQualifiedName();
+    String tgtCol2 = targetTable.getColumns().get(1).getFullyQualifiedName();
+
+    LineageDetails details = new LineageDetails();
+    details
+        .getColumnsLineage()
+        .add(new ColumnLineage().withFromColumns(List.of(srcCol1)).withToColumn(tgtCol1));
+    details
+        .getColumnsLineage()
+        .add(new ColumnLineage().withFromColumns(List.of(srcCol2)).withToColumn(tgtCol2));
+
+    AddLineage addLineage =
+        new AddLineage()
+            .withEdge(
+                new EntitiesEdge()
+                    .withFromEntity(sourceTable.getEntityReference())
+                    .withToEntity(targetTable.getEntityReference())
+                    .withLineageDetails(details));
+    executeAddLineage(client, addLineage);
+
+    String csvContent =
+        exportLineageWithRetry(client, sourceTable.getFullyQualifiedName(), "table", "0", "1", 1);
+    List<CSVRecord> rows = parseCsvRows(csvContent);
+
+    assertEdgeInCsv(rows, sourceTable.getFullyQualifiedName(), targetTable.getFullyQualifiedName());
+
+    boolean columnLineagePresent =
+        rows.stream()
+            .filter(
+                r ->
+                    sourceTable.getFullyQualifiedName().equals(r.get("fromFullyQualifiedName*"))
+                        && targetTable
+                            .getFullyQualifiedName()
+                            .equals(r.get("toFullyQualifiedName*")))
+            .anyMatch(r -> r.get("columnLineage") != null && !r.get("columnLineage").isEmpty());
+    assertTrue(columnLineagePresent);
+
+    deleteLineage(client, sourceTable.getEntityReference(), targetTable.getEntityReference());
+    cleanupTable(client, sourceTable);
+    cleanupTable(client, targetTable);
+  }
+
+  @Test
+  void testExportLineageVaryingDepths() throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    TestNamespace namespace = new TestNamespace("LineageResourceIT");
+
+    Table t1 = createTable(client, namespace, "export_depth_t1");
+    Table t2 = createTable(client, namespace, "export_depth_t2");
+    Table t3 = createTable(client, namespace, "export_depth_t3");
+    Table t4 = createTable(client, namespace, "export_depth_t4");
+    Table t5 = createTable(client, namespace, "export_depth_t5");
+
+    addLineage(client, t1, t2);
+    addLineage(client, t2, t3);
+    addLineage(client, t3, t4);
+    addLineage(client, t4, t5);
+
+    // Depth 1,1: direct neighbors of t3 are present
+    String csvDepth1 =
+        exportLineageWithRetry(client, t3.getFullyQualifiedName(), "table", "1", "1", 2);
+    List<CSVRecord> rowsDepth1 = parseCsvRows(csvDepth1);
+    assertEdgeInCsv(rowsDepth1, t2.getFullyQualifiedName(), t3.getFullyQualifiedName());
+    assertEdgeInCsv(rowsDepth1, t3.getFullyQualifiedName(), t4.getFullyQualifiedName());
+
+    // Depth 2,2: extended chain edges t1→t2 and t4→t5 are also present
+    String csvDepth2 =
+        exportLineageWithRetry(client, t3.getFullyQualifiedName(), "table", "2", "2", 4);
+    List<CSVRecord> rowsDepth2 = parseCsvRows(csvDepth2);
+    assertEdgeInCsv(rowsDepth2, t1.getFullyQualifiedName(), t2.getFullyQualifiedName());
+    assertEdgeInCsv(rowsDepth2, t4.getFullyQualifiedName(), t5.getFullyQualifiedName());
+    assertTrue(rowsDepth2.size() > rowsDepth1.size());
+
+    deleteLineage(client, t1.getEntityReference(), t2.getEntityReference());
+    deleteLineage(client, t2.getEntityReference(), t3.getEntityReference());
+    deleteLineage(client, t3.getEntityReference(), t4.getEntityReference());
+    deleteLineage(client, t4.getEntityReference(), t5.getEntityReference());
+
+    cleanupTable(client, t1);
+    cleanupTable(client, t2);
+    cleanupTable(client, t3);
+    cleanupTable(client, t4);
+    cleanupTable(client, t5);
+  }
+
+  private String exportLineageWithRetry(
+      OpenMetadataClient client,
+      String fqn,
+      String type,
+      String upstreamDepth,
+      String downstreamDepth,
+      int expectedMinRows) {
+    String[] holder = {null};
+    Awaitility.await("Export lineage CSV with at least " + expectedMinRows + " rows")
+        .atMost(Duration.ofSeconds(60))
+        .pollDelay(Duration.ofMillis(500))
+        .pollInterval(Duration.ofSeconds(2))
+        .ignoreExceptions()
+        .until(
+            () -> {
+              String csv =
+                  client.lineage().exportLineage(fqn, type, upstreamDepth, downstreamDepth);
+              try (CSVParser parser =
+                  CSVFormat.DEFAULT.withFirstRecordAsHeader().parse(new StringReader(csv))) {
+                List<CSVRecord> rows = parser.getRecords();
+                if (rows.size() >= expectedMinRows) {
+                  holder[0] = csv;
+                  return true;
+                }
+              }
+              return false;
+            });
+    return holder[0];
+  }
+
+  private List<CSVRecord> parseCsvRows(String csvContent) throws IOException {
+    try (CSVParser parser =
+        CSVFormat.DEFAULT.withFirstRecordAsHeader().parse(new StringReader(csvContent))) {
+      return parser.getRecords();
+    }
+  }
+
+  private void assertEdgeInCsv(List<CSVRecord> rows, String fromFqn, String toFqn) {
+    boolean found =
+        rows.stream()
+            .anyMatch(
+                r ->
+                    fromFqn.equals(r.get("fromFullyQualifiedName*"))
+                        && toFqn.equals(r.get("toFullyQualifiedName*")));
+    assertTrue(found, String.format("Expected edge %s -> %s not found in CSV", fromFqn, toFqn));
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/LineageRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/LineageRepository.java
@@ -629,7 +629,7 @@ public class LineageRepository {
       if (fromEntity == null || toEntity == null) {
         LOG.error(
             "Entity not found for IDs: fromEntityId={}, toEntityId={}", fromEntityId, toEntityId);
-        return;
+        continue;
       }
 
       Map<String, String> baseRow = new HashMap<>();


### PR DESCRIPTION


<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **Bug fix in LineageRepository:**
  - Changed `return` to `continue` in `writeEdge()` to process all edges instead of stopping at first missing entity
- **Regression tests added:**
  - `testAsyncExportSkipsMissingEntityAndContinuesRemainingEdges()` verifies edges after encountering missing node
  - `testExportLineageBasicChain()`, `testExportLineageWithColumnLineage()`, `testExportLineageVaryingDepths()` cover export scenarios with varying topologies and depths

<sub>This will update automatically on new commits.</sub>