### PR TITLE
feat(hive): add get_table_partition_details with metastore and parser…

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/hive/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/metadata.py
@@ -197,12 +197,20 @@ class HiveSource(CommonDbSourceService):
         if self._get_validated_metastore_connection():
             return False, None
 
+        # Sanitize identifiers: escape any backticks in names to prevent
+        # malformed HiveQL. Table/schema names come from the inspector but
+        # we guard defensively here.
+        safe_schema = schema_name.replace("`", "``")
+        safe_table = table_name.replace("`", "``")
+
         partition_keys: List[str] = []
         in_partition_section = False
         try:
             with self.engine.connect() as conn:
                 rows = conn.execute(
-                    text(f"DESCRIBE FORMATTED `{schema_name}`.`{table_name}`")
+                    text(
+                        f"DESCRIBE FORMATTED `{safe_schema}`.`{safe_table}`"
+                    )
                 )
                 for row in rows:
                     col_name = row[0].strip() if row[0] else ""
@@ -212,18 +220,19 @@ class HiveSource(CommonDbSourceService):
                         continue
 
                     if in_partition_section:
-                        # Bug fix 2: Break on any new section header.
+                        # Any new top-level section header signals the end of
+                        # the partition block — exit immediately so we never
+                        # collect metadata rows (e.g. "Database:", "Location:")
+                        # as partition keys.
                         # "# col_name" is the sub-header *within* the partition
-                        # block — skip it. Every other "#…" line marks a new
-                        # top-level section (e.g. "# Detailed Table Information",
-                        # "# Storage Information"), so we exit immediately instead
-                        # of continuing and collecting those rows as partition keys.
-                        if not col_name or (
-                            col_name.startswith("#") and col_name != "# col_name"
-                        ):
+                        # block and must be skipped, not treated as an exit.
+                        if col_name.startswith("#") and col_name != "# col_name":
                             break
-                        if col_name.startswith("#"):
-                            # "# col_name" sub-header — skip without breaking
+                        # Skip the "# col_name" sub-header and blank rows
+                        # (blank rows may appear between partition keys on some
+                        # Hive versions — skip rather than break so we don't
+                        # miss later keys).
+                        if not col_name or col_name.startswith("#"):
                             continue
                         partition_keys.append(col_name)
 

