### PR TITLE
ci: reduce checkout history footprint in PR workflows

### DIFF
--- a/.github/workflows/airflow-apis-tests.yml
+++ b/.github/workflows/airflow-apis-tests.yml
@@ -61,6 +61,7 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
+        filter: blob:none
 
     - name: Set up JDK 21
       uses: actions/setup-java@v4

--- a/.github/workflows/openmetadata-service-unit-tests.yml
+++ b/.github/workflows/openmetadata-service-unit-tests.yml
@@ -75,10 +75,6 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
-      - name: Fetch PR base branch
-        if: ${{ github.event_name == 'pull_request' }}
-        run: git fetch --no-tags --depth=1 origin ${{ github.event.pull_request.base.ref }}
-
       - name: Cache Maven dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/openmetadata-service-unit-tests.yml
+++ b/.github/workflows/openmetadata-service-unit-tests.yml
@@ -74,11 +74,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          fetch-depth: 0
 
       - name: Fetch PR base branch
         if: ${{ github.event_name == 'pull_request' }}
-        run: git fetch --no-tags origin ${{ github.event.pull_request.base.ref }}
+        run: git fetch --no-tags --depth=1 origin ${{ github.event.pull_request.base.ref }}
 
       - name: Cache Maven dependencies
         uses: actions/cache@v4

--- a/.github/workflows/py-operator-build-test.yml
+++ b/.github/workflows/py-operator-build-test.yml
@@ -66,7 +66,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
 
       - name: Setup Openmetadata Test Environment
         uses: ./.github/actions/setup-openmetadata-test-environment

--- a/.github/workflows/py-sonarcloud-nightly.yml
+++ b/.github/workflows/py-sonarcloud-nightly.yml
@@ -49,7 +49,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ env.BRANCH_NAME }}
-          fetch-depth: 0
 
       - name: Setup Openmetadata Test Environment
         uses: ./.github/actions/setup-openmetadata-test-environment
@@ -110,7 +109,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ env.BRANCH_NAME }}
-          fetch-depth: 0
 
       - name: Setup Openmetadata Test Environment
         uses: ./.github/actions/setup-openmetadata-test-environment
@@ -154,6 +152,7 @@ jobs:
         with:
           ref: ${{ env.BRANCH_NAME }}
           fetch-depth: 0
+          filter: blob:none
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -232,6 +232,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          filter: blob:none
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/ui-checkstyle.yml
+++ b/.github/workflows/ui-checkstyle.yml
@@ -379,8 +379,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-          filter: blob:none
 
       - uses: actions/setup-node@v4
         with:
@@ -464,8 +462,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-          filter: blob:none
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ui-checkstyle.yml
+++ b/.github/workflows/ui-checkstyle.yml
@@ -84,6 +84,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          filter: blob:none
 
       - uses: actions/setup-node@v4
         with:
@@ -194,6 +195,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          filter: blob:none
 
       - uses: actions/setup-node@v4
         with:
@@ -378,6 +380,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          filter: blob:none
 
       - uses: actions/setup-node@v4
         with:
@@ -462,6 +465,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          filter: blob:none
 
       - uses: actions/setup-node@v4
         with:
@@ -546,6 +550,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          filter: blob:none
 
       - uses: actions/setup-node@v4
         with:
@@ -654,6 +659,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          filter: blob:none
 
       - uses: actions/setup-node@v4
         with:
@@ -755,6 +761,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          filter: blob:none
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/yarn-coverage.yml
+++ b/.github/workflows/yarn-coverage.yml
@@ -48,8 +48,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          # Disabling shallow clone is recommended for improving relevancy of reporting
+          # Disabling shallow clone is recommended for improving relevancy of reporting.
+          # Use partial clone (blob:none) to avoid downloading every blob in history —
+          # commits/trees still available for Sonar blame; blobs fetched lazily as needed.
           fetch-depth: 0
+          filter: blob:none
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

Shrink `actions/checkout` clones across PR and nightly workflows. Each job now uses the smallest option that still works:

- **depth 1** (Actions default) — job doesn't walk history
- **`fetch-depth: 0 + filter: blob:none`** — job needs the commit graph (Sonar blame, `tj-actions/changed-files`) but not historical blob content; blobs are fetched lazily on demand

## Changes

| Workflow / job | Tier | Reason |
|---|---|---|
| `py-operator-build-test` | depth 1 | no Sonar, no git ops |
| `openmetadata-service-unit-tests` | depth 1 | Sonar skipped via `-Dsonar.skip=true`; removed dead `Fetch PR base branch` step |
| `ui-checkstyle` / `i18n-sync`, `app-docs` | depth 1 | only run `git status --porcelain` |
| `py-sonarcloud-nightly` / `py-unit-tests`, `py-integration-tests` | depth 1 | only upload coverage artifact |
| `airflow-apis-tests` | `blob:none` | SonarCloud blame |
| `yarn-coverage` | `blob:none` | SonarCloud blame |
| `py-tests` / `py-combine-coverage` | `blob:none` | SonarCloud blame |
| `py-sonarcloud-nightly` / `py-combine-coverage` | `blob:none` | SonarCloud blame |
| `ui-checkstyle` / `lint-src`, `license-header`, `lint-playwright`, `lint-core-components` | `blob:none` | `tj-actions/changed-files` needs base-diff |

## Out of scope

`maven-sonar-build.yml` runs Sonar via the `static-code-analysis` Maven profile with default depth 1 and no `-Dsonar.skip=true` — probably producing degraded blame silently. Fix needs *more* history, opposite direction of this PR.

## Test plan

- [ ] CI green on this PR
- [ ] Sonar reports still produce accurate blame
- [ ] `tj-actions/changed-files` jobs still detect changed files correctly