### PR TITLE
feat: Add database backup and restore utilities

### DIFF
--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -1017,6 +1017,11 @@
       <artifactId>owasp-java-html-sanitizer</artifactId>
       <version>${owasp-html-sanitizer.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>1.27.1</version>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -1020,7 +1020,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
-      <version>1.27.1</version>
+      <version>${commons-compress.version}</version>
     </dependency>
   </dependencies>
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/README.md
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/README.md
@@ -23,3 +23,100 @@ Each `Migration` class can optionally override the `getMigrationOps` method, e.g
 ```
 
 Then, the `MigrationProcess` implemented for that `Migration` version will execute this query on top of the common ones.
+
+## Database Backup and Restore
+
+The `OpenMetadataOperations` CLI provides commands to backup, restore, and test migrations against real data.
+
+### Backup
+
+Creates a `.tar.gz` archive of all OpenMetadata tables (excluding framework-managed tables like Flowable's `act_*`,
+`flw_*`, and Quartz's `qrtz_*`). The file is auto-named as `openmetadata_<version>_<timestamp>.tar.gz`.
+
+```bash
+./openmetadata-ops.sh backup -c conf/openmetadata.yaml --backup-path /path/to/dir/
+```
+
+The archive contains:
+- `metadata.json` — version, timestamp, database type, applied migration versions, and per-table column/type info
+- `tables/<table_name>.json` — one JSON array of rows per table
+
+### Restore
+
+Drops all existing tables, runs migrations up to the backup's schema version, then inserts the backup data
+in FK-safe topological order.
+
+```bash
+./openmetadata-ops.sh restore -c conf/openmetadata.yaml --backup-path /path/to/backup.tar.gz
+```
+
+### Batch size
+
+Both `backup` and `restore` accept `--batch-size` (default: 1000) to control how many rows are read/written per batch.
+
+## Testing Migrations
+
+The `test-migration` command validates that migrations run correctly against real production-like data. It:
+
+1. Drops all tables
+2. Runs migrations up to the backup's schema version (recreates the schema as it was when the backup was taken)
+3. Restores the backup data
+4. Runs each pending migration one-by-one, executing before/after test assertions
+
+```bash
+./openmetadata-ops.sh test-migration -c conf/openmetadata.yaml --backup-path /path/to/backup.tar.gz
+```
+
+### Writing migration tests
+
+Create a `MigrationTest` class under `migration/utils/` following the package naming convention
+`v<major><minor><patch>` (e.g., `v1130` for version `1.13.0`):
+
+```
+migration/utils/v1130/MigrationTest.java   → runs for migration version 1.13.0
+migration/utils/v1140/MigrationTest.java   → runs for migration version 1.14.0
+```
+
+Each test class implements `MigrationTestCase`:
+
+```java
+package org.openmetadata.service.migration.utils.v1130;
+
+public class MigrationTest implements MigrationTestCase {
+
+  @Override
+  public List<TestResult> validateBefore(Handle handle) {
+    // Query the database BEFORE this migration runs.
+    // Verify preconditions — e.g., a column exists, data is in the expected format.
+    return List.of(TestResult.pass("precondition check"));
+  }
+
+  @Override
+  public List<TestResult> validateAfter(Handle handle) {
+    // Query the database AFTER this migration runs.
+    // Verify the migration transformed data correctly.
+    return List.of(TestResult.pass("post-migration check"));
+  }
+}
+```
+
+`TestResult.pass(name)` and `TestResult.fail(name, detail)` are the two factory methods.
+
+State can be shared between `validateBefore` and `validateAfter` via instance fields — the runner uses
+the same instance for both calls. See `migration/utils/v1130/MigrationTest.java` for an example that
+captures `preview` field values before migration and verifies the derived `enabled` field after.
+
+### Workflow for validating a new migration
+
+1. Take a backup of a database running the **current** released version:
+   ```bash
+   ./openmetadata-ops.sh backup -c conf/openmetadata.yaml --backup-path ./backups/
+   ```
+2. Write your migration code under `migration/` as usual.
+3. Write a `MigrationTest` class for your version under `migration/utils/v<version>/`.
+4. Run `test-migration` against the backup:
+   ```bash
+   ./openmetadata-ops.sh test-migration -c conf/openmetadata.yaml --backup-path ./backups/openmetadata_1_13_0_20260321T120000.tar.gz
+   ```
+5. Review the summary table — all tests should show `PASS`. If a migration fails, the runner stops
+   and reports the partially-migrated state so you can fix and re-run.

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/api/MigrationTestCase.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/api/MigrationTestCase.java
@@ -1,0 +1,10 @@
+package org.openmetadata.service.migration.api;
+
+import java.util.List;
+import org.jdbi.v3.core.Handle;
+
+public interface MigrationTestCase {
+  List<TestResult> validateBefore(Handle handle);
+
+  List<TestResult> validateAfter(Handle handle);
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/api/MigrationWorkflow.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/api/MigrationWorkflow.java
@@ -46,7 +46,7 @@ public class MigrationWorkflow {
   public static final String SUCCESS_MSG = "Success";
   public static final String FAILED_MSG = "Failed due to : ";
   public static final String CURRENT = "Current";
-  private List<MigrationProcess> migrations;
+  @Getter private List<MigrationProcess> migrations;
   private final String nativeSQLScriptRootPath;
   private final ConnectionType connectionType;
   private final String extensionSQLScriptRootPath;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/api/MigrationWorkflow.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/api/MigrationWorkflow.java
@@ -19,6 +19,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.flywaydb.core.api.configuration.ClassicConfiguration;
 import org.flywaydb.core.api.configuration.Configuration;
@@ -55,6 +56,7 @@ public class MigrationWorkflow {
   private final MigrationDAO migrationDAO;
   private final Jdbi jdbi;
   private final boolean forceMigrations;
+  @Setter private String targetVersion;
   List<String> executedMigrations;
   private Optional<String> currentMaxMigrationVersion;
 
@@ -98,6 +100,13 @@ public class MigrationWorkflow {
             flywayPath);
     // Filter Migrations to Be Run
     this.migrations = filterAndGetMigrationsToRun(availableMigrations);
+
+    if (targetVersion != null) {
+      this.migrations =
+          this.migrations.stream()
+              .filter(m -> compareVersions(m.getVersion(), targetVersion) <= 0)
+              .toList();
+    }
   }
 
   public void validateMigrationsForServer() {
@@ -204,7 +213,7 @@ public class MigrationWorkflow {
     return processes;
   }
 
-  private static int compareVersions(String version1, String version2) {
+  public static int compareVersions(String version1, String version2) {
     int[] v1Parts = parseVersion(version1);
     int[] v2Parts = parseVersion(version2);
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/api/TestResult.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/api/TestResult.java
@@ -1,0 +1,11 @@
+package org.openmetadata.service.migration.api;
+
+public record TestResult(String name, boolean passed, String detail) {
+  public static TestResult pass(String name) {
+    return new TestResult(name, true, "");
+  }
+
+  public static TestResult fail(String name, String detail) {
+    return new TestResult(name, false, detail);
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1130/MigrationTest.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1130/MigrationTest.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import org.jdbi.v3.core.Handle;
 import org.openmetadata.service.migration.api.MigrationTestCase;
 import org.openmetadata.service.migration.api.TestResult;
@@ -13,7 +14,16 @@ import org.openmetadata.service.migration.api.TestResult;
 public class MigrationTest implements MigrationTestCase {
 
   private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final Pattern SAFE_IDENTIFIER = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_]*$");
   private static final String[] APP_TABLES = {"installed_apps", "apps_marketplace"};
+
+  static {
+    for (String table : APP_TABLES) {
+      if (!SAFE_IDENTIFIER.matcher(table).matches()) {
+        throw new IllegalArgumentException("Invalid table name in APP_TABLES: " + table);
+      }
+    }
+  }
 
   private final Map<String, Map<String, Boolean>> previewValues = new HashMap<>();
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1130/MigrationTest.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1130/MigrationTest.java
@@ -1,0 +1,97 @@
+package org.openmetadata.service.migration.utils.v1130;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.jdbi.v3.core.Handle;
+import org.openmetadata.service.migration.api.MigrationTestCase;
+import org.openmetadata.service.migration.api.TestResult;
+
+public class MigrationTest implements MigrationTestCase {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final String[] APP_TABLES = {"installed_apps", "apps_marketplace"};
+
+  private final Map<String, Map<String, Boolean>> previewValues = new HashMap<>();
+
+  @Override
+  public List<TestResult> validateBefore(Handle handle) {
+    List<TestResult> results = new ArrayList<>();
+    for (String table : APP_TABLES) {
+      results.add(validatePreviewFieldExists(handle, table));
+    }
+    return results;
+  }
+
+  @Override
+  public List<TestResult> validateAfter(Handle handle) {
+    List<TestResult> results = new ArrayList<>();
+    for (String table : APP_TABLES) {
+      results.add(validateEnabledFieldCorrect(handle, table));
+    }
+    return results;
+  }
+
+  private TestResult validatePreviewFieldExists(Handle handle, String table) {
+    String testName = table + ": preview field exists";
+    try {
+      List<String> rows =
+          handle.createQuery("SELECT json FROM " + table).mapTo(String.class).list();
+      if (rows.isEmpty()) {
+        return TestResult.pass(testName + " (no rows)");
+      }
+      Map<String, Boolean> tablePreview = new HashMap<>();
+      for (String jsonStr : rows) {
+        JsonNode node = MAPPER.readTree(jsonStr);
+        String name = node.has("name") ? node.get("name").asText() : "unknown";
+        if (!node.has("preview")) {
+          return TestResult.fail(testName, "App '" + name + "' missing 'preview' field");
+        }
+        tablePreview.put(name, node.get("preview").asBoolean());
+      }
+      previewValues.put(table, tablePreview);
+      return TestResult.pass(testName);
+    } catch (Exception e) {
+      return TestResult.fail(testName, e.getMessage());
+    }
+  }
+
+  private TestResult validateEnabledFieldCorrect(Handle handle, String table) {
+    String testName = table + ": enabled field has correct value";
+    try {
+      List<String> rows =
+          handle.createQuery("SELECT json FROM " + table).mapTo(String.class).list();
+      if (rows.isEmpty()) {
+        return TestResult.pass(testName + " (no rows)");
+      }
+      Map<String, Boolean> savedPreview = previewValues.getOrDefault(table, Map.of());
+      for (String jsonStr : rows) {
+        JsonNode node = MAPPER.readTree(jsonStr);
+        String name = node.has("name") ? node.get("name").asText() : "unknown";
+        if (!node.has("enabled")) {
+          return TestResult.fail(testName, "App '" + name + "' missing 'enabled' field");
+        }
+        if (!node.get("enabled").isBoolean()) {
+          return TestResult.fail(testName, "App '" + name + "': 'enabled' is not a boolean");
+        }
+        boolean enabled = node.get("enabled").asBoolean();
+        if (savedPreview.containsKey(name)) {
+          boolean expectedEnabled = !savedPreview.get(name);
+          if (enabled != expectedEnabled) {
+            return TestResult.fail(
+                testName,
+                String.format(
+                    "App '%s': expected enabled=%s (preview was %s) but got enabled=%s",
+                    name, expectedEnabled, savedPreview.get(name), enabled));
+          }
+        }
+      }
+      return TestResult.pass(testName);
+    } catch (Exception e) {
+      return TestResult.fail(testName, e.getMessage());
+    }
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/DatabaseBackupRestore.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/DatabaseBackupRestore.java
@@ -1,0 +1,407 @@
+package org.openmetadata.service.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.sql.Types;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
+import org.openmetadata.service.jdbi3.locator.ConnectionType;
+
+@Slf4j
+public class DatabaseBackupRestore {
+
+  private static final int BATCH_SIZE = 1000;
+  private static final ObjectMapper MAPPER =
+      new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+
+  private final Jdbi jdbi;
+  private final ConnectionType connectionType;
+  private final String databaseName;
+
+  public DatabaseBackupRestore(Jdbi jdbi, ConnectionType connectionType, String databaseName) {
+    this.jdbi = jdbi;
+    this.connectionType = connectionType;
+    this.databaseName = databaseName;
+  }
+
+  public List<String> discoverTables(Handle handle) {
+    String sql;
+    if (connectionType == ConnectionType.MYSQL) {
+      sql =
+          "SELECT table_name FROM information_schema.tables "
+              + "WHERE table_type = 'BASE TABLE' AND table_schema = :db ORDER BY table_name";
+      return handle.createQuery(sql).bind("db", databaseName).mapTo(String.class).list();
+    } else {
+      sql =
+          "SELECT table_name FROM information_schema.tables "
+              + "WHERE table_type = 'BASE TABLE' AND table_schema = 'public' ORDER BY table_name";
+      return handle.createQuery(sql).mapTo(String.class).list();
+    }
+  }
+
+  public List<String> discoverColumns(Handle handle, String tableName) {
+    String sql;
+    if (connectionType == ConnectionType.MYSQL) {
+      sql =
+          "SELECT column_name FROM information_schema.columns "
+              + "WHERE table_schema = :db AND table_name = :table "
+              + "AND (extra NOT LIKE '%GENERATED%' OR extra IS NULL) "
+              + "ORDER BY ordinal_position";
+      return handle
+          .createQuery(sql)
+          .bind("db", databaseName)
+          .bind("table", tableName)
+          .mapTo(String.class)
+          .list();
+    } else {
+      sql =
+          "SELECT column_name FROM information_schema.columns "
+              + "WHERE table_schema = 'public' AND table_name = :table "
+              + "AND (is_generated = 'NEVER' OR is_generated IS NULL) "
+              + "AND (column_default NOT LIKE 'nextval%' OR column_default IS NULL) "
+              + "ORDER BY ordinal_position";
+      return handle.createQuery(sql).bind("table", tableName).mapTo(String.class).list();
+    }
+  }
+
+  public static String extractDatabaseName(String jdbcUrl) {
+    String url = jdbcUrl;
+    int questionMark = url.indexOf('?');
+    if (questionMark > 0) {
+      url = url.substring(0, questionMark);
+    }
+    int lastSlash = url.lastIndexOf('/');
+    if (lastSlash < 0 || lastSlash == url.length() - 1) {
+      throw new IllegalArgumentException("Cannot extract database name from JDBC URL: " + jdbcUrl);
+    }
+    String dbName = url.substring(lastSlash + 1);
+    if (dbName.isEmpty()) {
+      throw new IllegalArgumentException("Cannot extract database name from JDBC URL: " + jdbcUrl);
+    }
+    return dbName;
+  }
+
+  public void backup(String backupPath) throws IOException {
+    LOG.info("Starting database backup to {}", backupPath);
+    try (FileOutputStream fos = new FileOutputStream(backupPath);
+        BufferedOutputStream bos = new BufferedOutputStream(fos);
+        GzipCompressorOutputStream gzos = new GzipCompressorOutputStream(bos);
+        TarArchiveOutputStream taos = new TarArchiveOutputStream(gzos)) {
+
+      taos.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+
+      ObjectNode metadata = MAPPER.createObjectNode();
+      metadata.put("timestamp", Instant.now().toString());
+      metadata.put("version", System.getProperty("project.version", "unknown"));
+      metadata.put("databaseType", connectionType.name());
+      metadata.put("databaseName", databaseName);
+      ObjectNode tablesMetadata = MAPPER.createObjectNode();
+
+      jdbi.useHandle(
+          handle -> {
+            List<String> tables = discoverTables(handle);
+            LOG.info("Discovered {} tables", tables.size());
+
+            for (String tableName : tables) {
+              backupTable(handle, tableName, taos, tablesMetadata);
+            }
+          });
+
+      metadata.set("tables", tablesMetadata);
+      byte[] metadataBytes = MAPPER.writeValueAsBytes(metadata);
+      TarArchiveEntry metadataEntry = new TarArchiveEntry("metadata.json");
+      metadataEntry.setSize(metadataBytes.length);
+      taos.putArchiveEntry(metadataEntry);
+      taos.write(metadataBytes);
+      taos.closeArchiveEntry();
+
+      LOG.info("Backup completed successfully");
+    }
+  }
+
+  private void backupTable(
+      Handle handle, String tableName, TarArchiveOutputStream taos, ObjectNode tablesMetadata)
+      throws IOException {
+    List<String> columns = discoverColumns(handle, tableName);
+    if (columns.isEmpty()) {
+      LOG.warn("No columns found for table {}, skipping", tableName);
+      return;
+    }
+
+    String quotedColumns = quoteColumns(columns);
+    String quotedTable = quoteIdentifier(tableName);
+
+    int offset = 0;
+    ArrayNode allRows = MAPPER.createArrayNode();
+
+    while (true) {
+      String sql =
+          String.format(
+              "SELECT %s FROM %s LIMIT %d OFFSET %d",
+              quotedColumns, quotedTable, BATCH_SIZE, offset);
+      List<Map<String, Object>> rows = handle.createQuery(sql).mapToMap().list();
+
+      for (Map<String, Object> row : rows) {
+        ObjectNode rowNode = MAPPER.createObjectNode();
+        for (String col : columns) {
+          Object val = row.get(col);
+          if (val == null) {
+            rowNode.putNull(col);
+          } else if (val instanceof Number number) {
+            if (val instanceof Long l) {
+              rowNode.put(col, l);
+            } else if (val instanceof Integer i) {
+              rowNode.put(col, i);
+            } else if (val instanceof Double d) {
+              rowNode.put(col, d);
+            } else if (val instanceof Float f) {
+              rowNode.put(col, f);
+            } else {
+              rowNode.put(col, number.longValue());
+            }
+          } else if (val instanceof Boolean b) {
+            rowNode.put(col, b);
+          } else if (val instanceof byte[] bytes) {
+            rowNode.put(col, bytes);
+          } else {
+            rowNode.put(col, val.toString());
+          }
+        }
+        allRows.add(rowNode);
+      }
+
+      if (rows.size() < BATCH_SIZE) {
+        break;
+      }
+      offset += BATCH_SIZE;
+    }
+
+    byte[] tableData = MAPPER.writeValueAsBytes(allRows);
+    TarArchiveEntry entry = new TarArchiveEntry("tables/" + tableName + ".json");
+    entry.setSize(tableData.length);
+    taos.putArchiveEntry(entry);
+    taos.write(tableData);
+    taos.closeArchiveEntry();
+
+    ObjectNode tableInfo = MAPPER.createObjectNode();
+    ArrayNode columnsArray = MAPPER.createArrayNode();
+    columns.forEach(columnsArray::add);
+    tableInfo.set("columns", columnsArray);
+    tableInfo.put("rowCount", allRows.size());
+    tablesMetadata.set(tableName, tableInfo);
+
+    LOG.info("Backed up table {} ({} rows, {} columns)", tableName, allRows.size(), columns.size());
+  }
+
+  public void restore(String backupPath, boolean force) throws IOException {
+    LOG.info("Starting database restore from {}", backupPath);
+
+    ObjectNode metadata = readMetadata(backupPath);
+    String backupDbType = metadata.get("databaseType").asText();
+    if (!backupDbType.equals(connectionType.name())) {
+      throw new IllegalStateException(
+          String.format(
+              "Backup database type '%s' does not match current connection type '%s'",
+              backupDbType, connectionType.name()));
+    }
+
+    LOG.info(
+        "Backup info - version: {}, timestamp: {}, databaseType: {}",
+        metadata.get("version").asText(),
+        metadata.get("timestamp").asText(),
+        backupDbType);
+
+    ObjectNode tablesMetadata = (ObjectNode) metadata.get("tables");
+
+    jdbi.useHandle(
+        handle -> {
+          if (force) {
+            truncateAllTables(handle, tablesMetadata);
+          } else {
+            validateTablesEmpty(handle, tablesMetadata);
+          }
+        });
+
+    try {
+      jdbi.useHandle(this::disableForeignKeyChecks);
+      restoreTablesFromArchive(backupPath, tablesMetadata);
+      LOG.info("Restore completed successfully");
+    } finally {
+      jdbi.useHandle(this::enableForeignKeyChecks);
+    }
+  }
+
+  private ObjectNode readMetadata(String backupPath) throws IOException {
+    try (FileInputStream fis = new FileInputStream(backupPath);
+        BufferedInputStream bis = new BufferedInputStream(fis);
+        GzipCompressorInputStream gzis = new GzipCompressorInputStream(bis);
+        TarArchiveInputStream tais = new TarArchiveInputStream(gzis)) {
+
+      TarArchiveEntry entry;
+      while ((entry = tais.getNextEntry()) != null) {
+        if ("metadata.json".equals(entry.getName())) {
+          byte[] content = tais.readAllBytes();
+          return (ObjectNode) MAPPER.readTree(content);
+        }
+      }
+    }
+    throw new IOException("metadata.json not found in backup archive");
+  }
+
+  private void restoreTablesFromArchive(String backupPath, ObjectNode tablesMetadata)
+      throws IOException {
+    try (FileInputStream fis = new FileInputStream(backupPath);
+        BufferedInputStream bis = new BufferedInputStream(fis);
+        GzipCompressorInputStream gzis = new GzipCompressorInputStream(bis);
+        TarArchiveInputStream tais = new TarArchiveInputStream(gzis)) {
+
+      TarArchiveEntry entry;
+      while ((entry = tais.getNextEntry()) != null) {
+        String name = entry.getName();
+        if (!name.startsWith("tables/") || !name.endsWith(".json")) {
+          continue;
+        }
+
+        String tableName = name.substring("tables/".length(), name.length() - ".json".length());
+        JsonNode tableMetaNode = tablesMetadata.get(tableName);
+        if (tableMetaNode == null) {
+          LOG.warn("No metadata found for table {}, skipping", tableName);
+          continue;
+        }
+
+        List<String> columns = new ArrayList<>();
+        tableMetaNode.get("columns").forEach(col -> columns.add(col.asText()));
+
+        byte[] content = tais.readAllBytes();
+        ArrayNode rows = (ArrayNode) MAPPER.readTree(content);
+
+        if (rows.isEmpty()) {
+          LOG.info("Table {} has no rows, skipping", tableName);
+          continue;
+        }
+
+        LOG.info("Restoring table {} ({} rows)", tableName, rows.size());
+        jdbi.useHandle(handle -> insertRows(handle, tableName, columns, rows));
+      }
+    }
+  }
+
+  private void validateTablesEmpty(Handle handle, ObjectNode tablesMetadata) {
+    List<String> nonEmptyTables = new ArrayList<>();
+    tablesMetadata
+        .fieldNames()
+        .forEachRemaining(
+            tableName -> {
+              String sql = String.format("SELECT COUNT(*) FROM %s", quoteIdentifier(tableName));
+              int count = handle.createQuery(sql).mapTo(Integer.class).one();
+              if (count > 0) {
+                nonEmptyTables.add(tableName + " (" + count + " rows)");
+              }
+            });
+
+    if (!nonEmptyTables.isEmpty()) {
+      throw new IllegalStateException(
+          "Cannot restore: the following tables are not empty. Use --force to truncate them: "
+              + String.join(", ", nonEmptyTables));
+    }
+  }
+
+  private void truncateAllTables(Handle handle, ObjectNode tablesMetadata) {
+    LOG.info("Truncating all target tables (force mode)");
+    disableForeignKeyChecks(handle);
+    try {
+      tablesMetadata
+          .fieldNames()
+          .forEachRemaining(
+              tableName -> {
+                String sql = String.format("TRUNCATE TABLE %s", quoteIdentifier(tableName));
+                handle.execute(sql);
+                LOG.info("Truncated table {}", tableName);
+              });
+    } finally {
+      enableForeignKeyChecks(handle);
+    }
+  }
+
+  void insertRows(Handle handle, String tableName, List<String> columns, ArrayNode rows) {
+    String quotedColumns = quoteColumns(columns);
+    String placeholders = columns.stream().map(c -> ":" + c).collect(Collectors.joining(", "));
+    String sql =
+        String.format(
+            "INSERT INTO %s (%s) VALUES (%s)",
+            quoteIdentifier(tableName), quotedColumns, placeholders);
+
+    int totalRows = rows.size();
+    for (int start = 0; start < totalRows; start += BATCH_SIZE) {
+      int end = Math.min(start + BATCH_SIZE, totalRows);
+      var batch = handle.prepareBatch(sql);
+      for (int i = start; i < end; i++) {
+        JsonNode row = rows.get(i);
+        for (String col : columns) {
+          JsonNode val = row.get(col);
+          if (val == null || val.isNull()) {
+            batch.bindNull(col, Types.VARCHAR);
+          } else if (val.isNumber()) {
+            if (val.isLong() || val.isInt() || val.isBigInteger()) {
+              batch.bind(col, val.longValue());
+            } else {
+              batch.bind(col, val.doubleValue());
+            }
+          } else if (val.isBoolean()) {
+            batch.bind(col, val.booleanValue());
+          } else {
+            batch.bind(col, val.asText());
+          }
+        }
+        batch.add();
+      }
+      batch.execute();
+    }
+  }
+
+  private void disableForeignKeyChecks(Handle handle) {
+    if (connectionType == ConnectionType.MYSQL) {
+      handle.execute("SET FOREIGN_KEY_CHECKS = 0");
+    } else {
+      handle.execute("SET session_replication_role = 'replica'");
+    }
+  }
+
+  private void enableForeignKeyChecks(Handle handle) {
+    if (connectionType == ConnectionType.MYSQL) {
+      handle.execute("SET FOREIGN_KEY_CHECKS = 1");
+    } else {
+      handle.execute("SET session_replication_role = 'origin'");
+    }
+  }
+
+  String quoteIdentifier(String identifier) {
+    if (connectionType == ConnectionType.MYSQL) {
+      return "`" + identifier + "`";
+    }
+    return "\"" + identifier + "\"";
+  }
+
+  String quoteColumns(List<String> columns) {
+    return columns.stream().map(this::quoteIdentifier).collect(Collectors.joining(", "));
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/DatabaseBackupRestore.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/DatabaseBackupRestore.java
@@ -215,7 +215,7 @@ public class DatabaseBackupRestore {
   public void restore(String backupPath, boolean force) throws IOException {
     LOG.info("Starting database restore from {}", backupPath);
 
-    ObjectNode metadata = readMetadata(backupPath);
+    ObjectNode metadata = readBackupMetadata(backupPath);
     String backupDbType = metadata.get("databaseType").asText();
     if (!backupDbType.equals(connectionType.name())) {
       throw new IllegalStateException(
@@ -250,7 +250,7 @@ public class DatabaseBackupRestore {
     }
   }
 
-  private ObjectNode readMetadata(String backupPath) throws IOException {
+  public static ObjectNode readBackupMetadata(String backupPath) throws IOException {
     try (FileInputStream fis = new FileInputStream(backupPath);
         BufferedInputStream bis = new BufferedInputStream(fis);
         GzipCompressorInputStream gzis = new GzipCompressorInputStream(bis);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/DatabaseBackupRestore.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/DatabaseBackupRestore.java
@@ -34,6 +34,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
@@ -113,7 +114,6 @@ public class DatabaseBackupRestore {
           "SELECT column_name FROM information_schema.columns "
               + "WHERE table_schema = current_schema() AND table_name = :table "
               + "AND (is_generated = 'NEVER' OR is_generated IS NULL) "
-              + "AND (column_default NOT LIKE 'nextval%' OR column_default IS NULL) "
               + "ORDER BY ordinal_position";
       return handle.createQuery(sql).bind("table", tableName).mapTo(String.class).list();
     }
@@ -310,8 +310,10 @@ public class DatabaseBackupRestore {
               for (String tableName : tables) {
                 backupTable(handle, tableName, taos, tablesMetadata);
               }
-            } finally {
               commitTransaction(handle);
+            } catch (Exception e) {
+              rollbackTransaction(handle);
+              throw e;
             }
           });
 
@@ -339,6 +341,14 @@ public class DatabaseBackupRestore {
 
   private void commitTransaction(Handle handle) {
     handle.execute("COMMIT");
+  }
+
+  private void rollbackTransaction(Handle handle) {
+    try {
+      handle.execute("ROLLBACK");
+    } catch (Exception e) {
+      LOG.warn("Failed to rollback transaction", e);
+    }
   }
 
   private void backupTable(
@@ -428,55 +438,48 @@ public class DatabaseBackupRestore {
       Path tempFile)
       throws IOException {
     int rowCount = 0;
+    String sql = String.format("SELECT %s FROM %s%s", quotedColumns, quotedTable, orderByClause);
+    int fetchSize = connectionType == ConnectionType.MYSQL ? Integer.MIN_VALUE : batchSize;
+
     try (OutputStream os = new BufferedOutputStream(new FileOutputStream(tempFile.toFile()));
-        JsonGenerator gen = new JsonFactory().createGenerator(os)) {
+        JsonGenerator gen = new JsonFactory().createGenerator(os);
+        Stream<Map<String, Object>> rows =
+            handle.createQuery(sql).setFetchSize(fetchSize).mapToMap().stream()) {
       gen.setCodec(MAPPER);
       gen.writeStartArray();
 
-      int offset = 0;
-      while (true) {
-        String sql =
-            String.format(
-                "SELECT %s FROM %s%s LIMIT %d OFFSET %d",
-                quotedColumns, quotedTable, orderByClause, batchSize, offset);
-        List<Map<String, Object>> rows = handle.createQuery(sql).mapToMap().list();
-
-        for (Map<String, Object> row : rows) {
-          gen.writeStartObject();
-          for (String col : columns) {
-            Object val = row.get(col);
-            if (val == null) {
-              gen.writeNullField(col);
-            } else if (val instanceof Number number) {
-              if (number instanceof Long l) {
-                gen.writeNumberField(col, l);
-              } else if (number instanceof Integer i) {
-                gen.writeNumberField(col, i);
-              } else if (number instanceof Double d) {
-                gen.writeNumberField(col, d);
-              } else if (number instanceof Float f) {
-                gen.writeNumberField(col, f);
-              } else if (number instanceof BigDecimal bd) {
-                gen.writeNumberField(col, bd);
-              } else {
-                gen.writeNumberField(col, number.longValue());
-              }
-            } else if (val instanceof Boolean b) {
-              gen.writeBooleanField(col, b);
-            } else if (val instanceof byte[] bytes) {
-              gen.writeBinaryField(col, bytes);
+      var iter = rows.iterator();
+      while (iter.hasNext()) {
+        Map<String, Object> row = iter.next();
+        gen.writeStartObject();
+        for (String col : columns) {
+          Object val = row.get(col);
+          if (val == null) {
+            gen.writeNullField(col);
+          } else if (val instanceof Number number) {
+            if (number instanceof Long l) {
+              gen.writeNumberField(col, l);
+            } else if (number instanceof Integer i) {
+              gen.writeNumberField(col, i);
+            } else if (number instanceof Double d) {
+              gen.writeNumberField(col, d);
+            } else if (number instanceof Float f) {
+              gen.writeNumberField(col, f);
+            } else if (number instanceof BigDecimal bd) {
+              gen.writeNumberField(col, bd);
             } else {
-              gen.writeStringField(col, val.toString());
+              gen.writeNumberField(col, number.longValue());
             }
+          } else if (val instanceof Boolean b) {
+            gen.writeBooleanField(col, b);
+          } else if (val instanceof byte[] bytes) {
+            gen.writeBinaryField(col, bytes);
+          } else {
+            gen.writeStringField(col, val.toString());
           }
-          gen.writeEndObject();
-          rowCount++;
         }
-
-        if (rows.size() < batchSize) {
-          break;
-        }
-        offset += batchSize;
+        gen.writeEndObject();
+        rowCount++;
       }
 
       gen.writeEndArray();
@@ -530,6 +533,7 @@ public class DatabaseBackupRestore {
     Path tempDir = Files.createTempDirectory("om_restore_");
     try {
       extractArchive(backupPath, tempDir, validTables);
+      validateArchiveCompleteness(tempDir, validTables);
       jdbi.useHandle(
           handle -> {
             Set<String> existingTables = new HashSet<>(discoverTables(handle));
@@ -552,6 +556,7 @@ public class DatabaseBackupRestore {
             restorableTables.forEach(t -> restorableMetadata.set(t, tablesMetadata.get(t)));
 
             restoreTablesInOrder(handle, insertOrder, restorableMetadata, tempDir);
+            resetSequences(handle);
             validateRestore(handle, restorableMetadata);
             LOG.info("Restore completed successfully");
           });
@@ -574,7 +579,13 @@ public class DatabaseBackupRestore {
                 "metadata.json exceeds maximum allowed size of " + MAX_METADATA_SIZE + " bytes");
           }
           byte[] content = tais.readNBytes((int) entry.getSize());
-          return (ObjectNode) MAPPER.readTree(content);
+          ObjectNode node = (ObjectNode) MAPPER.readTree(content);
+          for (String field : List.of("version", "databaseType", "tables")) {
+            if (!node.has(field)) {
+              throw new IOException("Backup metadata missing required field: " + field);
+            }
+          }
+          return node;
         }
       }
     }
@@ -608,6 +619,49 @@ public class DatabaseBackupRestore {
           tais.transferTo(os);
         }
       }
+    }
+  }
+
+  private void validateArchiveCompleteness(Path tempDir, Set<String> expectedTables)
+      throws IOException {
+    Set<String> missing = new HashSet<>();
+    for (String table : expectedTables) {
+      if (!Files.exists(tempDir.resolve(table + ".json"))) {
+        missing.add(table);
+      }
+    }
+    if (!missing.isEmpty()) {
+      throw new IOException(
+          String.format(
+              "Backup archive is incomplete: %d table(s) listed in metadata but missing from "
+                  + "archive: %s",
+              missing.size(), missing));
+    }
+  }
+
+  private void resetSequences(Handle handle) {
+    if (connectionType != ConnectionType.POSTGRES) {
+      return;
+    }
+    List<Map<String, Object>> seqColumns =
+        handle
+            .createQuery(
+                "SELECT table_name, column_name FROM information_schema.columns "
+                    + "WHERE table_schema = current_schema() "
+                    + "AND column_default LIKE 'nextval%'")
+            .mapToMap()
+            .list();
+
+    for (Map<String, Object> row : seqColumns) {
+      String tableName = (String) row.get("table_name");
+      String columnName = (String) row.get("column_name");
+      String sql =
+          String.format(
+              "SELECT setval(pg_get_serial_sequence(?, ?), "
+                  + "COALESCE((SELECT MAX(%s) FROM %s), 1))",
+              quoteIdentifier(columnName), quoteIdentifier(tableName));
+      handle.createQuery(sql).bind(0, tableName).bind(1, columnName).mapTo(Long.class).findOne();
+      LOG.info("Reset sequence for {}.{}", tableName, columnName);
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/DatabaseBackupRestore.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/DatabaseBackupRestore.java
@@ -19,6 +19,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -117,6 +118,30 @@ public class DatabaseBackupRestore {
               + "AND tc.constraint_type = 'PRIMARY KEY' "
               + "ORDER BY kcu.ordinal_position";
       return handle.createQuery(sql).bind("table", tableName).mapTo(String.class).list();
+    }
+  }
+
+  Set<String> discoverBinaryColumns(Handle handle, String tableName) {
+    String sql;
+    if (connectionType == ConnectionType.MYSQL) {
+      sql =
+          "SELECT column_name FROM information_schema.columns "
+              + "WHERE table_schema = :db AND table_name = :table "
+              + "AND data_type IN ('blob', 'tinyblob', 'mediumblob', 'longblob', 'binary', 'varbinary')";
+      return new HashSet<>(
+          handle
+              .createQuery(sql)
+              .bind("db", databaseName)
+              .bind("table", tableName)
+              .mapTo(String.class)
+              .list());
+    } else {
+      sql =
+          "SELECT column_name FROM information_schema.columns "
+              + "WHERE table_schema = current_schema() AND table_name = :table "
+              + "AND data_type = 'bytea'";
+      return new HashSet<>(
+          handle.createQuery(sql).bind("table", tableName).mapTo(String.class).list());
     }
   }
 
@@ -219,10 +244,15 @@ public class DatabaseBackupRestore {
       Files.deleteIfExists(tempFile);
     }
 
+    Set<String> binaryColumns = discoverBinaryColumns(handle, tableName);
+
     ObjectNode tableInfo = MAPPER.createObjectNode();
     ArrayNode columnsArray = MAPPER.createArrayNode();
     columns.forEach(columnsArray::add);
     tableInfo.set("columns", columnsArray);
+    ArrayNode binaryColumnsArray = MAPPER.createArrayNode();
+    binaryColumns.forEach(binaryColumnsArray::add);
+    tableInfo.set("binaryColumns", binaryColumnsArray);
     tableInfo.put("rowCount", rowCount);
     tablesMetadata.set(tableName, tableInfo);
 
@@ -400,8 +430,14 @@ public class DatabaseBackupRestore {
         List<String> columns = new ArrayList<>();
         tableMetaNode.get("columns").forEach(col -> columns.add(col.asText()));
 
+        Set<String> binaryColumns = new HashSet<>();
+        JsonNode binaryColumnsNode = tableMetaNode.get("binaryColumns");
+        if (binaryColumnsNode != null) {
+          binaryColumnsNode.forEach(col -> binaryColumns.add(col.asText()));
+        }
+
         LOG.info("Restoring table {}", tableName);
-        int rowCount = insertRowsStreaming(handle, tableName, columns, tais);
+        int rowCount = insertRowsStreaming(handle, tableName, columns, binaryColumns, tais);
         LOG.info("Restored table {} ({} rows)", tableName, rowCount);
       }
     }
@@ -445,7 +481,11 @@ public class DatabaseBackupRestore {
   }
 
   int insertRowsStreaming(
-      Handle handle, String tableName, List<String> columns, TarArchiveInputStream tais)
+      Handle handle,
+      String tableName,
+      List<String> columns,
+      Set<String> binaryColumns,
+      TarArchiveInputStream tais)
       throws IOException {
     String quotedColumns = quoteColumns(columns);
     String placeholders = columns.stream().map(c -> "?").collect(Collectors.joining(", "));
@@ -471,8 +511,8 @@ public class DatabaseBackupRestore {
           JsonNode val = row.get(col);
           if (val == null || val.isNull()) {
             batch.bind(idx, (Object) null);
-          } else if (val.isBinary()) {
-            batch.bind(idx, val.binaryValue());
+          } else if (binaryColumns.contains(col)) {
+            batch.bind(idx, Base64.getDecoder().decode(val.asText()));
           } else if (val.isNumber()) {
             if (val.isLong() || val.isInt() || val.isBigInteger()) {
               batch.bind(idx, val.longValue());

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/DatabaseBackupRestore.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/DatabaseBackupRestore.java
@@ -15,6 +15,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.math.BigDecimal;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -39,6 +40,7 @@ import org.openmetadata.service.jdbi3.locator.ConnectionType;
 public class DatabaseBackupRestore {
 
   private static final int BATCH_SIZE = 1000;
+  private static final long MAX_METADATA_SIZE = 10 * 1024 * 1024;
   private static final ObjectMapper MAPPER =
       new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
 
@@ -232,6 +234,7 @@ public class DatabaseBackupRestore {
 
     List<String> pkColumns = discoverPrimaryKeyColumns(handle, tableName);
     String orderByClause = buildOrderByClause(pkColumns, columns);
+    Set<String> binaryColumns = discoverBinaryColumns(handle, tableName);
 
     Path tempFile = Files.createTempFile("backup_" + tableName + "_", ".json");
     int rowCount;
@@ -243,8 +246,6 @@ public class DatabaseBackupRestore {
     } finally {
       Files.deleteIfExists(tempFile);
     }
-
-    Set<String> binaryColumns = discoverBinaryColumns(handle, tableName);
 
     ObjectNode tableInfo = MAPPER.createObjectNode();
     ArrayNode columnsArray = MAPPER.createArrayNode();
@@ -302,6 +303,8 @@ public class DatabaseBackupRestore {
                 gen.writeNumberField(col, d);
               } else if (number instanceof Float f) {
                 gen.writeNumberField(col, f);
+              } else if (number instanceof BigDecimal bd) {
+                gen.writeNumberField(col, bd);
               } else {
                 gen.writeNumberField(col, number.longValue());
               }
@@ -366,14 +369,13 @@ public class DatabaseBackupRestore {
 
     jdbi.useHandle(
         handle -> {
-          if (force) {
-            truncateAllTables(handle, tablesMetadata);
-          } else {
-            validateTablesEmpty(handle, tablesMetadata);
-          }
-
           disableForeignKeyChecks(handle);
           try {
+            if (force) {
+              truncateAllTables(handle, tablesMetadata);
+            } else {
+              validateTablesEmpty(handle, tablesMetadata);
+            }
             restoreTablesFromArchive(handle, backupPath, tablesMetadata, validTables);
             LOG.info("Restore completed successfully");
           } finally {
@@ -391,7 +393,11 @@ public class DatabaseBackupRestore {
       TarArchiveEntry entry;
       while ((entry = tais.getNextEntry()) != null) {
         if ("metadata.json".equals(entry.getName())) {
-          byte[] content = tais.readAllBytes();
+          if (entry.getSize() > MAX_METADATA_SIZE) {
+            throw new IOException(
+                "metadata.json exceeds maximum allowed size of " + MAX_METADATA_SIZE + " bytes");
+          }
+          byte[] content = tais.readNBytes((int) entry.getSize());
           return (ObjectNode) MAPPER.readTree(content);
         }
       }
@@ -465,19 +471,14 @@ public class DatabaseBackupRestore {
 
   private void truncateAllTables(Handle handle, ObjectNode tablesMetadata) {
     LOG.info("Truncating all target tables (force mode)");
-    disableForeignKeyChecks(handle);
-    try {
-      tablesMetadata
-          .fieldNames()
-          .forEachRemaining(
-              tableName -> {
-                String sql = String.format("TRUNCATE TABLE %s", quoteIdentifier(tableName));
-                handle.execute(sql);
-                LOG.info("Truncated table {}", tableName);
-              });
-    } finally {
-      enableForeignKeyChecks(handle);
-    }
+    tablesMetadata
+        .fieldNames()
+        .forEachRemaining(
+            tableName -> {
+              String sql = String.format("TRUNCATE TABLE %s", quoteIdentifier(tableName));
+              handle.execute(sql);
+              LOG.info("Truncated table {}", tableName);
+            });
   }
 
   int insertRowsStreaming(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/DatabaseBackupRestore.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/DatabaseBackupRestore.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
@@ -41,6 +42,7 @@ public class DatabaseBackupRestore {
 
   public static final int DEFAULT_BATCH_SIZE = 1000;
   private static final long MAX_METADATA_SIZE = 10 * 1024 * 1024;
+  private static final Pattern SAFE_IDENTIFIER = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_]*$");
   private static final ObjectMapper MAPPER =
       new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
 
@@ -568,10 +570,13 @@ public class DatabaseBackupRestore {
   }
 
   String quoteIdentifier(String identifier) {
-    if (connectionType == ConnectionType.MYSQL) {
-      return "`" + identifier.replace("`", "``") + "`";
+    if (!SAFE_IDENTIFIER.matcher(identifier).matches()) {
+      throw new IllegalArgumentException("Invalid SQL identifier: " + identifier);
     }
-    return "\"" + identifier.replace("\"", "\"\"") + "\"";
+    if (connectionType == ConnectionType.MYSQL) {
+      return "`" + identifier + "`";
+    }
+    return "\"" + identifier + "\"";
   }
 
   String quoteColumns(List<String> columns) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/DatabaseBackupRestore.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/DatabaseBackupRestore.java
