### PR TITLE
fix(devcontainer): add robust error handling to post-create.sh

### DIFF
--- a/.devcontainer/dev/post-create.sh
+++ b/.devcontainer/dev/post-create.sh
@@ -54,9 +54,15 @@ fi
 
 # Install frontend dependencies
 echo "Installing frontend dependencies..."
-cd openmetadata-ui/src/main/resources/ui
-yarn install --frozen-lockfile
-cd -
+UI_DIR="openmetadata-ui/src/main/resources/ui"
+if [ -d "$UI_DIR" ]; then
+  cd "$UI_DIR"
+  yarn install --frozen-lockfile || { echo "ERROR: yarn install failed"; exit 1; }
+  cd -
+else
+  echo "ERROR: UI directory $UI_DIR not found"
+  exit 1
+fi
 
 # Set up Python virtual environment for ingestion
 echo "Setting up Python ingestion environment..."
@@ -75,16 +81,21 @@ echo "Running python version: $($PYTHON_BIN --version)"
 # (which is volume-mounted and likely contains platform-incompatible binaries).
 VENV_DIR=".venv-devcontainer"
 
-"$PYTHON_BIN" -m venv "$VENV_DIR"
+if ! "$PYTHON_BIN" -m venv "$VENV_DIR"; then
+  echo "ERROR: Failed to create virtual environment $VENV_DIR"
+  exit 1
+fi
+
 source "$VENV_DIR/bin/activate"
-python -m pip install --upgrade pip
+python -m pip install --upgrade pip || { echo "ERROR: pip upgrade failed"; exit 1; }
 
 # Run Make targets from repo root to ensure scripts/ and ingestion/ paths resolve correctly
-make install_dev generate
+echo "Running make install_dev generate..."
+make install_dev generate || { echo "ERROR: make install_dev or generate failed"; exit 1; }
 
 # Verify prerequisites
 echo "Verifying prerequisites..."
-make prerequisites
+make prerequisites || { echo "ERROR: make prerequisites failed"; exit 1; }
 
 echo "=== Development environment ready ==="
 echo ""


### PR DESCRIPTION
### Describe your changes:
Fixes N/A

I worked on `.devcontainer/dev/post-create.sh` because the previous script lacked sufficient error handling, which made it difficult to diagnose why the development environment setup was failing during the `postCreateCommand` execution. 

**Changes made:**
- Added directory existence checks for the frontend UI path before running `yarn install`.
- Added explicit error handling and exit codes for `yarn install` failures.
- Added error handling for Python `venv` creation and `pip` upgrades.
- Added error handling for `make` commands (`install_dev`, `generate`, and `prerequisites`).
- Added descriptive error messages to identify exactly which stage of the setup process fails.

**How I tested my changes:**
- Verified the script logic by reviewing the execution flow.
- Ensured that any failure in a critical step (like `yarn` or `make`) will now trigger a clear `ERROR:` message in the logs instead of failing silently or with generic shell errors.
- (Recommendation) Users should check `/tmp/post-create.log` if the command fails to see the new detailed error output.

### Type of change:
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Bug fix
- [] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->