### PR TITLE
fix(e2e): improve lineage ingestion reliability with retry mechanism

### DIFF
--- a/ingestion/tests/cli_e2e/base/test_cli_db.py
+++ b/ingestion/tests/cli_e2e/base/test_cli_db.py
@@ -19,6 +19,7 @@ from unittest import TestCase
 
 import pytest
 from pydantic import TypeAdapter
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed
 
 from _openmetadata_testutils.pydantic.test_utils import assert_equal_pydantic_objects
 from metadata.data_quality.api.models import TestCaseDefinition
@@ -223,14 +224,35 @@ class CliDBBase(TestCase):
             if hasattr(self, "get_service_type"):
                 service_type = self.get_service_type()
 
+            # Metadata ingest runs once; the lineage ingest is retried separately
+            # because DB audit logs (BigQuery INFORMATION_SCHEMA.JOBS_BY_PROJECT,
+            # MSSQL sys.dm_exec_query_stats, Postgres pg_stat_statements) have
+            # eventual consistency — newly executed queries may not appear for
+            # 30-120s, causing the first lineage run to return 0 records.
             self.run_command()
-            self.build_config_file(
-                E2EType.LINEAGE,
-                {"source": f"{service_type}-lineage", **self.get_lineage_config_args()},
+
+            # Re-run the full lineage ingest + assert on each retry so that the
+            # ingestion re-reads the audit log (which may now be populated) and
+            # writes fresh lineage edges to OpenMetadata before asserting.
+            @retry(
+                retry=retry_if_exception_type((AssertionError, IndexError)),
+                wait=wait_fixed(30),
+                stop=stop_after_attempt(3),
+                reraise=True,
             )
-            result = self.run_command()
-            sink_status, source_status = self.retrieve_statuses(result)
-            self.assert_for_test_lineage(source_status, sink_status)
+            def _run_lineage_and_assert() -> None:
+                self.build_config_file(
+                    E2EType.LINEAGE,
+                    {
+                        "source": f"{service_type}-lineage",
+                        **self.get_lineage_config_args(),
+                    },
+                )
+                result = self.run_command()
+                sink_status, source_status = self.retrieve_statuses(result)
+                self.assert_for_test_lineage(source_status, sink_status)
+
+            _run_lineage_and_assert()
 
         @pytest.mark.order(12)
         def test_profiler_with_time_partition(self) -> None:


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:


<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **Retry mechanism added:**
  - Wrapped lineage ingestion in `@retry` decorator with 3 attempts and 30-second wait intervals to handle eventual consistency in DB audit logs
- **Why retry needed:**
  - BigQuery `INFORMATION_SCHEMA.JOBS_BY_PROJECT`, MSSQL `sys.dm_exec_query_stats`, and Postgres `pg_stat_statements` have eventual consistency delays (30-120s) causing first lineage run to return zero records

<sub>This will update automatically on new commits.</sub>