### PR TITLE
Fixes #26528: Remove demo "create-greeting" prompt from prompts.json

### DIFF
--- a/openmetadata-mcp/src/main/resources/json/data/mcp/prompts.json
+++ b/openmetadata-mcp/src/main/resources/json/data/mcp/prompts.json
@@ -1,21 +1,6 @@
 {
   "tools": [
     {
-      "name": "create-greeting",
-      "description": "Generate a customized greeting message",
-      "arguments": [
-        {
-          "name": "name",
-          "description": "Name of the person to greet",
-          "required": true
-        },
-        {
-          "name": "style",
-          "description": "The style of greeting, such a formal, excited, or casual. If not specified casual will be used"
-        }
-      ]
-    },
-    {
       "name": "search_metadata",
       "description": "Creates a prompt for Searching metadata in OpenMetadata.",
       "arguments": [


### PR DESCRIPTION
### Describe your changes:

Fixes #26528

Removed the demo `create-greeting` prompt from `prompts.json` as it is not required in production and should not be exposed to MCP clients.

- Deleted the `create-greeting` entry from the JSON file
- Ensured the JSON structure remains valid

### Type of change:
- [x] Bug fix