### PR TITLE
fix(oracle): change useDBATable default to false so SELECT_CATALOG_ROLE works out of the box

### DIFF
--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/oracleConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/oracleConnection.json
@@ -130,8 +130,8 @@
     "useDBATable": {
       "title": "Use DBA Tables",
       "type": "boolean",
-      "description": "Use Oracle DBA_* tables instead of ALL_* tables for metadata ingestion. Requires DBA privileges.",
-      "default": true
+      "description": "Use Oracle DBA_* tables instead of ALL_* tables for metadata ingestion. Requires DBA privileges. When disabled (default), ALL_* tables are used, which requires SELECT_CATALOG_ROLE.",
+      "default": false
     },
     "connectionOptions": {
       "title": "Connection Options",


### PR DESCRIPTION
## Summary

- The Oracle connector defaulted `useDBATable: true`, meaning it queries `DBA_*` system tables which require **DBA privileges**
- The documentation instructs users to only grant `SELECT_CATALOG_ROLE`, which provides access to `ALL_*` catalog tables — **not** `DBA_*` tables
- Users following the docs correctly (granting `SELECT_CATALOG_ROLE` as a default role) would still get permission errors because the connector was silently using `DBA_TABLES` etc.
- Fix: change the default to `false` so `ALL_*` tables are used by default, aligning with the documented `SELECT_CATALOG_ROLE` requirement
- Users with DBA privileges can still opt in by explicitly setting `useDBATable: true`

## Root Cause

```
useDBATable default: true  →  uses DBA_TABLES, DBA_VIEWS, etc.  →  requires DBA role
SELECT_CATALOG_ROLE        →  grants access to ALL_* views only  →  no access to DBA_* views
```

The documentation said "grant `SELECT_CATALOG_ROLE`" but the code required DBA privileges.

## Test plan

- [ ] Connect to Oracle with a user that has only `SELECT_CATALOG_ROLE` (no DBA privileges) — ingestion should succeed with default settings
- [ ] Connect to Oracle with a user that has DBA privileges and `useDBATable: true` — ingestion should still work
- [ ] Verify `CHECK_ACCESS_TO_ALL` test connection query passes for `SELECT_CATALOG_ROLE` users

https://claude.ai/code/session_012BT3gHMt3Yk4kW9BkK8xnK