### PR TITLE
Fix runtime spacy model loading for non-root containers

### DIFF
--- a/ingestion/operators/docker/Dockerfile
+++ b/ingestion/operators/docker/Dockerfile
@@ -85,6 +85,7 @@ COPY ingestion/operators/docker/*.py .
 RUN groupadd -g 1000 openmetadata && useradd -m -u 1000 -g 1000 openmetadata
 RUN chown -R openmetadata:openmetadata /ingestion
 ENV HOME=/home/openmetadata
+ENV PATH="/home/openmetadata/.local/bin:${PATH}"
 USER openmetadata
 
 # Disable pip cache dir

--- a/ingestion/operators/docker/Dockerfile.ci
+++ b/ingestion/operators/docker/Dockerfile.ci
@@ -87,6 +87,7 @@ COPY scripts/datamodel_generation.py /scripts/datamodel_generation.py
 RUN groupadd -g 1000 openmetadata && useradd -m -u 1000 -g 1000 openmetadata
 RUN chown -R openmetadata:openmetadata /ingestion
 ENV HOME=/home/openmetadata
+ENV PATH="/home/openmetadata/.local/bin:${PATH}"
 USER openmetadata
 
 # Disable pip cache dir


### PR DESCRIPTION
### Describe your changes:

Fixes this [OpenMetadata's Slack thread](https://openmetadata.slack.com/archives/C02B6955S4S/p1774031276927609)

I updated the operators `Dockerfile`s so we have a default `openmetadata` user (uid and gid of 1000) and run all `pip` installs for that user, so when code needs to install new packages at runtime (like `spacy`'s model download functionality) it does so in the same place as the rest of the libraries installed.

The problem we were facing was layered. First, when running a container with a user without a `HOME`, it defaults to `/`, which isn't writable by other than `root`, causing this error:

    ERROR: Could not install packages due to an OSError: [Errno 13] Permission denied: '/.local'

Secondly, even if bypassing this limitation by setting an environment variable `HOME=/tmp` we'd still have a problem instructing python where to find the recently downloaded and installed model, hence we'd get:

    OSError: [E050] Can't find model 'en_core_web_md'. It doesn't seem to be a Python package or a valid path to a data directory. 

#
### Type of change:
- [X] Bug fix

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [X] I have commented on my code, particularly in hard-to-understand areas. 