--- a/ingestion/src/metadata/ingestion/source/database/hive/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/metadata.py
@@ -13,14 +13,19 @@ Hive source methods.
 """
 
 import traceback
-from typing import Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 from pydantic import ValidationError
 from pyhive.sqlalchemy_hive import HiveDialect
 from sqlalchemy import text
 from sqlalchemy.engine.reflection import Inspector
 
-from metadata.generated.schema.entity.data.table import TableType
+from metadata.generated.schema.entity.data.table import (
+    PartitionColumnDetails,
+    PartitionIntervalTypes,
+    TablePartition,
+    TableType,
+)
 from metadata.generated.schema.entity.services.connections.database.hiveConnection import (
     HiveConnection,
 )
@@ -165,3 +170,79 @@ class HiveSource(CommonDbSourceService):
             logger.debug(traceback.format_exc())
             logger.warning(f"Failed to fetch schema definition for {table_name}: {exc}")
         return None
+
+    def get_table_partition_details(
+        self,
+        table_name: str,
+        schema_name: str,
+        inspector: Inspector,
+    ) -> Tuple[bool, Optional[TablePartition]]:
+        """
+        Extract partition key columns from DESCRIBE FORMATTED output.
+
+        Returns (is_partitioned, TablePartition) where TablePartition lists all
+        partition key columns with COLUMN_VALUE interval type.
+
+        Bug fixes vs original PR:
+        1. Metastore compatibility: skip DESCRIBE FORMATTED when a metastore
+           connection is active — the engine is MySQL/Postgres and won't
+           understand Hive SQL.
+        2. Parser section exit: break on *any* new section header inside the
+           partition block (not just "# Detailed"), so rows from later sections
+           are never mistaken for partition keys.
+        """
+        # Bug fix 1: DESCRIBE FORMATTED only works against a live Hive engine.
+        # When metastoreConnection is configured, self.engine points at
+        # MySQL/Postgres — running HiveQL there will raise an error.
+        if self._get_validated_metastore_connection():
+            return False, None
+
+        partition_keys: List[str] = []
+        in_partition_section = False
+        try:
+            with self.engine.connect() as conn:
+                rows = conn.execute(
+                    text(f"DESCRIBE FORMATTED `{schema_name}`.`{table_name}`")
+                )
+                for row in rows:
+                    col_name = row[0].strip() if row[0] else ""
+
+                    if col_name == "# Partition Information":
+                        in_partition_section = True
+                        continue
+
+                    if in_partition_section:
+                        # Bug fix 2: Break on any new section header.
+                        # "# col_name" is the sub-header *within* the partition
+                        # block — skip it. Every other "#…" line marks a new
+                        # top-level section (e.g. "# Detailed Table Information",
+                        # "# Storage Information"), so we exit immediately instead
+                        # of continuing and collecting those rows as partition keys.
+                        if not col_name or (
+                            col_name.startswith("#") and col_name != "# col_name"
+                        ):
+                            break
+                        if col_name.startswith("#"):
+                            # "# col_name" sub-header — skip without breaking
+                            continue
+                        partition_keys.append(col_name)
+
+        except Exception as exc:
+            logger.debug(traceback.format_exc())
+            logger.warning(
+                f"Failed to get partition details for {schema_name}.{table_name}: {exc}"
+            )
+
+        if not partition_keys:
+            return False, None
+
+        return True, TablePartition(
+            columns=[
+                PartitionColumnDetails(
+                    columnName=key,
+                    intervalType=PartitionIntervalTypes.COLUMN_VALUE,
+                    interval=None,
+                )
+                for key in partition_keys
+            ]
+        )

--- a/ingestion/tests/unit/topology/database/test_hive.py
+++ b/ingestion/tests/unit/topology/database/test_hive.py
@@ -1263,3 +1263,191 @@ class HiveSourceMetastoreValidationTest(TestCase):
         self.hive.service_connection.metastoreConnection = invalid_dict
         result = self.hive._get_validated_metastore_connection()
         self.assertIsNone(result)
+
+    # ---------------------------------------------------------------------------
+    # Tests for get_table_partition_details
+    # ---------------------------------------------------------------------------
+
+    def _make_describe_row(self, col_name, data_type="", comment=""):
+        """Helper: return a row tuple that mimics a DESCRIBE FORMATTED result."""
+        return (col_name, data_type, comment)
+
+    def _mock_engine_rows(self, rows):
+        """
+        Return a Mock engine whose connect().__enter__.execute() yields *rows*.
+        """
+        mock_conn = Mock()
+        mock_conn.execute.return_value = iter(rows)
+        mock_ctx = Mock()
+        mock_ctx.__enter__ = Mock(return_value=mock_conn)
+        mock_ctx.__exit__ = Mock(return_value=False)
+        mock_engine = Mock()
+        mock_engine.connect.return_value = mock_ctx
+        return mock_engine
+
+    def test_get_table_partition_details_basic(self):
+        """
+        Standard DESCRIBE FORMATTED output with one partition key.
+        Should return (True, TablePartition) with that key.
+        """
+        from metadata.generated.schema.entity.data.table import (
+            PartitionIntervalTypes,
+            TablePartition,
+        )
+
+        rows = [
+            self._make_describe_row("# col_name", "data_type", "comment"),
+            self._make_describe_row("id", "int"),
+            self._make_describe_row("name", "string"),
+            self._make_describe_row("dt", "string"),
+            self._make_describe_row(""),  # blank separator
+            self._make_describe_row("# Partition Information"),
+            self._make_describe_row("# col_name", "data_type", "comment"),
+            self._make_describe_row("dt", "string"),
+            self._make_describe_row(""),  # blank row — triggers break
+            self._make_describe_row("# Detailed Table Information"),
+            self._make_describe_row("Database:", "default"),
+        ]
+
+        self.hive.service_connection.metastoreConnection = None
+        self.hive.engine = self._mock_engine_rows(rows)
+
+        is_partitioned, partition = self.hive.get_table_partition_details(
+            table_name="events",
+            schema_name="default",
+            inspector=Mock(),
+        )
+
+        self.assertTrue(is_partitioned)
+        self.assertIsNotNone(partition)
+        self.assertEqual(len(partition.columns), 1)
+        self.assertEqual(partition.columns[0].columnName, "dt")
+        self.assertEqual(
+            partition.columns[0].intervalType, PartitionIntervalTypes.COLUMN_VALUE
+        )
+
+    def test_get_table_partition_details_multiple_keys(self):
+        """
+        Table with two partition keys — both should be captured.
+        """
+        rows = [
+            self._make_describe_row("id", "int"),
+            self._make_describe_row(""),
+            self._make_describe_row("# Partition Information"),
+            self._make_describe_row("# col_name", "data_type", "comment"),
+            self._make_describe_row("year", "int"),
+            self._make_describe_row("month", "int"),
+            self._make_describe_row("# Detailed Table Information"),
+        ]
+
+        self.hive.service_connection.metastoreConnection = None
+        self.hive.engine = self._mock_engine_rows(rows)
+
+        is_partitioned, partition = self.hive.get_table_partition_details(
+            table_name="logs",
+            schema_name="analytics",
+            inspector=Mock(),
+        )
+
+        self.assertTrue(is_partitioned)
+        keys = [c.columnName for c in partition.columns]
+        self.assertEqual(keys, ["year", "month"])
+
+    def test_get_table_partition_details_no_partition_section(self):
+        """
+        Table without a '# Partition Information' section — not partitioned.
+        """
+        rows = [
+            self._make_describe_row("id", "int"),
+            self._make_describe_row("name", "string"),
+            self._make_describe_row("# Detailed Table Information"),
+            self._make_describe_row("Database:", "default"),
+        ]
+
+        self.hive.service_connection.metastoreConnection = None
+        self.hive.engine = self._mock_engine_rows(rows)
+
+        is_partitioned, partition = self.hive.get_table_partition_details(
+            table_name="users",
+            schema_name="default",
+            inspector=Mock(),
+        )
+
+        self.assertFalse(is_partitioned)
+        self.assertIsNone(partition)
+
+    def test_get_table_partition_details_section_exit_bug(self):
+        """
+        Bug fix 2: parser must break on *any* new section header, not only
+        '# Detailed Table Information'.  Here '# Storage Information' follows
+        the partition block; rows after it must NOT be collected as partition keys.
+        """
+        rows = [
+            self._make_describe_row("id", "int"),
+            self._make_describe_row("# Partition Information"),
+            self._make_describe_row("# col_name", "data_type", "comment"),
+            self._make_describe_row("dt", "string"),
+            # A different section header — not "# Detailed"
+            self._make_describe_row("# Storage Information"),
+            self._make_describe_row("Location:", "hdfs://namenode/warehouse"),
+            self._make_describe_row("# Detailed Table Information"),
+            self._make_describe_row("Database:", "default"),
+        ]
+
+        self.hive.service_connection.metastoreConnection = None
+        self.hive.engine = self._mock_engine_rows(rows)
+
+        is_partitioned, partition = self.hive.get_table_partition_details(
+            table_name="events",
+            schema_name="default",
+            inspector=Mock(),
+        )
+
+        self.assertTrue(is_partitioned)
+        keys = [c.columnName for c in partition.columns]
+        # Only "dt" should be collected; "Location:" etc. must not appear
+        self.assertEqual(keys, ["dt"])
+
+    def test_get_table_partition_details_skips_metastore(self):
+        """
+        Bug fix 1: when a metastoreConnection is configured the engine is
+        MySQL/Postgres and won't understand DESCRIBE FORMATTED.
+        The method must return (False, None) immediately without touching the engine.
+        """
+        self.hive.service_connection.metastoreConnection = PostgresConnection(
+            hostPort="localhost:5432",
+            username="hive",
+            database="metastore",
+        )
+
+        mock_engine = Mock()
+        self.hive.engine = mock_engine
+
+        is_partitioned, partition = self.hive.get_table_partition_details(
+            table_name="events",
+            schema_name="default",
+            inspector=Mock(),
+        )
+
+        self.assertFalse(is_partitioned)
+        self.assertIsNone(partition)
+        # Engine must never be touched
+        mock_engine.connect.assert_not_called()
+
+    def test_get_table_partition_details_engine_error(self):
+        """
+        Engine raises an exception — method must swallow it and return (False, None).
+        """
+        mock_engine = Mock()
+        mock_engine.connect.side_effect = Exception("connection refused")
+        self.hive.service_connection.metastoreConnection = None
+        self.hive.engine = mock_engine
+
+        is_partitioned, partition = self.hive.get_table_partition_details(
+            table_name="broken",
+            schema_name="default",
+            inspector=Mock(),
+        )
+
+        self.assertFalse(is_partitioned)
+        self.assertIsNone(partition)

--- a/ingestion/tests/unit/topology/database/test_hive.py
+++ b/ingestion/tests/unit/topology/database/test_hive.py
@@ -1304,8 +1304,8 @@ class HiveSourceMetastoreValidationTest(TestCase):
             self._make_describe_row("# Partition Information"),
             self._make_describe_row("# col_name", "data_type", "comment"),
             self._make_describe_row("dt", "string"),
-            self._make_describe_row(""),  # blank row — triggers break
-            self._make_describe_row("# Detailed Table Information"),
+            self._make_describe_row(""),  # blank row — skipped, not a break
+            self._make_describe_row("# Detailed Table Information"),  # triggers break
             self._make_describe_row("Database:", "default"),
         ]
 
@@ -1375,6 +1375,34 @@ class HiveSourceMetastoreValidationTest(TestCase):
 
         self.assertFalse(is_partitioned)
         self.assertIsNone(partition)
+
+    def test_get_table_partition_details_blank_lines_between_keys(self):
+        """
+        Some Hive versions emit blank rows between partition key rows.
+        The parser must skip them and continue collecting keys, not break early.
+        """
+        rows = [
+            self._make_describe_row("id", "int"),
+            self._make_describe_row("# Partition Information"),
+            self._make_describe_row("# col_name", "data_type", "comment"),
+            self._make_describe_row("year", "int"),
+            self._make_describe_row(""),  # blank row between keys
+            self._make_describe_row("month", "int"),
+            self._make_describe_row("# Detailed Table Information"),
+        ]
+
+        self.hive.service_connection.metastoreConnection = None
+        self.hive.engine = self._mock_engine_rows(rows)
+
+        is_partitioned, partition = self.hive.get_table_partition_details(
+            table_name="logs",
+            schema_name="default",
+            inspector=Mock(),
+        )
+
+        self.assertTrue(is_partitioned)
+        keys = [c.columnName for c in partition.columns]
+        self.assertEqual(keys, ["year", "month"])
 
     def test_get_table_partition_details_section_exit_bug(self):
         """


### PR DESCRIPTION
----
## Summary by Gitar

- **New AI SDK examples:**
  - Added three interactive Jupyter notebooks in `ingestion/examples/` for metadata health reporting, LangChain integration, and conversational AI agents.
  - Included `requirements.txt` listing essential dependencies like `groq`, `pandas`, and `openmetadata-ingestion` for the new notebooks.
- **Documentation:**
  - Added a comprehensive `README.md` explaining the problem statement, solution, setup instructions, and file structure for the new AI SDK recipes.

<sub>This will update automatically on new commits.</sub>