### PR TITLE
fix(ui): restore atoms/table hooks consumed by collate-ui

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/shared/types/index.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/shared/types/index.ts
@@ -149,6 +149,7 @@ export interface TableViewConfig<T> {
   listing: ListingData<T>;
   enableSelection?: boolean;
   entityLabelKey?: string;
+  customTableRow?: React.ComponentType<Record<string, unknown>>;
 }
 
 export interface DropdownConfig {

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/table/useCardView.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/table/useCardView.tsx
@@ -1,0 +1,129 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { Box, Card, CardContent } from '@mui/material';
+import { isEmpty } from 'lodash';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ColumnConfig, ListingData } from '../shared/types';
+import { useCellRenderer } from './useCellRenderer';
+
+interface UseCardViewConfig<T> {
+  listing: ListingData<T>;
+  cardTemplate: (
+    entity: T,
+    renderCell: (entity: T, column: ColumnConfig<T>) => React.ReactNode
+  ) => React.ReactNode;
+}
+
+/**
+ * Renders entities in card grid using consumer-defined templates
+ *
+ * @description
+ * Provides flexible card view rendering where the consumer defines the exact
+ * card layout structure. Uses the same cell renderers as table view for
+ * complete consistency. Consumer provides card template function that
+ * receives entity data and renderCell function.
+ *
+ * @param config.listing - Entity listing data (same as table)
+ * @param config.cardTemplate - Function that defines card layout structure
+ *
+ * @example
+ * ```typescript
+ * const domainCardTemplate = (entity, renderCell) => (
+ *   <>
+ *     <Box>{renderCell(entity, nameColumn)}</Box>
+ *     <Box sx={{ display: 'flex', gap: 2 }}>
+ *       <Box sx={{ flex: 1 }}>{renderCell(entity, tagColumn)}</Box>
+ *       <Box sx={{ flex: 1 }}>{renderCell(entity, domainTypeColumn)}</Box>
+ *     </Box>
+ *     <Box>{renderCell(entity, ownerColumn)}</Box>
+ *   </>
+ * );
+ *
+ * const { cardView } = useCardView({
+ *   listing: domainListing,
+ *   cardTemplate: domainCardTemplate
+ * });
+ * ```
+ *
+ * @stability Stable - Uses stable cell renderer
+ * @complexity Low - Simple grid with consumer-defined content
+ */
+export const useCardView = <T extends { id: string }>({
+  listing,
+  cardTemplate,
+}: UseCardViewConfig<T>) => {
+  const { renderCell } = useCellRenderer({
+    columns: listing.columns,
+    renderers: listing.renderers,
+    chipSize: 'small',
+  });
+  const { t } = useTranslation();
+
+  const cardView = useMemo(
+    () =>
+      isEmpty(listing.entities) ? (
+        <Box
+          sx={{ textAlign: 'center', margin: '16px 24px', padding: '9px 0' }}>
+          {t('server.no-records-found')}
+        </Box>
+      ) : (
+        <Box
+          data-testid="card-view-container"
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(3, 1fr)', // Strict 3 columns
+            gap: 4, // 16px spacing
+            m: 6, // 24px margin
+          }}>
+          {listing.entities.map((entity) => (
+            <Card
+              data-testid="entity-card"
+              elevation={0}
+              key={entity.id}
+              sx={{
+                height: '100%',
+                cursor: 'pointer',
+                boxShadow: 'none',
+                '& .MuiCardContent-root': {
+                  padding: '20px !important',
+                },
+                '& .entity-avatar': {
+                  width: '54px',
+                  height: '54px',
+                  borderRadius: '8px',
+                  '& .MuiAvatar-img': {
+                    width: '28px',
+                    height: '28px',
+                  },
+                  '& svg': {
+                    width: '28px',
+                    height: '28px',
+                  },
+                },
+              }}
+              onClick={() => listing.actionHandlers?.onEntityClick?.(entity)}>
+              <CardContent>{cardTemplate(entity, renderCell)}</CardContent>
+            </Card>
+          ))}
+        </Box>
+      ),
+    [listing.entities, cardTemplate, renderCell, listing.actionHandlers]
+  );
+
+  return {
+    cardView,
+    renderCell, // Expose for custom templates
+  };
+};

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/table/useCellRenderer.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/table/useCellRenderer.tsx
@@ -1,0 +1,214 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { AvatarGroup, Box, Typography, useTheme } from '@mui/material';
+import { Avatar } from '@openmetadata/ui-core-components';
+import { Globe01 } from '@untitledui/icons';
+import { ReactNode, useMemo } from 'react';
+import { EntityType } from '../../../../enums/entity.enum';
+import { EntityReference } from '../../../../generated/entity/type';
+import { getEntityName } from '../../../../utils/EntityUtils';
+import { getEntityAvatarProps } from '../../../../utils/IconUtils';
+import { ProfilePicture } from '../ProfilePicture';
+import { CellRenderer, ColumnConfig } from '../shared/types';
+import TagsCell from './TagsCell';
+
+const EMPTY_VALUE_INDICATOR = '-';
+
+interface UseCellRendererProps<T> {
+  columns: ColumnConfig<T>[];
+  renderers?: CellRenderer<T>;
+  chipSize?: 'small' | 'large';
+}
+
+export const useCellRenderer = <
+  T extends { id: string; name?: string; displayName?: string }
+>(
+  props: UseCellRendererProps<T>
+) => {
+  const { renderers = {}, chipSize = 'large' } = props;
+  const theme = useTheme();
+
+  const defaultRenderers: CellRenderer<T> = useMemo(
+    () => ({
+      entityName: (entity: T) => {
+        const entityName = getEntityName(entity);
+
+        return (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+            <Avatar size="lg" {...getEntityAvatarProps(entity)} />
+            <Box>
+              <Typography
+                sx={{
+                  fontWeight: 500,
+                  color: 'text.primary',
+                  fontSize: '0.875rem',
+                  lineHeight: '20px',
+                }}>
+                {entityName}
+              </Typography>
+            </Box>
+          </Box>
+        );
+      },
+      owners: (entity: T, column?: ColumnConfig<T>) => {
+        const owners = column?.getValue
+          ? column.getValue(entity)
+          : entity[column?.key || 'owners'];
+
+        if (!owners || owners.length === 0) {
+          return (
+            <Typography sx={{ fontSize: '0.875rem', color: 'text.secondary' }}>
+              {EMPTY_VALUE_INDICATOR}
+            </Typography>
+          );
+        }
+
+        if (owners.length === 1) {
+          const owner = owners[0];
+          const isTeam = owner.type === EntityType.TEAM;
+
+          return (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <ProfilePicture
+                avatarType="solid"
+                displayName={owner.displayName}
+                isTeam={isTeam}
+                name={owner.name || ''}
+                size={16}
+              />
+              <Typography sx={{ fontSize: '0.875rem' }}>
+                {owner.displayName || owner.name}
+              </Typography>
+            </Box>
+          );
+        }
+
+        return (
+          <Box sx={{ display: 'flex', alignItems: 'left' }}>
+            <AvatarGroup
+              max={5}
+              sx={{
+                '& .MuiAvatar-root': {
+                  width: 24,
+                  height: 24,
+                  fontSize: '0.75rem',
+                },
+              }}>
+              {owners.map((owner: EntityReference, index: number) => {
+                const isTeam = owner.type === EntityType.TEAM;
+
+                return (
+                  <ProfilePicture
+                    avatarType="solid"
+                    displayName={owner.displayName}
+                    isTeam={isTeam}
+                    key={owner.id || index}
+                    name={owner.name || ''}
+                    size={24}
+                  />
+                );
+              })}
+            </AvatarGroup>
+          </Box>
+        );
+      },
+      tags: (entity: T, column?: ColumnConfig<T>) => {
+        const tags = column?.getValue
+          ? column.getValue(entity)
+          : entity[column?.key || 'tags'];
+
+        if (!tags || tags.length === 0) {
+          return (
+            <Typography sx={{ fontSize: '0.875rem', color: 'text.secondary' }}>
+              {EMPTY_VALUE_INDICATOR}
+            </Typography>
+          );
+        }
+
+        return <TagsCell chipSize={chipSize} tags={tags} />;
+      },
+      text: (entity: T, column?: ColumnConfig<T>) => {
+        const value = column?.getValue
+          ? column.getValue(entity)
+          : (entity as Record<string, unknown>)[column?.key || ''];
+
+        return (
+          <Typography sx={{ fontSize: '0.875rem' }}>
+            {value || EMPTY_VALUE_INDICATOR}
+          </Typography>
+        );
+      },
+      custom: (entity: T, column?: ColumnConfig<T>) => {
+        if (column?.customRenderer && renderers[column.customRenderer]) {
+          return renderers[column.customRenderer](entity);
+        }
+
+        return (
+          <Typography sx={{ fontSize: '0.875rem', color: 'text.secondary' }}>
+            {EMPTY_VALUE_INDICATOR}
+          </Typography>
+        );
+      },
+      domains: (entity: T, column?: ColumnConfig<T>) => {
+        const domains = column?.getValue
+          ? column.getValue(entity)
+          : (entity as Record<string, unknown>)[column?.key || 'domains'];
+
+        if (!domains || domains.length === 0) {
+          return (
+            <Typography sx={{ fontSize: '0.875rem', color: 'text.secondary' }}>
+              {EMPTY_VALUE_INDICATOR}
+            </Typography>
+          );
+        }
+
+        const domain = domains[0];
+
+        return (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Globe01 size={16} style={{ flexShrink: 0 }} />
+            <Typography
+              sx={{
+                fontSize: '0.875rem',
+              }}>
+              {domain.displayName || domain.name}
+            </Typography>
+          </Box>
+        );
+      },
+    }),
+    [renderers, theme, chipSize]
+  );
+
+  const renderCell = useMemo(
+    () =>
+      (entity: T, column: ColumnConfig<T>): ReactNode => {
+        const allRenderers = { ...defaultRenderers, ...renderers };
+        const renderer = allRenderers[column.render];
+
+        if (renderer) {
+          return renderer(entity, column);
+        }
+
+        return <span>-</span>;
+      },
+    [defaultRenderers, renderers]
+  );
+
+  return {
+    renderCell,
+    defaultRenderers,
+    allRenderers: { ...defaultRenderers, ...renderers },
+  };
+};

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/table/useDataTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/table/useDataTable.tsx
@@ -1,0 +1,143 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import {
+  Checkbox,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+} from '@mui/material';
+import { isEmpty } from 'lodash';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import Loader from '../../Loader/Loader';
+import { TableViewConfig } from '../shared/types';
+import { useTableRow } from './useTableRow';
+
+export const useDataTable = <T extends { id: string }>(
+  config: TableViewConfig<T>
+) => {
+  const { t } = useTranslation();
+  const {
+    listing,
+    enableSelection = true,
+    entityLabelKey = 'Items',
+    customTableRow,
+  } = config;
+
+  // Check if filters or search are active
+  const hasActiveSearch = listing.urlState?.searchQuery?.trim();
+  const hasActiveFilters =
+    listing.urlState?.filters &&
+    Object.values(listing.urlState.filters).some(
+      (filterValues: unknown) =>
+        Array.isArray(filterValues) && filterValues.length > 0
+    );
+  const hasActiveFiltersOrSearch = hasActiveSearch || hasActiveFilters;
+
+  const dataTable = useMemo(
+    () => (
+      <Table data-testid="table-view-container">
+        <TableHead>
+          <TableRow>
+            {enableSelection && (
+              <TableCell padding="checkbox">
+                <Checkbox
+                  checked={listing.isAllSelected}
+                  indeterminate={listing.isIndeterminate}
+                  size="medium"
+                  onChange={(e) => {
+                    e.stopPropagation();
+                    listing.handleSelectAll(e.target.checked);
+                  }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                  }}
+                />
+              </TableCell>
+            )}
+            {listing.columns.map((column) => (
+              <TableCell key={column.key}>{t(column.labelKey)}</TableCell>
+            ))}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {listing.loading ? (
+            <TableRow>
+              <TableCell
+                align="center"
+                colSpan={listing.columns.length + (enableSelection ? 1 : 0)}>
+                <Loader />
+              </TableCell>
+            </TableRow>
+          ) : isEmpty(listing.entities) && hasActiveFiltersOrSearch ? (
+            <TableRow>
+              <TableCell
+                align="center"
+                colSpan={listing.columns.length + (enableSelection ? 1 : 0)}>
+                {t('server.no-records-found')}
+              </TableCell>
+            </TableRow>
+          ) : (
+            listing.entities.map((entity) => {
+              if (customTableRow) {
+                const CustomTableRow = customTableRow;
+
+                return (
+                  <CustomTableRow
+                    entity={entity}
+                    isSelected={listing.isSelected(entity.id)}
+                    key={entity.id}
+                    onEntityClick={
+                      listing.actionHandlers.onEntityClick || (() => {})
+                    }
+                    onSelect={listing.handleSelect}
+                  />
+                );
+              }
+
+              // Use useTableRow hook instead of EntityTableRow component
+              const TableRowHook = () => {
+                const { tableRow } = useTableRow({
+                  entity,
+                  columns: listing.columns,
+                  renderers: listing.renderers,
+                  isSelected: listing.isSelected(entity.id),
+                  onSelect: listing.handleSelect,
+                  onEntityClick:
+                    listing.actionHandlers.onEntityClick || (() => {}),
+                  enableSelection,
+                });
+
+                return tableRow;
+              };
+
+              return <TableRowHook key={entity.id} />;
+            })
+          )}
+        </TableBody>
+      </Table>
+    ),
+    [listing, enableSelection, hasActiveFiltersOrSearch, customTableRow, t]
+  );
+
+  return {
+    dataTable,
+    isEmpty: isEmpty(listing.entities),
+    hasActiveFiltersOrSearch,
+    selectedCount: listing.selectedEntities.length,
+    entityLabelKey,
+  };
+};

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/table/useTableRow.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/table/useTableRow.tsx
@@ -1,0 +1,83 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { Checkbox, TableCell, TableRow } from '@mui/material';
+import { useMemo } from 'react';
+import { CellRenderer, ColumnConfig } from '../shared/types';
+import { useCellRenderer } from './useCellRenderer';
+
+interface TableRowConfig<T> {
+  entity: T;
+  columns: ColumnConfig<T>[];
+  renderers: CellRenderer<T>;
+  isSelected: boolean;
+  onSelect: (id: string, checked: boolean) => void;
+  onEntityClick: (entity: T) => void;
+  enableSelection?: boolean;
+}
+
+/**
+ * Renders table row using shared cell renderers
+ *
+ * @description
+ * Creates table row structure using useCellRenderer for all cell content.
+ * No duplicate rendering logic - delegates all rendering to useCellRenderer
+ * for perfect consistency with card view.
+ *
+ * @stability Stable - Uses shared cell renderer
+ * @complexity Low - Just table structure + shared rendering
+ */
+export const useTableRow = <T extends { id: string; name?: string }>(
+  config: TableRowConfig<T>
+) => {
+  const { renderCell } = useCellRenderer({
+    columns: config.columns,
+    renderers: config.renderers,
+    chipSize: 'large',
+  });
+
+  const tableRow = useMemo(
+    () => (
+      <TableRow
+        hover
+        data-testid={config.entity.name}
+        sx={{ cursor: 'pointer' }}
+        onClick={() => config.onEntityClick(config.entity)}>
+        {config.enableSelection && (
+          <TableCell padding="checkbox">
+            <Checkbox
+              checked={config.isSelected}
+              onChange={(e) => {
+                e.stopPropagation();
+                config.onSelect(config.entity.id, e.target.checked);
+              }}
+              onClick={(e) => {
+                e.stopPropagation();
+              }}
+            />
+          </TableCell>
+        )}
+        {config.columns.map((column) => (
+          <TableCell key={column.key}>
+            {renderCell(config.entity, column)}
+          </TableCell>
+        ))}
+      </TableRow>
+    ),
+    [config, renderCell]
+  );
+
+  return {
+    tableRow,
+  };
+};


### PR DESCRIPTION
## Summary
- Restores `useDataTable`, `useCellRenderer`, `useCardView`, `useTableRow`, and the `customTableRow` field on `TableViewConfig` that were removed in open-metadata/OpenMetadata#26882.
- collate-ui's `PipelinePage.tsx` imports `useDataTable`, so the removal broke the Collate CI Vite build with `Rollup failed to resolve import "openmetadata-ui/src/components/common/atoms/table/useDataTable"` (run [24129385153](https://github.com/open-metadata/openmetadata-collate/actions/runs/24129385153)).
- Keeps these atoms available for downstream consumers while the migration to the new Untitled UI table primitives continues.

## Test plan
- [ ] Re-run the Collate CI workflow against this branch and confirm the Vite build succeeds.
- [ ] Verify OpenMetadata UI build (`yarn build`) still passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)