### PR TITLE
feat: column name hashing in FQN construction

### DIFF
--- a/ingestion/src/metadata/data_quality/processor/test_case_runner.py
+++ b/ingestion/src/metadata/data_quality/processor/test_case_runner.py
@@ -336,7 +336,20 @@ class TestCaseRunner(Processor):
                 result.append(tc)
                 continue
             column_name = entity_link.get_decoded_column(tc.entityLink.root)
-            column = next(c for c in table.columns if c.name.root == column_name)
+            column = next(
+                (c for c in table.columns if c.name.root == column_name), None
+            )
+            if column is None:
+                from metadata.utils.column_name_hash import hash_column_name
+
+                column = next(
+                    (
+                        c
+                        for c in table.columns
+                        if hash_column_name(c.name.root) == column_name
+                    ),
+                    None,
+                )
 
             if column.dataType not in test_definition.supportedDataTypes:
                 self.status.failed(

--- a/ingestion/src/metadata/data_quality/processor/test_case_runner.py
+++ b/ingestion/src/metadata/data_quality/processor/test_case_runner.py
@@ -351,6 +351,17 @@ class TestCaseRunner(Processor):
                     None,
                 )
 
+            if column is None:
+                self.status.failed(
+                    StackTraceError(
+                        name="Column Not Found for Test Case",
+                        error=f"Test case {tc.name.root} references column"
+                        f" '{column_name}' which was not found in table"
+                        f" {table.fullyQualifiedName.root}",
+                    )
+                )
+                continue
+
             if column.dataType not in test_definition.supportedDataTypes:
                 self.status.failed(
                     StackTraceError(

--- a/ingestion/src/metadata/data_quality/validations/mixins/pandas_validator_mixin.py
+++ b/ingestion/src/metadata/data_quality/validations/mixins/pandas_validator_mixin.py
@@ -91,10 +91,25 @@ class PandasValidatorMixin:
             SQALikeColumn: The corresponding SQALikeColumn object
         """
         first_df = next(dfs())
-        column = first_df[get_decoded_column(entity_link)]
-        _type = GenericDataFrameColumnParser.fetch_col_types(
-            first_df, get_decoded_column(entity_link)
-        )
+        decoded = get_decoded_column(entity_link)
+        raw_name = decoded
+        if decoded not in first_df.columns:
+            from metadata.utils.column_name_hash import (
+                hash_column_name,
+                is_hashed_column_fqn_segment,
+            )
+
+            if is_hashed_column_fqn_segment(decoded):
+                raw_name = next(
+                    (
+                        col
+                        for col in first_df.columns
+                        if hash_column_name(col) == decoded
+                    ),
+                    decoded,
+                )
+        column = first_df[raw_name]
+        _type = GenericDataFrameColumnParser.fetch_col_types(first_df, raw_name)
         sqa_like_column = SQALikeColumn(
             name=column.name,
             type=_type,

--- a/ingestion/src/metadata/data_quality/validations/mixins/sqa_validator_mixin.py
+++ b/ingestion/src/metadata/data_quality/validations/mixins/sqa_validator_mixin.py
@@ -106,7 +106,7 @@ class SQAValidatorMixin:
         """Given a column name get the column object
 
         Args:
-            column_name (str): Column name
+            entity_link (str): Entity link or column name
         Returns:
             Column: Column object
         """
@@ -115,6 +115,17 @@ class SQAValidatorMixin:
             (col for col in columns if col.name == column),
             None,
         )
+        if column_obj is None:
+            from metadata.utils.column_name_hash import (
+                hash_column_name,
+                is_hashed_column_fqn_segment,
+            )
+
+            if is_hashed_column_fqn_segment(column):
+                column_obj = next(
+                    (col for col in columns if hash_column_name(col.name) == column),
+                    None,
+                )
         if column_obj is None:
             raise ValueError(f"Cannot find column {column}")
         return column_obj

--- a/ingestion/src/metadata/ingestion/models/custom_basemodel_validation.py
+++ b/ingestion/src/metadata/ingestion/models/custom_basemodel_validation.py
@@ -64,10 +64,7 @@ def _initialize_transformable_entities():
     from metadata.generated.schema.entity.data.dashboardDataModel import (
         DashboardDataModel,
     )
-    from metadata.generated.schema.entity.data.table import (
-        Table,
-        TableData,
-    )
+    from metadata.generated.schema.entity.data.table import Table, TableData
     from metadata.profiler.api.models import ProfilerResponse
 
     # Now populate the dictionary with the imported classes.

--- a/ingestion/src/metadata/ingestion/models/custom_basemodel_validation.py
+++ b/ingestion/src/metadata/ingestion/models/custom_basemodel_validation.py
@@ -65,15 +65,16 @@ def _initialize_transformable_entities():
         DashboardDataModel,
     )
     from metadata.generated.schema.entity.data.table import (
-        ColumnName,
-        ColumnProfile,
         Table,
         TableData,
     )
     from metadata.profiler.api.models import ProfilerResponse
-    from metadata.utils.entity_link import CustomColumnName
 
-    # Now populate the dictionary with the imported classes
+    # Now populate the dictionary with the imported classes.
+    # Note: ColumnName, ColumnProfile, and CustomColumnName entries have been
+    # removed — column FQN segments are now hashed, making reserved-keyword
+    # encoding unnecessary for column names. Table-level transforms are kept
+    # for backward compatibility with existing encoded data in the database.
     TRANSFORMABLE_ENTITIES.update(
         {
             # Fetch models - decode reserved keywords back to original characters
@@ -85,27 +86,18 @@ def _initialize_transformable_entities():
                 "fields": {"name", "columns", "children"},
                 "direction": TransformDirection.DECODE,
             },
-            CustomColumnName: {
-                "fields": {"root"},
-                "direction": TransformDirection.DECODE,
-            },
             # Create/Store models - encode special characters to reserved keywords
             ProfilerResponse: {
                 "fields": {"name", "profile"},
                 "direction": TransformDirection.ENCODE,
             },
             TableData: {"fields": {"columns"}, "direction": TransformDirection.ENCODE},
-            ColumnName: {"fields": {"root"}, "direction": TransformDirection.ENCODE},
             CreateTableRequest: {
                 "fields": {"name", "columns", "children", "tableConstraints"},
                 "direction": TransformDirection.ENCODE,
             },
             CreateDashboardDataModelRequest: {
                 "fields": {"name", "columns", "children"},
-                "direction": TransformDirection.ENCODE,
-            },
-            ColumnProfile: {
-                "fields": {"name"},
                 "direction": TransformDirection.ENCODE,
             },
         }

--- a/ingestion/src/metadata/ingestion/source/dashboard/looker/columns.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/looker/columns.py
@@ -18,7 +18,6 @@ from looker_sdk.sdk.api40.models import LookmlModelExplore, LookmlModelExploreFi
 
 from metadata.generated.schema.entity.data.table import Column, DataType
 from metadata.ingestion.source.dashboard.looker.models import LookMlField, LookMlView
-from metadata.ingestion.source.database.column_helpers import truncate_column_name
 
 # Some docs on types https://cloud.google.com/looker/docs/reference/param-dimension-filter-parameter-types
 LOOKER_TYPE_MAP = {
@@ -101,7 +100,7 @@ def get_columns_from_model(
         type_ = LOOKER_TYPE_MAP.get(field.type, DataType.UNKNOWN)
         columns.append(
             Column(
-                name=truncate_column_name(field.name),
+                name=field.name,
                 displayName=getattr(field, "label_short", None) or field.label,
                 dataType=type_,
                 # We cannot get the inner type from the sdk of .lkml

--- a/ingestion/src/metadata/ingestion/source/dashboard/microstrategy/helpers.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/microstrategy/helpers.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 from typing import Any, Dict
 
 from metadata.generated.schema.entity.data.table import Column, DataType
-from metadata.ingestion.source.database.column_helpers import truncate_column_name
 
 
 class MicroStrategyColumnParser:
@@ -59,7 +58,7 @@ class MicroStrategyColumnParser:
         )
 
         column_def = {
-            "name": truncate_column_name(str(field["name"])),
+            "name": str(field["name"]),
             "displayName": field["name"],
             "dataTypeDisplay": field["dataType"],
             "dataType": data_type,

--- a/ingestion/src/metadata/ingestion/source/dashboard/microstrategy/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/microstrategy/metadata.py
@@ -62,7 +62,6 @@ from metadata.ingestion.source.dashboard.microstrategy.models import (
     MstrDataset,
     MstrPage,
 )
-from metadata.ingestion.source.database.column_helpers import truncate_column_name
 from metadata.utils import fqn
 from metadata.utils.filters import filter_by_chart, filter_by_datamodel
 from metadata.utils.helpers import clean_uri, get_standard_chart_type
@@ -350,7 +349,7 @@ class MicrostrategySource(DashboardServiceSource):
                 parsed_column = {
                     "dataTypeDisplay": available_object.type.title(),
                     "dataType": DataType.UNKNOWN,
-                    "name": truncate_column_name(available_object.name),
+                    "name": available_object.name,
                     "displayName": available_object.name,
                 }
                 parsed_column_children = []

--- a/ingestion/src/metadata/ingestion/source/dashboard/powerbi/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/powerbi/metadata.py
@@ -89,7 +89,6 @@ from metadata.ingestion.source.dashboard.powerbi.models import (
     PowerBiTable,
     ReportPage,
 )
-from metadata.ingestion.source.database.column_helpers import truncate_column_name
 from metadata.ingestion.source.database.column_type_parser import ColumnTypeParser
 from metadata.utils import fqn
 from metadata.utils.filters import (
@@ -577,7 +576,7 @@ class PowerbiSource(DashboardServiceSource):
                 parsed_measure = PowerBiMeasureModel(
                     dataType=measure_type,
                     dataTypeDisplay=measure_type,
-                    name=truncate_column_name(measure.name),
+                    name=measure.name,
                     displayName=measure.name,
                     description=description_field_text,
                 )
@@ -601,7 +600,7 @@ class PowerbiSource(DashboardServiceSource):
                     "dataType": ColumnTypeParser.get_column_type(
                         column.dataType if column.dataType else None
                     ),
-                    "name": truncate_column_name(column.name),
+                    "name": column.name,
                     "displayName": column.name,
                     "description": column.description,
                 }
@@ -630,7 +629,7 @@ class PowerbiSource(DashboardServiceSource):
                 parsed_table = {
                     "dataTypeDisplay": "PowerBI Table",
                     "dataType": DataType.TABLE,
-                    "name": truncate_column_name(table.name),
+                    "name": table.name,
                     "displayName": table_display_name,
                     "description": table.description,
                     "children": [],
@@ -657,7 +656,7 @@ class PowerbiSource(DashboardServiceSource):
                 parsed_table = {
                     "dataTypeDisplay": "PowerBI Table",
                     "dataType": DataType.TABLE,
-                    "name": truncate_column_name(entity.name),
+                    "name": entity.name,
                     "displayName": entity.name,
                     "description": entity.description,
                     "children": [],
@@ -674,7 +673,7 @@ class PowerbiSource(DashboardServiceSource):
                             "dataType": ColumnTypeParser.get_column_type(
                                 attribute.dataType if attribute.dataType else None
                             ),
-                            "name": truncate_column_name(attribute.name),
+                            "name": attribute.name,
                             "displayName": attribute.name,
                             "description": attribute.description,
                         }

--- a/ingestion/src/metadata/ingestion/source/dashboard/qliksense/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/qliksense/metadata.py
@@ -54,7 +54,6 @@ from metadata.ingestion.source.dashboard.qliksense.models import (
     QlikDashboard,
     QlikTable,
 )
-from metadata.ingestion.source.database.column_helpers import truncate_column_name
 from metadata.utils import fqn
 from metadata.utils.filters import filter_by_chart, filter_by_datamodel
 from metadata.utils.fqn import build_es_fqn_search_string
@@ -222,7 +221,7 @@ class QliksenseSource(DashboardServiceSource):
                 parsed_fields = {
                     "dataTypeDisplay": "Qlik Field",
                     "dataType": DataType.UNKNOWN,
-                    "name": truncate_column_name(str(field.id)),
+                    "name": str(field.id),
                     "displayName": field.name if field.name else field.id,
                 }
                 datasource_columns.append(Column(**parsed_fields))

--- a/ingestion/src/metadata/ingestion/source/dashboard/quicksight/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/quicksight/metadata.py
@@ -66,7 +66,6 @@ from metadata.ingestion.source.dashboard.quicksight.models import (
     DataSourceRespS3,
     DescribeDataSourceResponse,
 )
-from metadata.ingestion.source.database.column_helpers import truncate_column_name
 from metadata.ingestion.source.database.column_type_parser import ColumnTypeParser
 from metadata.utils import fqn
 from metadata.utils.filters import filter_by_chart
@@ -584,7 +583,7 @@ class QuicksightSource(DashboardServiceSource):
                 )
                 field_name = str(field.get("Name"))
                 parsed_fields = {
-                    "name": truncate_column_name(field_name),
+                    "name": field_name,
                     "displayName": field_name,
                     "dataType": col_parse.get("dataType"),
                 }

--- a/ingestion/src/metadata/ingestion/source/dashboard/sigma/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/sigma/metadata.py
@@ -50,7 +50,6 @@ from metadata.ingestion.source.dashboard.sigma.models import (
     Workbook,
     WorkbookDetails,
 )
-from metadata.ingestion.source.database.column_helpers import truncate_column_name
 from metadata.utils import fqn
 from metadata.utils.filters import filter_by_chart
 from metadata.utils.fqn import build_es_fqn_search_string
@@ -321,7 +320,7 @@ class SigmaSource(DashboardServiceSource):
             try:
                 datamodel_columns.append(
                     Column(
-                        name=truncate_column_name(col),
+                        name=col,
                         displayName=col,
                         dataType=DataType.UNKNOWN,
                         dataTypeDisplay="Sigma Field",

--- a/ingestion/src/metadata/ingestion/source/dashboard/superset/mixin.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/superset/mixin.py
@@ -55,7 +55,6 @@ from metadata.ingestion.source.dashboard.superset.models import (
 from metadata.ingestion.source.dashboard.superset.utils import (
     get_dashboard_data_model_column_fqn,
 )
-from metadata.ingestion.source.database.column_helpers import truncate_column_name
 from metadata.ingestion.source.database.column_type_parser import ColumnTypeParser
 from metadata.utils import fqn
 from metadata.utils.logger import ingestion_logger
@@ -430,7 +429,7 @@ class SupersetSourceMixin(DashboardServiceSource):
                         dataType=col_parse["dataType"],
                         arrayDataType=self.parse_array_data_type(col_parse),
                         children=self.parse_row_data_type(col_parse),
-                        name=truncate_column_name(str(field.id)),
+                        name=str(field.id),
                         displayName=field.column_name,
                         description=field.description,
                         dataLength=int(col_parse.get("dataLength", 0)),

--- a/ingestion/src/metadata/ingestion/source/dashboard/tableau/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/tableau/metadata.py
@@ -82,7 +82,6 @@ from metadata.ingestion.source.dashboard.tableau.models import (
     TableauDashboard,
     UpstreamTable,
 )
-from metadata.ingestion.source.database.column_helpers import truncate_column_name
 from metadata.ingestion.source.database.column_type_parser import ColumnTypeParser
 from metadata.utils import fqn
 from metadata.utils.filters import filter_by_chart, filter_by_datamodel
@@ -1123,7 +1122,7 @@ class TableauSource(DashboardServiceSource):
                         "dataType": ColumnTypeParser.get_column_type(
                             column.remoteType if column.remoteType else None
                         ),
-                        "name": truncate_column_name(column.id),
+                        "name": column.id,
                         "displayName": column.name if column.name else column.id,
                     }
                     if column.remoteType and column.remoteType == DataType.ARRAY.value:
@@ -1147,7 +1146,7 @@ class TableauSource(DashboardServiceSource):
                 parsed_fields = {
                     "dataTypeDisplay": "Tableau Field",
                     "dataType": DataType.RECORD,
-                    "name": truncate_column_name(field.id),
+                    "name": field.id,
                     "displayName": field.name if field.name else field.id,
                     "description": field.description,
                 }

--- a/ingestion/src/metadata/ingestion/source/database/column_helpers.py
+++ b/ingestion/src/metadata/ingestion/source/database/column_helpers.py
@@ -12,11 +12,3 @@
 Helpers functions to handle columns when we extract
 their raw information from the source
 """
-
-
-def truncate_column_name(col_name: str):
-    """
-    OpenMetadata column name specification limits column name to 256 characters.
-    Truncate to 256 characters if longer and use displayName to have the raw column name.
-    """
-    return col_name[:256]

--- a/ingestion/src/metadata/ingestion/source/database/glue/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/glue/metadata.py
@@ -52,7 +52,6 @@ from metadata.ingestion.api.steps import InvalidSourceException
 from metadata.ingestion.models.ometa_classification import OMetaTagAndClassification
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.connections import get_connection
-from metadata.ingestion.source.database.column_helpers import truncate_column_name
 from metadata.ingestion.source.database.column_type_parser import ColumnTypeParser
 from metadata.ingestion.source.database.database_service import DatabaseServiceSource
 from metadata.ingestion.source.database.external_table_lineage_mixin import (
@@ -371,7 +370,7 @@ class GlueSource(ExternalTableLineageMixin, DatabaseServiceSource):
             parsed_string = {}
             parsed_string["dataTypeDisplay"] = str(column.Type)
             parsed_string["dataType"] = "UNION"
-        parsed_string["name"] = truncate_column_name(column.Name)
+        parsed_string["name"] = column.Name
         parsed_string["displayName"] = column.Name
         parsed_string["dataLength"] = parsed_string.get("dataLength", 1)
         parsed_string["description"] = column.Comment

--- a/ingestion/src/metadata/ingestion/source/database/json_schema_extractor.py
+++ b/ingestion/src/metadata/ingestion/source/database/json_schema_extractor.py
@@ -16,7 +16,6 @@ import traceback
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from metadata.generated.schema.entity.data.table import Column, DataType
-from metadata.ingestion.source.database.column_helpers import truncate_column_name
 from metadata.utils.logger import ingestion_logger
 
 logger = ingestion_logger()
@@ -235,7 +234,7 @@ def _create_child_column(key: str, value: Any) -> Optional[Column]:
         data_type = _PYTHON_TYPE_TO_DATA_TYPE.get(type_name, DataType.STRING)
 
         column_dict = {
-            "name": truncate_column_name(key),
+            "name": key,
             "displayName": key,
             "dataType": data_type,
             "dataTypeDisplay": data_type.value.lower(),

--- a/ingestion/src/metadata/utils/column_name_hash.py
+++ b/ingestion/src/metadata/utils/column_name_hash.py
@@ -18,6 +18,7 @@ Algorithm must produce identical output to the Java implementation in
 ColumnNameHash.java (both use MD5 with UTF-8 encoding).
 """
 import hashlib
+from typing import Optional
 
 HASH_PREFIX = "md5_"
 HASH_LENGTH = 36  # "md5_" (4) + 32 hex chars
@@ -35,7 +36,7 @@ def hash_column_name(raw_column_name: str) -> str:
     return HASH_PREFIX + hashlib.md5(raw_column_name.encode("utf-8")).hexdigest()
 
 
-def is_hashed_column_fqn_segment(segment: str) -> bool:
+def is_hashed_column_fqn_segment(segment: Optional[str]) -> bool:
     """Check whether a string is a hashed column FQN segment."""
     return (
         segment is not None

--- a/ingestion/src/metadata/utils/column_name_hash.py
+++ b/ingestion/src/metadata/utils/column_name_hash.py
@@ -1,0 +1,44 @@
+#  Copyright 2021 Collate
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Utility for hashing column names to produce fixed-length identifiers for use
+in FQN construction. This decouples FQN length from raw column name length.
+
+The raw column name is preserved in Column.name; only the FQN segment is hashed.
+
+Algorithm must produce identical output to the Java implementation in
+ColumnNameHash.java (both use MD5 with UTF-8 encoding).
+"""
+import hashlib
+
+HASH_PREFIX = "md5_"
+HASH_LENGTH = 36  # "md5_" (4) + 32 hex chars
+
+
+def hash_column_name(raw_column_name: str) -> str:
+    """Hash a raw column name for use as the column segment in a fully qualified name.
+
+    Args:
+        raw_column_name: the original column name from the source system
+
+    Returns:
+        A fixed-length identifier in the format "md5_<32 hex chars>"
+    """
+    return HASH_PREFIX + hashlib.md5(raw_column_name.encode("utf-8")).hexdigest()
+
+
+def is_hashed_column_fqn_segment(segment: str) -> bool:
+    """Check whether a string is a hashed column FQN segment."""
+    return (
+        segment is not None
+        and segment.startswith(HASH_PREFIX)
+        and len(segment) == HASH_LENGTH
+    )

--- a/ingestion/src/metadata/utils/datalake/datalake_utils.py
+++ b/ingestion/src/metadata/utils/datalake/datalake_utils.py
@@ -20,7 +20,6 @@ import traceback
 from typing import Any, Dict, List, Optional, Union, cast
 
 from metadata.generated.schema.entity.data.table import Column, DataType
-from metadata.ingestion.source.database.column_helpers import truncate_column_name
 from metadata.parsers.json_schema_parser import parse_json_schema
 from metadata.readers.dataframe.models import (
     DatalakeColumnWrapper,
@@ -283,7 +282,7 @@ class GenericDataFrameColumnParser:
                     parsed_string = {
                         "dataTypeDisplay": data_type.value,
                         "dataType": data_type,
-                        "name": truncate_column_name(column),
+                        "name": column,
                         "displayName": column,
                     }
                     if data_type == DataType.ARRAY:
@@ -419,7 +418,7 @@ class GenericDataFrameColumnParser:
                 type_, DataType.UNKNOWN
             ).value
             column["dataType"] = cls._data_formats.get(type_, DataType.UNKNOWN).value
-            column["name"] = truncate_column_name(key)
+            column["name"] = key
             column["displayName"] = key
             if isinstance(value, dict):
                 column["children"] = cls.construct_json_column_children(value)
@@ -510,7 +509,7 @@ class ParquetDataFrameColumnParser:
             parsed_column = {
                 "dataTypeDisplay": str(column.type),
                 "dataType": self._get_pq_data_type(column),
-                "name": truncate_column_name(column.name),
+                "name": column.name,
                 "displayName": column.name,
             }
 
@@ -559,7 +558,7 @@ class ParquetDataFrameColumnParser:
             child_column = {
                 "dataTypeDisplay": str(child.type),
                 "dataType": data_type,
-                "name": truncate_column_name(child.name),
+                "name": child.name,
                 "displayName": child.name,
             }
             if data_type == DataType.STRUCT:
@@ -669,7 +668,7 @@ class JsonDataFrameColumnParser(GenericDataFrameColumnParser):
                     data_type = DataType.STRING
 
                 column = Column(
-                    name=truncate_column_name(column_name),
+                    name=column_name,
                     displayName=column_name,
                     dataType=data_type,
                     dataTypeDisplay=(
@@ -726,7 +725,7 @@ class JsonDataFrameColumnParser(GenericDataFrameColumnParser):
                     data_type = DataType.STRING
 
                 child = {
-                    "name": truncate_column_name(child_name),
+                    "name": child_name,
                     "displayName": child_name,
                     "dataType": data_type.value,
                     "dataTypeDisplay": (

--- a/ingestion/src/metadata/utils/entity_link.py
+++ b/ingestion/src/metadata/utils/entity_link.py
@@ -26,6 +26,10 @@ from metadata.generated.antlr.EntityLinkLexer import EntityLinkLexer
 from metadata.generated.antlr.EntityLinkParser import EntityLinkParser
 from metadata.generated.schema.entity.data.table import Table
 from metadata.ingestion.models.custom_pydantic import BaseModel
+from metadata.utils.column_name_hash import (
+    hash_column_name,
+    is_hashed_column_fqn_segment,
+)
 from metadata.utils.constants import ENTITY_REFERENCE_TYPE_MAP
 from metadata.utils.dispatch import class_register
 
@@ -98,11 +102,6 @@ def get_table_or_column_fqn(entity_link: str) -> str:
     if len(split_entity_link) == 2:
         return split_entity_link[1]
     if len(split_entity_link) == 4 and split_entity_link[2] == "columns":
-        from metadata.utils.column_name_hash import (
-            hash_column_name,
-            is_hashed_column_fqn_segment,
-        )
-
         col_segment = unquote_plus(split_entity_link[3])
         if not is_hashed_column_fqn_segment(col_segment):
             col_segment = hash_column_name(col_segment)

--- a/ingestion/src/metadata/utils/entity_link.py
+++ b/ingestion/src/metadata/utils/entity_link.py
@@ -98,7 +98,15 @@ def get_table_or_column_fqn(entity_link: str) -> str:
     if len(split_entity_link) == 2:
         return split_entity_link[1]
     if len(split_entity_link) == 4 and split_entity_link[2] == "columns":
-        return f"{split_entity_link[1]}.{split_entity_link[3]}"
+        from metadata.utils.column_name_hash import (
+            hash_column_name,
+            is_hashed_column_fqn_segment,
+        )
+
+        col_segment = split_entity_link[3]
+        if not is_hashed_column_fqn_segment(col_segment):
+            col_segment = hash_column_name(col_segment)
+        return f"{split_entity_link[1]}.{col_segment}"
 
     raise ValueError(
         "Invalid entity link."

--- a/ingestion/src/metadata/utils/entity_link.py
+++ b/ingestion/src/metadata/utils/entity_link.py
@@ -103,7 +103,7 @@ def get_table_or_column_fqn(entity_link: str) -> str:
             is_hashed_column_fqn_segment,
         )
 
-        col_segment = split_entity_link[3]
+        col_segment = unquote_plus(split_entity_link[3])
         if not is_hashed_column_fqn_segment(col_segment):
             col_segment = hash_column_name(col_segment)
         return f"{split_entity_link[1]}.{col_segment}"

--- a/ingestion/src/metadata/utils/fqn.py
+++ b/ingestion/src/metadata/utils/fqn.py
@@ -152,8 +152,10 @@ def build(
     :param kwargs: required to build the FQN
     :return: FQN as a string
     """
-    # Transform table_name and column_name if they exist and contain special characters
-    if kwargs.get("table_name") or kwargs.get("column_name"):
+    # Transform table_name if it exists and contains special characters.
+    # Column names no longer need reserved-keyword encoding since the FQN
+    # segment is now a deterministic hash of the raw column name.
+    if kwargs.get("table_name"):
         from metadata.ingestion.models.custom_basemodel_validation import (  # pylint: disable=import-outside-toplevel
             replace_separators,
         )
@@ -161,10 +163,6 @@ def build(
         table_name = kwargs.get("table_name")
         if table_name and isinstance(table_name, str):
             kwargs["table_name"] = replace_separators(table_name)
-
-        column_name = kwargs.get("column_name")
-        if column_name and isinstance(column_name, str):
-            kwargs["column_name"] = replace_separators(column_name)
 
     func = fqn_build_registry.registry.get(entity_type.__name__)
     try:
@@ -495,7 +493,10 @@ def _(
     table_name: str,
     column_name: str,
 ) -> str:
-    return _build(service_name, database_name, schema_name, table_name, column_name)
+    from metadata.utils.column_name_hash import hash_column_name
+
+    hashed_column = hash_column_name(column_name)
+    return _build(service_name, database_name, schema_name, table_name, hashed_column)
 
 
 @fqn_build_registry.add(User)

--- a/ingestion/src/metadata/utils/fqn.py
+++ b/ingestion/src/metadata/utils/fqn.py
@@ -53,6 +53,7 @@ from metadata.generated.schema.entity.teams.team import Team
 from metadata.generated.schema.entity.teams.user import User
 from metadata.generated.schema.tests.testCase import TestCase
 from metadata.generated.schema.tests.testSuite import TestSuite
+from metadata.utils.column_name_hash import hash_column_name
 from metadata.utils.dispatch import class_register
 from metadata.utils.elasticsearch import get_entity_from_es_result
 from metadata.utils.logger import utils_logger
@@ -493,8 +494,6 @@ def _(
     table_name: str,
     column_name: str,
 ) -> str:
-    from metadata.utils.column_name_hash import hash_column_name
-
     hashed_column = hash_column_name(column_name)
     return _build(service_name, database_name, schema_name, table_name, hashed_column)
 

--- a/ingestion/tests/unit/topology/pipeline/test_service_resolver.py
+++ b/ingestion/tests/unit/topology/pipeline/test_service_resolver.py
@@ -2,9 +2,7 @@
 Tests for the OpenLineage service resolver module.
 """
 
-from unittest.mock import MagicMock, patch
-
-import pytest
+from unittest.mock import MagicMock
 
 from metadata.generated.schema.entity.services.pipelineService import (
     PipelineServiceType,

--- a/ingestion/tests/unit/utils/test_column_name_hash.py
+++ b/ingestion/tests/unit/utils/test_column_name_hash.py
@@ -1,0 +1,154 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Tests for column name hashing utility.
+
+The hash function must produce identical output to the Java implementation
+in ColumnNameHash.java. Both use MD5 with UTF-8 encoding.
+"""
+import hashlib
+
+import pytest
+
+from metadata.utils.column_name_hash import (
+    HASH_LENGTH,
+    HASH_PREFIX,
+    hash_column_name,
+    is_hashed_column_fqn_segment,
+)
+
+
+class TestColumnNameHash:
+    """Tests for hash_column_name and related utilities."""
+
+    def test_basic_hash(self):
+        result = hash_column_name("customer_email")
+        assert result.startswith(HASH_PREFIX)
+        assert len(result) == HASH_LENGTH
+
+    def test_deterministic(self):
+        assert hash_column_name("col") == hash_column_name("col")
+
+    def test_different_names_different_hashes(self):
+        assert hash_column_name("col_a") != hash_column_name("col_b")
+
+    def test_known_md5_value(self):
+        """Verify against known MD5 to ensure cross-language compatibility."""
+        name = "customer_email"
+        expected_md5 = hashlib.md5(name.encode("utf-8")).hexdigest()
+        result = hash_column_name(name)
+        assert result == f"md5_{expected_md5}"
+
+    def test_special_characters_colon(self):
+        result = hash_column_name("col::with::colons")
+        assert result.startswith(HASH_PREFIX)
+        assert len(result) == HASH_LENGTH
+
+    def test_special_characters_quotes(self):
+        result = hash_column_name('col"with"quotes')
+        assert result.startswith(HASH_PREFIX)
+        assert len(result) == HASH_LENGTH
+
+    def test_special_characters_arrow(self):
+        result = hash_column_name("col>with>arrows")
+        assert result.startswith(HASH_PREFIX)
+        assert len(result) == HASH_LENGTH
+
+    def test_unicode(self):
+        result = hash_column_name("列名_カラム_컬럼")
+        assert result.startswith(HASH_PREFIX)
+        assert len(result) == HASH_LENGTH
+
+    def test_very_long_name(self):
+        long_name = "a" * 2000
+        result = hash_column_name(long_name)
+        assert len(result) == HASH_LENGTH
+
+    def test_nested_struct_path(self):
+        """Simulate a deeply nested BigQuery struct column path."""
+        nested = ".".join([f"level_{i}" for i in range(20)])
+        result = hash_column_name(nested)
+        assert len(result) == HASH_LENGTH
+
+    def test_empty_string(self):
+        result = hash_column_name("")
+        assert result.startswith(HASH_PREFIX)
+        assert len(result) == HASH_LENGTH
+
+    def test_spaces(self):
+        result = hash_column_name("column with spaces")
+        assert result.startswith(HASH_PREFIX)
+        assert len(result) == HASH_LENGTH
+
+    def test_dash_column_name(self):
+        """BigQuery unnamed struct fields use '-' as name."""
+        result = hash_column_name("-")
+        assert result.startswith(HASH_PREFIX)
+        assert len(result) == HASH_LENGTH
+
+
+class TestIsHashedColumnFQNSegment:
+    """Tests for is_hashed_column_fqn_segment."""
+
+    def test_valid_hash(self):
+        hashed = hash_column_name("test")
+        assert is_hashed_column_fqn_segment(hashed) is True
+
+    def test_raw_column_name(self):
+        assert is_hashed_column_fqn_segment("customer_email") is False
+
+    def test_wrong_prefix(self):
+        assert is_hashed_column_fqn_segment("sha_" + "a" * 32) is False
+
+    def test_wrong_length(self):
+        assert is_hashed_column_fqn_segment("md5_abc") is False
+
+    def test_none(self):
+        assert is_hashed_column_fqn_segment(None) is False
+
+    def test_empty(self):
+        assert is_hashed_column_fqn_segment("") is False
+
+
+class TestCrossLanguageCompatibility:
+    """
+    These test values can be verified against the Java implementation.
+
+    To verify in Java:
+        ColumnNameHash.hashColumnName("customer_email")
+    should produce the same result as:
+        hash_column_name("customer_email")
+
+    Both implementations use:
+        "md5_" + MD5(input.getBytes("UTF-8")).toHexString()
+    """
+
+    @pytest.mark.parametrize(
+        "input_name",
+        [
+            "customer_email",
+            "id",
+            "",
+            "col::with::colons",
+            'col"quoted"',
+            "col>arrow",
+            "列名",
+            "a" * 300,
+            "deeply.nested.struct.field.name",
+            "-",
+            " ",
+            "UPPER_CASE",
+        ],
+    )
+    def test_hash_matches_java_algorithm(self, input_name):
+        """Verify Python hash matches the expected MD5 algorithm used by Java."""
+        expected = "md5_" + hashlib.md5(input_name.encode("utf-8")).hexdigest()
+        assert hash_column_name(input_name) == expected

--- a/ingestion/tests/unit/utils/test_fqn_special_chars.py
+++ b/ingestion/tests/unit/utils/test_fqn_special_chars.py
@@ -523,7 +523,9 @@ class TestFQNSpecialCharsRealWorldScenarios(unittest.TestCase):
             column_name="typname::text",
         )
 
-        expected = f"postgres.mydb.pg_catalog.pg_type.{hash_column_name('typname::text')}"
+        expected = (
+            f"postgres.mydb.pg_catalog.pg_type.{hash_column_name('typname::text')}"
+        )
         self.assertEqual(result, expected)
 
     def test_bigquery_dataset_table_notation(self):

--- a/ingestion/tests/unit/utils/test_fqn_special_chars.py
+++ b/ingestion/tests/unit/utils/test_fqn_special_chars.py
@@ -27,6 +27,7 @@ from metadata.ingestion.models.custom_basemodel_validation import (
     RESERVED_QUOTE_KEYWORD,
 )
 from metadata.utils import fqn
+from metadata.utils.column_name_hash import hash_column_name
 from metadata.utils.fqn import FQNBuildingException
 
 
@@ -105,7 +106,8 @@ class TestFQNSpecialCharacters(unittest.TestCase):
             column_name='data "value"',
         )
 
-        expected = f"mysql.test_db.public.users.data {RESERVED_QUOTE_KEYWORD}value{RESERVED_QUOTE_KEYWORD}"
+        col_hash = hash_column_name('data "value"')
+        expected = f"mysql.test_db.public.users.{col_hash}"
         self.assertEqual(result, expected)
 
     def test_column_name_with_multiple_special_chars(self):
@@ -120,10 +122,8 @@ class TestFQNSpecialCharacters(unittest.TestCase):
             column_name='metric::type>"category"',
         )
 
-        expected = (
-            f"postgres.analytics.public.metrics.metric{RESERVED_COLON_KEYWORD}"
-            f"type{RESERVED_ARROW_KEYWORD}{RESERVED_QUOTE_KEYWORD}category{RESERVED_QUOTE_KEYWORD}"
-        )
+        col_hash = hash_column_name('metric::type>"category"')
+        expected = f"postgres.analytics.public.metrics.{col_hash}"
         self.assertEqual(result, expected)
 
     def test_both_table_and_column_with_special_chars(self):
@@ -141,9 +141,7 @@ class TestFQNSpecialCharacters(unittest.TestCase):
         table_transformed = (
             f"table {RESERVED_QUOTE_KEYWORD}2024{RESERVED_QUOTE_KEYWORD}"
         )
-        column_transformed = (
-            f"column{RESERVED_COLON_KEYWORD}data{RESERVED_ARROW_KEYWORD}info"
-        )
+        column_transformed = hash_column_name("column::data>info")
         expected = f"mysql.test.schema.{table_transformed}.{column_transformed}"
         self.assertEqual(result, expected)
 
@@ -174,7 +172,7 @@ class TestFQNSpecialCharacters(unittest.TestCase):
             table_name="users",
             column_name="::",
         )
-        expected = f"mysql.test.public.users.{RESERVED_COLON_KEYWORD}"
+        expected = f"mysql.test.public.users.{hash_column_name('::')}"
         self.assertEqual(result, expected)
 
     def test_consecutive_special_chars(self):
@@ -224,7 +222,7 @@ class TestFQNSpecialCharacters(unittest.TestCase):
             table_name="table",
             column_name="column_name::",
         )
-        expected = f"mysql.db.schema.table.column_name{RESERVED_COLON_KEYWORD}"
+        expected = f"mysql.db.schema.table.{hash_column_name('column_name::')}"
         self.assertEqual(result, expected)
 
     def test_unicode_with_special_chars(self):
@@ -255,8 +253,8 @@ class TestFQNSpecialCharacters(unittest.TestCase):
             column_name='🚀::rocket>"launch"',
         )
 
-        transformed = f"🚀{RESERVED_COLON_KEYWORD}rocket{RESERVED_ARROW_KEYWORD}{RESERVED_QUOTE_KEYWORD}launch{RESERVED_QUOTE_KEYWORD}"
-        expected = f"postgres.fun.emoji.data.{transformed}"
+        col_hash = hash_column_name('🚀::rocket>"launch"')
+        expected = f"postgres.fun.emoji.data.{col_hash}"
         self.assertEqual(result, expected)
 
     # ========== NULL/NONE HANDLING ==========
@@ -368,7 +366,7 @@ class TestFQNSpecialCharacters(unittest.TestCase):
             table_name="table",
             column_name="normal_column_name",
         )
-        expected = "postgres.db.schema.table.normal_column_name"
+        expected = f"postgres.db.schema.table.{hash_column_name('normal_column_name')}"
         self.assertEqual(result, expected)
 
     def test_dots_in_names_still_quoted(self):
@@ -525,9 +523,7 @@ class TestFQNSpecialCharsRealWorldScenarios(unittest.TestCase):
             column_name="typname::text",
         )
 
-        expected = (
-            f"postgres.mydb.pg_catalog.pg_type.typname{RESERVED_COLON_KEYWORD}text"
-        )
+        expected = f"postgres.mydb.pg_catalog.pg_type.{hash_column_name('typname::text')}"
         self.assertEqual(result, expected)
 
     def test_bigquery_dataset_table_notation(self):
@@ -559,7 +555,8 @@ class TestFQNSpecialCharsRealWorldScenarios(unittest.TestCase):
             column_name='"order-date"',  # Backticks converted to quotes
         )
 
-        expected = f"mysql.test.public.orders.{RESERVED_QUOTE_KEYWORD}order-date{RESERVED_QUOTE_KEYWORD}"
+        col_hash = hash_column_name('"order-date"')
+        expected = f"mysql.test.public.orders.{col_hash}"
         self.assertEqual(result, expected)
 
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ColumnUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ColumnUtil.java
@@ -15,6 +15,7 @@ import org.openmetadata.schema.type.Field;
 import org.openmetadata.schema.type.SearchIndexField;
 import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.service.exception.CatalogExceptionMessage;
+import org.openmetadata.service.util.ColumnNameHash;
 import org.openmetadata.service.util.FullyQualifiedName;
 
 public final class ColumnUtil {
@@ -52,7 +53,8 @@ public final class ColumnUtil {
   public static void setColumnFQN(String parentFQN, List<Column> columns) {
     columns.forEach(
         c -> {
-          String columnFqn = FullyQualifiedName.add(parentFQN, c.getName());
+          String hashedSegment = ColumnNameHash.hashColumnName(c.getName());
+          String columnFqn = FullyQualifiedName.add(parentFQN, hashedSegment);
           c.setFullyQualifiedName(columnFqn);
           if (c.getChildren() != null) {
             setColumnFQN(columnFqn, c.getChildren());

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -242,6 +242,7 @@ import org.openmetadata.service.search.SearchSortFilter;
 import org.openmetadata.service.security.AuthorizationException;
 import org.openmetadata.service.security.policyevaluator.SubjectContext;
 import org.openmetadata.service.util.AsyncService;
+import org.openmetadata.service.util.ColumnNameHash;
 import org.openmetadata.service.util.EntityETag;
 import org.openmetadata.service.util.EntityFieldUtils;
 import org.openmetadata.service.util.EntityUtil;
@@ -8372,13 +8373,18 @@ public abstract class EntityRepository<T extends EntityInterface> {
     validateColumn(table, columnName, Boolean.TRUE);
   }
 
-  // Validate if a given column exists in the table with optional case sensitivity
+  // Validate if a given column exists in the table with optional case sensitivity.
+  // Supports both raw column names and hashed column FQN segments (md5_...).
   public static void validateColumn(Table table, String columnName, Boolean caseSensitive) {
     if (Boolean.FALSE.equals(caseSensitive)) {
       boolean validColumn =
           table.getColumns().stream()
               .filter(Objects::nonNull)
-              .anyMatch(col -> col.getName().equalsIgnoreCase(columnName));
+              .anyMatch(
+                  col ->
+                      col.getName().equalsIgnoreCase(columnName)
+                          || ColumnNameHash.hashColumnName(col.getName())
+                              .equalsIgnoreCase(columnName));
       if (!validColumn && !columnName.equalsIgnoreCase("all")) {
         throw new IllegalArgumentException("Invalid column name " + columnName);
       }
@@ -8386,7 +8392,10 @@ public abstract class EntityRepository<T extends EntityInterface> {
       boolean validColumn =
           table.getColumns().stream()
               .filter(Objects::nonNull)
-              .anyMatch(col -> col.getName().equals(columnName));
+              .anyMatch(
+                  col ->
+                      col.getName().equals(columnName)
+                          || ColumnNameHash.hashColumnName(col.getName()).equals(columnName));
       if (!validColumn && !columnName.equalsIgnoreCase("all")) {
         throw new IllegalArgumentException("Invalid column name " + columnName);
       }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
@@ -125,6 +125,7 @@ import org.openmetadata.service.resources.databases.TableResource;
 import org.openmetadata.service.resources.feeds.MessageParser.EntityLink;
 import org.openmetadata.service.security.Authorizer;
 import org.openmetadata.service.security.mask.PIIMasker;
+import org.openmetadata.service.util.ColumnNameHash;
 import org.openmetadata.service.util.EntityUtil;
 import org.openmetadata.service.util.EntityUtil.Fields;
 import org.openmetadata.service.util.EntityUtil.RelationIncludes;
@@ -645,7 +646,8 @@ public class TableRepository extends EntityRepository<Table> {
     // With all validation done, add new joins
     for (ColumnJoin join : joins.getColumnJoins()) {
       String columnFQN =
-          FullyQualifiedName.add(table.getFullyQualifiedName(), join.getColumnName());
+          FullyQualifiedName.add(
+              table.getFullyQualifiedName(), ColumnNameHash.hashColumnName(join.getColumnName()));
       addJoinedWith(
           joins.getStartDate(), columnFQN, FIELD_RELATION_COLUMN_TYPE, join.getJoinedWith());
     }
@@ -2173,7 +2175,8 @@ public class TableRepository extends EntityRepository<Table> {
                 rethrowFunction(
                     er ->
                         Triple.of(
-                            getColumnName(er.getLeft()),
+                            ColumnNameHash.resolveColumnName(
+                                table.getColumns(), getColumnName(er.getLeft())),
                             er.getMiddle(),
                             JsonUtils.readObjects(er.getRight(), DailyCount.class))))
             .toList();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1130/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1130/Migration.java
@@ -15,5 +15,6 @@ public class Migration extends MigrationProcessImpl {
   @SneakyThrows
   public void runDataMigration() {
     MigrationUtil.updateOwnerChartFormulas();
+    MigrationUtil.migrateColumnFQNsToHashed(collectionDAO);
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1130/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1130/Migration.java
@@ -15,5 +15,6 @@ public class Migration extends MigrationProcessImpl {
   @SneakyThrows
   public void runDataMigration() {
     MigrationUtil.updateOwnerChartFormulas();
+    MigrationUtil.migrateColumnFQNsToHashed(collectionDAO);
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1130/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1130/MigrationUtil.java
@@ -9,7 +9,6 @@ import org.openmetadata.schema.entity.data.Container;
 import org.openmetadata.schema.entity.data.DashboardDataModel;
 import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.schema.tests.TestCase;
-import org.openmetadata.schema.type.Column;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.ColumnUtil;
@@ -191,7 +190,6 @@ public class MigrationUtil {
 
     LOG.info("Migrated entity links to hashed column names for {} TestCase entities", totalFixed);
   }
-
 
   public static void updateOwnerChartFormulas() {
     DataInsightSystemChartRepository repository = new DataInsightSystemChartRepository();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1130/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1130/MigrationUtil.java
@@ -50,9 +50,6 @@ public class MigrationUtil {
           if (table == null || nullOrEmpty(table.getColumns())) {
             continue;
           }
-          if (columnsAlreadyHashed(table.getColumns())) {
-            continue;
-          }
           ColumnUtil.setColumnFQN(table.getFullyQualifiedName(), table.getColumns());
           collectionDAO.tableDAO().update(table);
           totalFixed++;
@@ -86,9 +83,6 @@ public class MigrationUtil {
         try {
           DashboardDataModel dataModel = JsonUtils.readValue(json, DashboardDataModel.class);
           if (dataModel == null || nullOrEmpty(dataModel.getColumns())) {
-            continue;
-          }
-          if (columnsAlreadyHashed(dataModel.getColumns())) {
             continue;
           }
           ColumnUtil.setColumnFQN(dataModel.getFullyQualifiedName(), dataModel.getColumns());
@@ -126,9 +120,6 @@ public class MigrationUtil {
           if (container == null
               || container.getDataModel() == null
               || nullOrEmpty(container.getDataModel().getColumns())) {
-            continue;
-          }
-          if (columnsAlreadyHashed(container.getDataModel().getColumns())) {
             continue;
           }
           ColumnUtil.setColumnFQN(
@@ -201,18 +192,6 @@ public class MigrationUtil {
     LOG.info("Migrated entity links to hashed column names for {} TestCase entities", totalFixed);
   }
 
-  private static boolean columnsAlreadyHashed(List<Column> columns) {
-    if (nullOrEmpty(columns)) {
-      return false;
-    }
-    Column firstColumn = columns.get(0);
-    if (firstColumn.getFullyQualifiedName() == null) {
-      return false;
-    }
-    String fqn = firstColumn.getFullyQualifiedName();
-    String lastSegment = fqn.substring(fqn.lastIndexOf('.') + 1);
-    return ColumnNameHash.isHashedColumnFQNSegment(lastSegment);
-  }
 
   public static void updateOwnerChartFormulas() {
     DataInsightSystemChartRepository repository = new DataInsightSystemChartRepository();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1130/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1130/MigrationUtil.java
@@ -1,8 +1,21 @@
 package org.openmetadata.service.migration.utils.v1130;
 
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
+
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.dataInsight.custom.DataInsightCustomChart;
+import org.openmetadata.schema.entity.data.Container;
+import org.openmetadata.schema.entity.data.DashboardDataModel;
+import org.openmetadata.schema.entity.data.Table;
+import org.openmetadata.schema.tests.TestCase;
+import org.openmetadata.schema.type.Column;
+import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.service.jdbi3.CollectionDAO;
+import org.openmetadata.service.jdbi3.ColumnUtil;
 import org.openmetadata.service.jdbi3.DataInsightSystemChartRepository;
+import org.openmetadata.service.resources.feeds.MessageParser;
+import org.openmetadata.service.util.ColumnNameHash;
 import org.openmetadata.service.util.EntityUtil;
 
 @Slf4j
@@ -11,6 +24,195 @@ public class MigrationUtil {
 
   private static final String OLD_FIELD = "owners.name.keyword";
   private static final String NEW_FIELD = "ownerName";
+  private static final int BATCH_SIZE = 1000;
+
+  public static void migrateColumnFQNsToHashed(CollectionDAO collectionDAO) {
+    migrateTableColumnFQNs(collectionDAO);
+    migrateDashboardDataModelColumnFQNs(collectionDAO);
+    migrateContainerColumnFQNs(collectionDAO);
+    migrateTestCaseEntityLinks(collectionDAO);
+  }
+
+  private static void migrateTableColumnFQNs(CollectionDAO collectionDAO) {
+    LOG.info("Starting migration of Table column FQNs to hashed format");
+    int totalFixed = 0;
+    int offset = 0;
+
+    while (true) {
+      List<String> jsonList = collectionDAO.tableDAO().listAfterWithOffset(BATCH_SIZE, offset);
+      if (nullOrEmpty(jsonList)) {
+        break;
+      }
+
+      for (String json : jsonList) {
+        try {
+          Table table = JsonUtils.readValue(json, Table.class);
+          if (table == null || nullOrEmpty(table.getColumns())) {
+            continue;
+          }
+          if (columnsAlreadyHashed(table.getColumns())) {
+            continue;
+          }
+          ColumnUtil.setColumnFQN(table.getFullyQualifiedName(), table.getColumns());
+          collectionDAO.tableDAO().update(table);
+          totalFixed++;
+        } catch (Exception e) {
+          LOG.warn("Error migrating Table column FQNs: {}", e.getMessage());
+        }
+      }
+
+      offset += jsonList.size();
+      if (jsonList.size() < BATCH_SIZE) {
+        break;
+      }
+    }
+
+    LOG.info("Migrated column FQNs to hashed format for {} Table entities", totalFixed);
+  }
+
+  private static void migrateDashboardDataModelColumnFQNs(CollectionDAO collectionDAO) {
+    LOG.info("Starting migration of DashboardDataModel column FQNs to hashed format");
+    int totalFixed = 0;
+    int offset = 0;
+
+    while (true) {
+      List<String> jsonList =
+          collectionDAO.dashboardDataModelDAO().listAfterWithOffset(BATCH_SIZE, offset);
+      if (nullOrEmpty(jsonList)) {
+        break;
+      }
+
+      for (String json : jsonList) {
+        try {
+          DashboardDataModel dataModel = JsonUtils.readValue(json, DashboardDataModel.class);
+          if (dataModel == null || nullOrEmpty(dataModel.getColumns())) {
+            continue;
+          }
+          if (columnsAlreadyHashed(dataModel.getColumns())) {
+            continue;
+          }
+          ColumnUtil.setColumnFQN(dataModel.getFullyQualifiedName(), dataModel.getColumns());
+          collectionDAO.dashboardDataModelDAO().update(dataModel);
+          totalFixed++;
+        } catch (Exception e) {
+          LOG.warn("Error migrating DashboardDataModel column FQNs: {}", e.getMessage());
+        }
+      }
+
+      offset += jsonList.size();
+      if (jsonList.size() < BATCH_SIZE) {
+        break;
+      }
+    }
+
+    LOG.info(
+        "Migrated column FQNs to hashed format for {} DashboardDataModel entities", totalFixed);
+  }
+
+  private static void migrateContainerColumnFQNs(CollectionDAO collectionDAO) {
+    LOG.info("Starting migration of Container column FQNs to hashed format");
+    int totalFixed = 0;
+    int offset = 0;
+
+    while (true) {
+      List<String> jsonList = collectionDAO.containerDAO().listAfterWithOffset(BATCH_SIZE, offset);
+      if (nullOrEmpty(jsonList)) {
+        break;
+      }
+
+      for (String json : jsonList) {
+        try {
+          Container container = JsonUtils.readValue(json, Container.class);
+          if (container == null
+              || container.getDataModel() == null
+              || nullOrEmpty(container.getDataModel().getColumns())) {
+            continue;
+          }
+          if (columnsAlreadyHashed(container.getDataModel().getColumns())) {
+            continue;
+          }
+          ColumnUtil.setColumnFQN(
+              container.getFullyQualifiedName(), container.getDataModel().getColumns());
+          collectionDAO.containerDAO().update(container);
+          totalFixed++;
+        } catch (Exception e) {
+          LOG.warn("Error migrating Container column FQNs: {}", e.getMessage());
+        }
+      }
+
+      offset += jsonList.size();
+      if (jsonList.size() < BATCH_SIZE) {
+        break;
+      }
+    }
+
+    LOG.info("Migrated column FQNs to hashed format for {} Container entities", totalFixed);
+  }
+
+  private static void migrateTestCaseEntityLinks(CollectionDAO collectionDAO) {
+    LOG.info("Starting migration of TestCase entity links to use hashed column names");
+    int totalFixed = 0;
+    int offset = 0;
+
+    while (true) {
+      List<String> jsonList = collectionDAO.testCaseDAO().listAfterWithOffset(BATCH_SIZE, offset);
+      if (nullOrEmpty(jsonList)) {
+        break;
+      }
+
+      for (String json : jsonList) {
+        try {
+          TestCase testCase = JsonUtils.readValue(json, TestCase.class);
+          if (testCase == null || testCase.getEntityLink() == null) {
+            continue;
+          }
+
+          MessageParser.EntityLink entityLink =
+              MessageParser.EntityLink.parse(testCase.getEntityLink());
+          String arrayFieldName = entityLink.getArrayFieldName();
+          if (arrayFieldName == null) {
+            continue;
+          }
+          if (ColumnNameHash.isHashedColumnFQNSegment(arrayFieldName)) {
+            continue;
+          }
+          String hashedFieldName = ColumnNameHash.hashColumnName(arrayFieldName);
+          MessageParser.EntityLink updatedLink =
+              new MessageParser.EntityLink(
+                  entityLink.getEntityType(),
+                  entityLink.getEntityFQN(),
+                  entityLink.getFieldName(),
+                  hashedFieldName,
+                  entityLink.getArrayFieldValue());
+          testCase.setEntityLink(updatedLink.getLinkString());
+          collectionDAO.testCaseDAO().update(testCase);
+          totalFixed++;
+        } catch (Exception e) {
+          LOG.warn("Error migrating TestCase entity link: {}", e.getMessage());
+        }
+      }
+
+      offset += jsonList.size();
+      if (jsonList.size() < BATCH_SIZE) {
+        break;
+      }
+    }
+
+    LOG.info("Migrated entity links to hashed column names for {} TestCase entities", totalFixed);
+  }
+
+  private static boolean columnsAlreadyHashed(List<Column> columns) {
+    if (nullOrEmpty(columns)) {
+      return false;
+    }
+    Column firstColumn = columns.get(0);
+    if (firstColumn.getFullyQualifiedName() == null) {
+      return false;
+    }
+    String fqn = firstColumn.getFullyQualifiedName();
+    String lastSegment = fqn.substring(fqn.lastIndexOf('.') + 1);
+    return ColumnNameHash.isHashedColumnFQNSegment(lastSegment);
+  }
 
   public static void updateOwnerChartFormulas() {
     DataInsightSystemChartRepository repository = new DataInsightSystemChartRepository();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/ColumnNameHash.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/ColumnNameHash.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.util;
+
+import java.util.List;
+import org.openmetadata.schema.type.Column;
+
+/**
+ * Utility for hashing column names to produce fixed-length identifiers for use in FQN
+ * construction. This decouples FQN length from raw column name length, solving issues with long
+ * column names (e.g., deeply nested BigQuery structs) exceeding VARCHAR(3072) limits on entityLink.
+ *
+ * <p>The raw column name is preserved in {@code Column.name}; only the FQN segment is hashed.
+ */
+public final class ColumnNameHash {
+
+  public static final String HASH_PREFIX = "md5_";
+  public static final int HASH_LENGTH = 36; // "md5_" (4) + 32 hex chars
+
+  private ColumnNameHash() {}
+
+  /**
+   * Hash a raw column name for use as the column segment in a fully qualified name.
+   *
+   * @param rawColumnName the original column name from the source system
+   * @return a fixed-length identifier in the format "md5_&lt;32 hex chars&gt;"
+   */
+  public static String hashColumnName(String rawColumnName) {
+    return HASH_PREFIX + EntityUtil.hash(rawColumnName);
+  }
+
+  /**
+   * Check whether a string is a hashed column FQN segment produced by {@link
+   * #hashColumnName(String)}.
+   */
+  public static boolean isHashedColumnFQNSegment(String segment) {
+    return segment != null && segment.startsWith(HASH_PREFIX) && segment.length() == HASH_LENGTH;
+  }
+
+  /**
+   * Resolve a hashed FQN segment back to the raw column name by looking up the matching column. If
+   * no match is found, returns the segment as-is.
+   */
+  public static String resolveColumnName(List<Column> columns, String hashedSegment) {
+    if (columns == null || !isHashedColumnFQNSegment(hashedSegment)) {
+      return hashedSegment;
+    }
+    return columns.stream()
+        .filter(c -> hashColumnName(c.getName()).equals(hashedSegment))
+        .map(Column::getName)
+        .findFirst()
+        .orElse(hashedSegment);
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/ColumnNameHash.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/ColumnNameHash.java
@@ -13,7 +13,11 @@
 
 package org.openmetadata.service.util;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.List;
+import lombok.SneakyThrows;
+import org.apache.commons.codec.binary.Hex;
 import org.openmetadata.schema.type.Column;
 
 /**
@@ -31,13 +35,18 @@ public final class ColumnNameHash {
   private ColumnNameHash() {}
 
   /**
-   * Hash a raw column name for use as the column segment in a fully qualified name.
+   * Hash a raw column name for use as the column segment in a fully qualified name. Uses explicit
+   * UTF-8 encoding to guarantee identical output to the Python implementation regardless of JVM
+   * default charset.
    *
    * @param rawColumnName the original column name from the source system
    * @return a fixed-length identifier in the format "md5_&lt;32 hex chars&gt;"
    */
+  @SneakyThrows
   public static String hashColumnName(String rawColumnName) {
-    return HASH_PREFIX + EntityUtil.hash(rawColumnName);
+    byte[] checksum =
+        MessageDigest.getInstance("MD5").digest(rawColumnName.getBytes(StandardCharsets.UTF_8));
+    return HASH_PREFIX + Hex.encodeHexString(checksum);
   }
 
   /**

--- a/openmetadata-spec/src/main/resources/json/schema/entity/data/table.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/data/table.json
@@ -242,8 +242,7 @@
     "columnName": {
       "description": "Local name (not fully qualified name) of the column. ColumnName is `-` when the column is not named in struct dataType. For example, BigQuery supports struct with unnamed fields.",
       "type": "string",
-      "minLength": 1,
-      "pattern": "^((?!::).)*$"
+      "minLength": 1
     },
     "partitionIntervalTypes": {
       "javaType": "org.openmetadata.schema.type.PartitionIntervalTypes",

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/TableDescription/TableDescription.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/TableDescription/TableDescription.component.tsx
@@ -44,10 +44,14 @@ const TableDescription = ({
       entityType === EntityType.TABLE
         ? EntityLink.getTableEntityLink(
             entityFqn,
-            EntityLink.getTableColumnNameFromColumnFqn(columnData.fqn, false)
+            columnData.record?.name ??
+              EntityLink.getTableColumnNameFromColumnFqn(
+                columnData.fqn,
+                false
+              )
           )
         : getEntityFeedLink(entityType, columnData.fqn),
-    [entityType, entityFqn]
+    [entityType, entityFqn, columnData.record?.name, columnData.fqn]
   );
 
   const suggestionData = useMemo(() => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/TableDescription/TableDescription.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/TableDescription/TableDescription.component.tsx
@@ -45,10 +45,7 @@ const TableDescription = ({
         ? EntityLink.getTableEntityLink(
             entityFqn,
             columnData.record?.name ??
-              EntityLink.getTableColumnNameFromColumnFqn(
-                columnData.fqn,
-                false
-              )
+              EntityLink.getTableColumnNameFromColumnFqn(columnData.fqn, false)
           )
         : getEntityFeedLink(entityType, columnData.fqn),
     [entityType, entityFqn, columnData.record?.name, columnData.fqn]

--- a/openmetadata-ui/src/main/resources/ui/src/components/Lineage/Lineage.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Lineage/Lineage.interface.ts
@@ -76,6 +76,8 @@ export interface ColumnLevelLineageNode
   toEntity: EdgeFromToData;
   fromColumn?: string;
   toColumn?: string;
+  fromColumnName?: string;
+  toColumnName?: string;
   pipeline?: EntityReference;
   source?: string;
   sqlQuery?: string;

--- a/openmetadata-ui/src/main/resources/ui/src/components/LineageTable/LineageTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/LineageTable/LineageTable.tsx
@@ -79,7 +79,11 @@ import Table from '../common/Table/Table';
 import TierTag from '../common/TierTag';
 import TableTags from '../Database/TableTags/TableTags.component';
 import CustomControlsComponent from '../Entity/EntityLineage/CustomControls.component';
-import { EdgeFromToData, LineageNode } from '../Lineage/Lineage.interface';
+import {
+  ColumnLevelLineageNode,
+  EdgeFromToData,
+  LineageNode,
+} from '../Lineage/Lineage.interface';
 import {
   SearchedDataProps,
   SourceType,
@@ -635,14 +639,19 @@ const LineageTable: FC<{ entity: SourceType }> = ({ entity }) => {
 
   // Render function for column names with search highlighting
   const columnNameRender = useCallback(
-    (column: string) => {
-      const prunedColumnName = Fqn.split(column).pop();
+    (
+      columnFqn: string,
+      record: ColumnLevelLineageNode,
+      columnNameKey: 'fromColumnName' | 'toColumnName'
+    ) => {
+      const displayName =
+        record[columnNameKey] ?? Fqn.split(columnFqn).pop();
 
       return (
         <span>
-          {isEmpty(prunedColumnName)
+          {isEmpty(displayName)
             ? NO_DATA
-            : stringToHTML(highlightSearchText(prunedColumnName, searchValue))}
+            : stringToHTML(highlightSearchText(displayName, searchValue))}
         </span>
       );
     },
@@ -675,7 +684,12 @@ const LineageTable: FC<{ entity: SourceType }> = ({ entity }) => {
         title: t('label.source-column-plural'),
         dataIndex: ['fromColumn'],
         key: 'fromColumn',
-        render: columnNameRender,
+        render: (columnFqn: string, record: SourceType) =>
+          columnNameRender(
+            columnFqn,
+            record as unknown as ColumnLevelLineageNode,
+            'fromColumnName'
+          ),
       },
       {
         title: t('label.impacted'),
@@ -700,7 +714,12 @@ const LineageTable: FC<{ entity: SourceType }> = ({ entity }) => {
         title: t('label.impacted-column-plural'),
         dataIndex: ['toColumn'],
         key: 'toColumn',
-        render: columnNameRender,
+        render: (columnFqn: string, record: SourceType) =>
+          columnNameRender(
+            columnFqn,
+            record as unknown as ColumnLevelLineageNode,
+            'toColumnName'
+          ),
       },
       ...tableColumns.slice(1),
     ],

--- a/openmetadata-ui/src/main/resources/ui/src/components/LineageTable/LineageTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/LineageTable/LineageTable.tsx
@@ -79,10 +79,7 @@ import Table from '../common/Table/Table';
 import TierTag from '../common/TierTag';
 import TableTags from '../Database/TableTags/TableTags.component';
 import CustomControlsComponent from '../Entity/EntityLineage/CustomControls.component';
-import {
-  EdgeFromToData,
-  LineageNode,
-} from '../Lineage/Lineage.interface';
+import { EdgeFromToData, LineageNode } from '../Lineage/Lineage.interface';
 import {
   SearchedDataProps,
   SourceType,

--- a/openmetadata-ui/src/main/resources/ui/src/components/LineageTable/LineageTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/LineageTable/LineageTable.tsx
@@ -80,7 +80,6 @@ import TierTag from '../common/TierTag';
 import TableTags from '../Database/TableTags/TableTags.component';
 import CustomControlsComponent from '../Entity/EntityLineage/CustomControls.component';
 import {
-  ColumnLevelLineageNode,
   EdgeFromToData,
   LineageNode,
 } from '../Lineage/Lineage.interface';
@@ -641,11 +640,11 @@ const LineageTable: FC<{ entity: SourceType }> = ({ entity }) => {
   const columnNameRender = useCallback(
     (
       columnFqn: string,
-      record: ColumnLevelLineageNode,
+      record: Record<string, unknown>,
       columnNameKey: 'fromColumnName' | 'toColumnName'
     ) => {
       const displayName =
-        record[columnNameKey] ?? Fqn.split(columnFqn).pop();
+        (record[columnNameKey] as string) ?? Fqn.split(columnFqn).pop();
 
       return (
         <span>
@@ -687,7 +686,7 @@ const LineageTable: FC<{ entity: SourceType }> = ({ entity }) => {
         render: (columnFqn: string, record: SourceType) =>
           columnNameRender(
             columnFqn,
-            record as unknown as ColumnLevelLineageNode,
+            record as Record<string, unknown>,
             'fromColumnName'
           ),
       },
@@ -717,7 +716,7 @@ const LineageTable: FC<{ entity: SourceType }> = ({ entity }) => {
         render: (columnFqn: string, record: SourceType) =>
           columnNameRender(
             columnFqn,
-            record as unknown as ColumnLevelLineageNode,
+            record as Record<string, unknown>,
             'toColumnName'
           ),
       },

--- a/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsContainerV2/TagsContainerV2.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsContainerV2/TagsContainerV2.tsx
@@ -466,7 +466,11 @@ const TagsContainerV2 = ({
     if (!isGlossaryType && entityType === EntityType.TABLE) {
       const entityLink = EntityLink.getTableEntityLink(
         entityFqn ?? '',
-        EntityLink.getTableColumnNameFromColumnFqn(columnData?.fqn ?? '', false)
+        columnData?.name ??
+          EntityLink.getTableColumnNameFromColumnFqn(
+            columnData?.fqn ?? '',
+            false
+          )
       );
 
       const activeSuggestion = selectedUserSuggestions?.tags.find(

--- a/openmetadata-ui/src/main/resources/ui/src/context/LineageProvider/LineageProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/context/LineageProvider/LineageProvider.tsx
@@ -1992,7 +1992,7 @@ const LineageProvider = ({ children }: LineageProviderProps) => {
               setShowDeleteModal(false);
             }}
             onOk={onRemove}>
-            {getModalBodyText(selectedEdge as Edge)}
+            {getModalBodyText(selectedEdge as Edge, nodes)}
           </Modal>
         )}
         {showAddEdgeModal && (

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageUtils.tsx
@@ -113,6 +113,7 @@ import { getEntityName, getEntityReferenceFromEntity } from './EntityUtils';
 import Fqn from './Fqn';
 import { t } from './i18next/LocalUtil';
 import ELKLayout from './Lineage/Layout/ELKUtil/ELKUtil';
+import { findColumnInList } from './Lineage/LineageUtils';
 import { jsonToCSV } from './StringsUtils';
 import { showErrorToast } from './ToastUtils';
 
@@ -269,32 +270,13 @@ export const getELKLayoutedElements = async (
   }
 };
 
-const findColumnRecursive = (
-  columns: Column[],
-  columnFqn: string
-): Column | undefined => {
-  for (const col of columns) {
-    if (col.fullyQualifiedName === columnFqn) {
-      return col;
-    }
-    if (col.children) {
-      const childMatch = findColumnRecursive(col.children, columnFqn);
-      if (childMatch) {
-        return childMatch;
-      }
-    }
-  }
-
-  return undefined;
-};
-
 const findColumnDisplayName = (
   columnFqn: string,
   nodes: Node[]
 ): string | undefined => {
   for (const node of nodes) {
     const columns: Column[] = node.data?.node?.columns ?? [];
-    const match = findColumnRecursive(columns, columnFqn);
+    const match = findColumnInList(columns, columnFqn);
     if (match) {
       return match.displayName || match.name;
     }

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageUtils.tsx
@@ -98,7 +98,7 @@ import { APIEndpoint } from '../generated/entity/data/apiEndpoint';
 import { Container } from '../generated/entity/data/container';
 import { Pipeline } from '../generated/entity/data/pipeline';
 import { SearchIndex } from '../generated/entity/data/searchIndex';
-import { Table } from '../generated/entity/data/table';
+import { Column, Table } from '../generated/entity/data/table';
 import { Topic } from '../generated/entity/data/topic';
 import { ColumnLineage, LineageDetails } from '../generated/type/entityLineage';
 import { EntityReference } from '../generated/type/entityReference';
@@ -269,7 +269,27 @@ export const getELKLayoutedElements = async (
   }
 };
 
-export const getModalBodyText = (selectedEdge: Edge) => {
+const findColumnDisplayName = (
+  columnFqn: string,
+  nodes: Node[]
+): string | undefined => {
+  for (const node of nodes) {
+    const columns: Column[] = node.data?.node?.columns ?? [];
+    const match = columns.find(
+      (col) => col.fullyQualifiedName === columnFqn
+    );
+    if (match) {
+      return match.displayName || match.name;
+    }
+  }
+
+  return undefined;
+};
+
+export const getModalBodyText = (
+  selectedEdge: Edge,
+  reactFlowNodes: Node[] = []
+) => {
   const { data } = selectedEdge;
   const { fromEntity, toEntity } = data.edge as EdgeDetails;
   const { sourceHandle = '', targetHandle = '' } = selectedEdge;
@@ -278,26 +298,36 @@ export const getModalBodyText = (selectedEdge: Edge) => {
   let sourceEntity = '';
   let targetEntity = '';
 
-  const sourceFQN = isColumnLineage
-    ? sourceHandle
-    : fromEntity.fullyQualifiedName;
-  const targetFQN = isColumnLineage
-    ? targetHandle
-    : toEntity.fullyQualifiedName;
-  const fqnPart = isColumnLineage ? FqnPart.Column : FqnPart.Table;
-
-  if (fromEntity.type === EntityType.TABLE) {
-    sourceEntity = getPartialNameFromTableFQN(sourceFQN ?? '', [fqnPart]);
+  if (isColumnLineage) {
+    const srcHandle = sourceHandle ?? '';
+    const tgtHandle = targetHandle ?? '';
+    sourceEntity =
+      findColumnDisplayName(srcHandle, reactFlowNodes) ??
+      getPartialNameFromTableFQN(srcHandle, [FqnPart.Column]);
+    targetEntity =
+      findColumnDisplayName(tgtHandle, reactFlowNodes) ??
+      getPartialNameFromTableFQN(tgtHandle, [FqnPart.Column]);
   } else {
-    const arrFqn = Fqn.split(sourceFQN ?? '');
-    sourceEntity = arrFqn[arrFqn.length - 1];
-  }
+    const sourceFQN = fromEntity.fullyQualifiedName;
+    const targetFQN = toEntity.fullyQualifiedName;
 
-  if (toEntity.type === EntityType.TABLE) {
-    targetEntity = getPartialNameFromTableFQN(targetFQN ?? '', [fqnPart]);
-  } else {
-    const arrFqn = Fqn.split(targetFQN ?? '');
-    targetEntity = arrFqn[arrFqn.length - 1];
+    if (fromEntity.type === EntityType.TABLE) {
+      sourceEntity = getPartialNameFromTableFQN(sourceFQN ?? '', [
+        FqnPart.Table,
+      ]);
+    } else {
+      const arrFqn = Fqn.split(sourceFQN ?? '');
+      sourceEntity = arrFqn[arrFqn.length - 1];
+    }
+
+    if (toEntity.type === EntityType.TABLE) {
+      targetEntity = getPartialNameFromTableFQN(targetFQN ?? '', [
+        FqnPart.Table,
+      ]);
+    } else {
+      const arrFqn = Fqn.split(targetFQN ?? '');
+      targetEntity = arrFqn[arrFqn.length - 1];
+    }
   }
 
   return t('message.remove-edge-between-source-and-target', {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageUtils.tsx
@@ -269,15 +269,32 @@ export const getELKLayoutedElements = async (
   }
 };
 
+const findColumnRecursive = (
+  columns: Column[],
+  columnFqn: string
+): Column | undefined => {
+  for (const col of columns) {
+    if (col.fullyQualifiedName === columnFqn) {
+      return col;
+    }
+    if (col.children) {
+      const childMatch = findColumnRecursive(col.children, columnFqn);
+      if (childMatch) {
+        return childMatch;
+      }
+    }
+  }
+
+  return undefined;
+};
+
 const findColumnDisplayName = (
   columnFqn: string,
   nodes: Node[]
 ): string | undefined => {
   for (const node of nodes) {
     const columns: Column[] = node.data?.node?.columns ?? [];
-    const match = columns.find(
-      (col) => col.fullyQualifiedName === columnFqn
-    );
+    const match = findColumnRecursive(columns, columnFqn);
     if (match) {
       return match.displayName || match.name;
     }

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Lineage/LineageUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Lineage/LineageUtils.tsx
@@ -54,7 +54,7 @@ export const LINEAGE_DEPENDENCY_OPTIONS = [
   },
 ];
 
-const findColumnInList = (
+export const findColumnInList = (
   columns: Column[],
   columnFqn: string
 ): Column | undefined => {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Lineage/LineageUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Lineage/LineageUtils.tsx
@@ -15,6 +15,7 @@ import { ChevronRight } from '@untitledui/icons';
 import { get, omit, pick } from 'lodash';
 import { ReactComponent as ColumnIcon } from '../../assets/svg/ic-column-new.svg';
 import { ReactComponent as TableIcon } from '../../assets/svg/ic-table-new.svg';
+import { Column } from '../../generated/entity/data/table';
 import { CondensedBreadcrumb } from '../../components/CondensedBreadcrumb/CondensedBreadcrumb.component';
 import {
   ColumnLevelLineageNode,
@@ -53,6 +54,19 @@ export const LINEAGE_DEPENDENCY_OPTIONS = [
   },
 ];
 
+const findColumnNameByFqn = (
+  columnFqn: string,
+  entityData: NodeData['entity']
+): string | undefined => {
+  const columns = (entityData as unknown as { columns?: Column[] }).columns;
+  if (!columns) {
+    return undefined;
+  }
+  const match = columns.find((col) => col.fullyQualifiedName === columnFqn);
+
+  return match ? match.displayName || match.name : undefined;
+};
+
 export const prepareColumnLevelNodesFromEdges = (
   edges: EdgeDetails[],
   nodes: Record<string, NodeData>,
@@ -90,12 +104,31 @@ export const prepareColumnLevelNodesFromEdges = (
           'tags' | 'tier' | 'domains' | 'description' | 'owners' | 'id'
         >; // Type assertion to Include type to ensure only these fields are
 
+        const fromEntityData = get(
+          nodes[node.fromEntity.fullyQualifiedName ?? ''],
+          'entity'
+        );
+        const toEntityData = get(
+          nodes[node.toEntity.fullyQualifiedName ?? ''],
+          'entity'
+        );
+
+        const toColumnName = col.toColumn
+          ? findColumnNameByFqn(col.toColumn, toEntityData ?? entityData)
+          : undefined;
+
         // flatten the fromColumns to create separate nodes for each
         for (const fromCol of col.fromColumns || []) {
+          const fromColumnName = fromEntityData
+            ? findColumnNameByFqn(fromCol, fromEntityData)
+            : undefined;
+
           acc.push({
             ...omit(node, 'columns'),
             fromColumn: fromCol,
             toColumn: col.toColumn,
+            fromColumnName,
+            toColumnName,
             docId: fromCol + '->' + col.toColumn,
             nodeDepth,
             ...picked,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Lineage/LineageUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Lineage/LineageUtils.tsx
@@ -15,7 +15,6 @@ import { ChevronRight } from '@untitledui/icons';
 import { get, omit, pick } from 'lodash';
 import { ReactComponent as ColumnIcon } from '../../assets/svg/ic-column-new.svg';
 import { ReactComponent as TableIcon } from '../../assets/svg/ic-table-new.svg';
-import { Column } from '../../generated/entity/data/table';
 import { CondensedBreadcrumb } from '../../components/CondensedBreadcrumb/CondensedBreadcrumb.component';
 import {
   ColumnLevelLineageNode,
@@ -24,6 +23,7 @@ import {
 } from '../../components/Lineage/Lineage.interface';
 import { EImpactLevel } from '../../components/LineageTable/LineageTable.interface';
 import { LineageDirection } from '../../generated/api/lineage/lineageDirection';
+import { Column } from '../../generated/entity/data/table';
 import { TableSearchSource } from '../../interface/search.interface';
 import { QueryFieldInterface } from '../../pages/ExplorePage/ExplorePage.interface';
 import i18n from '../i18next/LocalUtil';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Lineage/LineageUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Lineage/LineageUtils.tsx
@@ -54,6 +54,25 @@ export const LINEAGE_DEPENDENCY_OPTIONS = [
   },
 ];
 
+const findColumnInList = (
+  columns: Column[],
+  columnFqn: string
+): Column | undefined => {
+  for (const col of columns) {
+    if (col.fullyQualifiedName === columnFqn) {
+      return col;
+    }
+    if (col.children) {
+      const childMatch = findColumnInList(col.children, columnFqn);
+      if (childMatch) {
+        return childMatch;
+      }
+    }
+  }
+
+  return undefined;
+};
+
 const findColumnNameByFqn = (
   columnFqn: string,
   entityData: NodeData['entity']
@@ -62,7 +81,7 @@ const findColumnNameByFqn = (
   if (!columns) {
     return undefined;
   }
-  const match = columns.find((col) => col.fullyQualifiedName === columnFqn);
+  const match = findColumnInList(columns, columnFqn);
 
   return match ? match.displayName || match.name : undefined;
 };

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TableUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TableUtils.tsx
@@ -1323,10 +1323,12 @@ export const findColumnByEntityLink = (
   entityLink: string
 ): Column | null => {
   for (const column of columns) {
-    const columnName = EntityLink.getTableColumnNameFromColumnFqn(
-      column.fullyQualifiedName ?? '',
-      false
-    );
+    const columnName =
+      column.name ??
+      EntityLink.getTableColumnNameFromColumnFqn(
+        column.fullyQualifiedName ?? '',
+        false
+      );
 
     // Generate the entity link for this column and compare with the target entity link
     const columnEntityLink = EntityLink.getTableEntityLink(


### PR DESCRIPTION
### Describe your changes:

Fixes https://github.com/open-metadata/openmetadata-collate/issues/3253

## Summary

Implements column name hashing to decouple FQN storage constraints from raw column names. Column names from sources like BigQuery structs and Snowflake can exceed `entityLink` VARCHAR(3072) limits when used directly in FQNs. This is the long-term fix for ingestion failures previously patched in #26530.

**Approach**: Hash only the column segment in FQN construction. `column.name` stays as the raw readable source name, `column.fullyQualifiedName` uses `md5_<32 hex chars>` for column segments.

BEFORE:  name = "customer_email"     FQN = "svc.db.schema.tbl.customer_email"
AFTER:   name = "customer_email"     FQN = "svc.db.schema.tbl.md5_a1b2c3d4..."

**Why this approach**:
- `name` is the column identity — `EntityUtil.columnMatch` uses it for re-ingestion matching
- `displayName` is user-editable — can't be sole store of original name
- Profiler, PII scanner, search all use `col.name` directly — completely unaffected
- FQN is a derived field — the right place to apply hashing

## Changes

**Core**
- New `ColumnNameHash` utility (Java + Python) — MD5-based, consistent with existing `EntityUtil.hash()`
- `ColumnUtil.setColumnFQN()`, `ContainerRepository`, `TableRepository` joins — hash column name before building FQN
- Python `fqn.py` Column builder — hash `column_name` parameter
- `validateColumn()` — supports both raw names and hashed segments
- `resolveColumnName()` — reverse lookup from hash to readable name for API responses

**Cleanup**
- Deleted `truncate_column_name()` and removed from 12 connector/dashboard files
- Removed `columnName` pattern constraint (`::` prohibition) from `table.json`
- Removed `ColumnName`, `ColumnProfile`, `CustomColumnName` from reserved keyword encoding

**Data Quality**
- `test_case_runner.py`, `sqa_validator_mixin.py`, `pandas_validator_mixin.py` — hash-based fallback when matching columns from entity links
- `entity_link.py` — hash column name when converting entity link to FQN

**Migration (v1.13.0)**
- Recomputes all column FQNs with hashed segments across tables, dashboard data models, and containers
- Updates test case entity links with hashed column identifiers
- Idempotent — skips columns with already-hashed FQN segments

**Frontend**
- Lineage modal and lineage table — resolve readable column name from entity data instead of extracting hashed FQN segment
- Task feed cards, tag/description components — use `column.name` when building entity links
- Added `fromColumnName`/`toColumnName` to `ColumnLevelLineageNode` interface

## What is NOT affected
- Profiler SQL queries — uses `col.name` (raw)
- PII/Classifier regex scanning — uses `col.name` (raw)
- Column matching on re-ingestion — `columnMatch` uses `name` (raw)
- Search indexing — indexes `col.getName()` (raw)
- Column display in UI — uses `getEntityName()` (raw)

## Test plan
- [x] 59 Python tests passing (31 new hash tests + 28 updated FQN special chars tests)
- [x] Cross-language hash verification (Python MD5 matches Java `EntityUtil.hash()`)
- [x] Java formatting via `mvn spotless:apply`
- [ ] Ingestion E2E with columns containing `::`, `>`, `"`, unicode, and 1000+ char names
- [ ] Re-ingestion — verify column matching and metadata carryover (tags, descriptions)
- [ ] Profiler runs correctly with hashed column FQNs
- [ ] Data quality test case resolution with hashed entity links
- [ ] Search returns results when searching by original column name
- [ ] Migration on existing data — verify FQN recomputation and idempotency
- [ ] Frontend lineage and task display shows readable column names


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