@@ -14,16 +14,23 @@ import java.io.BufferedOutputStream;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.math.BigDecimal;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -43,6 +50,9 @@ public class DatabaseBackupRestore {
   public static final int DEFAULT_BATCH_SIZE = 1000;
   private static final long MAX_METADATA_SIZE = 10 * 1024 * 1024;
   private static final Pattern SAFE_IDENTIFIER = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_]*$");
+  private static final DateTimeFormatter BACKUP_TIMESTAMP_FORMAT =
+      DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss").withZone(ZoneOffset.UTC);
+  private static final List<String> EXCLUDED_TABLE_PREFIXES = List.of("act_", "flw_", "qrtz_");
   private static final ObjectMapper MAPPER =
       new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
 
@@ -77,6 +87,11 @@ public class DatabaseBackupRestore {
               + "ORDER BY table_name";
       return handle.createQuery(sql).mapTo(String.class).list();
     }
+  }
+
+  static boolean isExcludedFrameworkTable(String tableName) {
+    String lower = tableName.toLowerCase();
+    return EXCLUDED_TABLE_PREFIXES.stream().anyMatch(lower::startsWith);
   }
 
   public List<String> discoverColumns(Handle handle, String tableName) {
@@ -132,6 +147,48 @@ public class DatabaseBackupRestore {
     }
   }
 
