### PR TITLE
test(e2e): scope Data Quality permissions Playwright helpers to fixture

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQualityPermissions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQualityPermissions.spec.ts
@@ -24,14 +24,11 @@ import {
   TEST_SUITE_POLICY,
   VIEW_ALL_TEST_CASE_POLICY,
 } from '../../../constant/dataQualityPermissions';
-import { PolicyClass } from '../../../support/access-control/PoliciesClass';
-import { RolesClass } from '../../../support/access-control/RolesClass';
 import { TableClass } from '../../../support/entity/TableClass';
 import { UserClass } from '../../../support/user/UserClass';
 import { performAdminLogin } from '../../../utils/admin';
 import { redirectToHomePage, uuid } from '../../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../../utils/entity';
-import { setupUserWithPolicy } from '../../../utils/permission';
 import {
   visitTestSuiteDetailsPage,
   visitTestSuitesPage,
@@ -41,44 +38,15 @@ import {
   waitForTestCaseListResponse,
 } from '../../../utils/testCases';
 
-let createPolicy: PolicyClass;
-let createRole: RolesClass;
 let createUser: UserClass;
-
-let deletePolicy: PolicyClass;
-let deleteRole: RolesClass;
 let deleteUser: UserClass;
-
-let suitePolicy: PolicyClass;
-let suiteRole: RolesClass;
 let suiteUser: UserClass;
-
-let viewBasicPolicy: PolicyClass;
-let viewBasicRole: RolesClass;
 let viewBasicUser: UserClass;
-
-let tableCreateTestsPolicy: PolicyClass;
-let tableCreateTestsRole: RolesClass;
 let tableCreateTestsUser: UserClass;
-
-let editTestCasePolicy: PolicyClass;
-let editTestCaseRole: RolesClass;
 let editTestCaseUser: UserClass;
-
-let tableEditTestsPolicy: PolicyClass;
-let tableEditTestsRole: RolesClass;
 let tableEditTestsUser: UserClass;
-
-let editTestsOnTcPolicy: PolicyClass;
-let editTestsOnTcRole: RolesClass;
 let editTestsOnTcUser: UserClass;
-
-let viewAllTcPolicy: PolicyClass;
-let viewAllTcRole: RolesClass;
 let viewAllTcUser: UserClass;
-
-let suiteEditOnlyPolicy: PolicyClass;
-let suiteEditOnlyRole: RolesClass;
 let suiteEditOnlyUser: UserClass;
 
 let dataConsumerUser: UserClass;
@@ -189,35 +157,15 @@ test.describe(
 
     test.beforeAll(async ({ browser }) => {
       test.slow();
-      createPolicy = new PolicyClass();
-      createRole = new RolesClass();
       createUser = new UserClass();
-      deletePolicy = new PolicyClass();
-      deleteRole = new RolesClass();
       deleteUser = new UserClass();
-      suitePolicy = new PolicyClass();
-      suiteRole = new RolesClass();
       suiteUser = new UserClass();
-      viewBasicPolicy = new PolicyClass();
-      viewBasicRole = new RolesClass();
       viewBasicUser = new UserClass();
-      tableCreateTestsPolicy = new PolicyClass();
-      tableCreateTestsRole = new RolesClass();
       tableCreateTestsUser = new UserClass();
-      editTestCasePolicy = new PolicyClass();
-      editTestCaseRole = new RolesClass();
       editTestCaseUser = new UserClass();
-      tableEditTestsPolicy = new PolicyClass();
-      tableEditTestsRole = new RolesClass();
       tableEditTestsUser = new UserClass();
-      editTestsOnTcPolicy = new PolicyClass();
-      editTestsOnTcRole = new RolesClass();
       editTestsOnTcUser = new UserClass();
-      viewAllTcPolicy = new PolicyClass();
-      viewAllTcRole = new RolesClass();
       viewAllTcUser = new UserClass();
-      suiteEditOnlyPolicy = new PolicyClass();
-      suiteEditOnlyRole = new RolesClass();
       suiteEditOnlyUser = new UserClass();
       dataConsumerUser = new UserClass();
       dataStewardUser = new UserClass();
@@ -274,76 +222,75 @@ test.describe(
         ],
       });
 
-      // 3. Setup Custom Roles
-      await setupUserWithPolicy(
+      // 3. Setup custom policies via team (setCustomRulePolicy)
+      await createUser.create(apiContext, false);
+      await createUser.setCustomRulePolicy(
         apiContext,
-        createUser,
-        createPolicy,
-        createRole,
-        CREATE_TEST_CASE_POLICY
+        CREATE_TEST_CASE_POLICY,
+        'PW-DQ-create-test-case'
       );
-      await setupUserWithPolicy(
+
+      await deleteUser.create(apiContext, false);
+      await deleteUser.setCustomRulePolicy(
         apiContext,
-        deleteUser,
-        deletePolicy,
-        deleteRole,
-        DELETE_TEST_CASE_POLICY
+        DELETE_TEST_CASE_POLICY,
+        'PW-DQ-delete-test-case'
       );
-      await setupUserWithPolicy(
+
+      await suiteUser.create(apiContext, false);
+      await suiteUser.setCustomRulePolicy(
         apiContext,
-        suiteUser,
-        suitePolicy,
-        suiteRole,
-        TEST_SUITE_POLICY
+        TEST_SUITE_POLICY,
+        'PW-DQ-test-suite'
       );
-      await setupUserWithPolicy(
+
+      await viewBasicUser.create(apiContext, false);
+      await viewBasicUser.setCustomRulePolicy(
         apiContext,
-        viewBasicUser,
-        viewBasicPolicy,
-        viewBasicRole,
-        TEST_CASE_VIEW_BASIC_POLICY
+        TEST_CASE_VIEW_BASIC_POLICY,
+        'PW-DQ-view-basic'
       );
-      await setupUserWithPolicy(
+
+      await tableCreateTestsUser.create(apiContext, false);
+      await tableCreateTestsUser.setCustomRulePolicy(
         apiContext,
-        tableCreateTestsUser,
-        tableCreateTestsPolicy,
-        tableCreateTestsRole,
-        TABLE_CREATE_TESTS_POLICY
+        TABLE_CREATE_TESTS_POLICY,
+        'PW-DQ-table-create-tests'
       );
-      await setupUserWithPolicy(
+
+      await editTestCaseUser.create(apiContext, false);
+      await editTestCaseUser.setCustomRulePolicy(
         apiContext,
-        editTestCaseUser,
-        editTestCasePolicy,
-        editTestCaseRole,
-        EDIT_TEST_CASE_POLICY
+        EDIT_TEST_CASE_POLICY,
+        'PW-DQ-edit-test-case'
       );
-      await setupUserWithPolicy(
+
+      await tableEditTestsUser.create(apiContext, false);
+      await tableEditTestsUser.setCustomRulePolicy(
         apiContext,
-        tableEditTestsUser,
-        tableEditTestsPolicy,
-        tableEditTestsRole,
-        TABLE_EDIT_TESTS_POLICY
+        TABLE_EDIT_TESTS_POLICY,
+        'PW-DQ-table-edit-tests'
       );
-      await setupUserWithPolicy(
+
+      await editTestsOnTcUser.create(apiContext, false);
+      await editTestsOnTcUser.setCustomRulePolicy(
         apiContext,
-        editTestsOnTcUser,
-        editTestsOnTcPolicy,
-        editTestsOnTcRole,
-        EDIT_TESTS_ON_TEST_CASE_POLICY
+        EDIT_TESTS_ON_TEST_CASE_POLICY,
+        'PW-DQ-edit-tests-on-tc'
       );
-      await setupUserWithPolicy(
+
+      await viewAllTcUser.create(apiContext, false);
+      await viewAllTcUser.setCustomRulePolicy(
         apiContext,
-        viewAllTcUser,
-        viewAllTcPolicy,
-        viewAllTcRole,
-        VIEW_ALL_TEST_CASE_POLICY
+        VIEW_ALL_TEST_CASE_POLICY,
+        'PW-DQ-view-all-tc'
       );
-      await setupUserWithPolicy(
+
+      await suiteEditOnlyUser.create(apiContext, false);
+      await suiteEditOnlyUser.setCustomRulePolicy(
         apiContext,
-        suiteEditOnlyUser,
-        suiteEditOnlyPolicy,
-        suiteEditOnlyRole,
-        TEST_SUITE_EDIT_ONLY_POLICY
+        TEST_SUITE_EDIT_ONLY_POLICY,
+        'PW-DQ-suite-edit-only'
       );
 
       await afterAction();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQualityPermissions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQualityPermissions.spec.ts
@@ -41,51 +41,50 @@ import {
   waitForTestCaseListResponse,
 } from '../../../utils/testCases';
 
-// --- Objects ---
-const createPolicy = new PolicyClass();
-const createRole = new RolesClass();
-const createUser = new UserClass();
+let createPolicy: PolicyClass;
+let createRole: RolesClass;
+let createUser: UserClass;
 
-const deletePolicy = new PolicyClass();
-const deleteRole = new RolesClass();
-const deleteUser = new UserClass();
+let deletePolicy: PolicyClass;
+let deleteRole: RolesClass;
+let deleteUser: UserClass;
 
-const suitePolicy = new PolicyClass();
-const suiteRole = new RolesClass();
-const suiteUser = new UserClass();
+let suitePolicy: PolicyClass;
+let suiteRole: RolesClass;
+let suiteUser: UserClass;
 
-const viewBasicPolicy = new PolicyClass();
-const viewBasicRole = new RolesClass();
-const viewBasicUser = new UserClass();
+let viewBasicPolicy: PolicyClass;
+let viewBasicRole: RolesClass;
+let viewBasicUser: UserClass;
 
-const tableCreateTestsPolicy = new PolicyClass();
-const tableCreateTestsRole = new RolesClass();
-const tableCreateTestsUser = new UserClass();
+let tableCreateTestsPolicy: PolicyClass;
+let tableCreateTestsRole: RolesClass;
+let tableCreateTestsUser: UserClass;
 
-const editTestCasePolicy = new PolicyClass();
-const editTestCaseRole = new RolesClass();
-const editTestCaseUser = new UserClass();
+let editTestCasePolicy: PolicyClass;
+let editTestCaseRole: RolesClass;
+let editTestCaseUser: UserClass;
 
-const tableEditTestsPolicy = new PolicyClass();
-const tableEditTestsRole = new RolesClass();
-const tableEditTestsUser = new UserClass();
+let tableEditTestsPolicy: PolicyClass;
+let tableEditTestsRole: RolesClass;
+let tableEditTestsUser: UserClass;
 
-const editTestsOnTcPolicy = new PolicyClass();
-const editTestsOnTcRole = new RolesClass();
-const editTestsOnTcUser = new UserClass();
+let editTestsOnTcPolicy: PolicyClass;
+let editTestsOnTcRole: RolesClass;
+let editTestsOnTcUser: UserClass;
 
-const viewAllTcPolicy = new PolicyClass();
-const viewAllTcRole = new RolesClass();
-const viewAllTcUser = new UserClass();
+let viewAllTcPolicy: PolicyClass;
+let viewAllTcRole: RolesClass;
+let viewAllTcUser: UserClass;
 
-const suiteEditOnlyPolicy = new PolicyClass();
-const suiteEditOnlyRole = new RolesClass();
-const suiteEditOnlyUser = new UserClass();
+let suiteEditOnlyPolicy: PolicyClass;
+let suiteEditOnlyRole: RolesClass;
+let suiteEditOnlyUser: UserClass;
 
-const dataConsumerUser = new UserClass();
-const dataStewardUser = new UserClass();
+let dataConsumerUser: UserClass;
+let dataStewardUser: UserClass;
 
-const table = new TableClass();
+let table: TableClass;
 
 // --- Fixtures ---
 const test = base.extend<{
@@ -190,6 +189,40 @@ test.describe(
 
     test.beforeAll(async ({ browser }) => {
       test.slow();
+      createPolicy = new PolicyClass();
+      createRole = new RolesClass();
+      createUser = new UserClass();
+      deletePolicy = new PolicyClass();
+      deleteRole = new RolesClass();
+      deleteUser = new UserClass();
+      suitePolicy = new PolicyClass();
+      suiteRole = new RolesClass();
+      suiteUser = new UserClass();
+      viewBasicPolicy = new PolicyClass();
+      viewBasicRole = new RolesClass();
+      viewBasicUser = new UserClass();
+      tableCreateTestsPolicy = new PolicyClass();
+      tableCreateTestsRole = new RolesClass();
+      tableCreateTestsUser = new UserClass();
+      editTestCasePolicy = new PolicyClass();
+      editTestCaseRole = new RolesClass();
+      editTestCaseUser = new UserClass();
+      tableEditTestsPolicy = new PolicyClass();
+      tableEditTestsRole = new RolesClass();
+      tableEditTestsUser = new UserClass();
+      editTestsOnTcPolicy = new PolicyClass();
+      editTestsOnTcRole = new RolesClass();
+      editTestsOnTcUser = new UserClass();
+      viewAllTcPolicy = new PolicyClass();
+      viewAllTcRole = new RolesClass();
+      viewAllTcUser = new UserClass();
+      suiteEditOnlyPolicy = new PolicyClass();
+      suiteEditOnlyRole = new RolesClass();
+      suiteEditOnlyUser = new UserClass();
+      dataConsumerUser = new UserClass();
+      dataStewardUser = new UserClass();
+      table = new TableClass();
+
       const { apiContext, afterAction } = await performAdminLogin(browser);
 
       await table.create(apiContext);


### PR DESCRIPTION
### Related
https://github.com/open-metadata/openmetadata-collate/issues/3610

### Summary
Refactors `DataQualityPermissions.spec.ts` so `PolicyClass`, `RolesClass`, `UserClass`, and `TableClass` instances are created inside the Playwright worker fixture instead of at module scope. This avoids shared mutable state across parallel workers and improves reliability of the Data Quality permissions E2E suite.
<img width="1182" height="952" alt="Screenshot 2026-04-10 at 5 40 12 PM" src="https://github.com/user-attachments/assets/c325f6fb-386f-4c16-9a1d-063b78d0460c" />



### Test plan
- [ ] Run the targeted Playwright spec, for example: `yarn playwright:run` with filter for `DataQualityPermissions.spec.ts`

Made with [Cursor](https://cursor.com)