### PR TITLE
Potential fix for code scanning alert no. 1842: Artifact poisoning

### DIFF
--- a/.github/actions/setup-openmetadata-test-environment/action.yml
+++ b/.github/actions/setup-openmetadata-test-environment/action.yml
@@ -55,7 +55,7 @@ runs:
       if: ${{ inputs.install-server == 'true' }}
       run: |
         corepack enable
-        corepack prepare yarn@stable --activate
+        corepack prepare yarn@1.22.18 --activate
         yarn --version
       shell: bash
     # ------------------------------------------------------------------------------

--- a/.github/actions/setup-openmetadata-test-environment/action.yml
+++ b/.github/actions/setup-openmetadata-test-environment/action.yml
@@ -53,10 +53,7 @@ runs:
 
     - name: Install yarn
       if: ${{ inputs.install-server == 'true' }}
-      run: |
-        corepack enable
-        corepack prepare yarn@1.22.18 --activate
-        yarn --version
+      run: corepack enable
       shell: bash
     # ------------------------------------------------------------------------------
 

--- a/.github/actions/setup-openmetadata-test-environment/action.yml
+++ b/.github/actions/setup-openmetadata-test-environment/action.yml
@@ -53,7 +53,10 @@ runs:
 
     - name: Install yarn
       if: ${{ inputs.install-server == 'true' }}
-      run: npm install -g yarn
+      run: |
+        corepack enable
+        corepack prepare yarn@stable --activate
+        yarn --version
       shell: bash
     # ------------------------------------------------------------------------------
 

--- a/.github/workflows/update-playwright-e2e-docs.yml
+++ b/.github/workflows/update-playwright-e2e-docs.yml
@@ -40,7 +40,9 @@ jobs:
           cache-dependency-path: openmetadata-ui/src/main/resources/ui/yarn.lock
 
       - name: Install Yarn
-        run: npm install -g yarn
+        run: |
+          corepack enable
+          corepack prepare yarn@1.22.18 --activate
 
       - name: Install Dependencies
         working-directory: openmetadata-ui/src/main/resources/ui

--- a/.github/workflows/update-playwright-e2e-docs.yml
+++ b/.github/workflows/update-playwright-e2e-docs.yml
@@ -40,9 +40,7 @@ jobs:
           cache-dependency-path: openmetadata-ui/src/main/resources/ui/yarn.lock
 
       - name: Install Yarn
-        run: |
-          corepack enable
-          corepack prepare yarn@1.22.18 --activate
+        run: corepack enable
 
       - name: Install Dependencies
         working-directory: openmetadata-ui/src/main/resources/ui


### PR DESCRIPTION
Potential fix for [https://github.com/open-metadata/OpenMetadata/security/code-scanning/1842](https://github.com/open-metadata/OpenMetadata/security/code-scanning/1842)

To fix this without changing intended functionality, stop installing Yarn globally with `npm install -g yarn` and instead use Corepack (bundled with modern Node) to activate a pinned Yarn version. This avoids mutable global installs and reduces exposure from tainted workspace/job state.

Best single fix:
- Edit `.github/actions/setup-openmetadata-test-environment/action.yml`.
- Replace the `Install yarn` step command from `npm install -g yarn` to:
  - `corepack enable`
  - `corepack prepare yarn@stable --activate`
  - optionally `yarn --version` for visibility.
- Keep the existing `if` condition and shell.
- No workflow logic changes are required elsewhere.

This addresses all alert variants at the same sink location.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
