### PR TITLE
Fix: Add explicit tags.appliedAt mapping to prevent mapper_parsing_exception

### DIFF
--- a/openmetadata-spec/src/main/resources/elasticsearch/en/ai_agent_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/ai_agent_index_mapping.json
@@ -553,6 +553,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/ai_governance_policy_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/ai_governance_policy_index_mapping.json
@@ -553,6 +553,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/api_collection_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/api_collection_index_mapping.json
@@ -216,6 +216,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/api_endpoint_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/api_endpoint_index_mapping.json
@@ -685,6 +685,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/api_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/api_service_index_mapping.json
@@ -248,6 +248,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/chart_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/chart_index_mapping.json
@@ -388,6 +388,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/column_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/column_index_mapping.json
@@ -506,6 +506,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/container_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/container_index_mapping.json
@@ -789,6 +789,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/dashboard_data_model_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/dashboard_data_model_index_mapping.json
@@ -322,6 +322,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/dashboard_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/dashboard_index_mapping.json
@@ -670,6 +670,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/dashboard_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/dashboard_service_index_mapping.json
@@ -237,6 +237,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/data_products_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/data_products_index_mapping.json
@@ -293,6 +293,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/database_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/database_index_mapping.json
@@ -216,6 +216,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/database_schema_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/database_schema_index_mapping.json
@@ -529,6 +529,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/database_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/database_service_index_mapping.json
@@ -248,6 +248,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/directory_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/directory_index_mapping.json
@@ -493,6 +493,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/domain_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/domain_index_mapping.json
@@ -328,6 +328,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/drive_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/drive_service_index_mapping.json
@@ -254,6 +254,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/file_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/file_index_mapping.json
@@ -545,6 +545,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/glossary_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/glossary_index_mapping.json
@@ -350,6 +350,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/glossary_term_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/glossary_term_index_mapping.json
@@ -488,6 +488,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/ingestion_pipeline_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/ingestion_pipeline_index_mapping.json
@@ -370,6 +370,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/llm_model_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/llm_model_index_mapping.json
@@ -553,6 +553,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/llm_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/llm_service_index_mapping.json
@@ -240,6 +240,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/mcp_server_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/mcp_server_index_mapping.json
@@ -525,6 +525,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/mcp_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/mcp_service_index_mapping.json
@@ -228,6 +228,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/messaging_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/messaging_service_index_mapping.json
@@ -247,6 +247,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/metadata_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/metadata_service_index_mapping.json
@@ -292,6 +292,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/metric_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/metric_index_mapping.json
@@ -474,6 +474,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/mlmodel_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/mlmodel_index_mapping.json
@@ -666,6 +666,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/mlmodel_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/mlmodel_service_index_mapping.json
@@ -258,6 +258,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/pipeline_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/pipeline_index_mapping.json
@@ -569,6 +569,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/pipeline_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/pipeline_service_index_mapping.json
@@ -219,6 +219,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/prompt_template_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/prompt_template_index_mapping.json
@@ -553,6 +553,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/query_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/query_index_mapping.json
@@ -322,6 +322,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/search_entity_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/search_entity_index_mapping.json
@@ -530,6 +530,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/search_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/search_service_index_mapping.json
@@ -248,6 +248,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/security_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/security_service_index_mapping.json
@@ -281,6 +281,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/spreadsheet_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/spreadsheet_index_mapping.json
@@ -534,6 +534,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/storage_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/storage_service_index_mapping.json
@@ -243,6 +243,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/stored_procedure_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/stored_procedure_index_mapping.json
@@ -522,6 +522,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/table_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/table_index_mapping.json
@@ -743,6 +743,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/test_case_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/test_case_index_mapping.json
@@ -547,6 +547,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         },
         "type": "nested"

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/test_suite_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/test_suite_index_mapping.json
@@ -240,6 +240,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/topic_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/topic_index_mapping.json
@@ -548,6 +548,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/worksheet_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/worksheet_index_mapping.json
@@ -658,6 +658,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/api_collection_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/api_collection_index_mapping.json
@@ -240,6 +240,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/api_endpoint_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/api_endpoint_index_mapping.json
@@ -672,6 +672,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/api_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/api_service_index_mapping.json
@@ -243,6 +243,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/chart_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/chart_index_mapping.json
@@ -416,6 +416,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/column_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/column_index_mapping.json
@@ -511,6 +511,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/container_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/container_index_mapping.json
@@ -710,6 +710,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/dashboard_data_model_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/dashboard_data_model_index_mapping.json
@@ -425,6 +425,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/dashboard_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/dashboard_index_mapping.json
@@ -660,6 +660,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/dashboard_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/dashboard_service_index_mapping.json
@@ -241,6 +241,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/data_products_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/data_products_index_mapping.json
@@ -475,6 +475,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/database_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/database_index_mapping.json
@@ -252,6 +252,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/database_schema_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/database_schema_index_mapping.json
@@ -532,6 +532,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/database_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/database_service_index_mapping.json
@@ -243,6 +243,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/directory_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/directory_index_mapping.json
@@ -514,6 +514,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/domain_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/domain_index_mapping.json
@@ -278,6 +278,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/drive_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/drive_service_index_mapping.json
@@ -238,6 +238,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/file_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/file_index_mapping.json
@@ -529,6 +529,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/glossary_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/glossary_index_mapping.json
@@ -346,6 +346,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/glossary_term_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/glossary_term_index_mapping.json
@@ -497,6 +497,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/ingestion_pipeline_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/ingestion_pipeline_index_mapping.json
@@ -354,6 +354,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/messaging_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/messaging_service_index_mapping.json
@@ -242,6 +242,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/metadata_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/metadata_service_index_mapping.json
@@ -247,6 +247,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/metric_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/metric_index_mapping.json
@@ -470,6 +470,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/mlmodel_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/mlmodel_index_mapping.json
@@ -666,6 +666,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/mlmodel_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/mlmodel_service_index_mapping.json
@@ -253,6 +253,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/pipeline_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/pipeline_index_mapping.json
@@ -550,6 +550,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/pipeline_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/pipeline_service_index_mapping.json
@@ -204,6 +204,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/query_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/query_index_mapping.json
@@ -369,6 +369,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/search_entity_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/search_entity_index_mapping.json
@@ -428,6 +428,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/search_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/search_service_index_mapping.json
@@ -243,6 +243,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/security_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/security_service_index_mapping.json
@@ -437,6 +437,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/spreadsheet_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/spreadsheet_index_mapping.json
@@ -514,6 +514,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/storage_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/storage_service_index_mapping.json
@@ -238,6 +238,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/stored_procedure_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/stored_procedure_index_mapping.json
@@ -606,6 +606,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/table_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/table_index_mapping.json
@@ -892,6 +892,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/test_case_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/test_case_index_mapping.json
@@ -271,6 +271,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         },
         "type": "nested"

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/test_suite_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/test_suite_index_mapping.json
@@ -220,6 +220,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/topic_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/topic_index_mapping.json
@@ -649,6 +649,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/worksheet_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/worksheet_index_mapping.json
@@ -584,6 +584,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/api_collection_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/api_collection_index_mapping.json
@@ -234,6 +234,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/api_endpoint_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/api_endpoint_index_mapping.json
@@ -702,6 +702,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/api_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/api_service_index_mapping.json
@@ -266,6 +266,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/chart_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/chart_index_mapping.json
@@ -406,6 +406,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/column_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/column_index_mapping.json
@@ -525,6 +525,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/container_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/container_index_mapping.json
@@ -753,6 +753,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/dashboard_data_model_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/dashboard_data_model_index_mapping.json
@@ -339,6 +339,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/dashboard_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/dashboard_index_mapping.json
@@ -687,6 +687,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/dashboard_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/dashboard_service_index_mapping.json
@@ -255,6 +255,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/data_products_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/data_products_index_mapping.json
@@ -306,6 +306,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/database_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/database_index_mapping.json
@@ -234,6 +234,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/database_schema_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/database_schema_index_mapping.json
@@ -546,6 +546,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/database_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/database_service_index_mapping.json
@@ -266,6 +266,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/directory_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/directory_index_mapping.json
@@ -397,6 +397,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/domain_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/domain_index_mapping.json
@@ -346,6 +346,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/drive_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/drive_service_index_mapping.json
@@ -274,6 +274,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/file_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/file_index_mapping.json
@@ -452,6 +452,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/glossary_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/glossary_index_mapping.json
@@ -368,6 +368,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/glossary_term_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/glossary_term_index_mapping.json
@@ -506,6 +506,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/ingestion_pipeline_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/ingestion_pipeline_index_mapping.json
@@ -382,6 +382,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/messaging_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/messaging_service_index_mapping.json
@@ -265,6 +265,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/metadata_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/metadata_service_index_mapping.json
@@ -310,6 +310,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/metric_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/metric_index_mapping.json
@@ -444,6 +444,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/mlmodel_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/mlmodel_index_mapping.json
@@ -683,6 +683,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/mlmodel_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/mlmodel_service_index_mapping.json
@@ -276,6 +276,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/pipeline_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/pipeline_index_mapping.json
@@ -586,6 +586,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/pipeline_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/pipeline_service_index_mapping.json
@@ -237,6 +237,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/query_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/query_index_mapping.json
@@ -335,6 +335,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/search_entity_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/search_entity_index_mapping.json
@@ -552,6 +552,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/search_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/search_service_index_mapping.json
@@ -266,6 +266,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/security_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/security_service_index_mapping.json
@@ -281,6 +281,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/spreadsheet_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/spreadsheet_index_mapping.json
@@ -451,6 +451,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/storage_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/storage_service_index_mapping.json
@@ -261,6 +261,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/stored_procedure_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/stored_procedure_index_mapping.json
@@ -539,6 +539,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/table_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/table_index_mapping.json
@@ -751,6 +751,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/test_case_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/test_case_index_mapping.json
@@ -564,6 +564,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         },
         "type": "nested"

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/test_suite_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/test_suite_index_mapping.json
@@ -259,6 +259,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/topic_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/topic_index_mapping.json
@@ -565,6 +565,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/worksheet_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/worksheet_index_mapping.json
@@ -511,6 +511,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/api_collection_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/api_collection_index_mapping.json
@@ -211,6 +211,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/api_endpoint_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/api_endpoint_index_mapping.json
@@ -673,6 +673,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/api_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/api_service_index_mapping.json
@@ -233,6 +233,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/chart_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/chart_index_mapping.json
@@ -416,6 +416,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/column_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/column_index_mapping.json
@@ -503,6 +503,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/container_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/container_index_mapping.json
@@ -716,6 +716,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/dashboard_data_model_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/dashboard_data_model_index_mapping.json
@@ -425,6 +425,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/dashboard_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/dashboard_index_mapping.json
@@ -617,6 +617,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/dashboard_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/dashboard_service_index_mapping.json
@@ -229,6 +229,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/data_products_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/data_products_index_mapping.json
@@ -471,6 +471,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/database_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/database_index_mapping.json
@@ -212,6 +212,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/database_schema_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/database_schema_index_mapping.json
@@ -524,6 +524,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/database_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/database_service_index_mapping.json
@@ -243,6 +243,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/directory_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/directory_index_mapping.json
@@ -487,6 +487,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/domain_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/domain_index_mapping.json
@@ -278,6 +278,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/drive_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/drive_service_index_mapping.json
@@ -215,6 +215,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/file_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/file_index_mapping.json
@@ -502,6 +502,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/glossary_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/glossary_index_mapping.json
@@ -314,6 +314,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/glossary_term_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/glossary_term_index_mapping.json
@@ -485,6 +485,13 @@
           "state": {
             "type": "keyword",
             "normalizer": "lowercase_normalizer"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/ingestion_pipeline_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/ingestion_pipeline_index_mapping.json
@@ -361,6 +361,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/messaging_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/messaging_service_index_mapping.json
@@ -241,6 +241,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/metadata_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/metadata_service_index_mapping.json
@@ -240,6 +240,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/metric_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/metric_index_mapping.json
@@ -474,6 +474,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/mlmodel_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/mlmodel_index_mapping.json
@@ -656,6 +656,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/mlmodel_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/mlmodel_service_index_mapping.json
@@ -253,6 +253,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/pipeline_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/pipeline_index_mapping.json
@@ -553,6 +553,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/pipeline_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/pipeline_service_index_mapping.json
@@ -212,6 +212,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/query_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/query_index_mapping.json
@@ -304,6 +304,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/search_entity_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/search_entity_index_mapping.json
@@ -525,6 +525,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/search_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/search_service_index_mapping.json
@@ -233,6 +233,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/security_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/security_service_index_mapping.json
@@ -440,6 +440,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/spreadsheet_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/spreadsheet_index_mapping.json
@@ -487,6 +487,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/storage_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/storage_service_index_mapping.json
@@ -236,6 +236,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/stored_procedure_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/stored_procedure_index_mapping.json
@@ -606,6 +606,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/table_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/table_index_mapping.json
@@ -883,6 +883,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/test_case_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/test_case_index_mapping.json
@@ -180,6 +180,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         },
         "type": "nested"

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/test_suite_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/test_suite_index_mapping.json
@@ -195,6 +195,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/topic_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/topic_index_mapping.json
@@ -499,6 +499,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/worksheet_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/worksheet_index_mapping.json
@@ -559,6 +559,13 @@
           },
           "state": {
             "type": "keyword"
+          },
+          "appliedAt": {
+            "type": "date",
+            "format": "epoch_millis||strict_date_optional_time"
+          },
+          "appliedBy": {
+            "type": "keyword"
           }
         }
       },


