### PR TITLE
fix: cherry-pick 413 iterative bisection and TaggedOperation refactor into 1.12.5

### DIFF
--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -936,7 +936,6 @@
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-commons</artifactId>
-      <version>1.9.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/DataInsightsApp.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/DataInsightsApp.java
@@ -52,7 +52,6 @@ import org.quartz.JobExecutionContext;
 
 @Slf4j
 public class DataInsightsApp extends AbstractNativeApplication {
-  public static final String REPORT_DATA_TYPE_KEY = "ReportDataType";
   public static final String DATA_ASSET_INDEX_PREFIX = "di-data-assets";
   @Getter private Long timestamp;
   @Getter private int batchSize;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/processors/CreateReportDataProcessor.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/processors/CreateReportDataProcessor.java
@@ -20,10 +20,13 @@ import org.openmetadata.service.workflows.interfaces.Processor;
 public class CreateReportDataProcessor implements Processor<List<ReportData>, List<?>> {
   @Getter private final String name;
   private final StepStats stats = new StepStats();
+  private final ReportData.ReportDataType reportDataType;
 
-  public CreateReportDataProcessor(int total, String name) {
+  public CreateReportDataProcessor(
+      int total, String name, ReportData.ReportDataType reportDataType) {
     this.stats.withTotalRecords(total).withSuccessRecords(0).withFailedRecords(0);
     this.name = name;
+    this.reportDataType = reportDataType;
   }
 
   @Override
@@ -31,9 +34,6 @@ public class CreateReportDataProcessor implements Processor<List<ReportData>, Li
       throws SearchIndexException {
     List<ReportData> reportDataList = new ArrayList<>();
     try {
-      // TODO: Branch different ReportDataType process instead of having a generic Object.
-      ReportData.ReportDataType reportDataType =
-          (ReportData.ReportDataType) contextData.get("ReportDataType");
       Long timestamp = (Long) contextData.get(TIMESTAMP_KEY);
 
       for (Object eventData : input) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/sinks/ReportDataSink.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/sinks/ReportDataSink.java
@@ -1,11 +1,9 @@
 package org.openmetadata.service.apps.bundles.insights.sinks;
 
-import static org.openmetadata.service.apps.bundles.insights.DataInsightsApp.REPORT_DATA_TYPE_KEY;
 import static org.openmetadata.service.jdbi3.ReportDataRepository.REPORT_DATA_EXTENSION;
 import static org.openmetadata.service.workflows.searchIndex.ReindexingUtil.getUpdatedStats;
 
 import java.util.List;
-import java.util.Map;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.glassfish.jersey.internal.util.ExceptionUtils;
@@ -22,21 +20,19 @@ import org.openmetadata.service.workflows.interfaces.Sink;
 public class ReportDataSink implements Sink<List<ReportData>, Boolean> {
   @Getter private final String name;
   private final StepStats stats = new StepStats();
+  private final ReportData.ReportDataType reportDataType;
 
-  public ReportDataSink(int total, String name) {
+  public ReportDataSink(int total, String name, ReportData.ReportDataType reportDataType) {
     this.stats.withTotalRecords(total).withSuccessRecords(0).withFailedRecords(0);
     this.name = name;
+    this.reportDataType = reportDataType;
   }
 
   @Override
-  public Boolean write(List<ReportData> data, Map<String, Object> contextData)
-      throws SearchIndexException {
-    // TODO: Understand better how the deleteReportDataRecords and createReportDataRecords might
-    // fail.
+  // TODO: Understand better how the deleteReportDataRecords and createReportDataRecords might
+  // fail.
+  public Boolean write(List<ReportData> data) throws SearchIndexException {
     try {
-      ReportData.ReportDataType reportDataType =
-          (ReportData.ReportDataType) contextData.get(REPORT_DATA_TYPE_KEY);
-
       createReportDataRecords(data, reportDataType);
       updateStats(data.size(), 0);
     } catch (Exception e) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/costAnalysis/CostAnalysisWorkflow.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/costAnalysis/CostAnalysisWorkflow.java
@@ -1,6 +1,5 @@
 package org.openmetadata.service.apps.bundles.insights.workflows.costAnalysis;
 
-import static org.openmetadata.service.apps.bundles.insights.DataInsightsApp.REPORT_DATA_TYPE_KEY;
 import static org.openmetadata.service.apps.bundles.insights.utils.TimestampUtils.TIMESTAMP_KEY;
 
 import java.util.ArrayList;
@@ -221,11 +220,11 @@ public class CostAnalysisWorkflow {
       Map<String, Object> contextData) {
     Optional<String> error = Optional.empty();
 
-    contextData.put(REPORT_DATA_TYPE_KEY, ReportData.ReportDataType.RAW_COST_ANALYSIS_REPORT_DATA);
     CreateReportDataProcessor createReportdataProcessor =
         new CreateReportDataProcessor(
             rawCostAnalysisReportDataList.size(),
-            "[CostAnalysisWorkflow] Raw Cost Analysis Report Data Processor");
+            "[CostAnalysisWorkflow] Raw Cost Analysis Report Data Processor",
+            ReportData.ReportDataType.RAW_COST_ANALYSIS_REPORT_DATA);
 
     Optional<List<ReportData>> rawCostAnalysisReportData = Optional.empty();
 
@@ -248,9 +247,10 @@ public class CostAnalysisWorkflow {
       ReportDataSink reportDataSink =
           new ReportDataSink(
               rawCostAnalysisReportData.get().size(),
-              "[CostAnalysisWorkflow] Raw Cost Analysis Report Data " + "Sink");
+              "[CostAnalysisWorkflow] Raw Cost Analysis Report Data Sink",
+              ReportData.ReportDataType.RAW_COST_ANALYSIS_REPORT_DATA);
       try {
-        reportDataSink.write(rawCostAnalysisReportData.get(), contextData);
+        reportDataSink.write(rawCostAnalysisReportData.get());
       } catch (SearchIndexException ex) {
         error =
             Optional.of(
@@ -270,8 +270,6 @@ public class CostAnalysisWorkflow {
       Map<String, Object> contextData) {
     Optional<String> error = Optional.empty();
 
-    contextData.put(
-        REPORT_DATA_TYPE_KEY, ReportData.ReportDataType.AGGREGATED_COST_ANALYSIS_REPORT_DATA);
     AggregatedCostAnalysisReportDataAggregator aggregatedCostAnalysisReportDataAggregator =
         new AggregatedCostAnalysisReportDataAggregator(aggregatedCostAnalysisDataMap.size());
 
@@ -298,7 +296,8 @@ public class CostAnalysisWorkflow {
       CreateReportDataProcessor createReportdataProcessor =
           new CreateReportDataProcessor(
               aggregatedCostAnalysisReportDataList.get().size(),
-              "[CostAnalysisWorkflow] Aggregated Cost Analysis Report Data Processor");
+              "[CostAnalysisWorkflow] Aggregated Cost Analysis Report Data Processor",
+              ReportData.ReportDataType.AGGREGATED_COST_ANALYSIS_REPORT_DATA);
       Optional<List<ReportData>> aggregatedCostAnalysisReportData = Optional.empty();
 
       try {
@@ -321,9 +320,10 @@ public class CostAnalysisWorkflow {
         ReportDataSink reportDataSink =
             new ReportDataSink(
                 aggregatedCostAnalysisReportData.get().size(),
-                "[CostAnalysisWorkflow] Aggregated Cost Analysis Report Data Sink");
+                "[CostAnalysisWorkflow] Aggregated Cost Analysis Report Data Sink",
+                ReportData.ReportDataType.AGGREGATED_COST_ANALYSIS_REPORT_DATA);
         try {
-          reportDataSink.write(aggregatedCostAnalysisReportData.get(), contextData);
+          reportDataSink.write(aggregatedCostAnalysisReportData.get());
         } catch (SearchIndexException ex) {
           error =
               Optional.of(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/dataAssets/DataAssetsWorkflow.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/dataAssets/DataAssetsWorkflow.java
@@ -27,6 +27,7 @@ import org.openmetadata.schema.service.configuration.elasticsearch.ElasticSearch
 import org.openmetadata.schema.system.IndexingError;
 import org.openmetadata.schema.system.Stats;
 import org.openmetadata.schema.system.StepStats;
+import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.service.Entity;
@@ -47,6 +48,7 @@ import org.openmetadata.service.search.elasticsearch.ElasticSearchIndexSink;
 import org.openmetadata.service.search.opensearch.OpenSearchIndexSink;
 import org.openmetadata.service.workflows.interfaces.Processor;
 import org.openmetadata.service.workflows.interfaces.Sink;
+import org.openmetadata.service.workflows.interfaces.TaggedOperation;
 import org.openmetadata.service.workflows.searchIndex.PaginatedEntitiesSource;
 
 @Slf4j
@@ -54,6 +56,7 @@ public class DataAssetsWorkflow {
   public static final String DATA_STREAM_KEY = "DataStreamKey";
   public static final String ENTITY_TYPE_FIELDS_KEY = "EnityTypeFields";
   private static final String ALL_ENTITIES = "all";
+
   private final DataAssetsConfig dataAssetsConfig;
   private final int retentionDays = 30;
   private final Long startTimestamp;
@@ -250,7 +253,7 @@ public class DataAssetsWorkflow {
       PaginatedEntitiesSource source, Map<String, Object> contextData, int budget)
       throws SearchIndexException {
     Semaphore concurrencyLimit = new Semaphore(budget);
-    ConcurrentLinkedQueue<Object> operationsQueue = new ConcurrentLinkedQueue<>();
+    ConcurrentLinkedQueue<TaggedOperation<?>> opsQueue = new ConcurrentLinkedQueue<>();
 
     try (ExecutorService sourceExecutor = Executors.newVirtualThreadPerTaskExecutor()) {
       this.executor = sourceExecutor;
@@ -285,7 +288,8 @@ public class DataAssetsWorkflow {
                                 entityEnricher.enrichSingle(entity, contextData);
                             List<?> bulkOps =
                                 (List<?>) entityProcessor.process(enriched, contextData);
-                            operationsQueue.addAll(bulkOps);
+                            EntityReference ref = entity.getEntityReference();
+                            bulkOps.forEach(op -> opsQueue.add(new TaggedOperation<>(op, ref)));
                           } finally {
                             concurrencyLimit.release();
                           }
@@ -309,7 +313,7 @@ public class DataAssetsWorkflow {
             }
           }
 
-          drainAndFlush(operationsQueue, contextData);
+          drainAndFlush(opsQueue);
 
           batchFailed += batch.getErrors().size();
           source.updateStats(batchSuccess, batchFailed);
@@ -334,22 +338,22 @@ public class DataAssetsWorkflow {
     }
 
     try {
-      drainAndFlush(operationsQueue, contextData);
+      drainAndFlush(opsQueue);
     } finally {
       updateWorkflowStats(source.getName(), source.getStats());
     }
   }
 
   @SuppressWarnings("unchecked")
-  private void drainAndFlush(ConcurrentLinkedQueue<Object> queue, Map<String, Object> contextData)
+  private void drainAndFlush(ConcurrentLinkedQueue<TaggedOperation<?>> queue)
       throws SearchIndexException {
-    List<Object> batch = new ArrayList<>();
-    Object op;
-    while ((op = queue.poll()) != null) {
-      batch.add(op);
+    List<TaggedOperation<?>> batch = new ArrayList<>();
+    TaggedOperation<?> tagged;
+    while ((tagged = queue.poll()) != null) {
+      batch.add(tagged);
     }
     if (!batch.isEmpty()) {
-      searchIndexSink.write((List) batch, contextData);
+      searchIndexSink.write(batch);
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/dataQuality/DataQualityWorkflow.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/dataQuality/DataQualityWorkflow.java
@@ -34,6 +34,7 @@ import org.openmetadata.service.search.opensearch.OpenSearchIndexSink;
 import org.openmetadata.service.workflows.interfaces.Processor;
 import org.openmetadata.service.workflows.interfaces.Sink;
 import org.openmetadata.service.workflows.interfaces.Source;
+import org.openmetadata.service.workflows.interfaces.TaggedOperation;
 import org.openmetadata.service.workflows.searchIndex.PaginatedEntityTimeSeriesSource;
 
 @Slf4j
@@ -181,13 +182,23 @@ public class DataQualityWorkflow {
     }
   }
 
+  @SuppressWarnings("unchecked")
   private void processEntity(
       ResultList<? extends EntityTimeSeriesInterface> resultList,
       Map<String, Object> contextData,
       Source<?> paginatedSource)
       throws SearchIndexException {
     if (!resultList.getData().isEmpty()) {
-      searchIndexSink.write(entityProcessor.process(resultList, contextData), contextData);
+      LOG.debug(
+          "[DataQualityWorkflow] Processing a Batch of Size: {}, EntityType: {}",
+          resultList.getData().size(),
+          contextData.get(ENTITY_TYPE_KEY));
+      List<TaggedOperation<?>> taggedOps = new ArrayList<>();
+      for (EntityTimeSeriesInterface entity : resultList.getData()) {
+        Object op = entityProcessor.process(entity, contextData);
+        taggedOps.add(new TaggedOperation<>(op, entity.getEntityReference()));
+      }
+      searchIndexSink.write(taggedOps);
       paginatedSource.updateStats(resultList.getData().size(), 0);
     }
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/webAnalytics/WebAnalyticsWorkflow.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/insights/workflows/webAnalytics/WebAnalyticsWorkflow.java
@@ -1,6 +1,5 @@
 package org.openmetadata.service.apps.bundles.insights.workflows.webAnalytics;
 
-import static org.openmetadata.service.apps.bundles.insights.DataInsightsApp.REPORT_DATA_TYPE_KEY;
 import static org.openmetadata.service.apps.bundles.insights.utils.TimestampUtils.TIMESTAMP_KEY;
 
 import java.util.ArrayList;
@@ -209,12 +208,11 @@ public class WebAnalyticsWorkflow {
       Map<String, Object> contextData) {
     Optional<String> error = Optional.empty();
 
-    contextData.put(
-        REPORT_DATA_TYPE_KEY, ReportData.ReportDataType.WEB_ANALYTIC_ENTITY_VIEW_REPORT_DATA);
     CreateReportDataProcessor createReportDataProcessor =
         new CreateReportDataProcessor(
             entityViewReportData.values().size(),
-            "[WebAnalyticsWorkflow] Entity View Report Data Processor");
+            "[WebAnalyticsWorkflow] Entity View Report Data Processor",
+            ReportData.ReportDataType.WEB_ANALYTIC_ENTITY_VIEW_REPORT_DATA);
 
     Optional<List<ReportData>> entityViewReportDataList = Optional.empty();
 
@@ -237,10 +235,11 @@ public class WebAnalyticsWorkflow {
       ReportDataSink reportDataSink =
           new ReportDataSink(
               entityViewReportDataList.get().size(),
-              "[WebAnalyticsWorkflow] Entity View Report Data Sink");
+              "[WebAnalyticsWorkflow] Entity View Report Data Sink",
+              ReportData.ReportDataType.WEB_ANALYTIC_ENTITY_VIEW_REPORT_DATA);
 
       try {
-        reportDataSink.write(entityViewReportDataList.get(), contextData);
+        reportDataSink.write(entityViewReportDataList.get());
       } catch (SearchIndexException ex) {
         error = Optional.of(String.format("Failed Sinking Entity View Data: %s", ex.getMessage()));
         workflowStats.addFailure(error.get());
@@ -258,8 +257,6 @@ public class WebAnalyticsWorkflow {
       Map<String, Object> contextData) {
     Optional<String> error = Optional.empty();
 
-    contextData.put(
-        REPORT_DATA_TYPE_KEY, ReportData.ReportDataType.WEB_ANALYTIC_USER_ACTIVITY_REPORT_DATA);
     WebAnalyticsUserActivityAggregator webAnalyticsUserActivityAggregator =
         new WebAnalyticsUserActivityAggregator(userActivityData.size());
 
@@ -279,7 +276,8 @@ public class WebAnalyticsWorkflow {
     CreateReportDataProcessor createReportdataProcessor =
         new CreateReportDataProcessor(
             userActivityReportData.values().size(),
-            "[WebAnalyticsWorkflow] User Activity Report Data Processor");
+            "[WebAnalyticsWorkflow] User Activity Report Data Processor",
+            ReportData.ReportDataType.WEB_ANALYTIC_USER_ACTIVITY_REPORT_DATA);
     Optional<List<ReportData>> userActivityReportDataList = Optional.empty();
 
     // Process UserActivity ReportData
@@ -303,9 +301,10 @@ public class WebAnalyticsWorkflow {
       ReportDataSink reportDataSink =
           new ReportDataSink(
               userActivityReportDataList.get().size(),
-              "[WebAnalyticsWorkflow] User Activity Report Data Sink");
+              "[WebAnalyticsWorkflow] User Activity Report Data Sink",
+              ReportData.ReportDataType.WEB_ANALYTIC_USER_ACTIVITY_REPORT_DATA);
       try {
-        reportDataSink.write(userActivityReportDataList.get(), contextData);
+        reportDataSink.write(userActivityReportDataList.get());
       } catch (SearchIndexException ex) {
         error =
             Optional.of(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchEntityTimeSeriesProcessor.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchEntityTimeSeriesProcessor.java
@@ -4,18 +4,14 @@ import static org.openmetadata.service.workflows.searchIndex.ReindexingUtil.ENTI
 import static org.openmetadata.service.workflows.searchIndex.ReindexingUtil.getUpdatedStats;
 
 import es.co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
-import org.glassfish.jersey.internal.util.ExceptionUtils;
 import org.openmetadata.common.utils.CommonUtil;
 import org.openmetadata.schema.EntityTimeSeriesInterface;
 import org.openmetadata.schema.system.IndexingError;
 import org.openmetadata.schema.system.StepStats;
 import org.openmetadata.schema.utils.JsonUtils;
-import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.search.IndexMapping;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.SearchIndexException;
@@ -23,7 +19,7 @@ import org.openmetadata.service.workflows.interfaces.Processor;
 
 @Slf4j
 public class ElasticSearchEntityTimeSeriesProcessor
-    implements Processor<List<BulkOperation>, ResultList<? extends EntityTimeSeriesInterface>> {
+    implements Processor<BulkOperation, EntityTimeSeriesInterface> {
   private final StepStats stats = new StepStats();
 
   public ElasticSearchEntityTimeSeriesProcessor(int total) {
@@ -31,8 +27,7 @@ public class ElasticSearchEntityTimeSeriesProcessor
   }
 
   @Override
-  public List<BulkOperation> process(
-      ResultList<? extends EntityTimeSeriesInterface> input, Map<String, Object> contextData)
+  public BulkOperation process(EntityTimeSeriesInterface entity, Map<String, Object> contextData)
       throws SearchIndexException {
     String entityType = (String) contextData.get(ENTITY_TYPE_KEY);
     if (CommonUtil.nullOrEmpty(entityType)) {
@@ -40,44 +35,25 @@ public class ElasticSearchEntityTimeSeriesProcessor
           "[EsDataInsightProcessor] entityType cannot be null or empty.");
     }
 
-    LOG.debug(
-        "[EsDataInsightProcessor] Processing a Batch of Size: {}, EntityType: {} ",
-        input.getData().size(),
-        entityType);
-    List<BulkOperation> operations;
     try {
-      operations = buildBulkOperations(entityType, input.getData());
-      LOG.debug(
-          "[EsDataInsightProcessor] Batch Stats :- Submitted : {} Success: {} Failed: {}",
-          input.getData().size(),
-          input.getData().size(),
-          0);
-      updateStats(input.getData().size(), 0);
+      BulkOperation operation = getUpdateOperation(entityType, entity);
+      updateStats(1, 0);
+      return operation;
     } catch (Exception e) {
       IndexingError error =
           new IndexingError()
               .withErrorSource(IndexingError.ErrorSource.PROCESSOR)
-              .withSubmittedCount(input.getData().size())
-              .withFailedCount(input.getData().size())
+              .withSubmittedCount(1)
+              .withFailedCount(1)
               .withSuccessCount(0)
               .withMessage(
-                  "Data Insights Processor Encountered Failure. Converting requests to BulkOperation.")
-              .withStackTrace(ExceptionUtils.exceptionStackTraceAsString(e));
+                  "Data Insights Processor Encountered Failure. Converting request to BulkOperation.")
+              .withStackTrace(
+                  org.glassfish.jersey.internal.util.ExceptionUtils.exceptionStackTraceAsString(e));
       LOG.debug("[EsDataInsightsProcessor] Failed. Details: {}", JsonUtils.pojoToJson(error));
-      updateStats(0, input.getData().size());
+      updateStats(0, 1);
       throw new SearchIndexException(error);
     }
-    return operations;
-  }
-
-  private List<BulkOperation> buildBulkOperations(
-      String entityType, List<? extends EntityTimeSeriesInterface> entities) {
-    List<BulkOperation> operations = new ArrayList<>();
-    for (EntityTimeSeriesInterface entity : entities) {
-      BulkOperation operation = getUpdateOperation(entityType, entity);
-      operations.add(operation);
-    }
-    return operations;
   }
 
   private BulkOperation getUpdateOperation(String entityType, EntityTimeSeriesInterface entity) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchIndexSink.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchIndexSink.java
@@ -1,20 +1,22 @@
 package org.openmetadata.service.search.elasticsearch;
 
 import static org.openmetadata.schema.system.IndexingError.ErrorSource.SINK;
-import static org.openmetadata.service.workflows.searchIndex.ReindexingUtil.ENTITY_NAME_LIST_KEY;
 import static org.openmetadata.service.workflows.searchIndex.ReindexingUtil.getUpdatedStats;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import es.co.elastic.clients.elasticsearch._types.ElasticsearchException;
+import es.co.elastic.clients.elasticsearch.core.BulkResponse;
 import es.co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+import es.co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
 import es.co.elastic.clients.json.jackson.JacksonJsonpMapper;
 import jakarta.json.stream.JsonGenerator;
+import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Deque;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.glassfish.jersey.internal.util.ExceptionUtils;
 import org.openmetadata.schema.system.EntityError;
@@ -24,10 +26,11 @@ import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.exception.SearchIndexException;
 import org.openmetadata.service.search.SearchRepository;
 import org.openmetadata.service.workflows.interfaces.Sink;
+import org.openmetadata.service.workflows.interfaces.TaggedOperation;
 
 @Slf4j
 public class ElasticSearchIndexSink
-    implements Sink<List<BulkOperation>, es.co.elastic.clients.elasticsearch.core.BulkResponse> {
+    implements Sink<List<TaggedOperation<BulkOperation>>, BulkResponse> {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final JacksonJsonpMapper JACKSON_JSONP_MAPPER =
       new JacksonJsonpMapper(OBJECT_MAPPER);
@@ -44,53 +47,42 @@ public class ElasticSearchIndexSink
   }
 
   @Override
-  public es.co.elastic.clients.elasticsearch.core.BulkResponse write(
-      List<BulkOperation> data, Map<String, Object> contextData) throws SearchIndexException {
+  public BulkResponse write(List<TaggedOperation<BulkOperation>> data) throws SearchIndexException {
     LOG.debug("[EsSearchIndexSink] Processing a Batch of Size: {}", data.size());
     try {
-      List<?> entityNames =
-          (List<?>)
-              Optional.ofNullable(contextData.get(ENTITY_NAME_LIST_KEY))
-                  .orElse(Collections.emptyList());
       List<EntityError> entityErrorList = new ArrayList<>();
-      es.co.elastic.clients.elasticsearch.core.BulkResponse response = null;
+      BulkResponse response = null;
 
-      List<BulkOperation> bufferData = new ArrayList<>();
+      List<TaggedOperation<BulkOperation>> buffer = new ArrayList<>();
       long bufferSize = 0;
-      int requestIndex = 0;
 
-      for (BulkOperation operation : data) {
-        long operationSize = estimateBulkOperationSize(operation);
+      for (TaggedOperation<BulkOperation> tagged : data) {
+        long operationSize = estimateBulkOperationSize(tagged.operation());
 
         if (operationSize > maxPayLoadSizeInBytes) {
+          LOG.error(
+              "[EsSearchIndexSink] Entity size exceeds payload limit, skipping entity: {} (type={})",
+              tagged.entityRef().getId(),
+              tagged.entityRef().getType());
           entityErrorList.add(
               new EntityError()
                   .withMessage("Entity size exceeds elastic search maximum payload size")
-                  .withEntity(
-                      requestIndex < entityNames.size()
-                          ? entityNames.get(requestIndex)
-                          : String.format("Unknown entity at index %d", requestIndex)));
-          requestIndex++;
+                  .withEntity(tagged.entityRef()));
           continue;
         }
 
-        if (bufferSize + operationSize > maxPayLoadSizeInBytes && !bufferData.isEmpty()) {
-          response = searchRepository.getSearchClient().bulkElasticSearch(bufferData);
-          entityErrorList.addAll(
-              extractErrorsFromResponse(response, entityNames, requestIndex - bufferData.size()));
-          bufferData = new ArrayList<>();
+        if (bufferSize + operationSize > maxPayLoadSizeInBytes && !buffer.isEmpty()) {
+          response = sendWithBisection(buffer, entityErrorList);
+          buffer = new ArrayList<>();
           bufferSize = 0;
         }
 
-        bufferData.add(operation);
+        buffer.add(tagged);
         bufferSize += operationSize;
-        requestIndex++;
       }
 
-      if (!bufferData.isEmpty()) {
-        response = searchRepository.getSearchClient().bulkElasticSearch(bufferData);
-        entityErrorList.addAll(
-            extractErrorsFromResponse(response, entityNames, requestIndex - bufferData.size()));
+      if (!buffer.isEmpty()) {
+        response = sendWithBisection(buffer, entityErrorList);
       }
 
       LOG.debug(
@@ -130,6 +122,53 @@ public class ElasticSearchIndexSink
     }
   }
 
+  /**
+   * Sends bulk operations to Elasticsearch, iteratively bisecting the batch on 413 (Request Entity
+   * Too Large) responses. If a single operation exceeds the server limit, it is recorded as a
+   * failed entity and skipped so the rest of the batch can proceed.
+   */
+  private BulkResponse sendWithBisection(
+      List<TaggedOperation<BulkOperation>> taggedOps, List<EntityError> errorList)
+      throws IOException {
+    Deque<List<TaggedOperation<BulkOperation>>> pending = new ArrayDeque<>();
+    pending.push(taggedOps);
+    BulkResponse lastResponse = null;
+
+    while (!pending.isEmpty()) {
+      List<TaggedOperation<BulkOperation>> chunk = pending.pop();
+      List<BulkOperation> operations = chunk.stream().map(TaggedOperation::operation).toList();
+      try {
+        BulkResponse response = searchRepository.getSearchClient().bulkElasticSearch(operations);
+        errorList.addAll(extractErrorsFromResponse(response, chunk));
+        lastResponse = response;
+      } catch (ElasticsearchException e) {
+        if (e.status() != 413) {
+          throw e;
+        }
+        if (chunk.size() == 1) {
+          LOG.error(
+              "[EsSearchIndexSink] Single document exceeds Elasticsearch payload limit, skipping entity: {} (type={})",
+              chunk.getFirst().entityRef().getId(),
+              chunk.getFirst().entityRef().getType());
+          errorList.add(
+              new EntityError()
+                  .withMessage("Document exceeds Elasticsearch maximum payload size (413)")
+                  .withEntity(chunk.getFirst().entityRef()));
+          continue;
+        }
+        int mid = chunk.size() / 2;
+        LOG.warn(
+            "[EsSearchIndexSink] Bulk request rejected with 413, bisecting batch of {} into [{}, {}]",
+            chunk.size(),
+            mid,
+            chunk.size() - mid);
+        pending.push(chunk.subList(mid, chunk.size()));
+        pending.push(chunk.subList(0, mid));
+      }
+    }
+    return lastResponse;
+  }
+
   private long estimateBulkOperationSize(BulkOperation operation) {
     try {
       StringWriter writer = new StringWriter();
@@ -144,23 +183,16 @@ public class ElasticSearchIndexSink
   }
 
   private List<EntityError> extractErrorsFromResponse(
-      es.co.elastic.clients.elasticsearch.core.BulkResponse response,
-      List<?> entityNames,
-      int startIndex) {
+      BulkResponse response, List<TaggedOperation<BulkOperation>> taggedOps) {
     List<EntityError> errors = new ArrayList<>();
     if (response != null && response.errors()) {
       for (int i = 0; i < response.items().size(); i++) {
-        es.co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem item =
-            response.items().get(i);
+        BulkResponseItem item = response.items().get(i);
         if (item.error() != null) {
-          int entityIndex = startIndex + i;
           errors.add(
               new EntityError()
                   .withMessage(item.error().reason())
-                  .withEntity(
-                      entityIndex < entityNames.size()
-                          ? entityNames.get(entityIndex)
-                          : String.format("Unknown entity at index %d", entityIndex)));
+                  .withEntity(taggedOps.get(i).entityRef()));
         }
       }
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchEntityTimeSeriesProcessor.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchEntityTimeSeriesProcessor.java
@@ -3,18 +3,14 @@ package org.openmetadata.service.search.opensearch;
 import static org.openmetadata.service.workflows.searchIndex.ReindexingUtil.ENTITY_TYPE_KEY;
 import static org.openmetadata.service.workflows.searchIndex.ReindexingUtil.getUpdatedStats;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
-import org.glassfish.jersey.internal.util.ExceptionUtils;
 import org.openmetadata.common.utils.CommonUtil;
 import org.openmetadata.schema.EntityTimeSeriesInterface;
 import org.openmetadata.schema.system.IndexingError;
 import org.openmetadata.schema.system.StepStats;
 import org.openmetadata.schema.utils.JsonUtils;
-import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.search.IndexMapping;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.SearchIndexException;
@@ -23,7 +19,7 @@ import os.org.opensearch.client.opensearch.core.bulk.BulkOperation;
 
 @Slf4j
 public class OpenSearchEntityTimeSeriesProcessor
-    implements Processor<List<BulkOperation>, ResultList<? extends EntityTimeSeriesInterface>> {
+    implements Processor<BulkOperation, EntityTimeSeriesInterface> {
   private final StepStats stats = new StepStats();
 
   public OpenSearchEntityTimeSeriesProcessor(int total) {
@@ -31,8 +27,7 @@ public class OpenSearchEntityTimeSeriesProcessor
   }
 
   @Override
-  public List<BulkOperation> process(
-      ResultList<? extends EntityTimeSeriesInterface> input, Map<String, Object> contextData)
+  public BulkOperation process(EntityTimeSeriesInterface entity, Map<String, Object> contextData)
       throws SearchIndexException {
     String entityType = (String) contextData.get(ENTITY_TYPE_KEY);
     if (CommonUtil.nullOrEmpty(entityType)) {
@@ -40,45 +35,26 @@ public class OpenSearchEntityTimeSeriesProcessor
           "[OpenSearchDataInsightProcessor] entityType cannot be null or empty.");
     }
 
-    LOG.debug(
-        "[OpenSearchDataInsightProcessor] Processing a Batch of Size: {}, EntityType: {} ",
-        input.getData().size(),
-        entityType);
-    List<BulkOperation> operations;
     try {
-      operations = buildBulkOperations(entityType, input.getData());
-      LOG.debug(
-          "[OpenSearchDataInsightProcessor] Batch Stats :- Submitted : {} Success: {} Failed: {}",
-          input.getData().size(),
-          input.getData().size(),
-          0);
-      updateStats(input.getData().size(), 0);
+      BulkOperation operation = getUpdateOperation(entityType, entity);
+      updateStats(1, 0);
+      return operation;
     } catch (Exception e) {
       IndexingError error =
           new IndexingError()
               .withErrorSource(IndexingError.ErrorSource.PROCESSOR)
-              .withSubmittedCount(input.getData().size())
-              .withFailedCount(input.getData().size())
+              .withSubmittedCount(1)
+              .withFailedCount(1)
               .withSuccessCount(0)
               .withMessage(
-                  "Data Insights Processor Encountered Failure. Converting requests to BulkOperation.")
-              .withStackTrace(ExceptionUtils.exceptionStackTraceAsString(e));
+                  "Data Insights Processor Encountered Failure. Converting request to BulkOperation.")
+              .withStackTrace(
+                  org.glassfish.jersey.internal.util.ExceptionUtils.exceptionStackTraceAsString(e));
       LOG.debug(
           "[OpenSearchDataInsightsProcessor] Failed. Details: {}", JsonUtils.pojoToJson(error));
-      updateStats(0, input.getData().size());
+      updateStats(0, 1);
       throw new SearchIndexException(error);
     }
-    return operations;
-  }
-
-  private List<BulkOperation> buildBulkOperations(
-      String entityType, List<? extends EntityTimeSeriesInterface> entities) {
-    List<BulkOperation> operations = new ArrayList<>();
-    for (EntityTimeSeriesInterface entity : entities) {
-      BulkOperation operation = getUpdateOperation(entityType, entity);
-      operations.add(operation);
-    }
-    return operations;
   }
 
   private BulkOperation getUpdateOperation(String entityType, EntityTimeSeriesInterface entity) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchIndexSink.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchIndexSink.java
@@ -1,18 +1,17 @@
 package org.openmetadata.service.search.opensearch;
 
 import static org.openmetadata.schema.system.IndexingError.ErrorSource.SINK;
-import static org.openmetadata.service.workflows.searchIndex.ReindexingUtil.ENTITY_NAME_LIST_KEY;
 import static org.openmetadata.service.workflows.searchIndex.ReindexingUtil.getUpdatedStats;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.json.stream.JsonGenerator;
+import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Deque;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.glassfish.jersey.internal.util.ExceptionUtils;
 import org.openmetadata.schema.system.EntityError;
@@ -22,12 +21,15 @@ import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.exception.SearchIndexException;
 import org.openmetadata.service.search.SearchRepository;
 import org.openmetadata.service.workflows.interfaces.Sink;
+import org.openmetadata.service.workflows.interfaces.TaggedOperation;
 import os.org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import os.org.opensearch.client.opensearch._types.OpenSearchException;
+import os.org.opensearch.client.opensearch.core.BulkResponse;
 import os.org.opensearch.client.opensearch.core.bulk.BulkOperation;
 
 @Slf4j
 public class OpenSearchIndexSink
-    implements Sink<List<BulkOperation>, os.org.opensearch.client.opensearch.core.BulkResponse> {
+    implements Sink<List<TaggedOperation<BulkOperation>>, BulkResponse> {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final JacksonJsonpMapper JACKSON_JSONP_MAPPER =
       new JacksonJsonpMapper(OBJECT_MAPPER);
@@ -44,53 +46,42 @@ public class OpenSearchIndexSink
   }
 
   @Override
-  public os.org.opensearch.client.opensearch.core.BulkResponse write(
-      List<BulkOperation> data, Map<String, Object> contextData) throws SearchIndexException {
+  public BulkResponse write(List<TaggedOperation<BulkOperation>> data) throws SearchIndexException {
     LOG.debug("[OsSearchIndexSink] Processing a Batch of Size: {}", data.size());
     try {
-      List<?> entityNames =
-          (List<?>)
-              Optional.ofNullable(contextData.get(ENTITY_NAME_LIST_KEY))
-                  .orElse(Collections.emptyList());
       List<EntityError> entityErrorList = new ArrayList<>();
-      os.org.opensearch.client.opensearch.core.BulkResponse response = null;
+      BulkResponse response = null;
 
-      List<BulkOperation> bufferData = new ArrayList<>();
+      List<TaggedOperation<BulkOperation>> buffer = new ArrayList<>();
       long bufferSize = 0;
-      int requestIndex = 0;
 
-      for (BulkOperation operation : data) {
-        long operationSize = estimateBulkOperationSize(operation);
+      for (TaggedOperation<BulkOperation> tagged : data) {
+        long operationSize = estimateBulkOperationSize(tagged.operation());
 
         if (operationSize > maxPayLoadSizeInBytes) {
+          LOG.error(
+              "[OsSearchIndexSink] Entity size exceeds payload limit, skipping entity: {} (type={})",
+              tagged.entityRef().getId(),
+              tagged.entityRef().getType());
           entityErrorList.add(
               new EntityError()
                   .withMessage("Entity size exceeds opensearch maximum payload size")
-                  .withEntity(
-                      requestIndex < entityNames.size()
-                          ? entityNames.get(requestIndex)
-                          : String.format("Unknown entity at index %d", requestIndex)));
-          requestIndex++;
+                  .withEntity(tagged.entityRef()));
           continue;
         }
 
-        if (bufferSize + operationSize > maxPayLoadSizeInBytes && !bufferData.isEmpty()) {
-          response = searchRepository.getSearchClient().bulkOpenSearch(bufferData);
-          entityErrorList.addAll(
-              extractErrorsFromResponse(response, entityNames, requestIndex - bufferData.size()));
-          bufferData = new ArrayList<>();
+        if (bufferSize + operationSize > maxPayLoadSizeInBytes && !buffer.isEmpty()) {
+          response = sendWithBisection(buffer, entityErrorList);
+          buffer = new ArrayList<>();
           bufferSize = 0;
         }
 
-        bufferData.add(operation);
+        buffer.add(tagged);
         bufferSize += operationSize;
-        requestIndex++;
       }
 
-      if (!bufferData.isEmpty()) {
-        response = searchRepository.getSearchClient().bulkOpenSearch(bufferData);
-        entityErrorList.addAll(
-            extractErrorsFromResponse(response, entityNames, requestIndex - bufferData.size()));
+      if (!buffer.isEmpty()) {
+        response = sendWithBisection(buffer, entityErrorList);
       }
 
       LOG.debug(
@@ -130,6 +121,53 @@ public class OpenSearchIndexSink
     }
   }
 
+  /**
+   * Sends bulk operations to OpenSearch, iteratively bisecting the batch on 413 (Request Entity Too
+   * Large) responses. If a single operation exceeds the server limit, it is recorded as a failed
+   * entity and skipped so the rest of the batch can proceed.
+   */
+  private BulkResponse sendWithBisection(
+      List<TaggedOperation<BulkOperation>> taggedOps, List<EntityError> errorList)
+      throws IOException {
+    Deque<List<TaggedOperation<BulkOperation>>> pending = new ArrayDeque<>();
+    pending.push(taggedOps);
+    BulkResponse lastResponse = null;
+
+    while (!pending.isEmpty()) {
+      List<TaggedOperation<BulkOperation>> chunk = pending.pop();
+      List<BulkOperation> operations = chunk.stream().map(TaggedOperation::operation).toList();
+      try {
+        BulkResponse response = searchRepository.getSearchClient().bulkOpenSearch(operations);
+        errorList.addAll(extractErrorsFromResponse(response, chunk));
+        lastResponse = response;
+      } catch (OpenSearchException e) {
+        if (e.status() != 413) {
+          throw e;
+        }
+        if (chunk.size() == 1) {
+          LOG.error(
+              "[OsSearchIndexSink] Single document exceeds OpenSearch payload limit, skipping entity: {} (type={})",
+              chunk.getFirst().entityRef().getId(),
+              chunk.getFirst().entityRef().getType());
+          errorList.add(
+              new EntityError()
+                  .withMessage("Document exceeds OpenSearch maximum payload size (413)")
+                  .withEntity(chunk.getFirst().entityRef()));
+          continue;
+        }
+        int mid = chunk.size() / 2;
+        LOG.warn(
+            "[OsSearchIndexSink] Bulk request rejected with 413, bisecting batch of {} into [{}, {}]",
+            chunk.size(),
+            mid,
+            chunk.size() - mid);
+        pending.push(chunk.subList(mid, chunk.size()));
+        pending.push(chunk.subList(0, mid));
+      }
+    }
+    return lastResponse;
+  }
+
   private long estimateBulkOperationSize(BulkOperation operation) {
     try {
       StringWriter writer = new StringWriter();
@@ -144,23 +182,17 @@ public class OpenSearchIndexSink
   }
 
   private List<EntityError> extractErrorsFromResponse(
-      os.org.opensearch.client.opensearch.core.BulkResponse response,
-      List<?> entityNames,
-      int startIndex) {
+      BulkResponse response, List<TaggedOperation<BulkOperation>> taggedOps) {
     List<EntityError> errors = new ArrayList<>();
     if (response != null && response.errors()) {
       for (int i = 0; i < response.items().size(); i++) {
         os.org.opensearch.client.opensearch.core.bulk.BulkResponseItem item =
             response.items().get(i);
         if (item.error() != null) {
-          int entityIndex = startIndex + i;
           errors.add(
               new EntityError()
                   .withMessage(item.error().reason())
-                  .withEntity(
-                      entityIndex < entityNames.size()
-                          ? entityNames.get(entityIndex)
-                          : String.format("Unknown entity at index %d", entityIndex)));
+                  .withEntity(taggedOps.get(i).entityRef()));
         }
       }
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/workflows/interfaces/Sink.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/workflows/interfaces/Sink.java
@@ -13,9 +13,8 @@
 
 package org.openmetadata.service.workflows.interfaces;
 
-import java.util.Map;
 import org.openmetadata.service.exception.SearchIndexException;
 
 public interface Sink<I, O> extends Stats {
-  O write(I data, Map<String, Object> contextData) throws SearchIndexException;
+  O write(I data) throws SearchIndexException;
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/workflows/interfaces/TaggedOperation.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/workflows/interfaces/TaggedOperation.java
@@ -1,0 +1,5 @@
+package org.openmetadata.service.workflows.interfaces;
+
+import org.openmetadata.schema.type.EntityReference;
+
+public record TaggedOperation<T>(T operation, EntityReference entityRef) {}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/workflows/searchIndex/ReindexingUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/workflows/searchIndex/ReindexingUtil.java
@@ -48,7 +48,6 @@ public class ReindexingUtil {
   }
 
   public static final String ENTITY_TYPE_KEY = "entityType";
-  public static final String ENTITY_NAME_LIST_KEY = "entityNameList";
   public static final String TIMESTAMP_KEY = "@timestamp";
   public static final String TARGET_INDEX_KEY = "targetIndex";
   public static final String RECREATE_CONTEXT = "recreateContext";

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/elasticsearch/ElasticSearchIndexSinkTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/elasticsearch/ElasticSearchIndexSinkTest.java
@@ -5,17 +5,21 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import es.co.elastic.clients.elasticsearch._types.ElasticsearchException;
+import es.co.elastic.clients.elasticsearch._types.ErrorCause;
+import es.co.elastic.clients.elasticsearch._types.ErrorResponse;
 import es.co.elastic.clients.elasticsearch.core.BulkResponse;
 import es.co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
 import es.co.elastic.clients.elasticsearch.core.bulk.IndexOperation;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,9 +28,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.openmetadata.schema.system.StepStats;
+import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.service.exception.SearchIndexException;
 import org.openmetadata.service.search.SearchClient;
 import org.openmetadata.service.search.SearchRepository;
+import org.openmetadata.service.workflows.interfaces.TaggedOperation;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -58,19 +64,13 @@ class ElasticSearchIndexSinkTest {
 
   @Test
   void testWriteSuccess() throws Exception {
-    // Given
-    List<BulkOperation> operations = createMockBulkOperations(5);
-    Map<String, Object> contextData = new HashMap<>();
-    contextData.put(
-        "entityNameList", List.of("entity1", "entity2", "entity3", "entity4", "entity5"));
+    List<TaggedOperation<BulkOperation>> data = createTaggedOperations(5);
 
     when(searchClient.bulkElasticSearch(any())).thenReturn(bulkResponse);
     when(bulkResponse.errors()).thenReturn(false);
 
-    // When
-    BulkResponse result = sink.write(operations, contextData);
+    BulkResponse result = sink.write(data);
 
-    // Then
     assertNotNull(result);
     verify(searchClient, times(1)).bulkElasticSearch(any());
     assertEquals(5, sink.getStats().getSuccessRecords());
@@ -79,52 +79,104 @@ class ElasticSearchIndexSinkTest {
 
   @Test
   void testWriteWithErrors() throws Exception {
-    // Given
-    List<BulkOperation> operations = createMockBulkOperations(5);
-    Map<String, Object> contextData = new HashMap<>();
-    contextData.put(
-        "entityNameList", List.of("entity1", "entity2", "entity3", "entity4", "entity5"));
+    List<TaggedOperation<BulkOperation>> data = createTaggedOperations(5);
 
     when(searchClient.bulkElasticSearch(any()))
         .thenThrow(new RuntimeException("Bulk operation failed"));
 
-    // When & Then
-    assertThrows(SearchIndexException.class, () -> sink.write(operations, contextData));
+    assertThrows(SearchIndexException.class, () -> sink.write(data));
     assertEquals(0, sink.getStats().getSuccessRecords());
     assertEquals(5, sink.getStats().getFailedRecords());
   }
 
   @Test
   void testUpdateStats() {
-    // Given
     assertEquals(0, sink.getStats().getSuccessRecords());
     assertEquals(0, sink.getStats().getFailedRecords());
 
-    // When
     sink.updateStats(10, 2);
 
-    // Then
     assertEquals(10, sink.getStats().getSuccessRecords());
     assertEquals(2, sink.getStats().getFailedRecords());
   }
 
   @Test
   void testWriteWithEmptyData() throws Exception {
-    // Given
-    List<BulkOperation> operations = new ArrayList<>();
-    Map<String, Object> contextData = new HashMap<>();
+    List<TaggedOperation<BulkOperation>> data = new ArrayList<>();
 
-    // When & Then - should not throw exception for empty list
-    assertDoesNotThrow(() -> sink.write(operations, contextData));
+    assertDoesNotThrow(() -> sink.write(data));
     assertEquals(0, sink.getStats().getSuccessRecords());
     assertEquals(0, sink.getStats().getFailedRecords());
   }
 
-  private List<BulkOperation> createMockBulkOperations(int count) {
-    List<BulkOperation> operations = new ArrayList<>();
+  @Test
+  void testSingleDocumentExceedsPayloadLimit413() throws Exception {
+    List<TaggedOperation<BulkOperation>> data = createTaggedOperations(1);
+
+    ElasticsearchException e413 =
+        new ElasticsearchException(
+            "Request Entity Too Large",
+            new ErrorResponse.Builder()
+                .status(413)
+                .error(
+                    new ErrorCause.Builder()
+                        .reason("Request Entity Too Large")
+                        .type("request_entity_too_large")
+                        .build())
+                .build());
+
+    when(searchClient.bulkElasticSearch(any())).thenThrow(e413);
+
+    SearchIndexException ex = assertThrows(SearchIndexException.class, () -> sink.write(data));
+
+    assertEquals(1, ex.getIndexingError().getFailedCount());
+    assertEquals(0, ex.getIndexingError().getSuccessCount());
+  }
+
+  @Test
+  void testBisectionOnPayloadTooLargeWithMixedResults() throws Exception {
+    List<TaggedOperation<BulkOperation>> data = createTaggedOperations(4);
+
+    ElasticsearchException e413 =
+        new ElasticsearchException(
+            "Request Entity Too Large",
+            new ErrorResponse.Builder()
+                .status(413)
+                .error(
+                    new ErrorCause.Builder()
+                        .reason("Request Entity Too Large")
+                        .type("request_entity_too_large")
+                        .build())
+                .build());
+
+    BulkResponse successResponse = BulkResponse.of(b -> b.errors(false).items(List.of()).took(1));
+
+    // Call 1: full batch (4 ops) → 413, bisects into [0,1] and [2,3]
+    // Call 2: [0,1] → success
+    // Call 3: [2,3] → 413, bisects into [2] and [3]
+    // Call 4: [2] → success
+    // Call 5: [3] → 413 on single doc, recorded as error
+    when(searchClient.bulkElasticSearch(argThat(ops -> ops != null && ops.size() == 4)))
+        .thenThrow(e413);
+    when(searchClient.bulkElasticSearch(argThat(ops -> ops != null && ops.size() == 2)))
+        .thenReturn(successResponse)
+        .thenThrow(e413);
+    when(searchClient.bulkElasticSearch(argThat(ops -> ops != null && ops.size() == 1)))
+        .thenReturn(successResponse)
+        .thenThrow(e413);
+
+    SearchIndexException ex = assertThrows(SearchIndexException.class, () -> sink.write(data));
+
+    assertEquals(1, ex.getIndexingError().getFailedCount());
+    assertEquals(3, ex.getIndexingError().getSuccessCount());
+    verify(searchClient, times(5)).bulkElasticSearch(any());
+  }
+
+  private List<TaggedOperation<BulkOperation>> createTaggedOperations(int count) {
+    List<TaggedOperation<BulkOperation>> tagged = new ArrayList<>();
     for (int i = 0; i < count; i++) {
       int finalI = i;
-      operations.add(
+      BulkOperation op =
           BulkOperation.of(
               b ->
                   b.index(
@@ -132,8 +184,11 @@ class ElasticSearchIndexSinkTest {
                           io ->
                               io.index("test_index")
                                   .id("id_" + finalI)
-                                  .document(Map.of("field", "value" + finalI))))));
+                                  .document(Map.of("field", "value" + finalI)))));
+      tagged.add(
+          new TaggedOperation<>(
+              op, new EntityReference().withId(UUID.randomUUID()).withType("table")));
     }
-    return operations;
+    return tagged;
   }
 }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/OpenSearchIndexSinkTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/OpenSearchIndexSinkTest.java
@@ -5,14 +5,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,9 +22,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.openmetadata.schema.system.StepStats;
+import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.service.exception.SearchIndexException;
 import org.openmetadata.service.search.SearchClient;
 import org.openmetadata.service.search.SearchRepository;
+import org.openmetadata.service.workflows.interfaces.TaggedOperation;
+import os.org.opensearch.client.opensearch._types.ErrorCause;
+import os.org.opensearch.client.opensearch._types.ErrorResponse;
+import os.org.opensearch.client.opensearch._types.OpenSearchException;
 import os.org.opensearch.client.opensearch.core.BulkResponse;
 import os.org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import os.org.opensearch.client.opensearch.core.bulk.IndexOperation;
@@ -58,19 +64,13 @@ class OpenSearchIndexSinkTest {
 
   @Test
   void testWriteSuccess() throws Exception {
-    // Given
-    List<BulkOperation> operations = createMockBulkOperations(5);
-    Map<String, Object> contextData = new HashMap<>();
-    contextData.put(
-        "entityNameList", List.of("entity1", "entity2", "entity3", "entity4", "entity5"));
+    List<TaggedOperation<BulkOperation>> data = createTaggedOperations(5);
 
     when(searchClient.bulkOpenSearch(any())).thenReturn(bulkResponse);
     when(bulkResponse.errors()).thenReturn(false);
 
-    // When
-    BulkResponse result = sink.write(operations, contextData);
+    BulkResponse result = sink.write(data);
 
-    // Then
     assertNotNull(result);
     verify(searchClient, times(1)).bulkOpenSearch(any());
     assertEquals(5, sink.getStats().getSuccessRecords());
@@ -79,52 +79,102 @@ class OpenSearchIndexSinkTest {
 
   @Test
   void testWriteWithErrors() throws Exception {
-    // Given
-    List<BulkOperation> operations = createMockBulkOperations(5);
-    Map<String, Object> contextData = new HashMap<>();
-    contextData.put(
-        "entityNameList", List.of("entity1", "entity2", "entity3", "entity4", "entity5"));
+    List<TaggedOperation<BulkOperation>> data = createTaggedOperations(5);
 
     when(searchClient.bulkOpenSearch(any()))
         .thenThrow(new RuntimeException("Bulk operation failed"));
 
-    // When & Then
-    assertThrows(SearchIndexException.class, () -> sink.write(operations, contextData));
+    assertThrows(SearchIndexException.class, () -> sink.write(data));
     assertEquals(0, sink.getStats().getSuccessRecords());
     assertEquals(5, sink.getStats().getFailedRecords());
   }
 
   @Test
   void testUpdateStats() {
-    // Given
     assertEquals(0, sink.getStats().getSuccessRecords());
     assertEquals(0, sink.getStats().getFailedRecords());
 
-    // When
     sink.updateStats(12, 3);
 
-    // Then
     assertEquals(12, sink.getStats().getSuccessRecords());
     assertEquals(3, sink.getStats().getFailedRecords());
   }
 
   @Test
   void testWriteWithEmptyData() throws Exception {
-    // Given
-    List<BulkOperation> operations = new ArrayList<>();
-    Map<String, Object> contextData = new HashMap<>();
+    List<TaggedOperation<BulkOperation>> data = new ArrayList<>();
 
-    // When & Then - should not throw exception for empty list
-    assertDoesNotThrow(() -> sink.write(operations, contextData));
+    assertDoesNotThrow(() -> sink.write(data));
     assertEquals(0, sink.getStats().getSuccessRecords());
     assertEquals(0, sink.getStats().getFailedRecords());
   }
 
-  private List<BulkOperation> createMockBulkOperations(int count) {
-    List<BulkOperation> operations = new ArrayList<>();
+  @Test
+  void testSingleDocumentExceedsPayloadLimit413() throws Exception {
+    List<TaggedOperation<BulkOperation>> data = createTaggedOperations(1);
+
+    OpenSearchException e413 =
+        new OpenSearchException(
+            new ErrorResponse.Builder()
+                .status(413)
+                .error(
+                    new ErrorCause.Builder()
+                        .reason("Request Entity Too Large")
+                        .type("request_entity_too_large")
+                        .build())
+                .build());
+
+    when(searchClient.bulkOpenSearch(any())).thenThrow(e413);
+
+    SearchIndexException ex = assertThrows(SearchIndexException.class, () -> sink.write(data));
+
+    assertEquals(1, ex.getIndexingError().getFailedCount());
+    assertEquals(0, ex.getIndexingError().getSuccessCount());
+  }
+
+  @Test
+  void testBisectionOnPayloadTooLargeWithMixedResults() throws Exception {
+    List<TaggedOperation<BulkOperation>> data = createTaggedOperations(4);
+
+    OpenSearchException e413 =
+        new OpenSearchException(
+            new ErrorResponse.Builder()
+                .status(413)
+                .error(
+                    new ErrorCause.Builder()
+                        .reason("Request Entity Too Large")
+                        .type("request_entity_too_large")
+                        .build())
+                .build());
+
+    BulkResponse successResponse = BulkResponse.of(b -> b.errors(false).items(List.of()).took(1));
+
+    // Call 1: full batch (4 ops) → 413, bisects into [0,1] and [2,3]
+    // Call 2: [0,1] → success
+    // Call 3: [2,3] → 413, bisects into [2] and [3]
+    // Call 4: [2] → success
+    // Call 5: [3] → 413 on single doc, recorded as error
+    when(searchClient.bulkOpenSearch(argThat(ops -> ops != null && ops.size() == 4)))
+        .thenThrow(e413);
+    when(searchClient.bulkOpenSearch(argThat(ops -> ops != null && ops.size() == 2)))
+        .thenReturn(successResponse)
+        .thenThrow(e413);
+    when(searchClient.bulkOpenSearch(argThat(ops -> ops != null && ops.size() == 1)))
+        .thenReturn(successResponse)
+        .thenThrow(e413);
+
+    SearchIndexException ex = assertThrows(SearchIndexException.class, () -> sink.write(data));
+
+    assertEquals(1, ex.getIndexingError().getFailedCount());
+    assertEquals(3, ex.getIndexingError().getSuccessCount());
+    verify(searchClient, times(5)).bulkOpenSearch(any());
+  }
+
+  private List<TaggedOperation<BulkOperation>> createTaggedOperations(int count) {
+    List<TaggedOperation<BulkOperation>> tagged = new ArrayList<>();
     for (int i = 0; i < count; i++) {
       int finalI = i;
-      operations.add(
+      BulkOperation op =
           BulkOperation.of(
               b ->
                   b.index(
@@ -132,8 +182,11 @@ class OpenSearchIndexSinkTest {
                           io ->
                               io.index("test_index")
                                   .id("id_" + finalI)
-                                  .document(Map.of("field", "value" + finalI))))));
+                                  .document(Map.of("field", "value" + finalI)))));
+      tagged.add(
+          new TaggedOperation<>(
+              op, new EntityReference().withId(UUID.randomUUID()).withType("table")));
     }
-    return operations;
+    return tagged;
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
     <httpclient.version>4.5.14</httpclient.version>
     <spring.version>6.2.11</spring.version>
     <log4j.version>2.25.3</log4j.version>
-    <org.junit.jupiter.version>5.9.3</org.junit.jupiter.version>
+    <org.junit.jupiter.version>5.11.4</org.junit.jupiter.version>
     <dropwizard-health.version>5.0.0</dropwizard-health.version>
     <handlebars.version>4.5.0</handlebars.version>
     <fernet.version>1.5.0</fernet.version>
@@ -162,6 +162,13 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>${org.junit.jupiter.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <!-- Security: Force newer versions to fix vulnerabilities -->
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Cherry-pick of #26347 (`da400385d4`) from `main` into `1.12.5`.

## Changes

- Adds iterative bisection on 413 (Request Entity Too Large) responses in `ElasticSearchIndexSink` and `OpenSearchIndexSink` — instead of failing the whole batch, the sink splits it in half recursively until the oversized document is isolated and skipped with a clear error
- Introduces `TaggedOperation` wrapper so entity references are tracked through the bulk pipeline, ensuring errors report the actual entity instead of a positional index
- Conflict resolution: kept all `1.12.5`-specific test dependencies in `openmetadata-service/pom.xml` and dropped `junit-jupiter-params` which was removed by the original commit

## Motivation

The Data Insights Application on customer environments was failing with 413 errors when bulk indexing large entity batches. This fix was already merged to `main` but was missing from the `1.12.5` release branch.

Fixes #26344