### PR TITLE
Fix flaky User Profile Feed test by removing status check from waitForResponse predicate

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Users.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Users.spec.ts
@@ -197,13 +197,16 @@ test.describe('User with Admin Roles', () => {
 
     await visitUserListPage(adminPage);
 
-    await test.step("User shouldn't be allowed to create User with same Email", async () => {
-      await checkForUserExistError(adminPage, {
-        name: updatedUserDetails.name,
-        email: updatedUserDetails.email,
-        password: updatedUserDetails.password,
-      });
-    });
+    await test.step(
+      "User shouldn't be allowed to create User with same Email",
+      async () => {
+        await checkForUserExistError(adminPage, {
+          name: updatedUserDetails.name,
+          email: updatedUserDetails.email,
+          password: updatedUserDetails.password,
+        });
+      }
+    );
 
     await permanentDeleteUser(
       adminPage,
@@ -636,12 +639,12 @@ test.describe('User Profile Feed Interactions', () => {
     const userDetailsResponse = page.waitForResponse(
       (response) =>
         response.url().includes('/api/v1/users/name/') &&
-        response.status() === 200
+        response.request().method() === 'GET'
     );
 
     await userNameElement.click();
-    await userDetailsResponse;
-
+    const userData = await userDetailsResponse;
+    expect(userData.status()).toBe(200);
     // redirecting on new page
 
     // Verify we navigated to the correct user's profile
@@ -1147,24 +1150,27 @@ test.describe('User Profile Persona Interactions', () => {
     await adminPage.getByTestId('persona-details-card').waitFor();
 
     // Test clicking on persona chip to navigate to persona page
-    await test.step('Navigate to persona page by clicking on persona chip', async () => {
-      const personaCard = adminPage.locator(
-        '[data-testid="persona-details-card"]'
-      );
-      const personaChip = personaCard
-        .locator('[data-testid="chip-container"] [data-testid="tag-chip"]')
-        .first();
-      const personaLink = personaChip.locator('a').first();
+    await test.step(
+      'Navigate to persona page by clicking on persona chip',
+      async () => {
+        const personaCard = adminPage.locator(
+          '[data-testid="persona-details-card"]'
+        );
+        const personaChip = personaCard
+          .locator('[data-testid="chip-container"] [data-testid="tag-chip"]')
+          .first();
+        const personaLink = personaChip.locator('a').first();
 
-      // Verify the persona link has text content
-      await expect(personaLink).not.toHaveText('');
+        // Verify the persona link has text content
+        await expect(personaLink).not.toHaveText('');
 
-      // Click the persona link to navigate
-      await personaLink.click();
+        // Click the persona link to navigate
+        await personaLink.click();
 
-      // Verify we're on the persona page
-      expect(adminPage.url()).toContain('/persona/');
-    });
+        // Verify we're on the persona page
+        expect(adminPage.url()).toContain('/persona/');
+      }
+    );
 
     // Navigate back to user profile for removal test
     await test.step('Navigate back to user profile', async () => {
@@ -1258,21 +1264,24 @@ test.describe('User Profile Persona Interactions', () => {
     });
 
     // Test clicking on default persona chip to navigate to persona page
-    await test.step('Navigate to persona page by clicking on default persona chip', async () => {
-      const defaultPersonaChip = adminPage
-        .locator('.default-persona-text [data-testid="tag-chip"]')
-        .first();
-      const personaLink = defaultPersonaChip.locator('a').first();
+    await test.step(
+      'Navigate to persona page by clicking on default persona chip',
+      async () => {
+        const defaultPersonaChip = adminPage
+          .locator('.default-persona-text [data-testid="tag-chip"]')
+          .first();
+        const personaLink = defaultPersonaChip.locator('a').first();
 
-      // Verify the persona link has text content
-      await expect(personaLink).not.toHaveText('');
+        // Verify the persona link has text content
+        await expect(personaLink).not.toHaveText('');
 
-      // Click the persona link to navigate
-      await personaLink.click();
+        // Click the persona link to navigate
+        await personaLink.click();
 
-      // Verify we're on the persona page
-      expect(adminPage.url()).toContain('/persona/');
-    });
+        // Verify we're on the persona page
+        expect(adminPage.url()).toContain('/persona/');
+      }
+    );
 
     // Navigate back to user profile for removal test
     await test.step('Navigate back to user profile', async () => {


### PR DESCRIPTION

<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

**Summary**
- Fixed the "Should navigate to user profile from feed card avatar click" test that was timing out when the /api/v1/users/name/ endpoint returned a non-200 status
- Moved the status assertion out of the waitForResponse predicate and into an explicit expect call, so the test fails with a clear error message instead of silently hanging

<img width="1220" height="205" alt="Screenshot 2026-03-24 at 3 09 43 PM" src="https://github.com/user-attachments/assets/f3edbd35-7058-4e12-afe6-f6be9b2e2e2c" />

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