### PR DESCRIPTION
## Summary

- Added explicit `appliedAt` (`type: date`) and `appliedBy` (`type: keyword`) field mappings to the `tags` object in all 163 ES/OpenSearch index mapping files across all 4 locales (en, jp, ru, zh)
- Prevents `mapper_parsing_exception` when `tags.appliedAt` is dynamically mapped as `long` (from epoch millis during reindex) and later receives ISO 8601 strings during real-time indexing

## Problem

`tags.appliedAt` was not defined in any index mapping. OpenSearch dynamically maps it as `long` when the first document sends it as epoch millis (during reindex from sample/migrated data). When a new entity with tags is created via API, `appliedAt` is serialized as an ISO 8601 string (`2026-04-09T01:51:10.000160Z`). OpenSearch rejects the document:

```
mapper_parsing_exception: failed to parse field [tags.appliedAt] of type [long]
Preview of field's value: '2026-04-09T01:51:10.000160Z'
```

The entity is created in the DB but **silently fails to index** in the search engine — making it invisible to all search-based UIs.

This surfaced after the 1.12.5 certification migration (`c59235fd6e`) which populates `appliedAt` in `tag_usage` for the first time, triggering the dynamic `long` mapping during reindex.

## Fix

Added to `tags.properties` in every index mapping file:
```json
"appliedAt": {
    "type": "date",
    "format": "epoch_millis||strict_date_optional_time"
},
"appliedBy": {
    "type": "keyword"
}
```

The `date` type with `epoch_millis||strict_date_optional_time` format accepts **both** epoch millis and ISO 8601 strings, eliminating the mapping conflict regardless of document insertion order.

## Test plan

- [ ] Reindex after deployment to apply new mappings
- [ ] Create an entity with tags that have `appliedAt` populated — verify it appears in search
- [ ] Run `DataQuality.spec.ts` > `TestCase filters` Playwright test — should pass
- [ ] Verify no `mapper_parsing_exception` errors in server logs for `tags.appliedAt`