### PR TITLE
Fixes #26857: Remove redundant JSON serialization roundtrip in SettingsCache

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/settings/SettingsCache.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/settings/SettingsCache.java
@@ -524,8 +524,8 @@ public class SettingsCache {
 
   public static <T> T getSetting(SettingsType settingName, Class<T> clazz) {
     try {
-      String json = JsonUtils.pojoToJson(CACHE.get(settingName.toString()).getConfigValue());
-      return JsonUtils.readValue(json, clazz);
+      Object configValue = CACHE.get(settingName.toString()).getConfigValue();
+      return JsonUtils.convertValue(configValue, clazz);
     } catch (Exception ex) {
       LOG.error("Failed to fetch Settings . Setting {}", settingName, ex);
       throw new EntityNotFoundException("Setting not found");
@@ -535,8 +535,8 @@ public class SettingsCache {
   public static <T> T getSettingOrDefault(
       SettingsType settingName, T defaultValue, Class<T> clazz) {
     try {
-      String json = JsonUtils.pojoToJson(CACHE.get(settingName.toString()).getConfigValue());
-      return JsonUtils.readValue(json, clazz);
+      Object configValue = CACHE.get(settingName.toString()).getConfigValue();
+      return JsonUtils.convertValue(configValue, clazz);
     } catch (Exception ex) {
       LOG.error("Failed to fetch Settings . Setting {}", settingName, ex);
       return defaultValue;


### PR DESCRIPTION
### Describe your changes:

Fixes #26857

`SettingsCache.getSetting()` and `getSettingOrDefault()` were converting cached config values via a redundant `Object → JSON string → Object` roundtrip:

```java
// Before (two-step: serialize then deserialize)
String json = JsonUtils.pojoToJson(CACHE.get(settingName.toString()).getConfigValue());
return JsonUtils.readValue(json, clazz);
```

The cached `configValue` is already a `LinkedHashMap` (Jackson's default deserialization of JSON objects). Serializing it to a JSON string and immediately parsing it back is wasteful — `JsonUtils.convertValue()` (which delegates to `ObjectMapper.convertValue()`) does the same type conversion directly in memory without the intermediate string allocation.

```java
// After (direct in-memory conversion)
Object configValue = CACHE.get(settingName.toString()).getConfigValue();
return JsonUtils.convertValue(configValue, clazz);
```

This affects hot code paths — `getCertificationClassification()` alone is called 8+ times across `EntityRepository` during list views, tag fetches, and batch operations. Every other caller of `getSetting()`/`getSettingOrDefault()` (20+ call sites across EmailUtil, SecurityConfigurationManager, GlossaryTermRepository, etc.) also benefits.

**Testing:** `JsonUtils.convertValue(Object, Class<T>)` is an existing, well-tested utility already used elsewhere in the codebase. The behavioral contract is identical — both approaches deserialize a `LinkedHashMap` into the target POJO class using the same `ObjectMapper` instance.

#
### Type of change:
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.