### PR TITLE
add request access button to database, schema, and dashboard cards 

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetsHeader/DataAssetsHeader.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetsHeader/DataAssetsHeader.component.tsx
@@ -61,6 +61,7 @@ import { Thread } from '../../../generated/entity/feed/thread';
 import { useApplicationStore } from '../../../hooks/useApplicationStore';
 import { useCustomPages } from '../../../hooks/useCustomPages';
 import { useEntityRules } from '../../../hooks/useEntityRules';
+import { useRequestAccessUrl } from '../../../hooks/useRequestAccessUrl';
 import { triggerOnDemandApp } from '../../../rest/applicationAPI';
 import { getContractByEntityId } from '../../../rest/contractAPI';
 import { getActiveAnnouncement } from '../../../rest/feedsAPI';
@@ -404,6 +405,12 @@ export const DataAssetsHeader = ({
       return 'service';
     }
   }, [isDataAssetsWithServiceField, dataAsset]);
+  const { url: requestAccessUrl } = useRequestAccessUrl({
+    entityFqn: dataAsset.fullyQualifiedName,
+    entityType,
+    serviceName: dataAsset.service?.name,
+    serviceType: dataAsset.service?.type,
+  });
 
   const handleVoteChange = async (data: VotingDataProps) => {
     await onUpdateVote?.(data, dataAsset.id ?? '');
@@ -686,6 +693,16 @@ export const DataAssetsHeader = ({
                         </Button>
                       </Typography.Link>
                     </Tooltip>
+                  )}
+                  {requestAccessUrl && (
+                    <Button
+                      className="font-semibold"
+                      data-testid="request-access-button"
+                      href={requestAccessUrl}
+                      rel="noopener noreferrer"
+                      target="_blank">
+                      {t('label.request-access')}
+                    </Button>
                   )}
                   <ManageButton
                     isAsyncDelete

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetsHeader/DataAssetsHeader.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetsHeader/DataAssetsHeader.test.tsx
@@ -37,6 +37,13 @@ import { useRequiredParams } from '../../../utils/useRequiredParams';
 import { DataAssetsHeader } from './DataAssetsHeader.component';
 import { DataAssetsHeaderProps } from './DataAssetsHeader.interface';
 
+jest.mock('../../../hooks/useRequestAccessUrl', () => ({
+  useRequestAccessUrl: jest.fn().mockReturnValue({
+    url: null,
+    isLoading: false,
+  }),
+}));
+
 const mockProps: DataAssetsHeaderProps = {
   dataAsset: {
     id: 'assets-id',
@@ -263,6 +270,21 @@ describe('DataAssetsHeader component', () => {
       fields: 'parent',
     });
     expect(getDataQualityLineage).not.toHaveBeenCalled();
+  });
+
+  it('should render request access button when a request access URL is available', () => {
+    const { useRequestAccessUrl } = jest.requireMock(
+      '../../../hooks/useRequestAccessUrl'
+    );
+
+    useRequestAccessUrl.mockReturnValueOnce({
+      url: 'https://access.example.com/new',
+      isLoading: false,
+    });
+
+    render(<DataAssetsHeader {...mockProps} />);
+
+    expect(screen.getByTestId('request-access-button')).toBeInTheDocument();
   });
 
   it('should not call getContainerByName API if parent is undefined', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreSearchCard/ExploreSearchCard.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreSearchCard/ExploreSearchCard.test.tsx
@@ -17,6 +17,13 @@ import searchClassBase from '../../../utils/SearchClassBase';
 import ExploreSearchCard from './ExploreSearchCard';
 import { ExploreSearchCardProps } from './ExploreSearchCard.interface';
 
+jest.mock('../../../hooks/useRequestAccessUrl', () => ({
+  useRequestAccessUrl: jest.fn().mockReturnValue({
+    url: null,
+    isLoading: false,
+  }),
+}));
+
 jest.mock('../../../utils/RouterUtils', () => ({
   getDomainPath: jest.fn().mockReturnValue('/mock-domain'),
 }));
@@ -106,5 +113,23 @@ describe('ExploreSearchCard - Domain section', () => {
     renderCard({ domains: [] });
 
     expect(screen.queryByText('Domain')).not.toBeInTheDocument();
+  });
+
+  it('renders request access button when a request access URL is available', () => {
+    const { useRequestAccessUrl } = jest.requireMock(
+      '../../../hooks/useRequestAccessUrl'
+    );
+
+    useRequestAccessUrl.mockReturnValueOnce({
+      url: 'https://access.example.com/new',
+      isLoading: false,
+    });
+
+    renderCard({
+      entityType: 'database',
+      service: { id: 'service-1', name: 'sample', type: 'databaseService' },
+    });
+
+    expect(screen.getByTestId('request-access-button')).toBeInTheDocument();
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreSearchCard/ExploreSearchCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreSearchCard/ExploreSearchCard.tsx
@@ -30,6 +30,7 @@ import { Table } from '../../../generated/entity/data/table';
 import { EntityReference } from '../../../generated/entity/type';
 import { TagLabel } from '../../../generated/tests/testCase';
 import { AssetCertification } from '../../../generated/type/assetCertification';
+import { useRequestAccessUrl } from '../../../hooks/useRequestAccessUrl';
 import { TableColumnSearchSource } from '../../../interface/search.interface';
 import { getEntityName, highlightSearchText } from '../../../utils/EntityUtils';
 import searchClassBase from '../../../utils/SearchClassBase';
@@ -254,6 +255,12 @@ const ExploreSearchCard: React.FC<ExploreSearchCardProps> = forwardRef<
       () => searchClassBase.getEntityLink(source),
       [source]
     );
+    const { url: requestAccessUrl } = useRequestAccessUrl({
+      entityFqn: source.fullyQualifiedName,
+      entityType: source.entityType as EntityType,
+      serviceName: source.service?.name,
+      serviceType: source.service?.type,
+    });
 
     const header = useMemo(() => {
       const hasGlossaryTermStatus =
@@ -414,8 +421,20 @@ const ExploreSearchCard: React.FC<ExploreSearchCardProps> = forwardRef<
             ))}
           </div>
         ) : null}
