### PR TITLE
MINOR: Improve Tableau Datamodel Ingestion

### DIFF
--- a/ingestion/src/metadata/ingestion/source/dashboard/tableau/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/tableau/metadata.py
@@ -264,7 +264,8 @@ class TableauSource(DashboardServiceSource):
                 ),
                 sql=self._get_datamodel_sql_query(data_model=data_model),
                 owners=self.get_owner_ref(dashboard_details=dashboard_details),
-                project=self.get_project_name(dashboard_details=dashboard_details),
+                project=data_model.projectName
+                or self.get_project_name(dashboard_details=dashboard_details),
             )
             yield Either(right=data_model_request)
             self.register_record_datamodel(datamodel_request=data_model_request)
@@ -1144,12 +1145,20 @@ class TableauSource(DashboardServiceSource):
         datasource_columns = []
         for field in data_source.fields or []:
             try:
+                description = field.description or ""
+                if field.formula:
+                    formula_text = f"**Formula:** `{field.formula}`"
+                    description = (
+                        f"{description}\n\n{formula_text}"
+                        if description
+                        else formula_text
+                    )
                 parsed_fields = {
                     "dataTypeDisplay": "Tableau Field",
                     "dataType": DataType.RECORD,
                     "name": truncate_column_name(field.id),
                     "displayName": field.name if field.name else field.id,
-                    "description": field.description,
+                    "description": description or None,
                 }
                 child_columns = self.get_child_columns(field=field)
                 if child_columns:

--- a/ingestion/src/metadata/ingestion/source/dashboard/tableau/models.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/tableau/models.py
@@ -123,6 +123,7 @@ class DatasourceField(BaseModel):
     name: Optional[str] = None
     upstreamColumns: Optional[List[Union[UpstreamColumn, None]]] = None
     description: Optional[str] = None
+    formula: Optional[str] = None
 
 
 class UpstreamTableColumn(BaseModel):
@@ -158,6 +159,7 @@ class DataSource(BaseModel):
     id: str
     name: Optional[str] = None
     description: Optional[str] = None
+    projectName: Optional[str] = None
     tags: Optional[List[TableauDataModelTag]] = []
     fields: Optional[List[DatasourceField]] = None
     upstreamTables: Optional[List[UpstreamTable]] = None

