### PR TITLE
Disable Virtual Threads 

### DIFF
--- a/bin/openmetadata-server-start.sh
+++ b/bin/openmetadata-server-start.sh
@@ -105,7 +105,10 @@ fi
 if [ -z "$OPENMETADATA_JVM_PERFORMANCE_OPTS" ]; then
   export OPENMETADATA_JVM_PERFORMANCE_OPTS="\
     -server -XX:+UseG1GC \
+    -XX:+UnlockExperimentalVMOptions \
     -XX:MaxGCPauseMillis=200 \
+    -XX:G1NewSizePercent=5 \
+    -XX:G1MaxNewSizePercent=20 \
     -XX:InitiatingHeapOccupancyPercent=45 \
     -XX:+ExplicitGCInvokesConcurrent \
     -XX:+UseStringDeduplication \

--- a/bin/openmetadata.sh
+++ b/bin/openmetadata.sh
@@ -153,7 +153,7 @@ fi
 
 # JVM performance options
 if [[ -z "${CATALOG_JVM_PERF_OPTS}" ]]; then
-  CATALOG_JVM_PERF_OPTS="-server -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:+ExplicitGCInvokesConcurrent -Djava.awt.headless=true"
+  CATALOG_JVM_PERF_OPTS="-server -XX:+UseG1GC -XX:+UnlockExperimentalVMOptions -XX:MaxGCPauseMillis=200 -XX:G1NewSizePercent=5 -XX:G1MaxNewSizePercent=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:+ExplicitGCInvokesConcurrent -Djava.awt.headless=true"
 fi
 
 

--- a/conf/openmetadata.yaml
+++ b/conf/openmetadata.yaml
@@ -78,7 +78,7 @@ server:
   # Virtual Threads (Project Loom) - Recommended for Java 21+
   # Jetty 12 uses AdaptiveExecutionStrategy to route blocking tasks to virtual threads
   # while keeping non-blocking I/O on platform threads for optimal cache locality
-  enableVirtualThreads: ${SERVER_ENABLE_VIRTUAL_THREAD:-true}
+  enableVirtualThreads: ${SERVER_ENABLE_VIRTUAL_THREAD:-false}
   # Note: maxQueuedRequests removed in Dropwizard 5.0/Jetty 12
 
   # Request/Response logging (disable in production for performance)


### PR DESCRIPTION
  PostgreSQL JDBC 42.7.7 uses synchronized blocks around network I/O (sending queries, reading
   responses). With virtual threads, a thread that blocks inside synchronized gets pinned to
  its carrier thread — it cannot unmount even when waiting for I/O.

  With -XX:ActiveProcessorCount=2, there are exactly 2 ForkJoinPool carrier threads. The
  moment 2 concurrent SQL queries are executing on virtual threads, both carrier threads are
  pinned. The health probe's virtual thread becomes runnable but can't be scheduled — no
  carrier thread is free. Probe times out. Repeat indefinitely.

  Disabling virtual threads switches Jetty back to a 150-thread platform thread pool. Even if
  100 threads are blocked waiting for DB connections, 50 remain available for the health probe
   and other requests. The complete deadlock is impossible with platform threads

<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
