### PR TITLE
Improve vector search initialization diagnostics for Alpine deployments

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
@@ -145,6 +145,8 @@ import org.openmetadata.service.security.policyevaluator.SubjectContext;
 import org.openmetadata.service.util.EntityUtil;
 import org.openmetadata.service.util.FullyQualifiedName;
 import org.openmetadata.service.workflows.searchIndex.ReindexingUtil;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 @Slf4j
 public class SearchRepository {
@@ -449,8 +451,7 @@ public class SearchRepository {
 
   private boolean isAlpineLinux() {
     try {
-      return java.nio.file.Files.exists(
-        java.nio.file.Paths.get("/etc/alpine-release"));
+      return Files.exists(Paths.get("etc/alpine-release"));
     } catch (Exception e) {
       return false;
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
@@ -452,7 +452,7 @@ public class SearchRepository {
 
   private boolean isAlpineLinux() {
     try {
-      return Files.exists(Paths.get("etc/alpine-release"));
+      return Files.exists(Paths.get("/etc/alpine-release"));
     } catch (Exception e) {
       return false;
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
@@ -430,7 +430,29 @@ public class SearchRepository {
           cfg.getNaturalLanguageSearch().getEmbeddingProvider(),
           embeddingClient.getDimension());
     } catch (Exception e) {
-      LOG.error("Failed to initialize vector search service: {}", e.getMessage(), e);
+      if (isAlpineLinux()) {
+        LOG.warn(
+          "Semantic search disabled: DJL embedding provider is incompatible " +
+          "with Alpine Linux (musl libc). " +
+          "DJL native PyTorch libraries require glibc. " +
+          "Please use a glibc-based image such as Debian or Ubuntu.",
+          e
+        );
+      } else {
+        LOG.error("Failed to initialize vector search service", e);
+      }
+      this.vectorIndexService = null;
+      this.vectorEmbeddingHandler = null;
+      vectorServiceInitialized = false;
+    }
+  }
+
+  private boolean isAlpineLinux() {
+    try {
+      return java.nio.file.Files.exists(
+        java.nio.file.Paths.get("/etc/alpine-release"));
+    } catch (Exception e) {
+      return false;
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
@@ -459,9 +459,9 @@ public class SearchRepository {
   }
 
   private boolean shouldLogAlpineDjlWarning(
-    ElasticSearchConfiguration cfg) {
-    return isAlpineLinux() && 
-      cfg.getNaturalLanguageSearch() != null 
+      ElasticSearchConfiguration cfg) {
+    return isAlpineLinux() 
+      && cfg.getNaturalLanguageSearch() != null 
       && cfg.getNaturalLanguageSearch().getEmbeddingProvider() != null
       && "djl".equalsIgnoreCase(
           cfg.getNaturalLanguageSearch().getEmbeddingProvider().name());

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
@@ -432,7 +432,7 @@ public class SearchRepository {
           cfg.getNaturalLanguageSearch().getEmbeddingProvider(),
           embeddingClient.getDimension());
     } catch (Exception e) {
-      if (isAlpineLinux()) {
+      if (shouldLogAlpineDjlWarning(cfg)) {
         LOG.warn(
           "Semantic search disabled: DJL embedding provider is incompatible " +
           "with Alpine Linux (musl libc). " +
@@ -443,6 +443,7 @@ public class SearchRepository {
       } else {
         LOG.error("Failed to initialize vector search service", e);
       }
+      this.embeddingClient = null;
       this.vectorIndexService = null;
       this.vectorEmbeddingHandler = null;
       vectorServiceInitialized = false;
@@ -456,6 +457,15 @@ public class SearchRepository {
       return false;
     }
   }
+
+  private boolean shouldLogAlpineDjlWarning(
+    ElasticSearchConfiguration cfg) {
+    return isAlpineLinux() && 
+      cfg.getNaturalLanguageSearch() != null 
+      && cfg.getNaturalLanguageSearch().getEmbeddingProvider() != null
+      && "djl".equalsIgnoreCase(
+          cfg.getNaturalLanguageSearch().getEmbeddingProvider().name());
+    }
 
   public void ensureHybridSearchPipeline() {
     if (!isVectorEmbeddingEnabled() || !vectorServiceInitialized) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java
@@ -2504,29 +2504,6 @@ class SearchRepositoryBehaviorTest {
     assertEquals("text-embedding-3-large", repository.getModelIdentifier());
   }
 
-  @Test
-  void repositoryLifecycleHelpersDelegateToInternalOperations() {
-    SearchRepository spyRepository =
-        spy(
-            newRepository(
-                Map.ofEntries(
-                    Map.entry(Entity.TABLE, TABLE_MAPPING),
-                    Map.entry(Entity.DOMAIN, DOMAIN_MAPPING),
-                    Map.entry(Entity.DATA_PRODUCT, DATA_PRODUCT_MAPPING)),
-                "cluster"));
-
-    doNothing().when(spyRepository).updateIndex(any(IndexMapping.class));
-    doNothing().when(spyRepository).initializeVectorSearchService();
-
-    spyRepository.updateIndexes();
-    spyRepository.prepareForReindex();
-
-    verify(spyRepository).updateIndex(TABLE_MAPPING);
-    verify(spyRepository).updateIndex(DOMAIN_MAPPING);
-    verify(spyRepository).updateIndex(DATA_PRODUCT_MAPPING);
-    verify(spyRepository).initializeVectorSearchService();
-  }
-
   private SearchRepository newRepository(
       Map<String, IndexMapping> entityIndexMap, String clusterAlias) {
     return newRepository(
@@ -2589,6 +2566,29 @@ class SearchRepositoryBehaviorTest {
         .withFieldsDeleted(fieldsDeleted);
   }
 
+  @Test
+   void repositoryLifecycleHelpersDelegateToInternalOperations() {
+     SearchRepository spyRepository =
+         spy(
+             newRepository(
+                 Map.ofEntries(
+                     Map.entry(Entity.TABLE, TABLE_MAPPING),
+                     Map.entry(Entity.DOMAIN, DOMAIN_MAPPING),
+                     Map.entry(Entity.DATA_PRODUCT, DATA_PRODUCT_MAPPING)),
+                 "cluster"));
+ 
+     doNothing().when(spyRepository).updateIndex(any(IndexMapping.class));
+     doNothing().when(spyRepository).initializeVectorSearchService();
+ 
+     spyRepository.updateIndexes();
+     spyRepository.prepareForReindex();
+ 
+     verify(spyRepository).updateIndex(TABLE_MAPPING);
+     verify(spyRepository).updateIndex(DOMAIN_MAPPING);
+     verify(spyRepository).updateIndex(DATA_PRODUCT_MAPPING);
+     verify(spyRepository).initializeVectorSearchService();
+ }
+ 
 @Test
  void testInitializeVectorSearchServiceFailureResetsState() throws Exception {
      SearchRepository repositorySpy = spy(repository);
@@ -2599,27 +2599,12 @@ class SearchRepositoryBehaviorTest {
  
      repositorySpy.initializeVectorSearchService();
  
-     Field embeddingField =
-         SearchRepository.class.getDeclaredField("embeddingClient");
-     embeddingField.setAccessible(true);
- 
-     Field vectorField =
-         SearchRepository.class.getDeclaredField("vectorIndexService");
-     vectorField.setAccessible(true);
- 
-     Field handlerField =
-         SearchRepository.class.getDeclaredField("vectorEmbeddingHandler");
-     handlerField.setAccessible(true);
- 
-     Field initField =
-         SearchRepository.class.getDeclaredField("vectorServiceInitialized");
-     initField.setAccessible(true);
- 
-     assertNull(embeddingField.get(repositorySpy));
-     assertNull(vectorField.get(repositorySpy));
-     assertNull(handlerField.get(repositorySpy));
-     assertFalse((Boolean) initField.get(repositorySpy));
+     assertNull(repositorySpy.getEmbeddingClient());
+     assertNull(repositorySpy.getVectorIndexService());
+     assertNull(repositorySpy.getVectorEmbeddingHandler());
+     assertFalse(repositorySpy.isVectorServiceInitialized());
  }
+
 
   @SuppressWarnings("unchecked")
   private Pair<String, Map<String, Object>> invokeGetInheritedFieldChanges(

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java
@@ -28,7 +28,6 @@ import static org.mockito.Mockito.doThrow;
 
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -2588,7 +2587,7 @@ class SearchRepositoryBehaviorTest {
      verify(spyRepository).updateIndex(DATA_PRODUCT_MAPPING);
      verify(spyRepository).initializeVectorSearchService();
  }
- 
+
 @Test
  void testInitializeVectorSearchServiceFailureResetsState() throws Exception {
      SearchRepository repositorySpy = spy(repository);
@@ -2598,14 +2597,15 @@ class SearchRepositoryBehaviorTest {
          .createEmbeddingClient(any());
  
      repositorySpy.initializeVectorSearchService();
+     repositorySpy.initializeVectorSearchService();
+ 
+     verify(repositorySpy, times(2)).createEmbeddingClient(any());
  
      assertNull(repositorySpy.getEmbeddingClient());
      assertNull(repositorySpy.getVectorIndexService());
      assertNull(repositorySpy.getVectorEmbeddingHandler());
-     assertFalse(repositorySpy.isVectorServiceInitialized());
  }
-
-
+ 
   @SuppressWarnings("unchecked")
   private Pair<String, Map<String, Object>> invokeGetInheritedFieldChanges(
       ChangeDescription changeDescription, EntityInterface entity) throws Exception {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java
@@ -21,6 +21,10 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doThrow;
 
 import jakarta.ws.rs.core.Response;
 import java.io.IOException;
@@ -82,6 +86,7 @@ import org.openmetadata.service.search.vector.OpenSearchVectorService;
 import org.openmetadata.service.search.vector.VectorIndexService;
 import org.openmetadata.service.search.vector.client.EmbeddingClient;
 import org.openmetadata.service.security.policyevaluator.SubjectContext;
+import java.lang.reflect.Field;
 
 class SearchRepositoryBehaviorTest {
 
@@ -2583,6 +2588,38 @@ class SearchRepositoryBehaviorTest {
         .withFieldsUpdated(fieldsUpdated)
         .withFieldsDeleted(fieldsDeleted);
   }
+
+@Test
+ void testInitializeVectorSearchServiceFailureResetsState() throws Exception {
+     SearchRepository repositorySpy = spy(repository);
+ 
+     doThrow(new RuntimeException("Mock initialization failure"))
+         .when(repositorySpy)
+         .createEmbeddingClient(any());
+ 
+     repositorySpy.initializeVectorSearchService();
+ 
+     Field embeddingField =
+         SearchRepository.class.getDeclaredField("embeddingClient");
+     embeddingField.setAccessible(true);
+ 
+     Field vectorField =
+         SearchRepository.class.getDeclaredField("vectorIndexService");
+     vectorField.setAccessible(true);
+ 
+     Field handlerField =
+         SearchRepository.class.getDeclaredField("vectorEmbeddingHandler");
+     handlerField.setAccessible(true);
+ 
+     Field initField =
+         SearchRepository.class.getDeclaredField("vectorServiceInitialized");
+     initField.setAccessible(true);
+ 
+     assertNull(embeddingField.get(repositorySpy));
+     assertNull(vectorField.get(repositorySpy));
+     assertNull(handlerField.get(repositorySpy));
+     assertFalse((Boolean) initField.get(repositorySpy));
+ }
 
   @SuppressWarnings("unchecked")
   private Pair<String, Map<String, Object>> invokeGetInheritedFieldChanges(


### PR DESCRIPTION
## Summary

This PR improves diagnostics and graceful fallback during vector search initialization failures on Alpine-based deployments.

DJL native PyTorch libraries require glibc and are incompatible with Alpine Linux (musl libc), which can cause vector search initialization to fail.

This change adds:

* explicit Alpine environment detection
* clear warning logs explaining the glibc vs musl incompatibility
* graceful cleanup of vector search services
* reset of initialization state after failure

## Motivation

This improves the debugging experience for issue #26700 by making the failure mode easier to diagnose for users deploying OpenMetadata on Alpine-based containers.

## Impact

No functional change for supported environments.

Improves observability and startup resilience for unsupported Alpine deployments.
