### PR TITLE
fix: expose full error chain in bulk index sink error messages

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchIndexSink.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchIndexSink.java
@@ -5,6 +5,7 @@ import static org.openmetadata.service.workflows.searchIndex.ReindexingUtil.getU
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import es.co.elastic.clients.elasticsearch._types.ElasticsearchException;
+import es.co.elastic.clients.elasticsearch._types.ErrorCause;
 import es.co.elastic.clients.elasticsearch.core.BulkResponse;
 import es.co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
 import es.co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
@@ -17,6 +18,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.glassfish.jersey.internal.util.ExceptionUtils;
 import org.openmetadata.schema.system.EntityError;
@@ -191,12 +193,26 @@ public class ElasticSearchIndexSink
         if (item.error() != null) {
           errors.add(
               new EntityError()
-                  .withMessage(item.error().reason())
+                  .withMessage(buildErrorMessage(item.error()))
                   .withEntity(taggedOps.get(i).entityRef()));
         }
       }
     }
     return errors;
+  }
+
+  private String buildErrorMessage(ErrorCause error) {
+    String message = String.format("%s: %s", error.type(), error.reason());
+    if (error.causedBy() != null) {
+      message = String.format("%s | Caused by: %s", message, buildErrorMessage(error.causedBy()));
+    } else if (error.rootCause() != null && !error.rootCause().isEmpty()) {
+      String rootCauses =
+          error.rootCause().stream()
+              .map(c -> String.format("%s: %s", c.type(), c.reason()))
+              .collect(Collectors.joining("; "));
+      message = String.format("%s | Root cause: [%s]", message, rootCauses);
+    }
+    return message;
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchIndexSink.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchIndexSink.java
@@ -12,6 +12,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.glassfish.jersey.internal.util.ExceptionUtils;
 import org.openmetadata.schema.system.EntityError;
@@ -23,6 +24,7 @@ import org.openmetadata.service.search.SearchRepository;
 import org.openmetadata.service.workflows.interfaces.Sink;
 import org.openmetadata.service.workflows.interfaces.TaggedOperation;
 import os.org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import os.org.opensearch.client.opensearch._types.ErrorCause;
 import os.org.opensearch.client.opensearch._types.OpenSearchException;
 import os.org.opensearch.client.opensearch.core.BulkResponse;
 import os.org.opensearch.client.opensearch.core.bulk.BulkOperation;
@@ -191,12 +193,26 @@ public class OpenSearchIndexSink
         if (item.error() != null) {
           errors.add(
               new EntityError()
-                  .withMessage(item.error().reason())
+                  .withMessage(buildErrorMessage(item.error()))
                   .withEntity(taggedOps.get(i).entityRef()));
         }
       }
     }
     return errors;
+  }
+
+  private String buildErrorMessage(ErrorCause error) {
+    String message = String.format("%s: %s", error.type(), error.reason());
+    if (error.causedBy() != null) {
+      message = String.format("%s | Caused by: %s", message, buildErrorMessage(error.causedBy()));
+    } else if (error.rootCause() != null && !error.rootCause().isEmpty()) {
+      String rootCauses =
+          error.rootCause().stream()
+              .map(c -> String.format("%s: %s", c.type(), c.reason()))
+              .collect(Collectors.joining("; "));
+      message = String.format("%s | Root cause: [%s]", message, rootCauses);
+    }
+    return message;
   }
 
   @Override


### PR DESCRIPTION
## Summary

- `OpenSearchIndexSink` and `ElasticSearchIndexSink` previously only read `item.error().reason()` — the top-level message — discarding the `caused_by` / `rootCause` chain
- Added a `buildErrorMessage(ErrorCause)` helper that walks `causedBy()` recursively and falls back to the `rootCause()` list, following the pattern already used in `OpenSearchSearchManager` / `ElasticSearchSearchManager`

Error messages now surface the full chain, e.g.:
```
mapper_parsing_exception: failed to parse | Root cause: [illegal_argument_exception: Limit of total fields [1000] has been exceeded]
```

## Test plan
- Trigger a DI run that produces indexing errors and verify the full error chain appears in the failure message