### PR TITLE
fix(test): use polling assertion for asset count check

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/domain.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/domain.ts
@@ -443,9 +443,19 @@ export const checkDomainDisplayName = async (
 };
 
 export const checkAssetsCount = async (page: Page, count: number) => {
-  await expect(page.getByTestId('assets').getByTestId('count')).toContainText(
-    count.toString()
-  );
+  await expect
+    .poll(
+      async () => {
+        const text = await page
+          .getByTestId('assets')
+          .getByTestId('count')
+          .textContent();
+
+        return text?.trim();
+      },
+      { timeout: 30_000, intervals: [500, 1_000, 2_000] }
+    )
+    .toBe(count.toString());
 };
 
 export const verifyDomainOnAssetPages = async (


### PR DESCRIPTION
## Summary
- Replace direct `toContainText` assertion with `expect.poll` in `checkAssetsCount` to handle async count updates
- Adds retry intervals (500ms, 1s, 2s) with a 30s timeout to reduce test flakiness

## Test plan
- [ ] Run domain-related Playwright tests to verify asset count assertions pass reliably

🤖 Generated with [Claude Code](https://claude.com/claude-code)