### PR TITLE
Chore(UI): Playwright test util improvement

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExplorePageRightPanel.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExplorePageRightPanel.spec.ts
@@ -11,41 +11,41 @@
  *  limitations under the License.
  */
 
+import { PolicyClass } from '../../support/access-control/PoliciesClass';
+import { RolesClass } from '../../support/access-control/RolesClass';
+import { Domain } from '../../support/domain/Domain';
+import { ContainerClass } from '../../support/entity/ContainerClass';
+import { DashboardClass } from '../../support/entity/DashboardClass';
+import { DashboardDataModelClass } from '../../support/entity/DashboardDataModelClass';
+import { DatabaseClass } from '../../support/entity/DatabaseClass';
+import { DatabaseSchemaClass } from '../../support/entity/DatabaseSchemaClass';
+import { MlModelClass } from '../../support/entity/MlModelClass';
+import { PipelineClass } from '../../support/entity/PipelineClass';
+import { SearchIndexClass } from '../../support/entity/SearchIndexClass';
+import { TableClass } from '../../support/entity/TableClass';
+import { TopicClass } from '../../support/entity/TopicClass';
 import { expect, test as baseTest } from '../../support/fixtures/userPages';
+import { Glossary } from '../../support/glossary/Glossary';
+import { GlossaryTerm } from '../../support/glossary/GlossaryTerm';
+import { ClassificationClass } from '../../support/tag/ClassificationClass';
+import { TagClass } from '../../support/tag/TagClass';
+import { UserClass } from '../../support/user/UserClass';
+import { performAdminLogin } from '../../utils/admin';
+import { uuid } from '../../utils/common';
+import { getCurrentMillis } from '../../utils/dateTime';
+import {
+  openColumnDetailPanel,
+  waitForAllLoadersToDisappear,
+} from '../../utils/entity';
+import { getEntityFqn } from '../../utils/entityPanel';
+import { navigateToExploreAndSelectEntity } from '../../utils/explore';
+import { connectEdgeBetweenNodesViaAPI } from '../../utils/lineage';
 import { CustomPropertiesPageObject } from '../PageObject/Explore/CustomPropertiesPageObject';
 import { DataQualityPageObject } from '../PageObject/Explore/DataQualityPageObject';
 import { LineagePageObject } from '../PageObject/Explore/LineagePageObject';
 import { OverviewPageObject } from '../PageObject/Explore/OverviewPageObject';
 import { RightPanelPageObject } from '../PageObject/Explore/RightPanelPageObject';
 import { SchemaPageObject } from '../PageObject/Explore/SchemaPageObject';
-import { TableClass } from '../../support/entity/TableClass';
-import { ClassificationClass } from '../../support/tag/ClassificationClass';
-import { TagClass } from '../../support/tag/TagClass';
-import { Glossary } from '../../support/glossary/Glossary';
-import { GlossaryTerm } from '../../support/glossary/GlossaryTerm';
-import { uuid } from '../../utils/common';
-import { performAdminLogin } from '../../utils/admin';
-import { DashboardClass } from '../../support/entity/DashboardClass';
-import { DatabaseClass } from '../../support/entity/DatabaseClass';
-import { TopicClass } from '../../support/entity/TopicClass';
-import { PipelineClass } from '../../support/entity/PipelineClass';
-import { DatabaseSchemaClass } from '../../support/entity/DatabaseSchemaClass';
-import { DashboardDataModelClass } from '../../support/entity/DashboardDataModelClass';
-import { MlModelClass } from '../../support/entity/MlModelClass';
-import { ContainerClass } from '../../support/entity/ContainerClass';
-import { SearchIndexClass } from '../../support/entity/SearchIndexClass';
-import { Domain } from '../../support/domain/Domain';
-import { UserClass } from '../../support/user/UserClass';
-import { navigateToExploreAndSelectEntity } from '../../utils/explore';
-import { getEntityFqn } from '../../utils/entityPanel';
-import { connectEdgeBetweenNodesViaAPI } from '../../utils/lineage';
-import { getCurrentMillis } from '../../utils/dateTime';
-import { PolicyClass } from '../../support/access-control/PoliciesClass';
-import { RolesClass } from '../../support/access-control/RolesClass';
-import {
-  openColumnDetailPanel,
-  waitForAllLoadersToDisappear,
-} from '../../utils/entity';
 
 const domainEntity = new Domain();
 const user1 = new UserClass();
