### PR TITLE
Replace fragile .replace() chain with generic camelCase conversion in get_entity_from_create

### DIFF
--- a/ingestion/src/metadata/ingestion/ometa/ometa_api.py
+++ b/ingestion/src/metadata/ingestion/ometa/ometa_api.py
@@ -458,11 +458,11 @@ class OpenMetadata(
         """
         for prefix, replacement in OpenMetadata._FILE_NAME_PREFIX_OVERRIDES.items():
             if class_name.startswith(prefix):
-                return replacement + class_name[len(prefix):]
+                return replacement + class_name[len(prefix) :]
         match = re.match(r"^([A-Z]+)([A-Z][a-z])", class_name)
         if match:
             acronym = match.group(1)
-            return acronym.lower() + class_name[len(acronym):]
+            return acronym.lower() + class_name[len(acronym) :]
         return class_name[0].lower() + class_name[1:]
 
     def get_entity_from_create(self, create: Type[C]) -> Type[T]:

--- a/ingestion/tests/unit/test_ometa_endpoints.py
+++ b/ingestion/tests/unit/test_ometa_endpoints.py
@@ -12,6 +12,7 @@
 """
 OpenMetadata high-level API endpoint test
 """
+
 from unittest import TestCase
 
 from metadata.generated.schema.api.data.createTableProfile import (


### PR DESCRIPTION
### Describe your changes:

Fixes #26321

The `get_entity_from_create()` method in the Python SDK converted PascalCase class names to camelCase module file names using a hardcoded chain of 16 `.replace()` calls. Any entity not explicitly listed in the chain would get an incorrect file name — for example, `TestCaseResult` would produce `testCaseresult` instead of `testCaseResult`, causing `ModuleNotFoundError`.

**What I changed:**
- Added `_to_file_name()` static method that handles PascalCase → camelCase conversion generically using regex
- Handles leading acronyms (`API` → `api`, `AI` → `ai`), standard PascalCase (`GlossaryTerm` → `glossaryTerm`), and the `MlModel` → `mlmodel` exception via an override dict
- Replaced the entire `.replace()` chain with a single `self._to_file_name(class_name)` call
- Added 42 unit test assertions covering single-word, multi-word, acronym-prefix, and override cases

**Why:**
The old chain was fragile — every new entity with a multi-word name needed a manual entry, and missing entries silently produced wrong file names.

**How I tested:**
- Ran all 42 assertions covering every existing entity name and the reported broken cases
- Verified the mapping produces identical results to the old chain for all previously-handled entities

#
### Type of change:
- [x] Bug fix

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.