### PR TITLE
Fixes #21304: randomize sample data extraction for 100% percentage sampling

### DIFF
--- a/ingestion/src/metadata/sampler/sqlalchemy/sampler.py
+++ b/ingestion/src/metadata/sampler/sqlalchemy/sampler.py
@@ -155,17 +155,22 @@ class SQASampler(SamplerInterface, SQAInterfaceMixin):
         hash_object = hashlib.md5(encoded_name)
         return hash_object.hexdigest()
 
+    def _is_randomized_sample_enabled(self) -> bool:
+        """Treat None as default-enabled randomization for backward compatibility."""
+        return self.sample_config.randomizedSample is not False
+
     def get_sample_query(self, *, column=None) -> Query:
         """get query for sample data"""
         with self.session_factory() as client:
             if self.sample_config.profileSampleType == ProfileSampleType.PERCENTAGE:
+                profile_sample = self.sample_config.profileSample or 100
                 rnd = self._base_sample_query(
                     column,
                     (ModuloFn(RandomNumFn(), 100)).label(RANDOM_LABEL),
                 ).cte(f"{self.get_sampler_table_name()}_rnd")
                 session_query = client.query(rnd)
                 return session_query.where(
-                    rnd.c.random <= self.sample_config.profileSample
+                    rnd.c.random <= profile_sample
                 ).cte(f"{self.get_sampler_table_name()}_sample")
 
             table_query = client.query(self.raw_dataset)
