### PR TITLE
Fix: Resolve search export limit by adding stable tiebreaker sort for  pagination

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
@@ -2593,6 +2593,10 @@ public class SearchRepository {
       if (batch.getLastHitSortValues() != null) {
         searchAfter = Arrays.asList(batch.getLastHitSortValues());
       } else {
+        LOG.warn(
+            "Export pagination ended early: lastHitSortValues is null after exporting {} of {} rows. "
+                + "This likely means the sort field '{}' did not produce sort values.",
+            exported, totalHits, sortField);
         break;
       }
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
@@ -2596,7 +2596,9 @@ public class SearchRepository {
         LOG.warn(
             "Export pagination ended early: lastHitSortValues is null after exporting {} of {} rows. "
                 + "This likely means the sort field '{}' did not produce sort values.",
-            exported, totalHits, sortField);
+            exported,
+            totalHits,
+            sortField);
         break;
       }
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSearchManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSearchManager.java
@@ -975,7 +975,7 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
       String clusterAlias)
       throws IOException {
     ElasticSearchRequestBuilder requestBuilder =
-        buildSearchRequestBuilder(request, subjectContext, searchSettings, clusterAlias);
+        buildSearchRequestBuilder(request, subjectContext, searchSettings, clusterAlias, false);
 
     LOG.debug("Executing search on index: {}, query: {}", request.getIndex(), request.getQuery());
 
@@ -1017,7 +1017,7 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
     SearchSettings searchSettings =
         SettingsCache.getSetting(SettingsType.SEARCH_SETTINGS, SearchSettings.class);
     ElasticSearchRequestBuilder requestBuilder =
-        buildSearchRequestBuilder(request, subjectContext, searchSettings, clusterAlias);
+        buildSearchRequestBuilder(request, subjectContext, searchSettings, clusterAlias, true);
 
     try {
       SearchRequest searchRequest = requestBuilder.build(request.getIndex());
@@ -1060,7 +1060,8 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
       org.openmetadata.schema.search.SearchRequest request,
       SubjectContext subjectContext,
       SearchSettings searchSettings,
-      String clusterAlias)
+      String clusterAlias,
+      boolean isExport)
       throws IOException {
     if (!isClientAvailable) {
       throw new IOException("Elasticsearch client is not available");
@@ -1204,6 +1205,11 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
       if (sortField.equalsIgnoreCase("_score")) {
         requestBuilder.sort("name.keyword", SortOrder.Asc, "keyword");
       }
+    }
+
+    // Add tiebreaker sort for stable search_after pagination in export
+    if (isExport) {
+      requestBuilder.sort("_id", SortOrder.Asc, null);
     }
 
     // Build hierarchy query if needed

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSearchManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSearchManager.java
@@ -1016,7 +1016,7 @@ public class OpenSearchSearchManager implements SearchManagementClient {
       String clusterAlias)
       throws IOException {
     OpenSearchRequestBuilder requestBuilder =
-        buildSearchRequestBuilder(request, subjectContext, searchSettings, clusterAlias);
+        buildSearchRequestBuilder(request, subjectContext, searchSettings, clusterAlias, false);
 
     LOG.debug("Executing search on index: {}, query: {}", request.getIndex(), request.getQuery());
 
@@ -1053,7 +1053,7 @@ public class OpenSearchSearchManager implements SearchManagementClient {
     SearchSettings searchSettings =
         SettingsCache.getSetting(SettingsType.SEARCH_SETTINGS, SearchSettings.class);
     OpenSearchRequestBuilder requestBuilder =
-        buildSearchRequestBuilder(request, subjectContext, searchSettings, clusterAlias);
+        buildSearchRequestBuilder(request, subjectContext, searchSettings, clusterAlias, true);
 
     try {
       SearchRequest searchRequest = requestBuilder.build(request.getIndex());
@@ -1096,7 +1096,8 @@ public class OpenSearchSearchManager implements SearchManagementClient {
       org.openmetadata.schema.search.SearchRequest request,
       SubjectContext subjectContext,
       SearchSettings searchSettings,
-      String clusterAlias)
+      String clusterAlias,
+      boolean isExport)
       throws IOException {
     if (!isClientAvailable) {
       throw new IOException("OpenSearch client is not available");
@@ -1243,6 +1244,11 @@ public class OpenSearchSearchManager implements SearchManagementClient {
       if (sortField.equalsIgnoreCase("_score")) {
         requestBuilder.sort("name.keyword", SortOrder.Asc, "keyword");
       }
+    }
+
+    // Add tiebreaker sort for stable search_after pagination in export
+    if (isExport) {
+      requestBuilder.sort("_id", SortOrder.Asc, null);
     }
 
     // Build hierarchy query if needed

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryTest.java
@@ -342,7 +342,7 @@ class SearchRepositoryTest {
     // wait, we can't test private methods easily in Java unless we use reflection.
     // However, we can call exportSearchResults() which is public, but that's in SearchResource.
     // Wait, streamSearchResults is public!
-    doCallRealMethod().when(realSearchRepository).streamSearchResults(any(), any(), anyInt(), anyInt(), any());
+    doCallRealMethod().when(realSearchRepository).exportSearchResultsCsvStream(any(), any(), anyInt(), anyInt(), any());
     // writeCsvBatches is private, but it's called by streamSearchResults
     when(realSearchRepository.getSearchClient()).thenReturn(elasticSearchClient);
     
@@ -356,9 +356,9 @@ class SearchRepositoryTest {
     when(elasticSearchClient.searchForExport(any(), any())).thenReturn(batchMapper);
 
     java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
-    org.openmetadata.schema.system.ui.SubjectContext context = new org.openmetadata.schema.system.ui.SubjectContext();
+    org.openmetadata.service.security.policyevaluator.SubjectContext context = mock(org.openmetadata.service.security.policyevaluator.SubjectContext.class);
     
-    realSearchRepository.streamSearchResults(baseRequest, context, 10, 0, out);
+    realSearchRepository.exportSearchResultsCsvStream(baseRequest, context, 10, 0, out);
     
     String csv = out.toString();
     // Header should be present, plus 1 line of data
@@ -371,7 +371,7 @@ class SearchRepositoryTest {
   void testWriteCsvBatchesNormalPagination() throws Exception {
     SearchRepository realSearchRepository = mock(SearchRepository.class);
     when(realSearchRepository.getSearchClient()).thenReturn(elasticSearchClient);
-    doCallRealMethod().when(realSearchRepository).streamSearchResults(any(), any(), anyInt(), anyInt(), any());
+    doCallRealMethod().when(realSearchRepository).exportSearchResultsCsvStream(any(), any(), anyInt(), anyInt(), any());
 
     org.openmetadata.schema.search.SearchRequest baseRequest =
         new org.openmetadata.schema.search.SearchRequest().withIndex("table_search_index");
@@ -395,9 +395,9 @@ class SearchRepositoryTest {
         .thenReturn(batch2Mapper);
 
     java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
-    org.openmetadata.schema.system.ui.SubjectContext context = new org.openmetadata.schema.system.ui.SubjectContext();
+    org.openmetadata.service.security.policyevaluator.SubjectContext context = mock(org.openmetadata.service.security.policyevaluator.SubjectContext.class);
 
-    realSearchRepository.streamSearchResults(baseRequest, context, 1500, 0, out);
+    realSearchRepository.exportSearchResultsCsvStream(baseRequest, context, 1500, 0, out);
 
     String csv = out.toString();
     // Header (1) + Batch 1 (1000) + Batch 2 (500) = 1501 lines

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryTest.java
@@ -335,6 +335,76 @@ class SearchRepositoryTest {
     verify(mockBulkSink).close();
   }
 
+  @Test
+  void testWriteCsvBatchesPaginationBreak() throws Exception {
+    SearchRepository realSearchRepository = mock(SearchRepository.class);
+    // Needed to stub the protected/private calls if any, but writeCsvBatches is private.
+    // wait, we can't test private methods easily in Java unless we use reflection.
+    // However, we can call exportSearchResults() which is public, but that's in SearchResource.
+    // Wait, streamSearchResults is public!
+    doCallRealMethod().when(realSearchRepository).streamSearchResults(any(), any(), anyInt(), anyInt(), any());
+    // writeCsvBatches is private, but it's called by streamSearchResults
+    when(realSearchRepository.getSearchClient()).thenReturn(elasticSearchClient);
+    
+    org.openmetadata.schema.search.SearchRequest baseRequest =
+        new org.openmetadata.schema.search.SearchRequest().withIndex("table_search_index");
+
+    // First batch returns 1 result but no sort values --> this should cause an early break
+    List<Map<String, Object>> batchResults = List.of(Map.of("id", "123", "name", "table1", "entityType", "table"));
+    SearchResultListMapper batchMapper = new SearchResultListMapper(batchResults, 10, null);
+
+    when(elasticSearchClient.searchForExport(any(), any())).thenReturn(batchMapper);
+
+    java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+    org.openmetadata.schema.system.ui.SubjectContext context = new org.openmetadata.schema.system.ui.SubjectContext();
+    
+    realSearchRepository.streamSearchResults(baseRequest, context, 10, 0, out);
+    
+    String csv = out.toString();
+    // Header should be present, plus 1 line of data
+    assertEquals(2, csv.split("\n").length);
+    // verify searchForExport was only called once because sort values were null
+    verify(elasticSearchClient, times(1)).searchForExport(any(), any());
+  }
+
+  @Test
+  void testWriteCsvBatchesNormalPagination() throws Exception {
+    SearchRepository realSearchRepository = mock(SearchRepository.class);
+    when(realSearchRepository.getSearchClient()).thenReturn(elasticSearchClient);
+    doCallRealMethod().when(realSearchRepository).streamSearchResults(any(), any(), anyInt(), anyInt(), any());
+
+    org.openmetadata.schema.search.SearchRequest baseRequest =
+        new org.openmetadata.schema.search.SearchRequest().withIndex("table_search_index");
+
+    // First batch returns sort values
+    List<Map<String, Object>> batch1Results = new ArrayList<>();
+    for (int i = 0; i < SearchResultCsvExporter.BATCH_SIZE; i++) {
+        batch1Results.add(Map.of("id", "id" + i, "name", "table" + i, "entityType", "table"));
+    }
+    SearchResultListMapper batch1Mapper = new SearchResultListMapper(batch1Results, 1500, new Object[]{"sort1"});
+
+    // Second batch returns the rest
+    List<Map<String, Object>> batch2Results = new ArrayList<>();
+    for (int i = 0; i < 500; i++) {
+        batch2Results.add(Map.of("id", "id_b2_" + i, "name", "table_b2_" + i, "entityType", "table"));
+    }
+    SearchResultListMapper batch2Mapper = new SearchResultListMapper(batch2Results, 1500, null);
+
+    when(elasticSearchClient.searchForExport(any(), any()))
+        .thenReturn(batch1Mapper)
+        .thenReturn(batch2Mapper);
+
+    java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+    org.openmetadata.schema.system.ui.SubjectContext context = new org.openmetadata.schema.system.ui.SubjectContext();
+
+    realSearchRepository.streamSearchResults(baseRequest, context, 1500, 0, out);
+
+    String csv = out.toString();
+    // Header (1) + Batch 1 (1000) + Batch 2 (500) = 1501 lines
+    assertEquals(1501, csv.split("\n").length);
+    verify(elasticSearchClient, times(2)).searchForExport(any(), any());
+  }
+
   /** Mock entity that allows setting a specific entity type for testing */
   static class MockEntityWithType implements EntityInterface {
     private final UUID id = UUID.randomUUID();

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryTest.java
@@ -72,7 +72,7 @@ class SearchRepositoryTest {
     lenient().when(mockOsNewClient._transport()).thenReturn(mockOsTransport);
     lenient().when(openSearchClient.getNewClient()).thenReturn(mockOsNewClient);
     lenient().when(openSearchClient.isClientAvailable()).thenReturn(true);
-    
+
     // IMPORTANT: Mock the searchForExport method
     lenient()
         .when(elasticSearchClient.searchForExport(any(), any()))
@@ -343,11 +343,11 @@ class SearchRepositoryTest {
   @Test
   void testWriteCsvBatchesPaginationBreak() throws Exception {
     SearchRepository realSearchRepository = mock(SearchRepository.class);
-    
+
     doCallRealMethod()
         .when(realSearchRepository)
         .exportSearchResultsCsvStream(any(), any(), anyInt(), anyInt(), any());
-    
+
     when(realSearchRepository.getSearchClient()).thenReturn(elasticSearchClient);
 
     org.openmetadata.schema.search.SearchRequest baseRequest =
@@ -375,7 +375,7 @@ class SearchRepositoryTest {
   void testWriteCsvBatchesNormalPagination() throws Exception {
     SearchRepository realSearchRepository = mock(SearchRepository.class);
     when(realSearchRepository.getSearchClient()).thenReturn(elasticSearchClient);
-    
+
     doCallRealMethod()
         .when(realSearchRepository)
         .exportSearchResultsCsvStream(any(), any(), anyInt(), anyInt(), any());

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryTest.java
@@ -72,6 +72,11 @@ class SearchRepositoryTest {
     lenient().when(mockOsNewClient._transport()).thenReturn(mockOsTransport);
     lenient().when(openSearchClient.getNewClient()).thenReturn(mockOsNewClient);
     lenient().when(openSearchClient.isClientAvailable()).thenReturn(true);
+    
+    // IMPORTANT: Mock the searchForExport method
+    lenient()
+        .when(elasticSearchClient.searchForExport(any(), any()))
+        .thenReturn(null); // Will be overridden in individual tests
 
     // Enable calling real methods for the methods we want to test
     lenient().when(searchRepository.createBulkSink(10, 2, 1000000L)).thenCallRealMethod();
@@ -338,24 +343,21 @@ class SearchRepositoryTest {
   @Test
   void testWriteCsvBatchesPaginationBreak() throws Exception {
     SearchRepository realSearchRepository = mock(SearchRepository.class);
-    // Needed to stub the protected/private calls if any, but writeCsvBatches is private.
-    // wait, we can't test private methods easily in Java unless we use reflection.
-    // However, we can call exportSearchResults() which is public, but that's in SearchResource.
-    // Wait, streamSearchResults is public!
+    
     doCallRealMethod()
         .when(realSearchRepository)
         .exportSearchResultsCsvStream(any(), any(), anyInt(), anyInt(), any());
-    // writeCsvBatches is private, but it's called by streamSearchResults
+    
     when(realSearchRepository.getSearchClient()).thenReturn(elasticSearchClient);
 
     org.openmetadata.schema.search.SearchRequest baseRequest =
         new org.openmetadata.schema.search.SearchRequest().withIndex("table_search_index");
 
-    // First batch returns 1 result but no sort values --> this should cause an early break
     List<Map<String, Object>> batchResults =
         List.of(Map.of("id", "123", "name", "table1", "entityType", "table"));
     SearchResultListMapper batchMapper = new SearchResultListMapper(batchResults, 10, null);
 
+    // Ensure searchForExport is properly mocked
     when(elasticSearchClient.searchForExport(any(), any())).thenReturn(batchMapper);
 
     java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
@@ -365,9 +367,7 @@ class SearchRepositoryTest {
     realSearchRepository.exportSearchResultsCsvStream(baseRequest, context, 10, 0, out);
 
     String csv = out.toString();
-    // Header should be present, plus 1 line of data
     assertEquals(2, csv.split("\n").length);
-    // verify searchForExport was only called once because sort values were null
     verify(elasticSearchClient, times(1)).searchForExport(any(), any());
   }
 
@@ -375,6 +375,7 @@ class SearchRepositoryTest {
   void testWriteCsvBatchesNormalPagination() throws Exception {
     SearchRepository realSearchRepository = mock(SearchRepository.class);
     when(realSearchRepository.getSearchClient()).thenReturn(elasticSearchClient);
+    
     doCallRealMethod()
         .when(realSearchRepository)
         .exportSearchResultsCsvStream(any(), any(), anyInt(), anyInt(), any());
@@ -382,7 +383,6 @@ class SearchRepositoryTest {
     org.openmetadata.schema.search.SearchRequest baseRequest =
         new org.openmetadata.schema.search.SearchRequest().withIndex("table_search_index");
 
-    // First batch returns sort values
     List<Map<String, Object>> batch1Results = new ArrayList<>();
     for (int i = 0; i < SearchResultCsvExporter.BATCH_SIZE; i++) {
       batch1Results.add(Map.of("id", "id" + i, "name", "table" + i, "entityType", "table"));
@@ -390,13 +390,13 @@ class SearchRepositoryTest {
     SearchResultListMapper batch1Mapper =
         new SearchResultListMapper(batch1Results, 1500, new Object[] {"sort1"});
 
-    // Second batch returns the rest
     List<Map<String, Object>> batch2Results = new ArrayList<>();
     for (int i = 0; i < 500; i++) {
       batch2Results.add(Map.of("id", "id_b2_" + i, "name", "table_b2_" + i, "entityType", "table"));
     }
     SearchResultListMapper batch2Mapper = new SearchResultListMapper(batch2Results, 1500, null);
 
+    // Ensure the mock returns the mappers in sequence
     when(elasticSearchClient.searchForExport(any(), any()))
         .thenReturn(batch1Mapper)
         .thenReturn(batch2Mapper);
@@ -408,7 +408,6 @@ class SearchRepositoryTest {
     realSearchRepository.exportSearchResultsCsvStream(baseRequest, context, 1500, 0, out);
 
     String csv = out.toString();
-    // Header (1) + Batch 1 (1000) + Batch 2 (500) = 1501 lines
     assertEquals(1501, csv.split("\n").length);
     verify(elasticSearchClient, times(2)).searchForExport(any(), any());
   }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryTest.java
@@ -342,24 +342,28 @@ class SearchRepositoryTest {
     // wait, we can't test private methods easily in Java unless we use reflection.
     // However, we can call exportSearchResults() which is public, but that's in SearchResource.
     // Wait, streamSearchResults is public!
-    doCallRealMethod().when(realSearchRepository).exportSearchResultsCsvStream(any(), any(), anyInt(), anyInt(), any());
+    doCallRealMethod()
+        .when(realSearchRepository)
+        .exportSearchResultsCsvStream(any(), any(), anyInt(), anyInt(), any());
     // writeCsvBatches is private, but it's called by streamSearchResults
     when(realSearchRepository.getSearchClient()).thenReturn(elasticSearchClient);
-    
+
     org.openmetadata.schema.search.SearchRequest baseRequest =
         new org.openmetadata.schema.search.SearchRequest().withIndex("table_search_index");
 
     // First batch returns 1 result but no sort values --> this should cause an early break
-    List<Map<String, Object>> batchResults = List.of(Map.of("id", "123", "name", "table1", "entityType", "table"));
+    List<Map<String, Object>> batchResults =
+        List.of(Map.of("id", "123", "name", "table1", "entityType", "table"));
     SearchResultListMapper batchMapper = new SearchResultListMapper(batchResults, 10, null);
 
     when(elasticSearchClient.searchForExport(any(), any())).thenReturn(batchMapper);
 
     java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
-    org.openmetadata.service.security.policyevaluator.SubjectContext context = mock(org.openmetadata.service.security.policyevaluator.SubjectContext.class);
-    
+    org.openmetadata.service.security.policyevaluator.SubjectContext context =
+        mock(org.openmetadata.service.security.policyevaluator.SubjectContext.class);
+
     realSearchRepository.exportSearchResultsCsvStream(baseRequest, context, 10, 0, out);
-    
+
     String csv = out.toString();
     // Header should be present, plus 1 line of data
     assertEquals(2, csv.split("\n").length);
@@ -371,7 +375,9 @@ class SearchRepositoryTest {
   void testWriteCsvBatchesNormalPagination() throws Exception {
     SearchRepository realSearchRepository = mock(SearchRepository.class);
     when(realSearchRepository.getSearchClient()).thenReturn(elasticSearchClient);
-    doCallRealMethod().when(realSearchRepository).exportSearchResultsCsvStream(any(), any(), anyInt(), anyInt(), any());
+    doCallRealMethod()
+        .when(realSearchRepository)
+        .exportSearchResultsCsvStream(any(), any(), anyInt(), anyInt(), any());
 
     org.openmetadata.schema.search.SearchRequest baseRequest =
         new org.openmetadata.schema.search.SearchRequest().withIndex("table_search_index");
@@ -379,14 +385,15 @@ class SearchRepositoryTest {
     // First batch returns sort values
     List<Map<String, Object>> batch1Results = new ArrayList<>();
     for (int i = 0; i < SearchResultCsvExporter.BATCH_SIZE; i++) {
-        batch1Results.add(Map.of("id", "id" + i, "name", "table" + i, "entityType", "table"));
+      batch1Results.add(Map.of("id", "id" + i, "name", "table" + i, "entityType", "table"));
     }
-    SearchResultListMapper batch1Mapper = new SearchResultListMapper(batch1Results, 1500, new Object[]{"sort1"});
+    SearchResultListMapper batch1Mapper =
+        new SearchResultListMapper(batch1Results, 1500, new Object[] {"sort1"});
 
     // Second batch returns the rest
     List<Map<String, Object>> batch2Results = new ArrayList<>();
     for (int i = 0; i < 500; i++) {
-        batch2Results.add(Map.of("id", "id_b2_" + i, "name", "table_b2_" + i, "entityType", "table"));
+      batch2Results.add(Map.of("id", "id_b2_" + i, "name", "table_b2_" + i, "entityType", "table"));
     }
     SearchResultListMapper batch2Mapper = new SearchResultListMapper(batch2Results, 1500, null);
 
@@ -395,7 +402,8 @@ class SearchRepositoryTest {
         .thenReturn(batch2Mapper);
 
     java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
-    org.openmetadata.service.security.policyevaluator.SubjectContext context = mock(org.openmetadata.service.security.policyevaluator.SubjectContext.class);
+    org.openmetadata.service.security.policyevaluator.SubjectContext context =
+        mock(org.openmetadata.service.security.policyevaluator.SubjectContext.class);
 
     realSearchRepository.exportSearchResultsCsvStream(baseRequest, context, 1500, 0, out);
 


### PR DESCRIPTION

<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:


<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

## Description
This PR fixes a bug where CSV exports from the "Explore" page are unexpectedly truncated to exactly 1,000 rows. The root cause was that `search_after` pagination requires a stable sort order. Because the export batch builder didn't inject a unique tiebreaker, Elasticsearch/OpenSearch stopped producing sort values after the first batch, prematurely breaking the pagination loop.

## Changes Made
- **ElasticSearchSearchManager & OpenSearchSearchManager:** Modified `buildSearchRequestBuilder` to accept an `isExport` flag. When true, it automatically appends an `_id` tiebreaker sort to ensure all results have unique and stable sort identifiers. 
- **SearchRepository:** Added a `LOG.warn` when `lastHitSortValues` is null to provide better observability if pagination terminates unexpectedly.
- **SearchRepositoryTest:** Added test cases (`testWriteCsvBatchesNormalPagination` and `testWriteCsvBatchesPaginationBreak`) to verify pagination stream logic and early exit bounds.

## Validation Strategy
- Deployed locally and exported a result set of > 1,000 entities via the "All Matching Assets" option to verify the CSV successfully contains the complete dataset.
- Evaluated unit tests in `SearchRepositoryTest` via `mvn test`.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
