### PR TITLE
fix(playwright): replace loader waits with API response awaits in right panel tab navigation

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/PageObject/Explore/CustomPropertiesPageObject.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/PageObject/Explore/CustomPropertiesPageObject.ts
@@ -52,7 +52,14 @@ export class CustomPropertiesPageObject extends RightPanelBase {
    * @returns CustomPropertiesPageObject for method chaining
    */
   async navigateToCustomPropertiesTab(): Promise<CustomPropertiesPageObject> {
+    const typeResponse = this.page.waitForResponse(
+      (resp) =>
+        resp.url().includes('/metadata/types/name/') &&
+        resp.url().includes('fields=customProperties') &&
+        resp.request().method() === 'GET'
+    );
     await this.rightPanel.navigateToTab(RIGHT_PANEL_TAB.CUSTOM_PROPERTIES);
+    await typeResponse;
     await this.waitForLoadersToDisappear();
     return this;
   }

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/PageObject/Explore/DataQualityPageObject.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/PageObject/Explore/DataQualityPageObject.ts
@@ -83,7 +83,13 @@ export class DataQualityPageObject extends RightPanelBase {
    * @returns DataQualityPageObject for method chaining
    */
   async navigateToDataQualityTab(): Promise<DataQualityPageObject> {
+    const testCasesResponse = this.page.waitForResponse(
+      (resp) =>
+        resp.url().includes('/dataQuality/testCases/search/list') &&
+        resp.request().method() === 'GET'
+    );
     await this.rightPanel.navigateToTab('data quality');
+    await testCasesResponse;
     await this.waitForLoadersToDisappear();
     return this;
   }

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/PageObject/Explore/LineagePageObject.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/PageObject/Explore/LineagePageObject.ts
@@ -76,7 +76,13 @@ export class LineagePageObject extends RightPanelBase {
    * @returns LineagePageObject for method chaining
    */
   async navigateToLineageTab(): Promise<LineagePageObject> {
+    const lineageResponse = this.page.waitForResponse(
+      (resp) =>
+        resp.url().includes('/lineage/getLineage') &&
+        resp.request().method() === 'GET'
+    );
     await this.rightPanel.navigateToTab('lineage');
+    await lineageResponse;
     await this.waitForLoadersToDisappear();
     return this;
   }

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/PageObject/Explore/RightPanelPageObject.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/PageObject/Explore/RightPanelPageObject.ts
@@ -13,6 +13,7 @@
 
 import { expect, Locator, Page } from '@playwright/test';
 import { EntityClass } from '../../../support/entity/EntityClass';
+import { waitForAllLoadersToDisappear } from '../../../utils/entity';
 import { CustomPropertiesPageObject } from './CustomPropertiesPageObject';
 import { DataQualityPageObject } from './DataQualityPageObject';
 import { LineagePageObject } from './LineagePageObject';
@@ -935,7 +936,7 @@ export class RightPanelPageObject {
     await expect(this.panelLoaders).toHaveCount(0, { timeout });
 
     // Step 3: Wait for any remaining loaders on the page (fallback)
-    await this.pageLoader.waitFor({ state: 'hidden', timeout });
+    await this.waitForLoadersToDisappear(timeout);
 
     // Step 4: Ensure panel is still visible and stable
     await this.getSummaryPanel().waitFor({ state: 'visible' });
@@ -1021,8 +1022,8 @@ export class RightPanelPageObject {
   /**
    * Wait for all loaders to disappear
    */
-  async waitForLoadersToDisappear() {
-    await this.pageLoader.waitFor({ state: 'hidden' });
+  async waitForLoadersToDisappear(timeout?: number) {
+    await waitForAllLoadersToDisappear(this.page, 'loader', timeout);
   }
 
   /**

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/PageObject/Explore/RightPanelPageObject.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/PageObject/Explore/RightPanelPageObject.ts
@@ -935,7 +935,7 @@ export class RightPanelPageObject {
     await expect(this.panelLoaders).toHaveCount(0, { timeout });
 
     // Step 3: Wait for any remaining loaders on the page (fallback)
-    await this.pageLoader.waitFor({ state: 'detached', timeout });
+    await this.pageLoader.waitFor({ state: 'hidden', timeout });
 
     // Step 4: Ensure panel is still visible and stable
     await this.getSummaryPanel().waitFor({ state: 'visible' });
@@ -1022,7 +1022,7 @@ export class RightPanelPageObject {
    * Wait for all loaders to disappear
    */
   async waitForLoadersToDisappear() {
-    await this.pageLoader.waitFor({ state: 'detached' });
+    await this.pageLoader.waitFor({ state: 'hidden' });
   }
 
   /**


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

## Why

Tab navigation in the Explore right panel was flaky because tests relied on `waitFor({ state: 'detached' })` on `[data-testid="loader"]` after clicking a tab.
This is unreliable in two ways:

1. If the API response arrives before the `waitFor` executes, the loader has already been removed — `detached` can behave unexpectedly depending on whether the element was ever in the DOM.
2. `detached` requires the element to be completely absent from the DOM; if it is present but hidden (via CSS), the wait times out.

## What

- **`CustomPropertiesPageObject`** — awaits `GET /metadata/types/name/*?fields=customProperties` before asserting, guaranteeing the entity type definition (with custom property definitions) has loaded.
- **`LineagePageObject`** — awaits `GET /lineage/getLineage*` before asserting.
- **`DataQualityPageObject`** — awaits `GET /dataQuality/testCases/search/list*` before asserting.
- **`RightPanelPageObject`** — changes both `waitForLoadersToDisappear` and `waitForPanelLoaded` from `{ state: 'detached' }` → `{ state: 'hidden' }`, which resolves correctly whether or not the loader element is in the DOM.


<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->


<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
