### PR TITLE
Fix #18246: Preserve column order from source database during ingestion

### DIFF
--- a/ingestion/src/metadata/ingestion/models/patch_request.py
+++ b/ingestion/src/metadata/ingestion/models/patch_request.py
@@ -374,44 +374,103 @@ def build_patch(
                 source=source,
                 destination=destination,
                 array_entity_fields=array_entity_fields,
+                restrict_update_fields=restrict_update_fields,
+                override_metadata=override_metadata,
             )
 
         # special handler for tableConstraints
         _table_constraints_handler(source, destination)
 
-        # Get the difference between source and destination
+        # Determine which array entity fields are present in allowed_fields
+        active_array_fields = set()
+        if array_entity_fields:
+            for field in array_entity_fields:
+                if allowed_fields is None or field in allowed_fields:
+                    active_array_fields.add(field)
+
+        # Exclude array entity fields from the position-based jsonpatch diff.
+        # They are handled via full "replace" operations to preserve correct
+        # ordering when columns are added/removed/reordered.
         if allowed_fields:
+            non_array_allowed = {
+                k: v for k, v in allowed_fields.items() if k not in active_array_fields
+            }
+            if non_array_allowed:
+                patch = jsonpatch.make_patch(
+                    json.loads(
+                        source.model_dump_json(
+                            exclude_unset=True,
+                            exclude_none=True,
+                            include=non_array_allowed,
+                        )
+                    ),
+                    json.loads(
+                        destination.model_dump_json(
+                            exclude_unset=True,
+                            exclude_none=True,
+                            include=non_array_allowed,
+                        )
+                    ),
+                )
+            else:
+                patch = jsonpatch.JsonPatch([])
+        else:
+            array_exclude = (
+                {f: True for f in active_array_fields} if active_array_fields else None
+            )
             patch = jsonpatch.make_patch(
                 json.loads(
                     source.model_dump_json(
                         exclude_unset=True,
                         exclude_none=True,
-                        include=allowed_fields,
+                        exclude=array_exclude,
                     )
                 ),
                 json.loads(
                     destination.model_dump_json(
                         exclude_unset=True,
                         exclude_none=True,
-                        include=allowed_fields,
+                        exclude=array_exclude,
                     )
                 ),
             )
-        else:
-            patch: jsonpatch.JsonPatch = jsonpatch.make_patch(
-                json.loads(
-                    source.model_dump_json(exclude_unset=True, exclude_none=True)
-                ),
-                json.loads(
-                    destination.model_dump_json(exclude_unset=True, exclude_none=True)
-                ),
-            )
-        if not patch:
+
+        # Add full "replace" operations for array entity fields whose
+        # content changed.  The merge in _sort_array_entity_fields already
+        # applied the restrict_update_fields / override_metadata logic, so
+        # the replacement value is ready to use as-is.
+        for field in active_array_fields:
+            if hasattr(source, field) and hasattr(destination, field):
+                src_json = json.loads(
+                    source.model_dump_json(
+                        exclude_unset=True,
+                        exclude_none=True,
+                        include={field: True},
+                    )
+                )
+                dst_json = json.loads(
+                    destination.model_dump_json(
+                        exclude_unset=True,
+                        exclude_none=True,
+                        include={field: True},
+                    )
+                )
+                if src_json.get(field) != dst_json.get(field):
+                    patch.patch.append(
+                        {
+                            "op": "replace",
+                            "path": f"/{field}",
+                            "value": dst_json.get(field, []),
+                        }
+                    )
+
+        if not patch.patch:
             return None
 
