### PR TITLE
feat(hive): add MSSQL and Oracle backends for Hive metastore 

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/hive/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/connection.py
@@ -120,7 +120,9 @@ def get_connection(connection: HiveConnection) -> Engine:
     if connection.kerberosServiceName:
         if not connection.connectionArguments:
             connection.connectionArguments = init_empty_connection_arguments()
-        connection.connectionArguments.root["kerberos_service_name"] = connection.kerberosServiceName
+        connection.connectionArguments.root["kerberos_service_name"] = (
+            connection.kerberosServiceName
+        )
 
     # SSL cert paths (ssl_ca_certs, ssl_certfile, ssl_keyfile) are set by ssl_manager.setup_ssl()
     # via SSLManager.create_temp_file(). Do not assign sslConfig fields here directly —
@@ -283,8 +285,8 @@ def test_connection(
                 OracleConnection,
             ):
                 try:
-                    service_connection.metastoreConnection = (
-                        conn_cls.model_validate(metastore_conn)
+                    service_connection.metastoreConnection = conn_cls.model_validate(
+                        metastore_conn
                     )
                     break
                 except ValidationError:

--- a/ingestion/src/metadata/ingestion/source/database/hive/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/connection.py
@@ -68,6 +68,20 @@ HIVE_MSSQL_PYTDS_SCHEME = "hive+mssql.pytds"
 HIVE_MSSQL_PYMSSQL_SCHEME = "hive+mssql.pymssql"
 HIVE_ORACLE_SCHEME = "hive+oracle"
 
+METASTORE_CONNECTION_TYPES = (
+    PostgresConnection,
+    MysqlConnection,
+    MssqlConnection,
+    OracleConnection,
+)
+
+METASTORE_CONNECTION_TYPE_BY_TYPE = {
+    "Postgres": PostgresConnection,
+    "Mysql": MysqlConnection,
+    "Mssql": MssqlConnection,
+    "Oracle": OracleConnection,
+}
+
 # Monkey-patch the pyhive.hive module to use our custom connection
 import pyhive.hive  # noqa: E402
 
@@ -157,6 +171,45 @@ def get_mssql_metastore_connection_url(connection: MssqlConnection) -> str:
         url += f"driver={quote_plus(connection.driver)}"
 
     return url
+
+
+def get_validated_metastore_connection(
+    metastore_conn: Any,
+) -> PostgresConnection | MysqlConnection | MssqlConnection | OracleConnection | None:
+    """
+    Validate and return a Hive metastore connection.
+    Raw dicts are resolved by the type discriminator first to avoid matching a
+    different generated connection model with overlapping fields.
+    """
+    if not metastore_conn:
+        return None
+
+    if isinstance(metastore_conn, METASTORE_CONNECTION_TYPES):
+        return metastore_conn
+
+    if not isinstance(metastore_conn, dict) or len(metastore_conn) == 0:
+        return None
+
+    conn_type = metastore_conn.get("type")
+    if isinstance(conn_type, Enum):
+        conn_type = conn_type.value
+
+    if conn_type:
+        conn_cls = METASTORE_CONNECTION_TYPE_BY_TYPE.get(conn_type)
+        if not conn_cls:
+            return None
+        try:
+            return conn_cls.model_validate(metastore_conn)
+        except ValidationError:
+            return None
+
+    for conn_cls in METASTORE_CONNECTION_TYPES:
+        try:
+            return conn_cls.model_validate(metastore_conn)
+        except ValidationError:
+            continue
+
+    return None
 
 
 @singledispatch
@@ -300,26 +353,11 @@ def test_connection(
     metastore_conn = service_connection.metastoreConnection
 
     if metastore_conn:
-        if isinstance(
-            metastore_conn,
-            PostgresConnection | MysqlConnection | MssqlConnection | OracleConnection,
-        ):
-            engine = get_metastore_connection(metastore_conn)
-        elif isinstance(metastore_conn, dict) and len(metastore_conn) > 0:
-            for conn_cls in (
-                PostgresConnection,
-                MysqlConnection,
-                MssqlConnection,
-                OracleConnection,
-            ):
-                try:
-                    service_connection.metastoreConnection = conn_cls.model_validate(metastore_conn)
-                    break
-                except ValidationError:
-                    continue
-            else:
-                raise ValueError("Invalid metastore connection")
-            engine = get_metastore_connection(service_connection.metastoreConnection)
+        metastore_conn = get_validated_metastore_connection(metastore_conn)
+        if not metastore_conn:
+            raise ValueError("Invalid metastore connection")
+        service_connection.metastoreConnection = metastore_conn
+        engine = get_metastore_connection(metastore_conn)
 
     return test_connection_db_schema_sources(
         metadata=metadata,

--- a/ingestion/src/metadata/ingestion/source/database/hive/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/connection.py
@@ -29,8 +29,14 @@ from metadata.generated.schema.entity.services.connections.database.hiveConnecti
     HiveConnection,
     HiveScheme,
 )
+from metadata.generated.schema.entity.services.connections.database.mssqlConnection import (
+    MssqlConnection,
+)
 from metadata.generated.schema.entity.services.connections.database.mysqlConnection import (
     MysqlConnection,
+)
+from metadata.generated.schema.entity.services.connections.database.oracleConnection import (
+    OracleConnection,
 )
 from metadata.generated.schema.entity.services.connections.database.postgresConnection import (
     PostgresConnection,
@@ -57,6 +63,8 @@ from metadata.utils.ssl_manager import check_ssl_and_init
 
 HIVE_POSTGRES_SCHEME = "hive+postgres"
 HIVE_MYSQL_SCHEME = "hive+mysql"
+HIVE_MSSQL_SCHEME = "hive+mssql"
+HIVE_ORACLE_SCHEME = "hive+oracle"
 
 # Monkey-patch the pyhive.hive module to use our custom connection
 import pyhive.hive  # noqa: E402
@@ -195,6 +203,58 @@ def _(connection: MysqlConnection):
     )
 
 
+@get_metastore_connection.register
+def _(connection: MssqlConnection):
+    # import required to load sqlalchemy plugin
+    # pylint: disable=import-outside-toplevel,unused-import
+    from metadata.ingestion.source.database.hive.metastore_dialects.mssql import (  # nopycln: import
+        HiveMssqlMetaStoreDialect,
+    )
+
+    class CustomMssqlScheme(Enum):
+        HIVE_MSSQL = HIVE_MSSQL_SCHEME
+
+    class CustomMssqlConnection(MssqlConnection):
+        scheme: Optional[CustomMssqlScheme]
+
+    connection_copy = deepcopy(connection.__dict__)
+    connection_copy["scheme"] = CustomMssqlScheme.HIVE_MSSQL
+
+    custom_connection = CustomMssqlConnection(**connection_copy)
+
+    return create_generic_db_connection(
+        connection=custom_connection,
+        get_connection_url_fn=get_connection_url_common,
+        get_connection_args_fn=get_connection_args_common,
+    )
+
+
+@get_metastore_connection.register
+def _(connection: OracleConnection):
+    # import required to load sqlalchemy plugin
+    # pylint: disable=import-outside-toplevel,unused-import
+    from metadata.ingestion.source.database.hive.metastore_dialects.oracle import (  # nopycln: import
+        HiveOracleMetaStoreDialect,
+    )
+
+    class CustomOracleScheme(Enum):
+        HIVE_ORACLE = HIVE_ORACLE_SCHEME
+
+    class CustomOracleConnection(OracleConnection):
+        scheme: Optional[CustomOracleScheme]
+
+    connection_copy = deepcopy(connection.__dict__)
+    connection_copy["scheme"] = CustomOracleScheme.HIVE_ORACLE
+
+    custom_connection = CustomOracleConnection(**connection_copy)
+
+    return create_generic_db_connection(
+        connection=custom_connection,
+        get_connection_url_fn=get_connection_url_common,
+        get_connection_args_fn=get_connection_args_common,
+    )
+
+
 def test_connection(
     metadata: OpenMetadata,
     engine: Engine,
@@ -210,16 +270,27 @@ def test_connection(
     metastore_conn = service_connection.metastoreConnection
 
     if metastore_conn:
-        if isinstance(metastore_conn, (PostgresConnection, MysqlConnection)):
+        if isinstance(
+            metastore_conn,
+            (PostgresConnection, MysqlConnection, MssqlConnection, OracleConnection),
+        ):
             engine = get_metastore_connection(metastore_conn)
         elif isinstance(metastore_conn, dict) and len(metastore_conn) > 0:
-            try:
-                service_connection.metastoreConnection = PostgresConnection.model_validate(metastore_conn)
-            except ValidationError:
+            for conn_cls in (
+                PostgresConnection,
+                MysqlConnection,
+                MssqlConnection,
+                OracleConnection,
+            ):
                 try:
-                    service_connection.metastoreConnection = MysqlConnection.model_validate(metastore_conn)
+                    service_connection.metastoreConnection = (
+                        conn_cls.model_validate(metastore_conn)
+                    )
+                    break
                 except ValidationError:
-                    raise ValueError("Invalid metastore connection")  # noqa: B904
+                    continue
+            else:
+                raise ValueError("Invalid metastore connection")
             engine = get_metastore_connection(service_connection.metastoreConnection)
 
     return test_connection_db_schema_sources(

--- a/ingestion/src/metadata/ingestion/source/database/hive/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/connection.py
@@ -120,9 +120,9 @@ def get_connection(connection: HiveConnection) -> Engine:
     if connection.kerberosServiceName:
         if not connection.connectionArguments:
             connection.connectionArguments = init_empty_connection_arguments()
-        connection.connectionArguments.root["kerberos_service_name"] = (
-            connection.kerberosServiceName
-        )
+        connection.connectionArguments.root[
+            "kerberos_service_name"
+        ] = connection.kerberosServiceName
 
     # SSL cert paths (ssl_ca_certs, ssl_certfile, ssl_keyfile) are set by ssl_manager.setup_ssl()
     # via SSLManager.create_temp_file(). Do not assign sslConfig fields here directly —
@@ -238,6 +238,9 @@ def _(connection: OracleConnection):
     from metadata.ingestion.source.database.hive.metastore_dialects.oracle import (  # nopycln: import
         HiveOracleMetaStoreDialect,
     )
+    from metadata.ingestion.source.database.oracle.connection import (
+        OracleConnection as OracleConnectionHandler,
+    )
 
     class CustomOracleScheme(Enum):
         HIVE_ORACLE = HIVE_ORACLE_SCHEME
@@ -252,7 +255,7 @@ def _(connection: OracleConnection):
 
     return create_generic_db_connection(
         connection=custom_connection,
-        get_connection_url_fn=get_connection_url_common,
+        get_connection_url_fn=OracleConnectionHandler.get_connection_url,
         get_connection_args_fn=get_connection_args_common,
     )
 

--- a/ingestion/src/metadata/ingestion/source/database/hive/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/connection.py
@@ -16,7 +16,7 @@ Source connection handler
 from copy import deepcopy
 from enum import Enum
 from functools import singledispatch
-from typing import Any, Optional
+from typing import Any
 from urllib.parse import quote_plus
 
 from pydantic import SecretStr, ValidationError
@@ -63,7 +63,9 @@ from metadata.utils.ssl_manager import check_ssl_and_init
 
 HIVE_POSTGRES_SCHEME = "hive+postgres"
 HIVE_MYSQL_SCHEME = "hive+mysql"
-HIVE_MSSQL_SCHEME = "hive+mssql"
+HIVE_MSSQL_PYODBC_SCHEME = "hive+mssql.pyodbc"
+HIVE_MSSQL_PYTDS_SCHEME = "hive+mssql.pytds"
+HIVE_MSSQL_PYMSSQL_SCHEME = "hive+mssql.pymssql"
 HIVE_ORACLE_SCHEME = "hive+oracle"
 
 # Monkey-patch the pyhive.hive module to use our custom connection
@@ -120,9 +122,7 @@ def get_connection(connection: HiveConnection) -> Engine:
     if connection.kerberosServiceName:
         if not connection.connectionArguments:
             connection.connectionArguments = init_empty_connection_arguments()
-        connection.connectionArguments.root[
-            "kerberos_service_name"
-        ] = connection.kerberosServiceName
+        connection.connectionArguments.root["kerberos_service_name"] = connection.kerberosServiceName
 
     # SSL cert paths (ssl_ca_certs, ssl_certfile, ssl_keyfile) are set by ssl_manager.setup_ssl()
     # via SSLManager.create_temp_file(). Do not assign sslConfig fields here directly —
@@ -145,6 +145,20 @@ def get_connection(connection: HiveConnection) -> Engine:
     )
 
 
+def get_mssql_metastore_connection_url(connection: MssqlConnection) -> str:
+    """
+    Build the Hive metastore MSSQL URL while preserving the configured DBAPI.
+    """
+    url = get_connection_url_common(connection)
+    scheme = connection.scheme.value if connection.scheme else None
+
+    if scheme == HIVE_MSSQL_PYODBC_SCHEME and connection.driver:
+        url += "&" if "?" in url else "?"
+        url += f"driver={quote_plus(connection.driver)}"
+
+    return url
+
+
 @singledispatch
 def get_metastore_connection(connection: Any) -> Engine:
     """
@@ -157,7 +171,7 @@ def get_metastore_connection(connection: Any) -> Engine:
 def _(connection: PostgresConnection):
     # import required to load sqlalchemy plugin
     # pylint: disable=import-outside-toplevel,unused-import
-    from metadata.ingestion.source.database.hive.metastore_dialects.postgres import (  # nopycln: import  # noqa: PLC0415
+    from metadata.ingestion.source.database.hive.metastore_dialects.postgres import (  # nopycln: import  # noqa: PLC0415, RUF100
         HivePostgresMetaStoreDialect,  # noqa: F401
     )
 
@@ -165,7 +179,7 @@ def _(connection: PostgresConnection):
         HIVE_POSTGRES = HIVE_POSTGRES_SCHEME
 
     class CustomPostgresConnection(PostgresConnection):
-        scheme: Optional[CustomPostgresScheme]  # noqa: UP045
+        scheme: CustomPostgresScheme | None
 
     connection_copy = deepcopy(connection.__dict__)
     connection_copy["scheme"] = CustomPostgresScheme.HIVE_POSTGRES
@@ -183,7 +197,7 @@ def _(connection: PostgresConnection):
 def _(connection: MysqlConnection):
     # import required to load sqlalchemy plugin
     # pylint: disable=import-outside-toplevel,unused-import
-    from metadata.ingestion.source.database.hive.metastore_dialects.mysql import (  # nopycln: import  # noqa: PLC0415
+    from metadata.ingestion.source.database.hive.metastore_dialects.mysql import (  # nopycln: import  # noqa: PLC0415, RUF100
         HiveMysqlMetaStoreDialect,  # noqa: F401
     )
 
@@ -191,7 +205,7 @@ def _(connection: MysqlConnection):
         HIVE_MYSQL = HIVE_MYSQL_SCHEME
 
     class CustomMysqlConnection(MysqlConnection):
-        scheme: Optional[CustomMysqlScheme]  # noqa: UP045
+        scheme: CustomMysqlScheme | None
 
     connection_copy = deepcopy(connection.__dict__)
     connection_copy["scheme"] = CustomMysqlScheme.HIVE_MYSQL
@@ -209,24 +223,35 @@ def _(connection: MysqlConnection):
 def _(connection: MssqlConnection):
     # import required to load sqlalchemy plugin
     # pylint: disable=import-outside-toplevel,unused-import
-    from metadata.ingestion.source.database.hive.metastore_dialects.mssql import (  # nopycln: import
-        HiveMssqlMetaStoreDialect,
+    from metadata.ingestion.source.database.hive.metastore_dialects.mssql import (  # nopycln: import  # noqa: PLC0415, RUF100
+        HiveMssqlMetaStoreDialect,  # noqa: F401
+        HiveMssqlPymssqlMetaStoreDialect,  # noqa: F401
+        HiveMssqlPyodbcMetaStoreDialect,  # noqa: F401
     )
 
     class CustomMssqlScheme(Enum):
-        HIVE_MSSQL = HIVE_MSSQL_SCHEME
+        HIVE_MSSQL_PYODBC = HIVE_MSSQL_PYODBC_SCHEME
+        HIVE_MSSQL_PYTDS = HIVE_MSSQL_PYTDS_SCHEME
+        HIVE_MSSQL_PYMSSQL = HIVE_MSSQL_PYMSSQL_SCHEME
 
     class CustomMssqlConnection(MssqlConnection):
-        scheme: Optional[CustomMssqlScheme]
+        scheme: CustomMssqlScheme | None  # pyright: ignore[reportIncompatibleVariableOverride]
 
-    connection_copy = deepcopy(connection.__dict__)
-    connection_copy["scheme"] = CustomMssqlScheme.HIVE_MSSQL
+    hive_scheme_by_mssql_scheme = {
+        "mssql+pyodbc": CustomMssqlScheme.HIVE_MSSQL_PYODBC,
+        "mssql+pytds": CustomMssqlScheme.HIVE_MSSQL_PYTDS,
+        "mssql+pymssql": CustomMssqlScheme.HIVE_MSSQL_PYMSSQL,
+    }
+    if not connection.scheme:
+        raise ValueError("MSSQL metastore connection scheme is required")
+    connection_copy: dict[str, Any] = dict(deepcopy(connection.__dict__))
+    connection_copy["scheme"] = hive_scheme_by_mssql_scheme[connection.scheme.value]
 
     custom_connection = CustomMssqlConnection(**connection_copy)
 
     return create_generic_db_connection(
         connection=custom_connection,
-        get_connection_url_fn=get_connection_url_common,
+        get_connection_url_fn=get_mssql_metastore_connection_url,
         get_connection_args_fn=get_connection_args_common,
     )
 
@@ -235,10 +260,10 @@ def _(connection: MssqlConnection):
 def _(connection: OracleConnection):
     # import required to load sqlalchemy plugin
     # pylint: disable=import-outside-toplevel,unused-import
-    from metadata.ingestion.source.database.hive.metastore_dialects.oracle import (  # nopycln: import
-        HiveOracleMetaStoreDialect,
+    from metadata.ingestion.source.database.hive.metastore_dialects.oracle import (  # nopycln: import  # noqa: PLC0415, RUF100
+        HiveOracleMetaStoreDialect,  # noqa: F401
     )
-    from metadata.ingestion.source.database.oracle.connection import (
+    from metadata.ingestion.source.database.oracle.connection import (  # noqa: PLC0415, RUF100
         OracleConnection as OracleConnectionHandler,
     )
 
@@ -246,9 +271,9 @@ def _(connection: OracleConnection):
         HIVE_ORACLE = HIVE_ORACLE_SCHEME
 
     class CustomOracleConnection(OracleConnection):
-        scheme: Optional[CustomOracleScheme]
+        scheme: CustomOracleScheme | None  # pyright: ignore[reportIncompatibleVariableOverride]
 
-    connection_copy = deepcopy(connection.__dict__)
+    connection_copy: dict[str, Any] = dict(deepcopy(connection.__dict__))
     connection_copy["scheme"] = CustomOracleScheme.HIVE_ORACLE
 
     custom_connection = CustomOracleConnection(**connection_copy)
@@ -264,8 +289,8 @@ def test_connection(
     metadata: OpenMetadata,
     engine: Engine,
     service_connection: HiveConnection,
-    automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
-    timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
+    automation_workflow: AutomationWorkflow | None = None,
+    timeout_seconds: int | None = THREE_MIN,
 ) -> TestConnectionResult:
     """
     Test connection. This can be executed either as part
@@ -277,7 +302,7 @@ def test_connection(
     if metastore_conn:
         if isinstance(
             metastore_conn,
-            (PostgresConnection, MysqlConnection, MssqlConnection, OracleConnection),
+            PostgresConnection | MysqlConnection | MssqlConnection | OracleConnection,
         ):
             engine = get_metastore_connection(metastore_conn)
         elif isinstance(metastore_conn, dict) and len(metastore_conn) > 0:
@@ -288,9 +313,7 @@ def test_connection(
                 OracleConnection,
             ):
                 try:
-                    service_connection.metastoreConnection = conn_cls.model_validate(
-                        metastore_conn
-                    )
+                    service_connection.metastoreConnection = conn_cls.model_validate(metastore_conn)
                     break
                 except ValidationError:
                     continue

--- a/ingestion/src/metadata/ingestion/source/database/hive/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/metadata.py
@@ -13,7 +13,6 @@ Hive source methods.
 """
 
 import traceback
-from typing import Optional, Tuple, Union  # noqa: UP035
 
 from pydantic import ValidationError
 from pyhive.sqlalchemy_hive import HiveDialect
@@ -72,23 +71,21 @@ class HiveSource(CommonDbSourceService):
     service_connection: HiveConnection
 
     @classmethod
-    def create(cls, config_dict, metadata: OpenMetadata, pipeline_name: Optional[str] = None):  # noqa: UP045
+    def create(cls, config_dict, metadata: OpenMetadata, pipeline_name: str | None = None):
         config = WorkflowSource.model_validate(config_dict)
         connection: HiveConnection = config.serviceConnection.root.config
         if not isinstance(connection, HiveConnection):
             raise InvalidSourceException(f"Expected HiveConnection, but got {connection}")
         return cls(config, metadata)
 
-    def _parse_version(self, version: str) -> Tuple:  # noqa: UP006
+    def _parse_version(self, version: str) -> tuple:
         if "-" in version:
             version = version.replace("-", ".")
         return tuple(map(int, (version.split(".")[:3])))
 
     def _get_validated_metastore_connection(
         self,
-    ) -> Optional[
-        Union[PostgresConnection, MysqlConnection, MssqlConnection, OracleConnection]
-    ]:  # noqa: UP007, UP045
+    ) -> PostgresConnection | MysqlConnection | MssqlConnection | OracleConnection | None:
         """
         Validate and return the metastore connection if it exists.
         Handles cases where the connection may be a raw dict that needs validation.
@@ -98,19 +95,18 @@ class HiveSource(CommonDbSourceService):
         if not metastore_conn:
             return None
 
-        # Supported metastore connection types
-        METASTORE_CONNECTION_TYPES = (
+        metastore_connection_types = (
             PostgresConnection,
             MysqlConnection,
             MssqlConnection,
             OracleConnection,
         )
 
-        if isinstance(metastore_conn, METASTORE_CONNECTION_TYPES):
+        if isinstance(metastore_conn, metastore_connection_types):
             return metastore_conn
 
         if isinstance(metastore_conn, dict) and len(metastore_conn) > 0:
-            for conn_cls in METASTORE_CONNECTION_TYPES:
+            for conn_cls in metastore_connection_types:
                 try:
                     return conn_cls.model_validate(metastore_conn)
                 except ValidationError:
@@ -147,7 +143,7 @@ class HiveSource(CommonDbSourceService):
 
     def get_schema_definition(  # pylint: disable=unused-argument
         self, table_type: str, table_name: str, schema_name: str, inspector: Inspector
-    ) -> Optional[str]:  # noqa: UP045
+    ) -> str | None:
         """
         Get the DDL statement or View Definition for a table
         """

--- a/ingestion/src/metadata/ingestion/source/database/hive/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/metadata.py
@@ -24,8 +24,14 @@ from metadata.generated.schema.entity.data.table import TableType
 from metadata.generated.schema.entity.services.connections.database.hiveConnection import (
     HiveConnection,
 )
+from metadata.generated.schema.entity.services.connections.database.mssqlConnection import (
+    MssqlConnection,
+)
 from metadata.generated.schema.entity.services.connections.database.mysqlConnection import (
     MysqlConnection,
+)
+from metadata.generated.schema.entity.services.connections.database.oracleConnection import (
+    OracleConnection,
 )
 from metadata.generated.schema.entity.services.connections.database.postgresConnection import (
     PostgresConnection,
@@ -80,7 +86,9 @@ class HiveSource(CommonDbSourceService):
 
     def _get_validated_metastore_connection(
         self,
-    ) -> Optional[Union[PostgresConnection, MysqlConnection]]:  # noqa: UP007, UP045
+    ) -> Optional[
+        Union[PostgresConnection, MysqlConnection, MssqlConnection, OracleConnection]
+    ]:  # noqa: UP007, UP045
         """
         Validate and return the metastore connection if it exists.
         Handles cases where the connection may be a raw dict that needs validation.
@@ -90,18 +98,25 @@ class HiveSource(CommonDbSourceService):
         if not metastore_conn:
             return None
 
-        if isinstance(metastore_conn, (PostgresConnection, MysqlConnection)):
+        if isinstance(
+            metastore_conn,
+            (PostgresConnection, MysqlConnection, MssqlConnection, OracleConnection),
+        ):
             return metastore_conn
 
         if isinstance(metastore_conn, dict) and len(metastore_conn) > 0:
-            try:
-                return PostgresConnection.model_validate(metastore_conn)
-            except ValidationError:
+            for conn_cls in (
+                PostgresConnection,
+                MysqlConnection,
+                MssqlConnection,
+                OracleConnection,
+            ):
                 try:
-                    return MysqlConnection.model_validate(metastore_conn)
+                    return conn_cls.model_validate(metastore_conn)
                 except ValidationError:
-                    logger.warning("Invalid metastore connection configuration")
-                    return None
+                    continue
+            logger.warning("Invalid metastore connection configuration")
+            return None
 
         return None
 

--- a/ingestion/src/metadata/ingestion/source/database/hive/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/metadata.py
@@ -98,19 +98,19 @@ class HiveSource(CommonDbSourceService):
         if not metastore_conn:
             return None
 
-        if isinstance(
-            metastore_conn,
-            (PostgresConnection, MysqlConnection, MssqlConnection, OracleConnection),
-        ):
+        # Supported metastore connection types
+        METASTORE_CONNECTION_TYPES = (
+            PostgresConnection,
+            MysqlConnection,
+            MssqlConnection,
+            OracleConnection,
+        )
+
+        if isinstance(metastore_conn, METASTORE_CONNECTION_TYPES):
             return metastore_conn
 
         if isinstance(metastore_conn, dict) and len(metastore_conn) > 0:
-            for conn_cls in (
-                PostgresConnection,
-                MysqlConnection,
-                MssqlConnection,
-                OracleConnection,
-            ):
+            for conn_cls in METASTORE_CONNECTION_TYPES:
                 try:
                     return conn_cls.model_validate(metastore_conn)
                 except ValidationError:

--- a/ingestion/src/metadata/ingestion/source/database/hive/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/metadata.py
@@ -14,7 +14,6 @@ Hive source methods.
 
 import traceback
 
-from pydantic import ValidationError
 from pyhive.sqlalchemy_hive import HiveDialect
 from sqlalchemy import text
 from sqlalchemy.engine.reflection import Inspector
@@ -41,7 +40,10 @@ from metadata.generated.schema.metadataIngestion.workflow import (
 from metadata.ingestion.api.steps import InvalidSourceException
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.database.common_db_source import CommonDbSourceService
-from metadata.ingestion.source.database.hive.connection import get_metastore_connection
+from metadata.ingestion.source.database.hive.connection import (
+    get_metastore_connection,
+    get_validated_metastore_connection,
+)
 from metadata.ingestion.source.database.hive.utils import (
     get_columns,
     get_table_comment,
@@ -95,26 +97,11 @@ class HiveSource(CommonDbSourceService):
         if not metastore_conn:
             return None
 
-        metastore_connection_types = (
-            PostgresConnection,
-            MysqlConnection,
-            MssqlConnection,
-            OracleConnection,
-        )
-
-        if isinstance(metastore_conn, metastore_connection_types):
-            return metastore_conn
-
-        if isinstance(metastore_conn, dict) and len(metastore_conn) > 0:
-            for conn_cls in metastore_connection_types:
-                try:
-                    return conn_cls.model_validate(metastore_conn)
-                except ValidationError:
-                    continue
+        metastore_conn = get_validated_metastore_connection(metastore_conn)
+        if not metastore_conn:
             logger.warning("Invalid metastore connection configuration")
-            return None
 
-        return None
+        return metastore_conn
 
     def prepare(self):
         """

--- a/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/mssql/__init__.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/mssql/__init__.py
@@ -11,6 +11,7 @@
 """
 Hive Metastore MSSQL Dialect
 """
+
 from sqlalchemy.dialects import registry
 
 from .dialect import HiveMssqlMetaStoreDialect

--- a/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/mssql/__init__.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/mssql/__init__.py
@@ -14,12 +14,35 @@ Hive Metastore MSSQL Dialect
 
 from sqlalchemy.dialects import registry
 
-from .dialect import HiveMssqlMetaStoreDialect
+from metadata.ingestion.source.database.hive.metastore_dialects.mssql.dialect import (
+    HiveMssqlMetaStoreDialect,
+    HiveMssqlPymssqlMetaStoreDialect,
+    HiveMssqlPyodbcMetaStoreDialect,
+)
 
 __version__ = "0.1.0"
-__all__ = ["HiveMssqlMetaStoreDialect"]
+__all__ = [
+    "HiveMssqlMetaStoreDialect",
+    "HiveMssqlPymssqlMetaStoreDialect",
+    "HiveMssqlPyodbcMetaStoreDialect",
+]
 registry.register(
     "hive.mssql",
     "metadata.ingestion.source.database.hive.metastore_dialects.mssql.dialect",
     "HiveMssqlMetaStoreDialect",
+)
+registry.register(
+    "hive.mssql.pytds",
+    "metadata.ingestion.source.database.hive.metastore_dialects.mssql.dialect",
+    "HiveMssqlMetaStoreDialect",
+)
+registry.register(
+    "hive.mssql.pyodbc",
+    "metadata.ingestion.source.database.hive.metastore_dialects.mssql.dialect",
+    "HiveMssqlPyodbcMetaStoreDialect",
+)
+registry.register(
+    "hive.mssql.pymssql",
+    "metadata.ingestion.source.database.hive.metastore_dialects.mssql.dialect",
+    "HiveMssqlPymssqlMetaStoreDialect",
 )

--- a/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/mssql/__init__.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/mssql/__init__.py
@@ -1,0 +1,24 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Hive Metastore MSSQL Dialect
+"""
+from sqlalchemy.dialects import registry
+
+from .dialect import HiveMssqlMetaStoreDialect
+
+__version__ = "0.1.0"
+__all__ = ["HiveMssqlMetaStoreDialect"]
+registry.register(
+    "hive.mssql",
+    "metadata.ingestion.source.database.hive.metastore_dialects.mssql.dialect",
+    "HiveMssqlMetaStoreDialect",
+)

--- a/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/mssql/dialect.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/mssql/dialect.py
@@ -31,7 +31,7 @@ logger = ingestion_logger()
 class HiveMssqlMetaStoreDialect(HiveMetaStoreDialectMixin, MSDialect_pyodbc):
     """
     MSSQL metastore dialect class for Hive metastore backed by SQL Server.
-    Uses square-bracket quoting compatible with MSSQL and supports CTEs.
+    Uses unquoted identifiers and supports CTEs.
     """
 
     name = "hive"
@@ -115,7 +115,7 @@ class HiveMssqlMetaStoreDialect(HiveMetaStoreDialectMixin, MSDialect_pyodbc):
                 tbls.VIEW_ORIGINAL_TEXT AS view_def
             FROM TBLS tbls
             JOIN DBS dbs ON tbls.DB_ID = dbs.DB_ID
-            WHERE tbls.VIEW_ORIGINAL_TEXT IS NOT NULL;
+            WHERE tbls.VIEW_ORIGINAL_TEXT IS NOT NULL
         """
         return get_view_definition_wrapper(
             self,

--- a/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/mssql/dialect.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/mssql/dialect.py
@@ -1,0 +1,150 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Hive Metastore MSSQL Dialect Mixin
+"""
+from sqlalchemy import text
+from sqlalchemy.dialects.mssql.pyodbc import MSDialect_pyodbc
+from sqlalchemy.engine import reflection
+
+from metadata.ingestion.source.database.hive.metastore_dialects.mixin import (
+    HiveMetaStoreDialectMixin,
+)
+from metadata.utils.logger import ingestion_logger
+from metadata.utils.sqlalchemy_utils import (
+    get_table_comment_wrapper,
+    get_view_definition_wrapper,
+)
+
+logger = ingestion_logger()
+
+
+# pylint: disable=abstract-method
+class HiveMssqlMetaStoreDialect(HiveMetaStoreDialectMixin, MSDialect_pyodbc):
+    """
+    MSSQL metastore dialect class for Hive metastore backed by SQL Server.
+    Uses square-bracket quoting compatible with MSSQL and supports CTEs.
+    """
+
+    name = "hive"
+    driver = "mssql"
+    supports_statement_cache = False
+
+    def get_schema_names(self, connection, **kw):
+        # Equivalent to SHOW DATABASES
+        schema_names = [
+            row[0] for row in connection.execute(text("SELECT NAME FROM DBS;"))
+        ]
+        logger.debug(f"Fetched schema names: {schema_names}")
+        return schema_names
+
+    # pylint: disable=arguments-differ
+    def get_view_names(self, connection, schema=None, **kw):
+        query = self._get_table_names_base_query(schema=schema)
+        query += " WHERE TBL_TYPE = 'VIRTUAL_VIEW'"
+        view_names = [row[0] for row in connection.execute(text(query))]
+        logger.debug(f"Fetched view names for schema '{schema}': {view_names}")
+        return view_names
+
+    def _get_table_columns(self, connection, table_name, schema):
+        schema_join = (
+            f"""
+            JOIN DBS db ON tbsl.DB_ID = db.DB_ID
+            AND db.NAME = '{schema}'
+        """
+            if schema
+            else ""
+        )
+
+        query = f"""
+            WITH regular_columns AS (
+                SELECT
+                    col.COLUMN_NAME,
+                    col.TYPE_NAME,
+                    col.COMMENT
+                FROM COLUMNS_V2 col
+                JOIN CDS cds ON col.CD_ID = cds.CD_ID
+                JOIN SDS sds ON sds.CD_ID = cds.CD_ID
+                JOIN TBLS tbsl ON sds.SD_ID = tbsl.SD_ID
+                    AND tbsl.TBL_NAME = '{table_name}'
+                {schema_join}
+            ),
+            partition_columns AS (
+                SELECT
+                    pk.PKEY_NAME AS COLUMN_NAME,
+                    pk.PKEY_TYPE AS TYPE_NAME,
+                    pk.PKEY_COMMENT AS COMMENT
+                FROM PARTITION_KEYS pk
+                JOIN TBLS tbsl ON pk.TBL_ID = tbsl.TBL_ID
+                    AND tbsl.TBL_NAME = '{table_name}'
+                {schema_join}
+            )
+            SELECT * FROM regular_columns
+            UNION ALL
+            SELECT * FROM partition_columns
+        """
+        return connection.execute(text(query)).fetchall()
+
+    def _get_table_names_base_query(self, schema=None):
+        query = "SELECT TBL_NAME FROM TBLS tbl"
+        if schema:
+            query += f" JOIN DBS db ON tbl.DB_ID = db.DB_ID AND db.NAME = '{schema}'"
+        return query
+
+    def get_table_names(self, connection, schema=None, **kw):
+        query = self._get_table_names_base_query(schema=schema)
+        query += " WHERE (TBL_TYPE != 'VIRTUAL_VIEW' OR TBL_TYPE IS NULL)"
+        table_names = [row[0] for row in connection.execute(text(query))]
+        logger.debug(f"Fetched table names for schema '{schema}': {table_names}")
+        return table_names
+
+    @reflection.cache
+    def get_view_definition(self, connection, view_name, schema=None, **kw):
+        query = """
+            SELECT
+                dbs.NAME AS [schema],
+                tbls.TBL_NAME AS view_name,
+                tbls.VIEW_ORIGINAL_TEXT AS view_def
+            FROM TBLS tbls
+            JOIN DBS dbs ON tbls.DB_ID = dbs.DB_ID
+            WHERE tbls.VIEW_ORIGINAL_TEXT IS NOT NULL;
+        """
+        return get_view_definition_wrapper(
+            self,
+            connection,
+            table_name=view_name,
+            schema=schema,
+            query=query,
+        )
+
+    @reflection.cache
+    def get_table_comment(self, connection, table_name, schema=None, **kw):
+        query = """
+            SELECT
+                DBS.NAME AS [schema],
+                TBLS.TBL_NAME AS table_name,
+                TABLE_PARAMS.PARAM_VALUE AS table_comment
+            FROM DBS
+            JOIN TBLS ON DBS.DB_ID = TBLS.DB_ID
+            LEFT JOIN TABLE_PARAMS ON TBLS.TBL_ID = TABLE_PARAMS.TBL_ID
+                AND TABLE_PARAMS.PARAM_KEY = 'comment'
+        """
+        return get_table_comment_wrapper(
+            self,
+            connection,
+            table_name=table_name,
+            schema=schema,
+            query=query,
+        )
+
+    # pylint: disable=arguments-renamed
+    def get_dialect_cls(self):
+        return HiveMssqlMetaStoreDialect

--- a/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/mssql/dialect.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/mssql/dialect.py
@@ -11,6 +11,7 @@
 """
 Hive Metastore MSSQL Dialect Mixin
 """
+
 from sqlalchemy import text
 from sqlalchemy.dialects.mssql.pyodbc import MSDialect_pyodbc
 from sqlalchemy.engine import reflection
@@ -41,7 +42,7 @@ class HiveMssqlMetaStoreDialect(HiveMetaStoreDialectMixin, MSDialect_pyodbc):
     def get_schema_names(self, connection, **kw):
         # Equivalent to SHOW DATABASES
         schema_names = [
-            row[0] for row in connection.execute(text("SELECT NAME FROM DBS;"))
+            row[0] for row in connection.execute(text("SELECT NAME FROM DBS"))
         ]
         logger.debug(f"Fetched schema names: {schema_names}")
         return schema_names

--- a/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/mssql/dialect.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/mssql/dialect.py
@@ -13,7 +13,7 @@ Hive Metastore MSSQL Dialect Mixin
 """
 
 from sqlalchemy import text
-from sqlalchemy.dialects.mssql.pyodbc import MSDialect_pyodbc
+from sqlalchemy.dialects.mssql.base import MSDialect
 from sqlalchemy.engine import reflection
 
 from metadata.ingestion.source.database.hive.metastore_dialects.mixin import (
@@ -29,7 +29,7 @@ logger = ingestion_logger()
 
 
 # pylint: disable=abstract-method
-class HiveMssqlMetaStoreDialect(HiveMetaStoreDialectMixin, MSDialect_pyodbc):
+class HiveMssqlMetaStoreDialect(HiveMetaStoreDialectMixin, MSDialect):
     """
     MSSQL metastore dialect class for Hive metastore backed by SQL Server.
     Uses unquoted identifiers and supports CTEs.
@@ -49,21 +49,24 @@ class HiveMssqlMetaStoreDialect(HiveMetaStoreDialectMixin, MSDialect_pyodbc):
 
     # pylint: disable=arguments-differ
     def get_view_names(self, connection, schema=None, **kw):
-        query = self._get_table_names_base_query(schema=schema)
+        query, params = self._get_table_names_base_query(schema=schema)
         query += " WHERE TBL_TYPE = 'VIRTUAL_VIEW'"
-        view_names = [row[0] for row in connection.execute(text(query))]
+        view_names = [row[0] for row in connection.execute(text(query), params)]
         logger.debug(f"Fetched view names for schema '{schema}': {view_names}")
         return view_names
 
     def _get_table_columns(self, connection, table_name, schema):
+        params = {"table_name": table_name}
         schema_join = (
-            f"""
+            """
             JOIN DBS db ON tbsl.DB_ID = db.DB_ID
-            AND db.NAME = '{schema}'
+            AND db.NAME = :schema
         """
             if schema
             else ""
         )
+        if schema:
+            params["schema"] = schema
 
         query = f"""
             WITH regular_columns AS (
@@ -75,7 +78,7 @@ class HiveMssqlMetaStoreDialect(HiveMetaStoreDialectMixin, MSDialect_pyodbc):
                 JOIN CDS cds ON col.CD_ID = cds.CD_ID
                 JOIN SDS sds ON sds.CD_ID = cds.CD_ID
                 JOIN TBLS tbsl ON sds.SD_ID = tbsl.SD_ID
-                    AND tbsl.TBL_NAME = '{table_name}'
+                    AND tbsl.TBL_NAME = :table_name
                 {schema_join}
             ),
             partition_columns AS (
@@ -85,25 +88,27 @@ class HiveMssqlMetaStoreDialect(HiveMetaStoreDialectMixin, MSDialect_pyodbc):
                     pk.PKEY_COMMENT AS COMMENT
                 FROM PARTITION_KEYS pk
                 JOIN TBLS tbsl ON pk.TBL_ID = tbsl.TBL_ID
-                    AND tbsl.TBL_NAME = '{table_name}'
+                    AND tbsl.TBL_NAME = :table_name
                 {schema_join}
             )
             SELECT * FROM regular_columns
             UNION ALL
             SELECT * FROM partition_columns
         """
-        return connection.execute(text(query)).fetchall()
+        return connection.execute(text(query), params).fetchall()
 
     def _get_table_names_base_query(self, schema=None):
         query = "SELECT TBL_NAME FROM TBLS tbl"
+        params = {}
         if schema:
-            query += f" JOIN DBS db ON tbl.DB_ID = db.DB_ID AND db.NAME = '{schema}'"
-        return query
+            query += " JOIN DBS db ON tbl.DB_ID = db.DB_ID AND db.NAME = :schema"
+            params["schema"] = schema
+        return query, params
 
     def get_table_names(self, connection, schema=None, **kw):
-        query = self._get_table_names_base_query(schema=schema)
+        query, params = self._get_table_names_base_query(schema=schema)
         query += " WHERE (TBL_TYPE != 'VIRTUAL_VIEW' OR TBL_TYPE IS NULL)"
-        table_names = [row[0] for row in connection.execute(text(query))]
+        table_names = [row[0] for row in connection.execute(text(query), params)]
         logger.debug(f"Fetched table names for schema '{schema}': {table_names}")
         return table_names
 

--- a/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/mssql/dialect.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/mssql/dialect.py
@@ -8,13 +8,16 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+# pyright: reportIncompatibleMethodOverride=false
 """
 Hive Metastore MSSQL Dialect Mixin
 """
 
 from sqlalchemy import text
-from sqlalchemy.dialects.mssql.base import MSDialect
+from sqlalchemy.dialects.mssql.pymssql import MSDialect_pymssql
+from sqlalchemy.dialects.mssql.pyodbc import MSDialect_pyodbc
 from sqlalchemy.engine import reflection
+from sqlalchemy_pytds.dialect import MSDialect_pytds
 
 from metadata.ingestion.source.database.hive.metastore_dialects.mixin import (
     HiveMetaStoreDialectMixin,
@@ -29,21 +32,18 @@ logger = ingestion_logger()
 
 
 # pylint: disable=abstract-method
-class HiveMssqlMetaStoreDialect(HiveMetaStoreDialectMixin, MSDialect):
+class HiveMssqlMetaStoreDialectMixin(HiveMetaStoreDialectMixin):
     """
-    MSSQL metastore dialect class for Hive metastore backed by SQL Server.
+    MSSQL metastore dialect mixin for Hive metastore backed by SQL Server.
     Uses unquoted identifiers and supports CTEs.
     """
 
     name = "hive"
-    driver = "mssql"
     supports_statement_cache = False
 
     def get_schema_names(self, connection, **kw):
         # Equivalent to SHOW DATABASES
-        schema_names = [
-            row[0] for row in connection.execute(text("SELECT NAME FROM DBS"))
-        ]
+        schema_names = [row[0] for row in connection.execute(text("SELECT NAME FROM DBS"))]
         logger.debug(f"Fetched schema names: {schema_names}")
         return schema_names
 
@@ -153,4 +153,28 @@ class HiveMssqlMetaStoreDialect(HiveMetaStoreDialectMixin, MSDialect):
 
     # pylint: disable=arguments-renamed
     def get_dialect_cls(self):
-        return HiveMssqlMetaStoreDialect
+        return type(self)
+
+
+class HiveMssqlMetaStoreDialect(HiveMssqlMetaStoreDialectMixin, MSDialect_pytds):
+    """
+    MSSQL metastore dialect using the default pytds driver.
+    """
+
+    driver = "mssql.pytds"
+
+
+class HiveMssqlPyodbcMetaStoreDialect(HiveMssqlMetaStoreDialectMixin, MSDialect_pyodbc):
+    """
+    MSSQL metastore dialect using the pyodbc driver.
+    """
+
+    driver = "mssql.pyodbc"
+
+
+class HiveMssqlPymssqlMetaStoreDialect(HiveMssqlMetaStoreDialectMixin, MSDialect_pymssql):
+    """
+    MSSQL metastore dialect using the pymssql driver.
+    """
+
+    driver = "mssql.pymssql"

--- a/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/mysql/dialect.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/mysql/dialect.py
@@ -47,21 +47,24 @@ class HiveMysqlMetaStoreDialect(HiveMetaStoreDialectMixin, MySQLDialect_pymysql)
     def get_view_names(self, connection, schema=None, **kw):
         # Hive does not provide functionality to query tableType
         # This allows reflection to not crash at the cost of being inaccurate
-        query = self._get_table_names_base_query(schema=schema)
+        query, params = self._get_table_names_base_query(schema=schema)
         query += """ WHERE TBL_TYPE = 'VIRTUAL_VIEW'"""
-        view_names = [row[0] for row in connection.execute(text(query))]
+        view_names = [row[0] for row in connection.execute(text(query), params)]
         logger.debug(f"Fetched view names for schema '{schema}': {view_names}")
         return view_names
 
     def _get_table_columns(self, connection, table_name, schema):
+        params = {"table_name": table_name}
         schema_join = (
-            f"""
+            """
             JOIN DBS db on tbsl.DB_ID = db.DB_ID
-            AND db.NAME = '{schema}'
+            AND db.NAME = :schema
         """
             if schema
             else ""
         )
+        if schema:
+            params["schema"] = schema
 
         # Rewritten to avoid CTE syntax for MySQL < 8.0 compatibility
         # Using direct UNION ALL of subqueries instead of WITH clause
@@ -74,7 +77,7 @@ class HiveMysqlMetaStoreDialect(HiveMetaStoreDialectMixin, MySQLDialect_pymysql)
             JOIN CDS cds ON col.CD_ID = cds.CD_ID
             JOIN SDS sds ON sds.CD_ID = cds.CD_ID
             JOIN TBLS tbsl ON sds.SD_ID = tbsl.SD_ID
-                AND tbsl.TBL_NAME = '{table_name}'
+                AND tbsl.TBL_NAME = :table_name
             {schema_join}
             UNION ALL
             SELECT 
@@ -83,23 +86,25 @@ class HiveMysqlMetaStoreDialect(HiveMetaStoreDialectMixin, MySQLDialect_pymysql)
                 pk.PKEY_COMMENT as COMMENT
             FROM PARTITION_KEYS pk
             JOIN TBLS tbsl ON pk.TBL_ID = tbsl.TBL_ID
-                AND tbsl.TBL_NAME = '{table_name}'
+                AND tbsl.TBL_NAME = :table_name
             {schema_join}
         """  # noqa: W291
 
-        return connection.execute(text(query)).fetchall()
+        return connection.execute(text(query), params).fetchall()
 
     def _get_table_names_base_query(self, schema=None):
         query = "SELECT TBL_NAME from TBLS tbl"
+        params = {}
         if schema:
-            query += f""" JOIN DBS db on tbl.DB_ID = db.DB_ID
-            and db.NAME = '{schema}'"""
-        return query
+            query += """ JOIN DBS db on tbl.DB_ID = db.DB_ID
+            and db.NAME = :schema"""
+            params["schema"] = schema
+        return query, params
 
     def get_table_names(self, connection, schema=None, **kw):
-        query = self._get_table_names_base_query(schema=schema)
+        query, params = self._get_table_names_base_query(schema=schema)
         query += """ WHERE (TBL_TYPE != 'VIRTUAL_VIEW' OR TBL_TYPE IS NULL)"""
-        table_names = [row[0] for row in connection.execute(text(query))]
+        table_names = [row[0] for row in connection.execute(text(query), params)]
         logger.debug(f"Fetched table names for schema '{schema}': {table_names}")
         return table_names
 

--- a/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/oracle/__init__.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/oracle/__init__.py
@@ -1,0 +1,24 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Hive Metastore Oracle Dialect
+"""
+from sqlalchemy.dialects import registry
+
+from .dialect import HiveOracleMetaStoreDialect
+
+__version__ = "0.1.0"
+__all__ = ["HiveOracleMetaStoreDialect"]
+registry.register(
+    "hive.oracle",
+    "metadata.ingestion.source.database.hive.metastore_dialects.oracle.dialect",
+    "HiveOracleMetaStoreDialect",
+)

--- a/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/oracle/__init__.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/oracle/__init__.py
@@ -14,7 +14,9 @@ Hive Metastore Oracle Dialect
 
 from sqlalchemy.dialects import registry
 
-from .dialect import HiveOracleMetaStoreDialect
+from metadata.ingestion.source.database.hive.metastore_dialects.oracle.dialect import (
+    HiveOracleMetaStoreDialect,
+)
 
 __version__ = "0.1.0"
 __all__ = ["HiveOracleMetaStoreDialect"]

--- a/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/oracle/__init__.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/oracle/__init__.py
@@ -11,6 +11,7 @@
 """
 Hive Metastore Oracle Dialect
 """
+
 from sqlalchemy.dialects import registry
 
 from .dialect import HiveOracleMetaStoreDialect

--- a/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/oracle/dialect.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/oracle/dialect.py
@@ -8,6 +8,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+# pyright: reportIncompatibleMethodOverride=false
 """
 Hive Metastore Oracle Dialect Mixin
 """
@@ -41,9 +42,7 @@ class HiveOracleMetaStoreDialect(HiveMetaStoreDialectMixin, OracleDialect_cx_ora
 
     def get_schema_names(self, connection, **kw):
         # Equivalent to SHOW DATABASES
-        schema_names = [
-            row[0] for row in connection.execute(text('SELECT "NAME" FROM "DBS"'))
-        ]
+        schema_names = [row[0] for row in connection.execute(text('SELECT "NAME" FROM "DBS"'))]
         logger.debug(f"Fetched schema names: {schema_names}")
         return schema_names
 

--- a/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/oracle/dialect.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/oracle/dialect.py
@@ -49,21 +49,24 @@ class HiveOracleMetaStoreDialect(HiveMetaStoreDialectMixin, OracleDialect_cx_ora
 
     # pylint: disable=arguments-differ
     def get_view_names(self, connection, schema=None, **kw):
-        query = self._get_table_names_base_query(schema=schema)
+        query, params = self._get_table_names_base_query(schema=schema)
         query += """ WHERE "TBL_TYPE" = 'VIRTUAL_VIEW'"""
-        view_names = [row[0] for row in connection.execute(text(query))]
+        view_names = [row[0] for row in connection.execute(text(query), params)]
         logger.debug(f"Fetched view names for schema '{schema}': {view_names}")
         return view_names
 
     def _get_table_columns(self, connection, table_name, schema):
+        params = {"table_name": table_name}
         schema_join = (
-            f"""
+            """
             JOIN "DBS" db ON tbsl."DB_ID" = db."DB_ID"
-            AND db."NAME" = '{schema}'
+            AND db."NAME" = :schema
         """
             if schema
             else ""
         )
+        if schema:
+            params["schema"] = schema
 
         query = f"""
             WITH regular_columns AS (
@@ -75,7 +78,7 @@ class HiveOracleMetaStoreDialect(HiveMetaStoreDialectMixin, OracleDialect_cx_ora
                 JOIN "CDS" cds ON col."CD_ID" = cds."CD_ID"
                 JOIN "SDS" sds ON sds."CD_ID" = cds."CD_ID"
                 JOIN "TBLS" tbsl ON sds."SD_ID" = tbsl."SD_ID"
-                    AND tbsl."TBL_NAME" = '{table_name}'
+                    AND tbsl."TBL_NAME" = :table_name
                 {schema_join}
             ),
             partition_columns AS (
@@ -85,26 +88,28 @@ class HiveOracleMetaStoreDialect(HiveMetaStoreDialectMixin, OracleDialect_cx_ora
                     pk."PKEY_COMMENT" AS "COMMENT"
                 FROM "PARTITION_KEYS" pk
                 JOIN "TBLS" tbsl ON pk."TBL_ID" = tbsl."TBL_ID"
-                    AND tbsl."TBL_NAME" = '{table_name}'
+                    AND tbsl."TBL_NAME" = :table_name
                 {schema_join}
             )
             SELECT * FROM regular_columns
             UNION ALL
             SELECT * FROM partition_columns
         """
-        return connection.execute(text(query)).fetchall()
+        return connection.execute(text(query), params).fetchall()
 
     def _get_table_names_base_query(self, schema=None):
         query = 'SELECT "TBL_NAME" FROM "TBLS" tbl'
+        params = {}
         if schema:
-            query += f""" JOIN "DBS" db ON tbl."DB_ID" = db."DB_ID"
-            AND db."NAME" = '{schema}'"""
-        return query
+            query += """ JOIN "DBS" db ON tbl."DB_ID" = db."DB_ID"
+            AND db."NAME" = :schema"""
+            params["schema"] = schema
+        return query, params
 
     def get_table_names(self, connection, schema=None, **kw):
-        query = self._get_table_names_base_query(schema=schema)
+        query, params = self._get_table_names_base_query(schema=schema)
         query += """ WHERE ("TBL_TYPE" != 'VIRTUAL_VIEW' OR "TBL_TYPE" IS NULL)"""
-        table_names = [row[0] for row in connection.execute(text(query))]
+        table_names = [row[0] for row in connection.execute(text(query), params)]
         logger.debug(f"Fetched table names for schema '{schema}': {table_names}")
         return table_names
 

--- a/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/oracle/dialect.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/oracle/dialect.py
@@ -11,6 +11,7 @@
 """
 Hive Metastore Oracle Dialect Mixin
 """
+
 from sqlalchemy import text
 from sqlalchemy.dialects.oracle.cx_oracle import OracleDialect_cx_oracle
 from sqlalchemy.engine import reflection

--- a/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/oracle/dialect.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/oracle/dialect.py
@@ -1,0 +1,151 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Hive Metastore Oracle Dialect Mixin
+"""
+from sqlalchemy import text
+from sqlalchemy.dialects.oracle.cx_oracle import OracleDialect_cx_oracle
+from sqlalchemy.engine import reflection
+
+from metadata.ingestion.source.database.hive.metastore_dialects.mixin import (
+    HiveMetaStoreDialectMixin,
+)
+from metadata.utils.logger import ingestion_logger
+from metadata.utils.sqlalchemy_utils import (
+    get_table_comment_wrapper,
+    get_view_definition_wrapper,
+)
+
+logger = ingestion_logger()
+
+
+# pylint: disable=abstract-method
+class HiveOracleMetaStoreDialect(HiveMetaStoreDialectMixin, OracleDialect_cx_oracle):
+    """
+    Oracle metastore dialect class for Hive metastore backed by Oracle Database.
+    Uses double-quote identifiers compatible with Oracle and supports CTEs.
+    """
+
+    name = "hive"
+    driver = "oracle"
+    supports_statement_cache = False
+
+    def get_schema_names(self, connection, **kw):
+        # Equivalent to SHOW DATABASES
+        schema_names = [
+            row[0] for row in connection.execute(text('SELECT "NAME" FROM "DBS"'))
+        ]
+        logger.debug(f"Fetched schema names: {schema_names}")
+        return schema_names
+
+    # pylint: disable=arguments-differ
+    def get_view_names(self, connection, schema=None, **kw):
+        query = self._get_table_names_base_query(schema=schema)
+        query += """ WHERE "TBL_TYPE" = 'VIRTUAL_VIEW'"""
+        view_names = [row[0] for row in connection.execute(text(query))]
+        logger.debug(f"Fetched view names for schema '{schema}': {view_names}")
+        return view_names
+
+    def _get_table_columns(self, connection, table_name, schema):
+        schema_join = (
+            f"""
+            JOIN "DBS" db ON tbsl."DB_ID" = db."DB_ID"
+            AND db."NAME" = '{schema}'
+        """
+            if schema
+            else ""
+        )
+
+        query = f"""
+            WITH regular_columns AS (
+                SELECT
+                    col."COLUMN_NAME",
+                    col."TYPE_NAME",
+                    col."COMMENT"
+                FROM "COLUMNS_V2" col
+                JOIN "CDS" cds ON col."CD_ID" = cds."CD_ID"
+                JOIN "SDS" sds ON sds."CD_ID" = cds."CD_ID"
+                JOIN "TBLS" tbsl ON sds."SD_ID" = tbsl."SD_ID"
+                    AND tbsl."TBL_NAME" = '{table_name}'
+                {schema_join}
+            ),
+            partition_columns AS (
+                SELECT
+                    pk."PKEY_NAME" AS "COLUMN_NAME",
+                    pk."PKEY_TYPE" AS "TYPE_NAME",
+                    pk."PKEY_COMMENT" AS "COMMENT"
+                FROM "PARTITION_KEYS" pk
+                JOIN "TBLS" tbsl ON pk."TBL_ID" = tbsl."TBL_ID"
+                    AND tbsl."TBL_NAME" = '{table_name}'
+                {schema_join}
+            )
+            SELECT * FROM regular_columns
+            UNION ALL
+            SELECT * FROM partition_columns
+        """
+        return connection.execute(text(query)).fetchall()
+
+    def _get_table_names_base_query(self, schema=None):
+        query = 'SELECT "TBL_NAME" FROM "TBLS" tbl'
+        if schema:
+            query += f""" JOIN "DBS" db ON tbl."DB_ID" = db."DB_ID"
+            AND db."NAME" = '{schema}'"""
+        return query
+
+    def get_table_names(self, connection, schema=None, **kw):
+        query = self._get_table_names_base_query(schema=schema)
+        query += """ WHERE ("TBL_TYPE" != 'VIRTUAL_VIEW' OR "TBL_TYPE" IS NULL)"""
+        table_names = [row[0] for row in connection.execute(text(query))]
+        logger.debug(f"Fetched table names for schema '{schema}': {table_names}")
+        return table_names
+
+    @reflection.cache
+    def get_view_definition(self, connection, view_name, schema=None, **kw):
+        query = """
+            SELECT
+                dbs."NAME" AS "schema",
+                tbls."TBL_NAME" AS view_name,
+                tbls."VIEW_ORIGINAL_TEXT" AS view_def
+            FROM "TBLS" tbls
+            JOIN "DBS" dbs ON tbls."DB_ID" = dbs."DB_ID"
+            WHERE tbls."VIEW_ORIGINAL_TEXT" IS NOT NULL
+        """
+        return get_view_definition_wrapper(
+            self,
+            connection,
+            table_name=view_name,
+            schema=schema,
+            query=query,
+        )
+
+    @reflection.cache
+    def get_table_comment(self, connection, table_name, schema=None, **kw):
+        query = """
+            SELECT
+                "DBS"."NAME" AS "schema",
+                "TBLS"."TBL_NAME" AS table_name,
+                "TABLE_PARAMS"."PARAM_VALUE" AS table_comment
+            FROM "DBS"
+            JOIN "TBLS" ON "DBS"."DB_ID" = "TBLS"."DB_ID"
+            LEFT JOIN "TABLE_PARAMS" ON "TBLS"."TBL_ID" = "TABLE_PARAMS"."TBL_ID"
+                AND "TABLE_PARAMS"."PARAM_KEY" = 'comment'
+        """
+        return get_table_comment_wrapper(
+            self,
+            connection,
+            table_name=table_name,
+            schema=schema,
+            query=query,
+        )
+
+    # pylint: disable=arguments-renamed
+    def get_dialect_cls(self):
+        return HiveOracleMetaStoreDialect

--- a/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/postgres/dialect.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/postgres/dialect.py
@@ -48,22 +48,25 @@ class HivePostgresMetaStoreDialect(HiveMetaStoreDialectMixin, PGDialect_psycopg2
     def get_view_names(self, connection, schema=None, **kw):
         # Hive does not provide functionality to query tableType
         # This allows reflection to not crash at the cost of being inaccurate
-        query = self._get_table_names_base_query(schema=schema)
+        query, params = self._get_table_names_base_query(schema=schema)
         query += """ WHERE "TBL_TYPE" = 'VIRTUAL_VIEW'"""
-        view_names = [row[0] for row in connection.execute(text(query))]
+        view_names = [row[0] for row in connection.execute(text(query), params)]
         logger.debug(f"Fetched view names for schema '{schema}': {view_names}")
         return view_names
 
     def _get_table_columns(self, connection, table_name, schema):
         # Build schema join clause if schema is provided
+        params = {"table_name": table_name}
         schema_join = (
-            f"""
+            """
             JOIN "DBS" db on tbsl."DB_ID" = db."DB_ID"
-            AND db."NAME" = '{schema}'
+            AND db."NAME" = :schema
         """
             if schema
             else ""
         )
+        if schema:
+            params["schema"] = schema
 
         query = f"""
             WITH regular_columns AS (
@@ -76,7 +79,7 @@ class HivePostgresMetaStoreDialect(HiveMetaStoreDialectMixin, PGDialect_psycopg2
                 JOIN "CDS" cds ON col."CD_ID" = cds."CD_ID"
                 JOIN "SDS" sds ON sds."CD_ID" = cds."CD_ID"
                 JOIN "TBLS" tbsl ON sds."SD_ID" = tbsl."SD_ID"
-                    AND tbsl."TBL_NAME" = '{table_name}'
+                    AND tbsl."TBL_NAME" = :table_name
                 {schema_join}
             ),
             partition_columns AS (
@@ -87,27 +90,29 @@ class HivePostgresMetaStoreDialect(HiveMetaStoreDialectMixin, PGDialect_psycopg2
                     pk."PKEY_COMMENT" as "COMMENT"
                 FROM "PARTITION_KEYS" pk
                 JOIN "TBLS" tbsl ON pk."TBL_ID" = tbsl."TBL_ID"
-                    AND tbsl."TBL_NAME" = '{table_name}'
+                    AND tbsl."TBL_NAME" = :table_name
                 {schema_join}
             )
             -- Combine regular and partition columns
             SELECT * FROM regular_columns
             UNION ALL
             SELECT * FROM partition_columns
-        """  # noqa: W291
-        return connection.execute(text(query)).fetchall()
+        """
+        return connection.execute(text(query), params).fetchall()
 
     def _get_table_names_base_query(self, schema=None):
         query = 'SELECT "TBL_NAME" from "TBLS" tbl'
+        params = {}
         if schema:
-            query += f""" JOIN "DBS" db on tbl."DB_ID" = db."DB_ID"
-            and db."NAME" = '{schema}'"""
-        return query
+            query += """ JOIN "DBS" db on tbl."DB_ID" = db."DB_ID"
+            and db."NAME" = :schema"""
+            params["schema"] = schema
+        return query, params
 
     def get_table_names(self, connection, schema=None, **kw):
-        query = self._get_table_names_base_query(schema=schema)
+        query, params = self._get_table_names_base_query(schema=schema)
         query += """ WHERE ("TBL_TYPE" != 'VIRTUAL_VIEW' OR "TBL_TYPE" IS NULL)"""
-        table_names = [row[0] for row in connection.execute(text(query))]
+        table_names = [row[0] for row in connection.execute(text(query), params)]
         logger.debug(f"Fetched table names for schema '{schema}': {table_names}")
         return table_names
 

--- a/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/postgres/dialect.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/metastore_dialects/postgres/dialect.py
@@ -71,9 +71,9 @@ class HivePostgresMetaStoreDialect(HiveMetaStoreDialectMixin, PGDialect_psycopg2
         query = f"""
             WITH regular_columns AS (
                 -- Get regular table columns from COLUMNS_V2
-                SELECT 
+                SELECT
                     col."COLUMN_NAME",
-                    col."TYPE_NAME", 
+                    col."TYPE_NAME",
                     col."COMMENT"
                 FROM "COLUMNS_V2" col
                 JOIN "CDS" cds ON col."CD_ID" = cds."CD_ID"
@@ -84,7 +84,7 @@ class HivePostgresMetaStoreDialect(HiveMetaStoreDialectMixin, PGDialect_psycopg2
             ),
             partition_columns AS (
                 -- Get partition key columns from PARTITION_KEYS
-                SELECT 
+                SELECT
                     pk."PKEY_NAME" as "COLUMN_NAME",
                     pk."PKEY_TYPE" as "TYPE_NAME",
                     pk."PKEY_COMMENT" as "COMMENT"
@@ -120,13 +120,13 @@ class HivePostgresMetaStoreDialect(HiveMetaStoreDialectMixin, PGDialect_psycopg2
     def get_view_definition(self, connection, view_name, schema=None, **kw):
         query = """
             SELECT 
-                dbs."NAME" "schema", 
-                tbls."TBL_NAME" view_name, 
+                dbs."NAME" "schema",
+                tbls."TBL_NAME" view_name,
                 tbls."VIEW_ORIGINAL_TEXT" view_def
-            from 
-                "TBLS" tbls 
-                JOIN "DBS" dbs on tbls."DB_ID" = dbs."DB_ID" 
-            where 
+            from
+                "TBLS" tbls
+                JOIN "DBS" dbs on tbls."DB_ID" = dbs."DB_ID"
+            where
                 tbls."VIEW_ORIGINAL_TEXT" is not null;
         """  # noqa: W291
         return get_view_definition_wrapper(
@@ -141,14 +141,14 @@ class HivePostgresMetaStoreDialect(HiveMetaStoreDialectMixin, PGDialect_psycopg2
     def get_table_comment(self, connection, table_name, schema=None, **kw):
         query = """
             SELECT 
-                "DBS"."NAME" AS "schema", 
-                "TBLS"."TBL_NAME" AS table_name, 
-                "TABLE_PARAMS"."PARAM_VALUE" AS table_comment 
-            FROM 
-                "DBS" 
-            JOIN 
-                "TBLS" ON "DBS"."DB_ID" = "TBLS"."DB_ID" 
-                LEFT JOIN "TABLE_PARAMS" ON "TBLS"."TBL_ID" = "TABLE_PARAMS"."TBL_ID" 
+                "DBS"."NAME" AS "schema",
+                "TBLS"."TBL_NAME" AS table_name,
+                "TABLE_PARAMS"."PARAM_VALUE" AS table_comment
+            FROM
+                "DBS"
+            JOIN
+                "TBLS" ON "DBS"."DB_ID" = "TBLS"."DB_ID"
+                LEFT JOIN "TABLE_PARAMS" ON "TBLS"."TBL_ID" = "TABLE_PARAMS"."TBL_ID"
                 and "TABLE_PARAMS"."PARAM_KEY" = 'comment'
         """  # noqa: W291
         return get_table_comment_wrapper(

--- a/ingestion/src/metadata/ingestion/source/database/hive/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/queries.py
@@ -14,8 +14,6 @@ SQL Queries used during ingestion
 
 import textwrap
 
-HIVE_GET_COMMENTS = textwrap.dedent(
-    """
+HIVE_GET_COMMENTS = textwrap.dedent("""
     describe formatted {schema_name}.{table_name}
-    """
-)
+    """)

--- a/ingestion/src/metadata/ingestion/source/database/hive/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/queries.py
@@ -14,6 +14,8 @@ SQL Queries used during ingestion
 
 import textwrap
 
-HIVE_GET_COMMENTS = textwrap.dedent("""
+HIVE_GET_COMMENTS = textwrap.dedent(
+    """
     describe formatted {schema_name}.{table_name}
-    """)
+    """
+)

--- a/ingestion/src/metadata/sampler/processor.py
+++ b/ingestion/src/metadata/sampler/processor.py
@@ -15,7 +15,7 @@ Data Sampler for the PII Workflow
 from __future__ import annotations
 
 import traceback
-from typing import TYPE_CHECKING, Optional, cast
+from typing import TYPE_CHECKING, cast
 
 from metadata.generated.schema.configuration.profilerConfiguration import (
     ProfilerConfiguration,
@@ -96,11 +96,11 @@ class SamplerProcessor(Processor):
         try:
             settings = self.metadata.get_profiler_config_settings()
         except Exception as exc:
-            logger.debug(f"Could not fetch global profiler config: {exc}")
+            logger.debug("Could not fetch global profiler config: %s", exc, exc_info=True)
             settings = None
 
         if settings:
-            profiler_cfg = cast(ProfilerConfiguration, settings.config_value)  # noqa: TC006
+            profiler_cfg = cast(ProfilerConfiguration, settings.config_value)  # noqa: TC006, RUF100
             self._sample_data_config = profiler_cfg.sampleDataConfig
 
     @property
@@ -184,7 +184,7 @@ class SamplerProcessor(Processor):
         cls,
         config_dict: dict,
         metadata: OpenMetadata,
-        pipeline_name: Optional[str] = None,  # noqa: UP045
+        pipeline_name: str | None = None,
     ) -> Step:
         config = parse_workflow_config_gracefully(config_dict)
         return cls(config=config, metadata=metadata)

--- a/ingestion/src/metadata/sampler/processor.py
+++ b/ingestion/src/metadata/sampler/processor.py
@@ -93,7 +93,12 @@ class SamplerProcessor(Processor):
         self.sampler_class = import_sampler_class(self.service_type, source_type=self._interface_type)
 
         self._sample_data_config = None
-        settings = self.metadata.get_profiler_config_settings()
+        try:
+            settings = self.metadata.get_profiler_config_settings()
+        except Exception as exc:
+            logger.debug(f"Could not fetch global profiler config: {exc}")
+            settings = None
+
         if settings:
             profiler_cfg = cast(ProfilerConfiguration, settings.config_value)  # noqa: TC006
             self._sample_data_config = profiler_cfg.sampleDataConfig

--- a/ingestion/tests/cli_e2e/test_cli_hive.py
+++ b/ingestion/tests/cli_e2e/test_cli_hive.py
@@ -57,8 +57,7 @@ class HiveCliTest(CliCommonDB.TestSuite, SQACommonMethods):
             FROM e2e_cli_tests.persons
     """
 
-    insert_data_queries: List[str] = [  # noqa: RUF012, UP006
-        """
+    insert_data_queries: List[str] = ["""
     INSERT INTO e2e_cli_tests.persons (person_id, full_name, birthdate) VALUES
         (1,'Peter Parker', '2004-08-10'),
         (2,'Bruce Banner', '1988-12-18'),
@@ -66,8 +65,7 @@ class HiveCliTest(CliCommonDB.TestSuite, SQACommonMethods):
         (4,'Natasha Romanoff', '1997-12-03'),
         (5,'Wanda Maximoff', '1998-02-10'),
         (6,'Diana Prince', '1976-03-17')
-    """
-    ]
+    """]
 
     drop_table_query: str = """
         DROP TABLE IF EXISTS e2e_cli_tests.persons

--- a/ingestion/tests/cli_e2e/test_cli_hive.py
+++ b/ingestion/tests/cli_e2e/test_cli_hive.py
@@ -57,7 +57,7 @@ class HiveCliTest(CliCommonDB.TestSuite, SQACommonMethods):
             FROM e2e_cli_tests.persons
     """
 
-    insert_data_queries: List[str] = [
+    insert_data_queries: List[str] = [  # noqa: RUF012, UP006
         """
     INSERT INTO e2e_cli_tests.persons (person_id, full_name, birthdate) VALUES
         (1,'Peter Parker', '2004-08-10'),

--- a/ingestion/tests/cli_e2e/test_cli_hive.py
+++ b/ingestion/tests/cli_e2e/test_cli_hive.py
@@ -57,7 +57,8 @@ class HiveCliTest(CliCommonDB.TestSuite, SQACommonMethods):
             FROM e2e_cli_tests.persons
     """
 
-    insert_data_queries: List[str] = ["""
+    insert_data_queries: List[str] = [
+        """
     INSERT INTO e2e_cli_tests.persons (person_id, full_name, birthdate) VALUES
         (1,'Peter Parker', '2004-08-10'),
         (2,'Bruce Banner', '1988-12-18'),
@@ -65,7 +66,8 @@ class HiveCliTest(CliCommonDB.TestSuite, SQACommonMethods):
         (4,'Natasha Romanoff', '1997-12-03'),
         (5,'Wanda Maximoff', '1998-02-10'),
         (6,'Diana Prince', '1976-03-17')
-    """]
+    """
+    ]
 
     drop_table_query: str = """
         DROP TABLE IF EXISTS e2e_cli_tests.persons

--- a/ingestion/tests/unit/topology/database/test_hive.py
+++ b/ingestion/tests/unit/topology/database/test_hive.py
@@ -68,6 +68,7 @@ from metadata.ingestion.source.database.hive.connection import (
     get_connection,
     get_connection_url,
     get_mssql_metastore_connection_url,
+    get_validated_metastore_connection,
 )
 from metadata.ingestion.source.database.hive.connection import (
     test_connection as hive_test_connection,
@@ -1237,6 +1238,38 @@ class HiveSourceMetastoreValidationTest(TestCase):
         result = self.hive._get_validated_metastore_connection()
         self.assertIsInstance(result, OracleConnection)
         self.assertEqual(result.username, "oracle_user")
+
+    def test_get_validated_metastore_connection_uses_type_discriminator(self):
+        """
+        Test metastore dict validation uses type before trying overlapping models.
+        """
+        mssql_dict = {
+            "type": "Mssql",
+            "username": "mssql_user",
+            "hostPort": "localhost:1433",
+            "database": "hive_metastore",
+        }
+
+        result = get_validated_metastore_connection(mssql_dict)
+
+        self.assertIsInstance(result, MssqlConnection)
+        if isinstance(result, MssqlConnection):
+            self.assertEqual(result.username, "mssql_user")
+
+    def test_get_validated_metastore_connection_rejects_unknown_type(self):
+        """
+        Test unknown type values do not fall through to overlapping models.
+        """
+        invalid_dict = {
+            "type": "Unknown",
+            "username": "postgres_user",
+            "hostPort": "localhost:5432",
+            "database": "hive_metastore",
+        }
+
+        result = get_validated_metastore_connection(invalid_dict)
+
+        self.assertIsNone(result)
 
     def test_mssql_metastore_url_preserves_pytds_driver(self):
         """

--- a/ingestion/tests/unit/topology/database/test_hive.py
+++ b/ingestion/tests/unit/topology/database/test_hive.py
@@ -358,9 +358,15 @@ class HiveUnitTest(TestCase):
         self.thread_id = self.hive.context.get_current_thread_id()
         self.hive._inspector_map[self.thread_id] = types.SimpleNamespace()
 
-        self.hive._inspector_map[self.thread_id].get_pk_constraint = lambda table_name, schema_name: []
-        self.hive._inspector_map[self.thread_id].get_unique_constraints = lambda table_name, schema_name: []
-        self.hive._inspector_map[self.thread_id].get_foreign_keys = lambda table_name, schema_name: []
+        self.hive._inspector_map[self.thread_id].get_pk_constraint = (
+            lambda table_name, schema_name: []
+        )
+        self.hive._inspector_map[self.thread_id].get_unique_constraints = (
+            lambda table_name, schema_name: []
+        )
+        self.hive._inspector_map[self.thread_id].get_foreign_keys = (
+            lambda table_name, schema_name: []
+        )
 
     def test_yield_database(self):
         assert EXPECTED_DATABASE == [either.right for either in self.hive.yield_database(MOCK_DATABASE.name.root)]  # noqa: SIM300

--- a/ingestion/tests/unit/topology/database/test_hive.py
+++ b/ingestion/tests/unit/topology/database/test_hive.py
@@ -67,6 +67,7 @@ from metadata.ingestion.models.custom_pydantic import CustomSecretStr
 from metadata.ingestion.source.database.hive.connection import (
     get_connection,
     get_connection_url,
+    get_mssql_metastore_connection_url,
 )
 from metadata.ingestion.source.database.hive.connection import (
     test_connection as hive_test_connection,
@@ -358,15 +359,9 @@ class HiveUnitTest(TestCase):
         self.thread_id = self.hive.context.get_current_thread_id()
         self.hive._inspector_map[self.thread_id] = types.SimpleNamespace()
 
-        self.hive._inspector_map[
-            self.thread_id
-        ].get_pk_constraint = lambda table_name, schema_name: []
-        self.hive._inspector_map[
-            self.thread_id
-        ].get_unique_constraints = lambda table_name, schema_name: []
-        self.hive._inspector_map[
-            self.thread_id
-        ].get_foreign_keys = lambda table_name, schema_name: []
+        self.hive._inspector_map[self.thread_id].get_pk_constraint = lambda table_name, schema_name: []
+        self.hive._inspector_map[self.thread_id].get_unique_constraints = lambda table_name, schema_name: []
+        self.hive._inspector_map[self.thread_id].get_foreign_keys = lambda table_name, schema_name: []
 
     def test_yield_database(self):
         assert EXPECTED_DATABASE == [either.right for either in self.hive.yield_database(MOCK_DATABASE.name.root)]  # noqa: SIM300
@@ -1242,3 +1237,59 @@ class HiveSourceMetastoreValidationTest(TestCase):
         result = self.hive._get_validated_metastore_connection()
         self.assertIsInstance(result, OracleConnection)
         self.assertEqual(result.username, "oracle_user")
+
+    def test_mssql_metastore_url_preserves_pytds_driver(self):
+        """
+        Test MSSQL Hive metastore URL keeps the configured pytds DBAPI.
+        """
+        mssql_conn = types.SimpleNamespace(
+            username="mssql_user",
+            password=CustomSecretStr("password"),
+            hostPort="localhost:1433",
+            database="hive_metastore",
+            scheme=types.SimpleNamespace(value="hive+mssql.pytds"),
+            connectionOptions=None,
+        )
+
+        assert (
+            get_mssql_metastore_connection_url(mssql_conn)
+            == "hive+mssql.pytds://mssql_user:password@localhost:1433/hive_metastore"
+        )
+
+    def test_mssql_metastore_url_preserves_pymssql_driver(self):
+        """
+        Test MSSQL Hive metastore URL keeps the configured pymssql DBAPI.
+        """
+        mssql_conn = types.SimpleNamespace(
+            username="mssql_user",
+            password=CustomSecretStr("password"),
+            hostPort="localhost:1433",
+            database="hive_metastore",
+            scheme=types.SimpleNamespace(value="hive+mssql.pymssql"),
+            connectionOptions=None,
+        )
+
+        assert (
+            get_mssql_metastore_connection_url(mssql_conn)
+            == "hive+mssql.pymssql://mssql_user:password@localhost:1433/hive_metastore"
+        )
+
+    def test_mssql_metastore_url_preserves_pyodbc_driver(self):
+        """
+        Test MSSQL Hive metastore URL keeps pyodbc driver query parameters.
+        """
+        mssql_conn = types.SimpleNamespace(
+            username="mssql_user",
+            password=CustomSecretStr("password"),
+            hostPort="localhost:1433",
+            database="hive_metastore",
+            scheme=types.SimpleNamespace(value="hive+mssql.pyodbc"),
+            driver="ODBC Driver 18 for SQL Server",
+            connectionOptions=None,
+        )
+
+        assert (
+            get_mssql_metastore_connection_url(mssql_conn)
+            == "hive+mssql.pyodbc://mssql_user:password@localhost:1433/hive_metastore"
+            "?driver=ODBC+Driver+18+for+SQL+Server"
+        )

--- a/ingestion/tests/unit/topology/database/test_hive.py
+++ b/ingestion/tests/unit/topology/database/test_hive.py
@@ -37,8 +37,14 @@ from metadata.generated.schema.entity.services.connections.database.hiveConnecti
     HiveConnection,
     HiveScheme,
 )
+from metadata.generated.schema.entity.services.connections.database.mssqlConnection import (
+    MssqlConnection,
+)
 from metadata.generated.schema.entity.services.connections.database.mysqlConnection import (
     MysqlConnection,
+)
+from metadata.generated.schema.entity.services.connections.database.oracleConnection import (
+    OracleConnection,
 )
 from metadata.generated.schema.entity.services.connections.database.postgresConnection import (
     PostgresConnection,
@@ -1172,3 +1178,61 @@ class HiveSourceMetastoreValidationTest(TestCase):
         self.hive.service_connection.metastoreConnection = invalid_dict
         result = self.hive._get_validated_metastore_connection()
         self.assertIsNone(result)
+
+    def test_get_validated_metastore_connection_with_mssql_object(self):
+        """
+        Test _get_validated_metastore_connection returns MssqlConnection when already validated
+        """
+        mssql_conn = MssqlConnection(
+            username="mssql_user",
+            hostPort="localhost:1433",
+            database="hive_metastore",
+        )
+        self.hive.service_connection.metastoreConnection = mssql_conn
+        result = self.hive._get_validated_metastore_connection()
+        self.assertIsInstance(result, MssqlConnection)
+        self.assertEqual(result, mssql_conn)
+
+    def test_get_validated_metastore_connection_with_oracle_object(self):
+        """
+        Test _get_validated_metastore_connection returns OracleConnection when already validated
+        """
+        oracle_conn = OracleConnection(
+            username="oracle_user",
+            hostPort="localhost:1521",
+            oracleConnectionType={"oracleServiceName": "XE"},
+        )
+        self.hive.service_connection.metastoreConnection = oracle_conn
+        result = self.hive._get_validated_metastore_connection()
+        self.assertIsInstance(result, OracleConnection)
+        self.assertEqual(result, oracle_conn)
+
+    def test_get_validated_metastore_connection_with_mssql_dict(self):
+        """
+        Test _get_validated_metastore_connection parses dict as MssqlConnection
+        """
+        mssql_dict = {
+            "type": "Mssql",
+            "username": "mssql_user",
+            "hostPort": "localhost:1433",
+            "database": "hive_metastore",
+        }
+        self.hive.service_connection.metastoreConnection = mssql_dict
+        result = self.hive._get_validated_metastore_connection()
+        self.assertIsInstance(result, MssqlConnection)
+        self.assertEqual(result.username, "mssql_user")
+
+    def test_get_validated_metastore_connection_with_oracle_dict(self):
+        """
+        Test _get_validated_metastore_connection parses dict as OracleConnection
+        """
+        oracle_dict = {
+            "type": "Oracle",
+            "username": "oracle_user",
+            "hostPort": "localhost:1521",
+            "oracleConnectionType": {"oracleServiceName": "XE"},
+        }
+        self.hive.service_connection.metastoreConnection = oracle_dict
+        result = self.hive._get_validated_metastore_connection()
+        self.assertIsInstance(result, OracleConnection)
+        self.assertEqual(result.username, "oracle_user")

--- a/ingestion/tests/unit/topology/database/test_hive.py
+++ b/ingestion/tests/unit/topology/database/test_hive.py
@@ -358,15 +358,15 @@ class HiveUnitTest(TestCase):
         self.thread_id = self.hive.context.get_current_thread_id()
         self.hive._inspector_map[self.thread_id] = types.SimpleNamespace()
 
-        self.hive._inspector_map[self.thread_id].get_pk_constraint = (
-            lambda table_name, schema_name: []
-        )
-        self.hive._inspector_map[self.thread_id].get_unique_constraints = (
-            lambda table_name, schema_name: []
-        )
-        self.hive._inspector_map[self.thread_id].get_foreign_keys = (
-            lambda table_name, schema_name: []
-        )
+        self.hive._inspector_map[
+            self.thread_id
+        ].get_pk_constraint = lambda table_name, schema_name: []
+        self.hive._inspector_map[
+            self.thread_id
+        ].get_unique_constraints = lambda table_name, schema_name: []
+        self.hive._inspector_map[
+            self.thread_id
+        ].get_foreign_keys = lambda table_name, schema_name: []
 
     def test_yield_database(self):
         assert EXPECTED_DATABASE == [either.right for either in self.hive.yield_database(MOCK_DATABASE.name.root)]  # noqa: SIM300

--- a/ingestion/tests/unit/topology/database/test_hive_metastore_mssql_dialect.py
+++ b/ingestion/tests/unit/topology/database/test_hive_metastore_mssql_dialect.py
@@ -11,6 +11,7 @@
 """
 Test Hive MSSQL Metastore Dialect
 """
+
 from unittest.mock import MagicMock, Mock
 
 from metadata.ingestion.source.database.hive.metastore_dialects.mssql.dialect import (

--- a/ingestion/tests/unit/topology/database/test_hive_metastore_mssql_dialect.py
+++ b/ingestion/tests/unit/topology/database/test_hive_metastore_mssql_dialect.py
@@ -87,7 +87,7 @@ class TestHiveMssqlMetastoreDialectGetTableColumns:
         assert "PKEY_NAME" in executed_query
         assert "PKEY_TYPE" in executed_query
         assert "PKEY_COMMENT" in executed_query
-        assert executed_query.upper().count("SELECT") == 2
+        assert executed_query.upper().count("SELECT") == 4
 
     def test_get_table_columns_uses_unquoted_identifiers(self):
         """MSSQL dialect uses unquoted identifiers, not double-quoted like Postgres."""

--- a/ingestion/tests/unit/topology/database/test_hive_metastore_mssql_dialect.py
+++ b/ingestion/tests/unit/topology/database/test_hive_metastore_mssql_dialect.py
@@ -1,0 +1,196 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Test Hive MSSQL Metastore Dialect
+"""
+from unittest.mock import MagicMock, Mock
+
+from metadata.ingestion.source.database.hive.metastore_dialects.mssql.dialect import (
+    HiveMssqlMetaStoreDialect,
+)
+
+
+class TestHiveMssqlMetastoreDialectGetTableColumns:
+    """
+    MSSQL supports CTEs (unlike MySQL 5.7), so the dialect uses WITH clauses
+    and unquoted identifiers (MSSQL does not require quoting for standard names).
+    """
+
+    def setup_method(self):
+        self.dialect = HiveMssqlMetaStoreDialect()
+
+    def test_get_table_columns_uses_cte(self):
+        """MSSQL dialect uses WITH … AS (CTE) — unlike MySQL which uses UNION ALL only."""
+        mock_connection = Mock()
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [
+            ("col1", "nvarchar", "First column"),
+            ("col2", "int", "Second column"),
+            ("part_col", "nvarchar", "Partition column"),
+        ]
+        mock_connection.execute.return_value = mock_result
+
+        result = self.dialect._get_table_columns(
+            mock_connection, "test_table", "test_schema"
+        )
+
+        executed_query = str(mock_connection.execute.call_args[0][0])
+        assert "WITH" in executed_query.upper()
+        assert "UNION ALL" in executed_query.upper()
+        assert len(result) == 3
+
+    def test_get_table_columns_without_schema(self):
+        """Without schema, the DBS join should be absent."""
+        mock_connection = Mock()
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [("col1", "nvarchar", None)]
+        mock_connection.execute.return_value = mock_result
+
+        self.dialect._get_table_columns(mock_connection, "test_table", None)
+
+        executed_query = str(mock_connection.execute.call_args[0][0])
+        assert "test_table" in executed_query
+        assert "DBS" not in executed_query
+
+    def test_get_table_columns_with_schema_joins_dbs(self):
+        mock_connection = Mock()
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        mock_connection.execute.return_value = mock_result
+
+        self.dialect._get_table_columns(mock_connection, "test_table", "my_schema")
+
+        executed_query = str(mock_connection.execute.call_args[0][0])
+        assert "my_schema" in executed_query
+        assert "DBS" in executed_query
+
+    def test_get_table_columns_query_structure(self):
+        """Query must reference both regular and partition column tables."""
+        mock_connection = Mock()
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        mock_connection.execute.return_value = mock_result
+
+        self.dialect._get_table_columns(mock_connection, "test_table", "test_schema")
+
+        executed_query = str(mock_connection.execute.call_args[0][0])
+        assert "COLUMNS_V2" in executed_query
+        assert "PARTITION_KEYS" in executed_query
+        assert "PKEY_NAME" in executed_query
+        assert "PKEY_TYPE" in executed_query
+        assert "PKEY_COMMENT" in executed_query
+        assert executed_query.upper().count("SELECT") == 2
+
+    def test_get_table_columns_uses_unquoted_identifiers(self):
+        """MSSQL dialect uses unquoted identifiers, not double-quoted like Postgres."""
+        mock_connection = Mock()
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        mock_connection.execute.return_value = mock_result
+
+        self.dialect._get_table_columns(mock_connection, "test_table", "test_schema")
+
+        executed_query = str(mock_connection.execute.call_args[0][0])
+        # Should NOT use Postgres-style double-quoted identifiers
+        assert '"COLUMN_NAME"' not in executed_query
+        assert '"TBLS"' not in executed_query
+        # Should use plain unquoted identifiers
+        assert "COLUMN_NAME" in executed_query
+        assert "TBLS" in executed_query
+
+
+class TestHiveMssqlMetastoreDialectGetTableNames:
+    """
+    Null-safe TBL_TYPE filtering: NULL != 'VIRTUAL_VIEW' evaluates to NULL in SQL,
+    so rows with a NULL TBL_TYPE would be excluded without the IS NULL guard.
+    """
+
+    def setup_method(self):
+        self.dialect = HiveMssqlMetaStoreDialect()
+
+    def test_get_table_names_query_excludes_virtual_views(self):
+        mock_connection = Mock()
+        mock_connection.execute.return_value = [("table1",), ("table2",)]
+
+        result = self.dialect.get_table_names(mock_connection, schema="test_schema")
+
+        executed_query = str(mock_connection.execute.call_args[0][0])
+        assert "VIRTUAL_VIEW" in executed_query
+        assert "!=" in executed_query
+        assert result == ["table1", "table2"]
+
+    def test_get_table_names_query_includes_null_tbl_type(self):
+        """IS NULL guard ensures tables without a TBL_TYPE are included."""
+        mock_connection = Mock()
+        mock_connection.execute.return_value = []
+
+        self.dialect.get_table_names(mock_connection, schema="test_schema")
+
+        executed_query = str(mock_connection.execute.call_args[0][0])
+        assert "IS NULL" in executed_query.upper()
+        assert "TBL_TYPE" in executed_query
+
+    def test_get_table_names_query_uses_or_condition(self):
+        mock_connection = Mock()
+        mock_connection.execute.return_value = []
+
+        self.dialect.get_table_names(mock_connection, schema="test_schema")
+
+        executed_query = str(mock_connection.execute.call_args[0][0])
+        assert "OR" in executed_query.upper()
+        assert "TBL_TYPE" in executed_query
+        assert "VIRTUAL_VIEW" in executed_query
+        assert "IS NULL" in executed_query.upper()
+
+    def test_get_table_names_with_schema_joins_dbs(self):
+        mock_connection = Mock()
+        mock_connection.execute.return_value = [("my_table",)]
+
+        result = self.dialect.get_table_names(mock_connection, schema="my_schema")
+
+        executed_query = str(mock_connection.execute.call_args[0][0])
+        assert "DBS" in executed_query
+        assert "my_schema" in executed_query
+        assert result == ["my_table"]
+
+    def test_get_table_names_without_schema(self):
+        mock_connection = Mock()
+        mock_connection.execute.return_value = [("table_a",)]
+
+        result = self.dialect.get_table_names(mock_connection, schema=None)
+
+        executed_query = str(mock_connection.execute.call_args[0][0])
+        assert "TBL_TYPE" in executed_query
+        assert "IS NULL" in executed_query.upper()
+        assert "DBS" not in executed_query
+        assert result == ["table_a"]
+
+    def test_get_table_names_returns_empty_when_no_tables(self):
+        mock_connection = Mock()
+        mock_connection.execute.return_value = []
+
+        result = self.dialect.get_table_names(mock_connection, schema="empty_schema")
+
+        assert result == []
+
+    def test_get_schema_names_uses_unquoted_identifiers(self):
+        """MSSQL schema names query uses unquoted NAME column."""
+        mock_connection = Mock()
+        mock_connection.execute.return_value = [("db1",), ("db2",)]
+
+        result = self.dialect.get_schema_names(mock_connection)
+
+        executed_query = str(mock_connection.execute.call_args[0][0])
+        assert "NAME" in executed_query
+        assert "DBS" in executed_query
+        # MSSQL uses plain unquoted names, not Postgres-style "NAME"
+        assert '"NAME"' not in executed_query
+        assert result == ["db1", "db2"]

--- a/ingestion/tests/unit/topology/database/test_hive_metastore_mssql_dialect.py
+++ b/ingestion/tests/unit/topology/database/test_hive_metastore_mssql_dialect.py
@@ -16,6 +16,8 @@ from unittest.mock import MagicMock, Mock
 
 from metadata.ingestion.source.database.hive.metastore_dialects.mssql.dialect import (
     HiveMssqlMetaStoreDialect,
+    HiveMssqlPymssqlMetaStoreDialect,
+    HiveMssqlPyodbcMetaStoreDialect,
 )
 
 
@@ -28,6 +30,11 @@ class TestHiveMssqlMetastoreDialectGetTableColumns:
     def setup_method(self):
         self.dialect = HiveMssqlMetaStoreDialect()
 
+    def test_driver_specific_dialects(self):
+        assert HiveMssqlMetaStoreDialect.driver == "mssql.pytds"
+        assert HiveMssqlPyodbcMetaStoreDialect.driver == "mssql.pyodbc"
+        assert HiveMssqlPymssqlMetaStoreDialect.driver == "mssql.pymssql"
+
     def test_get_table_columns_uses_cte(self):
         """MSSQL dialect uses WITH … AS (CTE) — unlike MySQL which uses UNION ALL only."""
         mock_connection = Mock()
@@ -39,9 +46,7 @@ class TestHiveMssqlMetastoreDialectGetTableColumns:
         ]
         mock_connection.execute.return_value = mock_result
 
-        result = self.dialect._get_table_columns(
-            mock_connection, "test_table", "test_schema"
-        )
+        result = self.dialect._get_table_columns(mock_connection, "test_table", "test_schema")
 
         executed_query = str(mock_connection.execute.call_args[0][0])
         assert "WITH" in executed_query.upper()

--- a/ingestion/tests/unit/topology/database/test_hive_metastore_mssql_dialect.py
+++ b/ingestion/tests/unit/topology/database/test_hive_metastore_mssql_dialect.py
@@ -58,8 +58,9 @@ class TestHiveMssqlMetastoreDialectGetTableColumns:
         self.dialect._get_table_columns(mock_connection, "test_table", None)
 
         executed_query = str(mock_connection.execute.call_args[0][0])
-        assert "test_table" in executed_query
+        assert ":table_name" in executed_query
         assert "DBS" not in executed_query
+        assert mock_connection.execute.call_args[0][1] == {"table_name": "test_table"}
 
     def test_get_table_columns_with_schema_joins_dbs(self):
         mock_connection = Mock()
@@ -70,8 +71,12 @@ class TestHiveMssqlMetastoreDialectGetTableColumns:
         self.dialect._get_table_columns(mock_connection, "test_table", "my_schema")
 
         executed_query = str(mock_connection.execute.call_args[0][0])
-        assert "my_schema" in executed_query
+        assert ":schema" in executed_query
         assert "DBS" in executed_query
+        assert mock_connection.execute.call_args[0][1] == {
+            "schema": "my_schema",
+            "table_name": "test_table",
+        }
 
     def test_get_table_columns_query_structure(self):
         """Query must reference both regular and partition column tables."""
@@ -127,6 +132,7 @@ class TestHiveMssqlMetastoreDialectGetTableNames:
         assert "VIRTUAL_VIEW" in executed_query
         assert "!=" in executed_query
         assert result == ["table1", "table2"]
+        assert mock_connection.execute.call_args[0][1] == {"schema": "test_schema"}
 
     def test_get_table_names_query_includes_null_tbl_type(self):
         """IS NULL guard ensures tables without a TBL_TYPE are included."""
@@ -159,8 +165,9 @@ class TestHiveMssqlMetastoreDialectGetTableNames:
 
         executed_query = str(mock_connection.execute.call_args[0][0])
         assert "DBS" in executed_query
-        assert "my_schema" in executed_query
+        assert ":schema" in executed_query
         assert result == ["my_table"]
+        assert mock_connection.execute.call_args[0][1] == {"schema": "my_schema"}
 
     def test_get_table_names_without_schema(self):
         mock_connection = Mock()
@@ -173,6 +180,7 @@ class TestHiveMssqlMetastoreDialectGetTableNames:
         assert "IS NULL" in executed_query.upper()
         assert "DBS" not in executed_query
         assert result == ["table_a"]
+        assert mock_connection.execute.call_args[0][1] == {}
 
     def test_get_table_names_returns_empty_when_no_tables(self):
         mock_connection = Mock()

--- a/ingestion/tests/unit/topology/database/test_hive_metastore_mysql_dialect.py
+++ b/ingestion/tests/unit/topology/database/test_hive_metastore_mysql_dialect.py
@@ -68,11 +68,15 @@ class TestHiveMySQLMetastoreDialect(TestCase):
         self.assertIn("PARTITION_KEYS", executed_query)
         self.assertIn("TBLS", executed_query)
 
-        # Verify the query includes the table name
-        self.assertIn("test_table", executed_query)
+        # Verify the query uses bound parameters (no string interpolation)
+        self.assertIn(":table_name", executed_query)
+        self.assertIn(":schema", executed_query)
+        self.assertEqual(
+            mock_connection.execute.call_args[0][1],
+            {"schema": "test_schema", "table_name": "test_table"},
+        )
 
         # Verify the query includes the schema join
-        self.assertIn("test_schema", executed_query)
         self.assertIn("DBS", executed_query)
 
         # Verify the result
@@ -109,6 +113,11 @@ class TestHiveMySQLMetastoreDialect(TestCase):
 
         # Verify UNION ALL is present
         self.assertIn("UNION ALL", executed_query.upper())
+        self.assertIn(":table_name", executed_query)
+        self.assertEqual(
+            mock_connection.execute.call_args[0][1],
+            {"table_name": "test_table"},
+        )
 
         # Verify the result
         self.assertEqual(len(result), 1)
@@ -203,6 +212,7 @@ class TestHiveMySQLMetastoreDialectGetTableNames:
         assert "VIRTUAL_VIEW" in executed_query
         assert "!=" in executed_query
         assert result == ["table1", "table2"]
+        assert mock_connection.execute.call_args[0][1] == {"schema": "test_schema"}
 
     def test_get_table_names_query_includes_null_tbl_type(self):
         mock_connection = Mock()
@@ -234,8 +244,9 @@ class TestHiveMySQLMetastoreDialectGetTableNames:
 
         executed_query = str(mock_connection.execute.call_args[0][0])
         assert "DBS" in executed_query
-        assert "my_schema" in executed_query
+        assert ":schema" in executed_query
         assert result == ["my_table"]
+        assert mock_connection.execute.call_args[0][1] == {"schema": "my_schema"}
 
     def test_get_table_names_without_schema(self):
         mock_connection = Mock()
@@ -248,6 +259,7 @@ class TestHiveMySQLMetastoreDialectGetTableNames:
         assert "IS NULL" in executed_query.upper()
         assert "DBS" not in executed_query
         assert result == ["table_a"]
+        assert mock_connection.execute.call_args[0][1] == {}
 
     def test_get_table_names_returns_empty_when_no_tables(self):
         mock_connection = Mock()

--- a/ingestion/tests/unit/topology/database/test_hive_metastore_oracle_dialect.py
+++ b/ingestion/tests/unit/topology/database/test_hive_metastore_oracle_dialect.py
@@ -11,6 +11,7 @@
 """
 Test Hive Oracle Metastore Dialect
 """
+
 from unittest.mock import MagicMock, Mock
 
 from metadata.ingestion.source.database.hive.metastore_dialects.oracle.dialect import (

--- a/ingestion/tests/unit/topology/database/test_hive_metastore_oracle_dialect.py
+++ b/ingestion/tests/unit/topology/database/test_hive_metastore_oracle_dialect.py
@@ -1,0 +1,187 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Test Hive Oracle Metastore Dialect
+"""
+from unittest.mock import MagicMock, Mock
+
+from metadata.ingestion.source.database.hive.metastore_dialects.oracle.dialect import (
+    HiveOracleMetaStoreDialect,
+)
+
+
+class TestHiveOracleMetastoreDialectGetTableNames:
+    """
+    Oracle dialect uses double-quoted identifiers for case-insensitive column names,
+    matching the Postgres dialect behaviour. NULL-safe TBL_TYPE filtering applies.
+    """
+
+    def setup_method(self):
+        self.dialect = HiveOracleMetaStoreDialect()
+
+    def test_get_table_names_query_excludes_virtual_views(self):
+        mock_connection = Mock()
+        mock_connection.execute.return_value = [("table1",), ("table2",)]
+
+        result = self.dialect.get_table_names(mock_connection, schema="test_schema")
+
+        executed_query = str(mock_connection.execute.call_args[0][0])
+        assert "VIRTUAL_VIEW" in executed_query
+        assert "!=" in executed_query
+        assert result == ["table1", "table2"]
+
+    def test_get_table_names_query_includes_null_tbl_type(self):
+        mock_connection = Mock()
+        mock_connection.execute.return_value = []
+
+        self.dialect.get_table_names(mock_connection, schema="test_schema")
+
+        executed_query = str(mock_connection.execute.call_args[0][0])
+        assert "IS NULL" in executed_query.upper()
+        assert "TBL_TYPE" in executed_query
+
+    def test_get_table_names_query_uses_or_condition(self):
+        mock_connection = Mock()
+        mock_connection.execute.return_value = []
+
+        self.dialect.get_table_names(mock_connection, schema="test_schema")
+
+        executed_query = str(mock_connection.execute.call_args[0][0])
+        assert "OR" in executed_query.upper()
+        assert "TBL_TYPE" in executed_query
+        assert "VIRTUAL_VIEW" in executed_query
+        assert "IS NULL" in executed_query.upper()
+
+    def test_get_table_names_with_schema_joins_dbs(self):
+        mock_connection = Mock()
+        mock_connection.execute.return_value = [("my_table",)]
+
+        result = self.dialect.get_table_names(mock_connection, schema="my_schema")
+
+        executed_query = str(mock_connection.execute.call_args[0][0])
+        assert "DBS" in executed_query
+        assert "my_schema" in executed_query
+        assert result == ["my_table"]
+
+    def test_get_table_names_without_schema(self):
+        mock_connection = Mock()
+        mock_connection.execute.return_value = [("table_a",)]
+
+        result = self.dialect.get_table_names(mock_connection, schema=None)
+
+        executed_query = str(mock_connection.execute.call_args[0][0])
+        assert "TBL_TYPE" in executed_query
+        assert "IS NULL" in executed_query.upper()
+        assert "DBS" not in executed_query
+        assert result == ["table_a"]
+
+    def test_get_table_names_returns_empty_when_no_tables(self):
+        mock_connection = Mock()
+        mock_connection.execute.return_value = []
+
+        result = self.dialect.get_table_names(mock_connection, schema="empty_schema")
+
+        assert result == []
+
+    def test_get_schema_names_uses_quoted_identifiers(self):
+        """Oracle dialect uses double-quoted NAME to preserve case."""
+        mock_connection = Mock()
+        mock_connection.execute.return_value = [("db1",), ("db2",)]
+
+        result = self.dialect.get_schema_names(mock_connection)
+
+        executed_query = str(mock_connection.execute.call_args[0][0])
+        assert '"NAME"' in executed_query
+        assert '"DBS"' in executed_query
+        assert result == ["db1", "db2"]
+
+
+class TestHiveOracleMetastoreDialectGetTableColumns:
+    """
+    Oracle dialect uses CTE (WITH clause) and double-quoted identifiers,
+    matching the Postgres dialect pattern.
+    """
+
+    def setup_method(self):
+        self.dialect = HiveOracleMetaStoreDialect()
+
+    def test_get_table_columns_uses_cte(self):
+        mock_connection = Mock()
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [
+            ("col1", "VARCHAR2", "First column"),
+            ("col2", "NUMBER", "Second column"),
+        ]
+        mock_connection.execute.return_value = mock_result
+
+        result = self.dialect._get_table_columns(
+            mock_connection, "test_table", "test_schema"
+        )
+
+        executed_query = str(mock_connection.execute.call_args[0][0])
+        assert "WITH" in executed_query.upper()
+        assert "UNION ALL" in executed_query.upper()
+        assert len(result) == 2
+
+    def test_get_table_columns_with_schema(self):
+        mock_connection = Mock()
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [("col1", "VARCHAR2", None)]
+        mock_connection.execute.return_value = mock_result
+
+        self.dialect._get_table_columns(mock_connection, "test_table", "test_schema")
+
+        executed_query = str(mock_connection.execute.call_args[0][0])
+        assert "test_schema" in executed_query
+        assert '"DBS"' in executed_query
+
+    def test_get_table_columns_without_schema(self):
+        mock_connection = Mock()
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [("col1", "VARCHAR2", None)]
+        mock_connection.execute.return_value = mock_result
+
+        self.dialect._get_table_columns(mock_connection, "test_table", None)
+
+        executed_query = str(mock_connection.execute.call_args[0][0])
+        assert "test_table" in executed_query
+        assert '"COLUMNS_V2"' in executed_query
+        assert '"PARTITION_KEYS"' in executed_query
+
+    def test_get_table_columns_uses_quoted_identifiers(self):
+        """Oracle dialect uses double-quoted identifiers for case-sensitivity."""
+        mock_connection = Mock()
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        mock_connection.execute.return_value = mock_result
+
+        self.dialect._get_table_columns(mock_connection, "test_table", "test_schema")
+
+        executed_query = str(mock_connection.execute.call_args[0][0])
+        assert '"COLUMN_NAME"' in executed_query
+        assert '"TYPE_NAME"' in executed_query
+        assert '"TBLS"' in executed_query
+
+    def test_get_table_columns_contains_both_selects(self):
+        """Query must select from both COLUMNS_V2 and PARTITION_KEYS."""
+        mock_connection = Mock()
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        mock_connection.execute.return_value = mock_result
+
+        self.dialect._get_table_columns(mock_connection, "test_table", "test_schema")
+
+        executed_query = str(mock_connection.execute.call_args[0][0])
+        assert '"COLUMNS_V2"' in executed_query
+        assert '"PARTITION_KEYS"' in executed_query
+        assert '"PKEY_NAME"' in executed_query
+        assert '"PKEY_TYPE"' in executed_query
+        assert '"PKEY_COMMENT"' in executed_query

--- a/ingestion/tests/unit/topology/database/test_hive_metastore_oracle_dialect.py
+++ b/ingestion/tests/unit/topology/database/test_hive_metastore_oracle_dialect.py
@@ -38,6 +38,7 @@ class TestHiveOracleMetastoreDialectGetTableNames:
         assert "VIRTUAL_VIEW" in executed_query
         assert "!=" in executed_query
         assert result == ["table1", "table2"]
+        assert mock_connection.execute.call_args[0][1] == {"schema": "test_schema"}
 
     def test_get_table_names_query_includes_null_tbl_type(self):
         mock_connection = Mock()
@@ -69,8 +70,9 @@ class TestHiveOracleMetastoreDialectGetTableNames:
 
         executed_query = str(mock_connection.execute.call_args[0][0])
         assert "DBS" in executed_query
-        assert "my_schema" in executed_query
+        assert ":schema" in executed_query
         assert result == ["my_table"]
+        assert mock_connection.execute.call_args[0][1] == {"schema": "my_schema"}
 
     def test_get_table_names_without_schema(self):
         mock_connection = Mock()
@@ -83,6 +85,7 @@ class TestHiveOracleMetastoreDialectGetTableNames:
         assert "IS NULL" in executed_query.upper()
         assert "DBS" not in executed_query
         assert result == ["table_a"]
+        assert mock_connection.execute.call_args[0][1] == {}
 
     def test_get_table_names_returns_empty_when_no_tables(self):
         mock_connection = Mock()
@@ -141,8 +144,12 @@ class TestHiveOracleMetastoreDialectGetTableColumns:
         self.dialect._get_table_columns(mock_connection, "test_table", "test_schema")
 
         executed_query = str(mock_connection.execute.call_args[0][0])
-        assert "test_schema" in executed_query
+        assert ":schema" in executed_query
         assert '"DBS"' in executed_query
+        assert mock_connection.execute.call_args[0][1] == {
+            "schema": "test_schema",
+            "table_name": "test_table",
+        }
 
     def test_get_table_columns_without_schema(self):
         mock_connection = Mock()
@@ -153,9 +160,10 @@ class TestHiveOracleMetastoreDialectGetTableColumns:
         self.dialect._get_table_columns(mock_connection, "test_table", None)
 
         executed_query = str(mock_connection.execute.call_args[0][0])
-        assert "test_table" in executed_query
+        assert ":table_name" in executed_query
         assert '"COLUMNS_V2"' in executed_query
         assert '"PARTITION_KEYS"' in executed_query
+        assert mock_connection.execute.call_args[0][1] == {"table_name": "test_table"}
 
     def test_get_table_columns_uses_quoted_identifiers(self):
         """Oracle dialect uses double-quoted identifiers for case-sensitivity."""

--- a/ingestion/tests/unit/topology/database/test_hive_metastore_oracle_dialect.py
+++ b/ingestion/tests/unit/topology/database/test_hive_metastore_oracle_dialect.py
@@ -126,9 +126,7 @@ class TestHiveOracleMetastoreDialectGetTableColumns:
         ]
         mock_connection.execute.return_value = mock_result
 
-        result = self.dialect._get_table_columns(
-            mock_connection, "test_table", "test_schema"
-        )
+        result = self.dialect._get_table_columns(mock_connection, "test_table", "test_schema")
 
         executed_query = str(mock_connection.execute.call_args[0][0])
         assert "WITH" in executed_query.upper()

--- a/ingestion/tests/unit/topology/database/test_hive_metastore_postgres_dialect.py
+++ b/ingestion/tests/unit/topology/database/test_hive_metastore_postgres_dialect.py
@@ -40,6 +40,7 @@ class TestHivePostgresMetastoreDialectGetTableNames:
         assert "VIRTUAL_VIEW" in executed_query
         assert "!=" in executed_query
         assert result == ["table1", "table2"]
+        assert mock_connection.execute.call_args[0][1] == {"schema": "test_schema"}
 
     def test_get_table_names_query_includes_null_tbl_type(self):
         mock_connection = Mock()
@@ -71,8 +72,9 @@ class TestHivePostgresMetastoreDialectGetTableNames:
 
         executed_query = str(mock_connection.execute.call_args[0][0])
         assert "DBS" in executed_query
-        assert "my_schema" in executed_query
+        assert ":schema" in executed_query
         assert result == ["my_table"]
+        assert mock_connection.execute.call_args[0][1] == {"schema": "my_schema"}
 
     def test_get_table_names_without_schema(self):
         mock_connection = Mock()
@@ -85,6 +87,7 @@ class TestHivePostgresMetastoreDialectGetTableNames:
         assert "IS NULL" in executed_query.upper()
         assert "DBS" not in executed_query
         assert result == ["table_a"]
+        assert mock_connection.execute.call_args[0][1] == {}
 
     def test_get_table_names_returns_empty_when_no_tables(self):
         mock_connection = Mock()
@@ -129,8 +132,12 @@ class TestHivePostgresMetastoreDialectGetTableColumns:
         self.dialect._get_table_columns(mock_connection, "test_table", "test_schema")
 
         executed_query = str(mock_connection.execute.call_args[0][0])
-        assert "test_schema" in executed_query
+        assert ":schema" in executed_query
         assert '"DBS"' in executed_query
+        assert mock_connection.execute.call_args[0][1] == {
+            "schema": "test_schema",
+            "table_name": "test_table",
+        }
 
     def test_get_table_columns_without_schema(self):
         mock_connection = Mock()
@@ -141,9 +148,10 @@ class TestHivePostgresMetastoreDialectGetTableColumns:
         self.dialect._get_table_columns(mock_connection, "test_table", None)
 
         executed_query = str(mock_connection.execute.call_args[0][0])
-        assert "test_table" in executed_query
+        assert ":table_name" in executed_query
         assert '"COLUMNS_V2"' in executed_query
         assert '"PARTITION_KEYS"' in executed_query
+        assert mock_connection.execute.call_args[0][1] == {"table_name": "test_table"}
 
     def test_get_table_columns_uses_quoted_identifiers(self):
         """Postgres dialect uses double-quoted identifiers for case-sensitivity."""

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/hiveConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/hiveConnection.json
@@ -97,6 +97,12 @@
           "$ref": "./mysqlConnection.json"
         },
         {
+          "$ref": "./mssqlConnection.json"
+        },
+        {
+          "$ref": "./oracleConnection.json"
+        },
+        {
           "title": "None",
           "type": "object",
           "additionalProperties": false

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/automations/createWorkflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/automations/createWorkflow.ts
@@ -1282,7 +1282,7 @@ export interface ConfigObject {
     /**
      * Connect with oracle by either passing service name or database schema name.
      */
-    oracleConnectionType?: OracleConnectionType;
+    oracleConnectionType?: ConfigOracleConnectionType;
     /**
      * Controls how Oracle identifier names (tables, columns, schemas) are stored in
      * OpenMetadata. When disabled (default), Oracle's UPPERCASE unquoted identifiers (e.g.
@@ -4171,9 +4171,9 @@ export interface PurpleGCPCredentials {
 }
 
 /**
- * Underlying database connection
- *
  * Mssql Database Connection Config
+ *
+ * Underlying database connection
  */
 export interface DatabaseConnectionClass {
     connectionArguments?: { [key: string]: any };
@@ -4378,6 +4378,12 @@ export enum Logmech {
  * Postgres Database Connection Config
  *
  * Mysql Database Connection Config
+ *
+ * Mssql Database Connection Config
+ *
+ * Underlying database connection
+ *
+ * Oracle Database Connection Config
  */
 export interface HiveMetastoreConnectionDetails {
     /**
@@ -4405,11 +4411,17 @@ export interface HiveMetastoreConnectionDetails {
      *
      * Host and port of the MySQL service. For GCP CloudSQL, use the instance connection name in
      * the format 'project_id:region:instance_name'.
+     *
+     * Host and port of the MSSQL service.
+     *
+     * Host and port of the Oracle service.
      */
     hostPort?: string;
     /**
      * Ingest data from all databases in Postgres. You can use databaseFilterPattern on top of
      * this.
+     *
+     * Ingest data from all databases in Mssql. You can use databaseFilterPattern on top of this.
      */
     ingestAllDatabases?: boolean;
     /**
@@ -4430,6 +4442,9 @@ export interface HiveMetastoreConnectionDetails {
     scheme?: HiveMetastoreConnectionDetailsScheme;
     /**
      * SSL Configuration details.
+     *
+     * SSL/TLS certificate configuration for client authentication. Provide CA certificate,
+     * client certificate, and private key for mutual TLS authentication.
      */
     sslConfig?: ConsumerConfigSSLClass;
     sslMode?:   SSLMode;
@@ -4459,6 +4474,12 @@ export interface HiveMetastoreConnectionDetails {
      *
      * Username to connect to MySQL. This user should have privileges to read all the metadata
      * in Mysql.
+     *
+     * Username to connect to MSSQL. This user should have privileges to read all the metadata
+     * in MsSQL.
+     *
+     * Username to connect to Oracle. This user should have privileges to read all the metadata
+     * in Oracle.
      */
     username?: string;
     /**
@@ -4476,13 +4497,89 @@ export interface HiveMetastoreConnectionDetails {
      * Use slow logs to extract lineage.
      */
     useSlowLogs?: boolean;
+    /**
+     * ODBC driver version in case of pyodbc connection.
+     */
+    driver?: string;
+    /**
+     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
+     * between the client and server will be encrypted.
+     */
+    encrypt?: boolean;
+    /**
+     * Password to connect to MSSQL.
+     *
+     * Password to connect to Oracle.
+     */
+    password?: string;
+    /**
+     * Trust the server certificate without validation. Set to false in production to validate
+     * server certificates against the certificate authority.
+     */
+    trustServerCertificate?: boolean;
+    /**
+     * This directory will be used to set the LD_LIBRARY_PATH env variable. It is required if
+     * you need to enable thick connection mode. By default, we bring instant client 19 and
+     * point to /instantclient.
+     */
+    instantClientDirectory?: string;
+    /**
+     * Connect with oracle by either passing service name or database schema name.
+     */
+    oracleConnectionType?: HiveMetastoreConnectionDetailsOracleConnectionType;
+    /**
+     * Controls how Oracle identifier names (tables, columns, schemas) are stored in
+     * OpenMetadata. When disabled (default), Oracle's UPPERCASE unquoted identifiers (e.g.
+     * EMPLOYEES) are not guaranteed to be stored as-is — identifiers with the same letters but
+     * different case (e.g. unquoted EMPLOYEES and quoted 'employees') will collide into the
+     * same name. When enabled, names are stored exactly as Oracle persists them, which solves
+     * same-name collisions between quoted and unquoted identifiers. WARNING: enabling this
+     * after data has already been ingested with the default setting will change the stored
+     * names of all existing tables, columns, schemas, and constraints — breaking attached tags,
+     * descriptions, lineage, data quality tests, and any other metadata associated with those
+     * entities. If you must switch, soft-delete all previously ingested entities before
+     * re-ingesting.
+     */
+    preserveIdentifierCase?: boolean;
+    /**
+     * Use Oracle DBA_* tables instead of ALL_* tables for metadata ingestion. Requires DBA
+     * privileges.
+     */
+    useDBATable?: boolean;
+}
+
+/**
+ * Connect with oracle by either passing service name or database schema name.
+ */
+export interface HiveMetastoreConnectionDetailsOracleConnectionType {
+    /**
+     * databaseSchema of the data source. This is optional parameter, if you would like to
+     * restrict the metadata reading to a single databaseSchema. When left blank, OpenMetadata
+     * Ingestion attempts to scan all the databaseSchema.
+     */
+    databaseSchema?: string;
+    /**
+     * The Oracle Service name is the TNS alias that you give when you remotely connect to your
+     * database.
+     */
+    oracleServiceName?: string;
+    /**
+     * Pass the full constructed TNS string, e.g.,
+     * (DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST=myhost)(PORT=1530)))(CONNECT_DATA=(SID=MYSERVICENAME))).
+     */
+    oracleTNSConnection?: string;
+    [property: string]: any;
 }
 
 /**
  * SQLAlchemy driver scheme options.
  */
 export enum HiveMetastoreConnectionDetailsScheme {
+    MssqlPymssql = "mssql+pymssql",
+    MssqlPyodbc = "mssql+pyodbc",
+    MssqlPytds = "mssql+pytds",
     MysqlPymysql = "mysql+pymysql",
+    OracleCxOracle = "oracle+cx_oracle",
     PgspiderPsycopg2 = "pgspider+psycopg2",
     PostgresqlPsycopg2 = "postgresql+psycopg2",
 }
@@ -4493,7 +4590,9 @@ export enum HiveMetastoreConnectionDetailsScheme {
  * Service type.
  */
 export enum HiveMetastoreConnectionDetailsType {
+    Mssql = "Mssql",
     Mysql = "Mysql",
+    Oracle = "Oracle",
     Postgres = "Postgres",
 }
 
@@ -4563,7 +4662,7 @@ export interface OpenAPISchemaConnection {
 /**
  * Connect with oracle by either passing service name or database schema name.
  */
-export interface OracleConnectionType {
+export interface ConfigOracleConnectionType {
     /**
      * databaseSchema of the data source. This is optional parameter, if you would like to
      * restrict the metadata reading to a single databaseSchema. When left blank, OpenMetadata

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createDatabaseService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/services/createDatabaseService.ts
@@ -1894,6 +1894,10 @@ export enum Logmech {
  * Postgres Database Connection Config
  *
  * Mysql Database Connection Config
+ *
+ * Mssql Database Connection Config
+ *
+ * Oracle Database Connection Config
  */
 export interface HiveMetastoreConnectionDetails {
     /**
@@ -1921,11 +1925,17 @@ export interface HiveMetastoreConnectionDetails {
      *
      * Host and port of the MySQL service. For GCP CloudSQL, use the instance connection name in
      * the format 'project_id:region:instance_name'.
+     *
+     * Host and port of the MSSQL service.
+     *
+     * Host and port of the Oracle service.
      */
     hostPort?: string;
     /**
      * Ingest data from all databases in Postgres. You can use databaseFilterPattern on top of
      * this.
+     *
+     * Ingest data from all databases in Mssql. You can use databaseFilterPattern on top of this.
      */
     ingestAllDatabases?: boolean;
     /**
@@ -1946,6 +1956,9 @@ export interface HiveMetastoreConnectionDetails {
     scheme?: HiveMetastoreConnectionDetailsScheme;
     /**
      * SSL Configuration details.
+     *
+     * SSL/TLS certificate configuration for client authentication. Provide CA certificate,
+     * client certificate, and private key for mutual TLS authentication.
      */
     sslConfig?: Config;
     sslMode?:   SSLMode;
@@ -1975,6 +1988,12 @@ export interface HiveMetastoreConnectionDetails {
      *
      * Username to connect to MySQL. This user should have privileges to read all the metadata
      * in Mysql.
+     *
+     * Username to connect to MSSQL. This user should have privileges to read all the metadata
+     * in MsSQL.
+     *
+     * Username to connect to Oracle. This user should have privileges to read all the metadata
+     * in Oracle.
      */
     username?: string;
     /**
@@ -1992,6 +2011,55 @@ export interface HiveMetastoreConnectionDetails {
      * Use slow logs to extract lineage.
      */
     useSlowLogs?: boolean;
+    /**
+     * ODBC driver version in case of pyodbc connection.
+     */
+    driver?: string;
+    /**
+     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
+     * between the client and server will be encrypted.
+     */
+    encrypt?: boolean;
+    /**
+     * Password to connect to MSSQL.
+     *
+     * Password to connect to Oracle.
+     */
+    password?: string;
+    /**
+     * Trust the server certificate without validation. Set to false in production to validate
+     * server certificates against the certificate authority.
+     */
+    trustServerCertificate?: boolean;
+    /**
+     * This directory will be used to set the LD_LIBRARY_PATH env variable. It is required if
+     * you need to enable thick connection mode. By default, we bring instant client 19 and
+     * point to /instantclient.
+     */
+    instantClientDirectory?: string;
+    /**
+     * Connect with oracle by either passing service name or database schema name.
+     */
+    oracleConnectionType?: OracleConnectionType;
+    /**
+     * Controls how Oracle identifier names (tables, columns, schemas) are stored in
+     * OpenMetadata. When disabled (default), Oracle's UPPERCASE unquoted identifiers (e.g.
+     * EMPLOYEES) are not guaranteed to be stored as-is — identifiers with the same letters but
+     * different case (e.g. unquoted EMPLOYEES and quoted 'employees') will collide into the
+     * same name. When enabled, names are stored exactly as Oracle persists them, which solves
+     * same-name collisions between quoted and unquoted identifiers. WARNING: enabling this
+     * after data has already been ingested with the default setting will change the stored
+     * names of all existing tables, columns, schemas, and constraints — breaking attached tags,
+     * descriptions, lineage, data quality tests, and any other metadata associated with those
+     * entities. If you must switch, soft-delete all previously ingested entities before
+     * re-ingesting.
+     */
+    preserveIdentifierCase?: boolean;
+    /**
+     * Use Oracle DBA_* tables instead of ALL_* tables for metadata ingestion. Requires DBA
+     * privileges.
+     */
+    useDBATable?: boolean;
 }
 
 /**
@@ -2022,6 +2090,29 @@ export interface AuthTypeClass {
      * GCP credentials to use. If not provided, Application Default Credentials will be used.
      */
     gcpConfig?: GCPCredentials;
+}
+
+/**
+ * Connect with oracle by either passing service name or database schema name.
+ */
+export interface OracleConnectionType {
+    /**
+     * databaseSchema of the data source. This is optional parameter, if you would like to
+     * restrict the metadata reading to a single databaseSchema. When left blank, OpenMetadata
+     * Ingestion attempts to scan all the databaseSchema.
+     */
+    databaseSchema?: string;
+    /**
+     * The Oracle Service name is the TNS alias that you give when you remotely connect to your
+     * database.
+     */
+    oracleServiceName?: string;
+    /**
+     * Pass the full constructed TNS string, e.g.,
+     * (DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST=myhost)(PORT=1530)))(CONNECT_DATA=(SID=MYSERVICENAME))).
+     */
+    oracleTNSConnection?: string;
+    [property: string]: any;
 }
 
 /**
@@ -2112,7 +2203,11 @@ export interface AwsCredentials {
  * SQLAlchemy driver scheme options.
  */
 export enum HiveMetastoreConnectionDetailsScheme {
+    MssqlPymssql = "mssql+pymssql",
+    MssqlPyodbc = "mssql+pyodbc",
+    MssqlPytds = "mssql+pytds",
     MysqlPymysql = "mysql+pymysql",
+    OracleCxOracle = "oracle+cx_oracle",
     PgspiderPsycopg2 = "pgspider+psycopg2",
     PostgresqlPsycopg2 = "postgresql+psycopg2",
 }
@@ -2170,31 +2265,10 @@ export enum SSLMode {
  * Service type.
  */
 export enum HiveMetastoreConnectionDetailsType {
+    Mssql = "Mssql",
     Mysql = "Mysql",
+    Oracle = "Oracle",
     Postgres = "Postgres",
-}
-
-/**
- * Connect with oracle by either passing service name or database schema name.
- */
-export interface OracleConnectionType {
-    /**
-     * databaseSchema of the data source. This is optional parameter, if you would like to
-     * restrict the metadata reading to a single databaseSchema. When left blank, OpenMetadata
-     * Ingestion attempts to scan all the databaseSchema.
-     */
-    databaseSchema?: string;
-    /**
-     * The Oracle Service name is the TNS alias that you give when you remotely connect to your
-     * database.
-     */
-    oracleServiceName?: string;
-    /**
-     * Pass the full constructed TNS string, e.g.,
-     * (DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST=myhost)(PORT=1530)))(CONNECT_DATA=(SID=MYSERVICENAME))).
-     */
-    oracleTNSConnection?: string;
-    [property: string]: any;
 }
 
 /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/services/ingestionPipelines/createIngestionPipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/services/ingestionPipelines/createIngestionPipeline.ts
@@ -4523,7 +4523,7 @@ export interface ConfigObject {
     /**
      * Connect with oracle by either passing service name or database schema name.
      */
-    oracleConnectionType?: OracleConnectionType;
+    oracleConnectionType?: ConfigOracleConnectionType;
     /**
      * Controls how Oracle identifier names (tables, columns, schemas) are stored in
      * OpenMetadata. When disabled (default), Oracle's UPPERCASE unquoted identifiers (e.g.
@@ -6818,9 +6818,9 @@ export interface PurpleGCPCredentials {
 }
 
 /**
- * Underlying database connection
- *
  * Mssql Database Connection Config
+ *
+ * Underlying database connection
  */
 export interface DatabaseConnectionClass {
     connectionArguments?: { [key: string]: any };
@@ -7036,6 +7036,12 @@ export enum Logmech {
  * Postgres Database Connection Config
  *
  * Mysql Database Connection Config
+ *
+ * Mssql Database Connection Config
+ *
+ * Underlying database connection
+ *
+ * Oracle Database Connection Config
  */
 export interface HiveMetastoreConnectionDetails {
     /**
@@ -7063,11 +7069,17 @@ export interface HiveMetastoreConnectionDetails {
      *
      * Host and port of the MySQL service. For GCP CloudSQL, use the instance connection name in
      * the format 'project_id:region:instance_name'.
+     *
+     * Host and port of the MSSQL service.
+     *
+     * Host and port of the Oracle service.
      */
     hostPort?: string;
     /**
      * Ingest data from all databases in Postgres. You can use databaseFilterPattern on top of
      * this.
+     *
+     * Ingest data from all databases in Mssql. You can use databaseFilterPattern on top of this.
      */
     ingestAllDatabases?: boolean;
     /**
@@ -7088,6 +7100,9 @@ export interface HiveMetastoreConnectionDetails {
     scheme?: HiveMetastoreConnectionDetailsScheme;
     /**
      * SSL Configuration details.
+     *
+     * SSL/TLS certificate configuration for client authentication. Provide CA certificate,
+     * client certificate, and private key for mutual TLS authentication.
      */
     sslConfig?: DbtSSLConfigClass;
     sslMode?:   SSLMode;
@@ -7117,6 +7132,12 @@ export interface HiveMetastoreConnectionDetails {
      *
      * Username to connect to MySQL. This user should have privileges to read all the metadata
      * in Mysql.
+     *
+     * Username to connect to MSSQL. This user should have privileges to read all the metadata
+     * in MsSQL.
+     *
+     * Username to connect to Oracle. This user should have privileges to read all the metadata
+     * in Oracle.
      */
     username?: string;
     /**
@@ -7134,13 +7155,89 @@ export interface HiveMetastoreConnectionDetails {
      * Use slow logs to extract lineage.
      */
     useSlowLogs?: boolean;
+    /**
+     * ODBC driver version in case of pyodbc connection.
+     */
+    driver?: string;
+    /**
+     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
+     * between the client and server will be encrypted.
+     */
+    encrypt?: boolean;
+    /**
+     * Password to connect to MSSQL.
+     *
+     * Password to connect to Oracle.
+     */
+    password?: string;
+    /**
+     * Trust the server certificate without validation. Set to false in production to validate
+     * server certificates against the certificate authority.
+     */
+    trustServerCertificate?: boolean;
+    /**
+     * This directory will be used to set the LD_LIBRARY_PATH env variable. It is required if
+     * you need to enable thick connection mode. By default, we bring instant client 19 and
+     * point to /instantclient.
+     */
+    instantClientDirectory?: string;
+    /**
+     * Connect with oracle by either passing service name or database schema name.
+     */
+    oracleConnectionType?: HiveMetastoreConnectionDetailsOracleConnectionType;
+    /**
+     * Controls how Oracle identifier names (tables, columns, schemas) are stored in
+     * OpenMetadata. When disabled (default), Oracle's UPPERCASE unquoted identifiers (e.g.
+     * EMPLOYEES) are not guaranteed to be stored as-is — identifiers with the same letters but
+     * different case (e.g. unquoted EMPLOYEES and quoted 'employees') will collide into the
+     * same name. When enabled, names are stored exactly as Oracle persists them, which solves
+     * same-name collisions between quoted and unquoted identifiers. WARNING: enabling this
+     * after data has already been ingested with the default setting will change the stored
+     * names of all existing tables, columns, schemas, and constraints — breaking attached tags,
+     * descriptions, lineage, data quality tests, and any other metadata associated with those
+     * entities. If you must switch, soft-delete all previously ingested entities before
+     * re-ingesting.
+     */
+    preserveIdentifierCase?: boolean;
+    /**
+     * Use Oracle DBA_* tables instead of ALL_* tables for metadata ingestion. Requires DBA
+     * privileges.
+     */
+    useDBATable?: boolean;
+}
+
+/**
+ * Connect with oracle by either passing service name or database schema name.
+ */
+export interface HiveMetastoreConnectionDetailsOracleConnectionType {
+    /**
+     * databaseSchema of the data source. This is optional parameter, if you would like to
+     * restrict the metadata reading to a single databaseSchema. When left blank, OpenMetadata
+     * Ingestion attempts to scan all the databaseSchema.
+     */
+    databaseSchema?: string;
+    /**
+     * The Oracle Service name is the TNS alias that you give when you remotely connect to your
+     * database.
+     */
+    oracleServiceName?: string;
+    /**
+     * Pass the full constructed TNS string, e.g.,
+     * (DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST=myhost)(PORT=1530)))(CONNECT_DATA=(SID=MYSERVICENAME))).
+     */
+    oracleTNSConnection?: string;
+    [property: string]: any;
 }
 
 /**
  * SQLAlchemy driver scheme options.
  */
 export enum HiveMetastoreConnectionDetailsScheme {
+    MssqlPymssql = "mssql+pymssql",
+    MssqlPyodbc = "mssql+pyodbc",
+    MssqlPytds = "mssql+pytds",
     MysqlPymysql = "mysql+pymysql",
+    OracleCxOracle = "oracle+cx_oracle",
     PgspiderPsycopg2 = "pgspider+psycopg2",
     PostgresqlPsycopg2 = "postgresql+psycopg2",
 }
@@ -7151,7 +7248,9 @@ export enum HiveMetastoreConnectionDetailsScheme {
  * Service type.
  */
 export enum HiveMetastoreConnectionDetailsType {
+    Mssql = "Mssql",
     Mysql = "Mysql",
+    Oracle = "Oracle",
     Postgres = "Postgres",
 }
 
@@ -7221,7 +7320,7 @@ export interface OpenAPISchemaConnection {
 /**
  * Connect with oracle by either passing service name or database schema name.
  */
-export interface OracleConnectionType {
+export interface ConfigOracleConnectionType {
     /**
      * databaseSchema of the data source. This is optional parameter, if you would like to
      * restrict the metadata reading to a single databaseSchema. When left blank, OpenMetadata

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/testServiceConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/testServiceConnection.ts
@@ -1164,7 +1164,7 @@ export interface ConfigObject {
     /**
      * Connect with oracle by either passing service name or database schema name.
      */
-    oracleConnectionType?: OracleConnectionType;
+    oracleConnectionType?: ConfigOracleConnectionType;
     /**
      * Controls how Oracle identifier names (tables, columns, schemas) are stored in
      * OpenMetadata. When disabled (default), Oracle's UPPERCASE unquoted identifiers (e.g.
@@ -4053,9 +4053,9 @@ export interface PurpleGCPCredentials {
 }
 
 /**
- * Underlying database connection
- *
  * Mssql Database Connection Config
+ *
+ * Underlying database connection
  */
 export interface DatabaseConnectionClass {
     connectionArguments?: { [key: string]: any };
@@ -4260,6 +4260,12 @@ export enum Logmech {
  * Postgres Database Connection Config
  *
  * Mysql Database Connection Config
+ *
+ * Mssql Database Connection Config
+ *
+ * Underlying database connection
+ *
+ * Oracle Database Connection Config
  */
 export interface HiveMetastoreConnectionDetails {
     /**
@@ -4287,11 +4293,17 @@ export interface HiveMetastoreConnectionDetails {
      *
      * Host and port of the MySQL service. For GCP CloudSQL, use the instance connection name in
      * the format 'project_id:region:instance_name'.
+     *
+     * Host and port of the MSSQL service.
+     *
+     * Host and port of the Oracle service.
      */
     hostPort?: string;
     /**
      * Ingest data from all databases in Postgres. You can use databaseFilterPattern on top of
      * this.
+     *
+     * Ingest data from all databases in Mssql. You can use databaseFilterPattern on top of this.
      */
     ingestAllDatabases?: boolean;
     /**
@@ -4312,6 +4324,9 @@ export interface HiveMetastoreConnectionDetails {
     scheme?: HiveMetastoreConnectionDetailsScheme;
     /**
      * SSL Configuration details.
+     *
+     * SSL/TLS certificate configuration for client authentication. Provide CA certificate,
+     * client certificate, and private key for mutual TLS authentication.
      */
     sslConfig?: ConsumerConfigSSLClass;
     sslMode?:   SSLMode;
@@ -4341,6 +4356,12 @@ export interface HiveMetastoreConnectionDetails {
      *
      * Username to connect to MySQL. This user should have privileges to read all the metadata
      * in Mysql.
+     *
+     * Username to connect to MSSQL. This user should have privileges to read all the metadata
+     * in MsSQL.
+     *
+     * Username to connect to Oracle. This user should have privileges to read all the metadata
+     * in Oracle.
      */
     username?: string;
     /**
@@ -4358,13 +4379,89 @@ export interface HiveMetastoreConnectionDetails {
      * Use slow logs to extract lineage.
      */
     useSlowLogs?: boolean;
+    /**
+     * ODBC driver version in case of pyodbc connection.
+     */
+    driver?: string;
+    /**
+     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
+     * between the client and server will be encrypted.
+     */
+    encrypt?: boolean;
+    /**
+     * Password to connect to MSSQL.
+     *
+     * Password to connect to Oracle.
+     */
+    password?: string;
+    /**
+     * Trust the server certificate without validation. Set to false in production to validate
+     * server certificates against the certificate authority.
+     */
+    trustServerCertificate?: boolean;
+    /**
+     * This directory will be used to set the LD_LIBRARY_PATH env variable. It is required if
+     * you need to enable thick connection mode. By default, we bring instant client 19 and
+     * point to /instantclient.
+     */
+    instantClientDirectory?: string;
+    /**
+     * Connect with oracle by either passing service name or database schema name.
+     */
+    oracleConnectionType?: HiveMetastoreConnectionDetailsOracleConnectionType;
+    /**
+     * Controls how Oracle identifier names (tables, columns, schemas) are stored in
+     * OpenMetadata. When disabled (default), Oracle's UPPERCASE unquoted identifiers (e.g.
+     * EMPLOYEES) are not guaranteed to be stored as-is — identifiers with the same letters but
+     * different case (e.g. unquoted EMPLOYEES and quoted 'employees') will collide into the
+     * same name. When enabled, names are stored exactly as Oracle persists them, which solves
+     * same-name collisions between quoted and unquoted identifiers. WARNING: enabling this
+     * after data has already been ingested with the default setting will change the stored
+     * names of all existing tables, columns, schemas, and constraints — breaking attached tags,
+     * descriptions, lineage, data quality tests, and any other metadata associated with those
+     * entities. If you must switch, soft-delete all previously ingested entities before
+     * re-ingesting.
+     */
+    preserveIdentifierCase?: boolean;
+    /**
+     * Use Oracle DBA_* tables instead of ALL_* tables for metadata ingestion. Requires DBA
+     * privileges.
+     */
+    useDBATable?: boolean;
+}
+
+/**
+ * Connect with oracle by either passing service name or database schema name.
+ */
+export interface HiveMetastoreConnectionDetailsOracleConnectionType {
+    /**
+     * databaseSchema of the data source. This is optional parameter, if you would like to
+     * restrict the metadata reading to a single databaseSchema. When left blank, OpenMetadata
+     * Ingestion attempts to scan all the databaseSchema.
+     */
+    databaseSchema?: string;
+    /**
+     * The Oracle Service name is the TNS alias that you give when you remotely connect to your
+     * database.
+     */
+    oracleServiceName?: string;
+    /**
+     * Pass the full constructed TNS string, e.g.,
+     * (DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST=myhost)(PORT=1530)))(CONNECT_DATA=(SID=MYSERVICENAME))).
+     */
+    oracleTNSConnection?: string;
+    [property: string]: any;
 }
 
 /**
  * SQLAlchemy driver scheme options.
  */
 export enum HiveMetastoreConnectionDetailsScheme {
+    MssqlPymssql = "mssql+pymssql",
+    MssqlPyodbc = "mssql+pyodbc",
+    MssqlPytds = "mssql+pytds",
     MysqlPymysql = "mysql+pymysql",
+    OracleCxOracle = "oracle+cx_oracle",
     PgspiderPsycopg2 = "pgspider+psycopg2",
     PostgresqlPsycopg2 = "postgresql+psycopg2",
 }
@@ -4375,7 +4472,9 @@ export enum HiveMetastoreConnectionDetailsScheme {
  * Service type.
  */
 export enum HiveMetastoreConnectionDetailsType {
+    Mssql = "Mssql",
     Mysql = "Mysql",
+    Oracle = "Oracle",
     Postgres = "Postgres",
 }
 
@@ -4445,7 +4544,7 @@ export interface OpenAPISchemaConnection {
 /**
  * Connect with oracle by either passing service name or database schema name.
  */
-export interface OracleConnectionType {
+export interface ConfigOracleConnectionType {
     /**
      * databaseSchema of the data source. This is optional parameter, if you would like to
      * restrict the metadata reading to a single databaseSchema. When left blank, OpenMetadata

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/workflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/automations/workflow.ts
@@ -1835,7 +1835,7 @@ export interface ConfigObject {
     /**
      * Connect with oracle by either passing service name or database schema name.
      */
-    oracleConnectionType?: OracleConnectionType;
+    oracleConnectionType?: ConfigOracleConnectionType;
     /**
      * Controls how Oracle identifier names (tables, columns, schemas) are stored in
      * OpenMetadata. When disabled (default), Oracle's UPPERCASE unquoted identifiers (e.g.
@@ -4561,9 +4561,9 @@ export interface PurpleGCPCredentials {
 }
 
 /**
- * Underlying database connection
- *
  * Mssql Database Connection Config
+ *
+ * Underlying database connection
  */
 export interface DatabaseConnectionClass {
     connectionArguments?: { [key: string]: any };
@@ -4768,6 +4768,12 @@ export enum Logmech {
  * Postgres Database Connection Config
  *
  * Mysql Database Connection Config
+ *
+ * Mssql Database Connection Config
+ *
+ * Underlying database connection
+ *
+ * Oracle Database Connection Config
  */
 export interface HiveMetastoreConnectionDetails {
     /**
@@ -4795,11 +4801,17 @@ export interface HiveMetastoreConnectionDetails {
      *
      * Host and port of the MySQL service. For GCP CloudSQL, use the instance connection name in
      * the format 'project_id:region:instance_name'.
+     *
+     * Host and port of the MSSQL service.
+     *
+     * Host and port of the Oracle service.
      */
     hostPort?: string;
     /**
      * Ingest data from all databases in Postgres. You can use databaseFilterPattern on top of
      * this.
+     *
+     * Ingest data from all databases in Mssql. You can use databaseFilterPattern on top of this.
      */
     ingestAllDatabases?: boolean;
     /**
@@ -4820,6 +4832,9 @@ export interface HiveMetastoreConnectionDetails {
     scheme?: HiveMetastoreConnectionDetailsScheme;
     /**
      * SSL Configuration details.
+     *
+     * SSL/TLS certificate configuration for client authentication. Provide CA certificate,
+     * client certificate, and private key for mutual TLS authentication.
      */
     sslConfig?: ConsumerConfigSSLClass;
     sslMode?:   SSLMode;
@@ -4849,6 +4864,12 @@ export interface HiveMetastoreConnectionDetails {
      *
      * Username to connect to MySQL. This user should have privileges to read all the metadata
      * in Mysql.
+     *
+     * Username to connect to MSSQL. This user should have privileges to read all the metadata
+     * in MsSQL.
+     *
+     * Username to connect to Oracle. This user should have privileges to read all the metadata
+     * in Oracle.
      */
     username?: string;
     /**
@@ -4866,13 +4887,89 @@ export interface HiveMetastoreConnectionDetails {
      * Use slow logs to extract lineage.
      */
     useSlowLogs?: boolean;
+    /**
+     * ODBC driver version in case of pyodbc connection.
+     */
+    driver?: string;
+    /**
+     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
+     * between the client and server will be encrypted.
+     */
+    encrypt?: boolean;
+    /**
+     * Password to connect to MSSQL.
+     *
+     * Password to connect to Oracle.
+     */
+    password?: string;
+    /**
+     * Trust the server certificate without validation. Set to false in production to validate
+     * server certificates against the certificate authority.
+     */
+    trustServerCertificate?: boolean;
+    /**
+     * This directory will be used to set the LD_LIBRARY_PATH env variable. It is required if
+     * you need to enable thick connection mode. By default, we bring instant client 19 and
+     * point to /instantclient.
+     */
+    instantClientDirectory?: string;
+    /**
+     * Connect with oracle by either passing service name or database schema name.
+     */
+    oracleConnectionType?: HiveMetastoreConnectionDetailsOracleConnectionType;
+    /**
+     * Controls how Oracle identifier names (tables, columns, schemas) are stored in
+     * OpenMetadata. When disabled (default), Oracle's UPPERCASE unquoted identifiers (e.g.
+     * EMPLOYEES) are not guaranteed to be stored as-is — identifiers with the same letters but
+     * different case (e.g. unquoted EMPLOYEES and quoted 'employees') will collide into the
+     * same name. When enabled, names are stored exactly as Oracle persists them, which solves
+     * same-name collisions between quoted and unquoted identifiers. WARNING: enabling this
+     * after data has already been ingested with the default setting will change the stored
+     * names of all existing tables, columns, schemas, and constraints — breaking attached tags,
+     * descriptions, lineage, data quality tests, and any other metadata associated with those
+     * entities. If you must switch, soft-delete all previously ingested entities before
+     * re-ingesting.
+     */
+    preserveIdentifierCase?: boolean;
+    /**
+     * Use Oracle DBA_* tables instead of ALL_* tables for metadata ingestion. Requires DBA
+     * privileges.
+     */
+    useDBATable?: boolean;
+}
+
+/**
+ * Connect with oracle by either passing service name or database schema name.
+ */
+export interface HiveMetastoreConnectionDetailsOracleConnectionType {
+    /**
+     * databaseSchema of the data source. This is optional parameter, if you would like to
+     * restrict the metadata reading to a single databaseSchema. When left blank, OpenMetadata
+     * Ingestion attempts to scan all the databaseSchema.
+     */
+    databaseSchema?: string;
+    /**
+     * The Oracle Service name is the TNS alias that you give when you remotely connect to your
+     * database.
+     */
+    oracleServiceName?: string;
+    /**
+     * Pass the full constructed TNS string, e.g.,
+     * (DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST=myhost)(PORT=1530)))(CONNECT_DATA=(SID=MYSERVICENAME))).
+     */
+    oracleTNSConnection?: string;
+    [property: string]: any;
 }
 
 /**
  * SQLAlchemy driver scheme options.
  */
 export enum HiveMetastoreConnectionDetailsScheme {
+    MssqlPymssql = "mssql+pymssql",
+    MssqlPyodbc = "mssql+pyodbc",
+    MssqlPytds = "mssql+pytds",
     MysqlPymysql = "mysql+pymysql",
+    OracleCxOracle = "oracle+cx_oracle",
     PgspiderPsycopg2 = "pgspider+psycopg2",
     PostgresqlPsycopg2 = "postgresql+psycopg2",
 }
@@ -4883,7 +4980,9 @@ export enum HiveMetastoreConnectionDetailsScheme {
  * Service type.
  */
 export enum HiveMetastoreConnectionDetailsType {
+    Mssql = "Mssql",
     Mysql = "Mysql",
+    Oracle = "Oracle",
     Postgres = "Postgres",
 }
 
@@ -4953,7 +5052,7 @@ export interface OpenAPISchemaConnection {
 /**
  * Connect with oracle by either passing service name or database schema name.
  */
-export interface OracleConnectionType {
+export interface ConfigOracleConnectionType {
     /**
      * databaseSchema of the data source. This is optional parameter, if you would like to
      * restrict the metadata reading to a single databaseSchema. When left blank, OpenMetadata

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/database/hiveConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/database/hiveConnection.ts
@@ -13,7 +13,7 @@
 /**
  * Hive SQL Connection Config
  */
-export interface HiveConnection {
+export interface HiveConnectionNew {
     /**
      * Authentication mode to connect to hive.
      */
@@ -135,6 +135,10 @@ export interface FilterPattern {
  * Postgres Database Connection Config
  *
  * Mysql Database Connection Config
+ *
+ * Mssql Database Connection Config
+ *
+ * Oracle Database Connection Config
  */
 export interface HiveMetastoreConnectionDetails {
     /**
@@ -160,13 +164,18 @@ export interface HiveMetastoreConnectionDetails {
     /**
      * Host and port of the source service.
      *
-     * Host and port of the MySQL service. For GCP CloudSQL, use the instance connection name in
-     * the format 'project_id:region:instance_name'.
+     * Host and port of the MySQL service.
+     *
+     * Host and port of the MSSQL service.
+     *
+     * Host and port of the Oracle service.
      */
     hostPort?: string;
     /**
      * Ingest data from all databases in Postgres. You can use databaseFilterPattern on top of
      * this.
+     *
+     * Ingest data from all databases in Mssql. You can use databaseFilterPattern on top of this.
      */
     ingestAllDatabases?: boolean;
     /**
@@ -187,6 +196,9 @@ export interface HiveMetastoreConnectionDetails {
     scheme?: Scheme;
     /**
      * SSL Configuration details.
+     *
+     * SSL/TLS certificate configuration for client authentication. Provide CA certificate,
+     * client certificate, and private key for mutual TLS authentication.
      */
     sslConfig?: Config;
     sslMode?:   SSLMode;
@@ -216,6 +228,12 @@ export interface HiveMetastoreConnectionDetails {
      *
      * Username to connect to MySQL. This user should have privileges to read all the metadata
      * in Mysql.
+     *
+     * Username to connect to MSSQL. This user should have privileges to read all the metadata
+     * in MsSQL.
+     *
+     * Username to connect to Oracle. This user should have privileges to read all the metadata
+     * in Oracle.
      */
     username?: string;
     /**
@@ -233,6 +251,55 @@ export interface HiveMetastoreConnectionDetails {
      * Use slow logs to extract lineage.
      */
     useSlowLogs?: boolean;
+    /**
+     * ODBC driver version in case of pyodbc connection.
+     */
+    driver?: string;
+    /**
+     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
+     * between the client and server will be encrypted.
+     */
+    encrypt?: boolean;
+    /**
+     * Password to connect to MSSQL.
+     *
+     * Password to connect to Oracle.
+     */
+    password?: string;
+    /**
+     * Trust the server certificate without validation. Set to false in production to validate
+     * server certificates against the certificate authority.
+     */
+    trustServerCertificate?: boolean;
+    /**
+     * This directory will be used to set the LD_LIBRARY_PATH env variable. It is required if
+     * you need to enable thick connection mode. By default, we bring instant client 19 and
+     * point to /instantclient.
+     */
+    instantClientDirectory?: string;
+    /**
+     * Connect with oracle by either passing service name or database schema name.
+     */
+    oracleConnectionType?: OracleConnectionType;
+    /**
+     * Controls how Oracle identifier names (tables, columns, schemas) are stored in
+     * OpenMetadata. When disabled (default), Oracle's UPPERCASE unquoted identifiers (e.g.
+     * EMPLOYEES) are not guaranteed to be stored as-is — identifiers with the same letters but
+     * different case (e.g. unquoted EMPLOYEES and quoted 'employees') will collide into the
+     * same name. When enabled, names are stored exactly as Oracle persists them, which solves
+     * same-name collisions between quoted and unquoted identifiers. WARNING: enabling this
+     * after data has already been ingested with the default setting will change the stored
+     * names of all existing tables, columns, schemas, and constraints — breaking attached tags,
+     * descriptions, lineage, data quality tests, and any other metadata associated with those
+     * entities. If you must switch, soft-delete all previously ingested entities before
+     * re-ingesting.
+     */
+    preserveIdentifierCase?: boolean;
+    /**
+     * Use Oracle DBA_* tables instead of ALL_* tables for metadata ingestion. Requires DBA
+     * privileges.
+     */
+    useDBATable?: boolean;
 }
 
 /**
@@ -243,26 +310,14 @@ export interface HiveMetastoreConnectionDetails {
  * IAM Auth Database Connection Config
  *
  * Azure Database Connection Config
- *
- * GCP CloudSQL Database Connection Config. Uses the Google Cloud SQL Python Connector.
  */
 export interface AuthConfigurationType {
     /**
      * Password to connect to source.
-     *
-     * Database user password. Leave empty if using IAM database authentication.
      */
     password?:    string;
     awsConfig?:   AWSCredentials;
     azureConfig?: AzureCredentials;
-    /**
-     * Use GCP IAM for database authentication instead of a password.
-     */
-    enableIamAuth?: boolean;
-    /**
-     * GCP credentials to use. If not provided, Application Default Credentials will be used.
-     */
-    gcpConfig?: GCPCredentials;
 }
 
 /**
@@ -348,121 +403,25 @@ export interface AzureCredentials {
 }
 
 /**
- * GCP credentials to use. If not provided, Application Default Credentials will be used.
- *
- * GCP credentials configs.
+ * Connect with oracle by either passing service name or database schema name.
  */
-export interface GCPCredentials {
+export interface OracleConnectionType {
     /**
-     * We support two ways of authenticating to GCP i.e via GCP Credentials Values or GCP
-     * Credentials Path
+     * databaseSchema of the data source. This is optional parameter, if you would like to
+     * restrict the metadata reading to a single databaseSchema. When left blank, OpenMetadata
+     * Ingestion attempts to scan all the databaseSchema.
      */
-    gcpConfig: GCPCredentialsConfiguration;
+    databaseSchema?: string;
     /**
-     * we enable the authenticated service account to impersonate another service account
+     * The Oracle Service name is the TNS alias that you give when you remotely connect to your
+     * database.
      */
-    gcpImpersonateServiceAccount?: GCPImpersonateServiceAccountValues;
-}
-
-/**
- * We support two ways of authenticating to GCP i.e via GCP Credentials Values or GCP
- * Credentials Path
- *
- * Pass the raw credential values provided by GCP
- *
- * Pass the path of file containing the GCP credentials info
- *
- * Use the application default credentials
- */
-export interface GCPCredentialsConfiguration {
+    oracleServiceName?: string;
     /**
-     * Google Cloud auth provider certificate.
+     * Pass the full constructed TNS string, e.g.,
+     * (DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST=myhost)(PORT=1530)))(CONNECT_DATA=(SID=MYSERVICENAME))).
      */
-    authProviderX509CertUrl?: string;
-    /**
-     * Google Cloud auth uri.
-     */
-    authUri?: string;
-    /**
-     * Google Cloud email.
-     */
-    clientEmail?: string;
-    /**
-     * Google Cloud Client ID.
-     */
-    clientId?: string;
-    /**
-     * Google Cloud client certificate uri.
-     */
-    clientX509CertUrl?: string;
-    /**
-     * Google Cloud private key.
-     */
-    privateKey?: string;
-    /**
-     * Google Cloud private key id.
-     */
-    privateKeyId?: string;
-    /**
-     * Project ID
-     *
-     * GCP Project ID to parse metadata from
-     */
-    projectId?: string[] | string;
-    /**
-     * Google Cloud token uri.
-     */
-    tokenUri?: string;
-    /**
-     * Google Cloud Platform account type.
-     *
-     * Google Cloud Platform ADC ( Application Default Credentials )
-     */
-    type?: string;
-    /**
-     * Path of the file containing the GCP credentials info
-     */
-    path?: string;
-    /**
-     * Google Security Token Service audience which contains the resource name for the workload
-     * identity pool and the provider identifier in that pool.
-     */
-    audience?: string;
-    /**
-     * This object defines the mechanism used to retrieve the external credential from the local
-     * environment so that it can be exchanged for a GCP access token via the STS endpoint
-     */
-    credentialSource?: { [key: string]: string };
-    /**
-     * Google Cloud Platform account type.
-     */
-    externalType?: string;
-    /**
-     * Google Security Token Service subject token type based on the OAuth 2.0 token exchange
-     * spec.
-     */
-    subjectTokenType?: string;
-    /**
-     * Google Security Token Service token exchange endpoint.
-     */
-    tokenURL?: string;
-    [property: string]: any;
-}
-
-/**
- * we enable the authenticated service account to impersonate another service account
- *
- * Pass the values to impersonate a service account of Google Cloud
- */
-export interface GCPImpersonateServiceAccountValues {
-    /**
-     * The impersonated service account email
-     */
-    impersonateServiceAccount?: string;
-    /**
-     * Number of seconds the delegated credential should be valid
-     */
-    lifetime?: number;
+    oracleTNSConnection?: string;
     [property: string]: any;
 }
 
@@ -554,7 +513,11 @@ export interface AwsCredentials {
  * SQLAlchemy driver scheme options.
  */
 export enum Scheme {
+    MssqlPymssql = "mssql+pymssql",
+    MssqlPyodbc = "mssql+pyodbc",
+    MssqlPytds = "mssql+pytds",
     MysqlPymysql = "mysql+pymysql",
+    OracleCxOracle = "oracle+cx_oracle",
     PgspiderPsycopg2 = "pgspider+psycopg2",
     PostgresqlPsycopg2 = "postgresql+psycopg2",
 }
@@ -563,6 +526,9 @@ export enum Scheme {
  * Client SSL configuration
  *
  * SSL Configuration details.
+ *
+ * SSL/TLS certificate configuration for client authentication. Provide CA certificate,
+ * client certificate, and private key for mutual TLS authentication.
  *
  * OpenMetadata Client configured to validate SSL certificates.
  */
@@ -599,7 +565,9 @@ export enum SSLMode {
  * Service type.
  */
 export enum Type {
+    Mssql = "Mssql",
     Mysql = "Mysql",
+    Oracle = "Oracle",
     Postgres = "Postgres",
 }
 

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/database/hiveConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/database/hiveConnection.ts
@@ -13,7 +13,7 @@
 /**
  * Hive SQL Connection Config
  */
-export interface HiveConnectionNew {
+export interface HiveConnection {
     /**
      * Authentication mode to connect to hive.
      */
@@ -164,7 +164,8 @@ export interface HiveMetastoreConnectionDetails {
     /**
      * Host and port of the source service.
      *
-     * Host and port of the MySQL service.
+     * Host and port of the MySQL service. For GCP CloudSQL, use the instance connection name in
+     * the format 'project_id:region:instance_name'.
      *
      * Host and port of the MSSQL service.
      *
@@ -310,14 +311,26 @@ export interface HiveMetastoreConnectionDetails {
  * IAM Auth Database Connection Config
  *
  * Azure Database Connection Config
+ *
+ * GCP CloudSQL Database Connection Config. Uses the Google Cloud SQL Python Connector.
  */
 export interface AuthConfigurationType {
     /**
      * Password to connect to source.
+     *
+     * Database user password. Leave empty if using IAM database authentication.
      */
     password?:    string;
     awsConfig?:   AWSCredentials;
     azureConfig?: AzureCredentials;
+    /**
+     * Use GCP IAM for database authentication instead of a password.
+     */
+    enableIamAuth?: boolean;
+    /**
+     * GCP credentials to use. If not provided, Application Default Credentials will be used.
+     */
+    gcpConfig?: GCPCredentials;
 }
 
 /**
@@ -400,6 +413,125 @@ export interface AzureCredentials {
      * Key Vault Name
      */
     vaultName?: string;
+}
+
+/**
+ * GCP credentials to use. If not provided, Application Default Credentials will be used.
+ *
+ * GCP credentials configs.
+ */
+export interface GCPCredentials {
+    /**
+     * We support two ways of authenticating to GCP i.e via GCP Credentials Values or GCP
+     * Credentials Path
+     */
+    gcpConfig: GCPCredentialsConfiguration;
+    /**
+     * we enable the authenticated service account to impersonate another service account
+     */
+    gcpImpersonateServiceAccount?: GCPImpersonateServiceAccountValues;
+}
+
+/**
+ * We support two ways of authenticating to GCP i.e via GCP Credentials Values or GCP
+ * Credentials Path
+ *
+ * Pass the raw credential values provided by GCP
+ *
+ * Pass the path of file containing the GCP credentials info
+ *
+ * Use the application default credentials
+ */
+export interface GCPCredentialsConfiguration {
+    /**
+     * Google Cloud auth provider certificate.
+     */
+    authProviderX509CertUrl?: string;
+    /**
+     * Google Cloud auth uri.
+     */
+    authUri?: string;
+    /**
+     * Google Cloud email.
+     */
+    clientEmail?: string;
+    /**
+     * Google Cloud Client ID.
+     */
+    clientId?: string;
+    /**
+     * Google Cloud client certificate uri.
+     */
+    clientX509CertUrl?: string;
+    /**
+     * Google Cloud private key.
+     */
+    privateKey?: string;
+    /**
+     * Google Cloud private key id.
+     */
+    privateKeyId?: string;
+    /**
+     * Project ID
+     *
+     * GCP Project ID to parse metadata from
+     */
+    projectId?: string[] | string;
+    /**
+     * Google Cloud token uri.
+     */
+    tokenUri?: string;
+    /**
+     * Google Cloud Platform account type.
+     *
+     * Google Cloud Platform ADC ( Application Default Credentials )
+     */
+    type?: string;
+    /**
+     * Path of the file containing the GCP credentials info
+     */
+    path?: string;
+    /**
+     * Google Security Token Service audience which contains the resource name for the workload
+     * identity pool and the provider identifier in that pool.
+     */
+    audience?: string;
+    /**
+     * This object defines the mechanism used to retrieve the external credential from the local
+     * environment so that it can be exchanged for a GCP access token via the STS endpoint
+     */
+    credentialSource?: { [key: string]: string };
+    /**
+     * Google Cloud Platform account type.
+     */
+    externalType?: string;
+    /**
+     * Google Security Token Service subject token type based on the OAuth 2.0 token exchange
+     * spec.
+     */
+    subjectTokenType?: string;
+    /**
+     * Google Security Token Service token exchange endpoint.
+     */
+    tokenURL?: string;
+    [property: string]: any;
+}
+
+/**
+ * we enable the authenticated service account to impersonate another service account
+ *
+ * Pass the values to impersonate a service account of Google Cloud
+ */
+export interface GCPImpersonateServiceAccountValues {
+    /**
+     * The impersonated service account email
+     */
+    impersonateServiceAccount?: string;
+    /**
+     * Number of seconds the delegated credential should be valid
+     */
+    lifetime?: number;
+    [property: string]: any;
 }
 
 /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/serviceConnection.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/connections/serviceConnection.ts
@@ -1433,7 +1433,7 @@ export interface ConfigObject {
     /**
      * Connect with oracle by either passing service name or database schema name.
      */
-    oracleConnectionType?: OracleConnectionType;
+    oracleConnectionType?: ConfigOracleConnectionType;
     /**
      * Controls how Oracle identifier names (tables, columns, schemas) are stored in
      * OpenMetadata. When disabled (default), Oracle's UPPERCASE unquoted identifiers (e.g.
@@ -4082,9 +4082,9 @@ export interface PurpleGCPCredentials {
 }
 
 /**
- * Underlying database connection
- *
  * Mssql Database Connection Config
+ *
+ * Underlying database connection
  */
 export interface DatabaseConnectionClass {
     connectionArguments?: { [key: string]: any };
@@ -4300,6 +4300,12 @@ export enum Logmech {
  * Postgres Database Connection Config
  *
  * Mysql Database Connection Config
+ *
+ * Mssql Database Connection Config
+ *
+ * Underlying database connection
+ *
+ * Oracle Database Connection Config
  */
 export interface HiveMetastoreConnectionDetails {
     /**
@@ -4327,11 +4333,17 @@ export interface HiveMetastoreConnectionDetails {
      *
      * Host and port of the MySQL service. For GCP CloudSQL, use the instance connection name in
      * the format 'project_id:region:instance_name'.
+     *
+     * Host and port of the MSSQL service.
+     *
+     * Host and port of the Oracle service.
      */
     hostPort?: string;
     /**
      * Ingest data from all databases in Postgres. You can use databaseFilterPattern on top of
      * this.
+     *
+     * Ingest data from all databases in Mssql. You can use databaseFilterPattern on top of this.
      */
     ingestAllDatabases?: boolean;
     /**
@@ -4352,6 +4364,9 @@ export interface HiveMetastoreConnectionDetails {
     scheme?: HiveMetastoreConnectionDetailsScheme;
     /**
      * SSL Configuration details.
+     *
+     * SSL/TLS certificate configuration for client authentication. Provide CA certificate,
+     * client certificate, and private key for mutual TLS authentication.
      */
     sslConfig?: ConsumerConfigSSLClass;
     sslMode?:   SSLMode;
@@ -4381,6 +4396,12 @@ export interface HiveMetastoreConnectionDetails {
      *
      * Username to connect to MySQL. This user should have privileges to read all the metadata
      * in Mysql.
+     *
+     * Username to connect to MSSQL. This user should have privileges to read all the metadata
+     * in MsSQL.
+     *
+     * Username to connect to Oracle. This user should have privileges to read all the metadata
+     * in Oracle.
      */
     username?: string;
     /**
@@ -4398,13 +4419,89 @@ export interface HiveMetastoreConnectionDetails {
      * Use slow logs to extract lineage.
      */
     useSlowLogs?: boolean;
+    /**
+     * ODBC driver version in case of pyodbc connection.
+     */
+    driver?: string;
+    /**
+     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
+     * between the client and server will be encrypted.
+     */
+    encrypt?: boolean;
+    /**
+     * Password to connect to MSSQL.
+     *
+     * Password to connect to Oracle.
+     */
+    password?: string;
+    /**
+     * Trust the server certificate without validation. Set to false in production to validate
+     * server certificates against the certificate authority.
+     */
+    trustServerCertificate?: boolean;
+    /**
+     * This directory will be used to set the LD_LIBRARY_PATH env variable. It is required if
+     * you need to enable thick connection mode. By default, we bring instant client 19 and
+     * point to /instantclient.
+     */
+    instantClientDirectory?: string;
+    /**
+     * Connect with oracle by either passing service name or database schema name.
+     */
+    oracleConnectionType?: HiveMetastoreConnectionDetailsOracleConnectionType;
+    /**
+     * Controls how Oracle identifier names (tables, columns, schemas) are stored in
+     * OpenMetadata. When disabled (default), Oracle's UPPERCASE unquoted identifiers (e.g.
+     * EMPLOYEES) are not guaranteed to be stored as-is — identifiers with the same letters but
+     * different case (e.g. unquoted EMPLOYEES and quoted 'employees') will collide into the
+     * same name. When enabled, names are stored exactly as Oracle persists them, which solves
+     * same-name collisions between quoted and unquoted identifiers. WARNING: enabling this
+     * after data has already been ingested with the default setting will change the stored
+     * names of all existing tables, columns, schemas, and constraints — breaking attached tags,
+     * descriptions, lineage, data quality tests, and any other metadata associated with those
+     * entities. If you must switch, soft-delete all previously ingested entities before
+     * re-ingesting.
+     */
+    preserveIdentifierCase?: boolean;
+    /**
+     * Use Oracle DBA_* tables instead of ALL_* tables for metadata ingestion. Requires DBA
+     * privileges.
+     */
+    useDBATable?: boolean;
+}
+
+/**
+ * Connect with oracle by either passing service name or database schema name.
+ */
+export interface HiveMetastoreConnectionDetailsOracleConnectionType {
+    /**
+     * databaseSchema of the data source. This is optional parameter, if you would like to
+     * restrict the metadata reading to a single databaseSchema. When left blank, OpenMetadata
+     * Ingestion attempts to scan all the databaseSchema.
+     */
+    databaseSchema?: string;
+    /**
+     * The Oracle Service name is the TNS alias that you give when you remotely connect to your
+     * database.
+     */
+    oracleServiceName?: string;
+    /**
+     * Pass the full constructed TNS string, e.g.,
+     * (DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST=myhost)(PORT=1530)))(CONNECT_DATA=(SID=MYSERVICENAME))).
+     */
+    oracleTNSConnection?: string;
+    [property: string]: any;
 }
 
 /**
  * SQLAlchemy driver scheme options.
  */
 export enum HiveMetastoreConnectionDetailsScheme {
+    MssqlPymssql = "mssql+pymssql",
+    MssqlPyodbc = "mssql+pyodbc",
+    MssqlPytds = "mssql+pytds",
     MysqlPymysql = "mysql+pymysql",
+    OracleCxOracle = "oracle+cx_oracle",
     PgspiderPsycopg2 = "pgspider+psycopg2",
     PostgresqlPsycopg2 = "postgresql+psycopg2",
 }
@@ -4415,7 +4512,9 @@ export enum HiveMetastoreConnectionDetailsScheme {
  * Service type.
  */
 export enum HiveMetastoreConnectionDetailsType {
+    Mssql = "Mssql",
     Mysql = "Mysql",
+    Oracle = "Oracle",
     Postgres = "Postgres",
 }
 
@@ -4485,7 +4584,7 @@ export interface OpenAPISchemaConnection {
 /**
  * Connect with oracle by either passing service name or database schema name.
  */
-export interface OracleConnectionType {
+export interface ConfigOracleConnectionType {
     /**
      * databaseSchema of the data source. This is optional parameter, if you would like to
      * restrict the metadata reading to a single databaseSchema. When left blank, OpenMetadata

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/databaseService.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/databaseService.ts
@@ -2025,6 +2025,10 @@ export enum Logmech {
  * Postgres Database Connection Config
  *
  * Mysql Database Connection Config
+ *
+ * Mssql Database Connection Config
+ *
+ * Oracle Database Connection Config
  */
 export interface HiveMetastoreConnectionDetails {
     /**
@@ -2052,11 +2056,17 @@ export interface HiveMetastoreConnectionDetails {
      *
      * Host and port of the MySQL service. For GCP CloudSQL, use the instance connection name in
      * the format 'project_id:region:instance_name'.
+     *
+     * Host and port of the MSSQL service.
+     *
+     * Host and port of the Oracle service.
      */
     hostPort?: string;
     /**
      * Ingest data from all databases in Postgres. You can use databaseFilterPattern on top of
      * this.
+     *
+     * Ingest data from all databases in Mssql. You can use databaseFilterPattern on top of this.
      */
     ingestAllDatabases?: boolean;
     /**
@@ -2077,6 +2087,9 @@ export interface HiveMetastoreConnectionDetails {
     scheme?: HiveMetastoreConnectionDetailsScheme;
     /**
      * SSL Configuration details.
+     *
+     * SSL/TLS certificate configuration for client authentication. Provide CA certificate,
+     * client certificate, and private key for mutual TLS authentication.
      */
     sslConfig?: Config;
     sslMode?:   SSLMode;
@@ -2106,6 +2119,12 @@ export interface HiveMetastoreConnectionDetails {
      *
      * Username to connect to MySQL. This user should have privileges to read all the metadata
      * in Mysql.
+     *
+     * Username to connect to MSSQL. This user should have privileges to read all the metadata
+     * in MsSQL.
+     *
+     * Username to connect to Oracle. This user should have privileges to read all the metadata
+     * in Oracle.
      */
     username?: string;
     /**
@@ -2123,6 +2142,55 @@ export interface HiveMetastoreConnectionDetails {
      * Use slow logs to extract lineage.
      */
     useSlowLogs?: boolean;
+    /**
+     * ODBC driver version in case of pyodbc connection.
+     */
+    driver?: string;
+    /**
+     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
+     * between the client and server will be encrypted.
+     */
+    encrypt?: boolean;
+    /**
+     * Password to connect to MSSQL.
+     *
+     * Password to connect to Oracle.
+     */
+    password?: string;
+    /**
+     * Trust the server certificate without validation. Set to false in production to validate
+     * server certificates against the certificate authority.
+     */
+    trustServerCertificate?: boolean;
+    /**
+     * This directory will be used to set the LD_LIBRARY_PATH env variable. It is required if
+     * you need to enable thick connection mode. By default, we bring instant client 19 and
+     * point to /instantclient.
+     */
+    instantClientDirectory?: string;
+    /**
+     * Connect with oracle by either passing service name or database schema name.
+     */
+    oracleConnectionType?: OracleConnectionType;
+    /**
+     * Controls how Oracle identifier names (tables, columns, schemas) are stored in
+     * OpenMetadata. When disabled (default), Oracle's UPPERCASE unquoted identifiers (e.g.
+     * EMPLOYEES) are not guaranteed to be stored as-is — identifiers with the same letters but
+     * different case (e.g. unquoted EMPLOYEES and quoted 'employees') will collide into the
+     * same name. When enabled, names are stored exactly as Oracle persists them, which solves
+     * same-name collisions between quoted and unquoted identifiers. WARNING: enabling this
+     * after data has already been ingested with the default setting will change the stored
+     * names of all existing tables, columns, schemas, and constraints — breaking attached tags,
+     * descriptions, lineage, data quality tests, and any other metadata associated with those
+     * entities. If you must switch, soft-delete all previously ingested entities before
+     * re-ingesting.
+     */
+    preserveIdentifierCase?: boolean;
+    /**
+     * Use Oracle DBA_* tables instead of ALL_* tables for metadata ingestion. Requires DBA
+     * privileges.
+     */
+    useDBATable?: boolean;
 }
 
 /**
@@ -2153,6 +2221,29 @@ export interface AuthTypeClass {
      * GCP credentials to use. If not provided, Application Default Credentials will be used.
      */
     gcpConfig?: GCPCredentials;
+}
+
+/**
+ * Connect with oracle by either passing service name or database schema name.
+ */
+export interface OracleConnectionType {
+    /**
+     * databaseSchema of the data source. This is optional parameter, if you would like to
+     * restrict the metadata reading to a single databaseSchema. When left blank, OpenMetadata
+     * Ingestion attempts to scan all the databaseSchema.
+     */
+    databaseSchema?: string;
+    /**
+     * The Oracle Service name is the TNS alias that you give when you remotely connect to your
+     * database.
+     */
+    oracleServiceName?: string;
+    /**
+     * Pass the full constructed TNS string, e.g.,
+     * (DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST=myhost)(PORT=1530)))(CONNECT_DATA=(SID=MYSERVICENAME))).
+     */
+    oracleTNSConnection?: string;
+    [property: string]: any;
 }
 
 /**
@@ -2243,7 +2334,11 @@ export interface AwsCredentials {
  * SQLAlchemy driver scheme options.
  */
 export enum HiveMetastoreConnectionDetailsScheme {
+    MssqlPymssql = "mssql+pymssql",
+    MssqlPyodbc = "mssql+pyodbc",
+    MssqlPytds = "mssql+pytds",
     MysqlPymysql = "mysql+pymysql",
+    OracleCxOracle = "oracle+cx_oracle",
     PgspiderPsycopg2 = "pgspider+psycopg2",
     PostgresqlPsycopg2 = "postgresql+psycopg2",
 }
@@ -2301,31 +2396,10 @@ export enum SSLMode {
  * Service type.
  */
 export enum HiveMetastoreConnectionDetailsType {
+    Mssql = "Mssql",
     Mysql = "Mysql",
+    Oracle = "Oracle",
     Postgres = "Postgres",
-}
-
-/**
- * Connect with oracle by either passing service name or database schema name.
- */
-export interface OracleConnectionType {
-    /**
-     * databaseSchema of the data source. This is optional parameter, if you would like to
-     * restrict the metadata reading to a single databaseSchema. When left blank, OpenMetadata
-     * Ingestion attempts to scan all the databaseSchema.
-     */
-    databaseSchema?: string;
-    /**
-     * The Oracle Service name is the TNS alias that you give when you remotely connect to your
-     * database.
-     */
-    oracleServiceName?: string;
-    /**
-     * Pass the full constructed TNS string, e.g.,
-     * (DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST=myhost)(PORT=1530)))(CONNECT_DATA=(SID=MYSERVICENAME))).
-     */
-    oracleTNSConnection?: string;
-    [property: string]: any;
 }
 
 /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/ingestionPipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/ingestionPipeline.ts
@@ -5055,7 +5055,7 @@ export interface ConfigObject {
     /**
      * Connect with oracle by either passing service name or database schema name.
      */
-    oracleConnectionType?: OracleConnectionType;
+    oracleConnectionType?: ConfigOracleConnectionType;
     /**
      * Controls how Oracle identifier names (tables, columns, schemas) are stored in
      * OpenMetadata. When disabled (default), Oracle's UPPERCASE unquoted identifiers (e.g.
@@ -7331,9 +7331,9 @@ export interface PurpleGCPCredentials {
 }
 
 /**
- * Underlying database connection
- *
  * Mssql Database Connection Config
+ *
+ * Underlying database connection
  */
 export interface DatabaseConnectionClass {
     connectionArguments?: { [key: string]: any };
@@ -7549,6 +7549,12 @@ export enum Logmech {
  * Postgres Database Connection Config
  *
  * Mysql Database Connection Config
+ *
+ * Mssql Database Connection Config
+ *
+ * Underlying database connection
+ *
+ * Oracle Database Connection Config
  */
 export interface HiveMetastoreConnectionDetails {
     /**
@@ -7576,11 +7582,17 @@ export interface HiveMetastoreConnectionDetails {
      *
      * Host and port of the MySQL service. For GCP CloudSQL, use the instance connection name in
      * the format 'project_id:region:instance_name'.
+     *
+     * Host and port of the MSSQL service.
+     *
+     * Host and port of the Oracle service.
      */
     hostPort?: string;
     /**
      * Ingest data from all databases in Postgres. You can use databaseFilterPattern on top of
      * this.
+     *
+     * Ingest data from all databases in Mssql. You can use databaseFilterPattern on top of this.
      */
     ingestAllDatabases?: boolean;
     /**
@@ -7601,6 +7613,9 @@ export interface HiveMetastoreConnectionDetails {
     scheme?: HiveMetastoreConnectionDetailsScheme;
     /**
      * SSL Configuration details.
+     *
+     * SSL/TLS certificate configuration for client authentication. Provide CA certificate,
+     * client certificate, and private key for mutual TLS authentication.
      */
     sslConfig?: DbtSSLConfigClass;
     sslMode?:   SSLMode;
@@ -7630,6 +7645,12 @@ export interface HiveMetastoreConnectionDetails {
      *
      * Username to connect to MySQL. This user should have privileges to read all the metadata
      * in Mysql.
+     *
+     * Username to connect to MSSQL. This user should have privileges to read all the metadata
+     * in MsSQL.
+     *
+     * Username to connect to Oracle. This user should have privileges to read all the metadata
+     * in Oracle.
      */
     username?: string;
     /**
@@ -7647,13 +7668,89 @@ export interface HiveMetastoreConnectionDetails {
      * Use slow logs to extract lineage.
      */
     useSlowLogs?: boolean;
+    /**
+     * ODBC driver version in case of pyodbc connection.
+     */
+    driver?: string;
+    /**
+     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
+     * between the client and server will be encrypted.
+     */
+    encrypt?: boolean;
+    /**
+     * Password to connect to MSSQL.
+     *
+     * Password to connect to Oracle.
+     */
+    password?: string;
+    /**
+     * Trust the server certificate without validation. Set to false in production to validate
+     * server certificates against the certificate authority.
+     */
+    trustServerCertificate?: boolean;
+    /**
+     * This directory will be used to set the LD_LIBRARY_PATH env variable. It is required if
+     * you need to enable thick connection mode. By default, we bring instant client 19 and
+     * point to /instantclient.
+     */
+    instantClientDirectory?: string;
+    /**
+     * Connect with oracle by either passing service name or database schema name.
+     */
+    oracleConnectionType?: HiveMetastoreConnectionDetailsOracleConnectionType;
+    /**
+     * Controls how Oracle identifier names (tables, columns, schemas) are stored in
+     * OpenMetadata. When disabled (default), Oracle's UPPERCASE unquoted identifiers (e.g.
+     * EMPLOYEES) are not guaranteed to be stored as-is — identifiers with the same letters but
+     * different case (e.g. unquoted EMPLOYEES and quoted 'employees') will collide into the
+     * same name. When enabled, names are stored exactly as Oracle persists them, which solves
+     * same-name collisions between quoted and unquoted identifiers. WARNING: enabling this
+     * after data has already been ingested with the default setting will change the stored
+     * names of all existing tables, columns, schemas, and constraints — breaking attached tags,
+     * descriptions, lineage, data quality tests, and any other metadata associated with those
+     * entities. If you must switch, soft-delete all previously ingested entities before
+     * re-ingesting.
+     */
+    preserveIdentifierCase?: boolean;
+    /**
+     * Use Oracle DBA_* tables instead of ALL_* tables for metadata ingestion. Requires DBA
+     * privileges.
+     */
+    useDBATable?: boolean;
+}
+
+/**
+ * Connect with oracle by either passing service name or database schema name.
+ */
+export interface HiveMetastoreConnectionDetailsOracleConnectionType {
+    /**
+     * databaseSchema of the data source. This is optional parameter, if you would like to
+     * restrict the metadata reading to a single databaseSchema. When left blank, OpenMetadata
+     * Ingestion attempts to scan all the databaseSchema.
+     */
+    databaseSchema?: string;
+    /**
+     * The Oracle Service name is the TNS alias that you give when you remotely connect to your
+     * database.
+     */
+    oracleServiceName?: string;
+    /**
+     * Pass the full constructed TNS string, e.g.,
+     * (DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST=myhost)(PORT=1530)))(CONNECT_DATA=(SID=MYSERVICENAME))).
+     */
+    oracleTNSConnection?: string;
+    [property: string]: any;
 }
 
 /**
  * SQLAlchemy driver scheme options.
  */
 export enum HiveMetastoreConnectionDetailsScheme {
+    MssqlPymssql = "mssql+pymssql",
+    MssqlPyodbc = "mssql+pyodbc",
+    MssqlPytds = "mssql+pytds",
     MysqlPymysql = "mysql+pymysql",
+    OracleCxOracle = "oracle+cx_oracle",
     PgspiderPsycopg2 = "pgspider+psycopg2",
     PostgresqlPsycopg2 = "postgresql+psycopg2",
 }
@@ -7664,7 +7761,9 @@ export enum HiveMetastoreConnectionDetailsScheme {
  * Service type.
  */
 export enum HiveMetastoreConnectionDetailsType {
+    Mssql = "Mssql",
     Mysql = "Mysql",
+    Oracle = "Oracle",
     Postgres = "Postgres",
 }
 
@@ -7734,7 +7833,7 @@ export interface OpenAPISchemaConnection {
 /**
  * Connect with oracle by either passing service name or database schema name.
  */
-export interface OracleConnectionType {
+export interface ConfigOracleConnectionType {
     /**
      * databaseSchema of the data source. This is optional parameter, if you would like to
      * restrict the metadata reading to a single databaseSchema. When left blank, OpenMetadata

--- a/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/testSuitePipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/testSuitePipeline.ts
@@ -1531,7 +1531,7 @@ export interface ConfigObject {
     /**
      * Connect with oracle by either passing service name or database schema name.
      */
-    oracleConnectionType?: OracleConnectionType;
+    oracleConnectionType?: ConfigOracleConnectionType;
     /**
      * Controls how Oracle identifier names (tables, columns, schemas) are stored in
      * OpenMetadata. When disabled (default), Oracle's UPPERCASE unquoted identifiers (e.g.
@@ -4180,9 +4180,9 @@ export interface PurpleGCPCredentials {
 }
 
 /**
- * Underlying database connection
- *
  * Mssql Database Connection Config
+ *
+ * Underlying database connection
  */
 export interface DatabaseConnectionClass {
     connectionArguments?: { [key: string]: any };
@@ -4398,6 +4398,12 @@ export enum Logmech {
  * Postgres Database Connection Config
  *
  * Mysql Database Connection Config
+ *
+ * Mssql Database Connection Config
+ *
+ * Underlying database connection
+ *
+ * Oracle Database Connection Config
  */
 export interface HiveMetastoreConnectionDetails {
     /**
@@ -4425,11 +4431,17 @@ export interface HiveMetastoreConnectionDetails {
      *
      * Host and port of the MySQL service. For GCP CloudSQL, use the instance connection name in
      * the format 'project_id:region:instance_name'.
+     *
+     * Host and port of the MSSQL service.
+     *
+     * Host and port of the Oracle service.
      */
     hostPort?: string;
     /**
      * Ingest data from all databases in Postgres. You can use databaseFilterPattern on top of
      * this.
+     *
+     * Ingest data from all databases in Mssql. You can use databaseFilterPattern on top of this.
      */
     ingestAllDatabases?: boolean;
     /**
@@ -4450,6 +4462,9 @@ export interface HiveMetastoreConnectionDetails {
     scheme?: HiveMetastoreConnectionDetailsScheme;
     /**
      * SSL Configuration details.
+     *
+     * SSL/TLS certificate configuration for client authentication. Provide CA certificate,
+     * client certificate, and private key for mutual TLS authentication.
      */
     sslConfig?: ConsumerConfigSSLClass;
     sslMode?:   SSLMode;
@@ -4479,6 +4494,12 @@ export interface HiveMetastoreConnectionDetails {
      *
      * Username to connect to MySQL. This user should have privileges to read all the metadata
      * in Mysql.
+     *
+     * Username to connect to MSSQL. This user should have privileges to read all the metadata
+     * in MsSQL.
+     *
+     * Username to connect to Oracle. This user should have privileges to read all the metadata
+     * in Oracle.
      */
     username?: string;
     /**
@@ -4496,13 +4517,89 @@ export interface HiveMetastoreConnectionDetails {
      * Use slow logs to extract lineage.
      */
     useSlowLogs?: boolean;
+    /**
+     * ODBC driver version in case of pyodbc connection.
+     */
+    driver?: string;
+    /**
+     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
+     * between the client and server will be encrypted.
+     */
+    encrypt?: boolean;
+    /**
+     * Password to connect to MSSQL.
+     *
+     * Password to connect to Oracle.
+     */
+    password?: string;
+    /**
+     * Trust the server certificate without validation. Set to false in production to validate
+     * server certificates against the certificate authority.
+     */
+    trustServerCertificate?: boolean;
+    /**
+     * This directory will be used to set the LD_LIBRARY_PATH env variable. It is required if
+     * you need to enable thick connection mode. By default, we bring instant client 19 and
+     * point to /instantclient.
+     */
+    instantClientDirectory?: string;
+    /**
+     * Connect with oracle by either passing service name or database schema name.
+     */
+    oracleConnectionType?: HiveMetastoreConnectionDetailsOracleConnectionType;
+    /**
+     * Controls how Oracle identifier names (tables, columns, schemas) are stored in
+     * OpenMetadata. When disabled (default), Oracle's UPPERCASE unquoted identifiers (e.g.
+     * EMPLOYEES) are not guaranteed to be stored as-is — identifiers with the same letters but
+     * different case (e.g. unquoted EMPLOYEES and quoted 'employees') will collide into the
+     * same name. When enabled, names are stored exactly as Oracle persists them, which solves
+     * same-name collisions between quoted and unquoted identifiers. WARNING: enabling this
+     * after data has already been ingested with the default setting will change the stored
+     * names of all existing tables, columns, schemas, and constraints — breaking attached tags,
+     * descriptions, lineage, data quality tests, and any other metadata associated with those
+     * entities. If you must switch, soft-delete all previously ingested entities before
+     * re-ingesting.
+     */
+    preserveIdentifierCase?: boolean;
+    /**
+     * Use Oracle DBA_* tables instead of ALL_* tables for metadata ingestion. Requires DBA
+     * privileges.
+     */
+    useDBATable?: boolean;
+}
+
+/**
+ * Connect with oracle by either passing service name or database schema name.
+ */
+export interface HiveMetastoreConnectionDetailsOracleConnectionType {
+    /**
+     * databaseSchema of the data source. This is optional parameter, if you would like to
+     * restrict the metadata reading to a single databaseSchema. When left blank, OpenMetadata
+     * Ingestion attempts to scan all the databaseSchema.
+     */
+    databaseSchema?: string;
+    /**
+     * The Oracle Service name is the TNS alias that you give when you remotely connect to your
+     * database.
+     */
+    oracleServiceName?: string;
+    /**
+     * Pass the full constructed TNS string, e.g.,
+     * (DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST=myhost)(PORT=1530)))(CONNECT_DATA=(SID=MYSERVICENAME))).
+     */
+    oracleTNSConnection?: string;
+    [property: string]: any;
 }
 
 /**
  * SQLAlchemy driver scheme options.
  */
 export enum HiveMetastoreConnectionDetailsScheme {
+    MssqlPymssql = "mssql+pymssql",
+    MssqlPyodbc = "mssql+pyodbc",
+    MssqlPytds = "mssql+pytds",
     MysqlPymysql = "mysql+pymysql",
+    OracleCxOracle = "oracle+cx_oracle",
     PgspiderPsycopg2 = "pgspider+psycopg2",
     PostgresqlPsycopg2 = "postgresql+psycopg2",
 }
@@ -4513,7 +4610,9 @@ export enum HiveMetastoreConnectionDetailsScheme {
  * Service type.
  */
 export enum HiveMetastoreConnectionDetailsType {
+    Mssql = "Mssql",
     Mysql = "Mysql",
+    Oracle = "Oracle",
     Postgres = "Postgres",
 }
 
@@ -4583,7 +4682,7 @@ export interface OpenAPISchemaConnection {
 /**
  * Connect with oracle by either passing service name or database schema name.
  */
-export interface OracleConnectionType {
+export interface ConfigOracleConnectionType {
     /**
      * databaseSchema of the data source. This is optional parameter, if you would like to
      * restrict the metadata reading to a single databaseSchema. When left blank, OpenMetadata

--- a/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/workflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/workflow.ts
@@ -1522,7 +1522,7 @@ export interface ConfigObject {
     /**
      * Connect with oracle by either passing service name or database schema name.
      */
-    oracleConnectionType?: OracleConnectionType;
+    oracleConnectionType?: ConfigOracleConnectionType;
     /**
      * Controls how Oracle identifier names (tables, columns, schemas) are stored in
      * OpenMetadata. When disabled (default), Oracle's UPPERCASE unquoted identifiers (e.g.
@@ -4199,9 +4199,9 @@ export interface PurpleGCPCredentials {
 }
 
 /**
- * Underlying database connection
- *
  * Mssql Database Connection Config
+ *
+ * Underlying database connection
  */
 export interface DatabaseConnectionClass {
     connectionArguments?: { [key: string]: any };
@@ -4417,6 +4417,12 @@ export enum Logmech {
  * Postgres Database Connection Config
  *
  * Mysql Database Connection Config
+ *
+ * Mssql Database Connection Config
+ *
+ * Underlying database connection
+ *
+ * Oracle Database Connection Config
  */
 export interface HiveMetastoreConnectionDetails {
     /**
@@ -4444,11 +4450,17 @@ export interface HiveMetastoreConnectionDetails {
      *
      * Host and port of the MySQL service. For GCP CloudSQL, use the instance connection name in
      * the format 'project_id:region:instance_name'.
+     *
+     * Host and port of the MSSQL service.
+     *
+     * Host and port of the Oracle service.
      */
     hostPort?: string;
     /**
      * Ingest data from all databases in Postgres. You can use databaseFilterPattern on top of
      * this.
+     *
+     * Ingest data from all databases in Mssql. You can use databaseFilterPattern on top of this.
      */
     ingestAllDatabases?: boolean;
     /**
@@ -4469,6 +4481,9 @@ export interface HiveMetastoreConnectionDetails {
     scheme?: HiveMetastoreConnectionDetailsScheme;
     /**
      * SSL Configuration details.
+     *
+     * SSL/TLS certificate configuration for client authentication. Provide CA certificate,
+     * client certificate, and private key for mutual TLS authentication.
      */
     sslConfig?: ConsumerConfigSSLClass;
     sslMode?:   SSLMode;
@@ -4498,6 +4513,12 @@ export interface HiveMetastoreConnectionDetails {
      *
      * Username to connect to MySQL. This user should have privileges to read all the metadata
      * in Mysql.
+     *
+     * Username to connect to MSSQL. This user should have privileges to read all the metadata
+     * in MsSQL.
+     *
+     * Username to connect to Oracle. This user should have privileges to read all the metadata
+     * in Oracle.
      */
     username?: string;
     /**
@@ -4515,13 +4536,89 @@ export interface HiveMetastoreConnectionDetails {
      * Use slow logs to extract lineage.
      */
     useSlowLogs?: boolean;
+    /**
+     * ODBC driver version in case of pyodbc connection.
+     */
+    driver?: string;
+    /**
+     * Enable SSL/TLS encryption for the MSSQL connection. When enabled, all data transmitted
+     * between the client and server will be encrypted.
+     */
+    encrypt?: boolean;
+    /**
+     * Password to connect to MSSQL.
+     *
+     * Password to connect to Oracle.
+     */
+    password?: string;
+    /**
+     * Trust the server certificate without validation. Set to false in production to validate
+     * server certificates against the certificate authority.
+     */
+    trustServerCertificate?: boolean;
+    /**
+     * This directory will be used to set the LD_LIBRARY_PATH env variable. It is required if
+     * you need to enable thick connection mode. By default, we bring instant client 19 and
+     * point to /instantclient.
+     */
+    instantClientDirectory?: string;
+    /**
+     * Connect with oracle by either passing service name or database schema name.
+     */
+    oracleConnectionType?: HiveMetastoreConnectionDetailsOracleConnectionType;
+    /**
+     * Controls how Oracle identifier names (tables, columns, schemas) are stored in
+     * OpenMetadata. When disabled (default), Oracle's UPPERCASE unquoted identifiers (e.g.
+     * EMPLOYEES) are not guaranteed to be stored as-is — identifiers with the same letters but
+     * different case (e.g. unquoted EMPLOYEES and quoted 'employees') will collide into the
+     * same name. When enabled, names are stored exactly as Oracle persists them, which solves
+     * same-name collisions between quoted and unquoted identifiers. WARNING: enabling this
+     * after data has already been ingested with the default setting will change the stored
+     * names of all existing tables, columns, schemas, and constraints — breaking attached tags,
+     * descriptions, lineage, data quality tests, and any other metadata associated with those
+     * entities. If you must switch, soft-delete all previously ingested entities before
+     * re-ingesting.
+     */
+    preserveIdentifierCase?: boolean;
+    /**
+     * Use Oracle DBA_* tables instead of ALL_* tables for metadata ingestion. Requires DBA
+     * privileges.
+     */
+    useDBATable?: boolean;
+}
+
+/**
+ * Connect with oracle by either passing service name or database schema name.
+ */
+export interface HiveMetastoreConnectionDetailsOracleConnectionType {
+    /**
+     * databaseSchema of the data source. This is optional parameter, if you would like to
+     * restrict the metadata reading to a single databaseSchema. When left blank, OpenMetadata
+     * Ingestion attempts to scan all the databaseSchema.
+     */
+    databaseSchema?: string;
+    /**
+     * The Oracle Service name is the TNS alias that you give when you remotely connect to your
+     * database.
+     */
+    oracleServiceName?: string;
+    /**
+     * Pass the full constructed TNS string, e.g.,
+     * (DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST=myhost)(PORT=1530)))(CONNECT_DATA=(SID=MYSERVICENAME))).
+     */
+    oracleTNSConnection?: string;
+    [property: string]: any;
 }
 
 /**
  * SQLAlchemy driver scheme options.
  */
 export enum HiveMetastoreConnectionDetailsScheme {
+    MssqlPymssql = "mssql+pymssql",
+    MssqlPyodbc = "mssql+pyodbc",
+    MssqlPytds = "mssql+pytds",
     MysqlPymysql = "mysql+pymysql",
+    OracleCxOracle = "oracle+cx_oracle",
     PgspiderPsycopg2 = "pgspider+psycopg2",
     PostgresqlPsycopg2 = "postgresql+psycopg2",
 }
@@ -4532,7 +4629,9 @@ export enum HiveMetastoreConnectionDetailsScheme {
  * Service type.
  */
 export enum HiveMetastoreConnectionDetailsType {
+    Mssql = "Mssql",
     Mysql = "Mysql",
+    Oracle = "Oracle",
     Postgres = "Postgres",
 }
 
@@ -4602,7 +4701,7 @@ export interface OpenAPISchemaConnection {
 /**
  * Connect with oracle by either passing service name or database schema name.
  */
-export interface OracleConnectionType {
+export interface ConfigOracleConnectionType {
     /**
      * databaseSchema of the data source. This is optional parameter, if you would like to
      * restrict the metadata reading to a single databaseSchema. When left blank, OpenMetadata


### PR DESCRIPTION
Fixes #12787

Adds MSSQL and Oracle as supported backends for Hive metastore, alongside the existing MySQL and PostgreSQL support.

**Changes**
- New `metastore_dialects/mssql/` and `metastore_dialects/oracle/` packages with SQL dialect implementations
- `hiveConnection.json`: add `mssqlConnection` and `oracleConnection` to `metastoreConnection.oneOf`
- `connection.py`: register `@get_metastore_connection` singledispatch handlers for `MssqlConnection` and `OracleConnection`
- `metadata.py`: extend `_get_validated_metastore_connection` to handle both new connection types
- Unit tests: dialect-level SQL tests and metastore connection validation tests for both backends

**MSSQL notes**: uses CTEs (unlike MySQL 5.7) with unquoted identifiers  
**Oracle notes**: uses CTEs with double-quoted identifiers (mirrors Postgres pattern)

----
## Summary by Gitar

- **SQL security:**
  - Parameterized all metastore dialect queries across MSSQL, Oracle, MySQL, and Postgres to prevent SQL injection.
- **Stability improvements:**
  - Added error handling in `SamplerProcessor` to gracefully tolerate transient failures when fetching profiler configurations.
- **Refactoring:**
  - Consolidated metastore connection validation into a centralized `get_validated_metastore_connection` helper.
  - Optimized validation logic to use a type-discriminator map before attempting fallback schema matching.
- **Testing:**
  - Added unit tests for `get_validated_metastore_connection` to verify correct model resolution and invalid type rejection.
- **Dependencies:**
  - Added `MssqlConnection` and `OracleConnection` types to `hiveConnection.json` to enable schema-level support.

<sub>This will update automatically on new commits.</sub>