### PR TITLE
fix: normalize usageSummary.date format and add explicit ES mapping

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -6201,8 +6201,9 @@ public interface CollectionDAO {
             new UsageStats()
                 .withCount(r.getInt("count30"))
                 .withPercentileRank(r.getDouble("percentile30"));
+        java.sql.Date usageDate = r.getDate("usageDate");
         return new UsageDetails()
-            .withDate(r.getString("usageDate"))
+            .withDate(usageDate != null ? usageDate.toString() : null)
             .withDailyStats(dailyStats)
             .withWeeklyStats(weeklyStats)
             .withMonthlyStats(monthlyStats);
@@ -6244,9 +6245,10 @@ public interface CollectionDAO {
             new UsageStats()
                 .withCount(r.getInt("count30"))
                 .withPercentileRank(r.getDouble("percentile30"));
+        java.sql.Date usageDate = r.getDate("usageDate");
         UsageDetails usageDetails =
             new UsageDetails()
-                .withDate(r.getString("usageDate"))
+                .withDate(usageDate != null ? usageDate.toString() : null)
                 .withDailyStats(dailyStats)
                 .withWeeklyStats(weeklyStats)
                 .withMonthlyStats(monthlyStats);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/UsageRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/UsageRepository.java
@@ -260,8 +260,9 @@ public class UsageRepository {
           new UsageStats()
               .withCount(r.getInt("count30"))
               .withPercentileRank(r.getDouble("percentile30"));
+      java.sql.Date usageDate = r.getDate("usageDate");
       return new UsageDetails()
-          .withDate(r.getString("usageDate"))
+          .withDate(usageDate != null ? usageDate.toString() : null)
           .withDailyStats(dailyStats)
           .withWeeklyStats(weeklyStats)
           .withMonthlyStats(monthlyStats);

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/UsageDetailsMapperTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/UsageDetailsMapperTest.java
@@ -1,0 +1,112 @@
+package org.openmetadata.service.jdbi3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.when;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.jdbi.v3.core.statement.StatementContext;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.openmetadata.schema.type.UsageDetails;
+
+public class UsageDetailsMapperTest {
+
+  private ResultSet mockResultSet(java.sql.Date usageDate) throws SQLException {
+    ResultSet r = Mockito.mock(ResultSet.class);
+    when(r.getDate("usageDate")).thenReturn(usageDate);
+    when(r.getInt("count1")).thenReturn(10);
+    when(r.getDouble("percentile1")).thenReturn(80.0);
+    when(r.getInt("count7")).thenReturn(70);
+    when(r.getDouble("percentile7")).thenReturn(75.0);
+    when(r.getInt("count30")).thenReturn(300);
+    when(r.getDouble("percentile30")).thenReturn(70.0);
+    return r;
+  }
+
+  private ResultSet mockResultSetWithId(java.sql.Date usageDate) throws SQLException {
+    ResultSet r = mockResultSet(usageDate);
+    when(r.getString("id")).thenReturn("test-entity-id");
+    return r;
+  }
+
+  private StatementContext mockContext() {
+    return Mockito.mock(StatementContext.class);
+  }
+
+  @Test
+  void testCollectionDAOUsageDetailsMapperWithDate() throws SQLException {
+    java.sql.Date date = java.sql.Date.valueOf("2026-03-19");
+    ResultSet r = mockResultSet(date);
+
+    CollectionDAO.UsageDAO.UsageDetailsMapper mapper =
+        new CollectionDAO.UsageDAO.UsageDetailsMapper();
+    UsageDetails result = mapper.map(r, mockContext());
+
+    assertEquals("2026-03-19", result.getDate());
+    assertEquals(10, result.getDailyStats().getCount());
+    assertEquals(70, result.getWeeklyStats().getCount());
+    assertEquals(300, result.getMonthlyStats().getCount());
+  }
+
+  @Test
+  void testCollectionDAOUsageDetailsMapperWithNullDate() throws SQLException {
+    ResultSet r = mockResultSet(null);
+
+    CollectionDAO.UsageDAO.UsageDetailsMapper mapper =
+        new CollectionDAO.UsageDAO.UsageDetailsMapper();
+    UsageDetails result = mapper.map(r, mockContext());
+
+    assertNull(result.getDate());
+  }
+
+  @Test
+  void testCollectionDAOUsageDetailsWithIdMapperWithDate() throws SQLException {
+    java.sql.Date date = java.sql.Date.valueOf("2026-03-19");
+    ResultSet r = mockResultSetWithId(date);
+
+    CollectionDAO.UsageDAO.UsageDetailsWithIdMapper mapper =
+        new CollectionDAO.UsageDAO.UsageDetailsWithIdMapper();
+    CollectionDAO.UsageDAO.UsageDetailsWithId result = mapper.map(r, mockContext());
+
+    assertEquals("test-entity-id", result.getEntityId());
+    assertEquals("2026-03-19", result.getUsageDetails().getDate());
+  }
+
+  @Test
+  void testCollectionDAOUsageDetailsWithIdMapperWithNullDate() throws SQLException {
+    ResultSet r = mockResultSetWithId(null);
+
+    CollectionDAO.UsageDAO.UsageDetailsWithIdMapper mapper =
+        new CollectionDAO.UsageDAO.UsageDetailsWithIdMapper();
+    CollectionDAO.UsageDAO.UsageDetailsWithId result = mapper.map(r, mockContext());
+
+    assertEquals("test-entity-id", result.getEntityId());
+    assertNull(result.getUsageDetails().getDate());
+  }
+
+  @Test
+  void testUsageRepositoryMapperWithDate() throws SQLException {
+    java.sql.Date date = java.sql.Date.valueOf("2026-03-19");
+    ResultSet r = mockResultSet(date);
+
+    UsageRepository.UsageDetailsMapper mapper = new UsageRepository.UsageDetailsMapper();
+    UsageDetails result = mapper.map(r, mockContext());
+
+    assertEquals("2026-03-19", result.getDate());
+    assertEquals(10, result.getDailyStats().getCount());
+    assertEquals(70, result.getWeeklyStats().getCount());
+    assertEquals(300, result.getMonthlyStats().getCount());
+  }
+
+  @Test
+  void testUsageRepositoryMapperWithNullDate() throws SQLException {
+    ResultSet r = mockResultSet(null);
+
+    UsageRepository.UsageDetailsMapper mapper = new UsageRepository.UsageDetailsMapper();
+    UsageDetails result = mapper.map(r, mockContext());
+
+    assertNull(result.getDate());
+  }
+}

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/ai_agent_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/ai_agent_index_mapping.json
@@ -485,6 +485,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/ai_governance_policy_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/ai_governance_policy_index_mapping.json
@@ -485,6 +485,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/container_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/container_index_mapping.json
@@ -713,6 +713,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/dashboard_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/dashboard_index_mapping.json
@@ -594,6 +594,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/database_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/database_index_mapping.json
@@ -510,6 +510,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/database_schema_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/database_schema_index_mapping.json
@@ -459,6 +459,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/llm_model_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/llm_model_index_mapping.json
@@ -485,6 +485,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/mlmodel_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/mlmodel_index_mapping.json
@@ -590,6 +590,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/prompt_template_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/prompt_template_index_mapping.json
@@ -485,6 +485,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/table_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/table_index_mapping.json
@@ -664,6 +664,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/container_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/container_index_mapping.json
@@ -641,6 +641,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/dashboard_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/dashboard_index_mapping.json
@@ -585,6 +585,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/database_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/database_index_mapping.json
@@ -513,6 +513,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/database_schema_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/database_schema_index_mapping.json
@@ -463,6 +463,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/directory_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/directory_index_mapping.json
@@ -436,6 +436,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/file_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/file_index_mapping.json
@@ -448,6 +448,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/mlmodel_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/mlmodel_index_mapping.json
@@ -585,6 +585,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/spreadsheet_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/spreadsheet_index_mapping.json
@@ -436,6 +436,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/table_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/table_index_mapping.json
@@ -808,6 +808,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/worksheet_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/worksheet_index_mapping.json
@@ -506,6 +506,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/container_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/container_index_mapping.json
@@ -678,6 +678,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/dashboard_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/dashboard_index_mapping.json
@@ -612,6 +612,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/database_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/database_index_mapping.json
@@ -521,6 +521,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/database_schema_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/database_schema_index_mapping.json
@@ -471,6 +471,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/mlmodel_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/mlmodel_index_mapping.json
@@ -608,6 +608,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/table_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/table_index_mapping.json
@@ -673,6 +673,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/container_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/container_index_mapping.json
@@ -647,6 +647,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/dashboard_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/dashboard_index_mapping.json
@@ -542,6 +542,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/database_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/database_index_mapping.json
@@ -508,6 +508,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/database_schema_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/database_schema_index_mapping.json
@@ -455,6 +455,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/directory_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/directory_index_mapping.json
@@ -409,6 +409,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/file_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/file_index_mapping.json
@@ -421,6 +421,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/mlmodel_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/mlmodel_index_mapping.json
@@ -575,6 +575,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/spreadsheet_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/spreadsheet_index_mapping.json
@@ -409,6 +409,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/table_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/table_index_mapping.json
@@ -805,6 +805,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/worksheet_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/worksheet_index_mapping.json
@@ -481,6 +481,10 @@
                 "type": "long"
               }
             }
+          },
+          "date": {
+            "type": "date",
+            "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
           }
         }
       },


