### PR TITLE
Chore/two digit branches

### DIFF
--- a/.github/workflows/git-create-release-branch.yml
+++ b/.github/workflows/git-create-release-branch.yml
@@ -28,12 +28,11 @@ jobs:
           RELEASE_VERSION="${RELEASE_VERSION}.0"
           echo "Release version is in format X.Y, appending .0 to make it X.Y.0: $RELEASE_VERSION"
         fi
-        
         make update_all RELEASE_VERSION=$RELEASE_VERSION
-    # - name: Commit changes to ${{ inputs.release_branch_name }} branch
-    #   uses: EndBug/add-and-commit@v9
-    #   with:
-    #     default_author: github_actions
-    #     message: 'chore(release): Prepare Branch for `${{ inputs.release_branch_name }}`'
-    #     add: '.'
-    #     new_branch: ${{ inputs.release_branch_name }}
+    - name: Commit changes to ${{ inputs.release_branch_name }} branch
+      uses: EndBug/add-and-commit@v9
+      with:
+        default_author: github_actions
+        message: 'chore(release): Prepare Branch for `${{ inputs.release_branch_name }}`'
+        add: '.'
+        new_branch: ${{ inputs.release_branch_name }}

--- a/.github/workflows/git-create-release-branch.yml
+++ b/.github/workflows/git-create-release-branch.yml
@@ -23,11 +23,17 @@ jobs:
         ref: ${{ inputs.base_branch_name }}
     - name: Update application versions
       run: |
-        make update_all RELEASE_VERSION=${{ inputs.release_branch_name }}
-    - name: Commit changes to ${{ inputs.release_branch_name }} branch
-      uses: EndBug/add-and-commit@v9
-      with:
-        default_author: github_actions
-        message: 'chore(release): Prepare Branch for `${{ inputs.release_branch_name }}`'
-        add: '.'
-        new_branch: ${{ inputs.release_branch_name }}
+        RELEASE_VERSION=${{ inputs.release_branch_name }}
+        if [[ $RELEASE_VERSION =~ ^[0-9]+\.[0-9]+$ ]]; then
+          RELEASE_VERSION="${RELEASE_VERSION}.0"
+          echo "Release version is in format X.Y, appending .0 to make it X.Y.0: $RELEASE_VERSION"
+        fi
+        
+        make update_all RELEASE_VERSION=$RELEASE_VERSION
+    # - name: Commit changes to ${{ inputs.release_branch_name }} branch
+    #   uses: EndBug/add-and-commit@v9
+    #   with:
+    #     default_author: github_actions
+    #     message: 'chore(release): Prepare Branch for `${{ inputs.release_branch_name }}`'
+    #     add: '.'
+    #     new_branch: ${{ inputs.release_branch_name }}


### PR DESCRIPTION
This PR will:
- Add support for 2-digit branches, executing the `make update_all` with an extra `.0` if not provided