-        # For a user editable fields like descriptions, tags we only want to support "add" operation in patch
-        # we will remove the other operations.
-        # This will only be applicable if the override_metadata field is set to False.
+        # For user-editable fields like descriptions and tags we only want
+        # to support "add" operations in the patch.  Array entity field
+        # "replace" operations (e.g. /columns) pass through because their
+        # paths do not contain restricted field names.
         if restrict_update_fields:
             updated_operations = JsonPatchUpdater.from_restrict_update_fields(
                 restrict_update_fields
@@ -515,42 +574,82 @@ def _table_constraints_handler(source: T, destination: T):
     setattr(destination, "tableConstraints", rearranged_constraints)
 
 
+def _should_update_restricted_field(
+    source_value, dest_value, override_metadata: bool
+) -> bool:
+    """Decide whether a restricted field should be updated from destination.
+
+    Mirrors the restrict_update_fields filter semantics:
+    - ADD   (source empty → dest has value): always allowed
+    - REPLACE (both have values):           only with override
+    - REMOVE  (source has value → dest empty): never allowed
+    """
+    source_empty = source_value is None or (
+        isinstance(source_value, list) and len(source_value) == 0
+    )
+    dest_empty = dest_value is None or (
+        isinstance(dest_value, list) and len(dest_value) == 0
+    )
+    if dest_empty:
+        return False
+    if source_empty:
+        return True
+    return override_metadata
+
+
 def _sort_array_entity_fields(
     source: T,
     destination: T,
     array_entity_fields: Optional[List] = None,
+    restrict_update_fields: Optional[List] = None,
+    override_metadata: Optional[bool] = False,
 ):
     """
-    Sort the array entity fields to make sure the order is consistent
+    Reorder array entity fields to match the destination order (the actual
+    source database column order), while merging metadata from source
+    (the existing entity in OpenMetadata) for columns that already exist.
+
+    The merge respects restrict_update_fields / override_metadata so the
+    resulting array can be used as a full replacement value without further
+    filtering.
     """
+    restrict_set = set(restrict_update_fields or [])
+
     for field in array_entity_fields or []:
         if hasattr(destination, field) and hasattr(source, field):
             destination_attributes = getattr(destination, field)
             source_attributes = getattr(source, field)
 
-            # Create a dictionary of destination attributes for easy lookup
-            destination_dict = {
-                _get_attribute_name(attr): attr for attr in destination_attributes
+            source_dict = {
+                _get_attribute_name(attr): attr for attr in source_attributes
             }
 
             updated_attributes = []
-            for source_attr in source_attributes or []:
-                # Update the destination attribute with the source attribute
-                destination_attr = destination_dict.get(
-                    _get_attribute_name(source_attr)
-                )
-                if destination_attr:
+            for dest_attr in destination_attributes or []:
+                source_attr = source_dict.get(_get_attribute_name(dest_attr))
+                if source_attr:
+                    update_dict = {}
+                    for k, v in dest_attr.__dict__.items():
+                        if k not in dest_attr.model_fields_set:
+                            continue
+                        if k in restrict_set:
+                            src_val = getattr(source_attr, k, None)
+                            if not _should_update_restricted_field(
+                                src_val, v, override_metadata
+                            ):
+                                continue
+                        update_dict[k] = v
                     updated_attributes.append(
-                        source_attr.model_copy(update=destination_attr.__dict__)
+                        source_attr.model_copy(update=update_dict)
                     )
-                    # Remove the updated attribute from the destination dictionary
-                    del destination_dict[_get_attribute_name(source_attr)]
                 else:
-                    updated_attributes.append(None)
+                    updated_attributes.append(dest_attr)
 
-            # Combine the updated attributes with the remaining destination attributes
-            final_attributes = updated_attributes + list(destination_dict.values())
-            setattr(destination, field, final_attributes)
+            for idx, attr in enumerate(updated_attributes):
+                if hasattr(attr, "ordinalPosition"):
+                    attr.ordinalPosition = idx + 1
+
+            setattr(destination, field, updated_attributes)
 
 
 def _remove_change_description(entity: T) -> T:

--- a/ingestion/tests/integration/mysql/conftest.py
+++ b/ingestion/tests/integration/mysql/conftest.py
@@ -91,8 +91,7 @@ def create_service_request(mysql_container):
                 "config": {
                     "username": mysql_container.username,
                     "authType": {"password": mysql_container.password},
-                    "hostPort": "localhost:"
-                    + mysql_container.get_exposed_port(mysql_container.port),
+                    "hostPort": f"localhost:{mysql_container.get_exposed_port(mysql_container.port)}",
                     "databaseSchema": mysql_container.dbname,
                 }
             },

--- a/ingestion/tests/integration/mysql/test_column_order.py
+++ b/ingestion/tests/integration/mysql/test_column_order.py
@@ -1,0 +1,73 @@
+import pytest
+from sqlalchemy import create_engine, text
+
+from metadata.generated.schema.entity.data.table import Table
+from metadata.workflow.metadata import MetadataWorkflow
+
+
+@pytest.fixture(scope="module")
+def mysql_engine(mysql_container):
+    engine = create_engine(mysql_container.get_connection_url())
+    yield engine
+    engine.dispose()
+
+
+@pytest.fixture()
+def column_order_table(mysql_engine):
+    with mysql_engine.connect() as conn:
+        conn.execute(text("DROP TABLE IF EXISTS employees.column_order_test"))
+        conn.execute(
+            text(
+                "CREATE TABLE employees.column_order_test ("
+                "  id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,"
+                "  name VARCHAR(100),"
+                "  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP"
+                ")"
+            )
+        )
+        conn.commit()
+    yield
+    with mysql_engine.connect() as conn:
+        conn.execute(text("DROP TABLE IF EXISTS employees.column_order_test"))
+        conn.commit()
+
+
+def test_column_order_preserved_after_adding_column_in_middle(
+    patch_passwords_for_db_services,
+    run_workflow,
+    ingestion_config,
+    metadata,
+    db_service,
+    mysql_engine,
+    column_order_table,
+):
+    run_workflow(MetadataWorkflow, ingestion_config)
+
+    table_fqn = (
+        f"{db_service.fullyQualifiedName.root}.default.employees.column_order_test"
+    )
+    table = metadata.get_by_name(entity=Table, fqn=table_fqn)
+    assert table is not None
+    assert len(table.columns) == 3
+    assert table.columns[0].name.root == "id"
+    assert table.columns[1].name.root == "name"
+    assert table.columns[2].name.root == "created_at"
+
+    with mysql_engine.connect() as conn:
+        conn.execute(
+            text(
+                "ALTER TABLE employees.column_order_test "
+                "ADD COLUMN email VARCHAR(255) AFTER name"
+            )
+        )
+        conn.commit()
+
+    run_workflow(MetadataWorkflow, ingestion_config)
+
+    table = metadata.get_by_name(entity=Table, fqn=table_fqn)
+    assert table is not None
+    assert len(table.columns) == 4
+    assert table.columns[0].name.root == "id"
+    assert table.columns[1].name.root == "name"
+    assert table.columns[2].name.root == "email"
+    assert table.columns[3].name.root == "created_at"

--- a/ingestion/tests/integration/ometa/test_ometa_topology_patch.py
+++ b/ingestion/tests/integration/ometa/test_ometa_topology_patch.py
@@ -233,6 +233,39 @@ def table_entity_three(metadata, topology_schema, topology_columns, topology_use
     metadata.delete(entity=Table, entity_id=table.id, hard_delete=True)
 
 
+@pytest.fixture(scope="module")
+def table_entity_column_order(metadata, topology_schema):
+    """Table for testing column order after table recreation (issue #18246)."""
+    table_name = generate_name()
+    create = CreateTableRequest(
+        name=table_name,
+        databaseSchema=topology_schema.fullyQualifiedName,
+        columns=[
+            Column(
+                name="id",
+                dataType=DataType.INT,
+                description=Markdown("primary key"),
+            ),
+            Column(
+                name="name",
+                dataType=DataType.VARCHAR,
+                dataLength=100,
+                description=Markdown("user name"),
+            ),
+            Column(
+                name="created_at",
+                dataType=DataType.TIMESTAMP,
+                description=Markdown("creation timestamp"),
+            ),
+        ],
+    )
+    table = _safe_create_or_update(metadata, create)
+
+    yield table
+
+    metadata.delete(entity=Table, entity_id=table.id, hard_delete=True)
+
+
 class TestOMetaTopologyPatchAPI:
     """
     Topology Patch API integration tests.
@@ -294,27 +327,28 @@ class TestOMetaTopologyPatchAPI:
         assert table_entity.displayName == "TABLE ONE"
         assert table_entity.tags[0].tagFQN.root == "PersonalData.Personal"
 
-        # Column tests - order should be preserved, values merged
-        assert table_entity.columns[0].description.root == "test column1"
-        assert table_entity.columns[0].name.root == "column1"
-        assert table_entity.columns[0].displayName is None
-        assert table_entity.columns[1].description.root == "test column2"
-        assert table_entity.columns[1].name.root == "column2"
-        assert table_entity.columns[1].displayName == "COLUMN TWO"
-        assert table_entity.columns[2].description.root == "test column3"
-        assert table_entity.columns[2].name.root == "column3"
-        assert table_entity.columns[2].displayName == "COLUMN THREE"
-        assert table_entity.columns[2].tags[0].tagFQN.root == "PII.Sensitive"
-        assert table_entity.columns[2].tags[1].tagFQN.root == "Tier.Tier2"
-        assert table_entity.columns[3].description.root == "test column4"
-        assert table_entity.columns[3].name.root == "column4"
-        assert table_entity.columns[3].displayName == "COLUMN FOUR"
-        assert table_entity.columns[3].tags[0].tagFQN.root == "PII.Sensitive"
-        assert table_entity.columns[4].description.root == "test column5"
-        assert table_entity.columns[4].name.root == "column5"
-        assert table_entity.columns[4].displayName == "COLUMN FIVE"
-        assert table_entity.columns[4].tags[0].tagFQN.root == "PersonalData.Personal"
-        assert len(table_entity.columns[4].tags) == 1
+        # Column tests - order follows destination [col3, col4, col5, col1, col2]
+        # Restricted fields (description, displayName, tags) preserved from source
+        assert table_entity.columns[0].name.root == "column3"
+        assert table_entity.columns[0].description.root == "test column3"
+        assert table_entity.columns[0].displayName == "COLUMN THREE"
+        assert table_entity.columns[0].tags[0].tagFQN.root == "PII.Sensitive"
+        assert table_entity.columns[0].tags[1].tagFQN.root == "Tier.Tier2"
+        assert table_entity.columns[1].name.root == "column4"
+        assert table_entity.columns[1].description.root == "test column4"
+        assert table_entity.columns[1].displayName == "COLUMN FOUR"
+        assert table_entity.columns[1].tags[0].tagFQN.root == "PII.Sensitive"
+        assert table_entity.columns[2].name.root == "column5"
+        assert table_entity.columns[2].description.root == "test column5"
+        assert table_entity.columns[2].displayName == "COLUMN FIVE"
+        assert table_entity.columns[2].tags[0].tagFQN.root == "PersonalData.Personal"
+        assert len(table_entity.columns[2].tags) == 1
+        assert table_entity.columns[3].name.root == "column1"
+        assert table_entity.columns[3].description.root == "test column1"
+        assert table_entity.columns[3].displayName is None
+        assert table_entity.columns[4].name.root == "column2"
+        assert table_entity.columns[4].description.root == "test column2"
+        assert table_entity.columns[4].displayName == "COLUMN TWO"
 
     def test_topology_patch_table_columns_with_add_del(
         self, metadata, table_entity_two
@@ -348,16 +382,17 @@ class TestOMetaTopologyPatchAPI:
         table_entity = metadata.get_by_id(
             entity=Table, entity_id=table_entity_two.id.root
         )
-        assert table_entity.columns[0].description.root == "test column1"
-        assert table_entity.columns[0].name.root == "column1"
-        assert table_entity.columns[1].description.root == "test column3"
+        # Order follows destination: [col7, col3, col5, col1, col6]
+        assert table_entity.columns[0].name.root == "column7"
+        assert table_entity.columns[0].description.root == "test column7"
         assert table_entity.columns[1].name.root == "column3"
-        assert table_entity.columns[2].description.root == "test column5"
+        assert table_entity.columns[1].description.root == "test column3"
         assert table_entity.columns[2].name.root == "column5"
-        assert table_entity.columns[3].description.root == "test column7"
-        assert table_entity.columns[3].name.root == "column7"
-        assert table_entity.columns[4].description.root == "test column6"
+        assert table_entity.columns[2].description.root == "test column5"
+        assert table_entity.columns[3].name.root == "column1"
+        assert table_entity.columns[3].description.root == "test column1"
         assert table_entity.columns[4].name.root == "column6"
+        assert table_entity.columns[4].description.root == "test column6"
 
     def test_topology_patch_with_override_enabled(
         self, metadata, table_entity_three, topology_users
@@ -420,24 +455,87 @@ class TestOMetaTopologyPatchAPI:
         assert table_entity.displayName == "TABLE THREE OVERRIDEN"
         assert table_entity.tags[0].tagFQN.root == "PII.Sensitive"
 
-        assert table_entity.columns[0].description.root == "test column1 overriden"
-        assert table_entity.columns[0].name.root == "column1"
-        assert table_entity.columns[0].displayName == "COLUMN ONE OVERRIDEN"
-        assert table_entity.columns[1].description.root == "test column3"
+        # With override + destination order, columns follow the destination order
+        assert table_entity.columns[0].name.root == "column7"
+        assert table_entity.columns[0].description.root == "test column7"
+
         assert table_entity.columns[1].name.root == "column3"
+        assert table_entity.columns[1].description.root == "test column3"
         assert table_entity.columns[1].displayName == "COLUMN THREE OVERRIDEN"
         assert table_entity.columns[1].tags[0].tagFQN.root == "PII.Sensitive"
         assert table_entity.columns[1].tags[1].tagFQN.root == "Tier.Tier2"
-        assert table_entity.columns[2].description.root == "test column4 overriden"
-        assert table_entity.columns[2].name.root == "column4"
-        assert table_entity.columns[2].displayName is None
-        assert table_entity.columns[3].description.root == "test column5"
-        assert table_entity.columns[3].name.root == "column5"
-        assert table_entity.columns[3].displayName == "COLUMN FIVE"
-        assert table_entity.columns[3].tags[0].tagFQN.root == "PII.Sensitive"
-        assert table_entity.columns[4].description.root == "test column7"
-        assert table_entity.columns[4].name.root == "column7"
-        assert table_entity.columns[4].displayName is None
-        assert table_entity.columns[5].description.root == "test column6"
-        assert table_entity.columns[5].name.root == "column6"
-        assert table_entity.columns[5].displayName == "COLUMN SIX"
+
+        assert table_entity.columns[2].name.root == "column5"
+        assert table_entity.columns[2].description.root == "test column5"
+        assert table_entity.columns[2].displayName == "COLUMN FIVE"
+        assert table_entity.columns[2].tags[0].tagFQN.root == "PII.Sensitive"
+
+        assert table_entity.columns[3].name.root == "column1"
+        assert table_entity.columns[3].description.root == "test column1 overriden"
+        assert table_entity.columns[3].displayName == "COLUMN ONE OVERRIDEN"
+
+        assert table_entity.columns[4].name.root == "column6"
+        assert table_entity.columns[4].description.root == "test column6"
+        assert table_entity.columns[4].displayName == "COLUMN SIX"
+
+        assert table_entity.columns[5].name.root == "column4"
+        assert table_entity.columns[5].description.root == "test column4 overriden"
+
+    def test_topology_patch_column_order_with_new_column_in_middle(
+        self, metadata, table_entity_column_order
+    ):
+        """
+        Reproduce issue #18246: a new column added in the middle should appear
+        at its correct position, not appended at the end.
+
+        Simulates: table dropped and recreated with a new column inserted
+        between existing columns.
+        Original:  [id, name, created_at]
+        Recreated: [id, name, name_2, created_at]
+        Expected:  [id, name, name_2, created_at] (not [id, name, created_at, name_2])
+        """
+        new_columns_list = [
+            Column(
+                name="id",
+                dataType=DataType.INT,
+            ),
+            Column(
+                name="name",
+                dataType=DataType.VARCHAR,
+                dataLength=100,
+            ),
+            Column(
+                name="name_2",
+                dataType=DataType.VARCHAR,
+                dataLength=100,
+                description=Markdown("secondary name"),
+            ),
+            Column(
+                name="created_at",
+                dataType=DataType.TIMESTAMP,
+            ),
+        ]
+        updated_table = table_entity_column_order.model_copy(deep=True)
+        updated_table.columns = new_columns_list
+        metadata.patch(
+            entity=type(table_entity_column_order),
+            source=table_entity_column_order,
+            destination=updated_table,
+            allowed_fields=ALLOWED_COMMON_PATCH_FIELDS,
+            restrict_update_fields=RESTRICT_UPDATE_LIST,
+            array_entity_fields=ARRAY_ENTITY_FIELDS,
+        )
+        table_entity = metadata.get_by_id(
+            entity=Table, entity_id=table_entity_column_order.id.root
+        )
+        assert len(table_entity.columns) == 4
+        assert table_entity.columns[0].name.root == "id"
+        assert table_entity.columns[1].name.root == "name"
+        assert table_entity.columns[2].name.root == "name_2"
+        assert table_entity.columns[3].name.root == "created_at"
+        # Existing columns preserve their descriptions
+        assert table_entity.columns[0].description.root == "primary key"
+        assert table_entity.columns[1].description.root == "user name"
+        assert table_entity.columns[3].description.root == "creation timestamp"
+        # New column has its own description
+        assert table_entity.columns[2].description.root == "secondary name"

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TableResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TableResourceIT.java
@@ -4920,6 +4920,53 @@ public class TableResourceIT extends BaseEntityIT<Table, CreateTable> {
     }
   }
 
+  /**
+   * Issue #18246: When a table is recreated with a new column in the middle, the PUT (ingestion
+   * re-run) should preserve the actual column order from the source database.
+   */
+  @Test
+  void put_columnOrderPreservedWhenNewColumnAddedInMiddle(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+
+    // Step 1: Create table with [id, name, created_at] (simulates first ingestion)
+    CreateTable createRequest = createRequest(ns.prefix("column_order_table"), ns);
+    createRequest.setColumns(
+        List.of(
+            ColumnBuilder.of("id", "INT").ordinalPosition(1).build(),
+            ColumnBuilder.of("name", "VARCHAR").dataLength(100).ordinalPosition(2).build(),
+            ColumnBuilder.of("created_at", "TIMESTAMP").ordinalPosition(3).build()));
+    Table table = createEntity(createRequest);
+
+    assertEquals(3, table.getColumns().size());
+    assertEquals("id", table.getColumns().get(0).getName());
+    assertEquals("name", table.getColumns().get(1).getName());
+    assertEquals("created_at", table.getColumns().get(2).getName());
+
+    // Step 2: Simulate table recreation with new column in the middle:
+    // [id, name, name_2, created_at]
+    createRequest.setColumns(
+        List.of(
+            ColumnBuilder.of("id", "INT").ordinalPosition(1).build(),
+            ColumnBuilder.of("name", "VARCHAR").dataLength(100).ordinalPosition(2).build(),
+            ColumnBuilder.of("name_2", "VARCHAR").dataLength(10).ordinalPosition(3).build(),
+            ColumnBuilder.of("created_at", "TIMESTAMP").ordinalPosition(4).build()));
+    Table updatedTable = client.tables().createOrUpdate(createRequest);
+
+    // Verify column order matches the source database order
+    assertEquals(4, updatedTable.getColumns().size());
+    assertEquals("id", updatedTable.getColumns().get(0).getName(), "id should be at position 0");
+    assertEquals(
+        "name", updatedTable.getColumns().get(1).getName(), "name should be at position 1");
+    assertEquals(
+        "name_2",
+        updatedTable.getColumns().get(2).getName(),
+        "name_2 should be at position 2 (not appended at end)");
+    assertEquals(
+        "created_at",
+        updatedTable.getColumns().get(3).getName(),
+        "created_at should be at position 3");
+  }
+
   private void validateTableFieldsAfterImport(Table original, Table imported) {
     if (original.getDescription() != null) {
       assertEquals(


### PR DESCRIPTION
Column order now always reflects the actual database schema. Previously, _sort_array_entity_fields iterated in stored-entity order and appended new columns at the end. Now it iterates in destination (database) order, merges metadata from the stored entity using model_fields_set, and emits a single "replace /columns" patch operation instead of position-based per-element diffs.

<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