### PR DESCRIPTION
## Problem

Elasticsearch/OpenSearch throws parse errors when reindexing entities with `usageSummary`:

```
failed to parse field [usageSummary.date] of type [date] in document with id '...'
Preview of field's value: '2026-03-19 00:00:00'
```

**Root cause (two issues):**

1. `usageSummary.date` was not defined in ES index mappings, so ES used dynamic mapping and inferred the type as `date` with default format (`strict_date_optional_time`). This format only accepts ISO 8601 (`T`-separated), not space-separated datetime strings.

2. MySQL JDBC's `ResultSet.getString()` returns `DATE` columns as `"yyyy-MM-dd HH:mm:ss"` (with time component), which doesn't match the dynamically-inferred ES format, causing parse errors.

## Fix

### 1. Java: normalize date output (root cause)

Changed `r.getString("usageDate")` to `r.getDate("usageDate").toString()` in both `UsageDetailsMapper` and `UsageDetailsWithIdMapper`.

`java.sql.Date.toString()` always returns `"yyyy-MM-dd"` regardless of JDBC driver behavior.

Affected files:
- `CollectionDAO.java` (2 mappers)
- `UsageRepository.java` (1 mapper)

### 2. ES mapping: add explicit `usageSummary.date` field (defensive fix)

Added explicit `date` field definition to `usageSummary.properties` in all index mapping JSON files across all languages (`en`, `jp`, `zh`, `ru`) for all entities that have `usageSummary` (table, dashboard, mlmodel, database, databaseSchema, container, and others).

```json
"date": {
  "type": "date",
  "format": "strict_date_optional_time||yyyy-MM-dd HH:mm:ss||epoch_millis"
}
```

This ensures that even if legacy data with `"yyyy-MM-dd HH:mm:ss"` format exists, reindexing will not fail.

## Why both fixes are needed

- Fix 1 alone: new data is safe, but reindexing legacy data with old format would still fail
- Fix 2 alone: ES accepts both formats, but root cause (inconsistent date serialization) remains
- Both together: complete fix for new and existing data

## Testing

- Verified ES mapping is applied correctly on local Docker environment
- Confirmed `"2026-03-19"` (new format) indexes successfully ✅
- Confirmed `"2026-03-19 00:00:00"` (legacy format) indexes successfully ✅ (was failing before)

Fixes #26678

🤖 Generated with [Claude Code](https://claude.com/claude-code)