@@ -174,12 +179,12 @@ class SQASampler(SamplerInterface, SQAInterfaceMixin):
             session_query = self._base_sample_query(
                 column,
                 (ModuloFn(RandomNumFn(), table_query.count())).label(RANDOM_LABEL)
-                if self.sample_config.randomizedSample
+                if self._is_randomized_sample_enabled()
                 else None,
             )
             query = (
                 session_query.order_by(RANDOM_LABEL)
-                if self.sample_config.randomizedSample
+                if self._is_randomized_sample_enabled()
                 else session_query
             )
             return query.limit(self.sample_config.profileSample).cte(
@@ -205,6 +210,24 @@ class SQASampler(SamplerInterface, SQAInterfaceMixin):
 
         return self.get_sample_query(column=column)
 
+    def _get_dataset_for_sample_data(self) -> Union[type, AliasedClass]:
+        """Get dataset used specifically for sample data extraction.
+
+        For percentage=100 (or unset percentage treated as 100), profiling metrics use
+        the raw dataset for backward compatibility. Sample-data extraction, however,
+        should still honor randomized sampling when enabled.
+        """
+        if (
+            self._is_randomized_sample_enabled()
+            and self.sample_config.profileSampleType == ProfileSampleType.PERCENTAGE
+            and (
+                self.sample_config.profileSample is None
+                or self.sample_config.profileSample == 100
+            )
+        ):
+            return self.get_sample_query()
+        return self.get_dataset()
+
     def fetch_sample_data(self, columns: Optional[List[Column]] = None) -> TableData:
         """
         Use the sampler to retrieve sample data rows as per limit given by user
@@ -218,16 +241,21 @@ class SQASampler(SamplerInterface, SQAInterfaceMixin):
             return self._fetch_sample_data_from_user_query()
 
         # Add new RandomNumFn column
-        ds = self.get_dataset()
+        ds = self._get_dataset_for_sample_data()
+        ds_columns = inspect(ds).c
+        random_column = next(
+            (col for col in ds_columns if col.name == RANDOM_LABEL), None
+        )
+
         if not columns:
-            sqa_columns = [col for col in inspect(ds).c if col.name != RANDOM_LABEL]
+            sqa_columns = [col for col in ds_columns if col.name != RANDOM_LABEL]
         else:
             # we can't directly use columns as it is bound to self.raw_dataset and not the rnd table.
             # If we use it, it will result in a cross join between self.raw_dataset and rnd table
             names = [col.name for col in columns]
             sqa_columns = [
                 col
-                for col in inspect(ds).c
+                for col in ds_columns
                 if col.name != RANDOM_LABEL and col.name in names
             ]
 
@@ -250,12 +278,10 @@ class SQASampler(SamplerInterface, SQAInterfaceMixin):
                     select_columns.append(col)
 
             # Create query with modified columns
-            sqa_sample = (
-                client.query(*select_columns)
-                .select_from(ds)
-                .limit(self.sample_limit)
-                .all()
-            )
+            query = client.query(*select_columns).select_from(ds)
+            if self._is_randomized_sample_enabled() and random_column is not None:
+                query = query.order_by(random_column)
+            sqa_sample = query.limit(self.sample_limit).all()
 
         # Process rows: handle array columns and truncate large text values
         # to prevent OOM in downstream processing.

--- a/ingestion/tests/unit/observability/profiler/sqlalchemy/test_sample.py
+++ b/ingestion/tests/unit/observability/profiler/sqlalchemy/test_sample.py
@@ -22,6 +22,7 @@ from sqlalchemy.orm import DeclarativeBase
 
 from metadata.generated.schema.entity.data.table import Column as EntityColumn
 from metadata.generated.schema.entity.data.table import ColumnName, DataType, Table
+from metadata.generated.schema.entity.data.table import ProfileSampleType
 from metadata.generated.schema.entity.services.connections.database.sqliteConnection import (
     SQLiteConnection,
     SQLiteScheme,
@@ -360,6 +361,83 @@ class SampleTest(TestCase):
         assert len(sample_data.columns) == 2
         names = [col.root for col in sample_data.columns]
         assert names == ["id", "name"]
+
+    def test_full_percentage_randomized_sample_data_uses_sampling_query(
+        self, sampler_mock
+    ):
+        """
+        When profile sample is 100% and randomized sampling is enabled, sample data
+        extraction should still use the randomized sampling query.
+        """
+        with patch.object(SQASampler, "build_table_orm", return_value=User):
+            sampler = SQASampler(
+                service_connection_config=self.sqlite_conn,
+                ometa_client=None,
+                entity=None,
+                sample_config=SampleConfig(
+                    profileSampleType=ProfileSampleType.PERCENTAGE,
+                    profileSample=100,
+                    randomizedSample=True,
+                ),
+                sample_data_count=5,
+            )
+
+        with patch.object(
+            sampler, "get_sample_query", wraps=sampler.get_sample_query
+        ) as mock_get_sample_query:
+            sampler.fetch_sample_data()
+            assert mock_get_sample_query.called
+
+    def test_full_percentage_non_randomized_sample_data_skips_sampling_query(
+        self, sampler_mock
+    ):
+        """
+        When randomization is disabled, sample data extraction should preserve
+        deterministic behavior and avoid randomized sampling queries.
+        """
+        with patch.object(SQASampler, "build_table_orm", return_value=User):
+            sampler = SQASampler(
+                service_connection_config=self.sqlite_conn,
+                ometa_client=None,
+                entity=None,
+                sample_config=SampleConfig(
+                    profileSampleType=ProfileSampleType.PERCENTAGE,
+                    profileSample=100,
+                    randomizedSample=False,
+                ),
+                sample_data_count=5,
+            )
+
+        with patch.object(
+            sampler, "get_sample_query", wraps=sampler.get_sample_query
+        ) as mock_get_sample_query:
+            sampler.fetch_sample_data()
+            assert not mock_get_sample_query.called
+
+    def test_full_percentage_none_randomized_sample_data_uses_sampling_query(
+        self, sampler_mock
+    ):
+        """
+        randomizedSample=None should follow the default-enabled randomization behavior.
+        """
+        with patch.object(SQASampler, "build_table_orm", return_value=User):
+            sampler = SQASampler(
+                service_connection_config=self.sqlite_conn,
+                ometa_client=None,
+                entity=None,
+                sample_config=SampleConfig(
+                    profileSampleType=ProfileSampleType.PERCENTAGE,
+                    profileSample=100,
+                    randomizedSample=None,
+                ),
+                sample_data_count=5,
+            )
+
+        with patch.object(
+            sampler, "get_sample_query", wraps=sampler.get_sample_query
+        ) as mock_get_sample_query:
+            sampler.fetch_sample_data()
+            assert mock_get_sample_query.called
 
     @classmethod
     def tearDownClass(cls) -> None:


### PR DESCRIPTION
### Describe your changes:

Fixes #21304

This change fixes deterministic sample-data extraction in AutoClassification runs when table profiler settings are `profileSampleType=PERCENTAGE` and `profileSample=100`.

I worked on this because with 100% percentage sampling, the SQLAlchemy sampler short-circuited to the raw dataset path and `fetch_sample_data()` applied `LIMIT` without randomized ordering, which repeatedly returned the first N rows instead of randomized samples.

What changed:
- Updated SQLAlchemy sampler to keep metric behavior unchanged while randomizing sample-data extraction path at 100% percentage sampling.
- Added `_get_dataset_for_sample_data()` to use sampling query for sample-data extraction when randomization is enabled.
- Added explicit random ordering before `LIMIT` in `fetch_sample_data()` when random column is available.
- Hardened handling for `randomizedSample=None` so it follows default-enabled behavior (`None` is treated as enabled unless explicitly `False`).
- Added regression tests for:
  - `100% + randomizedSample=True` uses sampling query
  - `100% + randomizedSample=False` keeps non-randomized path
  - `100% + randomizedSample=None` uses randomized path

How I tested:
- Added unit tests in `ingestion/tests/unit/observability/profiler/sqlalchemy/test_sample.py`.
- Ran syntax validation:
  - `python3 -m py_compile ingestion/src/metadata/sampler/sqlalchemy/sampler.py ingestion/tests/unit/observability/profiler/sqlalchemy/test_sample.py`
- Ran diff hygiene:
  - `git diff --check`
- Note: running `pytest` end-to-end in this environment is blocked by missing generated Python schemas (`metadata.generated`) in local setup.

#
### Type of change:
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
