### PR TITLE
Fixes #22916: Add chart-level lineage for Metabase connector

### DIFF
--- a/ingestion/src/metadata/ingestion/source/dashboard/metabase/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/metabase/metadata.py
@@ -335,6 +335,18 @@ class MetabaseSource(DashboardServiceSource):
             return None
         return self.metadata.get_by_name(DatabaseService, db_service_name)
 
+    def _get_chart_entity(self, chart_details: MetabaseChart):
+        chart_fqn = fqn.build(
+            self.metadata,
+            entity_type=LineageChart,
+            service_name=self.config.serviceName,
+            chart_name=str(chart_details.id),
+        )
+        return self.metadata.get_by_name(
+            entity=LineageChart,
+            fqn=chart_fqn,
+        )
+
     # pylint: disable=too-many-locals
     def _yield_lineage_from_query(
         self,
@@ -377,6 +389,18 @@ class MetabaseSource(DashboardServiceSource):
             logger.debug(f"[{query_hash}] Database {database_name} does not match prefix {prefix_database_name}")
             return
 
+        to_fqn = fqn.build(
+            self.metadata,
+            entity_type=LineageDashboard,
+            service_name=self.config.serviceName,
+            dashboard_name=dashboard_name,
+        )
+        to_entity = self.metadata.get_by_name(
+            entity=LineageDashboard,
+            fqn=to_fqn,
+        )
+        chart_entity = self._get_chart_entity(chart_details)
+
         for table in lineage_parser.source_tables:
             database_schema_name, table = fqn.split(str(table))[-2:]  # noqa: PLW2901
             database_schema_name = self.check_database_schema_name(database_schema_name)
@@ -403,27 +427,6 @@ class MetabaseSource(DashboardServiceSource):
                 entity_type=Table,
                 fqn_search_string=fqn_search_string,
                 fetch_multiple_entities=True,
-            )
-            to_fqn = fqn.build(
-                self.metadata,
-                entity_type=LineageDashboard,
-                service_name=self.config.serviceName,
-                dashboard_name=dashboard_name,
-            )
-            to_entity = self.metadata.get_by_name(
-                entity=LineageDashboard,
-                fqn=to_fqn,
-            )
-
-            chart_fqn = fqn.build(
-                self.metadata,
-                entity_type=LineageChart,
-                service_name=self.config.serviceName,
-                chart_name=str(chart_details.id),
-            )
-            chart_entity = self.metadata.get_by_name(
-                entity=LineageChart,
-                fqn=chart_fqn,
             )
 
             for from_entity in from_entities or []:
@@ -485,17 +488,7 @@ class MetabaseSource(DashboardServiceSource):
             entity=LineageDashboard,
             fqn=to_fqn,
         )
-
-        chart_fqn = fqn.build(
-            self.metadata,
-            entity_type=LineageChart,
-            service_name=self.config.serviceName,
-            chart_name=str(chart_details.id),
-        )
-        chart_entity = self.metadata.get_by_name(
-            entity=LineageChart,
-            fqn=chart_fqn,
-        )
+        chart_entity = self._get_chart_entity(chart_details)
 
         for from_entity in from_entities or []:
             yield self._get_add_lineage_request(to_entity=to_entity, from_entity=from_entity)

--- a/ingestion/src/metadata/ingestion/source/dashboard/metabase/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/metabase/metadata.py
@@ -431,7 +431,10 @@ class MetabaseSource(DashboardServiceSource):
 
             for from_entity in from_entities or []:
                 yield self._get_add_lineage_request(to_entity=to_entity, from_entity=from_entity)