--- a/ingestion/src/metadata/ingestion/source/dashboard/tableau/queries.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/tableau/queries.py
@@ -27,6 +27,9 @@ workbooks(filter:{{luid: "{workbook_id}"}}){{
         id
         name
         description
+        ... on PublishedDatasource {{
+          projectName
+        }}
         tags {{
           name
         }}
@@ -39,6 +42,9 @@ workbooks(filter:{{luid: "{workbook_id}"}}){{
             remoteType
           }}
           description
+          ... on CalculatedField {{
+            formula
+          }}
         }}
       }}
       fields {{
@@ -50,6 +56,9 @@ workbooks(filter:{{luid: "{workbook_id}"}}){{
           remoteType
         }}
         description
+        ... on CalculatedField {{
+          formula
+        }}
       }}
       upstreamTables {{
         id

--- a/ingestion/tests/unit/topology/dashboard/test_tableau.py
+++ b/ingestion/tests/unit/topology/dashboard/test_tableau.py
@@ -34,9 +34,11 @@ from metadata.ingestion.source.dashboard.tableau.metadata import (
 )
 from metadata.ingestion.source.dashboard.tableau.models import (
     DataSource,
+    DatasourceField,
     TableauBaseModel,
     TableauChart,
     TableauOwner,
+    UpstreamColumn,
     UpstreamTable,
 )
 
@@ -871,3 +873,206 @@ class TableauUnitTest(TestCase):
 
                 mock_get_by_name.assert_called_once()
                 assert result is None
+
+    def test_datamodel_uses_own_project_over_dashboard_project(self):
+        """
+        Test that when a published datasource has its own projectName,
+        the datamodel request uses it instead of the dashboard's project.
+        """
+        dashboard_with_project = TableauDashboard(
+            id="wb-001",
+            name="Sales Overview",
+            project=TableauBaseModel(id="p1", name="Marketing"),
+            charts=[],
+            dataModels=[
+                DataSource(
+                    id="ds-pub-001",
+                    name="Revenue Metrics",
+                    projectName="Finance",
+                    fields=[],
+                )
+            ],
+            tags=[],
+        )
+
+        results = list(
+            self.tableau._create_datamodel_request(
+                data_model=dashboard_with_project.dataModels[0],
+                dashboard_details=dashboard_with_project,
+            )
+        )
+        assert len(results) == 1
+        assert results[0].right.project == "Finance"
+
+    def test_datamodel_falls_back_to_dashboard_project(self):
+        """
+        Test that when a datasource has no projectName (e.g. embedded),
+        it falls back to the dashboard's project.
+        """
+        dashboard_with_project = TableauDashboard(
+            id="wb-002",
+            name="Ops Dashboard",
+            project=TableauBaseModel(id="p2", name="Operations"),
+            charts=[],
+            dataModels=[
+                DataSource(
+                    id="ds-emb-001",
+                    name="Order Volumes",
+                    fields=[],
+                )
+            ],
+            tags=[],
+        )
+
+        results = list(
+            self.tableau._create_datamodel_request(
+                data_model=dashboard_with_project.dataModels[0],
+                dashboard_details=dashboard_with_project,
+            )
+        )
+        assert len(results) == 1
+        assert results[0].right.project == "Operations"
+
+    def test_datamodel_project_none_when_both_missing(self):
+        """
+        Test that project is None when neither the datasource nor the
+        dashboard has a project.
+        """
+        dashboard_no_project = TableauDashboard(
+            id="wb-003",
+            name="Ad Hoc Analysis",
+            charts=[],
+            dataModels=[
+                DataSource(
+                    id="ds-emb-002",
+                    name="Temp Data",
+                    fields=[],
+                )
+            ],
+            tags=[],
+        )
+
+        results = list(
+            self.tableau._create_datamodel_request(
+                data_model=dashboard_no_project.dataModels[0],
+                dashboard_details=dashboard_no_project,
+            )
+        )
+        assert len(results) == 1
+        assert results[0].right.project is None
+
+    def test_column_description_includes_formula(self):
+        """
+        Test that when a field has a formula (CalculatedField), the column
+        description is enriched with the formula text.
+        """
+        data_source = DataSource(
+            id="ds-calc-001",
+            name="Delivery Metrics",
+            fields=[
+                DatasourceField(
+                    id="fld-001",
+                    name="On Time Rate",
+                    description="Percentage of deliveries completed within SLA.",
+                    formula="SUM([On Time Count])/SUM([Total Deliveries])",
+                    upstreamColumns=[
+                        UpstreamColumn(
+                            id="col-001",
+                            name="ON_TIME_COUNT",
+                            remoteType="NUMERIC",
+                        ),
+                        UpstreamColumn(
+                            id="col-002",
+                            name="TOTAL_DELIVERIES",
+                            remoteType="NUMERIC",
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+        columns = self.tableau.get_column_info(data_source)
+        assert len(columns) == 1
+        desc = columns[0].description.root
+        assert "Percentage of deliveries completed within SLA." in desc
+        assert "**Formula:** `SUM([On Time Count])/SUM([Total Deliveries])`" in desc
+
+    def test_column_description_formula_only_when_no_description(self):
+        """
+        Test that when a calculated field has a formula but no description,
+        the column description is just the formula text.
+        """
+        data_source = DataSource(
+            id="ds-calc-002",
+            name="Territory Analysis",
+            fields=[
+                DatasourceField(
+                    id="fld-002",
+                    name="Region Bucket",
+                    description=None,
+                    formula="[Sales Region]",
+                    upstreamColumns=[],
+                ),
+            ],
+        )
+
+        columns = self.tableau.get_column_info(data_source)
+        assert len(columns) == 1
+        desc = columns[0].description.root
+        assert desc == "**Formula:** `[Sales Region]`"
+
+    def test_column_description_without_formula(self):
+        """
+        Test that a regular field (non-calculated) keeps its plain description.
+        """
+        data_source = DataSource(
+            id="ds-reg-001",
+            name="Customer Facts",
+            fields=[
+                DatasourceField(
+                    id="fld-003",
+                    name="Signup Date",
+                    description="Date the customer signed up.",
+                    formula=None,
+                    upstreamColumns=[
+                        UpstreamColumn(
+                            id="col-003",
+                            name="SIGNUP_DATE",
+                            remoteType="DATE",
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+        columns = self.tableau.get_column_info(data_source)
+        assert len(columns) == 1
+        assert columns[0].description.root == "Date the customer signed up."
+
+    def test_column_no_description_no_formula(self):
+        """
+        Test that a field with no description and no formula gets None description.
+        """
+        data_source = DataSource(
+            id="ds-reg-002",
+            name="Raw Events",
+            fields=[
+                DatasourceField(
+                    id="fld-004",
+                    name="Event Timestamp",
+                    description=None,
+                    formula=None,
+                    upstreamColumns=[
+                        UpstreamColumn(
+                            id="col-004",
+                            name="EVENT_TS",
+                            remoteType="DATETIME",
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+        columns = self.tableau.get_column_info(data_source)
+        assert len(columns) == 1
+        assert columns[0].description is None


### PR DESCRIPTION
## Summary
- **Datamodel project resolution**: Published datasources now use their own `projectName` from Tableau's GraphQL API (via `... on PublishedDatasource` inline fragment) instead of inheriting the parent dashboard's project. Falls back to the dashboard project for embedded datasources.
- **Calculated field formulas**: Column descriptions now include the formula for calculated fields (via `... on CalculatedField` inline fragment), appended as `**Formula:** \`<formula>\`` to the existing description.
- **Unit tests**: Added 7 tests covering project name resolution (own project, fallback, both missing) and formula enrichment in column descriptions.

## Test plan
- [x] Unit tests added and passing for datamodel project name resolution
- [x] Unit tests added and passing for column description formula enrichment
- [x] Manually verified with live Tableau instance that `projectName` is returned for published datasources via inline fragment
- [x] Run full ingestion against a Tableau instance to verify end-to-end behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)