### PR TITLE
Fixes 26513: updated the openapi schema to return a consistent structure

### DIFF
--- a/openmetadata-spec/src/main/resources/json/schema/type/entityHistory.json
+++ b/openmetadata-spec/src/main/resources/json/schema/type/entityHistory.json
@@ -28,6 +28,7 @@
           "description": "Previous value of the field. Note that this is a JSON string and use the corresponding field type to deserialize it.",
           "anyOf": [
             { "type": "object" },
+            { "type": "array" },
             { "type": "boolean" },
             { "type": "string" },
             { "type": "number" },
@@ -38,6 +39,7 @@
           "description": "New value of the field. Note that this is a JSON string and use the corresponding field type to deserialize it.",
           "anyOf": [
             { "type": "object" },
+            { "type": "array" },
             { "type": "boolean" },
             { "type": "string" },
             { "type": "number" },

--- a/openmetadata-spec/src/main/resources/json/schema/type/entityHistory.json
+++ b/openmetadata-spec/src/main/resources/json/schema/type/entityHistory.json
@@ -24,7 +24,7 @@
           "description": "Name of the entity field that changed.",
           "$ref": "#/definitions/fieldName"
         },
-         "oldValue": {
+        "oldValue": {
           "description": "Previous value of the field. Note that this is a JSON string and use the corresponding field type to deserialize it.",
           "anyOf": [
             { "type": "object" },

--- a/openmetadata-spec/src/main/resources/json/schema/type/entityHistory.json
+++ b/openmetadata-spec/src/main/resources/json/schema/type/entityHistory.json
@@ -24,11 +24,25 @@
           "description": "Name of the entity field that changed.",
           "$ref": "#/definitions/fieldName"
         },
-        "oldValue": {
-          "description": "Previous value of the field. Note that this is a JSON string and use the corresponding field type to deserialize it."
+         "oldValue": {
+          "description": "Previous value of the field. Note that this is a JSON string and use the corresponding field type to deserialize it.",
+          "anyOf": [
+            { "type": "object" },
+            { "type": "boolean" },
+            { "type": "string" },
+            { "type": "number" },
+            { "type": "null" }
+          ]
         },
         "newValue": {
-          "description": "New value of the field. Note that this is a JSON string and use the corresponding field type to deserialize it."
+          "description": "New value of the field. Note that this is a JSON string and use the corresponding field type to deserialize it.",
+          "anyOf": [
+            { "type": "object" },
+            { "type": "boolean" },
+            { "type": "string" },
+            { "type": "number" },
+            { "type": "null" }
+          ]
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes https://github.com/open-metadata/OpenMetadata/issues/26513

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

What changes did you make?
I updated the JSON Schema for fieldChange in entityHistory.json. I replaced the untyped oldValue and newValue fields with an anyOf definition that explicitly allows string, boolean, number, object, and null types.

Why did you make them?
Currently, these fields lack type definitions, causing the Python Pydantic generator to produce models that can fail with TypeError: 'bool' object is not iterable when encountering boolean values in the version history (e.g., changes to a 'deleted' flag). This matches issues reported by users in the community using the Python SDK. By defining the types, we ensure the Pydantic parser handles primitive values directly rather than attempting to iterate over them as complex objects.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
(This is a non-breaking schema relaxation, so migration isn't required)

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
