### PR TITLE
Fix: Search ranking - usage/tier boosts act as tiebreakers, not override text relevance 

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/SystemResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/SystemResourceIT.java
@@ -747,6 +747,86 @@ public class SystemResourceIT {
   }
 
   @Test
+  void test_defaultSearchRankingBoostConfiguration() throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+
+    client
+        .getHttpClient()
+        .executeForString(
+            HttpMethod.PUT,
+            "/v1/system/settings/reset/" + SettingsType.SEARCH_SETTINGS.value(),
+            null,
+            RequestOptions.builder().build());
+
+    String settingsJson =
+        client
+            .getHttpClient()
+            .executeForString(
+                HttpMethod.GET,
+                "/v1/system/settings/" + SettingsType.SEARCH_SETTINGS.value(),
+                null,
+                RequestOptions.builder().build());
+
+    Settings settings = MAPPER.readValue(settingsJson, Settings.class);
+    SearchSettings searchConfig =
+        MAPPER.convertValue(settings.getConfigValue(), SearchSettings.class);
+
+    AssetTypeConfiguration tableConfig =
+        searchConfig.getAssetTypeConfigurations().stream()
+            .filter(conf -> "table".equalsIgnoreCase(conf.getAssetType()))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Table configuration not found"));
+
+    assertEquals(
+        AssetTypeConfiguration.BoostMode.MULTIPLY,
+        tableConfig.getBoostMode(),
+        "Table boost mode should be multiply for tiebreaker scoring");
+
+    assertNotNull(tableConfig.getFieldValueBoosts());
+    assertEquals(2, tableConfig.getFieldValueBoosts().size());
+
+    FieldValueBoost usageCountBoost =
+        tableConfig.getFieldValueBoosts().stream()
+            .filter(b -> "usageSummary.monthlyStats.count".equals(b.getField()))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Usage count field value boost not found"));
+    assertEquals(0.002, usageCountBoost.getFactor(), 1e-6);
+
+    FieldValueBoost percentileBoost =
+        tableConfig.getFieldValueBoosts().stream()
+            .filter(b -> "usageSummary.monthlyStats.percentileRank".equals(b.getField()))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Percentile rank field value boost not found"));
+    assertEquals(0.0005, percentileBoost.getFactor(), 1e-6);
+
+    List<TermBoost> globalTermBoosts = searchConfig.getGlobalSettings().getTermBoosts();
+    assertNotNull(globalTermBoosts);
+    assertEquals(3, globalTermBoosts.size());
+
+    TermBoost tier1Boost =
+        globalTermBoosts.stream()
+            .filter(t -> "Tier.Tier1".equals(t.getValue()))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Tier1 term boost not found"));
+    assertEquals("tier.tagFQN", tier1Boost.getField());
+    assertEquals(0.05, tier1Boost.getBoost(), 1e-6);
+
+    TermBoost tier2Boost =
+        globalTermBoosts.stream()
+            .filter(t -> "Tier.Tier2".equals(t.getValue()))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Tier2 term boost not found"));
+    assertEquals(0.03, tier2Boost.getBoost(), 1e-6);
+
+    TermBoost tier3Boost =
+        globalTermBoosts.stream()
+            .filter(t -> "Tier.Tier3".equals(t.getValue()))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Tier3 term boost not found"));
+    assertEquals(0.01, tier3Boost.getBoost(), 1e-6);
+  }
+
+  @Test
   void test_resetSearchSettingsToDefault() throws Exception {
     OpenMetadataClient client = SdkClients.adminClient();
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/searchSettingUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/searchSettingUtils.ts
@@ -67,19 +67,19 @@ export const mockEntitySearchConfig = {
   fieldValueBoosts: [
     {
       field: 'usageSummary.monthlyStats.count',
-      factor: 3,
+      factor: 0.002,
       modifier: 'log1p',
       missing: 0,
     },
     {
       field: 'usageSummary.monthlyStats.percentileRank',
-      factor: 1,
+      factor: 0.0005,
       modifier: 'none',
       missing: 0,
     },
   ],
   scoreMode: 'sum',
-  boostMode: 'sum',
+  boostMode: 'multiply',
 };
 
 export async function setSliderValue(


### PR DESCRIPTION
## Summary

- Changed search scoring from additive (`sum`) to multiplicative (`multiply`) boost mode so that usage and tier boosts act as **tiebreakers** rather than overriding text relevance
- Reduced boost factor magnitudes (e.g., tier boosts from 50/30/10 → 0.05/0.03/0.01, usage factors from 3.0/1.0 → 0.002/0.0005) so they gently nudge rankings without dominating text match scores
- Added a baseline `weight=1.0` function to both ElasticSearch and OpenSearch builders to prevent score collapse when documents have no tier/usage data in multiply mode
- Fixed Playwright `SearchSettings.spec.ts` test that was asserting stale default values (`boostMode: 'sum'`, old factor values)
- Added integration test (`test_defaultSearchRankingBoostConfiguration`) validating the new default boost configuration values

## Why

Previously, high usage counts or tier tags could push irrelevant results above highly relevant text matches. For example, a table with heavy usage but a vague name match would rank above an exact name match with no usage data. By switching to multiplicative scoring with small factors, the text relevance score remains the primary ranking signal, and usage/tier only differentiate between results with similar text scores.

## Key implementation details

| Change | Before | After |
|--------|--------|-------|
| `boostMode` (all asset types) | `sum` | `multiply` |
| Tier1/Tier2/Tier3 boosts | 50 / 30 / 10 | 0.05 / 0.03 / 0.01 |
| Usage count factor (global) | 4.0 (sqrt) | 0.002 (log1p) |
| Usage count factor (table) | 3.0 (log1p) | 0.002 (log1p) |
| Percentile rank factor | 1.0 | 0.0005 |
| Baseline weight function | none | `weight(match_all, 1.0)` |

The baseline weight ensures that when all boost functions evaluate to 0 (no tier, no usage), the multiplicative result is 1.0 instead of 0, preserving the original text relevance score.

## Files changed

- `searchSettings.json` — Updated default boost mode and factor values for all asset types
- `ElasticSearchSourceBuilderFactory.java` — Added baseline weight function, changed default composite boost mode to MULTIPLY
- `OpenSearchSourceBuilderFactory.java` — Same changes as ElasticSearch (parallel implementation)
- `SearchSourceBuilderFactoryTest.java` — Realigned unit test assertions to new factor values
- `searchSettingUtils.ts` — Fixed Playwright mock data to match new defaults
- `SystemResourceIT.java` — Added integration test for default boost configuration

## Test plan

- [x] Playwright test `SearchSettings.spec.ts > Restore default search settings` passes with updated mock values
- [x] Integration test `test_defaultSearchRankingBoostConfiguration` validates boostMode=MULTIPLY, tier boosts (0.05/0.03/0.01), and field value factors (0.002/0.0005)
- [x] Existing `SearchSourceBuilderFactoryTest` unit tests realigned and passing

Closes #26941

This PR was written using [Vibe Kanban](https://vibekanban.com)