### PR TITLE
Add release notes for 1.12.4

### DIFF
--- a/content/product-updates/v1.12.4.md
+++ b/content/product-updates/v1.12.4.md
@@ -1,6 +1,12 @@
-# OpenMetadata 1.12.4 Release Notes
+---
+id: 124
+version: v1.12.4
+date: "Released on 31st March 2026."
+---
 
-## Improvements
+## Changelog
+
+### ✨ Improvements
 
 - AI: Add OAuth support for MCP server with database-backed token persistence and automatic refresh [#25391](https://github.com/open-metadata/OpenMetadata/pull/25391)
 - AI: Add MCP bot impersonation with audit logging and change event publishing [#26488](https://github.com/open-metadata/OpenMetadata/pull/26488)
@@ -12,7 +18,7 @@
 - Integration: Add Trino metadata exporter for pushing OpenMetadata descriptions and tags to Trino [#25970](https://github.com/open-metadata/OpenMetadata/pull/25970)
 - Platform: Parallelize DataAssetsWorkflow with virtual threads for improved ingestion throughput [#25817](https://github.com/open-metadata/OpenMetadata/pull/25817)
 
-## Fixes
+### 🔧 Fixes
 
 - Discovery: Fix hasDomain() search filter to use OR logic for multi-domain users [#26397](https://github.com/open-metadata/OpenMetadata/pull/26397)
 - Data Observability: Fix Trino table diff to use table-specific catalog and schema from FQN instead of service-level defaults [#26604](https://github.com/open-metadata/OpenMetadata/pull/26604)


### PR DESCRIPTION
## Summary
- Add changelog for 1.12.4 release covering 9 improvements and 13 fixes new since 1.12.3
- Highlights: Airflow 3.x connector, MCP OAuth & impersonation, self-approval prevention, SAP HANA table functions, Trino exporter, parallel DataAssetsWorkflow
- Excludes items already documented in 1.12.3 release notes

## Improvements
| Category | Description | PR |
|----------|-------------|----|
| AI | MCP OAuth with token persistence | #25391 |
| AI | MCP bot impersonation with audit logging | #26488 |
| Governance | Self-approval prevention for workflows | #26289 |
| Governance | Fields filter in event-based workflows | #26230 |
| Ingestion | Airflow 3.x API-based connector | #26624 |
| Ingestion | SAP HANA table function ingestion & lineage | #26711 |
| Ingestion | Power BI query parsing debug logs | #26339 |
| Integration | Trino metadata exporter | #25970 |
| Platform | Parallel DataAssetsWorkflow with virtual threads | #25817 |

## Fixes
| Category | Description | PR |
|----------|-------------|----|
| Discovery | hasDomain() OR logic for multi-domain users | #26397 |
| Data Observability | Trino table diff catalog/schema from FQN | #26604 |
| Data Observability | DI config field name correction | #26642 |
| Ingestion | GCS excluded bucket test connection | #26627 |
| Ingestion | Hive NULL TBL_TYPE handling | #26540 |
| Governance | FQN quoting in self-approval prevention | #26766 |
| Lineage | Async export dropping edges on missing node | #26562 |
| Platform | Race condition in async event consumers | #26718 |
| Platform | App endpoint authorization (trigger/deploy) | #26590 |
| Platform | Sensitive config removed from TestConnection response | #26762 |
| Platform | UI crash on feed JSON parse failure | #26553 |
| Platform | Metric breadcrumb span tag fix | #26793 |
| Platform | Flaky search index application fix | #26795 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)