@@ -199,12 +199,12 @@ test.describe('Right Panel Test Suite', () => {
           const fqn = getEntityFqn(entityInstance);
 
           await test.step('Navigate to entity', async () => {
-            await navigateToExploreAndSelectEntity(
-              adminPage,
-              entityInstance.entity.name,
-              entityInstance.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: adminPage,
+              entityName: entityInstance.entity.name,
+              endpoint: entityInstance.endpoint,
+              fullyQualifiedName: fqn,
+            });
             await rightPanel.waitForPanelVisible();
             rightPanel.setEntityConfig(entityInstance);
             await overview.navigateToOverviewTab();
@@ -253,12 +253,12 @@ test.describe('Right Panel Test Suite', () => {
             await overview.removeTag([tagToUpdate]);
             await waitForAllLoadersToDisappear(adminPage);
 
-            await navigateToExploreAndSelectEntity(
-              adminPage,
-              entityInstance.entity.name,
-              entityInstance.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: adminPage,
+              entityName: entityInstance.entity.name,
+              endpoint: entityInstance.endpoint,
+              fullyQualifiedName: fqn,
+            });
             await rightPanel.waitForPanelVisible();
             rightPanel.setEntityConfig(entityInstance);
             await overview.navigateToOverviewTab();
@@ -273,12 +273,12 @@ test.describe('Right Panel Test Suite', () => {
             await overview.removeTier();
             await waitForAllLoadersToDisappear(adminPage);
 
-            await navigateToExploreAndSelectEntity(
-              adminPage,
-              entityInstance.entity.name,
-              entityInstance.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: adminPage,
+              entityName: entityInstance.entity.name,
+              endpoint: entityInstance.endpoint,
+              fullyQualifiedName: fqn,
+            });
             await rightPanel.waitForPanelVisible();
             rightPanel.setEntityConfig(entityInstance);
             await overview.navigateToOverviewTab();
@@ -293,12 +293,12 @@ test.describe('Right Panel Test Suite', () => {
             await overview.removeGlossaryTerm([glossaryTermToUpdate]);
             await waitForAllLoadersToDisappear(adminPage);
 
-            await navigateToExploreAndSelectEntity(
-              adminPage,
-              entityInstance.entity.name,
-              entityInstance.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: adminPage,
+              entityName: entityInstance.entity.name,
+              endpoint: entityInstance.endpoint,
+              fullyQualifiedName: fqn,
+            });
             await rightPanel.waitForPanelVisible();
             rightPanel.setEntityConfig(entityInstance);
             await overview.navigateToOverviewTab();
@@ -315,12 +315,12 @@ test.describe('Right Panel Test Suite', () => {
             await overview.removeDomain(domainToUpdate);
             await waitForAllLoadersToDisappear(adminPage);
 
-            await navigateToExploreAndSelectEntity(
-              adminPage,
-              entityInstance.entity.name,
-              entityInstance.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: adminPage,
+              entityName: entityInstance.entity.name,
+              endpoint: entityInstance.endpoint,
+              fullyQualifiedName: fqn,
+            });
             await rightPanel.waitForPanelVisible();
             rightPanel.setEntityConfig(entityInstance);
             await overview.navigateToOverviewTab();
@@ -335,12 +335,12 @@ test.describe('Right Panel Test Suite', () => {
             await overview.removeOwner([user1.getUserDisplayName()], 'Users');
             await waitForAllLoadersToDisappear(adminPage);
 
-            await navigateToExploreAndSelectEntity(
-              adminPage,
-              entityInstance.entity.name,
-              entityInstance.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: adminPage,
+              entityName: entityInstance.entity.name,
+              endpoint: entityInstance.endpoint,
+              fullyQualifiedName: fqn,
+            });
             await rightPanel.waitForPanelVisible();
             rightPanel.setEntityConfig(entityInstance);
             await overview.navigateToOverviewTab();
@@ -426,12 +426,12 @@ test.describe('Right Panel Test Suite', () => {
             );
 
             const fqn = getEntityFqn(entityInstance);
-            await navigateToExploreAndSelectEntity(
-              adminPage,
-              entityInstance.entity.name,
-              entityInstance.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: adminPage,
+              entityName: entityInstance.entity.name,
+              endpoint: entityInstance.endpoint,
+              fullyQualifiedName: fqn,
+            });
             await rightPanel.waitForPanelVisible();
             await schema.navigateToSchemaTab();
             await schema.shouldBeVisible();
@@ -523,12 +523,12 @@ test.describe('Right Panel Test Suite', () => {
             rightPanel,
           }) => {
             const fqn = getEntityFqn(entityInstance);
-            await navigateToExploreAndSelectEntity(
-              adminPage,
-              entityInstance.entity.name,
-              entityInstance.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: adminPage,
+              entityName: entityInstance.entity.name,
+              endpoint: entityInstance.endpoint,
+              fullyQualifiedName: fqn,
+            });
             await rightPanel.waitForPanelLoaded();
             await rightPanel.validateRightPanelForAsset(entityType);
           });
@@ -550,12 +550,12 @@ test.describe('Right Panel Test Suite', () => {
             );
 
             const fqn = getEntityFqn(entityInstance);
-            await navigateToExploreAndSelectEntity(
-              adminPage,
-              entityInstance.entity.name,
-              entityInstance.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: adminPage,
+              entityName: entityInstance.entity.name,
+              endpoint: entityInstance.endpoint,
+              fullyQualifiedName: fqn,
+            });
             await rightPanel.waitForPanelVisible();
             await lineage.navigateToLineageTab();
             await lineage.shouldBeVisible();
@@ -575,12 +575,12 @@ test.describe('Right Panel Test Suite', () => {
             );
 
             const fqn = getEntityFqn(entityInstance);
-            await navigateToExploreAndSelectEntity(
-              adminPage,
-              entityInstance.entity.name,
-              entityInstance.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: adminPage,
+              entityName: entityInstance.entity.name,
+              endpoint: entityInstance.endpoint,
+              fullyQualifiedName: fqn,
+            });
             await rightPanel.waitForPanelLoaded();
             await rightPanel.waitForPanelVisible();
             await lineage.navigateToLineageTab();
@@ -627,12 +627,12 @@ test.describe('Right Panel Test Suite', () => {
             );
 
             const fqn = getEntityFqn(testTable);
-            await navigateToExploreAndSelectEntity(
-              adminPage,
-              testTable.entity.name,
-              testTable.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: adminPage,
+              entityName: testTable.entity.name,
+              endpoint: testTable.endpoint,
+              fullyQualifiedName: fqn,
+            });
 
             const rightPanel = new RightPanelPageObject(adminPage, testTable);
             const localLineage = new LineagePageObject(rightPanel);
@@ -693,12 +693,12 @@ test.describe('Right Panel Test Suite', () => {
             );
 
             const fqn = getEntityFqn(entityInstance);
-            await navigateToExploreAndSelectEntity(
-              adminPage,
-              entityInstance.entity.name,
-              entityInstance.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: adminPage,
+              entityName: entityInstance.entity.name,
+              endpoint: entityInstance.endpoint,
+              fullyQualifiedName: fqn,
+            });
             await rightPanel.waitForPanelLoaded();
             await rightPanel.waitForPanelVisible();
             await dataQuality.navigateToDataQualityTab();
@@ -718,12 +718,12 @@ test.describe('Right Panel Test Suite', () => {
             );
 
             const fqn = getEntityFqn(entityInstance);
-            await navigateToExploreAndSelectEntity(
-              adminPage,
-              entityInstance.entity.name,
-              entityInstance.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: adminPage,
+              entityName: entityInstance.entity.name,
+              endpoint: entityInstance.endpoint,
+              fullyQualifiedName: fqn,
+            });
             await rightPanel.waitForPanelLoaded();
             await rightPanel.waitForPanelVisible();
             await dataQuality.navigateToDataQualityTab();
@@ -745,12 +745,12 @@ test.describe('Right Panel Test Suite', () => {
             );
 
             const fqn = getEntityFqn(entityInstance);
-            await navigateToExploreAndSelectEntity(
-              adminPage,
-              entityInstance.entity.name,
-              entityInstance.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: adminPage,
+              entityName: entityInstance.entity.name,
+              endpoint: entityInstance.endpoint,
+              fullyQualifiedName: fqn,
+            });
             await rightPanel.waitForPanelLoaded();
             await rightPanel.waitForPanelVisible();
             await dataQuality.navigateToDataQualityTab();
@@ -819,12 +819,12 @@ test.describe('Right Panel Test Suite', () => {
             );
 
             const fqn = getEntityFqn(testTable);
-            await navigateToExploreAndSelectEntity(
-              adminPage,
-              testTable.entity.name,
-              testTable.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: adminPage,
+              entityName: testTable.entity.name,
+              endpoint: testTable.endpoint,
+              fullyQualifiedName: fqn,
+            });
             const rightPanel = new RightPanelPageObject(adminPage);
             const localDQ = new DataQualityPageObject(rightPanel);
             await rightPanel.waitForPanelLoaded();
@@ -907,12 +907,12 @@ test.describe('Right Panel Test Suite', () => {
             );
 
             const fqn = getEntityFqn(testTable);
-            await navigateToExploreAndSelectEntity(
-              adminPage,
-              testTable.entity.name,
-              testTable.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: adminPage,
+              entityName: testTable.entity.name,
+              endpoint: testTable.endpoint,
+              fullyQualifiedName: fqn,
+            });
             const rightPanel = new RightPanelPageObject(adminPage);
             const localDQ = new DataQualityPageObject(rightPanel);
             await rightPanel.waitForPanelLoaded();
@@ -991,12 +991,12 @@ test.describe('Right Panel Test Suite', () => {
             );
 
             const fqn = getEntityFqn(testTable);
-            await navigateToExploreAndSelectEntity(
-              adminPage,
-              testTable.entity.name,
-              testTable.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: adminPage,
+              entityName: testTable.entity.name,
+              endpoint: testTable.endpoint,
+              fullyQualifiedName: fqn,
+            });
             const rightPanel = new RightPanelPageObject(adminPage);
             const localDQ = new DataQualityPageObject(rightPanel);
             await rightPanel.waitForPanelLoaded();
@@ -1041,12 +1041,12 @@ test.describe('Right Panel Test Suite', () => {
             );
 
             const fqn = getEntityFqn(entityInstance);
-            await navigateToExploreAndSelectEntity(
-              adminPage,
-              entityInstance.entity.name,
-              entityInstance.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: adminPage,
+              entityName: entityInstance.entity.name,
+              endpoint: entityInstance.endpoint,
+              fullyQualifiedName: fqn,
+            });
             await rightPanel.waitForPanelVisible();
             await customProperties.navigateToCustomPropertiesTab();
             await customProperties.shouldShowCustomPropertiesContainer();
@@ -1065,12 +1065,12 @@ test.describe('Right Panel Test Suite', () => {
             );
 
             const fqn = getEntityFqn(entityInstance);
-            await navigateToExploreAndSelectEntity(
-              adminPage,
-              entityInstance.entity.name,
-              entityInstance.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: adminPage,
+              entityName: entityInstance.entity.name,
+              endpoint: entityInstance.endpoint,
+              fullyQualifiedName: fqn,
+            });
             await rightPanel.waitForPanelVisible();
             await customProperties.navigateToCustomPropertiesTab();
             await customProperties.shouldShowCustomPropertiesContainer();
@@ -1094,12 +1094,12 @@ test.describe('Right Panel Test Suite', () => {
             );
 
             const fqn = getEntityFqn(entityInstance);
-            await navigateToExploreAndSelectEntity(
-              adminPage,
-              entityInstance.entity.name,
-              entityInstance.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: adminPage,
+              entityName: entityInstance.entity.name,
+              endpoint: entityInstance.endpoint,
+              fullyQualifiedName: fqn,
+            });
             await rightPanel.waitForPanelVisible();
             await customProperties.navigateToCustomPropertiesTab();
             await customProperties.shouldShowCustomPropertiesContainer();
@@ -1124,12 +1124,12 @@ test.describe('Right Panel Test Suite', () => {
             );
 
             const fqn = getEntityFqn(entityInstance);
-            await navigateToExploreAndSelectEntity(
-              adminPage,
-              entityInstance.entity.name,
-              entityInstance.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: adminPage,
+              entityName: entityInstance.entity.name,
+              endpoint: entityInstance.endpoint,
+              fullyQualifiedName: fqn,
+            });
             await rightPanel.waitForPanelVisible();
             await customProperties.navigateToCustomPropertiesTab();
             await customProperties.shouldShowCustomPropertiesContainer();
@@ -1151,12 +1151,12 @@ test.describe('Right Panel Test Suite', () => {
             customProperties,
           }) => {
             const fqn = getEntityFqn(entityInstance);
-            await navigateToExploreAndSelectEntity(
-              adminPage,
-              entityInstance.entity.name,
-              entityInstance.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: adminPage,
+              entityName: entityInstance.entity.name,
+              endpoint: entityInstance.endpoint,
+              fullyQualifiedName: fqn,
+            });
             await rightPanel.waitForPanelVisible();
             rightPanel.setEntityConfig(entityInstance);
 
@@ -1184,12 +1184,12 @@ test.describe('Right Panel Test Suite', () => {
             );
 
             const fqn = getEntityFqn(entityInstance);
-            await navigateToExploreAndSelectEntity(
-              adminPage,
-              entityInstance.entity.name,
-              entityInstance.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: adminPage,
+              entityName: entityInstance.entity.name,
+              endpoint: entityInstance.endpoint,
+              fullyQualifiedName: fqn,
+            });
             await rightPanel.waitForPanelVisible();
             await customProperties.navigateToCustomPropertiesTab();
             await customProperties.shouldShowCustomPropertiesContainer();
@@ -1260,12 +1260,12 @@ test.describe('Right Panel Test Suite', () => {
               await deletedUser.create(apiContext);
 
               const fqn = getEntityFqn(entityInstance);
-              await navigateToExploreAndSelectEntity(
-                adminPage,
-                entityInstance.entity.name,
-                entityInstance.endpoint,
-                fqn
-              );
+              await navigateToExploreAndSelectEntity({
+                page: adminPage,
+                entityName: entityInstance.entity.name,
+                endpoint: entityInstance.endpoint,
+                fullyQualifiedName: fqn,
+              });
               await rightPanel.waitForPanelVisible();
               rightPanel.setEntityConfig(entityInstance);
 
@@ -1312,12 +1312,12 @@ test.describe('Right Panel Test Suite', () => {
                 deletedTag.data.displayName;
 
               const fqn = getEntityFqn(entityInstance);
-              await navigateToExploreAndSelectEntity(
-                adminPage,
-                entityInstance.entity.name,
-                entityInstance.endpoint,
-                fqn
-              );
+              await navigateToExploreAndSelectEntity({
+                page: adminPage,
+                entityName: entityInstance.entity.name,
+                endpoint: entityInstance.endpoint,
+                fullyQualifiedName: fqn,
+              });
               await rightPanel.waitForPanelVisible();
               rightPanel.setEntityConfig(entityInstance);
 
@@ -1360,12 +1360,12 @@ test.describe('Right Panel Test Suite', () => {
                 deletedGlossaryTerm.data.displayName;
 
               const fqn = getEntityFqn(entityInstance);
-              await navigateToExploreAndSelectEntity(
-                adminPage,
-                entityInstance.entity.name,
-                entityInstance.endpoint,
-                fqn
-              );
+              await navigateToExploreAndSelectEntity({
+                page: adminPage,
+                entityName: entityInstance.entity.name,
+                endpoint: entityInstance.endpoint,
+                fullyQualifiedName: fqn,
+              });
               await rightPanel.waitForPanelVisible();
               rightPanel.setEntityConfig(entityInstance);
 
@@ -1432,12 +1432,12 @@ test.describe('Right Panel Test Suite', () => {
             dataStewardPage,
           }) => {
             const fqn = getEntityFqn(entityInstance);
-            await navigateToExploreAndSelectEntity(
-              dataStewardPage,
-              entityInstance.entity.name,
-              entityInstance.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: dataStewardPage,
+              entityName: entityInstance.entity.name,
+              endpoint: entityInstance.endpoint,
+              fullyQualifiedName: fqn,
+            });
             await dataStewardPage
               .getByTestId('entity-summary-panel-container')
               .waitFor({
@@ -1460,12 +1460,12 @@ test.describe('Right Panel Test Suite', () => {
             dataStewardPage,
           }) => {
             const fqn = getEntityFqn(entityInstance);
-            await navigateToExploreAndSelectEntity(
-              dataStewardPage,
-              entityInstance.entity.name,
-              entityInstance.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: dataStewardPage,
+              entityName: entityInstance.entity.name,
+              endpoint: entityInstance.endpoint,
+              fullyQualifiedName: fqn,
+            });
             await dataStewardPage
               .getByTestId('entity-summary-panel-container')
               .waitFor({
@@ -1487,12 +1487,12 @@ test.describe('Right Panel Test Suite', () => {
             dataStewardPage,
           }) => {
             const fqn = getEntityFqn(entityInstance);
-            await navigateToExploreAndSelectEntity(
-              dataStewardPage,
-              entityInstance.entity.name,
-              entityInstance.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: dataStewardPage,
+              entityName: entityInstance.entity.name,
+              endpoint: entityInstance.endpoint,
+              fullyQualifiedName: fqn,
+            });
             await dataStewardPage
               .getByTestId('entity-summary-panel-container')
               .waitFor({
@@ -1512,12 +1512,12 @@ test.describe('Right Panel Test Suite', () => {
             dataStewardPage,
           }) => {
             const fqn = getEntityFqn(entityInstance);
-            await navigateToExploreAndSelectEntity(
-              dataStewardPage,
-              entityInstance.entity.name,
-              entityInstance.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: dataStewardPage,
+              entityName: entityInstance.entity.name,
+              endpoint: entityInstance.endpoint,
+              fullyQualifiedName: fqn,
+            });
             await dataStewardPage
               .getByTestId('entity-summary-panel-container')
               .waitFor({
@@ -1537,12 +1537,12 @@ test.describe('Right Panel Test Suite', () => {
             dataStewardPage,
           }) => {
             const fqn = getEntityFqn(entityInstance);
-            await navigateToExploreAndSelectEntity(
-              dataStewardPage,
-              entityInstance.entity.name,
-              entityInstance.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: dataStewardPage,
+              entityName: entityInstance.entity.name,
+              endpoint: entityInstance.endpoint,
+              fullyQualifiedName: fqn,
+            });
             await dataStewardPage
               .getByTestId('entity-summary-panel-container')
               .waitFor({
@@ -1562,12 +1562,12 @@ test.describe('Right Panel Test Suite', () => {
             dataStewardPage,
           }) => {
             const fqn = getEntityFqn(entityInstance);
-            await navigateToExploreAndSelectEntity(
-              dataStewardPage,
-              entityInstance.entity.name,
-              entityInstance.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: dataStewardPage,
+              entityName: entityInstance.entity.name,
+              endpoint: entityInstance.endpoint,
+              fullyQualifiedName: fqn,
+            });
             await dataStewardPage
               .getByTestId('entity-summary-panel-container')
               .waitFor({
@@ -1609,12 +1609,12 @@ test.describe('Right Panel Test Suite', () => {
             dataStewardPage,
           }) => {
             const fqn = getEntityFqn(entityInstance);
-            await navigateToExploreAndSelectEntity(
-              dataStewardPage,
-              entityInstance.entity.name,
-              entityInstance.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: dataStewardPage,
+              entityName: entityInstance.entity.name,
+              endpoint: entityInstance.endpoint,
+              fullyQualifiedName: fqn,
+            });
             await dataStewardPage
               .getByTestId('entity-summary-panel-container')
               .waitFor({ state: 'visible' });
@@ -1688,12 +1688,12 @@ test.describe('Right Panel Test Suite', () => {
             dataConsumerPage,
           }) => {
             const fqn = getEntityFqn(entityInstance);
-            await navigateToExploreAndSelectEntity(
-              dataConsumerPage,
-              entityInstance.entity.name,
-              entityInstance.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: dataConsumerPage,
+              entityName: entityInstance.entity.name,
+              endpoint: entityInstance.endpoint,
+              fullyQualifiedName: fqn,
+            });
             await dataConsumerPage
               .getByTestId('entity-summary-panel-container')
               .waitFor({
@@ -1716,12 +1716,12 @@ test.describe('Right Panel Test Suite', () => {
             dataConsumerPage,
           }) => {
             const fqn = getEntityFqn(entityInstance);
-            await navigateToExploreAndSelectEntity(
-              dataConsumerPage,
-              entityInstance.entity.name,
-              entityInstance.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: dataConsumerPage,
+              entityName: entityInstance.entity.name,
+              endpoint: entityInstance.endpoint,
+              fullyQualifiedName: fqn,
+            });
             await dataConsumerPage
               .getByTestId('entity-summary-panel-container')
               .waitFor({
@@ -1741,12 +1741,12 @@ test.describe('Right Panel Test Suite', () => {
             dataConsumerPage,
           }) => {
             const fqn = getEntityFqn(entityInstance);
-            await navigateToExploreAndSelectEntity(
-              dataConsumerPage,
-              entityInstance.entity.name,
-              entityInstance.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: dataConsumerPage,
+              entityName: entityInstance.entity.name,
+              endpoint: entityInstance.endpoint,
+              fullyQualifiedName: fqn,
+            });
             await dataConsumerPage
               .getByTestId('entity-summary-panel-container')
               .waitFor({
@@ -1766,12 +1766,12 @@ test.describe('Right Panel Test Suite', () => {
             dataConsumerPage,
           }) => {
             const fqn = getEntityFqn(entityInstance);
-            await navigateToExploreAndSelectEntity(
-              dataConsumerPage,
-              entityInstance.entity.name,
-              entityInstance.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: dataConsumerPage,
+              entityName: entityInstance.entity.name,
+              endpoint: entityInstance.endpoint,
+              fullyQualifiedName: fqn,
+            });
             await dataConsumerPage
               .getByTestId('entity-summary-panel-container')
               .waitFor({
@@ -1791,12 +1791,12 @@ test.describe('Right Panel Test Suite', () => {
             dataConsumerPage,
           }) => {
             const fqn = getEntityFqn(entityInstance);
-            await navigateToExploreAndSelectEntity(
-              dataConsumerPage,
-              entityInstance.entity.name,
-              entityInstance.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: dataConsumerPage,
+              entityName: entityInstance.entity.name,
+              endpoint: entityInstance.endpoint,
+              fullyQualifiedName: fqn,
+            });
             await dataConsumerPage
               .getByTestId('entity-summary-panel-container')
               .waitFor({
@@ -1842,12 +1842,12 @@ test.describe('Right Panel Test Suite', () => {
             // which would grant elevated permissions and make domain buttons
             // visible unexpectedly. The fixture user is never set as owner.
             const fqn = getEntityFqn(entityInstance);
-            await navigateToExploreAndSelectEntity(
-              dataConsumerPage,
-              entityInstance.entity.name,
-              entityInstance.endpoint,
-              fqn
-            );
+            await navigateToExploreAndSelectEntity({
+              page: dataConsumerPage,
+              entityName: entityInstance.entity.name,
+              endpoint: entityInstance.endpoint,
+              fullyQualifiedName: fqn,
+            });
             await dataConsumerPage
               .getByTestId('entity-summary-panel-container')
               .waitFor({ state: 'visible' });
@@ -1882,12 +1882,12 @@ test.describe('Right Panel Test Suite', () => {
         // When an entity has an owner, EditOwners is no longer granted to all
         // users — DataConsumer (which lacks EditOwners / EditAll) cannot see
         // the edit-owners button.
-        await navigateToExploreAndSelectEntity(
-          adminPage,
-          dcOwnerTestTable.entity.name,
-          dcOwnerTestTable.endpoint,
-          fqn
-        );
+        await navigateToExploreAndSelectEntity({
+          page: adminPage,
+          entityName: dcOwnerTestTable.entity.name,
+          endpoint: dcOwnerTestTable.endpoint,
+          fullyQualifiedName: fqn,
+        });
         await adminPage
           .getByTestId('entity-summary-panel-container')
           .waitFor({ state: 'visible' });
@@ -1902,12 +1902,12 @@ test.describe('Right Panel Test Suite', () => {
         // The pre-configured DataConsumer fixture user (NOT user1, NOT the owner)
         // navigates to the same entity and verifies that edit-owners is NOT
         // visible (restricted by role when the entity already has an owner).
-        await navigateToExploreAndSelectEntity(
-          dataConsumerPage,
-          dcOwnerTestTable.entity.name,
-          dcOwnerTestTable.endpoint,
-          fqn
-        );
+        await navigateToExploreAndSelectEntity({
+          page: dataConsumerPage,
+          entityName: dcOwnerTestTable.entity.name,
+          endpoint: dcOwnerTestTable.endpoint,
+          fullyQualifiedName: fqn,
+        });
         await dataConsumerPage
           .getByTestId('entity-summary-panel-container')
           .waitFor({ state: 'visible' });
@@ -1935,12 +1935,12 @@ test.describe('Right Panel Test Suite', () => {
           await testEntity.create(apiContext);
 
           const fqn = getEntityFqn(testEntity);
-          await navigateToExploreAndSelectEntity(
-            adminPage,
-            testEntity.entity.name,
-            testEntity.endpoint,
-            fqn
-          );
+          await navigateToExploreAndSelectEntity({
+            page: adminPage,
+            entityName: testEntity.entity.name,
+            endpoint: testEntity.endpoint,
+            fullyQualifiedName: fqn,
+          });
           await rightPanel.waitForPanelVisible();
           rightPanel.setEntityConfig(testEntity);
 
@@ -1969,12 +1969,12 @@ test.describe('Right Panel Test Suite', () => {
           await testEntity.create(apiContext);
 
           const fqn = getEntityFqn(testEntity);
-          await navigateToExploreAndSelectEntity(
-            adminPage,
-            testEntity.entity.name,
-            testEntity.endpoint,
-            fqn
-          );
+          await navigateToExploreAndSelectEntity({
+            page: adminPage,
+            entityName: testEntity.entity.name,
+            endpoint: testEntity.endpoint,
+            fullyQualifiedName: fqn,
+          });
           await rightPanel.waitForPanelVisible();
           rightPanel.setEntityConfig(testEntity);
 
@@ -2003,12 +2003,12 @@ test.describe('Right Panel Test Suite', () => {
           await testEntity.create(apiContext);
 
           const fqn = getEntityFqn(testEntity);
-          await navigateToExploreAndSelectEntity(
-            adminPage,
-            testEntity.entity.name,
-            testEntity.endpoint,
-            fqn
-          );
+          await navigateToExploreAndSelectEntity({
+            page: adminPage,
+            entityName: testEntity.entity.name,
+            endpoint: testEntity.endpoint,
+            fullyQualifiedName: fqn,
+          });
           await rightPanel.waitForPanelVisible();
           rightPanel.setEntityConfig(testEntity);
 
@@ -2042,12 +2042,12 @@ test.describe('Right Panel Test Suite', () => {
           await testEntity.create(apiContext);
 
           const fqn = getEntityFqn(testEntity);
-          await navigateToExploreAndSelectEntity(
-            adminPage,
-            testEntity.entity.name,
-            testEntity.endpoint,
-            fqn
-          );
+          await navigateToExploreAndSelectEntity({
+            page: adminPage,
+            entityName: testEntity.entity.name,
+            endpoint: testEntity.endpoint,
+            fullyQualifiedName: fqn,
+          });
           await rightPanel.waitForPanelVisible();
           rightPanel.setEntityConfig(testEntity);
 
@@ -2078,12 +2078,12 @@ test.describe('Right Panel Test Suite', () => {
           await testEntity.create(apiContext);
 
           const fqn = getEntityFqn(testEntity);
-          await navigateToExploreAndSelectEntity(
-            adminPage,
-            testEntity.entity.name,
-            testEntity.endpoint,
-            fqn
-          );
+          await navigateToExploreAndSelectEntity({
+            page: adminPage,
+            entityName: testEntity.entity.name,
+            endpoint: testEntity.endpoint,
+            fullyQualifiedName: fqn,
+          });
           await rightPanel.waitForPanelVisible();
           rightPanel.setEntityConfig(testEntity);
 
@@ -2116,12 +2116,12 @@ test.describe('Right Panel Test Suite', () => {
           await testEntity.create(apiContext);
 
           const fqn = getEntityFqn(testEntity);
-          await navigateToExploreAndSelectEntity(
-            adminPage,
-            testEntity.entity.name,
-            testEntity.endpoint,
-            fqn
-          );
+          await navigateToExploreAndSelectEntity({
+            page: adminPage,
+            entityName: testEntity.entity.name,
+            endpoint: testEntity.endpoint,
+            fullyQualifiedName: fqn,
+          });
           await rightPanel.waitForPanelVisible();
           rightPanel.setEntityConfig(testEntity);
 
@@ -2147,12 +2147,12 @@ test.describe('Right Panel Test Suite', () => {
           await testEntity.create(apiContext);
 
           const fqn = getEntityFqn(testEntity);
-          await navigateToExploreAndSelectEntity(
-            adminPage,
-            testEntity.entity.name,
-            testEntity.endpoint,
-            fqn
-          );
+          await navigateToExploreAndSelectEntity({
+            page: adminPage,
+            entityName: testEntity.entity.name,
+            endpoint: testEntity.endpoint,
+            fullyQualifiedName: fqn,
+          });
           await rightPanel.waitForPanelVisible();
           rightPanel.setEntityConfig(testEntity);
 
@@ -2219,12 +2219,12 @@ test.describe('Right Panel Test Suite', () => {
             // Use the shared entity instance from entityMap which is already created in beforeAll
             try {
               const fqn = getEntityFqn(entityInstance);
-              await navigateToExploreAndSelectEntity(
-                authenticatedPage,
-                entityInstance.entity.name,
-                entityInstance.endpoint,
-                fqn
-              );
+              await navigateToExploreAndSelectEntity({
+                page: authenticatedPage,
+                entityName: entityInstance.entity.name,
+                endpoint: entityInstance.endpoint,
+                fullyQualifiedName: fqn,
+              });
               await rightPanel.waitForPanelVisible();
               rightPanel.setEntityConfig(entityInstance);
 
@@ -2241,12 +2241,12 @@ test.describe('Right Panel Test Suite', () => {
               // Reload the entity panel and verify description is gone.
               // waitForPanelLoaded waits for panel loaders to finish, ensuring the
               // entity data (description) has been fetched from the server before asserting.
-              await navigateToExploreAndSelectEntity(
-                authenticatedPage,
-                entityInstance.entity.name,
-                entityInstance.endpoint,
-                fqn
-              );
+              await navigateToExploreAndSelectEntity({
+                page: authenticatedPage,
+                entityName: entityInstance.entity.name,
+                endpoint: entityInstance.endpoint,
+                fullyQualifiedName: fqn,
+              });
               await rightPanel.waitForPanelLoaded();
 
               // The description text should no longer be present
@@ -2296,12 +2296,12 @@ test.describe('Right Panel Test Suite', () => {
 
         try {
           const tableFqn = getEntityFqn(entitySwitchTable);
-          await navigateToExploreAndSelectEntity(
-            authenticatedPage,
-            entitySwitchTable.entity.displayName,
-            entitySwitchTable.endpoint,
-            tableFqn
-          );
+          await navigateToExploreAndSelectEntity({
+            page: authenticatedPage,
+            entityName: entitySwitchTable.entity.displayName,
+            endpoint: entitySwitchTable.endpoint,
+            fullyQualifiedName: tableFqn,
+          });
           await rightPanel.waitForPanelVisible();
           rightPanel.setEntityConfig(entitySwitchTable);
           await localOverview.navigateToOverviewTab();
@@ -2317,12 +2317,12 @@ test.describe('Right Panel Test Suite', () => {
           await expect(tableNameInPanel).toBeVisible();
 
           const dashboardFqn = getEntityFqn(entitySwitchDashboard);
-          await navigateToExploreAndSelectEntity(
-            authenticatedPage,
-            entitySwitchDashboard.entity.displayName,
-            entitySwitchDashboard.endpoint,
-            dashboardFqn
-          );
+          await navigateToExploreAndSelectEntity({
+            page: authenticatedPage,
+            entityName: entitySwitchDashboard.entity.displayName,
+            endpoint: entitySwitchDashboard.endpoint,
+            fullyQualifiedName: dashboardFqn,
+          });
           await rightPanel.waitForPanelLoaded();
           await rightPanel.waitForPanelVisible();
           rightPanel.setEntityConfig(entitySwitchDashboard);
@@ -2362,12 +2362,12 @@ test.describe('Right Panel Test Suite', () => {
           await testEntity.create(apiContext);
 
           const fqn = getEntityFqn(testEntity);
-          await navigateToExploreAndSelectEntity(
-            authenticatedPage,
-            testEntity.entity.name,
-            testEntity.endpoint,
-            fqn
-          );
+          await navigateToExploreAndSelectEntity({
+            page: authenticatedPage,
+            entityName: testEntity.entity.name,
+            endpoint: testEntity.endpoint,
+            fullyQualifiedName: fqn,
+          });
           await rightPanel.waitForPanelVisible();
           rightPanel.setEntityConfig(testEntity);
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/entityPanel.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/entityPanel.ts
@@ -25,13 +25,19 @@ export const getEntityFqn = (
   ).entityResponseData?.fullyQualifiedName;
 };
 
-export const openEntitySummaryPanel = async (
-  page: Page,
-  entityName: string,
-  endpoint?: string,
-  fullyQualifiedName?: string,
-  exploreTab?: string
-) => {
+export const openEntitySummaryPanel = async ({
+  page,
+  entityName,
+  endpoint,
+  fullyQualifiedName,
+  exploreTab,
+}: {
+  page: Page;
+  entityName: string;
+  endpoint?: string;
+  fullyQualifiedName?: string;
+  exploreTab?: string;
+}) => {
   if (
     endpoint &&
     ENDPOINT_TO_FILTER_MAP[endpoint] &&
@@ -101,7 +107,7 @@ export async function navigateToExploreAndSelectTable(
     response.url().includes('/permissions')
   );
 
-  await openEntitySummaryPanel(page, entityName, endpoint);
+  await openEntitySummaryPanel({ page, entityName, endpoint });
 
   const permissionsResponse = await permissionsResponsePromise;
   expect(permissionsResponse.status()).toBe(200);

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/explore.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/explore.ts
@@ -360,26 +360,32 @@ export const verifyEntitiesAreSorted = async (page: Page) => {
   expect(entityNames).toEqual(sortedEntityNames);
 };
 
-export const navigateToExploreAndSelectEntity = async (
-  page: Page,
-  entityName: string,
-  endpoint?: string,
-  fullyQualifiedName?: string,
-  exploreTab?: string
-) => {
+export const navigateToExploreAndSelectEntity = async ({
+  page,
+  entityName,
+  endpoint,
+  fullyQualifiedName,
+  exploreTab,
+}: {
+  page: Page;
+  entityName: string;
+  endpoint?: string;
+  fullyQualifiedName?: string;
+  exploreTab?: string;
+}) => {
   await redirectToExplorePage(page);
 
   await expect(page.locator('[data-testid="loader"]')).toHaveCount(0, {
     timeout: 30000,
   });
 
-  await openEntitySummaryPanel(
+  await openEntitySummaryPanel({
     page,
     entityName,
     endpoint,
     fullyQualifiedName,
-    exploreTab
-  );
+    exploreTab,
+  });
 };
 
 export const getFlatColumnCountOfTable = (


### PR DESCRIPTION
I worked on adding a tab selection logic while searching by text to avoid flakiness

----
## Summary by Gitar

- **Refactored function signatures:**
  - Converted `navigateToExploreAndSelectEntity` and `openEntitySummaryPanel` from positional to object parameters for improved clarity
  - Updated 40+ call sites in `ExplorePageRightPanel.spec.ts` to use new object-based syntax
- **Enhanced tab selection:**
  - Added `exploreTab` parameter to enable tab selection logic when searching by text to reduce test flakiness

<sub>This will update automatically on new commits.</sub>