### PR TITLE
Chore(UI): Fix the ui-checkstyle workflow for the json changes

### DIFF
--- a/.github/workflows/ui-checkstyle.yml
+++ b/.github/workflows/ui-checkstyle.yml
@@ -119,7 +119,7 @@ jobs:
             echo "No added or modified files to process."
             exit 0
           fi
-          TS_FILES=$(echo "$CHANGED_FILES" | tr ' ' '\n' | grep -E '\.(ts|tsx|js|jsx)$' | tr '\n' ' ')
+          TS_FILES=$(echo "$CHANGED_FILES" | tr ' ' '\n' | awk '/\.(ts|tsx|js|jsx)$/ { printf "%s ", $0 }')
           if [ -n "$TS_FILES" ]; then
             yarn organize-imports:cli $TS_FILES
           fi
@@ -581,10 +581,7 @@ jobs:
             echo "No added or modified files to process."
             exit 0
           fi
-          TS_FILES=$(echo "$CHANGED_FILES" | tr ' ' '\n' | grep -E '\.(ts|tsx|js|jsx)$' | tr '\n' ' ')
-          if [ -n "$TS_FILES" ]; then
-            yarn organize-imports:cli $TS_FILES
-          fi
+          yarn organize-imports:cli $CHANGED_FILES
           yarn lint:base --fix $CHANGED_FILES
           yarn pretty:base --write $CHANGED_FILES
           if [ -n "$(git status --porcelain)" ]; then


### PR DESCRIPTION
This pull request makes a small but important update to the `ui-checkstyle.yml` GitHub Actions workflow. The change ensures that the `organize-imports:cli` script is only run on TypeScript and JavaScript files, rather than all changed files.

- Updated the workflow to filter `CHANGED_FILES` so that `yarn organize-imports:cli` only processes files with `.ts`, `.tsx`, `.js`, or `.jsx` extensions, preventing errors when non-JS/TS files are present. (.github/workflows/ui-checkstyle.yml) [[1]](diffhunk://#diff-76abebe4ffa2556fde777de189dd882d1f9cf7225bc961e633792d89a5d30db2L122-R125) [[2]](diffhunk://#diff-76abebe4ffa2556fde777de189dd882d1f9cf7225bc961e633792d89a5d30db2L581-R587)