### PR TITLE
fix: display FQN in CustomProperty entity references

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/PropertyValue.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/PropertyValue.tsx
@@ -864,11 +864,21 @@ export const PropertyValue: FC<PropertyValueProps> = ({
           searchClassBase.getEntityIcon(item.type)
         )}
       </div>
-      <Typography.Text
-        className="text-left text-primary truncate w-max-full"
-        ellipsis={{ tooltip: true }}>
-        {getEntityName(item)}
-      </Typography.Text>
+      <div className="d-flex flex-column">
+        <Typography.Text
+          className="text-left text-primary truncate w-max-full"
+          ellipsis={{ tooltip: true }}>
+          {getEntityName(item)}
+        </Typography.Text>
+        {item.fullyQualifiedName && (
+          <Typography.Text
+            className="text-left text-grey-muted truncate w-max-full"
+            ellipsis={{ tooltip: item.fullyQualifiedName }}
+            style={{ fontSize: '12px' }}>
+            {item.fullyQualifiedName}
+          </Typography.Text>
+        )}
+      </div>
     </Link>
   );
 


### PR DESCRIPTION
## Description
When customProperty lists tables or other entities, only the entity name was shown without the fully qualified name (FQN). This made it difficult to distinguish entities with the same name across different systems.

## Changes
- Added FQN display in smaller text (12px, grey-muted) below the entity name in entity reference values
- The FQN is shown with ellipsis truncation and tooltip for full text

## Screenshots
Before: Only entity name shown
After: Entity name + FQN shown (FQN in smaller grey text)

## Testing
- The change affects the `getEntityRefLinkValue` function in PropertyValue.tsx
- This function is used for both `entityReference` and `entityReferenceList` custom property types

Fixes #26939