### PR TITLE
Fixes #15627: Support safe profiler metrics for complex data types

### DIFF
--- a/ingestion/src/metadata/profiler/orm/converter/common.py
+++ b/ingestion/src/metadata/profiler/orm/converter/common.py
@@ -63,6 +63,7 @@ class CommonMapTypes:
         DataType.GEOGRAPHY: sqa_types.SQASGeography,
         DataType.ENUM: sqlalchemy.Enum,
         DataType.JSON: sqlalchemy.JSON,
+        DataType.SUPER: sqlalchemy.JSON,
         DataType.UUID: CustomTypes.UUID.value,
         DataType.BYTEA: CustomTypes.BYTEA.value,
         DataType.NTEXT: sqlalchemy.NVARCHAR,

--- a/ingestion/src/metadata/profiler/orm/registry.py
+++ b/ingestion/src/metadata/profiler/orm/registry.py
@@ -137,6 +137,25 @@ NOT_COMPUTE = {
     DataType.XML.value,
     CustomTypes.UNDETERMINED.value.__name__,
 }
+COMPLEX_PROFILABLE_TYPES = {
+    sqlalchemy.ARRAY.__name__,
+    sqlalchemy.JSON.__name__,
+    sqa_types.SQAMap.__name__,
+    sqa_types.SQAStruct.__name__,
+    sqa_types.SQASet.__name__,
+    sqa_types.SQAUnion.__name__,
+    sqa_types.SQASGeography.__name__,
+    DataType.ARRAY.value,
+    DataType.JSON.value,
+    DataType.MAP.value,
+    DataType.STRUCT.value,
+    DataType.SET.value,
+    DataType.UNION.value,
+    DataType.GEOGRAPHY.value,
+    DataType.GEOMETRY.value,
+    DataType.SUPER.value,
+    CustomTypes.ARRAY.value.__name__,
+}
 FLOAT_SET = {sqlalchemy.types.DECIMAL, sqlalchemy.types.FLOAT}
 
 QUANTIFIABLE_SET = {
@@ -208,6 +227,16 @@ def is_concatenable(_type) -> bool:
     if isinstance(_type, DataType):
         return _type.value in CONCATENABLE_SET
     return issubclass(_type.__class__, Concatenable)
+
+
+def is_complex_profiler_type(_type) -> bool:
+    """
+    Check if the type is a complex type for which we support
+    a restricted subset of profiler metrics.
+    """
+    if isinstance(_type, DataType):
+        return _type.value in COMPLEX_PROFILABLE_TYPES
+    return _type.__class__.__name__ in COMPLEX_PROFILABLE_TYPES
 
 
 def is_value_non_numeric(value) -> bool:

--- a/ingestion/src/metadata/profiler/processor/core.py
+++ b/ingestion/src/metadata/profiler/processor/core.py
@@ -50,7 +50,7 @@ from metadata.profiler.metrics.core import (
     TMetric,
 )
 from metadata.profiler.metrics.static.row_count import RowCount
-from metadata.profiler.orm.registry import NOT_COMPUTE
+from metadata.profiler.orm.registry import NOT_COMPUTE, is_complex_profiler_type
 from metadata.profiler.processor.metric_filter import MetricFilter
 from metadata.utils.logger import profiler_logger
 
@@ -377,7 +377,10 @@ class Profiler(Generic[TMetric]):
         columns = [
             column
             for column in self.columns
-            if column.type.__class__.__name__ not in NOT_COMPUTE
+            if (
+                column.type.__class__.__name__ not in NOT_COMPUTE
+                or is_complex_profiler_type(column.type)
+            )
         ]
         static_metrics = [
             ThreadPoolMetrics(

--- a/ingestion/src/metadata/profiler/processor/metric_filter.py
+++ b/ingestion/src/metadata/profiler/processor/metric_filter.py
@@ -34,6 +34,7 @@ from metadata.profiler.metrics.core import (
     TMetric,
 )
 from metadata.profiler.orm.converter.converter_registry import converter_registry
+from metadata.profiler.orm.registry import is_complex_profiler_type
 from metadata.profiler.registry import MetricRegistry
 from metadata.utils.dependency_injector.dependency_injector import (
     DependencyNotFoundError,
@@ -45,6 +46,11 @@ from metadata.utils.sqa_like_column import SQALikeColumn
 
 class MetricFilter:
     """Metric filter class for profiler"""
+
+    COMPLEX_TYPE_METRIC_ALLOWLIST = {
+        StaticMetric: {"valuesCount", "nullCount"},
+        ComposedMetric: {"nullProportion"},
+    }
 
     @inject
     def __init__(
@@ -280,5 +286,9 @@ class MetricFilter:
         )
         if metrics:
             metrics = self.filter_column_metrics_from_table_config(metrics, column)
+
+        if is_complex_profiler_type(column.type):
+            allowed_metrics = self.COMPLEX_TYPE_METRIC_ALLOWLIST.get(metric_type, set())
+            return [metric for metric in metrics if metric.name() in allowed_metrics]
 
         return metrics

--- a/ingestion/tests/unit/observability/profiler/sqlalchemy/test_profiler.py
+++ b/ingestion/tests/unit/observability/profiler/sqlalchemy/test_profiler.py
@@ -47,8 +47,9 @@ from metadata.ingestion.source import sqa_types
 from metadata.profiler.interface.sqlalchemy.profiler_interface import (
     SQAProfilerInterface,
 )
-from metadata.profiler.metrics.core import MetricTypes, add_props
+from metadata.profiler.metrics.core import ComposedMetric, MetricTypes, add_props
 from metadata.profiler.metrics.registry import Metrics
+from metadata.profiler.orm.converter.common import CommonMapTypes
 from metadata.profiler.processor.core import MissingMetricException, Profiler
 from metadata.profiler.processor.default import DefaultProfiler
 from metadata.sampler.sqlalchemy.sampler import SQASampler
@@ -273,6 +274,55 @@ class ProfilerTest(TestCase):
                     assert metric.metrics[0].name.root == "custom_metric"
                 else:
                     assert metric.metrics[0].name() == "firstQuartile"
+
+    def test_complex_types_prepare_only_safe_metrics(self):
+        """Check that complex types only prepare safe metrics."""
+
+        class ComplexTypes(Base):
+            __tablename__ = "complex_types"
+            id = Column(Integer, primary_key=True)
+            array_col = Column(sqlalchemy.ARRAY(Integer, dimensions=1))
+            json_col = Column(sqlalchemy.JSON)
+            map_col = Column(sqa_types.SQAMap)
+            struct_col = Column(sqa_types.SQAStruct)
+
+        profiler = Profiler(
+            Metrics.valuesCount.value,
+            Metrics.nullCount.value,
+            Metrics.distinctCount.value,
+            Metrics.nullProportion.value,
+            Metrics.distinctProportion.value,
+            profiler_interface=self.sqa_profiler_interface,
+        )
+        profiler._columns = [
+            ComplexTypes.__table__.c.array_col,
+            ComplexTypes.__table__.c.json_col,
+            ComplexTypes.__table__.c.map_col,
+            ComplexTypes.__table__.c.struct_col,
+        ]
+
+        metrics = profiler._prepare_column_metrics()
+        static_metrics = {
+            metric.column.name: [col_metric.name() for col_metric in metric.metrics]
+            for metric in metrics
+            if metric.metric_type is MetricTypes.Static and metric.metrics
+        }
+
+        for column_name in {"array_col", "json_col", "map_col", "struct_col"}:
+            assert static_metrics[column_name] == ["valuesCount", "nullCount"]
+
+        composed_metrics = profiler.metric_filter.get_column_metrics(
+            ComposedMetric,
+            ComplexTypes.__table__.c.json_col,
+            self.sqa_profiler_interface.table_entity.serviceType,
+        )
+        assert [metric.name() for metric in composed_metrics] == ["nullProportion"]
+
+    def test_common_map_types_maps_super_to_json(self):
+        """Check that SUPER columns can be mapped for profiling."""
+        column = EntityColumn(name=ColumnName("payload"), dataType=DataType.SUPER)
+
+        assert CommonMapTypes().map_types(column, None) == sqlalchemy.JSON
 
     def test__prepare_table_metrics(self):
         """test _prepare_table_metrics returns as expected"""


### PR DESCRIPTION
### Describe your changes:

Fixes #15627

I worked on a narrow first step for profiler support on complex data types.

Today, complex columns are filtered out early by the profiler and never reach metric execution. This means even safe generic metrics like `nullCount` are skipped. Also, Redshift `SUPER` is recognized during type parsing but was not mapped in the profiler converter.

This PR keeps the fix intentionally small and safe:
- adds profiler mapping for `DataType.SUPER`
- allows complex types to be profiled with a restricted metric subset
- enables only safe generic metrics for complex types:
  - `valuesCount`
  - `nullCount`
  - `nullProportion`

I intentionally did not broaden support to all metrics for JSON/ARRAY/geo, and I did not add string-cast-based size metrics in this PR. Those can be handled in follow-up work with clearer per-type/per-dialect semantics.

How I tested it:
- added focused unit tests for:
  - restricted metric preparation on complex columns
  - `SUPER` type mapping in the profiler converter
- ran syntax validation with `python3 -m py_compile` on the touched files

Note:
- full pytest execution was not possible in this local checkout because the generated Python schema package (`metadata.generated`) is not present here.

#
### Type of change:
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Improvement
- [x] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->