+  Set<String> discoverJsonbColumns(Handle handle, String tableName) {
+    if (connectionType == ConnectionType.POSTGRES) {
+      String sql =
+          "SELECT column_name FROM information_schema.columns "
+              + "WHERE table_schema = current_schema() AND table_name = :table "
+              + "AND data_type = 'jsonb'";
+      return new HashSet<>(
+          handle.createQuery(sql).bind("table", tableName).mapTo(String.class).list());
+    }
+    return Set.of();
+  }
+
+  Map<String, String> discoverCastableColumns(Handle handle, String tableName) {
+    if (connectionType == ConnectionType.POSTGRES) {
+      String sql =
+          "SELECT column_name, data_type FROM information_schema.columns "
+              + "WHERE table_schema = current_schema() AND table_name = :table "
+              + "AND data_type IN ('uuid', 'timestamp without time zone', 'timestamp with time zone')";
+      Map<String, String> result = new HashMap<>();
+      handle
+          .createQuery(sql)
+          .bind("table", tableName)
+          .map(
+              (rs, ctx) -> {
+                result.put(rs.getString("column_name"), rs.getString("data_type"));
+                return null;
+              })
+          .list();
+      return result;
+    }
+    return Map.of();
+  }
+
+  static String pgCastFor(String dataType) {
+    return switch (dataType) {
+      case "uuid" -> "uuid";
+      case "timestamp without time zone" -> "timestamp";
+      case "timestamp with time zone" -> "timestamptz";
+      default -> null;
+    };
+  }
+
   Set<String> discoverBinaryColumns(Handle handle, String tableName) {
     String sql;
     if (connectionType == ConnectionType.MYSQL) {
@@ -173,7 +230,47 @@ public class DatabaseBackupRestore {
     return dbName;
   }
 
-  public void backup(String backupPath) throws IOException {
+  static String getCatalogVersion() {
+    try (InputStream in = DatabaseBackupRestore.class.getResourceAsStream("/catalog/VERSION")) {
+      if (in != null) {
+        Properties props = new Properties();
+        props.load(in);
+        return props.getProperty("version", "unknown");
+      }
+    } catch (IOException e) {
+      LOG.warn("Failed to read /catalog/VERSION", e);
+    }
+    return "unknown";
+  }
+
+  static List<String> queryMigrationVersions(Handle handle) {
+    try {
+      return handle
+          .createQuery("SELECT version FROM SERVER_CHANGE_LOG ORDER BY version")
+          .mapTo(String.class)
+          .list();
+    } catch (Exception e) {
+      LOG.warn("Could not query SERVER_CHANGE_LOG for migration versions", e);
+      return List.of();
+    }
+  }
+
+  static String buildBackupFileName(String version, Instant timestamp) {
+    String safeVersion = version.replace(".", "_");
+    String ts = BACKUP_TIMESTAMP_FORMAT.format(timestamp);
+    return String.format("openmetadata_%s_%s.tar.gz", safeVersion, ts);
+  }
+
+  public String backup(String backupDir) throws IOException {
+    Path dir = Path.of(backupDir);
+    if (!Files.isDirectory(dir)) {
+      throw new IOException("Backup path is not a directory: " + backupDir);
+    }
+    String version = getCatalogVersion();
+    String fileName = buildBackupFileName(version, Instant.now());
+    Path backupFile = dir.resolve(fileName);
+    String backupPath = backupFile.toString();
+
     LOG.info("Starting database backup to {}", backupPath);
     try (FileOutputStream fos = new FileOutputStream(backupPath);
         BufferedOutputStream bos = new BufferedOutputStream(fos);
@@ -184,7 +281,7 @@ public class DatabaseBackupRestore {
 
       ObjectNode metadata = MAPPER.createObjectNode();
       metadata.put("timestamp", Instant.now().toString());
-      metadata.put("version", System.getProperty("project.version", "unknown"));
+      metadata.put("version", version);
       metadata.put("databaseType", connectionType.name());
       metadata.put("databaseName", databaseName);
       ObjectNode tablesMetadata = MAPPER.createObjectNode();
@@ -193,8 +290,22 @@ public class DatabaseBackupRestore {
           handle -> {
             beginRepeatableReadTransaction(handle);
             try {
-              List<String> tables = discoverTables(handle);
-              LOG.info("Discovered {} tables", tables.size());
+              List<String> migrationVersions = queryMigrationVersions(handle);
+              ArrayNode versionsArray = MAPPER.createArrayNode();
+              migrationVersions.forEach(versionsArray::add);
+              metadata.set("migrationVersions", versionsArray);
+              LOG.info(
+                  "Recorded {} migration versions in backup metadata", migrationVersions.size());
+
+              List<String> allTables = discoverTables(handle);
+              List<String> tables =
+                  allTables.stream()
+                      .filter(t -> !isExcludedFrameworkTable(t))
+                      .collect(Collectors.toList());
+              LOG.info(
+                  "Backing up {} tables ({} framework-managed tables skipped)",
+                  tables.size(),
+                  allTables.size() - tables.size());
 
               for (String tableName : tables) {
                 backupTable(handle, tableName, taos, tablesMetadata);
@@ -212,8 +323,9 @@ public class DatabaseBackupRestore {
       taos.write(metadataBytes);
       taos.closeArchiveEntry();
 
-      LOG.info("Backup completed successfully");
+      LOG.info("Backup completed successfully: {}", backupPath);
     }
+    return backupPath;
   }
 
   private void beginRepeatableReadTransaction(Handle handle) {
@@ -242,8 +354,9 @@ public class DatabaseBackupRestore {
     String quotedTable = quoteIdentifier(tableName);
 
     List<String> pkColumns = discoverPrimaryKeyColumns(handle, tableName);
-    String orderByClause = buildOrderByClause(pkColumns, columns);
+    String orderByClause = buildOrderByClause(handle, tableName, pkColumns, columns);
     Set<String> binaryColumns = discoverBinaryColumns(handle, tableName);
+    Set<String> jsonbColumns = discoverJsonbColumns(handle, tableName);
 
     Path tempFile = Files.createTempFile("backup_" + tableName + "_", ".json");
     int rowCount;
@@ -263,16 +376,47 @@ public class DatabaseBackupRestore {
     ArrayNode binaryColumnsArray = MAPPER.createArrayNode();
     binaryColumns.forEach(binaryColumnsArray::add);
     tableInfo.set("binaryColumns", binaryColumnsArray);
+    if (!jsonbColumns.isEmpty()) {
+      ArrayNode jsonbColumnsArray = MAPPER.createArrayNode();
+      jsonbColumns.forEach(jsonbColumnsArray::add);
+      tableInfo.set("jsonbColumns", jsonbColumnsArray);
+    }
     tableInfo.put("rowCount", rowCount);
     tablesMetadata.set(tableName, tableInfo);
 
     LOG.info("Backed up table {} ({} rows, {} columns)", tableName, rowCount, columns.size());
   }
 
-  private String buildOrderByClause(List<String> pkColumns, List<String> allColumns) {
-    List<String> orderColumns = pkColumns.isEmpty() ? List.of(allColumns.get(0)) : pkColumns;
-    return " ORDER BY "
-        + orderColumns.stream().map(this::quoteIdentifier).collect(Collectors.joining(", "));
+  private String buildOrderByClause(
+      Handle handle, String tableName, List<String> pkColumns, List<String> allColumns) {
+    if (!pkColumns.isEmpty()) {
+      return " ORDER BY "
+          + pkColumns.stream().map(this::quoteIdentifier).collect(Collectors.joining(", "));
+    }
+    Set<String> unorderableColumns = discoverUnorderableColumns(handle, tableName);
+    List<String> orderableCandidates =
+        allColumns.stream().filter(c -> !unorderableColumns.contains(c)).toList();
+    if (orderableCandidates.isEmpty()) {
+      if (connectionType == ConnectionType.POSTGRES) {
+        return " ORDER BY ctid";
+      }
+      return "";
+    }
+    return " ORDER BY " + quoteIdentifier(orderableCandidates.get(0));
+  }
+
+  Set<String> discoverUnorderableColumns(Handle handle, String tableName) {
+    String sql;
+    if (connectionType == ConnectionType.MYSQL) {
+      return Set.of();
+    } else {
+      sql =
+          "SELECT column_name FROM information_schema.columns "
+              + "WHERE table_schema = current_schema() AND table_name = :table "
+              + "AND data_type = 'json'";
+      return new HashSet<>(
+          handle.createQuery(sql).bind("table", tableName).mapTo(String.class).list());
+    }
   }
 
   private int writeTableToTempFile(
@@ -353,7 +497,7 @@ public class DatabaseBackupRestore {
     taos.closeArchiveEntry();
   }
 
-  public void restore(String backupPath, boolean force) throws IOException {
+  public void restore(String backupPath) throws IOException {
     LOG.info("Starting database restore from {}", backupPath);
 
     ObjectNode metadata = readBackupMetadata(backupPath);
@@ -374,23 +518,46 @@ public class DatabaseBackupRestore {
     ObjectNode tablesMetadata = (ObjectNode) metadata.get("tables");
 
     Set<String> validTables = new HashSet<>();
-    tablesMetadata.fieldNames().forEachRemaining(validTables::add);
+    tablesMetadata
+        .fieldNames()
+        .forEachRemaining(
+            t -> {
+              if (!isExcludedFrameworkTable(t) && SAFE_IDENTIFIER.matcher(t).matches()) {
+                validTables.add(t);
+              }
+            });
 
-    jdbi.useHandle(
-        handle -> {
-          disableForeignKeyChecks(handle);
-          try {
-            if (force) {
-              truncateAllTables(handle, tablesMetadata);
-            } else {
-              validateTablesEmpty(handle, tablesMetadata);
+    Path tempDir = Files.createTempDirectory("om_restore_");
+    try {
+      extractArchive(backupPath, tempDir, validTables);
+      jdbi.useHandle(
+          handle -> {
+            Set<String> existingTables = new HashSet<>(discoverTables(handle));
+            Set<String> restorableTables = new HashSet<>(validTables);
+            restorableTables.retainAll(existingTables);
+
+            if (restorableTables.size() < validTables.size()) {
+              Set<String> skipped = new HashSet<>(validTables);
+              skipped.removeAll(restorableTables);
+              LOG.warn(
+                  "Skipping {} tables from backup that do not exist in the current schema: {}",
+                  skipped.size(),
+                  skipped);
             }
-            restoreTablesFromArchive(handle, backupPath, tablesMetadata, validTables);
+
+            Map<String, Set<String>> dependencies = discoverForeignKeyDependencies(handle);
+            List<String> insertOrder = topologicalSort(restorableTables, dependencies);
+
+            ObjectNode restorableMetadata = MAPPER.createObjectNode();
+            restorableTables.forEach(t -> restorableMetadata.set(t, tablesMetadata.get(t)));
+
+            restoreTablesInOrder(handle, insertOrder, restorableMetadata, tempDir);
+            validateRestore(handle, restorableMetadata);
             LOG.info("Restore completed successfully");
-          } finally {
-            enableForeignKeyChecks(handle);
-          }
-        });
+          });
+    } finally {
+      cleanupTempDirectory(tempDir);
+    }
   }
 
   public static ObjectNode readBackupMetadata(String backupPath) throws IOException {
@@ -414,8 +581,7 @@ public class DatabaseBackupRestore {
     throw new IOException("metadata.json not found in backup archive");
   }
 
-  private void restoreTablesFromArchive(
-      Handle handle, String backupPath, ObjectNode tablesMetadata, Set<String> validTables)
+  private void extractArchive(String backupPath, Path tempDir, Set<String> validTables)
       throws IOException {
     try (FileInputStream fis = new FileInputStream(backupPath);
         BufferedInputStream bis = new BufferedInputStream(fis);
@@ -428,66 +594,228 @@ public class DatabaseBackupRestore {
         if (!name.startsWith("tables/") || !name.endsWith(".json")) {
           continue;
         }
-
         String tableName = name.substring("tables/".length(), name.length() - ".json".length());
-
         if (!validTables.contains(tableName)) {
           LOG.warn("Table {} from archive not in metadata, skipping", tableName);
           continue;
         }
-
-        JsonNode tableMetaNode = tablesMetadata.get(tableName);
-        if (tableMetaNode == null) {
-          LOG.warn("No metadata found for table {}, skipping", tableName);
+        Path outFile = tempDir.resolve(tableName + ".json").normalize();
+        if (!outFile.startsWith(tempDir)) {
+          LOG.warn("Skipping archive entry with path outside temp directory: {}", name);
           continue;
         }
-
-        List<String> columns = new ArrayList<>();
-        tableMetaNode.get("columns").forEach(col -> columns.add(col.asText()));
-
-        Set<String> binaryColumns = new HashSet<>();
-        JsonNode binaryColumnsNode = tableMetaNode.get("binaryColumns");
-        if (binaryColumnsNode != null) {
-          binaryColumnsNode.forEach(col -> binaryColumns.add(col.asText()));
+        try (OutputStream os = new BufferedOutputStream(new FileOutputStream(outFile.toFile()))) {
+          tais.transferTo(os);
         }
+      }
+    }
+  }
 
-        LOG.info("Restoring table {}", tableName);
-        int rowCount = insertRowsStreaming(handle, tableName, columns, binaryColumns, tais);
+  private void restoreTablesInOrder(
+      Handle handle, List<String> orderedTables, ObjectNode tablesMetadata, Path tempDir)
+      throws IOException {
+    for (String tableName : orderedTables) {
+      JsonNode tableMetaNode = tablesMetadata.get(tableName);
+      if (tableMetaNode == null) {
+        LOG.warn("No metadata found for table {}, skipping", tableName);
+        continue;
+      }
+      Path tableFile = tempDir.resolve(tableName + ".json");
+      if (!Files.exists(tableFile)) {
+        LOG.warn("No data file found for table {}, skipping", tableName);
+        continue;
+      }
+
+      List<String> columns = new ArrayList<>();
+      tableMetaNode.get("columns").forEach(col -> columns.add(col.asText()));
+
+      Set<String> binaryColumns = new HashSet<>();
+      JsonNode binaryColumnsNode = tableMetaNode.get("binaryColumns");
+      if (binaryColumnsNode != null) {
+        binaryColumnsNode.forEach(col -> binaryColumns.add(col.asText()));
+      }
+
+      Set<String> jsonbColumns;
+      JsonNode jsonbColumnsNode = tableMetaNode.get("jsonbColumns");
+      if (jsonbColumnsNode != null) {
+        jsonbColumns = new HashSet<>();
+        jsonbColumnsNode.forEach(col -> jsonbColumns.add(col.asText()));
+      } else {
+        jsonbColumns = discoverJsonbColumns(handle, tableName);
+      }
+
+      Map<String, String> castableColumns = discoverCastableColumns(handle, tableName);
+
+      handle.execute(String.format("DELETE FROM %s", quoteIdentifier(tableName)));
+      LOG.info("Restoring table {}", tableName);
+      try (InputStream is = new BufferedInputStream(new FileInputStream(tableFile.toFile()))) {
+        int rowCount =
+            insertRowsStreaming(
+                handle, tableName, columns, binaryColumns, jsonbColumns, castableColumns, is);
         LOG.info("Restored table {} ({} rows)", tableName, rowCount);
       }
     }
   }
 
-  private void validateTablesEmpty(Handle handle, ObjectNode tablesMetadata) {
-    List<String> nonEmptyTables = new ArrayList<>();
+  void validateRestore(Handle handle, ObjectNode tablesMetadata) {
+    LOG.info("Validating restore...");
+    List<String> mismatches = new ArrayList<>();
+
     tablesMetadata
-        .fieldNames()
+        .fields()
         .forEachRemaining(
-            tableName -> {
-              String sql = String.format("SELECT COUNT(*) FROM %s", quoteIdentifier(tableName));
-              int count = handle.createQuery(sql).mapTo(Integer.class).one();
-              if (count > 0) {
-                nonEmptyTables.add(tableName + " (" + count + " rows)");
+            entry -> {
+              String tableName = entry.getKey();
+              JsonNode meta = entry.getValue();
+
+              int expectedRows = meta.has("rowCount") ? meta.get("rowCount").asInt() : -1;
+              int expectedColumns = meta.has("columns") ? meta.get("columns").size() : -1;
+
+              long actualRows =
+                  handle
+                      .createQuery(
+                          String.format("SELECT COUNT(*) FROM %s", quoteIdentifier(tableName)))
+                      .mapTo(Long.class)
+                      .one();
+
+              if (expectedRows > 0) {
+                LOG.info(
+                    "Validated table {}: {} rows (expected {})",
+                    tableName,
+                    actualRows,
+                    expectedRows);
+              }
+
+              if (expectedRows > 0 && actualRows != expectedRows) {
+                mismatches.add(
+                    String.format(
+                        "Table %s: expected %d rows, found %d",
+                        tableName, expectedRows, actualRows));
+              }
+
+              if (expectedColumns >= 0) {
+                List<String> actualColumns = discoverColumns(handle, tableName);
+                if (actualColumns.size() != expectedColumns) {
+                  mismatches.add(
+                      String.format(
+                          "Table %s: expected %d columns, found %d",
+                          tableName, expectedColumns, actualColumns.size()));
+                }
               }
             });
 
-    if (!nonEmptyTables.isEmpty()) {
+    if (mismatches.isEmpty()) {
+      LOG.info("Restore validation passed: all tables match expected row and column counts");
+    } else {
+      for (String mismatch : mismatches) {
+        LOG.warn("Restore validation mismatch: {}", mismatch);
+      }
       throw new IllegalStateException(
-          "Cannot restore: the following tables are not empty. Use --force to truncate them: "
-              + String.join(", ", nonEmptyTables));
+          "Restore validation failed with " + mismatches.size() + " mismatch(es): " + mismatches);
     }
   }
 
-  private void truncateAllTables(Handle handle, ObjectNode tablesMetadata) {
-    LOG.info("Truncating all target tables (force mode)");
-    tablesMetadata
-        .fieldNames()
-        .forEachRemaining(
-            tableName -> {
-              String sql = String.format("TRUNCATE TABLE %s", quoteIdentifier(tableName));
-              handle.execute(sql);
-              LOG.info("Truncated table {}", tableName);
-            });
+  Map<String, Set<String>> discoverForeignKeyDependencies(Handle handle) {
+    String sql;
+    if (connectionType == ConnectionType.MYSQL) {
+      sql =
+          "SELECT TABLE_NAME AS fk_table, REFERENCED_TABLE_NAME AS ref_table "
+              + "FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE "
+              + "WHERE REFERENCED_TABLE_NAME IS NOT NULL "
+              + "AND TABLE_SCHEMA = :db";
+    } else {
+      sql =
+          "SELECT tc.table_name AS fk_table, ccu.table_name AS ref_table "
+              + "FROM information_schema.table_constraints tc "
+              + "JOIN information_schema.constraint_column_usage ccu "
+              + "ON tc.constraint_name = ccu.constraint_name "
+              + "AND tc.table_schema = ccu.table_schema "
+              + "WHERE tc.constraint_type = 'FOREIGN KEY' "
+              + "AND tc.table_schema = current_schema()";
+    }
+
+    List<Map<String, Object>> rows;
+    if (connectionType == ConnectionType.MYSQL) {
+      rows = handle.createQuery(sql).bind("db", databaseName).mapToMap().list();
+    } else {
+      rows = handle.createQuery(sql).mapToMap().list();
+    }
+
+    Map<String, Set<String>> dependencies = new HashMap<>();
+    for (Map<String, Object> row : rows) {
+      String tableName = (String) row.get("fk_table");
+      String referencedTable = (String) row.get("ref_table");
+      dependencies.computeIfAbsent(tableName, k -> new HashSet<>()).add(referencedTable);
+    }
+    return dependencies;
+  }
+
+  static List<String> topologicalSort(
+      Collection<String> tables, Map<String, Set<String>> dependsOn) {
+    Set<String> tableSet = new HashSet<>(tables);
+    Map<String, Integer> inDegree = new HashMap<>();
+    Map<String, Set<String>> dependents = new HashMap<>();
+
+    for (String table : tableSet) {
+      inDegree.put(table, 0);
+      dependents.put(table, new HashSet<>());
+    }
+
+    for (String table : tableSet) {
+      for (String dep : dependsOn.getOrDefault(table, Set.of())) {
+        if (tableSet.contains(dep) && !dep.equals(table)) {
+          inDegree.merge(table, 1, Integer::sum);
+          dependents.get(dep).add(table);
+        }
+      }
+    }
+
+    ArrayDeque<String> queue = new ArrayDeque<>();
+    for (String table : tableSet) {
+      if (inDegree.get(table) == 0) {
+        queue.add(table);
+      }
+    }
+
+    List<String> sorted = new ArrayList<>();
+    while (!queue.isEmpty()) {
+      String table = queue.poll();
+      sorted.add(table);
+      for (String dependent : dependents.getOrDefault(table, Set.of())) {
+        int newDegree = inDegree.get(dependent) - 1;
+        inDegree.put(dependent, newDegree);
+        if (newDegree == 0) {
+          queue.add(dependent);
+        }
+      }
+    }
+
+    if (sorted.size() != tableSet.size()) {
+      LOG.warn("Circular FK dependencies detected; appending remaining tables");
+      for (String table : tableSet) {
+        if (!sorted.contains(table)) {
+          sorted.add(table);
+        }
+      }
+    }
+
+    return sorted;
+  }
+
+  private static void cleanupTempDirectory(Path tempDir) {
+    try (var stream = Files.list(tempDir)) {
+      stream.forEach(
+          path -> {
+            try {
+              Files.deleteIfExists(path);
+            } catch (IOException e) {
+              LOG.warn("Failed to delete temp file: {}", path, e);
+            }
+          });
+      Files.deleteIfExists(tempDir);
+    } catch (IOException e) {
+      LOG.warn("Failed to clean up temp directory: {}", tempDir, e);
+    }
   }
 
   int insertRowsStreaming(
@@ -495,17 +823,31 @@ public class DatabaseBackupRestore {
       String tableName,
       List<String> columns,
       Set<String> binaryColumns,
-      TarArchiveInputStream tais)
+      Set<String> jsonbColumns,
+      Map<String, String> castableColumns,
+      InputStream inputStream)
       throws IOException {
     String quotedColumns = quoteColumns(columns);
-    String placeholders = columns.stream().map(c -> "?").collect(Collectors.joining(", "));
+    String placeholders =
+        columns.stream()
+            .map(
+                c -> {
+                  if (jsonbColumns.contains(c)) return "CAST(? AS jsonb)";
+                  String castType = castableColumns.get(c);
+                  if (castType != null) {
+                    String pgType = pgCastFor(castType);
+                    if (pgType != null) return "CAST(? AS " + pgType + ")";
+                  }
+                  return "?";
+                })
+            .collect(Collectors.joining(", "));
     String sql =
         String.format(
             "INSERT INTO %s (%s) VALUES (%s)",
             quoteIdentifier(tableName), quotedColumns, placeholders);
 
     int totalRows = 0;
-    try (JsonParser parser = new JsonFactory().createParser(tais)) {
+    try (JsonParser parser = new JsonFactory().createParser(inputStream)) {
       JsonToken token = parser.nextToken();
       if (token != JsonToken.START_ARRAY) {
         return 0;
@@ -551,22 +893,6 @@ public class DatabaseBackupRestore {
       }
     }
     return totalRows;
-  }
-
-  private void disableForeignKeyChecks(Handle handle) {
-    if (connectionType == ConnectionType.MYSQL) {
-      handle.execute("SET FOREIGN_KEY_CHECKS = 0");
-    } else {
-      handle.execute("SET session_replication_role = 'replica'");
-    }
-  }
-
-  private void enableForeignKeyChecks(Handle handle) {
-    if (connectionType == ConnectionType.MYSQL) {
-      handle.execute("SET FOREIGN_KEY_CHECKS = 1");
-    } else {
-      handle.execute("SET session_replication_role = 'origin'");
-    }
   }
 
   String quoteIdentifier(String identifier) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/DatabaseBackupRestore.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/DatabaseBackupRestore.java
@@ -1,5 +1,9 @@
 package org.openmetadata.service.util;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -10,11 +14,15 @@ import java.io.BufferedOutputStream;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.sql.Types;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
@@ -53,7 +61,8 @@ public class DatabaseBackupRestore {
     } else {
       sql =
           "SELECT table_name FROM information_schema.tables "
-              + "WHERE table_type = 'BASE TABLE' AND table_schema = 'public' ORDER BY table_name";
+              + "WHERE table_type = 'BASE TABLE' AND table_schema = current_schema() "
+              + "ORDER BY table_name";
       return handle.createQuery(sql).mapTo(String.class).list();
     }
   }
@@ -75,10 +84,38 @@ public class DatabaseBackupRestore {
     } else {
       sql =
           "SELECT column_name FROM information_schema.columns "
-              + "WHERE table_schema = 'public' AND table_name = :table "
+              + "WHERE table_schema = current_schema() AND table_name = :table "
               + "AND (is_generated = 'NEVER' OR is_generated IS NULL) "
               + "AND (column_default NOT LIKE 'nextval%' OR column_default IS NULL) "
               + "ORDER BY ordinal_position";
+      return handle.createQuery(sql).bind("table", tableName).mapTo(String.class).list();
+    }
+  }
+
+  List<String> discoverPrimaryKeyColumns(Handle handle, String tableName) {
+    String sql;
+    if (connectionType == ConnectionType.MYSQL) {
+      sql =
+          "SELECT kcu.column_name FROM information_schema.key_column_usage kcu "
+              + "WHERE kcu.table_schema = :db AND kcu.table_name = :table "
+              + "AND kcu.constraint_name = 'PRIMARY' "
+              + "ORDER BY kcu.ordinal_position";
+      return handle
+          .createQuery(sql)
+          .bind("db", databaseName)
+          .bind("table", tableName)
+          .mapTo(String.class)
+          .list();
+    } else {
+      sql =
+          "SELECT kcu.column_name "
+              + "FROM information_schema.table_constraints tc "
+              + "JOIN information_schema.key_column_usage kcu "
+              + "ON tc.constraint_name = kcu.constraint_name "
+              + "AND tc.table_schema = kcu.table_schema "
+              + "WHERE tc.table_schema = current_schema() AND tc.table_name = :table "
+              + "AND tc.constraint_type = 'PRIMARY KEY' "
+              + "ORDER BY kcu.ordinal_position";
       return handle.createQuery(sql).bind("table", tableName).mapTo(String.class).list();
     }
   }
@@ -118,11 +155,16 @@ public class DatabaseBackupRestore {
 
       jdbi.useHandle(
           handle -> {
-            List<String> tables = discoverTables(handle);
-            LOG.info("Discovered {} tables", tables.size());
+            beginRepeatableReadTransaction(handle);
+            try {
+              List<String> tables = discoverTables(handle);
+              LOG.info("Discovered {} tables", tables.size());
 
-            for (String tableName : tables) {
-              backupTable(handle, tableName, taos, tablesMetadata);
+              for (String tableName : tables) {
+                backupTable(handle, tableName, taos, tablesMetadata);
+              }
+            } finally {
+              commitTransaction(handle);
             }
           });
 
@@ -138,6 +180,19 @@ public class DatabaseBackupRestore {
     }
   }
 
+  private void beginRepeatableReadTransaction(Handle handle) {
+    if (connectionType == ConnectionType.MYSQL) {
+      handle.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ");
+      handle.execute("START TRANSACTION");
+    } else {
+      handle.execute("BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ");
+    }
+  }
+
+  private void commitTransaction(Handle handle) {
+    handle.execute("COMMIT");
+  }
+
   private void backupTable(
       Handle handle, String tableName, TarArchiveOutputStream taos, ObjectNode tablesMetadata)
       throws IOException {
@@ -150,66 +205,110 @@ public class DatabaseBackupRestore {
     String quotedColumns = quoteColumns(columns);
     String quotedTable = quoteIdentifier(tableName);
 
-    int offset = 0;
-    ArrayNode allRows = MAPPER.createArrayNode();
+    List<String> pkColumns = discoverPrimaryKeyColumns(handle, tableName);
+    String orderByClause = buildOrderByClause(pkColumns, columns);
 
-    while (true) {
-      String sql =
-          String.format(
-              "SELECT %s FROM %s LIMIT %d OFFSET %d",
-              quotedColumns, quotedTable, BATCH_SIZE, offset);
-      List<Map<String, Object>> rows = handle.createQuery(sql).mapToMap().list();
-
-      for (Map<String, Object> row : rows) {
-        ObjectNode rowNode = MAPPER.createObjectNode();
-        for (String col : columns) {
-          Object val = row.get(col);
-          if (val == null) {
-            rowNode.putNull(col);
-          } else if (val instanceof Number number) {
-            if (val instanceof Long l) {
-              rowNode.put(col, l);
-            } else if (val instanceof Integer i) {
-              rowNode.put(col, i);
-            } else if (val instanceof Double d) {
-              rowNode.put(col, d);
-            } else if (val instanceof Float f) {
-              rowNode.put(col, f);
-            } else {
-              rowNode.put(col, number.longValue());
-            }
-          } else if (val instanceof Boolean b) {
-            rowNode.put(col, b);
-          } else if (val instanceof byte[] bytes) {
-            rowNode.put(col, bytes);
-          } else {
-            rowNode.put(col, val.toString());
-          }
-        }
-        allRows.add(rowNode);
-      }
-
-      if (rows.size() < BATCH_SIZE) {
-        break;
-      }
-      offset += BATCH_SIZE;
+    Path tempFile = Files.createTempFile("backup_" + tableName + "_", ".json");
+    int rowCount;
+    try {
+      rowCount =
+          writeTableToTempFile(
+              handle, quotedColumns, quotedTable, orderByClause, columns, tempFile);
+      addTempFileToTar(taos, tempFile, "tables/" + tableName + ".json");
+    } finally {
+      Files.deleteIfExists(tempFile);
     }
-
-    byte[] tableData = MAPPER.writeValueAsBytes(allRows);
-    TarArchiveEntry entry = new TarArchiveEntry("tables/" + tableName + ".json");
-    entry.setSize(tableData.length);
-    taos.putArchiveEntry(entry);
-    taos.write(tableData);
-    taos.closeArchiveEntry();
 
     ObjectNode tableInfo = MAPPER.createObjectNode();
     ArrayNode columnsArray = MAPPER.createArrayNode();
     columns.forEach(columnsArray::add);
     tableInfo.set("columns", columnsArray);
-    tableInfo.put("rowCount", allRows.size());
+    tableInfo.put("rowCount", rowCount);
     tablesMetadata.set(tableName, tableInfo);
 
-    LOG.info("Backed up table {} ({} rows, {} columns)", tableName, allRows.size(), columns.size());
+    LOG.info("Backed up table {} ({} rows, {} columns)", tableName, rowCount, columns.size());
+  }
+
+  private String buildOrderByClause(List<String> pkColumns, List<String> allColumns) {
+    List<String> orderColumns = pkColumns.isEmpty() ? List.of(allColumns.get(0)) : pkColumns;
+    return " ORDER BY "
+        + orderColumns.stream().map(this::quoteIdentifier).collect(Collectors.joining(", "));
+  }
+
+  private int writeTableToTempFile(
+      Handle handle,
+      String quotedColumns,
+      String quotedTable,
+      String orderByClause,
+      List<String> columns,
+      Path tempFile)
+      throws IOException {
+    int rowCount = 0;
+    try (OutputStream os = new BufferedOutputStream(new FileOutputStream(tempFile.toFile()));
+        JsonGenerator gen = new JsonFactory().createGenerator(os)) {
+      gen.setCodec(MAPPER);
+      gen.writeStartArray();
+
+      int offset = 0;
+      while (true) {
+        String sql =
+            String.format(
+                "SELECT %s FROM %s%s LIMIT %d OFFSET %d",
+                quotedColumns, quotedTable, orderByClause, BATCH_SIZE, offset);
+        List<Map<String, Object>> rows = handle.createQuery(sql).mapToMap().list();
+
+        for (Map<String, Object> row : rows) {
+          gen.writeStartObject();
+          for (String col : columns) {
+            Object val = row.get(col);
+            if (val == null) {
+              gen.writeNullField(col);
+            } else if (val instanceof Number number) {
+              if (number instanceof Long l) {
+                gen.writeNumberField(col, l);
+              } else if (number instanceof Integer i) {
+                gen.writeNumberField(col, i);
+              } else if (number instanceof Double d) {
+                gen.writeNumberField(col, d);
+              } else if (number instanceof Float f) {
+                gen.writeNumberField(col, f);
+              } else {
+                gen.writeNumberField(col, number.longValue());
+              }
+            } else if (val instanceof Boolean b) {
+              gen.writeBooleanField(col, b);
+            } else if (val instanceof byte[] bytes) {
+              gen.writeBinaryField(col, bytes);
+            } else {
+              gen.writeStringField(col, val.toString());
+            }
+          }
+          gen.writeEndObject();
+          rowCount++;
+        }
+
+        if (rows.size() < BATCH_SIZE) {
+          break;
+        }
+        offset += BATCH_SIZE;
+      }
+
+      gen.writeEndArray();
+    }
+    return rowCount;
+  }
+
+  private void addTempFileToTar(TarArchiveOutputStream taos, Path tempFile, String entryName)
+      throws IOException {
+    long fileSize = Files.size(tempFile);
+    TarArchiveEntry entry = new TarArchiveEntry(entryName);
+    entry.setSize(fileSize);
+    taos.putArchiveEntry(entry);
+
+    try (FileInputStream fis = new FileInputStream(tempFile.toFile())) {
+      fis.transferTo(taos);
+    }
+    taos.closeArchiveEntry();
   }
 
   public void restore(String backupPath, boolean force) throws IOException {
@@ -232,6 +331,9 @@ public class DatabaseBackupRestore {
 
     ObjectNode tablesMetadata = (ObjectNode) metadata.get("tables");
 
+    Set<String> validTables = new HashSet<>();
+    tablesMetadata.fieldNames().forEachRemaining(validTables::add);
+
     jdbi.useHandle(
         handle -> {
           if (force) {
@@ -239,15 +341,15 @@ public class DatabaseBackupRestore {
           } else {
             validateTablesEmpty(handle, tablesMetadata);
           }
-        });
 
-    try {
-      jdbi.useHandle(this::disableForeignKeyChecks);
-      restoreTablesFromArchive(backupPath, tablesMetadata);
-      LOG.info("Restore completed successfully");
-    } finally {
-      jdbi.useHandle(this::enableForeignKeyChecks);
-    }
+          disableForeignKeyChecks(handle);
+          try {
+            restoreTablesFromArchive(handle, backupPath, tablesMetadata, validTables);
+            LOG.info("Restore completed successfully");
+          } finally {
+            enableForeignKeyChecks(handle);
+          }
+        });
   }
 
   public static ObjectNode readBackupMetadata(String backupPath) throws IOException {
@@ -267,7 +369,8 @@ public class DatabaseBackupRestore {
     throw new IOException("metadata.json not found in backup archive");
   }
 
-  private void restoreTablesFromArchive(String backupPath, ObjectNode tablesMetadata)
+  private void restoreTablesFromArchive(
+      Handle handle, String backupPath, ObjectNode tablesMetadata, Set<String> validTables)
       throws IOException {
     try (FileInputStream fis = new FileInputStream(backupPath);
         BufferedInputStream bis = new BufferedInputStream(fis);
@@ -282,6 +385,12 @@ public class DatabaseBackupRestore {
         }
 
         String tableName = name.substring("tables/".length(), name.length() - ".json".length());
+
+        if (!validTables.contains(tableName)) {
+          LOG.warn("Table {} from archive not in metadata, skipping", tableName);
+          continue;
+        }
+
         JsonNode tableMetaNode = tablesMetadata.get(tableName);
         if (tableMetaNode == null) {
           LOG.warn("No metadata found for table {}, skipping", tableName);
@@ -291,16 +400,9 @@ public class DatabaseBackupRestore {
         List<String> columns = new ArrayList<>();
         tableMetaNode.get("columns").forEach(col -> columns.add(col.asText()));
 
-        byte[] content = tais.readAllBytes();
-        ArrayNode rows = (ArrayNode) MAPPER.readTree(content);
-
-        if (rows.isEmpty()) {
-          LOG.info("Table {} has no rows, skipping", tableName);
-          continue;
-        }
-
-        LOG.info("Restoring table {} ({} rows)", tableName, rows.size());
-        jdbi.useHandle(handle -> insertRows(handle, tableName, columns, rows));
+        LOG.info("Restoring table {}", tableName);
+        int rowCount = insertRowsStreaming(handle, tableName, columns, tais);
+        LOG.info("Restored table {} ({} rows)", tableName, rowCount);
       }
     }
   }
@@ -342,40 +444,63 @@ public class DatabaseBackupRestore {
     }
   }
 
-  void insertRows(Handle handle, String tableName, List<String> columns, ArrayNode rows) {
+  int insertRowsStreaming(
+      Handle handle, String tableName, List<String> columns, TarArchiveInputStream tais)
+      throws IOException {
     String quotedColumns = quoteColumns(columns);
-    String placeholders = columns.stream().map(c -> ":" + c).collect(Collectors.joining(", "));
+    String placeholders = columns.stream().map(c -> "?").collect(Collectors.joining(", "));
     String sql =
         String.format(
             "INSERT INTO %s (%s) VALUES (%s)",
             quoteIdentifier(tableName), quotedColumns, placeholders);
 
-    int totalRows = rows.size();
-    for (int start = 0; start < totalRows; start += BATCH_SIZE) {
-      int end = Math.min(start + BATCH_SIZE, totalRows);
+    int totalRows = 0;
+    try (JsonParser parser = new JsonFactory().createParser(tais)) {
+      JsonToken token = parser.nextToken();
+      if (token != JsonToken.START_ARRAY) {
+        return 0;
+      }
+
       var batch = handle.prepareBatch(sql);
-      for (int i = start; i < end; i++) {
-        JsonNode row = rows.get(i);
-        for (String col : columns) {
+      int batchCount = 0;
+
+      while (parser.nextToken() != JsonToken.END_ARRAY) {
+        ObjectNode row = MAPPER.readTree(parser);
+        for (int idx = 0; idx < columns.size(); idx++) {
+          String col = columns.get(idx);
           JsonNode val = row.get(col);
           if (val == null || val.isNull()) {
-            batch.bindNull(col, Types.VARCHAR);
+            batch.bind(idx, (Object) null);
+          } else if (val.isBinary()) {
+            batch.bind(idx, val.binaryValue());
           } else if (val.isNumber()) {
             if (val.isLong() || val.isInt() || val.isBigInteger()) {
-              batch.bind(col, val.longValue());
+              batch.bind(idx, val.longValue());
             } else {
-              batch.bind(col, val.doubleValue());
+              batch.bind(idx, val.doubleValue());
             }
           } else if (val.isBoolean()) {
-            batch.bind(col, val.booleanValue());
+            batch.bind(idx, val.booleanValue());
           } else {
-            batch.bind(col, val.asText());
+            batch.bind(idx, val.asText());
           }
         }
         batch.add();
+        batchCount++;
+        totalRows++;
+
+        if (batchCount >= BATCH_SIZE) {
+          batch.execute();
+          batch = handle.prepareBatch(sql);
+          batchCount = 0;
+        }
       }
-      batch.execute();
+
+      if (batchCount > 0) {
+        batch.execute();
+      }
     }
+    return totalRows;
   }
 
   private void disableForeignKeyChecks(Handle handle) {
@@ -396,9 +521,9 @@ public class DatabaseBackupRestore {
 
   String quoteIdentifier(String identifier) {
     if (connectionType == ConnectionType.MYSQL) {
-      return "`" + identifier + "`";
+      return "`" + identifier.replace("`", "``") + "`";
     }
-    return "\"" + identifier + "\"";
+    return "\"" + identifier.replace("\"", "\"\"") + "\"";
   }
 
   String quoteColumns(List<String> columns) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/DatabaseBackupRestore.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/DatabaseBackupRestore.java
@@ -39,7 +39,7 @@ import org.openmetadata.service.jdbi3.locator.ConnectionType;
 @Slf4j
 public class DatabaseBackupRestore {
 
-  private static final int BATCH_SIZE = 1000;
+  public static final int DEFAULT_BATCH_SIZE = 1000;
   private static final long MAX_METADATA_SIZE = 10 * 1024 * 1024;
   private static final ObjectMapper MAPPER =
       new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
@@ -47,11 +47,18 @@ public class DatabaseBackupRestore {
   private final Jdbi jdbi;
   private final ConnectionType connectionType;
   private final String databaseName;
+  private final int batchSize;
 
   public DatabaseBackupRestore(Jdbi jdbi, ConnectionType connectionType, String databaseName) {
+    this(jdbi, connectionType, databaseName, DEFAULT_BATCH_SIZE);
+  }
+
+  public DatabaseBackupRestore(
+      Jdbi jdbi, ConnectionType connectionType, String databaseName, int batchSize) {
     this.jdbi = jdbi;
     this.connectionType = connectionType;
     this.databaseName = databaseName;
+    this.batchSize = batchSize;
   }
 
   public List<String> discoverTables(Handle handle) {
@@ -285,7 +292,7 @@ public class DatabaseBackupRestore {
         String sql =
             String.format(
                 "SELECT %s FROM %s%s LIMIT %d OFFSET %d",
-                quotedColumns, quotedTable, orderByClause, BATCH_SIZE, offset);
+                quotedColumns, quotedTable, orderByClause, batchSize, offset);
         List<Map<String, Object>> rows = handle.createQuery(sql).mapToMap().list();
 
         for (Map<String, Object> row : rows) {
@@ -320,10 +327,10 @@ public class DatabaseBackupRestore {
           rowCount++;
         }
 
-        if (rows.size() < BATCH_SIZE) {
+        if (rows.size() < batchSize) {
           break;
         }
-        offset += BATCH_SIZE;
+        offset += batchSize;
       }
 
       gen.writeEndArray();
@@ -530,7 +537,7 @@ public class DatabaseBackupRestore {
         batchCount++;
         totalRows++;
 
-        if (batchCount >= BATCH_SIZE) {
+        if (batchCount >= batchSize) {
           batch.execute();
           batch = handle.prepareBatch(sql);
           batchCount = 0;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/MigrationTestRunner.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/MigrationTestRunner.java
@@ -1,0 +1,281 @@
+package org.openmetadata.service.util;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.Jdbi;
+import org.openmetadata.service.OpenMetadataApplicationConfig;
+import org.openmetadata.service.jdbi3.MigrationDAO;
+import org.openmetadata.service.jdbi3.locator.ConnectionType;
+import org.openmetadata.service.migration.api.MigrationProcess;
+import org.openmetadata.service.migration.api.MigrationTestCase;
+import org.openmetadata.service.migration.api.MigrationWorkflow;
+import org.openmetadata.service.migration.api.TestResult;
+import org.openmetadata.service.migration.context.MigrationWorkflowContext;
+
+@Slf4j
+public class MigrationTestRunner {
+
+  record MigrationTestEntry(
+      String version, String testName, String phase, boolean passed, String detail) {}
+
+  private final Jdbi jdbi;
+  private final ConnectionType connectionType;
+  private final OpenMetadataApplicationConfig config;
+  private final String nativeSQLScriptRootPath;
+  private final String extensionSQLScriptRootPath;
+
+  public MigrationTestRunner(
+      Jdbi jdbi,
+      ConnectionType connectionType,
+      OpenMetadataApplicationConfig config,
+      String nativeSQLScriptRootPath,
+      String extensionSQLScriptRootPath) {
+    this.jdbi = jdbi;
+    this.connectionType = connectionType;
+    this.config = config;
+    this.nativeSQLScriptRootPath = nativeSQLScriptRootPath;
+    this.extensionSQLScriptRootPath = extensionSQLScriptRootPath;
+  }
+
+  public int run(String backupPath) throws IOException {
+    DatabaseBackupRestore backupRestore =
+        new DatabaseBackupRestore(
+            jdbi,
+            connectionType,
+            DatabaseBackupRestore.extractDatabaseName(config.getDataSourceFactory().getUrl()));
+    backupRestore.restore(backupPath, true);
+
+    ObjectNode metadata = DatabaseBackupRestore.readBackupMetadata(backupPath);
+    String backupTimestamp = metadata.has("timestamp") ? metadata.get("timestamp").asText() : "N/A";
+    String backupDbType =
+        metadata.has("databaseType") ? metadata.get("databaseType").asText() : "N/A";
+
+    MigrationDAO migrationDAO = jdbi.onDemand(MigrationDAO.class);
+    List<String> executedVersions;
+    try {
+      executedVersions = migrationDAO.getMigrationVersions();
+    } catch (Exception e) {
+      executedVersions = Collections.emptyList();
+    }
+    String sourceVersion =
+        executedVersions.stream().max(MigrationTestRunner::compareVersions).orElse("unknown");
+
+    MigrationWorkflow workflow =
+        new MigrationWorkflow(
+            jdbi,
+            nativeSQLScriptRootPath,
+            connectionType,
+            extensionSQLScriptRootPath,
+            config.getMigrationConfiguration().getFlywayPath(),
+            config,
+            true);
+    workflow.loadMigrations();
+
+    List<MigrationProcess> migrations = workflow.getMigrations();
+    String targetVersion =
+        migrations.isEmpty() ? sourceVersion : migrations.get(migrations.size() - 1).getVersion();
+
+    List<MigrationTestEntry> entries = new ArrayList<>();
+
+    try (Handle handle = jdbi.open()) {
+      MigrationWorkflowContext context = new MigrationWorkflowContext(handle);
+      context.computeInitialContext(sourceVersion);
+
+      for (MigrationProcess process : migrations) {
+        String version = process.getVersion();
+        String versionPkg = versionToPackage(version);
+        MigrationTestCase testCase = loadTestCase(versionPkg);
+
+        if (testCase != null) {
+          entries.addAll(runValidation(testCase::validateBefore, handle, version, "BEFORE"));
+        }
+
+        boolean migrationFailed = false;
+        try {
+          process.initialize(handle, jdbi);
+          process.runSchemaChanges(true);
+          process.runDataMigration();
+          process.runPostDDLScripts(true);
+          context.computeMigrationContext(process, true);
+          workflow.updateMigrationStepInDB(process, context);
+        } catch (Exception e) {
+          migrationFailed = true;
+          LOG.error("Migration {} failed", version, e);
+          entries.add(
+              new MigrationTestEntry(version, "migration execution", "RUN", false, e.getMessage()));
+        }
+
+        if (testCase != null) {
+          entries.addAll(runValidation(testCase::validateAfter, handle, version, "AFTER"));
+        } else if (!migrationFailed) {
+          entries.add(new MigrationTestEntry(version, "(no tests)", "-", true, ""));
+        }
+
+        if (migrationFailed) {
+          break;
+        }
+      }
+    }
+
+    printSummary(entries, sourceVersion, targetVersion, backupDbType, backupTimestamp);
+
+    long failCount = entries.stream().filter(e -> !e.passed() && !"-".equals(e.phase())).count();
+    return failCount > 0 ? 1 : 0;
+  }
+
+  @FunctionalInterface
+  private interface ValidationSupplier {
+    List<TestResult> run(Handle handle);
+  }
+
+  private List<MigrationTestEntry> runValidation(
+      ValidationSupplier supplier, Handle handle, String version, String phase) {
+    List<MigrationTestEntry> entries = new ArrayList<>();
+    try {
+      List<TestResult> results = supplier.run(handle);
+      for (TestResult result : results) {
+        entries.add(
+            new MigrationTestEntry(
+                version, result.name(), phase, result.passed(), result.detail()));
+      }
+    } catch (Exception e) {
+      entries.add(
+          new MigrationTestEntry(version, "validation error", phase, false, e.getMessage()));
+    }
+    return entries;
+  }
+
+  private MigrationTestCase loadTestCase(String versionPkg) {
+    String className =
+        String.format("org.openmetadata.service.migration.tests.%s.MigrationTest", versionPkg);
+    try {
+      Class<?> clazz = Class.forName(className);
+      return (MigrationTestCase) clazz.getDeclaredConstructor().newInstance();
+    } catch (ClassNotFoundException e) {
+      return null;
+    } catch (Exception e) {
+      LOG.warn("Failed to instantiate test class {}", className, e);
+      return null;
+    }
+  }
+
+  static String versionToPackage(String version) {
+    String base = version.contains("-") ? version.split("-")[0] : version;
+    String[] parts = base.split("\\.");
+    StringBuilder sb = new StringBuilder("v");
+    for (String part : parts) {
+      sb.append(Integer.parseInt(part));
+    }
+    return sb.toString();
+  }
+
+  private void printSummary(
+      List<MigrationTestEntry> entries,
+      String sourceVersion,
+      String targetVersion,
+      String dbType,
+      String backupTimestamp) {
+    int colVersion = 10;
+    int colTest = 30;
+    int colPhase = 8;
+    int colResult = 8;
+
+    for (MigrationTestEntry entry : entries) {
+      colVersion = Math.max(colVersion, entry.version().length() + 2);
+      colTest = Math.max(colTest, entry.testName().length() + 2);
+    }
+
+    String headerFmt =
+        " %-" + colVersion + "s| %-" + colTest + "s| %-" + colPhase + "s| %-" + colResult + "s";
+    int totalWidth = colVersion + colTest + colPhase + colResult + 7;
+    String separator = "-".repeat(totalWidth);
+    String doubleSeparator = "=".repeat(totalWidth);
+
+    System.out.println(doubleSeparator);
+    System.out.println(centerText("Migration Test Summary", totalWidth));
+    System.out.println(doubleSeparator);
+    System.out.printf(" Source version  : %s%n", sourceVersion);
+    System.out.printf(" Target version  : %s%n", targetVersion);
+    System.out.printf(" Database type   : %s%n", dbType);
+    System.out.printf(" Backup timestamp: %s%n", backupTimestamp);
+    System.out.println(separator);
+    System.out.printf(headerFmt + "%n", "Migration", "Test", "Phase", "Result");
+    System.out.println(separator);
+
+    int passed = 0;
+    int failed = 0;
+
+    for (MigrationTestEntry entry : entries) {
+      String result;
+      if ("-".equals(entry.phase())) {
+        result = "-";
+      } else if (entry.passed()) {
+        result = "PASS";
+        passed++;
+      } else {
+        result = "FAIL";
+        failed++;
+      }
+
+      System.out.printf(headerFmt + "%n", entry.version(), entry.testName(), entry.phase(), result);
+
+      if (!entry.passed() && !entry.detail().isEmpty() && !"-".equals(entry.phase())) {
+        System.out.printf(
+            " %-"
+                + colVersion
+                + "s|   %-"
+                + (colTest - 2)
+                + "s| %-"
+                + colPhase
+                + "s| %-"
+                + colResult
+                + "s%n",
+            "",
+            entry.detail(),
+            "",
+            "");
+      }
+    }
+
+    System.out.println(separator);
+    System.out.printf(" Total: %d passed, %d failed%n", passed, failed);
+    System.out.println(doubleSeparator);
+  }
+
+  private static String centerText(String text, int width) {
+    if (text.length() >= width) {
+      return text;
+    }
+    int padding = (width - text.length()) / 2;
+    return " ".repeat(padding) + text;
+  }
+
+  private static int compareVersions(String v1, String v2) {
+    int[] parts1 = parseVersionParts(v1);
+    int[] parts2 = parseVersionParts(v2);
+    int length = Math.max(parts1.length, parts2.length);
+    for (int i = 0; i < length; i++) {
+      int p1 = i < parts1.length ? parts1[i] : 0;
+      int p2 = i < parts2.length ? parts2[i] : 0;
+      if (p1 != p2) {
+        return Integer.compare(p1, p2);
+      }
+    }
+    return 0;
+  }
+
+  private static int[] parseVersionParts(String version) {
+    String base = version.contains("-") ? version.split("-")[0] : version;
+    String[] parts = base.split("\\.");
+    int[] numbers = new int[parts.length];
+    for (int i = 0; i < parts.length; i++) {
+      numbers[i] = Integer.parseInt(parts[i]);
+    }
+    return numbers;
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/MigrationTestRunner.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/MigrationTestRunner.java
@@ -3,13 +3,11 @@ package org.openmetadata.service.util;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
-import org.openmetadata.service.jdbi3.MigrationDAO;
 import org.openmetadata.service.jdbi3.locator.ConnectionType;
 import org.openmetadata.service.migration.api.MigrationProcess;
 import org.openmetadata.service.migration.api.MigrationTestCase;
@@ -47,28 +45,35 @@ public class MigrationTestRunner {
   }
 
   public int run(String backupPath, int batchSize) throws IOException {
+    ObjectNode metadata = DatabaseBackupRestore.readBackupMetadata(backupPath);
+    String backupVersion = metadata.get("version").asText();
+    String backupTimestamp = metadata.has("timestamp") ? metadata.get("timestamp").asText() : "N/A";
+    String backupDbType =
+        metadata.has("databaseType") ? metadata.get("databaseType").asText() : "N/A";
+    String sourceVersion = OpenMetadataOperations.resolveTargetVersion(metadata, backupVersion);
+
     DatabaseBackupRestore backupRestore =
         new DatabaseBackupRestore(
             jdbi,
             connectionType,
             DatabaseBackupRestore.extractDatabaseName(config.getDataSourceFactory().getUrl()),
             batchSize);
-    backupRestore.restore(backupPath, true);
 
-    ObjectNode metadata = DatabaseBackupRestore.readBackupMetadata(backupPath);
-    String backupTimestamp = metadata.has("timestamp") ? metadata.get("timestamp").asText() : "N/A";
-    String backupDbType =
-        metadata.has("databaseType") ? metadata.get("databaseType").asText() : "N/A";
+    LOG.info("Running migrations up to version {}", sourceVersion);
+    MigrationWorkflow setupWorkflow =
+        new MigrationWorkflow(
+            jdbi,
+            nativeSQLScriptRootPath,
+            connectionType,
+            extensionSQLScriptRootPath,
+            config.getMigrationConfiguration().getFlywayPath(),
+            config,
+            false);
+    setupWorkflow.setTargetVersion(sourceVersion);
+    setupWorkflow.loadMigrations();
+    setupWorkflow.runMigrationWorkflows(true);
 
-    MigrationDAO migrationDAO = jdbi.onDemand(MigrationDAO.class);
-    List<String> executedVersions;
-    try {
-      executedVersions = migrationDAO.getMigrationVersions();
-    } catch (Exception e) {
-      executedVersions = Collections.emptyList();
-    }
-    String sourceVersion =
-        executedVersions.stream().max(MigrationTestRunner::compareVersions).orElse("unknown");
+    backupRestore.restore(backupPath);
 
     MigrationWorkflow workflow =
         new MigrationWorkflow(
@@ -78,7 +83,7 @@ public class MigrationTestRunner {
             extensionSQLScriptRootPath,
             config.getMigrationConfiguration().getFlywayPath(),
             config,
-            true);
+            false);
     workflow.loadMigrations();
 
     List<MigrationProcess> migrations = workflow.getMigrations();
@@ -161,7 +166,7 @@ public class MigrationTestRunner {
 
   private MigrationTestCase loadTestCase(String versionPkg) {
     String className =
-        String.format("org.openmetadata.service.migration.tests.%s.MigrationTest", versionPkg);
+        String.format("org.openmetadata.service.migration.utils.%s.MigrationTest", versionPkg);
     try {
       Class<?> clazz = Class.forName(className);
       return (MigrationTestCase) clazz.getDeclaredConstructor().newInstance();
@@ -175,13 +180,7 @@ public class MigrationTestRunner {
 
   static String versionToPackage(String version) {
     String base = version.contains("-") ? version.split("-")[0] : version;
-    String[] parts = base.split("\\.");
-    StringBuilder sb = new StringBuilder("v");
-    for (int i = 0; i < parts.length; i++) {
-      if (i > 0) sb.append("_");
-      sb.append(Integer.parseInt(parts[i]));
-    }
-    return sb.toString();
+    return "v" + base.replace(".", "");
   }
 
   private void printSummary(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/MigrationTestRunner.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/MigrationTestRunner.java
@@ -99,7 +99,14 @@ public class MigrationTestRunner {
       for (MigrationProcess process : migrations) {
         String version = process.getVersion();
         String versionPkg = versionToPackage(version);
-        MigrationTestCase testCase = loadTestCase(versionPkg);
+        MigrationTestCase testCase = null;
+        try {
+          testCase = loadTestCase(versionPkg);
+        } catch (RuntimeException e) {
+          entries.add(
+              new MigrationTestEntry(
+                  version, "test class instantiation", "LOAD", false, e.getMessage()));
+        }
 
         if (testCase != null) {
           entries.addAll(runValidation(testCase::validateBefore, handle, version, "BEFORE"));
@@ -173,8 +180,8 @@ public class MigrationTestRunner {
     } catch (ClassNotFoundException e) {
       return null;
     } catch (Exception e) {
-      LOG.warn("Failed to instantiate test class {}", className, e);
-      return null;
+      throw new RuntimeException(
+          String.format("Failed to instantiate migration test class %s", className), e);
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/MigrationTestRunner.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/MigrationTestRunner.java
@@ -115,7 +115,7 @@ public class MigrationTestRunner {
               new MigrationTestEntry(version, "migration execution", "RUN", false, e.getMessage()));
         }
 
-        if (testCase != null) {
+        if (testCase != null && !migrationFailed) {
           entries.addAll(runValidation(testCase::validateAfter, handle, version, "AFTER"));
         } else if (!migrationFailed) {
           entries.add(new MigrationTestEntry(version, "(no tests)", "-", true, ""));
@@ -177,8 +177,9 @@ public class MigrationTestRunner {
     String base = version.contains("-") ? version.split("-")[0] : version;
     String[] parts = base.split("\\.");
     StringBuilder sb = new StringBuilder("v");
-    for (String part : parts) {
-      sb.append(Integer.parseInt(part));
+    for (int i = 0; i < parts.length; i++) {
+      if (i > 0) sb.append("_");
+      sb.append(Integer.parseInt(parts[i]));
     }
     return sb.toString();
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/MigrationTestRunner.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/MigrationTestRunner.java
@@ -43,11 +43,16 @@ public class MigrationTestRunner {
   }
 
   public int run(String backupPath) throws IOException {
+    return run(backupPath, DatabaseBackupRestore.DEFAULT_BATCH_SIZE);
+  }
+
+  public int run(String backupPath, int batchSize) throws IOException {
     DatabaseBackupRestore backupRestore =
         new DatabaseBackupRestore(
             jdbi,
             connectionType,
-            DatabaseBackupRestore.extractDatabaseName(config.getDataSourceFactory().getUrl()));
+            DatabaseBackupRestore.extractDatabaseName(config.getDataSourceFactory().getUrl()),
+            batchSize);
     backupRestore.restore(backupPath, true);
 
     ObjectNode metadata = DatabaseBackupRestore.readBackupMetadata(backupPath);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/MigrationTestRunner.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/MigrationTestRunner.java
@@ -117,6 +117,10 @@ public class MigrationTestRunner {
         }
 
         if (migrationFailed) {
+          LOG.warn(
+              "Migration {} failed. The database is in a partially-migrated state. "
+                  + "Re-restore the backup before retrying.",
+              version);
           break;
         }
       }
@@ -196,16 +200,16 @@ public class MigrationTestRunner {
     String separator = "-".repeat(totalWidth);
     String doubleSeparator = "=".repeat(totalWidth);
 
-    System.out.println(doubleSeparator);
-    System.out.println(centerText("Migration Test Summary", totalWidth));
-    System.out.println(doubleSeparator);
-    System.out.printf(" Source version  : %s%n", sourceVersion);
-    System.out.printf(" Target version  : %s%n", targetVersion);
-    System.out.printf(" Database type   : %s%n", dbType);
-    System.out.printf(" Backup timestamp: %s%n", backupTimestamp);
-    System.out.println(separator);
-    System.out.printf(headerFmt + "%n", "Migration", "Test", "Phase", "Result");
-    System.out.println(separator);
+    LOG.info(doubleSeparator);
+    LOG.info(centerText("Migration Test Summary", totalWidth));
+    LOG.info(doubleSeparator);
+    LOG.info(" Source version  : {}", sourceVersion);
+    LOG.info(" Target version  : {}", targetVersion);
+    LOG.info(" Database type   : {}", dbType);
+    LOG.info(" Backup timestamp: {}", backupTimestamp);
+    LOG.info(separator);
+    LOG.info(String.format(headerFmt, "Migration", "Test", "Phase", "Result"));
+    LOG.info(separator);
 
     int passed = 0;
     int failed = 0;
@@ -222,10 +226,10 @@ public class MigrationTestRunner {
         failed++;
       }
 
-      System.out.printf(headerFmt + "%n", entry.version(), entry.testName(), entry.phase(), result);
+      LOG.info(String.format(headerFmt, entry.version(), entry.testName(), entry.phase(), result));
 
       if (!entry.passed() && !entry.detail().isEmpty() && !"-".equals(entry.phase())) {
-        System.out.printf(
+        String detailFmt =
             " %-"
                 + colVersion
                 + "s|   %-"
@@ -234,17 +238,14 @@ public class MigrationTestRunner {
                 + colPhase
                 + "s| %-"
                 + colResult
-                + "s%n",
-            "",
-            entry.detail(),
-            "",
-            "");
+                + "s";
+        LOG.info(String.format(detailFmt, "", entry.detail(), "", ""));
       }
     }
 
-    System.out.println(separator);
-    System.out.printf(" Total: %d passed, %d failed%n", passed, failed);
-    System.out.println(doubleSeparator);
+    LOG.info(separator);
+    LOG.info(" Total: {} passed, {} failed", passed, failed);
+    LOG.info(doubleSeparator);
   }
 
   private static String centerText(String text, int width) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
@@ -173,7 +173,7 @@ public class OpenMetadataOperations implements Callable<Integer> {
             + "'drop-create', 'changelog', 'migrate', 'migrate-secrets', 'reindex', 'reembed', 'reindex-rdf', 'reindexdi', 'deploy-pipelines', "
             + "'dbServiceCleanup', 'relationshipCleanup', 'tagUsageCleanup', 'drop-indexes', 'remove-security-config', 'create-indexes', "
             + "'setOpenMetadataUrl', 'configureEmailSettings', 'get-security-config', 'update-security-config', 'install-app', 'delete-app', 'create-user', 'reset-password', "
-            + "'syncAlertOffset', 'analyze-tables', 'cleanup-flowable-history', 'regenerate-bot-tokens'");
+            + "'syncAlertOffset', 'analyze-tables', 'cleanup-flowable-history', 'regenerate-bot-tokens', 'backup', 'restore'");
     LOG.info(
         "Use 'reindex --auto-tune' for automatic performance optimization based on cluster capabilities");
     LOG.info(
@@ -2606,6 +2606,54 @@ public class OpenMetadataOperations implements Callable<Integer> {
       return 0;
     } catch (Exception e) {
       LOG.error("Failed to cleanup Flowable history due to ", e);
+      return 1;
+    }
+  }
+
+  @Command(name = "backup", description = "Backup the entire database to a .tar.gz archive.")
+  public Integer backup(
+      @Option(
+              names = {"--backup-path"},
+              required = true,
+              description = "Path where the backup .tar.gz file will be created")
+          String backupPath) {
+    try {
+      parseConfig();
+      ConnectionType connType = ConnectionType.from(config.getDataSourceFactory().getDriverClass());
+      String databaseName =
+          DatabaseBackupRestore.extractDatabaseName(config.getDataSourceFactory().getUrl());
+      DatabaseBackupRestore backupRestore = new DatabaseBackupRestore(jdbi, connType, databaseName);
+      backupRestore.backup(backupPath);
+      return 0;
+    } catch (Exception e) {
+      LOG.error("Backup failed", e);
+      return 1;
+    }
+  }
+
+  @Command(name = "restore", description = "Restore the database from a .tar.gz backup archive.")
+  public Integer restore(
+      @Option(
+              names = {"--backup-path"},
+              required = true,
+              description = "Path to the backup .tar.gz file to restore from")
+          String backupPath,
+      @Option(
+              names = {"--force"},
+              defaultValue = "false",
+              description =
+                  "Force restore by truncating existing tables. Without this flag, restore fails if tables have data.")
+          boolean force) {
+    try {
+      parseConfig();
+      ConnectionType connType = ConnectionType.from(config.getDataSourceFactory().getDriverClass());
+      String databaseName =
+          DatabaseBackupRestore.extractDatabaseName(config.getDataSourceFactory().getUrl());
+      DatabaseBackupRestore backupRestore = new DatabaseBackupRestore(jdbi, connType, databaseName);
+      backupRestore.restore(backupPath, force);
+      return 0;
+    } catch (Exception e) {
+      LOG.error("Restore failed", e);
       return 1;
     }
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
@@ -2620,6 +2620,7 @@ public class OpenMetadataOperations implements Callable<Integer> {
     try {
       parseConfig();
       ConnectionType connType = ConnectionType.from(config.getDataSourceFactory().getDriverClass());
+      DatasourceConfig.initialize(connType.label);
       String databaseName =
           DatabaseBackupRestore.extractDatabaseName(config.getDataSourceFactory().getUrl());
       DatabaseBackupRestore backupRestore = new DatabaseBackupRestore(jdbi, connType, databaseName);
@@ -2647,6 +2648,7 @@ public class OpenMetadataOperations implements Callable<Integer> {
     try {
       parseConfig();
       ConnectionType connType = ConnectionType.from(config.getDataSourceFactory().getDriverClass());
+      DatasourceConfig.initialize(connType.label);
       String databaseName =
           DatabaseBackupRestore.extractDatabaseName(config.getDataSourceFactory().getUrl());
       DatabaseBackupRestore backupRestore = new DatabaseBackupRestore(jdbi, connType, databaseName);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
@@ -2668,7 +2668,19 @@ public class OpenMetadataOperations implements Callable<Integer> {
               required = true,
               description =
                   "Path to the backup .tar.gz file to restore and test migrations against")
-          String backupPath) {
+          String backupPath,
+      @Option(
+              names = {"--force"},
+              defaultValue = "false",
+              description =
+                  "Force execution. This command restores a backup (truncating all tables) before running migrations. Pass --force to confirm.")
+          boolean force) {
+    if (!force) {
+      LOG.error(
+          "test-migration restores a backup which truncates all existing tables. "
+              + "Pass --force to confirm you want to proceed.");
+      return 1;
+    }
     try {
       parseConfig();
       ConnectionType connType = ConnectionType.from(config.getDataSourceFactory().getDriverClass());

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
@@ -2616,14 +2616,22 @@ public class OpenMetadataOperations implements Callable<Integer> {
               names = {"--backup-path"},
               required = true,
               description = "Path where the backup .tar.gz file will be created")
-          String backupPath) {
+          String backupPath,
+      @Option(
+              names = {"--batch-size"},
+              defaultValue = "1000",
+              description =
+                  "Number of rows to read/write per batch. Default: "
+                      + DatabaseBackupRestore.DEFAULT_BATCH_SIZE)
+          int batchSize) {
     try {
       parseConfig();
       ConnectionType connType = ConnectionType.from(config.getDataSourceFactory().getDriverClass());
       DatasourceConfig.initialize(connType.label);
       String databaseName =
           DatabaseBackupRestore.extractDatabaseName(config.getDataSourceFactory().getUrl());
-      DatabaseBackupRestore backupRestore = new DatabaseBackupRestore(jdbi, connType, databaseName);
+      DatabaseBackupRestore backupRestore =
+          new DatabaseBackupRestore(jdbi, connType, databaseName, batchSize);
       backupRestore.backup(backupPath);
       return 0;
     } catch (Exception e) {
@@ -2644,14 +2652,22 @@ public class OpenMetadataOperations implements Callable<Integer> {
               defaultValue = "false",
               description =
                   "Force restore by truncating existing tables. Without this flag, restore fails if tables have data.")
-          boolean force) {
+          boolean force,
+      @Option(
+              names = {"--batch-size"},
+              defaultValue = "1000",
+              description =
+                  "Number of rows to insert per batch. Default: "
+                      + DatabaseBackupRestore.DEFAULT_BATCH_SIZE)
+          int batchSize) {
     try {
       parseConfig();
       ConnectionType connType = ConnectionType.from(config.getDataSourceFactory().getDriverClass());
       DatasourceConfig.initialize(connType.label);
       String databaseName =
           DatabaseBackupRestore.extractDatabaseName(config.getDataSourceFactory().getUrl());
-      DatabaseBackupRestore backupRestore = new DatabaseBackupRestore(jdbi, connType, databaseName);
+      DatabaseBackupRestore backupRestore =
+          new DatabaseBackupRestore(jdbi, connType, databaseName, batchSize);
       backupRestore.restore(backupPath, force);
       return 0;
     } catch (Exception e) {
@@ -2676,7 +2692,14 @@ public class OpenMetadataOperations implements Callable<Integer> {
               defaultValue = "false",
               description =
                   "Force execution. This command restores a backup (truncating all tables) before running migrations. Pass --force to confirm.")
-          boolean force) {
+          boolean force,
+      @Option(
+              names = {"--batch-size"},
+              defaultValue = "1000",
+              description =
+                  "Number of rows per batch during restore. Default: "
+                      + DatabaseBackupRestore.DEFAULT_BATCH_SIZE)
+          int batchSize) {
     if (!force) {
       LOG.error(
           "test-migration restores a backup which truncates all existing tables. "
@@ -2690,7 +2713,7 @@ public class OpenMetadataOperations implements Callable<Integer> {
       MigrationTestRunner runner =
           new MigrationTestRunner(
               jdbi, connType, config, nativeSQLScriptRootPath, extensionSQLScriptRootPath);
-      return runner.run(backupPath);
+      return runner.run(backupPath, batchSize);
     } catch (Exception e) {
       LOG.error("Migration test failed", e);
       return 1;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
@@ -173,7 +173,7 @@ public class OpenMetadataOperations implements Callable<Integer> {
             + "'drop-create', 'changelog', 'migrate', 'migrate-secrets', 'reindex', 'reembed', 'reindex-rdf', 'reindexdi', 'deploy-pipelines', "
             + "'dbServiceCleanup', 'relationshipCleanup', 'tagUsageCleanup', 'drop-indexes', 'remove-security-config', 'create-indexes', "
             + "'setOpenMetadataUrl', 'configureEmailSettings', 'get-security-config', 'update-security-config', 'install-app', 'delete-app', 'create-user', 'reset-password', "
-            + "'syncAlertOffset', 'analyze-tables', 'cleanup-flowable-history', 'regenerate-bot-tokens', 'backup', 'restore'");
+            + "'syncAlertOffset', 'analyze-tables', 'cleanup-flowable-history', 'regenerate-bot-tokens', 'backup', 'restore', 'test-migration'");
     LOG.info(
         "Use 'reindex --auto-tune' for automatic performance optimization based on cluster capabilities");
     LOG.info(
@@ -2654,6 +2654,31 @@ public class OpenMetadataOperations implements Callable<Integer> {
       return 0;
     } catch (Exception e) {
       LOG.error("Restore failed", e);
+      return 1;
+    }
+  }
+
+  @Command(
+      name = "test-migration",
+      description =
+          "Test database migrations by restoring a backup and running pending migrations with before/after validation.")
+  public Integer testMigration(
+      @Option(
+              names = {"--backup-path"},
+              required = true,
+              description =
+                  "Path to the backup .tar.gz file to restore and test migrations against")
+          String backupPath) {
+    try {
+      parseConfig();
+      ConnectionType connType = ConnectionType.from(config.getDataSourceFactory().getDriverClass());
+      DatasourceConfig.initialize(connType.label);
+      MigrationTestRunner runner =
+          new MigrationTestRunner(
+              jdbi, connType, config, nativeSQLScriptRootPath, extensionSQLScriptRootPath);
+      return runner.run(backupPath);
+    } catch (Exception e) {
+      LOG.error("Migration test failed", e);
       return 1;
     }
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
@@ -16,6 +16,7 @@ import ch.qos.logback.classic.LoggerContext;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.FileConfigurationSourceProvider;
@@ -2615,7 +2616,9 @@ public class OpenMetadataOperations implements Callable<Integer> {
       @Option(
               names = {"--backup-path"},
               required = true,
-              description = "Path where the backup .tar.gz file will be created")
+              description =
+                  "Directory where the backup file will be created. "
+                      + "The file is named automatically as openmetadata_<version>_<timestamp>.tar.gz")
           String backupPath,
       @Option(
               names = {"--batch-size"},
@@ -2632,7 +2635,8 @@ public class OpenMetadataOperations implements Callable<Integer> {
           DatabaseBackupRestore.extractDatabaseName(config.getDataSourceFactory().getUrl());
       DatabaseBackupRestore backupRestore =
           new DatabaseBackupRestore(jdbi, connType, databaseName, batchSize);
-      backupRestore.backup(backupPath);
+      String outputPath = backupRestore.backup(backupPath);
+      LOG.info("Backup saved to: {}", outputPath);
       return 0;
     } catch (Exception e) {
       LOG.error("Backup failed", e);
@@ -2648,12 +2652,6 @@ public class OpenMetadataOperations implements Callable<Integer> {
               description = "Path to the backup .tar.gz file to restore from")
           String backupPath,
       @Option(
-              names = {"--force"},
-              defaultValue = "false",
-              description =
-                  "Force restore by truncating existing tables. Without this flag, restore fails if tables have data.")
-          boolean force,
-      @Option(
               names = {"--batch-size"},
               defaultValue = "1000",
               description =
@@ -2664,16 +2662,63 @@ public class OpenMetadataOperations implements Callable<Integer> {
       parseConfig();
       ConnectionType connType = ConnectionType.from(config.getDataSourceFactory().getDriverClass());
       DatasourceConfig.initialize(connType.label);
+
       String databaseName =
           DatabaseBackupRestore.extractDatabaseName(config.getDataSourceFactory().getUrl());
       DatabaseBackupRestore backupRestore =
           new DatabaseBackupRestore(jdbi, connType, databaseName, batchSize);
-      backupRestore.restore(backupPath, force);
+
+      ObjectNode metadata = DatabaseBackupRestore.readBackupMetadata(backupPath);
+      String backupVersion = metadata.get("version").asText();
+      String targetVersion = resolveTargetVersion(metadata, backupVersion);
+
+      LOG.info("Dropping all tables before restore");
+      dropAllTables();
+
+      LOG.info("Running migrations up to version {}", targetVersion);
+      MigrationWorkflow workflow =
+          new MigrationWorkflow(
+              jdbi,
+              nativeSQLScriptRootPath,
+              connType,
+              extensionSQLScriptRootPath,
+              config.getMigrationConfiguration().getFlywayPath(),
+              config,
+              false);
+      workflow.setTargetVersion(targetVersion);
+      workflow.loadMigrations();
+      workflow.runMigrationWorkflows(true);
+
+      backupRestore.restore(backupPath);
       return 0;
     } catch (Exception e) {
       LOG.error("Restore failed", e);
       return 1;
     }
+  }
+
+  static String resolveTargetVersion(ObjectNode metadata, String fallbackVersion) {
+    JsonNode versionsNode = metadata.get("migrationVersions");
+    if (versionsNode != null && versionsNode.isArray() && !versionsNode.isEmpty()) {
+      String maxVersion = null;
+      for (JsonNode v : versionsNode) {
+        String ver = v.asText();
+        if (maxVersion == null || MigrationWorkflow.compareVersions(ver, maxVersion) > 0) {
+          maxVersion = ver;
+        }
+      }
+      if (maxVersion != null) {
+        LOG.info(
+            "Using max migration version {} from backup metadata (pom version: {})",
+            maxVersion,
+            fallbackVersion);
+        return maxVersion;
+      }
+    }
+    LOG.info(
+        "No migrationVersions in backup metadata, falling back to pom version: {}",
+        fallbackVersion);
+    return fallbackVersion;
   }
 
   @Command(
@@ -2688,28 +2733,18 @@ public class OpenMetadataOperations implements Callable<Integer> {
                   "Path to the backup .tar.gz file to restore and test migrations against")
           String backupPath,
       @Option(
-              names = {"--force"},
-              defaultValue = "false",
-              description =
-                  "Force execution. This command restores a backup (truncating all tables) before running migrations. Pass --force to confirm.")
-          boolean force,
-      @Option(
               names = {"--batch-size"},
               defaultValue = "1000",
               description =
                   "Number of rows per batch during restore. Default: "
                       + DatabaseBackupRestore.DEFAULT_BATCH_SIZE)
           int batchSize) {
-    if (!force) {
-      LOG.error(
-          "test-migration restores a backup which truncates all existing tables. "
-              + "Pass --force to confirm you want to proceed.");
-      return 1;
-    }
     try {
       parseConfig();
       ConnectionType connType = ConnectionType.from(config.getDataSourceFactory().getDriverClass());
       DatasourceConfig.initialize(connType.label);
+      LOG.info("Dropping all tables before test-migration");
+      dropAllTables();
       MigrationTestRunner runner =
           new MigrationTestRunner(
               jdbi, connType, config, nativeSQLScriptRootPath, extensionSQLScriptRootPath);

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/DatabaseBackupRestoreTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/DatabaseBackupRestoreTest.java
@@ -1,0 +1,38 @@
+package org.openmetadata.service.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class DatabaseBackupRestoreTest {
+
+  @Test
+  void testExtractDatabaseNameMySQL() {
+    assertEquals(
+        "openmetadata_db",
+        DatabaseBackupRestore.extractDatabaseName(
+            "jdbc:mysql://localhost:3306/openmetadata_db?useSSL=false"));
+  }
+
+  @Test
+  void testExtractDatabaseNamePostgres() {
+    assertEquals(
+        "openmetadata_db",
+        DatabaseBackupRestore.extractDatabaseName(
+            "jdbc:postgresql://localhost:5432/openmetadata_db?sslmode=disable"));
+  }
+
+  @Test
+  void testExtractDatabaseNameNoParams() {
+    assertEquals(
+        "mydb", DatabaseBackupRestore.extractDatabaseName("jdbc:mysql://localhost:3306/mydb"));
+  }
+
+  @Test
+  void testExtractDatabaseNameEmptyThrows() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> DatabaseBackupRestore.extractDatabaseName("jdbc:mysql://localhost:3306/"));
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/DatabaseBackupRestoreTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/DatabaseBackupRestoreTest.java
@@ -1,6 +1,7 @@
 package org.openmetadata.service.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -8,11 +9,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.BufferedOutputStream;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.time.Instant;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
@@ -210,5 +217,159 @@ class DatabaseBackupRestoreTest {
     assertEquals("id", resultTables.get("users").get("columns").get(0).asText());
     assertEquals("name", resultTables.get("users").get("columns").get(1).asText());
     assertEquals("email", resultTables.get("users").get("columns").get(2).asText());
+  }
+
+  @Test
+  void testBuildBackupFileName() {
+    Instant timestamp = Instant.parse("2026-03-19T14:30:45Z");
+    String result = DatabaseBackupRestore.buildBackupFileName("1.6.0", timestamp);
+    assertEquals("openmetadata_1_6_0_20260319T143045.tar.gz", result);
+  }
+
+  @Test
+  void testBuildBackupFileNameUnknownVersion() {
+    Instant timestamp = Instant.parse("2026-01-01T00:00:00Z");
+    String result = DatabaseBackupRestore.buildBackupFileName("unknown", timestamp);
+    assertEquals("openmetadata_unknown_20260101T000000.tar.gz", result);
+  }
+
+  @Test
+  void testBuildBackupFileNameSnapshotVersion() {
+    Instant timestamp = Instant.parse("2026-06-15T09:15:30Z");
+    String result = DatabaseBackupRestore.buildBackupFileName("1.7.0-SNAPSHOT", timestamp);
+    assertEquals("openmetadata_1_7_0-SNAPSHOT_20260615T091530.tar.gz", result);
+  }
+
+  @Test
+  void testTopologicalSortNoDependencies() {
+    Set<String> tables = Set.of("a", "b", "c");
+    List<String> sorted = DatabaseBackupRestore.topologicalSort(tables, Map.of());
+    assertEquals(3, sorted.size());
+    assertEquals(tables, new HashSet<>(sorted));
+  }
+
+  @Test
+  void testTopologicalSortSimpleChain() {
+    Set<String> tables = Set.of("parent", "child", "grandchild");
+    Map<String, Set<String>> deps =
+        Map.of(
+            "child", Set.of("parent"),
+            "grandchild", Set.of("child"));
+
+    List<String> sorted = DatabaseBackupRestore.topologicalSort(tables, deps);
+    assertTrue(sorted.indexOf("parent") < sorted.indexOf("child"));
+    assertTrue(sorted.indexOf("child") < sorted.indexOf("grandchild"));
+  }
+
+  @Test
+  void testTopologicalSortDiamond() {
+    Set<String> tables = Set.of("root", "left", "right", "leaf");
+    Map<String, Set<String>> deps =
+        Map.of(
+            "left", Set.of("root"),
+            "right", Set.of("root"),
+            "leaf", Set.of("left", "right"));
+
+    List<String> sorted = DatabaseBackupRestore.topologicalSort(tables, deps);
+    assertTrue(sorted.indexOf("root") < sorted.indexOf("left"));
+    assertTrue(sorted.indexOf("root") < sorted.indexOf("right"));
+    assertTrue(sorted.indexOf("left") < sorted.indexOf("leaf"));
+    assertTrue(sorted.indexOf("right") < sorted.indexOf("leaf"));
+  }
+
+  @Test
+  void testTopologicalSortSelfReferenceIgnored() {
+    Set<String> tables = Set.of("self_ref");
+    Map<String, Set<String>> deps = Map.of("self_ref", Set.of("self_ref"));
+
+    List<String> sorted = DatabaseBackupRestore.topologicalSort(tables, deps);
+    assertEquals(List.of("self_ref"), sorted);
+  }
+
+  @Test
+  void testTopologicalSortExternalDependencyIgnored() {
+    Set<String> tables = Set.of("a", "b");
+    Map<String, Set<String>> deps = Map.of("a", Set.of("external_table"));
+
+    List<String> sorted = DatabaseBackupRestore.topologicalSort(tables, deps);
+    assertEquals(2, sorted.size());
+    assertEquals(tables, new HashSet<>(sorted));
+  }
+
+  @Test
+  void testTopologicalSortCircularDependency() {
+    Set<String> tables = Set.of("a", "b");
+    Map<String, Set<String>> deps =
+        Map.of(
+            "a", Set.of("b"),
+            "b", Set.of("a"));
+
+    List<String> sorted = DatabaseBackupRestore.topologicalSort(tables, deps);
+    assertEquals(2, sorted.size());
+    assertEquals(tables, new HashSet<>(sorted));
+  }
+
+  @Test
+  void testIsExcludedFrameworkTable() {
+    assertTrue(DatabaseBackupRestore.isExcludedFrameworkTable("act_ru_task"));
+    assertTrue(DatabaseBackupRestore.isExcludedFrameworkTable("act_ge_property"));
+    assertTrue(DatabaseBackupRestore.isExcludedFrameworkTable("flw_event_resource"));
+    assertTrue(DatabaseBackupRestore.isExcludedFrameworkTable("qrtz_job_details"));
+    assertFalse(DatabaseBackupRestore.isExcludedFrameworkTable("user_entity"));
+    assertFalse(DatabaseBackupRestore.isExcludedFrameworkTable("table_entity"));
+    assertFalse(DatabaseBackupRestore.isExcludedFrameworkTable("SERVER_CHANGE_LOG"));
+    assertFalse(DatabaseBackupRestore.isExcludedFrameworkTable("SERVER_MIGRATION_SQL_LOGS"));
+  }
+
+  @Test
+  void testResolveTargetVersionWithMigrationVersions() {
+    ObjectNode metadata = MAPPER.createObjectNode();
+    metadata.put("version", "1.12.0-SNAPSHOT");
+    var versions = MAPPER.createArrayNode();
+    versions.add("0.0.0");
+    versions.add("1.11.0");
+    versions.add("1.12.0");
+    versions.add("1.12.1");
+    metadata.set("migrationVersions", versions);
+
+    assertEquals(
+        "1.12.1", OpenMetadataOperations.resolveTargetVersion(metadata, "1.12.0-SNAPSHOT"));
+  }
+
+  @Test
+  void testResolveTargetVersionFallsBackToPomVersion() {
+    ObjectNode metadata = MAPPER.createObjectNode();
+    metadata.put("version", "1.12.0-SNAPSHOT");
+
+    assertEquals(
+        "1.12.0-SNAPSHOT",
+        OpenMetadataOperations.resolveTargetVersion(metadata, "1.12.0-SNAPSHOT"));
+  }
+
+  @Test
+  void testResolveTargetVersionEmptyMigrationVersions() {
+    ObjectNode metadata = MAPPER.createObjectNode();
+    metadata.put("version", "1.12.0-SNAPSHOT");
+    metadata.set("migrationVersions", MAPPER.createArrayNode());
+
+    assertEquals(
+        "1.12.0-SNAPSHOT",
+        OpenMetadataOperations.resolveTargetVersion(metadata, "1.12.0-SNAPSHOT"));
+  }
+
+  @Test
+  void testInsertRowsStreamingFromFile(@TempDir Path tempDir) throws IOException {
+    Path jsonFile = tempDir.resolve("test_table.json");
+    String jsonContent = "[{\"id\":1,\"name\":\"alice\"},{\"id\":2,\"name\":\"bob\"}]";
+    java.nio.file.Files.writeString(jsonFile, jsonContent);
+
+    DatabaseBackupRestore instance =
+        new DatabaseBackupRestore(null, ConnectionType.MYSQL, "testdb");
+
+    try (InputStream is = new FileInputStream(jsonFile.toFile())) {
+      // insertRowsStreaming requires a Handle, so we just verify the InputStream signature compiles
+      // Full integration testing is done in the integration test suite
+      assertNotNull(is);
+    }
   }
 }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/DatabaseBackupRestoreTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/DatabaseBackupRestoreTest.java
@@ -68,17 +68,26 @@ class DatabaseBackupRestoreTest {
   }
 
   @Test
-  void testQuoteIdentifierMySQLWithEmbeddedBacktick() {
+  void testQuoteIdentifierMySQLRejectsInvalidIdentifier() {
     DatabaseBackupRestore mysqlInstance =
         new DatabaseBackupRestore(null, ConnectionType.MYSQL, "testdb");
-    assertEquals("`col``name`", mysqlInstance.quoteIdentifier("col`name"));
+    assertThrows(IllegalArgumentException.class, () -> mysqlInstance.quoteIdentifier("col`name"));
   }
 
   @Test
-  void testQuoteIdentifierPostgresWithEmbeddedDoubleQuote() {
+  void testQuoteIdentifierPostgresRejectsInvalidIdentifier() {
     DatabaseBackupRestore pgInstance =
         new DatabaseBackupRestore(null, ConnectionType.POSTGRES, "testdb");
-    assertEquals("\"col\"\"name\"", pgInstance.quoteIdentifier("col\"name"));
+    assertThrows(IllegalArgumentException.class, () -> pgInstance.quoteIdentifier("col\"name"));
+  }
+
+  @Test
+  void testQuoteIdentifierRejectsSqlInjection() {
+    DatabaseBackupRestore mysqlInstance =
+        new DatabaseBackupRestore(null, ConnectionType.MYSQL, "testdb");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> mysqlInstance.quoteIdentifier("foo; DROP TABLE users; --"));
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/DatabaseBackupRestoreTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/DatabaseBackupRestoreTest.java
@@ -1,11 +1,28 @@
 package org.openmetadata.service.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.BufferedOutputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.openmetadata.service.jdbi3.locator.ConnectionType;
 
 class DatabaseBackupRestoreTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
 
   @Test
   void testExtractDatabaseNameMySQL() {
@@ -34,5 +51,155 @@ class DatabaseBackupRestoreTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> DatabaseBackupRestore.extractDatabaseName("jdbc:mysql://localhost:3306/"));
+  }
+
+  @Test
+  void testQuoteIdentifierMySQL() {
+    DatabaseBackupRestore mysqlInstance =
+        new DatabaseBackupRestore(null, ConnectionType.MYSQL, "testdb");
+    assertEquals("`foo`", mysqlInstance.quoteIdentifier("foo"));
+  }
+
+  @Test
+  void testQuoteIdentifierPostgres() {
+    DatabaseBackupRestore pgInstance =
+        new DatabaseBackupRestore(null, ConnectionType.POSTGRES, "testdb");
+    assertEquals("\"foo\"", pgInstance.quoteIdentifier("foo"));
+  }
+
+  @Test
+  void testQuoteIdentifierMySQLWithEmbeddedBacktick() {
+    DatabaseBackupRestore mysqlInstance =
+        new DatabaseBackupRestore(null, ConnectionType.MYSQL, "testdb");
+    assertEquals("`col``name`", mysqlInstance.quoteIdentifier("col`name"));
+  }
+
+  @Test
+  void testQuoteIdentifierPostgresWithEmbeddedDoubleQuote() {
+    DatabaseBackupRestore pgInstance =
+        new DatabaseBackupRestore(null, ConnectionType.POSTGRES, "testdb");
+    assertEquals("\"col\"\"name\"", pgInstance.quoteIdentifier("col\"name"));
+  }
+
+  @Test
+  void testQuoteColumnsMySQL() {
+    DatabaseBackupRestore mysqlInstance =
+        new DatabaseBackupRestore(null, ConnectionType.MYSQL, "testdb");
+    String result = mysqlInstance.quoteColumns(List.of("id", "name", "email"));
+    assertEquals("`id`, `name`, `email`", result);
+  }
+
+  @Test
+  void testQuoteColumnsPostgres() {
+    DatabaseBackupRestore pgInstance =
+        new DatabaseBackupRestore(null, ConnectionType.POSTGRES, "testdb");
+    String result = pgInstance.quoteColumns(List.of("id", "name", "email"));
+    assertEquals("\"id\", \"name\", \"email\"", result);
+  }
+
+  @Test
+  void testQuoteColumnsSingleColumn() {
+    DatabaseBackupRestore mysqlInstance =
+        new DatabaseBackupRestore(null, ConnectionType.MYSQL, "testdb");
+    assertEquals("`id`", mysqlInstance.quoteColumns(List.of("id")));
+  }
+
+  @Test
+  void testReadBackupMetadataMissingThrows(@TempDir Path tempDir) throws IOException {
+    Path archivePath = tempDir.resolve("no-metadata.tar.gz");
+    try (FileOutputStream fos = new FileOutputStream(archivePath.toFile());
+        BufferedOutputStream bos = new BufferedOutputStream(fos);
+        GzipCompressorOutputStream gzos = new GzipCompressorOutputStream(bos);
+        TarArchiveOutputStream taos = new TarArchiveOutputStream(gzos)) {
+      byte[] content = "some data".getBytes(StandardCharsets.UTF_8);
+      TarArchiveEntry entry = new TarArchiveEntry("tables/users.json");
+      entry.setSize(content.length);
+      taos.putArchiveEntry(entry);
+      taos.write(content);
+      taos.closeArchiveEntry();
+    }
+
+    IOException ex =
+        assertThrows(
+            IOException.class,
+            () -> DatabaseBackupRestore.readBackupMetadata(archivePath.toString()));
+    assertTrue(ex.getMessage().contains("metadata.json not found"));
+  }
+
+  @Test
+  void testReadBackupMetadataSuccess(@TempDir Path tempDir) throws IOException {
+    Path archivePath = tempDir.resolve("with-metadata.tar.gz");
+
+    ObjectNode metadata = MAPPER.createObjectNode();
+    metadata.put("timestamp", "2026-01-15T10:30:00Z");
+    metadata.put("version", "1.6.0");
+    metadata.put("databaseType", "MYSQL");
+    metadata.put("databaseName", "openmetadata_db");
+
+    byte[] metadataBytes = MAPPER.writeValueAsBytes(metadata);
+
+    try (FileOutputStream fos = new FileOutputStream(archivePath.toFile());
+        BufferedOutputStream bos = new BufferedOutputStream(fos);
+        GzipCompressorOutputStream gzos = new GzipCompressorOutputStream(bos);
+        TarArchiveOutputStream taos = new TarArchiveOutputStream(gzos)) {
+      TarArchiveEntry entry = new TarArchiveEntry("metadata.json");
+      entry.setSize(metadataBytes.length);
+      taos.putArchiveEntry(entry);
+      taos.write(metadataBytes);
+      taos.closeArchiveEntry();
+    }
+
+    ObjectNode result = DatabaseBackupRestore.readBackupMetadata(archivePath.toString());
+    assertNotNull(result);
+    assertEquals("2026-01-15T10:30:00Z", result.get("timestamp").asText());
+    assertEquals("1.6.0", result.get("version").asText());
+    assertEquals("MYSQL", result.get("databaseType").asText());
+    assertEquals("openmetadata_db", result.get("databaseName").asText());
+  }
+
+  @Test
+  void testReadBackupMetadataRoundTrip(@TempDir Path tempDir) throws IOException {
+    Path archivePath = tempDir.resolve("round-trip.tar.gz");
+
+    ObjectNode tablesMetadata = MAPPER.createObjectNode();
+    ObjectNode usersTable = MAPPER.createObjectNode();
+    usersTable.putArray("columns").add("id").add("name").add("email");
+    usersTable.putArray("binaryColumns");
+    usersTable.put("rowCount", 42);
+    tablesMetadata.set("users", usersTable);
+
+    ObjectNode metadata = MAPPER.createObjectNode();
+    metadata.put("timestamp", "2026-03-19T08:00:00Z");
+    metadata.put("version", "1.6.0");
+    metadata.put("databaseType", "POSTGRES");
+    metadata.put("databaseName", "om_db");
+    metadata.set("tables", tablesMetadata);
+
+    byte[] metadataBytes = MAPPER.writeValueAsBytes(metadata);
+
+    try (FileOutputStream fos = new FileOutputStream(archivePath.toFile());
+        BufferedOutputStream bos = new BufferedOutputStream(fos);
+        GzipCompressorOutputStream gzos = new GzipCompressorOutputStream(bos);
+        TarArchiveOutputStream taos = new TarArchiveOutputStream(gzos)) {
+      TarArchiveEntry entry = new TarArchiveEntry("metadata.json");
+      entry.setSize(metadataBytes.length);
+      taos.putArchiveEntry(entry);
+      taos.write(metadataBytes);
+      taos.closeArchiveEntry();
+    }
+
+    ObjectNode result = DatabaseBackupRestore.readBackupMetadata(archivePath.toString());
+    assertNotNull(result);
+    assertEquals("POSTGRES", result.get("databaseType").asText());
+    assertEquals("om_db", result.get("databaseName").asText());
+
+    ObjectNode resultTables = (ObjectNode) result.get("tables");
+    assertNotNull(resultTables);
+    assertNotNull(resultTables.get("users"));
+    assertEquals(42, resultTables.get("users").get("rowCount").asInt());
+    assertEquals(3, resultTables.get("users").get("columns").size());
+    assertEquals("id", resultTables.get("users").get("columns").get(0).asText());
+    assertEquals("name", resultTables.get("users").get("columns").get(1).asText());
+    assertEquals("email", resultTables.get("users").get("columns").get(2).asText());
   }
 }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/DatabaseBackupRestoreTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/DatabaseBackupRestoreTest.java
@@ -143,6 +143,34 @@ class DatabaseBackupRestoreTest {
   }
 
   @Test
+  void testReadBackupMetadataMissingRequiredFieldThrows(@TempDir Path tempDir) throws IOException {
+    Path archivePath = tempDir.resolve("incomplete-metadata.tar.gz");
+
+    ObjectNode metadata = MAPPER.createObjectNode();
+    metadata.put("version", "1.6.0");
+    metadata.put("databaseType", "MYSQL");
+
+    byte[] metadataBytes = MAPPER.writeValueAsBytes(metadata);
+
+    try (FileOutputStream fos = new FileOutputStream(archivePath.toFile());
+        BufferedOutputStream bos = new BufferedOutputStream(fos);
+        GzipCompressorOutputStream gzos = new GzipCompressorOutputStream(bos);
+        TarArchiveOutputStream taos = new TarArchiveOutputStream(gzos)) {
+      TarArchiveEntry entry = new TarArchiveEntry("metadata.json");
+      entry.setSize(metadataBytes.length);
+      taos.putArchiveEntry(entry);
+      taos.write(metadataBytes);
+      taos.closeArchiveEntry();
+    }
+
+    IOException ex =
+        assertThrows(
+            IOException.class,
+            () -> DatabaseBackupRestore.readBackupMetadata(archivePath.toString()));
+    assertTrue(ex.getMessage().contains("missing required field: tables"));
+  }
+
+  @Test
   void testReadBackupMetadataSuccess(@TempDir Path tempDir) throws IOException {
     Path archivePath = tempDir.resolve("with-metadata.tar.gz");
 
@@ -151,6 +179,7 @@ class DatabaseBackupRestoreTest {
     metadata.put("version", "1.6.0");
     metadata.put("databaseType", "MYSQL");
     metadata.put("databaseName", "openmetadata_db");
+    metadata.set("tables", MAPPER.createObjectNode());
 
     byte[] metadataBytes = MAPPER.writeValueAsBytes(metadata);
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/MigrationTestRunnerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/MigrationTestRunnerTest.java
@@ -1,6 +1,7 @@
 package org.openmetadata.service.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -9,32 +10,32 @@ class MigrationTestRunnerTest {
 
   @Test
   void testVersionToPackageStandard() {
-    assertEquals("v1120", MigrationTestRunner.versionToPackage("1.12.0"));
+    assertEquals("v1_12_0", MigrationTestRunner.versionToPackage("1.12.0"));
   }
 
   @Test
   void testVersionToPackageSingleDigit() {
-    assertEquals("v110", MigrationTestRunner.versionToPackage("1.1.0"));
+    assertEquals("v1_1_0", MigrationTestRunner.versionToPackage("1.1.0"));
   }
 
   @Test
   void testVersionToPackageWithPatch() {
-    assertEquals("v1115", MigrationTestRunner.versionToPackage("1.1.15"));
+    assertEquals("v1_1_15", MigrationTestRunner.versionToPackage("1.1.15"));
   }
 
   @Test
   void testVersionToPackageWithExtension() {
-    assertEquals("v1120", MigrationTestRunner.versionToPackage("1.12.0-collate"));
+    assertEquals("v1_12_0", MigrationTestRunner.versionToPackage("1.12.0-collate"));
   }
 
   @Test
   void testVersionToPackageMajorOnly() {
-    assertEquals("v200", MigrationTestRunner.versionToPackage("2.0.0"));
+    assertEquals("v2_0_0", MigrationTestRunner.versionToPackage("2.0.0"));
   }
 
   @Test
   void testVersionToPackageTwoParts() {
-    assertEquals("v10", MigrationTestRunner.versionToPackage("1.0"));
+    assertEquals("v1_0", MigrationTestRunner.versionToPackage("1.0"));
   }
 
   @Test
@@ -49,6 +50,13 @@ class MigrationTestRunnerTest {
 
   @Test
   void testVersionToPackageWithExtensionTwoParts() {
-    assertEquals("v16", MigrationTestRunner.versionToPackage("1.6-SNAPSHOT"));
+    assertEquals("v1_6", MigrationTestRunner.versionToPackage("1.6-SNAPSHOT"));
+  }
+
+  @Test
+  void testVersionToPackageNoCollision() {
+    String v1 = MigrationTestRunner.versionToPackage("1.12.0");
+    String v2 = MigrationTestRunner.versionToPackage("1.1.20");
+    assertNotEquals(v1, v2);
   }
 }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/MigrationTestRunnerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/MigrationTestRunnerTest.java
@@ -1,0 +1,33 @@
+package org.openmetadata.service.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class MigrationTestRunnerTest {
+
+  @Test
+  void testVersionToPackageStandard() {
+    assertEquals("v1120", MigrationTestRunner.versionToPackage("1.12.0"));
+  }
+
+  @Test
+  void testVersionToPackageSingleDigit() {
+    assertEquals("v110", MigrationTestRunner.versionToPackage("1.1.0"));
+  }
+
+  @Test
+  void testVersionToPackageWithPatch() {
+    assertEquals("v1115", MigrationTestRunner.versionToPackage("1.1.15"));
+  }
+
+  @Test
+  void testVersionToPackageWithExtension() {
+    assertEquals("v1120", MigrationTestRunner.versionToPackage("1.12.0-collate"));
+  }
+
+  @Test
+  void testVersionToPackageMajorOnly() {
+    assertEquals("v200", MigrationTestRunner.versionToPackage("2.0.0"));
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/MigrationTestRunnerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/MigrationTestRunnerTest.java
@@ -1,8 +1,6 @@
 package org.openmetadata.service.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
@@ -10,32 +8,32 @@ class MigrationTestRunnerTest {
 
   @Test
   void testVersionToPackageStandard() {
-    assertEquals("v1_12_0", MigrationTestRunner.versionToPackage("1.12.0"));
+    assertEquals("v1120", MigrationTestRunner.versionToPackage("1.12.0"));
   }
 
   @Test
   void testVersionToPackageSingleDigit() {
-    assertEquals("v1_1_0", MigrationTestRunner.versionToPackage("1.1.0"));
+    assertEquals("v110", MigrationTestRunner.versionToPackage("1.1.0"));
   }
 
   @Test
   void testVersionToPackageWithPatch() {
-    assertEquals("v1_1_15", MigrationTestRunner.versionToPackage("1.1.15"));
+    assertEquals("v1115", MigrationTestRunner.versionToPackage("1.1.15"));
   }
 
   @Test
   void testVersionToPackageWithExtension() {
-    assertEquals("v1_12_0", MigrationTestRunner.versionToPackage("1.12.0-collate"));
+    assertEquals("v1120", MigrationTestRunner.versionToPackage("1.12.0-collate"));
   }
 
   @Test
   void testVersionToPackageMajorOnly() {
-    assertEquals("v2_0_0", MigrationTestRunner.versionToPackage("2.0.0"));
+    assertEquals("v200", MigrationTestRunner.versionToPackage("2.0.0"));
   }
 
   @Test
   void testVersionToPackageTwoParts() {
-    assertEquals("v1_0", MigrationTestRunner.versionToPackage("1.0"));
+    assertEquals("v10", MigrationTestRunner.versionToPackage("1.0"));
   }
 
   @Test
@@ -44,19 +42,7 @@ class MigrationTestRunnerTest {
   }
 
   @Test
-  void testVersionToPackageInvalidNonNumericThrows() {
-    assertThrows(NumberFormatException.class, () -> MigrationTestRunner.versionToPackage("abc"));
-  }
-
-  @Test
   void testVersionToPackageWithExtensionTwoParts() {
-    assertEquals("v1_6", MigrationTestRunner.versionToPackage("1.6-SNAPSHOT"));
-  }
-
-  @Test
-  void testVersionToPackageNoCollision() {
-    String v1 = MigrationTestRunner.versionToPackage("1.12.0");
-    String v2 = MigrationTestRunner.versionToPackage("1.1.20");
-    assertNotEquals(v1, v2);
+    assertEquals("v16", MigrationTestRunner.versionToPackage("1.6-SNAPSHOT"));
   }
 }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/MigrationTestRunnerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/MigrationTestRunnerTest.java
@@ -1,6 +1,7 @@
 package org.openmetadata.service.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
@@ -29,5 +30,25 @@ class MigrationTestRunnerTest {
   @Test
   void testVersionToPackageMajorOnly() {
     assertEquals("v200", MigrationTestRunner.versionToPackage("2.0.0"));
+  }
+
+  @Test
+  void testVersionToPackageTwoParts() {
+    assertEquals("v10", MigrationTestRunner.versionToPackage("1.0"));
+  }
+
+  @Test
+  void testVersionToPackageSinglePart() {
+    assertEquals("v3", MigrationTestRunner.versionToPackage("3"));
+  }
+
+  @Test
+  void testVersionToPackageInvalidNonNumericThrows() {
+    assertThrows(NumberFormatException.class, () -> MigrationTestRunner.versionToPackage("abc"));
+  }
+
+  @Test
+  void testVersionToPackageWithExtensionTwoParts() {
+    assertEquals("v16", MigrationTestRunner.versionToPackage("1.6-SNAPSHOT"));
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,7 @@
     <commonmark.version>0.26.0</commonmark.version>
     <flexmark.version>0.64.8</flexmark.version>
     <owasp-html-sanitizer.version>20260101.1</owasp-html-sanitizer.version>
+    <commons-compress.version>1.27.1</commons-compress.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
## Summary

Adds CLI commands for full database backup, restore, and migration testing to `OpenMetadataOperations`. Supports both MySQL and PostgreSQL.

### Core components

- **`DatabaseBackupRestore`** — Backs up all OpenMetadata tables to a `.tar.gz` archive and restores them with FK-safe ordering
- **`MigrationTestRunner`** + **`MigrationTestCase`** interface — Runs pending migrations one-by-one against a restored backup, executing before/after validation assertions per version
- **`MigrationWorkflow.targetVersion`** — New setter to cap migrations at a specific version, used by restore and test-migration to replay only the migrations that existed at backup time

### Key design decisions

- **Backup auto-names the output file** as `openmetadata_<version>_<timestamp>.tar.gz` in the given directory
- **Restore drops all tables first**, then runs migrations up to the backup's max migration version to recreate the schema, then inserts backup data — no `--force` flag needed
- **Framework tables are excluded** (`act_*`, `flw_*`, `qrtz_*`) since Flowable/Quartz recreate their own tables on startup
- **Migration versions are recorded** in backup metadata so restore targets the exact schema version, not the pom version
- **FK-safe restore order** via topological sort of foreign key dependencies, with graceful handling of circular refs
- **PostgreSQL cast support** for `jsonb`, `uuid`, and `timestamp` columns during restore
- **Path traversal protection** — table names from backup metadata are validated against `SAFE_IDENTIFIER` and extracted paths are normalized to prevent writes outside the temp directory

### Usage

```bash
# Backup (auto-generates filename in the given directory)
./openmetadata-ops.sh backup -c conf/openmetadata.yaml --backup-path /path/to/dir/

# Restore (drops all tables, runs migrations to backup version, inserts data)
./openmetadata-ops.sh restore -c conf/openmetadata.yaml --backup-path /path/to/openmetadata_1_6_0_20260319T143045.tar.gz

# Test migrations against a backup
./openmetadata-ops.sh test-migration -c conf/openmetadata.yaml --backup-path /path/to/backup.tar.gz

# All commands support --batch-size (default: 1000)
./openmetadata-ops.sh backup -c conf/openmetadata.yaml --backup-path /path/to/dir/ --batch-size 5000
```

### Migration test framework

Define test classes per migration version following this convention:

```java
package org.openmetadata.service.migration.utils.v1130; // for version 1.13.0

public class MigrationTest implements MigrationTestCase {
  @Override
  public List<TestResult> validateBefore(Handle handle) {
    // assertions on data state before this migration runs
  }
  @Override
  public List<TestResult> validateAfter(Handle handle) {
    // assertions on data state after this migration runs
  }
}
```

The `test-migration` command outputs a summary table:

```
====================================================================================
                               Migration Test Summary
====================================================================================
 Source version  : 1.11.5
 Target version  : 1.13.0
 Database type   : POSTGRES
 Backup timestamp: 2026-03-21T17:17:25.309110Z
------------------------------------------------------------------------------------
 Migration | Test                                               | Phase   | Result  
------------------------------------------------------------------------------------
 1.11.2    | (no tests)                                         | -       | -       
 1.11.6    | (no tests)                                         | -       | -       
 1.11.8    | (no tests)                                         | -       | -       
 1.11.9    | (no tests)                                         | -       | -       
 1.11.11   | (no tests)                                         | -       | -       
 1.11.12   | (no tests)                                         | -       | -       
 1.12.0    | (no tests)                                         | -       | -       
 1.12.1    | (no tests)                                         | -       | -       
 1.12.2    | (no tests)                                         | -       | -       
 1.12.3    | (no tests)                                         | -       | -       
 1.13.0    | installed_apps: preview field exists               | BEFORE  | PASS    
 1.13.0    | apps_marketplace: preview field exists             | BEFORE  | PASS    
 1.13.0    | installed_apps: enabled field has correct value    | AFTER   | PASS    
 1.13.0    | apps_marketplace: enabled field has correct value  | AFTER   | PASS    
------------------------------------------------------------------------------------
 Total: 4 passed, 0 failed
====================================================================================
```

### Archive structure

```
backup.tar.gz
├── metadata.json          # version, timestamp, databaseType, migrationVersions, per-table column/type info
└── tables/
    ├── user_entity.json   # JSON array of rows
    ├── table_entity.json
    └── ...
```

## Test plan

- [x] Unit tests for `extractDatabaseName` — MySQL, PostgreSQL, no-params, empty-throws (4 tests)
- [x] Unit tests for `quoteIdentifier` / `quoteColumns` — MySQL, PostgreSQL, SQL injection rejection (7 tests)
- [x] Unit tests for `readBackupMetadata` — missing metadata, success, round-trip (3 tests)
- [x] Unit tests for `buildBackupFileName` — standard, unknown, snapshot versions (3 tests)
- [x] Unit tests for `topologicalSort` — no deps, chain, diamond, self-ref, external, circular (6 tests)
- [x] Unit tests for `isExcludedFrameworkTable` — framework prefixes and OpenMetadata tables (1 test)
- [x] Unit tests for `resolveTargetVersion` — with migration versions, fallback, empty array (3 tests)
- [x] Unit tests for `versionToPackage` — standard, single digit, patch, extension, major, two-part, single-part (7 tests)
- [ ] Manual test: backup against a local MySQL database, verify archive structure
- [ ] Manual test: restore to a clean database, verify data integrity
- [ ] Manual test: test-migration with a sample `MigrationTest` class
- [ ] Manual test: backup and restore with PostgreSQL, verify jsonb/uuid casts


🤖 Generated with [Claude Code](https://claude.com/claude-code)