### PR TITLE
Chore(UI): Ignore scripts folder for playwright and sonar check

### DIFF
--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -30,6 +30,7 @@ on:
       - "!docker/development/docker-compose-postgres.yml"
       - "openmetadata-ui/src/main/resources/ui/playwright/doc-generator/**"
       - "openmetadata-ui/src/main/resources/ui/playwright/docs/**"
+      - "openmetadata-ui/src/main/resources/ui/scripts/**"
 
 permissions:
   contents: read

--- a/.github/workflows/yarn-coverage.yml
+++ b/.github/workflows/yarn-coverage.yml
@@ -10,6 +10,7 @@ on:
       - openmetadata-ui/src/main/resources/ui/**
       - "!openmetadata-ui/src/main/resources/ui/playwright/doc-generator/**"
       - "!openmetadata-ui/src/main/resources/ui/playwright/docs/**"
+      - "!openmetadata-ui/src/main/resources/ui/scripts/**"
 
 permissions:
   contents: read


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow file patterns to ensure that changes in the `openmetadata-ui/src/main/resources/ui/scripts/**` directory are handled appropriately by the relevant workflows.

Workflow trigger updates:

* The `playwright-postgresql-e2e` workflow will now run when files in `openmetadata-ui/src/main/resources/ui/scripts/**` are changed.
* The `yarn-coverage` workflow will now ignore changes to files in `openmetadata-ui/src/main/resources/ui/scripts/**`.