### PR TITLE
Fixes #26696: Preserve sequence function string arguments during query masking

### DIFF
--- a/ingestion/src/metadata/ingestion/lineage/masker.py
+++ b/ingestion/src/metadata/ingestion/lineage/masker.py
@@ -166,14 +166,15 @@ def mask_literals_with_sqlfluff(
 
         def _is_inside_sequence_function_sqlfluff(segment) -> bool:
             """Check if a segment is inside a sequence function like NEXTVAL, CURRVAL, etc."""
-            parent = segment.get_parent()
-            while parent:
+            result = segment.get_parent()
+            while result:
+                parent, _ = result
                 if parent.is_type("function"):
                     name_seg = parent.get_child("function_name")
                     if name_seg and name_seg.raw.upper() in SEQUENCE_FUNCTIONS:
                         return True
                     return False
-                parent = parent.get_parent()
+                result = parent.get_parent()
             return False
 
         def replace_literals(segment, in_groupby_orderby=False):

--- a/ingestion/tests/unit/lineage/masker/test_query_masker_dialect_specific.py
+++ b/ingestion/tests/unit/lineage/masker/test_query_masker_dialect_specific.py
@@ -215,21 +215,27 @@ class TestQueryMaskerDialectSpecific(TestCase):
             {
                 "query": "INSERT INTO target_table SELECT NEXTVAL('reporting', 'my_sequence'), col1 FROM source_table WHERE status = 'active';",  # noqa: E501
                 "expected": "INSERT INTO target_table SELECT NEXTVAL('reporting', 'my_sequence'), col1 FROM source_table WHERE status = ?;",  # noqa: E501
-                "dialect": Dialect.ANSI.value,
+                "dialect": Dialect.VERTICA.value,
             },
             {
                 "query": "SELECT CURRVAL('public', 'id_seq') FROM dual;",
                 "expected": "SELECT CURRVAL('public', 'id_seq') FROM dual;",
-                "dialect": Dialect.ANSI.value,
+                "dialect": Dialect.VERTICA.value,
             },
             {
                 "query": "SELECT SETVAL('myschema', 'myseq', 100) FROM dual;",
                 "expected": "SELECT SETVAL('myschema', 'myseq', ?) FROM dual;",
-                "dialect": Dialect.ANSI.value,
+                "dialect": Dialect.VERTICA.value,
             },
         ]
 
         for test_case in query_test_cases:
+            assert_masked_query(
+                test_case["query"],
+                test_case["expected"],
+                test_case["dialect"],
+                "SqlFluff",
+            )
             assert_masked_query(
                 test_case["query"],
                 test_case["expected"],


### PR DESCRIPTION
### Describe your changes:

Fixes #26696

The query masker in `masker.py` replaces all string and numeric literals with `?` for privacy before storing the SQL in `LineageDetails.sqlQuery` (displayed in the UI). However, `NEXTVAL('schema', 'sequence')` arguments are schema/sequence **identifiers**, not sensitive data values. The masker incorrectly treated them as regular string literals, producing `NEXTVAL(?, ?)` in the lineage UI.

**Changes:**
- **SqlParse path**: Added `_is_inside_sequence_function()` that walks the AST parent chain to detect `Function` nodes with names in `{NEXTVAL, CURRVAL, SETVAL, LASTVAL}`. String literals inside these functions are preserved; numeric literals (e.g., SETVAL's value arg) are still masked.
- **SqlFluff path**: Equivalent `_is_inside_sequence_function_sqlfluff()` using sqlfluff's `get_parent()`/`get_child("function_name")` API.
- **Unit tests**: Added `test_vertica_nextval_arguments_preserved` covering NEXTVAL, CURRVAL, and SETVAL scenarios.

**Test Results:**

| Query | Before | After |
|---|---|---|
| `NEXTVAL('reporting', 'my_seq')` | `NEXTVAL(?, ?)` | `NEXTVAL('reporting', 'my_seq')` |
| `CURRVAL('public', 'id_seq')` | `CURRVAL(?, ?)` | `CURRVAL('public', 'id_seq')` |
| `SETVAL('schema', 'seq', 100)` | `SETVAL(?, ?, ?)` | `SETVAL('schema', 'seq', ?)` |
| `UPPER('secret')` | `UPPER(?)` | `UPPER(?)` *(unchanged)* |
| `WHERE status = 'active'` | `WHERE status = ?` | `WHERE status = ?` *(unchanged)* |

#
### Type of change:
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.