### PR TITLE
MINOR: Remove unrelated cross db not supported log message from common lineage source

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/lineage_source.py
+++ b/ingestion/src/metadata/ingestion/source/database/lineage_source.py
@@ -525,9 +525,7 @@ class LineageSource(QueryParserSource, ABC):
         """
         By default cross database lineage is not supported.
         """
-        logger.info(
-            f"Processing Cross Database Lineage not supported for {str(self.service_connection.type.value)}"
-        )
+        pass
 
     def _iter(
         self, *_, **__

--- a/ingestion/src/metadata/ingestion/source/database/lineage_source.py
+++ b/ingestion/src/metadata/ingestion/source/database/lineage_source.py
@@ -525,7 +525,6 @@ class LineageSource(QueryParserSource, ABC):
         """
         By default cross database lineage is not supported.
         """
-        pass
 
     def _iter(
         self, *_, **__


### PR DESCRIPTION
### Describe your changes:

This PR aims to remove `"Processing Cross Database Lineage not supported for {str(self.service_connection.type.value)}"` message from the common lineage source since this is not relevant for all the connectors.

This should address queries like https://github.com/open-metadata/OpenMetadata/issues/23716

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