-                yield self._get_add_lineage_request(to_entity=chart_entity, from_entity=from_entity)
+                if chart_entity and isinstance(from_entity, Table):
+                    chart_lineage = self._get_add_lineage_request(to_entity=chart_entity, from_entity=from_entity)
+                    if chart_lineage:
+                        yield chart_lineage
 
     def _yield_lineage_from_api(
         self,
@@ -492,4 +495,7 @@ class MetabaseSource(DashboardServiceSource):
 
         for from_entity in from_entities or []:
             yield self._get_add_lineage_request(to_entity=to_entity, from_entity=from_entity)
-            yield self._get_add_lineage_request(to_entity=chart_entity, from_entity=from_entity)
+            if chart_entity and isinstance(from_entity, Table):
+                chart_lineage = self._get_add_lineage_request(to_entity=chart_entity, from_entity=from_entity)
+                if chart_lineage:
+                    yield chart_lineage

--- a/ingestion/src/metadata/ingestion/source/dashboard/metabase/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/metabase/metadata.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, Iterable, List, Optional  # noqa: UP035
 from metadata.generated.schema.api.data.createChart import CreateChartRequest
 from metadata.generated.schema.api.data.createDashboard import CreateDashboardRequest
 from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
-from metadata.generated.schema.entity.data.chart import Chart
+from metadata.generated.schema.entity.data.chart import Chart as LineageChart
 from metadata.generated.schema.entity.data.dashboard import (
     Dashboard as LineageDashboard,
 )
@@ -199,7 +199,7 @@ class MetabaseSource(DashboardServiceSource):
                     FullyQualifiedEntityName(
                         fqn.build(
                             self.metadata,
-                            entity_type=Chart,
+                            entity_type=LineageChart,
                             service_name=self.context.get().dashboard_service,
                             chart_name=chart,
                         )
@@ -415,8 +415,20 @@ class MetabaseSource(DashboardServiceSource):
                 fqn=to_fqn,
             )
 
+            chart_fqn = fqn.build(
+                self.metadata,
+                entity_type=LineageChart,
+                service_name=self.config.serviceName,
+                chart_name=str(chart_details.id),
+            )
+            chart_entity = self.metadata.get_by_name(
+                entity=LineageChart,
+                fqn=chart_fqn,
+            )
+
             for from_entity in from_entities or []:
                 yield self._get_add_lineage_request(to_entity=to_entity, from_entity=from_entity)
+                yield self._get_add_lineage_request(to_entity=chart_entity, from_entity=from_entity)
 
     def _yield_lineage_from_api(
         self,
@@ -474,5 +486,17 @@ class MetabaseSource(DashboardServiceSource):
             fqn=to_fqn,
         )
 
+        chart_fqn = fqn.build(
+            self.metadata,
+            entity_type=LineageChart,
+            service_name=self.config.serviceName,
+            chart_name=str(chart_details.id),
+        )
+        chart_entity = self.metadata.get_by_name(
+            entity=LineageChart,
+            fqn=chart_fqn,
+        )
+
         for from_entity in from_entities or []:
             yield self._get_add_lineage_request(to_entity=to_entity, from_entity=from_entity)
+            yield self._get_add_lineage_request(to_entity=chart_entity, from_entity=from_entity)

--- a/ingestion/src/metadata/ingestion/source/dashboard/metabase/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/metabase/metadata.py
@@ -335,7 +335,7 @@ class MetabaseSource(DashboardServiceSource):
             return None
         return self.metadata.get_by_name(DatabaseService, db_service_name)
 
-    def _get_chart_entity(self, chart_details: MetabaseChart) -> Optional[LineageChart]:
+    def _get_chart_entity(self, chart_details: MetabaseChart) -> LineageChart | None:
         chart_fqn = fqn.build(
             self.metadata,
             entity_type=LineageChart,

--- a/ingestion/src/metadata/ingestion/source/dashboard/metabase/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/metabase/metadata.py
@@ -335,13 +335,15 @@ class MetabaseSource(DashboardServiceSource):
             return None
         return self.metadata.get_by_name(DatabaseService, db_service_name)
 
-    def _get_chart_entity(self, chart_details: MetabaseChart):
+    def _get_chart_entity(self, chart_details: MetabaseChart) -> Optional[LineageChart]:
         chart_fqn = fqn.build(
             self.metadata,
             entity_type=LineageChart,
             service_name=self.config.serviceName,
             chart_name=str(chart_details.id),
         )
+        if not chart_fqn:
+            return None
         return self.metadata.get_by_name(
             entity=LineageChart,
             fqn=chart_fqn,
@@ -395,9 +397,13 @@ class MetabaseSource(DashboardServiceSource):
             service_name=self.config.serviceName,
             dashboard_name=dashboard_name,
         )
-        to_entity = self.metadata.get_by_name(
-            entity=LineageDashboard,
-            fqn=to_fqn,
+        to_entity = (
+            self.metadata.get_by_name(
+                entity=LineageDashboard,
+                fqn=to_fqn,
+            )
+            if to_fqn
+            else None
         )
         chart_entity = self._get_chart_entity(chart_details)
 
@@ -430,7 +436,13 @@ class MetabaseSource(DashboardServiceSource):
             )
 
             for from_entity in from_entities or []:
-                yield self._get_add_lineage_request(to_entity=to_entity, from_entity=from_entity)
+                if to_entity:
+                    dashboard_lineage = self._get_add_lineage_request(
+                        to_entity=to_entity,
+                        from_entity=from_entity,
+                    )
+                    if dashboard_lineage:
+                        yield dashboard_lineage
                 if chart_entity and isinstance(from_entity, Table):
                     chart_lineage = self._get_add_lineage_request(to_entity=chart_entity, from_entity=from_entity)
                     if chart_lineage:
@@ -487,14 +499,24 @@ class MetabaseSource(DashboardServiceSource):
             dashboard_name=dashboard_name,
         )
 
-        to_entity = self.metadata.get_by_name(
-            entity=LineageDashboard,
-            fqn=to_fqn,
+        to_entity = (
+            self.metadata.get_by_name(
+                entity=LineageDashboard,
+                fqn=to_fqn,
+            )
+            if to_fqn
+            else None
         )
         chart_entity = self._get_chart_entity(chart_details)
 
         for from_entity in from_entities or []:
-            yield self._get_add_lineage_request(to_entity=to_entity, from_entity=from_entity)
+            if to_entity:
+                dashboard_lineage = self._get_add_lineage_request(
+                    to_entity=to_entity,
+                    from_entity=from_entity,
+                )
+                if dashboard_lineage:
+                    yield dashboard_lineage
             if chart_entity and isinstance(from_entity, Table):
                 chart_lineage = self._get_add_lineage_request(to_entity=chart_entity, from_entity=from_entity)
                 if chart_lineage:

--- a/ingestion/src/metadata/ingestion/source/dashboard/metabase/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/metabase/metadata.py
@@ -434,8 +434,9 @@ class MetabaseSource(DashboardServiceSource):
                 fqn_search_string=fqn_search_string,
                 fetch_multiple_entities=True,
             )
+            from_tables = [from_entities] if isinstance(from_entities, Table) else from_entities or []
 
-            for from_entity in from_entities or []:
+            for from_entity in from_tables:
                 if to_entity:
                     dashboard_lineage = self._get_add_lineage_request(
                         to_entity=to_entity,
@@ -492,6 +493,7 @@ class MetabaseSource(DashboardServiceSource):
             fqn_search_string=fqn_search_string,
             fetch_multiple_entities=True,
         )
+        from_tables = [from_entities] if isinstance(from_entities, Table) else from_entities or []
         to_fqn = fqn.build(
             self.metadata,
             entity_type=LineageDashboard,
@@ -509,7 +511,7 @@ class MetabaseSource(DashboardServiceSource):
         )
         chart_entity = self._get_chart_entity(chart_details)
 
-        for from_entity in from_entities or []:
+        for from_entity in from_tables:
             if to_entity:
                 dashboard_lineage = self._get_add_lineage_request(
                     to_entity=to_entity,

--- a/ingestion/tests/unit/topology/dashboard/test_metabase.py
+++ b/ingestion/tests/unit/topology/dashboard/test_metabase.py
@@ -22,6 +22,7 @@ from unittest.mock import patch
 from metadata.generated.schema.api.data.createChart import CreateChartRequest
 from metadata.generated.schema.api.data.createDashboard import CreateDashboardRequest
 from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
+from metadata.generated.schema.entity.data.chart import Chart as LineageChart
 from metadata.generated.schema.entity.data.dashboard import (
     Dashboard as LineageDashboard,
 )
@@ -78,6 +79,12 @@ Mock_DATABASE_SCHEMA_DEFAULT = "<default>"
 EXAMPLE_DASHBOARD = LineageDashboard(
     id="7b3766b1-7eb4-4ad4-b7c8-15a8b16edfdd",
     name="lineage_dashboard",
+    service=EntityReference(id="c3eb265f-5445-4ad3-ba5e-797d3a3071bb", type="dashboardService"),
+)
+
+EXAMPLE_CHART = LineageChart(
+    id="a1b2c3d4-1234-5678-abcd-ef0123456789",
+    name="lineage_chart",
     service=EntityReference(id="c3eb265f-5445-4ad3-ba5e-797d3a3071bb", type="dashboardService"),
 )
 
@@ -159,6 +166,20 @@ EXPECTED_LINEAGE = AddLineageRequest(
         toEntity=EntityReference(
             id="7b3766b1-7eb4-4ad4-b7c8-15a8b16edfdd",
             type="dashboard",
+        ),
+        lineageDetails=LineageDetails(source=LineageSource.DashboardLineage),
+    )
+)
+
+EXPECTED_CHART_LINEAGE = AddLineageRequest(
+    edge=EntitiesEdge(
+        fromEntity=EntityReference(
+            id="0bd6bd6f-7fea-4a98-98c7-3b37073629c7",
+            type="table",
+        ),
+        toEntity=EntityReference(
+            id="a1b2c3d4-1234-5678-abcd-ef0123456789",
+            type="chart",
         ),
         lineageDetails=LineageDetails(source=LineageSource.DashboardLineage),
     )
@@ -265,7 +286,6 @@ class MetabaseUnitTest(TestCase):
         self.assertEqual(EXPECTED_DASHBOARD, [res.right for res in results])
 
     @patch.object(fqn, "build", return_value=None)
-    @patch.object(OpenMetadata, "get_by_name", return_value=EXAMPLE_DASHBOARD)
     @patch.object(OpenMetadata, "search_in_any_service", return_value=EXAMPLE_TABLE)
     @patch.object(MetabaseSource, "_get_database_service", return_value=MOCK_DATABASE_SERVICE)
     def test_yield_lineage(self, *_):
@@ -275,35 +295,64 @@ class MetabaseUnitTest(TestCase):
         self.metabase.client.get_database = lambda *_: None
         self.metabase.client.get_table = lambda *_: MetabaseTable(schema="test_schema", display_name="test_table")
 
-        # if no db service name then no lineage generated
-        result = self.metabase.yield_dashboard_lineage_details(
-            dashboard_details=MOCK_DASHBOARD_DETAILS, db_service_prefix=None
-        )
-        self.assertEqual(next(result).right, EXPECTED_LINEAGE)
+        # _yield_lineage_from_api: get_by_name called for dashboard then chart
+        # _yield_lineage_from_query: get_by_name called for dashboard then chart
+        # Total for MOCK_DASHBOARD_DETAILS (cards 1, 2): 4 calls → dashboard, chart, dashboard, chart
+        with patch.object(
+            OpenMetadata,
+            "get_by_name",
+            side_effect=[
+                EXAMPLE_DASHBOARD,
+                EXAMPLE_CHART,
+                EXAMPLE_DASHBOARD,
+                EXAMPLE_CHART,
+            ],
+        ):
+            result = self.metabase.yield_dashboard_lineage_details(
+                dashboard_details=MOCK_DASHBOARD_DETAILS, db_service_prefix=None
+            )
+            lineage_results = [r.right for r in result if r.right is not None]
+            self.assertIn(EXPECTED_LINEAGE, lineage_results)
+            self.assertIn(EXPECTED_CHART_LINEAGE, lineage_results)
 
-        # test out _yield_lineage_from_api
-        mock_dashboard = deepcopy(MOCK_DASHBOARD_DETAILS)
-        mock_dashboard.card_ids = [MOCK_DASHBOARD_DETAILS.card_ids[0]]
-        result = self.metabase.yield_dashboard_lineage_details(
-            dashboard_details=mock_dashboard,
-            db_service_prefix=f"{MOCK_DATABASE_SERVICE.name}",
-        )
-        self.assertEqual(next(result).right, EXPECTED_LINEAGE)
+        # test out _yield_lineage_from_api (card 1 only): 2 calls → dashboard, chart
+        with patch.object(
+            OpenMetadata,
+            "get_by_name",
+            side_effect=[EXAMPLE_DASHBOARD, EXAMPLE_CHART],
+        ):
+            mock_dashboard = deepcopy(MOCK_DASHBOARD_DETAILS)
+            mock_dashboard.card_ids = [MOCK_DASHBOARD_DETAILS.card_ids[0]]
+            result = self.metabase.yield_dashboard_lineage_details(
+                dashboard_details=mock_dashboard,
+                db_service_prefix=f"{MOCK_DATABASE_SERVICE.name}",
+            )
+            lineage_results = [r.right for r in result if r.right is not None]
+            self.assertIn(EXPECTED_LINEAGE, lineage_results)
+            self.assertIn(EXPECTED_CHART_LINEAGE, lineage_results)
 
-        # test out _yield_lineage_from_query
-        mock_dashboard.card_ids = [MOCK_DASHBOARD_DETAILS.card_ids[1]]
-        result = self.metabase.yield_dashboard_lineage_details(
-            dashboard_details=mock_dashboard,
-            db_service_prefix=f"{MOCK_DATABASE_SERVICE.name}",
-        )
-        self.assertEqual(next(result).right, EXPECTED_LINEAGE)
+        # test out _yield_lineage_from_query (card 2 only): 2 calls → dashboard, chart
+        with patch.object(
+            OpenMetadata,
+            "get_by_name",
+            side_effect=[EXAMPLE_DASHBOARD, EXAMPLE_CHART],
+        ):
+            mock_dashboard.card_ids = [MOCK_DASHBOARD_DETAILS.card_ids[1]]
+            result = self.metabase.yield_dashboard_lineage_details(
+                dashboard_details=mock_dashboard,
+                db_service_prefix=f"{MOCK_DATABASE_SERVICE.name}",
+            )
+            lineage_results = [r.right for r in result if r.right is not None]
+            self.assertIn(EXPECTED_LINEAGE, lineage_results)
+            self.assertIn(EXPECTED_CHART_LINEAGE, lineage_results)
 
         # test out if no query type
-        mock_dashboard.card_ids = [MOCK_DASHBOARD_DETAILS.card_ids[2]]
-        result = self.metabase.yield_dashboard_lineage_details(
-            dashboard_details=mock_dashboard, db_service_prefix="db.service.name"
-        )
-        self.assertEqual(list(result), [])
+        with patch.object(OpenMetadata, "get_by_name", return_value=EXAMPLE_DASHBOARD):
+            mock_dashboard.card_ids = [MOCK_DASHBOARD_DETAILS.card_ids[2]]
+            result = self.metabase.yield_dashboard_lineage_details(
+                dashboard_details=mock_dashboard, db_service_prefix="db.service.name"
+            )
+            self.assertEqual(list(result), [])
 
     def test_include_owners_flag_enabled(self):
         """

--- a/ingestion/tests/unit/topology/dashboard/test_metabase.py
+++ b/ingestion/tests/unit/topology/dashboard/test_metabase.py
@@ -54,7 +54,6 @@ from metadata.ingestion.source.dashboard.metabase.models import (
     MetabaseTable,
     Native,
 )
-from metadata.utils import fqn
 
 MOCK_DASHBOARD_SERVICE = DashboardService(
     id="c3eb265f-5445-4ad3-ba5e-797d3a3071bb",
@@ -339,6 +338,43 @@ class MetabaseUnitTest(TestCase):
             self.assertIn(EXPECTED_LINEAGE, lineage_results)
             self.assertIn(EXPECTED_CHART_LINEAGE, lineage_results)
 
+        # test out missing chart entity: dashboard lineage should still be yielded
+        with (
+            patch.object(
+                MetabaseSource,
+                "_get_chart_entity",
+                return_value=None,
+            ),
+            patch.object(
+                OpenMetadata,
+                "get_by_name",
+                side_effect=[EXAMPLE_DASHBOARD],
+            ),
+        ):
+            mock_dashboard.card_ids = [MOCK_DASHBOARD_DETAILS.card_ids[0]]
+            result = self.metabase.yield_dashboard_lineage_details(
+                dashboard_details=mock_dashboard,
+                db_service_prefix=f"{MOCK_DATABASE_SERVICE.name}",
+            )
+            lineage_results = [r.right for r in result if r.right is not None]
+            self.assertIn(EXPECTED_LINEAGE, lineage_results)
+            self.assertNotIn(EXPECTED_CHART_LINEAGE, lineage_results)
+
+        # test out missing dashboard entity: chart lineage should still be yielded
+        with patch.object(
+            OpenMetadata,
+            "get_by_name",
+            return_value=None,
+        ):
+            mock_dashboard.card_ids = [MOCK_DASHBOARD_DETAILS.card_ids[0]]
+            result = self.metabase.yield_dashboard_lineage_details(
+                dashboard_details=mock_dashboard,
+                db_service_prefix=f"{MOCK_DATABASE_SERVICE.name}",
+            )
+            lineage_results = [r.right for r in result if r.right is not None]
+            self.assertNotIn(EXPECTED_LINEAGE, lineage_results)
+            self.assertIn(EXPECTED_CHART_LINEAGE, lineage_results)
+
         # test out if no query type
         with patch.object(OpenMetadata, "get_by_name", return_value=EXAMPLE_DASHBOARD):
             mock_dashboard.card_ids = [MOCK_DASHBOARD_DETAILS.card_ids[2]]
@@ -465,7 +501,7 @@ class MetabaseUnitTest(TestCase):
         self.metabase.chart_source_state = set()
         list(self.metabase.yield_dashboard_chart(MOCK_DASHBOARD_DETAILS))
         assert len(self.metabase.chart_source_state) == 3
-        for fqn in self.metabase.chart_source_state:  # noqa: F402
+        for fqn in self.metabase.chart_source_state:
             assert "mock_metabase" in fqn
 
         # Test 8: New format with stages but no native query

--- a/ingestion/tests/unit/topology/dashboard/test_metabase.py
+++ b/ingestion/tests/unit/topology/dashboard/test_metabase.py
@@ -285,8 +285,8 @@ class MetabaseUnitTest(TestCase):
         results = list(self.metabase.yield_dashboard(MOCK_DASHBOARD_DETAILS))
         self.assertEqual(EXPECTED_DASHBOARD, [res.right for res in results])
 
-    @patch.object(fqn, "build", return_value=None)
     @patch.object(OpenMetadata, "search_in_any_service", return_value=EXAMPLE_TABLE)
+    @patch.object(MetabaseSource, "_get_chart_entity", return_value=EXAMPLE_CHART)
     @patch.object(MetabaseSource, "_get_database_service", return_value=MOCK_DATABASE_SERVICE)
     def test_yield_lineage(self, *_):
         """
@@ -295,11 +295,11 @@ class MetabaseUnitTest(TestCase):
         self.metabase.client.get_database = lambda *_: None
         self.metabase.client.get_table = lambda *_: MetabaseTable(schema="test_schema", display_name="test_table")
 
-        # _yield_lineage_from_api (card 1) + _yield_lineage_from_query (card 2): 4 get_by_name calls
+        # _yield_lineage_from_api (card 1) + _yield_lineage_from_query (card 2): 2 dashboard lookups
         with patch.object(
             OpenMetadata,
             "get_by_name",
-            side_effect=[EXAMPLE_DASHBOARD, EXAMPLE_CHART, EXAMPLE_DASHBOARD, EXAMPLE_CHART],
+            side_effect=[EXAMPLE_DASHBOARD, EXAMPLE_DASHBOARD],
         ):
             result = self.metabase.yield_dashboard_lineage_details(
                 dashboard_details=MOCK_DASHBOARD_DETAILS, db_service_prefix=None
@@ -308,11 +308,11 @@ class MetabaseUnitTest(TestCase):
             self.assertIn(EXPECTED_LINEAGE, lineage_results)
             self.assertIn(EXPECTED_CHART_LINEAGE, lineage_results)
 
-        # test out _yield_lineage_from_api (card 1 only): 2 get_by_name calls
+        # test out _yield_lineage_from_api (card 1 only): 1 dashboard lookup
         with patch.object(
             OpenMetadata,
             "get_by_name",
-            side_effect=[EXAMPLE_DASHBOARD, EXAMPLE_CHART],
+            side_effect=[EXAMPLE_DASHBOARD],
         ):
             mock_dashboard = deepcopy(MOCK_DASHBOARD_DETAILS)
             mock_dashboard.card_ids = [MOCK_DASHBOARD_DETAILS.card_ids[0]]
@@ -324,11 +324,11 @@ class MetabaseUnitTest(TestCase):
             self.assertIn(EXPECTED_LINEAGE, lineage_results)
             self.assertIn(EXPECTED_CHART_LINEAGE, lineage_results)
 
-        # test out _yield_lineage_from_query (card 2 only): 2 get_by_name calls
+        # test out _yield_lineage_from_query (card 2 only): 1 dashboard lookup
         with patch.object(
             OpenMetadata,
             "get_by_name",
-            side_effect=[EXAMPLE_DASHBOARD, EXAMPLE_CHART],
+            side_effect=[EXAMPLE_DASHBOARD],
         ):
             mock_dashboard.card_ids = [MOCK_DASHBOARD_DETAILS.card_ids[1]]
             result = self.metabase.yield_dashboard_lineage_details(

--- a/ingestion/tests/unit/topology/dashboard/test_metabase.py
+++ b/ingestion/tests/unit/topology/dashboard/test_metabase.py
@@ -295,18 +295,11 @@ class MetabaseUnitTest(TestCase):
         self.metabase.client.get_database = lambda *_: None
         self.metabase.client.get_table = lambda *_: MetabaseTable(schema="test_schema", display_name="test_table")
 
-        # _yield_lineage_from_api: get_by_name called for dashboard then chart
-        # _yield_lineage_from_query: get_by_name called for dashboard then chart
-        # Total for MOCK_DASHBOARD_DETAILS (cards 1, 2): 4 calls → dashboard, chart, dashboard, chart
+        # _yield_lineage_from_api (card 1) + _yield_lineage_from_query (card 2): 4 get_by_name calls
         with patch.object(
             OpenMetadata,
             "get_by_name",
-            side_effect=[
-                EXAMPLE_DASHBOARD,
-                EXAMPLE_CHART,
-                EXAMPLE_DASHBOARD,
-                EXAMPLE_CHART,
-            ],
+            side_effect=[EXAMPLE_DASHBOARD, EXAMPLE_CHART, EXAMPLE_DASHBOARD, EXAMPLE_CHART],
         ):
             result = self.metabase.yield_dashboard_lineage_details(
                 dashboard_details=MOCK_DASHBOARD_DETAILS, db_service_prefix=None
@@ -315,7 +308,7 @@ class MetabaseUnitTest(TestCase):
             self.assertIn(EXPECTED_LINEAGE, lineage_results)
             self.assertIn(EXPECTED_CHART_LINEAGE, lineage_results)
 
-        # test out _yield_lineage_from_api (card 1 only): 2 calls → dashboard, chart
+        # test out _yield_lineage_from_api (card 1 only): 2 get_by_name calls
         with patch.object(
             OpenMetadata,
             "get_by_name",
@@ -331,7 +324,7 @@ class MetabaseUnitTest(TestCase):
             self.assertIn(EXPECTED_LINEAGE, lineage_results)
             self.assertIn(EXPECTED_CHART_LINEAGE, lineage_results)
 
-        # test out _yield_lineage_from_query (card 2 only): 2 calls → dashboard, chart
+        # test out _yield_lineage_from_query (card 2 only): 2 get_by_name calls
         with patch.object(
             OpenMetadata,
             "get_by_name",

--- a/pom.xml
+++ b/pom.xml
@@ -733,7 +733,7 @@
         <enabled>false</enabled>
       </snapshots>
       <id>central</id>
-      <url>https://repo1.maven.org/maven2/</url>
+      <url>https://repo.maven.apache.org/maven2/</url>
     </repository>
     <repository>
       <releases>


### PR DESCRIPTION
### Describe your changes:                                                                             
                            
Fixes #22916                                                                                           
                                                          
The Metabase connector was only creating lineage between source tables and dashboards, but not between
source tables and individual charts.                                                                  
                                    
In both `_yield_lineage_from_query` and `_yield_lineage_from_api`, added a lineage edge from the source
 table to the chart entity in addition to the existing table → dashboard edge.                         
                                                                              
Validated end-to-end on a local OpenMetadata 1.12.3 instance with a live Metabase connection.          
                                                                                                       
### Type of change:
- [x] Bug fix                                                                                          
                                                            
  ### Checklist:                                                                                         
  - [x] I have read the **CONTRIBUTING** document.
  - [x] My PR title is `Fixes <issue-number>: <short explanation>`                                       
  - [ ] I have commented on my code, particularly in hard-to-understand areas.
  - [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
                                                                                                         
  <!-- Bug fix -->
  - [x] I have added a test that covers the exact scenario we are fixing.

----
## Summary by Gitar

- **Metabase connector:**
  - Added chart-level lineage generation by creating lineage edges between source tables and chart entities.
  - Implemented `_get_chart_entity` helper and added type guards to safely handle chart and dashboard lineage lookups.
  - Normalized lineage search results and improved resilience when specific entity lookups return None.
- **Testing:**
  - Updated `test_yield_lineage` to assert chart-level lineage and added fallback cases for missing chart or dashboard entities.
- **Build infrastructure:**
  - Updated Maven Central repository URL to the canonical `https://repo.maven.apache.org/maven2/` address in `pom.xml`.

<sub>This will update automatically on new commits.</sub>