### PR TITLE
Fix(Security): Upgrade netty-bom to 4.1.132.Final (CVE-2026-33870, CVE-2026-33871)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -669,7 +669,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>
-        <version>4.1.129.Final</version>
+        <version>4.1.132.Final</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Summary

Upgrades `io.netty:netty-bom` from `4.1.129.Final` to `4.1.132.Final` to fix two HIGH severity vulnerabilities in the server image (`docker.io/openmetadata/server`).

## Vulnerabilities Fixed

### CVE-2026-33870 — HTTP Request Smuggling (`netty-codec-http`)
- **Severity:** HIGH (CVSS 8.7)
- **Package:** `io.netty:netty-codec-http@4.1.129.Final`
- **Description:** Incorrect parsing of quoted strings within chunked transfer encoding extension values allows an attacker to inject arbitrary HTTP requests into a connection.
- **Advisory:** https://github.com/netty/netty/security/advisories/GHSA-pwqr-wmgm-9rr8

### CVE-2026-33871 — HTTP/2 DoS via CONTINUATION Frame Flood (`netty-codec-http2`)
- **Severity:** HIGH (CVSS 8.7)
- **Package:** `io.netty:netty-codec-http2@4.1.129.Final`
- **Description:** Sending a large number of zero-byte CONTINUATION frames bypasses size-based mitigations and causes excessive CPU consumption, rendering the server unresponsive.
- **Advisory:** https://github.com/netty/netty/security/advisories/GHSA-w9fj-cfpg-grvv

## Fix

Single change in `pom.xml` — the `netty-bom` BOM controls all `io.netty:*` artifact versions, so one bump fixes both CVEs:

```diff
- <version>4.1.129.Final</version>
+ <version>4.1.132.Final</version>
```

## Verification — 4.1.132.Final has NO known vulnerabilities

- `netty-codec-http@4.1.132.Final`: https://ossindex.sonatype.org/component/pkg:maven/io.netty/netty-codec-http@4.1.132.Final
- `netty-codec-http2@4.1.132.Final`: https://ossindex.sonatype.org/component/pkg:maven/io.netty/netty-codec-http2@4.1.132.Final
- Official release by Netty core maintainer (`@chrisvest`, `@normanmaurer`) on March 24, 2026: https://github.com/netty/netty/releases/tag/netty-4.1.132.Final