### PR TITLE
MINOR: Handle case sensitivity for table constraints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -453,6 +453,7 @@ These checks run automatically in CI. Code that violates them **will not merge**
 - **Keep connector-specific logic in connector-specific files**, not in generic/shared files like `builders.py`
 - Example: Redshift IAM auth should be in `ingestion/src/metadata/ingestion/source/database/redshift/connection.py`, not in `ingestion/src/metadata/ingestion/connections/builders.py`
 - This keeps the codebase modular and prevents generic utilities from becoming cluttered with connector-specific edge cases
+- **Use `model_str()` for Pydantic RootModel to string conversion** — OpenMetadata schema types like `ColumnName`, `EntityName`, `FullyQualifiedEntityName`, and `UUID` are Pydantic `RootModel[str]` subclasses where `str()` returns `"root='value'"` instead of the raw value. Always use `model_str()` from `metadata.ingestion.ometa.utils` instead of manual `hasattr(x, "root")` / `str(x.root)` checks.
 
 ### Testing Philosophy
 - **Test real behavior, not mock wiring** - if a test requires mocking 3+ classes just to verify a method call, it's testing the wrong thing

--- a/ingestion/src/metadata/ingestion/source/database/common_db_source.py
+++ b/ingestion/src/metadata/ingestion/source/database/common_db_source.py
@@ -576,6 +576,9 @@ class CommonDbSourceService(
                 foreign_columns=foreign_columns,
                 columns=columns,
             )
