### PR TITLE
test(e2e): Logs viewer empty state and bundle pipeline streamable logs

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/LogsViewer.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/LogsViewer.spec.ts
@@ -57,7 +57,6 @@ test.describe(
     test('Logs page shows breadcrumb, summary, and log viewer or empty state after opening from bundle suite pipeline tab', async ({
       page,
     }) => {
-      test.slow();
       // 6 minutes
       test.setTimeout(6 * 60 * 1000);
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/LogsViewer.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/LogsViewer.spec.ts
@@ -24,8 +24,8 @@ import { waitForAllLoadersToDisappear } from '../../utils/entity';
 import { waitForFirstPipelineStatusNotQueued } from '../../utils/logsViewer';
 import { test } from '../fixtures/pages';
 
-const table = new TableClass();
-const bundleTestSuite = new BundleTestSuiteClass();
+let table: TableClass;
+let bundleTestSuite: BundleTestSuiteClass;
 
 test.describe(
   'Logs viewer page',
@@ -39,6 +39,9 @@ test.describe(
     test.beforeAll(
       'Create table, bundle test suite, pipeline, and run pipeline for logs viewer',
       async ({ browser }) => {
+        table = new TableClass();
+        bundleTestSuite = new BundleTestSuiteClass();
+
         const { apiContext, afterAction } = await performAdminLogin(browser);
 
         await table.create(apiContext);
@@ -55,6 +58,7 @@ test.describe(
       page,
     }) => {
       test.slow();
+      // 6 minutes
       test.setTimeout(6 * 60 * 1000);
 
       await test.step('Open Data Quality → Bundle Suites and click on the newly created bundle', async () => {
@@ -127,7 +131,14 @@ test.describe(
         expect(hasLogContent || hasNoLogsEmptyState).toBeTruthy();
       });
 
-      await test.step('Verify action buttons work when log content is present', async () => {
+      await test.step('Verify action buttons when logs exist, or skip if empty state', async () => {
+        const noLogsAvailable = page.getByText(/No logs are available/i);
+
+        // If no logs are available, skip the test
+        if (await noLogsAvailable.isVisible()) {
+          return;
+        }
+
         const jumpToEnd = page.getByTestId('jump-to-end-button');
         const downloadBtn = page.getByTestId('download');
         const copyToClipboardBtn = page.getByTestId('copy-secret');

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/BundleTestSuiteClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/BundleTestSuiteClass.ts
@@ -49,6 +49,7 @@ export class BundleTestSuiteClass {
           },
           name: `pw-bundle-suite-pipeline-${uuid()}`,
           loggerLevel: 'INFO',
+          enableStreamableLogs: true,
           pipelineType: 'TestSuite',
           service: {
             id: testSuiteData.id,


### PR DESCRIPTION
### Related
https://github.com/open-metadata/openmetadata-collate/issues/3610

### Summary
- **Logs viewer Playwright spec**: In the final step, if the UI shows **No logs are available**, skip assertions on jump-to-end, download, and copy-to-clipboard (those controls are not rendered in the empty state). Otherwise assert the action buttons as before.
- **Bundle test suite pipeline helper**: Set **`enableStreamableLogs: true`** on the TestSuite ingestion pipeline created for logs viewer E2E so log streaming can be exercised when the server is configured for it.

### Test plan
- [ ] `yarn playwright:run` (or targeted run) for `playwright/e2e/Pages/LogsViewer.spec.ts`

Made with [Cursor](https://cursor.com)