### PR TITLE
Fixes #27091 : Fix resource leaks in SamlSettingsHolder, SamlValidator, and IndexResource

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/system/IndexResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/system/IndexResource.java
@@ -8,6 +8,7 @@ import jakarta.ws.rs.core.Response;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
@@ -18,11 +19,17 @@ public class IndexResource {
   private String indexHtml;
 
   public IndexResource() {
-    InputStream inputStream = getClass().getResourceAsStream("/assets/index.html");
-    indexHtml =
-        new BufferedReader(new InputStreamReader(inputStream))
-            .lines()
-            .collect(Collectors.joining("\n"));
+    try (InputStream inputStream = getClass().getResourceAsStream("/assets/index.html")) {
+      if (inputStream == null) {
+        throw new IllegalStateException("Resource /assets/index.html not found on classpath");
+      }
+      try (BufferedReader reader =
+          new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
+        indexHtml = reader.lines().collect(Collectors.joining("\n"));
+      }
+    } catch (java.io.IOException e) {
+      throw new IllegalStateException("Failed to read /assets/index.html", e);
+    }
   }
 
   public void initialize(OpenMetadataApplicationConfig config) {
@@ -32,11 +39,18 @@ public class IndexResource {
   public static String getIndexFile(String basePath) {
     LOG.info("IndexResource.getIndexFile called with basePath: [{}]", basePath);
 
-    InputStream inputStream = IndexResource.class.getResourceAsStream("/assets/index.html");
-    String indexHtml =
-        new BufferedReader(new InputStreamReader(inputStream))
-            .lines()
-            .collect(Collectors.joining("\n"));
+    String indexHtml;
+    try (InputStream inputStream = IndexResource.class.getResourceAsStream("/assets/index.html")) {
+      if (inputStream == null) {
+        throw new IllegalStateException("Resource /assets/index.html not found on classpath");
+      }
+      try (BufferedReader reader =
+          new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
+        indexHtml = reader.lines().collect(Collectors.joining("\n"));
+      }
+    } catch (java.io.IOException e) {
+      throw new IllegalStateException("Failed to read /assets/index.html", e);
+    }
 
     String result = indexHtml.replace("${basePath}", basePath);
     String basePathLine =

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/auth/validator/SamlValidator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/auth/validator/SamlValidator.java
@@ -294,46 +294,50 @@ public class SamlValidator {
 
       URL url = new URL(urlWithParams);
       HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-      conn.setRequestMethod("GET");
-      conn.setConnectTimeout(5000);
-      conn.setReadTimeout(5000);
-      conn.setInstanceFollowRedirects(false);
-      int responseCode = conn.getResponseCode();
-      LOG.debug("IdP response code to SAML request: {}", responseCode);
+      try {
+        conn.setRequestMethod("GET");
+        conn.setConnectTimeout(5000);
+        conn.setReadTimeout(5000);
+        conn.setInstanceFollowRedirects(false);
+        int responseCode = conn.getResponseCode();
+        LOG.debug("IdP response code to SAML request: {}", responseCode);
 
-      // Analyze response
-      if (responseCode == 404) {
-        return ValidationErrorBuilder.createFieldError(
-            ValidationErrorBuilder.FieldPaths.SAML_IDP_SSO_URL,
-            "SSO Login URL not found (HTTP 404). The URL '" + ssoUrl + "' does not exist.");
-      } else if (responseCode == 405) {
-        return ValidationErrorBuilder.createFieldError(
-            ValidationErrorBuilder.FieldPaths.SAML_IDP_SSO_URL,
-            "SSO URL doesn't accept GET requests (HTTP 405). Please check the SSO URL configuration.");
-      } else if (responseCode >= 200 && responseCode < 400) {
-        // 200 or 302 means the IdP accepted our SAML request
-        return null; // Success - SSO Login URL validated
-      } else if (responseCode >= 400 && responseCode < 500) {
-        // 400-499 could mean wrong URL or IdP rejecting the request
-        // Read a bit of the response to check for specific errors
-        String responseSnippet = readResponseSnippet(conn);
-        if (responseSnippet.toLowerCase().contains("saml")
-            || responseSnippet.toLowerCase().contains("invalid")) {
-          // Warning case - treat as success
-          LOG.warn(
-              "SSO URL responded with client error (HTTP {}). This might be due to the test SAML request format.",
-              responseCode);
-          return null;
+        // Analyze response
+        if (responseCode == 404) {
+          return ValidationErrorBuilder.createFieldError(
+              ValidationErrorBuilder.FieldPaths.SAML_IDP_SSO_URL,
+              "SSO Login URL not found (HTTP 404). The URL '" + ssoUrl + "' does not exist.");
+        } else if (responseCode == 405) {
+          return ValidationErrorBuilder.createFieldError(
+              ValidationErrorBuilder.FieldPaths.SAML_IDP_SSO_URL,
+              "SSO URL doesn't accept GET requests (HTTP 405). Please check the SSO URL configuration.");
+        } else if (responseCode >= 200 && responseCode < 400) {
+          // 200 or 302 means the IdP accepted our SAML request
+          return null; // Success - SSO Login URL validated
+        } else if (responseCode >= 400 && responseCode < 500) {
+          // 400-499 could mean wrong URL or IdP rejecting the request
+          // Read a bit of the response to check for specific errors
+          String responseSnippet = readResponseSnippet(conn);
+          if (responseSnippet.toLowerCase().contains("saml")
+              || responseSnippet.toLowerCase().contains("invalid")) {
+            // Warning case - treat as success
+            LOG.warn(
+                "SSO URL responded with client error (HTTP {}). This might be due to the test SAML request format.",
+                responseCode);
+            return null;
+          }
+          return ValidationErrorBuilder.createFieldError(
+              ValidationErrorBuilder.FieldPaths.SAML_IDP_SSO_URL,
+              "SSO URL returned error (HTTP "
+                  + responseCode
+                  + "). Please verify the URL is correct.");
+        } else {
+          return ValidationErrorBuilder.createFieldError(
+              ValidationErrorBuilder.FieldPaths.SAML_IDP_SSO_URL,
+              "SSO URL is not accessible (HTTP " + responseCode + ")");
         }
-        return ValidationErrorBuilder.createFieldError(
-            ValidationErrorBuilder.FieldPaths.SAML_IDP_SSO_URL,
-            "SSO URL returned error (HTTP "
-                + responseCode
-                + "). Please verify the URL is correct.");
-      } else {
-        return ValidationErrorBuilder.createFieldError(
-            ValidationErrorBuilder.FieldPaths.SAML_IDP_SSO_URL,
-            "SSO URL is not accessible (HTTP " + responseCode + ")");
+      } finally {
+        conn.disconnect();
       }
     } catch (Exception e) {
       LOG.warn("SSO URL validation failed", e);
@@ -376,10 +380,13 @@ public class SamlValidator {
       java.io.ByteArrayOutputStream bytesOut = new java.io.ByteArrayOutputStream();
       java.util.zip.Deflater deflater =
           new java.util.zip.Deflater(java.util.zip.Deflater.DEFLATED, true);
-      java.util.zip.DeflaterOutputStream deflaterStream =
-          new java.util.zip.DeflaterOutputStream(bytesOut, deflater);
-      deflaterStream.write(samlRequestXml.getBytes(StandardCharsets.UTF_8));
-      deflaterStream.finish();
+      try (java.util.zip.DeflaterOutputStream deflaterStream =
+          new java.util.zip.DeflaterOutputStream(bytesOut, deflater)) {
+        deflaterStream.write(samlRequestXml.getBytes(StandardCharsets.UTF_8));
+        deflaterStream.finish();
+      } finally {
+        deflater.end();
+      }
 
       // Base64 encode
       String base64Request = Base64.getEncoder().encodeToString(bytesOut.toByteArray());
@@ -395,15 +402,15 @@ public class SamlValidator {
 
   private String readResponseSnippet(HttpURLConnection conn) {
     try {
-      java.io.InputStream inputStream = conn.getErrorStream();
-      if (inputStream == null) {
-        inputStream = conn.getInputStream();
-      }
+      java.io.InputStream errorStream = conn.getErrorStream();
+      java.io.InputStream inputStream = (errorStream != null) ? errorStream : conn.getInputStream();
       if (inputStream != null) {
-        byte[] buffer = new byte[500];
-        int bytesRead = inputStream.read(buffer);
-        if (bytesRead > 0) {
-          return new String(buffer, 0, bytesRead, StandardCharsets.UTF_8);
+        try (inputStream) {
+          byte[] buffer = new byte[500];
+          int bytesRead = inputStream.read(buffer);
+          if (bytesRead > 0) {
+            return new String(buffer, 0, bytesRead, StandardCharsets.UTF_8);
+          }
         }
       }
     } catch (Exception e) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/saml/SamlSettingsHolder.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/saml/SamlSettingsHolder.java
@@ -118,9 +118,9 @@ public class SamlSettingsHolder {
           && !CommonUtil.nullOrEmpty(securityConfig.getKeyStorePassword())
           && !CommonUtil.nullOrEmpty(securityConfig.getKeyStoreAlias())) {
         KeyStore keyStore = KeyStore.getInstance("JKS");
-        keyStore.load(
-            new FileInputStream(securityConfig.getKeyStoreFilePath()),
-            securityConfig.getKeyStorePassword().toCharArray());
+        try (FileInputStream fis = new FileInputStream(securityConfig.getKeyStoreFilePath())) {
+          keyStore.load(fis, securityConfig.getKeyStorePassword().toCharArray());
+        }
         samlData.put(SettingsBuilder.KEYSTORE_KEY, keyStore);
         samlData.put(SettingsBuilder.KEYSTORE_ALIAS, securityConfig.getKeyStoreAlias());
         samlData.put(SettingsBuilder.KEYSTORE_KEY_PASSWORD, securityConfig.getKeyStorePassword());


### PR DESCRIPTION
## Fix resource leaks in SamlSettingsHolder, SamlValidator, and IndexResource

Fixes #27091

### Describe your changes

Close three resource leak bugs across `openmetadata-service` where streams and connections were opened but never closed, leaking file descriptors and TCP sockets.

**SamlSettingsHolder — FileInputStream never closed**
`SamlSettingsHolder.initDefaultSettings()` created a `FileInputStream` inline inside `keyStore.load(new FileInputStream(...))`. Since the stream reference was never assigned to a variable, it could never be closed — leaking a file descriptor on every SAML settings load.

**Fix:** Wrap in try-with-resources:
```java
try (FileInputStream fis = new FileInputStream(securityConfig.getKeyStoreFilePath())) {
    keyStore.load(fis, securityConfig.getKeyStorePassword().toCharArray());
}
```

**SamlValidator — HttpURLConnection never disconnected**
`SamlValidator.validateIdpConnectivity()` opened an `HttpURLConnection` to test the IdP SSO URL but never called `conn.disconnect()` in any code path, leaking a TCP socket per validation. Additionally:
- `readResponseSnippet()` read from the connection's error/input stream without closing it
- `createTestSamlRequest()` created a `DeflaterOutputStream` and `Deflater` without closing them

**Fix:** Wrapped the connection usage in try-finally with `conn.disconnect()`, wrapped `readResponseSnippet`'s stream in try-with-resources, and wrapped the deflater streams in try-with-resources with `deflater.end()` in finally.

**IndexResource — InputStream and BufferedReader never closed**
Both the constructor and `getIndexFile()` opened an `InputStream` via `getResourceAsStream()` and wrapped it in a `BufferedReader`, but neither was ever closed. Additionally, no null check existed — a missing resource would cause an unhelpful NPE.

**Fix:** Wrapped both methods in try-with-resources with null checks that throw `IllegalStateException` with clear context.

This continues the resource leak cleanup pattern from PR #27063, which fixed identical `InputStream` leaks in `SchemaFieldExtractor`.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document
- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project (`mvn spotless:check` passes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
