### PR TITLE
Add scripts path to skip file

### DIFF
--- a/.github/workflows/playwright-postgresql-e2e-skip.yml
+++ b/.github/workflows/playwright-postgresql-e2e-skip.yml
@@ -29,6 +29,7 @@ on:
       - "!docker/development/docker-compose-postgres.yml"
       - "openmetadata-ui/src/main/resources/ui/playwright/doc-generator/**"
       - "openmetadata-ui/src/main/resources/ui/playwright/docs/**"
+      - "openmetadata-ui/src/main/resources/ui/scripts/**"
 
 jobs:
   playwright-ci-postgresql:


### PR DESCRIPTION
This pull request makes a minor update to the workflow trigger configuration by expanding the set of paths that will cause the workflow to be skipped.

* Updated the workflow skip list in `.github/workflows/playwright-postgresql-e2e-skip.yml` to include changes in the `openmetadata-ui/src/main/resources/ui/scripts/**` directory.