-        {actionPopoverContent && (
-          <Space className="explore-card-actions">{actionPopoverContent}</Space>
+        {(actionPopoverContent || requestAccessUrl) && (
+          <Space className="explore-card-actions">
+            {actionPopoverContent}
+            {requestAccessUrl && (
+              <Button
+                data-testid="request-access-button"
+                href={requestAccessUrl}
+                rel="noopener noreferrer"
+                target="_blank"
+                type="link">
+                {t('label.request-access')}
+              </Button>
+            )}
+          </Space>
         )}
       </div>
     );

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useRequestAccessUrl.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useRequestAccessUrl.test.ts
@@ -1,0 +1,106 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { renderHook, waitFor } from '@testing-library/react';
+import { EntityType } from '../enums/entity.enum';
+import { getServiceByFQN } from '../rest/serviceAPI';
+import {
+  useRequestAccessUrl,
+  __clearRequestAccessUrlCacheForTests,
+} from './useRequestAccessUrl';
+
+jest.mock('../rest/serviceAPI', () => ({
+  getServiceByFQN: jest.fn(),
+}));
+
+jest.mock('../utils/RouterUtils', () => ({
+  getEntityDetailsPath: jest.fn((entityType: string, fqn: string) => {
+    return `/${entityType}/${fqn}`;
+  }),
+}));
+
+describe('useRequestAccessUrl', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __clearRequestAccessUrlCacheForTests();
+  });
+
+  it('should resolve request access URLs from service connection options', async () => {
+    (getServiceByFQN as jest.Mock).mockResolvedValue({
+      connection: {
+        config: {
+          connectionOptions: {
+            requestAccessUrlTemplate:
+              'https://access.example.com/new?asset={{entityFqnEncoded}}&url={{entityUrlEncoded}}',
+          },
+        },
+      },
+    });
+
+    const { result } = renderHook(() =>
+      useRequestAccessUrl({
+        entityFqn: 'service.db.schema',
+        entityType: EntityType.DATABASE_SCHEMA,
+        serviceName: 'sample_service',
+        serviceType: 'databaseService',
+      })
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(getServiceByFQN).toHaveBeenCalledWith(
+      'databaseServices',
+      'sample_service'
+    );
+    expect(result.current.url).toBe(
+      'https://access.example.com/new?asset=service.db.schema&url=http%3A%2F%2Flocalhost%2FdatabaseSchema%2Fservice.db.schema'
+    );
+  });
+
+  it('should not fetch service data for unsupported entity types', () => {
+    const { result } = renderHook(() =>
+      useRequestAccessUrl({
+        entityFqn: 'service.db.table',
+        entityType: EntityType.TABLE,
+        serviceName: 'sample_service',
+        serviceType: 'databaseService',
+      })
+    );
+
+    expect(getServiceByFQN).not.toHaveBeenCalled();
+    expect(result.current.url).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('should return null when the service has no request access URL configured', async () => {
+    (getServiceByFQN as jest.Mock).mockResolvedValue({
+      connection: {
+        config: {
+          connectionOptions: {},
+        },
+      },
+    });
+
+    const { result } = renderHook(() =>
+      useRequestAccessUrl({
+        entityFqn: 'service.db',
+        entityType: EntityType.DATABASE,
+        serviceName: 'sample_service',
+        serviceType: 'databaseService',
+      })
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.url).toBeNull();
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useRequestAccessUrl.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useRequestAccessUrl.ts
@@ -1,0 +1,164 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { get } from 'lodash';
+import { useEffect, useMemo, useState } from 'react';
+import { EntityType } from '../enums/entity.enum';
+import { ServiceCategoryPlural } from '../enums/service.enum';
+import { getServiceByFQN } from '../rest/serviceAPI';
+import { getRequestAccessUrl } from '../utils/RequestAccessUtils';
+import { getEntityDetailsPath } from '../utils/RouterUtils';
+
+type CacheEntry = {
+  value: Record<string, string> | undefined;
+  timestamp: number;
+  inFlight?: Promise<Record<string, string> | undefined>;
+};
+
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const connectionOptionsCache = new Map<string, CacheEntry>();
+
+export const __clearRequestAccessUrlCacheForTests = () => {
+  connectionOptionsCache.clear();
+};
+
+const SUPPORTED_ENTITY_TYPES = new Set<EntityType>([
+  EntityType.DATABASE,
+  EntityType.DATABASE_SCHEMA,
+  EntityType.DASHBOARD,
+]);
+
+export const isRequestAccessSupportedEntityType = (
+  entityType?: EntityType
+): entityType is EntityType =>
+  entityType ? SUPPORTED_ENTITY_TYPES.has(entityType) : false;
+
+export const useRequestAccessUrl = ({
+  entityFqn,
+  entityType,
+  serviceName,
+  serviceType,
+}: {
+  entityFqn?: string;
+  entityType?: EntityType;
+  serviceName?: string;
+  serviceType?: string;
+}) => {
+  const [url, setUrl] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const serviceCategory = useMemo(
+    () =>
+      serviceType
+        ? ServiceCategoryPlural[
+            serviceType as keyof typeof ServiceCategoryPlural
+          ]
+        : undefined,
+    [serviceType]
+  );
+
+  useEffect(() => {
+    if (
+      !entityFqn ||
+      !entityType ||
+      !serviceName ||
+      !serviceCategory ||
+      !isRequestAccessSupportedEntityType(entityType)
+    ) {
+      setUrl(null);
+      setIsLoading(false);
+
+      return;
+    }
+
+    let isMounted = true;
+
+    const fetchRequestAccessUrl = async () => {
+      setUrl(null);
+      setIsLoading(true);
+
+      try {
+        const cacheKey = `${serviceCategory}::${serviceName}`;
+        let connectionOptions: Record<string, string> | undefined;
+
+        const now = Date.now();
+        const cachedEntry = connectionOptionsCache.get(cacheKey);
+
+        if (cachedEntry && now - cachedEntry.timestamp >= CACHE_TTL_MS) {
+          connectionOptionsCache.delete(cacheKey);
+        }
+
+        const freshEntry = connectionOptionsCache.get(cacheKey);
+        if (freshEntry?.inFlight) {
+          connectionOptions = await freshEntry.inFlight;
+        } else if (freshEntry && now - freshEntry.timestamp < CACHE_TTL_MS) {
+          connectionOptions = freshEntry.value;
+        } else {
+          const inFlight = (async () => {
+            const service = await getServiceByFQN(serviceCategory, serviceName);
+
+            return get(service, 'connection.config.connectionOptions') as
+              | Record<string, string>
+              | undefined;
+          })();
+
+          connectionOptionsCache.set(cacheKey, {
+            value: undefined,
+            timestamp: now,
+            inFlight,
+          });
+
+          try {
+            connectionOptions = await inFlight;
+            connectionOptionsCache.set(cacheKey, {
+              value: connectionOptions,
+              timestamp: Date.now(),
+            });
+          } catch (err) {
+            connectionOptionsCache.delete(cacheKey);
+            throw err;
+          }
+        }
+        const entityUrl = `${window.location.origin}${getEntityDetailsPath(
+          entityType,
+          entityFqn
+        )}`;
+
+        if (isMounted) {
+          setUrl(
+            getRequestAccessUrl({
+              connectionOptions,
+              entityFqn,
+              entityUrl,
+            })
+          );
+        }
+      } catch {
+        if (isMounted) {
+          setUrl(null);
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    fetchRequestAccessUrl();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [entityFqn, entityType, serviceCategory, serviceName]);
+
+  return { url, isLoading };
+};

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ar-sa.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ar-sa.json
@@ -1671,6 +1671,7 @@
     "reply-lowercase-plural": "ردود",
     "reposition": "إعادة تموضع",
     "request": "طلب",
+    "request-access": "Request Access",
     "request-method": "طريقة الطلب",
     "request-schema-field": "حقل مخطط الطلب",
     "request-tag-plural": "طلب وسوم",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/de-de.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/de-de.json
@@ -1671,6 +1671,7 @@
     "reply-lowercase-plural": "antworten",
     "reposition": "Neu positionieren",
     "request": "Anfrage",
+    "request-access": "Request Access",
     "request-method": "Anfrage Methode",
     "request-schema-field": "Anfrage Feld Schema",
     "request-tag-plural": "Tag-Anfragen",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
@@ -1671,6 +1671,7 @@
     "reply-lowercase-plural": "replies",
     "reposition": "Reposition",
     "request": "Request",
+    "request-access": "Request Access",
     "request-method": "Request Method",
     "request-schema-field": "Request Schema Field",
     "request-tag-plural": "Request Tags",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/es-es.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/es-es.json
@@ -1671,6 +1671,7 @@
     "reply-lowercase-plural": "respuestas",
     "reposition": "Reposicionar",
     "request": "Petición",
+    "request-access": "Request Access",
     "request-method": "Petición Método",
     "request-schema-field": "Petición Campo del Esquema",
     "request-tag-plural": "Etiquetas de solicitud",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/fr-fr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/fr-fr.json
@@ -1671,6 +1671,7 @@
     "reply-lowercase-plural": "réponses",
     "reposition": "Repositionner",
     "request": "Requête",
+    "request-access": "Request Access",
     "request-method": "Méthode de Requête",
     "request-schema-field": "Champ de Schéma de Requête",
     "request-tag-plural": "Demander l'ajout de tags",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/gl-es.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/gl-es.json
@@ -1671,6 +1671,7 @@
     "reply-lowercase-plural": "respostas",
     "reposition": "Reposicionar",
     "request": "Solicitude",
+    "request-access": "Request Access",
     "request-method": "Método de solicitude",
     "request-schema-field": "Campo de esquema de solicitude",
     "request-tag-plural": "Solicitar etiquetas",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/he-he.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/he-he.json
@@ -1671,6 +1671,7 @@
     "reply-lowercase-plural": "תגובות",
     "reposition": "שנה מיקום",
     "request": "בקשה",
+    "request-access": "Request Access",
     "request-method": "שיטת בקשה",
     "request-schema-field": "שדה סכמת בקשה",
     "request-tag-plural": "בקשת תגיות",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ja-jp.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ja-jp.json
@@ -1671,6 +1671,7 @@
     "reply-lowercase-plural": "返信",
     "reposition": "位置変更",
     "request": "リクエスト",
+    "request-access": "Request Access",
     "request-method": "リクエストメソッド",
     "request-schema-field": "リクエストスキーマフィールド",
     "request-tag-plural": "タグをリクエスト",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ko-kr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ko-kr.json
@@ -1671,6 +1671,7 @@
     "reply-lowercase-plural": "답글들",
     "reposition": "위치 변경",
     "request": "요청",
+    "request-access": "Request Access",
     "request-method": "요청 메서드",
     "request-schema-field": "요청 스키마 필드",
     "request-tag-plural": "태그 요청",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/mr-in.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/mr-in.json
@@ -1671,6 +1671,7 @@
     "reply-lowercase-plural": "उत्तरे",
     "reposition": "स्थिती बदला",
     "request": "विनंती",
+    "request-access": "Request Access",
     "request-method": "विनंती पद्धत",
     "request-schema-field": "विनंती स्कीमा फील्ड",
     "request-tag-plural": "विनंती टॅग",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/nl-nl.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/nl-nl.json
@@ -1671,6 +1671,7 @@
     "reply-lowercase-plural": "antwoorden",
     "reposition": "Herpositioneren",
     "request": "Verzoek",
+    "request-access": "Request Access",
     "request-method": "Request Method",
     "request-schema-field": "Request Schema Field",
     "request-tag-plural": "Aanvraagtags",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pr-pr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pr-pr.json
@@ -1671,6 +1671,7 @@
     "reply-lowercase-plural": "پاسخ‌ها",
     "reposition": "Reposition",
     "request": "درخواست",
+    "request-access": "Request Access",
     "request-method": "روش درخواست",
     "request-schema-field": "فیلد اسکیما درخواست",
     "request-tag-plural": "برچسب‌های درخواست",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-br.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-br.json
@@ -1671,6 +1671,7 @@
     "reply-lowercase-plural": "respostas",
     "reposition": "Reposicionar",
     "request": "Solicitação",
+    "request-access": "Request Access",
     "request-method": "Método de solicitação",
     "request-schema-field": "Campo de esquema da requisição",
     "request-tag-plural": "Solicitar Tags",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-pt.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-pt.json
@@ -1671,6 +1671,7 @@
     "reply-lowercase-plural": "respostas",
     "reposition": "Reposicionar",
     "request": "Pedido",
+    "request-access": "Request Access",
     "request-method": "Método de Pedido",
     "request-schema-field": "Campo do Esquema de Pedido",
     "request-tag-plural": "Solicitar Etiquetas",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ru-ru.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ru-ru.json
@@ -1671,6 +1671,7 @@
     "reply-lowercase-plural": "ответы",
     "reposition": "Изменить положение",
     "request": "Запрос",
+    "request-access": "Request Access",
     "request-method": "Метод запроса",
     "request-schema-field": "Поле схемы запроса",
     "request-tag-plural": "Предложить тег",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/th-th.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/th-th.json
@@ -1671,6 +1671,7 @@
     "reply-lowercase-plural": "คำตอบหลายรายการ",
     "reposition": "ปรับตำแหน่งใหม่",
     "request": "คำขอ",
+    "request-access": "Request Access",
     "request-method": "วิธีการของคำขอ",
     "request-schema-field": "ฟิลด์สคีมาของคำขอ",
     "request-tag-plural": "แท็กคำขอ",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/tr-tr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/tr-tr.json
@@ -1671,6 +1671,7 @@
     "reply-lowercase-plural": "yanıtlar",
     "reposition": "Yeniden konumlandır",
     "request": "İstek",
+    "request-access": "Request Access",
     "request-method": "İstek Metodu",
     "request-schema-field": "İstek Şema Alanı",
     "request-tag-plural": "Etiket İste",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-cn.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-cn.json
@@ -1671,6 +1671,7 @@
     "reply-lowercase-plural": "回复",
     "reposition": "重新定位",
     "request": "请求",
+    "request-access": "Request Access",
     "request-method": "请求方式",
     "request-schema-field": "请求架构字段",
     "request-tag-plural": "请求补充标签",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-tw.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-tw.json
@@ -1671,6 +1671,7 @@
     "reply-lowercase-plural": "回覆",
     "reposition": "重新定位",
     "request": "請求",
+    "request-access": "Request Access",
     "request-method": "請求方法",
     "request-schema-field": "請求結構欄位",
     "request-tag-plural": "請求標籤",

--- a/openmetadata-ui/src/main/resources/ui/src/utils/RequestAccessUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/RequestAccessUtils.test.ts
@@ -1,0 +1,76 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import {
+  getRequestAccessUrl,
+  resolveRequestAccessUrl,
+} from './RequestAccessUtils';
+
+describe('RequestAccessUtils', () => {
+  it('should resolve encoded entity placeholders in URL templates', () => {
+    const result = resolveRequestAccessUrl(
+      'https://access.example.com/new?asset={{entityFqnEncoded}}&url={{entityUrlEncoded}}',
+      'sample.service.db',
+      'http://localhost:3000/database/sample.service.db'
+    );
+
+    expect(result).toBe(
+      'https://access.example.com/new?asset=sample.service.db&url=http%3A%2F%2Flocalhost%3A3000%2Fdatabase%2Fsample.service.db'
+    );
+  });
+
+  it('should prefer requestAccessUrl over requestAccessUrlTemplate', () => {
+    const result = getRequestAccessUrl({
+      connectionOptions: {
+        requestAccessUrl: 'https://access.example.com/direct',
+        requestAccessUrlTemplate:
+          'https://access.example.com/new?asset={{entityFqnEncoded}}',
+      },
+      entityFqn: 'sample.service.db',
+      entityUrl: 'http://localhost:3000/database/sample.service.db',
+    });
+
+    expect(result).toBe('https://access.example.com/direct');
+  });
+
+  it('should return null when request access connection options are missing', () => {
+    const result = getRequestAccessUrl({
+      connectionOptions: {},
+      entityFqn: 'sample.service.db',
+      entityUrl: 'http://localhost:3000/database/sample.service.db',
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('should reject unsafe URL protocols', () => {
+    const resultDirect = getRequestAccessUrl({
+      connectionOptions: {
+        requestAccessUrl: 'javascript:alert(1)',
+      },
+      entityFqn: 'sample.service.db',
+      entityUrl: 'http://localhost:3000/database/sample.service.db',
+    });
+
+    expect(resultDirect).toBeNull();
+
+    const resultTemplate = getRequestAccessUrl({
+      connectionOptions: {
+        requestAccessUrlTemplate: 'data:text/html,hello',
+      },
+      entityFqn: 'sample.service.db',
+      entityUrl: 'http://localhost:3000/database/sample.service.db',
+    });
+
+    expect(resultTemplate).toBeNull();
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/RequestAccessUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/RequestAccessUtils.ts
@@ -1,0 +1,66 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+const ENTITY_FQN_ENCODED_TOKEN = '{{entityFqnEncoded}}';
+const ENTITY_URL_ENCODED_TOKEN = '{{entityUrlEncoded}}';
+
+export const REQUEST_ACCESS_URL = 'requestAccessUrl';
+export const REQUEST_ACCESS_URL_TEMPLATE = 'requestAccessUrlTemplate';
+
+export type RequestAccessConnectionOptions = Record<string, string> | undefined;
+
+const isSafeUrl = (url: string): boolean => {
+  try {
+    const parsed = new URL(url);
+
+    return ['http:', 'https:'].includes(parsed.protocol);
+  } catch {
+    return false;
+  }
+};
+
+export const resolveRequestAccessUrl = (
+  template: string,
+  entityFqn: string,
+  entityUrl: string
+) => {
+  return template
+    .replaceAll(ENTITY_FQN_ENCODED_TOKEN, encodeURIComponent(entityFqn))
+    .replaceAll(ENTITY_URL_ENCODED_TOKEN, encodeURIComponent(entityUrl));
+};
+
+export const getRequestAccessUrl = ({
+  connectionOptions,
+  entityFqn,
+  entityUrl,
+}: {
+  connectionOptions?: RequestAccessConnectionOptions;
+  entityFqn: string;
+  entityUrl: string;
+}) => {
+  const directUrl = connectionOptions?.[REQUEST_ACCESS_URL]?.trim();
+
+  if (directUrl && isSafeUrl(directUrl)) {
+    return directUrl;
+  }
+
+  const template = connectionOptions?.[REQUEST_ACCESS_URL_TEMPLATE]?.trim();
+
+  if (!template) {
+    return null;
+  }
+
+  const resolved = resolveRequestAccessUrl(template, entityFqn, entityUrl);
+
+  return isSafeUrl(resolved) ? resolved : null;
+};


### PR DESCRIPTION
## Summary
- add a shared request-access URL resolver and hook backed by service `connectionOptions`
- show a `Request Access` button on explore cards and entity headers for supported assets
- add focused unit tests for the resolver, hook, and UI surfaces

## Notes
- supported connection option keys: `requestAccessUrl`, `requestAccessUrlTemplate`
- supported asset types: `database`, `databaseSchema`, `dashboard`

## Test Plan
- `git diff --check`
- `node -e "JSON.parse(require('fs').readFileSync('openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json','utf8')); console.log('json_ok')"`
- `yarn test --runInBand src/utils/RequestAccessUtils.test.ts`
- `yarn test --runInBand src/hooks/useRequestAccessUrl.test.ts`
- remaining frontend verification was not completed in this environment because repo-generated frontend artifacts and broader UI typecheck issues are present locally

Fixes #25575