### PR TITLE
Fix #1751: correct tableConstraint to tableConstraints in DI config

### DIFF
--- a/openmetadata-service/src/main/resources/dataInsights/config.json
+++ b/openmetadata-service/src/main/resources/dataInsights/config.json
@@ -20,7 +20,7 @@
       "tableType",
       "columns",
       "databaseSchema",
-      "tableConstraint",
+      "tableConstraints",
       "database",
       "service",
       "serviceType"


### PR DESCRIPTION
Fixes https://github.com/open-metadata/openmetadata-collate/issues/1751

## Summary

- The DI field allowlist in `config.json` has `"tableConstraint"` (singular), but the Table entity schema property is `"tableConstraints"` (plural)
- The `retainAll()` filter in `DataInsightsEntityEnricherProcessor` silently drops the field because the names don't match
- This means `tableConstraints` data is never indexed into DI documents, so any custom chart referencing it (e.g. "count joins per database") returns empty results
- Fix: `tableConstraint` → `tableConstraints` (one character)

Note: PR #22199 attempted this fix but introduced the singular/plural typo.

## Test plan

- [x] Clean environment, load 5000 tables, patch 50 with FOREIGN_KEY constraints
- [x] Before fix: `exists` query on `tableConstraints` returns 0 DI documents
- [x] After fix: `exists` query returns 34 documents with full constraint data