+            table_constraints = self.normalize_table_constraints(
+                table_constraints, columns
+            )
 
             description = (
                 Markdown(db_description)

--- a/ingestion/src/metadata/ingestion/source/database/database_service.py
+++ b/ingestion/src/metadata/ingestion/source/database/database_service.py
@@ -345,6 +345,31 @@ class DatabaseServiceSource(
         if self.source_config.includeTags:
             yield from self.yield_database_tag(database_name) or []
 
+    @staticmethod
+    def normalize_table_constraints(
+        table_constraints: List[TableConstraint],
+        columns: List[Column],
+    ) -> List[TableConstraint]:
+        """
+        Normalize constraint column names to match actual column definitions.
+        Some data sources (e.g., BigQuery) may return constraint column names
+        with different casing than the column definitions, causing validation
+        failures on the backend.
+        """
+        if not table_constraints or not columns:
+            return table_constraints or []
+        column_name_map = {}
+        for col in columns:
+            col_name = col.name.root if hasattr(col.name, "root") else str(col.name)
+            if col_name:
+                column_name_map[col_name.lower()] = col_name
+        for constraint in table_constraints:
+            if constraint.columns:
+                constraint.columns = [
+                    column_name_map.get(c.lower(), c) for c in constraint.columns
+                ]
+        return table_constraints
+
     def update_table_constraints(
         self,
         table_name,

--- a/ingestion/src/metadata/ingestion/source/database/database_service.py
+++ b/ingestion/src/metadata/ingestion/source/database/database_service.py
@@ -65,6 +65,7 @@ from metadata.ingestion.models.topology import (
     TopologyContextManager,
     TopologyNode,
 )
+from metadata.ingestion.ometa.utils import model_str
 from metadata.ingestion.source.connections import test_connection_common
 from metadata.utils import fqn
 from metadata.utils.execution_time_tracker import calculate_execution_time
@@ -360,7 +361,7 @@ class DatabaseServiceSource(
             return table_constraints or []
         column_name_map = {}
         for col in columns:
-            col_name = col.name.root if hasattr(col.name, "root") else str(col.name)
+            col_name = model_str(col.name)
             if col_name:
                 column_name_map[col_name.lower()] = col_name
         for constraint in table_constraints:

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/metadata.py
@@ -424,6 +424,9 @@ class UnitycatalogSource(
             table_constraints = self.update_table_constraints(
                 primary_constraints, foreign_constraints, columns
             )
+            table_constraints = self.normalize_table_constraints(
+                table_constraints, columns
+            )
 
             schema_definition = self.get_schema_definition(
                 table_name=table_name, table_type=table_type, table=table

--- a/ingestion/tests/unit/topology/database/test_common_db_source.py
+++ b/ingestion/tests/unit/topology/database/test_common_db_source.py
@@ -22,8 +22,10 @@ from metadata.generated.schema.entity.data.table import (
     ConstraintType,
     DataType,
     Table,
+    TableConstraint,
 )
 from metadata.ingestion.source.database.common_db_source import CommonDbSourceService
+from metadata.ingestion.source.database.database_service import DatabaseServiceSource
 
 
 @pytest.fixture
@@ -213,3 +215,122 @@ class TestPrepareForeignConstraintsReferredSchema:
 
         assert result is None
         assert len(source.context.get_global.return_value.foreign_tables) == 1
+
+
+class TestNormalizeTableConstraints:
+    """Test DatabaseServiceSource.normalize_table_constraints."""
+
+    def test_case_mismatch_is_normalized(self):
+        """Constraint column names with different casing should be
+        normalized to match actual column definitions."""
+        columns = [
+            Column(name="Entity_ID", dataType=DataType.INT),
+            Column(name="Entity_Type", dataType=DataType.INT),
+        ]
+        constraints = [
+            TableConstraint(
+                constraintType=ConstraintType.CLUSTER_KEY,
+                columns=["Entity_id", "Entity_Type"],
+            )
+        ]
+        result = DatabaseServiceSource.normalize_table_constraints(constraints, columns)
+        assert result[0].columns == ["Entity_ID", "Entity_Type"]
+
+    def test_all_lowercase_constraint_columns(self):
+        """Fully lowercase constraint columns should resolve to actual casing."""
+        columns = [
+            Column(name="OrderID", dataType=DataType.INT),
+            Column(name="CustomerName", dataType=DataType.STRING),
+        ]
+        constraints = [
+            TableConstraint(
+                constraintType=ConstraintType.PRIMARY_KEY,
+                columns=["orderid", "customername"],
+            )
+        ]
+        result = DatabaseServiceSource.normalize_table_constraints(constraints, columns)
+        assert result[0].columns == ["OrderID", "CustomerName"]
+
+    def test_already_matching_columns_unchanged(self):
+        """Columns that already match should pass through unchanged."""
+        columns = [
+            Column(name="id", dataType=DataType.INT),
+            Column(name="name", dataType=DataType.STRING),
+        ]
+        constraints = [
+            TableConstraint(
+                constraintType=ConstraintType.UNIQUE,
+                columns=["id", "name"],
+            )
+        ]
+        result = DatabaseServiceSource.normalize_table_constraints(constraints, columns)
+        assert result[0].columns == ["id", "name"]
+
+    def test_unmatched_columns_preserved(self):
+        """Constraint columns not found in column definitions should be
+        kept as-is (fallback)."""
+        columns = [
+            Column(name="id", dataType=DataType.INT),
+        ]
+        constraints = [
+            TableConstraint(
+                constraintType=ConstraintType.CLUSTER_KEY,
+                columns=["id", "missing_col"],
+            )
+        ]
+        result = DatabaseServiceSource.normalize_table_constraints(constraints, columns)
+        assert result[0].columns == ["id", "missing_col"]
+
+    def test_empty_constraints_returns_empty(self):
+        """Empty or None constraints should return an empty list."""
+        columns = [Column(name="id", dataType=DataType.INT)]
+        assert DatabaseServiceSource.normalize_table_constraints([], columns) == []
+        assert DatabaseServiceSource.normalize_table_constraints(None, columns) == []
+
+    def test_empty_columns_returns_constraints_unchanged(self):
+        """Empty columns list should return constraints as-is."""
+        constraints = [
+            TableConstraint(
+                constraintType=ConstraintType.PRIMARY_KEY,
+                columns=["id"],
+            )
+        ]
+        result = DatabaseServiceSource.normalize_table_constraints(constraints, [])
+        assert result[0].columns == ["id"]
+
+    def test_multiple_constraints_normalized(self):
+        """All constraints in the list should be normalized."""
+        columns = [
+            Column(name="Entity_ID", dataType=DataType.INT),
+            Column(name="Created_At", dataType=DataType.DATETIME),
+        ]
+        constraints = [
+            TableConstraint(
+                constraintType=ConstraintType.CLUSTER_KEY,
+                columns=["entity_id"],
+            ),
+            TableConstraint(
+                constraintType=ConstraintType.PRIMARY_KEY,
+                columns=["ENTITY_ID"],
+            ),
+        ]
+        result = DatabaseServiceSource.normalize_table_constraints(constraints, columns)
+        assert result[0].columns == ["Entity_ID"]
+        assert result[1].columns == ["Entity_ID"]
+
+    def test_constraint_with_none_columns_skipped(self):
+        """Constraints with None columns field should not cause errors."""
+        columns = [Column(name="id", dataType=DataType.INT)]
+        constraints = [
+            TableConstraint(
+                constraintType=ConstraintType.CLUSTER_KEY,
+                columns=None,
+            ),
+            TableConstraint(
+                constraintType=ConstraintType.PRIMARY_KEY,
+                columns=["ID"],
+            ),
+        ]
+        result = DatabaseServiceSource.normalize_table_constraints(constraints, columns)
+        assert result[0].columns is None
+        assert result[1].columns == ["id"]


### PR DESCRIPTION
## Summary
- Added `normalize_table_constraints()` static method in `DatabaseServiceSource` base class that normalizes constraint column names to match actual column definitions using case-insensitive lookup
- Applied normalization in `CommonDbSourceService.yield_table()` (covers all SQL connectors) and `UnitycatalogSource.yield_table()`
- Fixes `Invalid column name found in table constraint` errors caused by data sources (e.g., BigQuery) returning constraint column names with different casing than column definitions

## Test plan
- [x] Added 8 unit tests in `test_common_db_source.py::TestNormalizeTableConstraints` covering:
  - Case mismatch normalization (`Entity_id` → `Entity_ID`)
  - All-lowercase constraint columns
  - Already matching columns (no-op)
  - Unmatched columns preserved as fallback
  - Empty/None constraints and columns
  - Multiple constraints normalized
  - Constraints with None columns field

🤖 Generated with [Claude Code](https://claude.com/claude-code)