### PR TITLE
Fixes 26434: [openlinege] Resolve openlineage pipeline/job to it's integration type

### DIFF
--- a/ingestion/src/metadata/ingestion/source/pipeline/openlineage/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/openlineage/metadata.py
@@ -202,11 +202,15 @@ class OpenlineageSource(PipelineServiceSource):
         except KeyError:
             raise ValueError("Topic name is not present")
 
-        broker_hostname = urlparse(namespace).hostname
+        parsed = urlparse(namespace)
+        broker_hostname = parsed.hostname
         if not broker_hostname:
             raise ValueError(
                 f"Could not extract broker hostname from namespace: {namespace}"
             )
+
+        if parsed.port:
+            broker_hostname = f"{broker_hostname}:{parsed.port}"
 
         return TopicDetails(name=name, broker_hostname=broker_hostname)
 
@@ -250,9 +254,9 @@ class OpenlineageSource(PipelineServiceSource):
                         bootstrap_servers = svc.connection.config.bootstrapServers or ""
                         svc_fqn = svc.fullyQualifiedName.root
                         for broker in bootstrap_servers.split(","):
-                            hostname = broker.strip().split(":")[0]
-                            if hostname:
-                                self._broker_to_service[hostname] = svc_fqn
+                            broker = broker.strip()
+                            if broker:
+                                self._broker_to_service[broker] = svc_fqn
                     except Exception:
                         logger.debug(
                             f"Could not extract bootstrapServers from service {svc.name}"

--- a/ingestion/src/metadata/ingestion/source/pipeline/openlineage/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/openlineage/metadata.py
@@ -62,6 +62,13 @@ from metadata.ingestion.source.pipeline.openlineage.models import (
     TopicDetails,
     TopicFQN,
 )
+from metadata.ingestion.source.pipeline.openlineage.service_resolver import (
+    build_service_name,
+    extract_integration_type,
+    find_pipeline_by_namespace,
+    get_or_create_pipeline_service,
+    resolve_pipeline_service_type,
+)
 from metadata.ingestion.source.pipeline.openlineage.utils import (
     FQNNotFoundException,
     message_to_open_lineage_event,
@@ -87,6 +94,8 @@ class OpenlineageSource(PipelineServiceSource):
     """
 
     _db_service_names_warned: bool = False
+    _service_cache: Dict[str, str]
+    _current_pipeline_service: Optional[str] = None
 
     @classmethod
     def create(
@@ -102,7 +111,8 @@ class OpenlineageSource(PipelineServiceSource):
         return cls(config, metadata)
 
     def prepare(self):
-        """Nothing to prepare"""
+        self._service_cache = {}
+        self._current_pipeline_service = None
 
     def close(self) -> None:
         self.metadata.compute_percentile(Pipeline, self.today)
@@ -514,16 +524,50 @@ class OpenlineageSource(PipelineServiceSource):
 
         return OpenlineageSource._create_output_lineage_dict(_result)
 
+    def _resolve_pipeline_service(self, pipeline_details: OpenLineageEvent) -> str:
+        """
+        Resolve the pipeline service for the current event.
+
+        Resolution order:
+        1. **Namespace fallback** — try ``namespace.jobName`` as a pipeline
+           FQN.  If a pipeline already exists (e.g. ingested by a native
+           Airflow connector), reuse its service.
+        2. **Integration type** — extract from
+           ``job.facets.jobType.integration`` and create a typed service
+           (e.g. ``spark_openlineage``).
+        3. **Default** — fall back to the configured OpenLineage service.
+        """
+        fallback = self.context.get().pipeline_service
+
+        ns_result = find_pipeline_by_namespace(self.metadata, pipeline_details)
+        if ns_result:
+            service_name, _ = ns_result
+            return service_name
+
+        integration = extract_integration_type(pipeline_details)
+        service_name = build_service_name(integration, fallback)
+
+        if service_name != fallback:
+            service_type = resolve_pipeline_service_type(integration)
+            get_or_create_pipeline_service(
+                self.metadata, service_name, service_type, self._service_cache
+            )
+
+        return service_name
+
     def yield_pipeline(
         self, pipeline_details: OpenLineageEvent
     ) -> Iterable[Either[CreatePipelineRequest]]:
         pipeline_name = self.get_pipeline_name(pipeline_details)
+        self._current_pipeline_service = self._resolve_pipeline_service(
+            pipeline_details
+        )
         try:
             description = f"""```json
             {json.dumps(pipeline_details.run_facet, indent=4).strip()}```"""
             request = CreatePipelineRequest(
                 name=pipeline_name,
-                service=self.context.get().pipeline_service,
+                service=self._current_pipeline_service,
                 description=description,
             )
 
@@ -597,10 +641,13 @@ class OpenlineageSource(PipelineServiceSource):
             for n in product(input_edges, output_edges)
         ]
 
+        service_name = (
+            self._current_pipeline_service or self.context.get().pipeline_service
+        )
         pipeline_fqn = fqn.build(
             metadata=self.metadata,
             entity_type=Pipeline,
-            service_name=self.context.get().pipeline_service,
+            service_name=service_name,
             pipeline_name=self.context.get().pipeline,
         )
 

--- a/ingestion/src/metadata/ingestion/source/pipeline/openlineage/service_resolver.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/openlineage/service_resolver.py
@@ -1,0 +1,151 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Resolves the pipeline service type and name from OpenLineage event metadata.
+
+OpenLineage events carry integration identity (Spark, Flink, Airflow, etc.)
+in job facets. This module extracts that information and maps it to the
+appropriate OMD PipelineServiceType, creating services as needed.
+"""
+
+from typing import Dict, Optional, Tuple
+
+from metadata.generated.schema.api.services.createPipelineService import (
+    CreatePipelineServiceRequest,
+)
+from metadata.generated.schema.entity.data.pipeline import Pipeline
+from metadata.generated.schema.entity.services.pipelineService import (
+    PipelineService,
+    PipelineServiceType,
+)
+from metadata.generated.schema.type.basic import EntityName
+from metadata.ingestion.ometa.ometa_api import OpenMetadata
+from metadata.ingestion.source.pipeline.openlineage.models import OpenLineageEvent
+from metadata.utils.logger import ingestion_logger
+
+logger = ingestion_logger()
+
+INTEGRATION_TO_SERVICE_TYPE: Dict[str, PipelineServiceType] = {
+    "spark": PipelineServiceType.Spark,
+    "flink": PipelineServiceType.Flink,
+    "airflow": PipelineServiceType.Airflow,
+    "dbt": PipelineServiceType.DBTCloud,
+    "dagster": PipelineServiceType.Dagster,
+}
+
+SERVICE_NAME_SUFFIX = "_openlineage"
+
+
+def extract_integration_type(event: OpenLineageEvent) -> Optional[str]:
+    """
+    Extract the integration type from an OpenLineage event via the
+    standard ``job.facets.jobType.integration`` field.
+
+    Returns a lowercase string like "spark", "flink", "airflow", or None.
+    """
+    try:
+        integration = event.job["facets"]["jobType"]["integration"]
+        if integration:
+            return integration.strip().lower()
+    except (KeyError, TypeError, AttributeError):
+        pass
+
+    return None
+
+
+def find_pipeline_by_namespace(
+    metadata: OpenMetadata,
+    event: OpenLineageEvent,
+) -> Optional[Tuple[str, Pipeline]]:
+    """
+    Try to find an existing pipeline using ``namespace.jobName`` as FQN.
+
+    When pipelines are ingested by native connectors (e.g. Airflow), the OL
+    job namespace often matches the pipeline service name already present in
+    OMD.  Checking this first avoids creating duplicate pipelines under a new
+    service.
+
+    Returns ``(service_name, pipeline_entity)`` on hit, or ``None``.
+    """
+    try:
+        namespace = event.job.get("namespace")
+        name = event.job.get("name")
+    except (AttributeError, TypeError):
+        return None
+
+    if not namespace or not name:
+        return None
+
+    fallback_fqn = f"{namespace}.{name}"
+    existing = metadata.get_by_name(Pipeline, fallback_fqn)
+    if existing:
+        logger.info(f"Resolved pipeline via namespace fallback: {fallback_fqn}")
+        return namespace, existing
+
+    return None
+
+
+def resolve_pipeline_service_type(
+    integration: Optional[str],
+) -> PipelineServiceType:
+    """Map an integration string to a PipelineServiceType enum."""
+    if integration and integration in INTEGRATION_TO_SERVICE_TYPE:
+        return INTEGRATION_TO_SERVICE_TYPE[integration]
+    return PipelineServiceType.OpenLineage
+
+
+def build_service_name(integration: Optional[str], fallback_service: str) -> str:
+    """
+    Build the pipeline service name.
+
+    If integration is recognized, returns "{integration}_openlineage".
+    Otherwise returns the fallback (the configured OpenLineage service name).
+    """
+    if integration and integration in INTEGRATION_TO_SERVICE_TYPE:
+        return f"{integration}{SERVICE_NAME_SUFFIX}"
+    return fallback_service
+
+
+def get_or_create_pipeline_service(
+    metadata: OpenMetadata,
+    service_name: str,
+    service_type: PipelineServiceType,
+    _cache: Optional[Dict[str, str]] = None,
+) -> str:
+    """
+    Ensure a PipelineService with the given name and type exists in OMD.
+
+    Uses an external cache dict to avoid repeated API calls within a session.
+    Returns the service name.
+    """
+    if _cache is not None and service_name in _cache:
+        return _cache[service_name]
+
+    existing = metadata.get_by_name(PipelineService, service_name)
+    if existing:
+        if _cache is not None:
+            _cache[service_name] = service_name
+        return service_name
+
+    logger.info(
+        f"Creating pipeline service '{service_name}' with type '{service_type.value}'"
+    )
+    request = CreatePipelineServiceRequest(
+        name=EntityName(service_name),
+        serviceType=service_type,
+    )
+    metadata.create_or_update(request)
+
+    if _cache is not None:
+        _cache[service_name] = service_name
+
+    return service_name

--- a/ingestion/tests/unit/topology/pipeline/test_openlineage.py
+++ b/ingestion/tests/unit/topology/pipeline/test_openlineage.py
@@ -1169,7 +1169,7 @@ class OpenLineageUnitTest(unittest.TestCase):
         self.assertIsNotNone(result.topic_details)
         self.assertIsNone(result.table_details)
         self.assertEqual(result.topic_details.name, "my-events-topic")
-        self.assertEqual(result.topic_details.broker_hostname, "broker-host")
+        self.assertEqual(result.topic_details.broker_hostname, "broker-host:9092")
 
     def test_entity_detection_non_kafka_namespace_returns_table(self):
         """Test that non-kafka namespaces (e.g. bigquery, hive) are detected as tables."""
@@ -1193,7 +1193,7 @@ class OpenLineageUnitTest(unittest.TestCase):
             {"name": "topic1", "namespace": "kafka://my-broker:9092"}
         )
         self.assertEqual(result.name, "topic1")
-        self.assertEqual(result.broker_hostname, "my-broker")
+        self.assertEqual(result.broker_hostname, "my-broker:9092")
 
         # Broker without port
         result = OpenlineageSource._get_topic_details(

--- a/ingestion/tests/unit/topology/pipeline/test_service_resolver.py
+++ b/ingestion/tests/unit/topology/pipeline/test_service_resolver.py
@@ -1,0 +1,272 @@
+"""
+Tests for the OpenLineage service resolver module.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from metadata.generated.schema.entity.services.pipelineService import (
+    PipelineServiceType,
+)
+from metadata.ingestion.source.pipeline.openlineage.models import OpenLineageEvent
+from metadata.ingestion.source.pipeline.openlineage.service_resolver import (
+    build_service_name,
+    extract_integration_type,
+    find_pipeline_by_namespace,
+    get_or_create_pipeline_service,
+    resolve_pipeline_service_type,
+)
+
+
+class TestExtractIntegrationType:
+    def test_extracts_from_job_type_integration(self):
+        event = OpenLineageEvent(
+            run_facet={},
+            job={
+                "name": "my_job",
+                "namespace": "test",
+                "facets": {
+                    "jobType": {
+                        "integration": "SPARK",
+                        "jobType": "JOB",
+                        "processingType": "BATCH",
+                    }
+                },
+            },
+            event_type="COMPLETE",
+            inputs=[],
+            outputs=[],
+        )
+        assert extract_integration_type(event) == "spark"
+
+    def test_extracts_flink(self):
+        event = OpenLineageEvent(
+            run_facet={},
+            job={
+                "name": "flink_job",
+                "namespace": "test",
+                "facets": {
+                    "jobType": {
+                        "integration": "FLINK",
+                        "jobType": "JOB",
+                        "processingType": "STREAMING",
+                    }
+                },
+            },
+            event_type="COMPLETE",
+            inputs=[],
+            outputs=[],
+        )
+        assert extract_integration_type(event) == "flink"
+
+    def test_extracts_airflow(self):
+        event = OpenLineageEvent(
+            run_facet={},
+            job={
+                "name": "my_dag",
+                "namespace": "airflow",
+                "facets": {
+                    "jobType": {
+                        "integration": "AIRFLOW",
+                        "jobType": "DAG",
+                    }
+                },
+            },
+            event_type="COMPLETE",
+            inputs=[],
+            outputs=[],
+        )
+        assert extract_integration_type(event) == "airflow"
+
+    def test_returns_none_when_no_facets(self):
+        event = OpenLineageEvent(
+            run_facet={},
+            job={"name": "my_job", "namespace": "test"},
+            event_type="COMPLETE",
+            inputs=[],
+            outputs=[],
+        )
+        assert extract_integration_type(event) is None
+
+    def test_returns_none_when_no_job_type(self):
+        event = OpenLineageEvent(
+            run_facet={},
+            job={
+                "name": "my_job",
+                "namespace": "test",
+                "facets": {"sql": {"query": "SELECT 1"}},
+            },
+            event_type="COMPLETE",
+            inputs=[],
+            outputs=[],
+        )
+        assert extract_integration_type(event) is None
+
+    def test_returns_none_when_integration_is_empty(self):
+        event = OpenLineageEvent(
+            run_facet={},
+            job={
+                "name": "my_job",
+                "namespace": "test",
+                "facets": {"jobType": {"integration": ""}},
+            },
+            event_type="COMPLETE",
+            inputs=[],
+            outputs=[],
+        )
+        assert extract_integration_type(event) is None
+
+    def test_handles_case_insensitive(self):
+        event = OpenLineageEvent(
+            run_facet={},
+            job={
+                "name": "my_job",
+                "namespace": "test",
+                "facets": {"jobType": {"integration": "Spark"}},
+            },
+            event_type="COMPLETE",
+            inputs=[],
+            outputs=[],
+        )
+        assert extract_integration_type(event) == "spark"
+
+
+class TestResolvePipelineServiceType:
+    def test_spark(self):
+        assert resolve_pipeline_service_type("spark") == PipelineServiceType.Spark
+
+    def test_flink(self):
+        assert resolve_pipeline_service_type("flink") == PipelineServiceType.Flink
+
+    def test_airflow(self):
+        assert resolve_pipeline_service_type("airflow") == PipelineServiceType.Airflow
+
+    def test_dbt(self):
+        assert resolve_pipeline_service_type("dbt") == PipelineServiceType.DBTCloud
+
+    def test_unknown_falls_back_to_openlineage(self):
+        assert (
+            resolve_pipeline_service_type("unknown") == PipelineServiceType.OpenLineage
+        )
+
+    def test_none_falls_back_to_openlineage(self):
+        assert resolve_pipeline_service_type(None) == PipelineServiceType.OpenLineage
+
+
+class TestBuildServiceName:
+    def test_known_integration(self):
+        assert build_service_name("spark", "my_ol_service") == "spark_openlineage"
+
+    def test_flink_integration(self):
+        assert build_service_name("flink", "my_ol_service") == "flink_openlineage"
+
+    def test_unknown_integration_uses_fallback(self):
+        assert build_service_name("unknown_engine", "my_ol_service") == "my_ol_service"
+
+    def test_none_integration_uses_fallback(self):
+        assert build_service_name(None, "my_ol_service") == "my_ol_service"
+
+
+class TestGetOrCreatePipelineService:
+    def test_returns_from_cache(self):
+        metadata = MagicMock()
+        cache = {"spark_openlineage": "spark_openlineage"}
+
+        result = get_or_create_pipeline_service(
+            metadata, "spark_openlineage", PipelineServiceType.Spark, cache
+        )
+
+        assert result == "spark_openlineage"
+        metadata.get_by_name.assert_not_called()
+
+    def test_returns_existing_service(self):
+        metadata = MagicMock()
+        metadata.get_by_name.return_value = MagicMock()
+        cache = {}
+
+        result = get_or_create_pipeline_service(
+            metadata, "spark_openlineage", PipelineServiceType.Spark, cache
+        )
+
+        assert result == "spark_openlineage"
+        assert "spark_openlineage" in cache
+        metadata.create_or_update.assert_not_called()
+
+    def test_creates_service_when_not_found(self):
+        metadata = MagicMock()
+        metadata.get_by_name.return_value = None
+        cache = {}
+
+        result = get_or_create_pipeline_service(
+            metadata, "spark_openlineage", PipelineServiceType.Spark, cache
+        )
+
+        assert result == "spark_openlineage"
+        assert "spark_openlineage" in cache
+        metadata.create_or_update.assert_called_once()
+        request = metadata.create_or_update.call_args[0][0]
+        assert request.name.root == "spark_openlineage"
+        assert request.serviceType == PipelineServiceType.Spark
+
+
+class TestFindPipelineByNamespace:
+    def _make_event(self, namespace="airflow_prod", name="my_dag"):
+        return OpenLineageEvent(
+            run_facet={},
+            job={"name": name, "namespace": namespace},
+            event_type="COMPLETE",
+            inputs=[],
+            outputs=[],
+        )
+
+    def test_finds_existing_pipeline(self):
+        metadata = MagicMock()
+        pipeline = MagicMock()
+        metadata.get_by_name.return_value = pipeline
+
+        result = find_pipeline_by_namespace(metadata, self._make_event())
+
+        assert result is not None
+        service_name, found_pipeline = result
+        assert service_name == "airflow_prod"
+        assert found_pipeline is pipeline
+        metadata.get_by_name.assert_called_once()
+
+    def test_returns_none_when_not_found(self):
+        metadata = MagicMock()
+        metadata.get_by_name.return_value = None
+
+        result = find_pipeline_by_namespace(metadata, self._make_event())
+
+        assert result is None
+
+    def test_returns_none_when_no_namespace(self):
+        metadata = MagicMock()
+        event = self._make_event(namespace=None)
+
+        result = find_pipeline_by_namespace(metadata, event)
+
+        assert result is None
+        metadata.get_by_name.assert_not_called()
+
+    def test_returns_none_when_no_name(self):
+        metadata = MagicMock()
+        event = self._make_event(name=None)
+
+        result = find_pipeline_by_namespace(metadata, event)
+
+        assert result is None
+        metadata.get_by_name.assert_not_called()
+
+    def test_uses_namespace_dot_name_as_fqn(self):
+        metadata = MagicMock()
+        metadata.get_by_name.return_value = None
+
+        find_pipeline_by_namespace(
+            metadata, self._make_event(namespace="my_airflow", name="etl_dag")
+        )
+
+        from metadata.generated.schema.entity.data.pipeline import Pipeline
+
+        metadata.get_by_name.assert_called_once_with(Pipeline, "my_airflow.etl_dag")


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes https://github.com/open-metadata/OpenMetadata/issues/26734

**What changes did you make?**
- Added pipeline namespace fallback to the batch ingestion path tries namespace.jobName as FQN to match pipelines already ingested by native connectors (e.g. Airflow), matching the Java API behavior in: https://github.com/open-metadata/OpenMetadata/commit/b7797fe3ef8becb99f56e07f7c8efe9eee4c1d83.
- Added integration type detection from `job.facets.jobType.integration` to auto-resolve the pipeline service type (Spark, Flink, Airflow, etc.) instead of placing all pipelines under a generic "OpenLineage" service.
- Resolution order: namespace lookup → integration type → default fallback.
<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->


<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [x] I have added tests around the new logic.
- [x] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
This pull request introduces a robust mechanism for resolving and managing pipeline service types and names based on OpenLineage event metadata. The main focus is to ensure that pipelines ingested from various integrations (like Spark, Flink, Airflow) are correctly attributed to their respective pipeline services, avoiding duplication and improving metadata accuracy. The changes include a new service resolver module, updates to the OpenLineage ingestion logic to use this resolver, and comprehensive tests for the new logic.

Key changes include:

**Pipeline Service Resolution and Attribution:**

* Added a new module, `service_resolver.py`, which provides utilities to extract integration types from OpenLineage events, resolve the appropriate pipeline service type, build service names, check for existing pipeline services, and create new ones as needed. This ensures that pipelines from different integrations are accurately mapped to their respective services, and avoids creating duplicate pipeline services.
* Updated `OpenlineageSource` in `metadata.py` to use the new resolver for determining the pipeline service for each event. The resolution order is: (1) check for an existing pipeline by namespace, (2) use the integration type to select or create a service, (3) fall back to the default OpenLineage service. Service name caching is introduced to minimize redundant lookups and creations. [[1]](diffhunk://#diff-b651d51a4e73232b337728b0b3ec4b654db22d4b671d27b79124acdf978f138aR65-R71) [[2]](diffhunk://#diff-b651d51a4e73232b337728b0b3ec4b654db22d4b671d27b79124acdf978f138aR97-R98) [[3]](diffhunk://#diff-b651d51a4e73232b337728b0b3ec4b654db22d4b671d27b79124acdf978f138aL105-R115) [[4]](diffhunk://#diff-b651d51a4e73232b337728b0b3ec4b654db22d4b671d27b79124acdf978f138aR531-R574) [[5]](diffhunk://#diff-b651d51a4e73232b337728b0b3ec4b654db22d4b671d27b79124acdf978f138aR648-R654)

**Broker Hostname Extraction Fixes:**

* Improved extraction of broker hostnames in `_get_topic_details` to include the port if present (e.g., `broker-host:9092` instead of just `broker-host`), ensuring more accurate topic identification. Related test cases updated accordingly. [[1]](diffhunk://#diff-b651d51a4e73232b337728b0b3ec4b654db22d4b671d27b79124acdf978f138aL195-R214) [[2]](diffhunk://#diff-0c8f744f40d1dc8944ed97b5a886584deecb63413b60e5056dff4821f81392e7L1172-R1172) [[3]](diffhunk://#diff-0c8f744f40d1dc8944ed97b5a886584deecb63413b60e5056dff4821f81392e7L1196-R1196)

**Testing and Validation:**

* Added a comprehensive test suite for the new service resolver logic in `test_service_resolver.py`, covering all utility functions and edge cases (integration extraction, service type resolution, service name construction, caching, and pipeline lookup by namespace).

**Kafka Broker Mapping:**

* Fixed broker-to-service mapping logic to use the full broker string (including port) rather than just the hostname, improving the accuracy of service associations for Kafka brokers.

These improvements collectively make the OpenLineage ingestion more robust, extensible, and accurate in environments with multiple pipeline integrations and services.