### PR TITLE
test(e2e): remove redundant awaits in Profiler Playwright spec

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/Profiler.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/Profiler.spec.ts
@@ -82,7 +82,6 @@ const validateProfilerAccessForRole = async (
       name: 'Column Profile',
     })
     .click();
-  await listColumnApiCall;
   const listColumnResponse = await listColumnApiCall;
 
   expect(listColumnResponse.status()).toBe(200);
@@ -96,7 +95,6 @@ const validateProfilerAccessForRole = async (
     )
     .getByText(tableInstance.entity.columns[1].name)
     .click();
-  await getProfilerInfo;
   const getProfilerInfoResponse = await getProfilerInfo;
 
   expect(getProfilerInfoResponse.status()).toBe(200);


### PR DESCRIPTION
### Related
https://github.com/open-metadata/openmetadata-collate/issues/3610

### Summary
Removes duplicate `await` calls on the same API request promises in `Profiler.spec.ts` (the response is already awaited on the following line). This keeps the spec clearer and avoids redundant work.

<img width="1194" height="325" alt="Screenshot 2026-04-10 at 5 49 06 PM" src="https://github.com/user-attachments/assets/5112d1ce-d1c8-4057-9f95-40cbd01a3357" />


### Test plan
- [ ] Run the Profiler E2E spec (e.g. filter Playwright to `Profiler.spec.ts`).

Made with [Cursor](https://cursor.com)