### PR TITLE
MINOR: Address review comments from #27236

### DIFF
--- a/ingestion/src/metadata/ingestion/source/dashboard/looker/utils.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/looker/utils.py
@@ -14,7 +14,6 @@ Utilities for Looker service
 """
 
 import os
-import re
 import shutil
 from typing import Optional, Union
 
@@ -32,7 +31,7 @@ from metadata.generated.schema.security.credentials.githubCredentials import (
 from metadata.generated.schema.security.credentials.gitlabCredentials import (
     GitlabCredentials,
 )
-from metadata.utils.logger import ingestion_logger
+from metadata.utils.logger import ingestion_logger, sanitize_url_credentials
 
 logger = ingestion_logger()
 
@@ -102,5 +101,5 @@ def _clone_repo(
 
         logger.info(f"repo {repo_name} cloned to {path}")
     except Exception as exc:
-        sanitized_msg = re.sub(r"https://[^@]+@", "https://****@", str(exc))
-        logger.error(f"GitHubCloneReader::_clone: ERROR {sanitized_msg}")
+        sanitized_msg = sanitize_url_credentials(str(exc))
+        logger.error(f"_clone_repo: ERROR {sanitized_msg}")

--- a/ingestion/src/metadata/utils/fqn.py
+++ b/ingestion/src/metadata/utils/fqn.py
@@ -699,8 +699,9 @@ def split_table_name(table_name: str) -> Dict[str, Optional[str]]:
     # Revisit: Check the antlr grammer for issue when string has double quotes
     # Issue Link: https://github.com/open-metadata/OpenMetadata/issues/8874
     details: List[str] = split(table_name.replace('"', ""))
-    # Pad None to the left until size of list is 3
-    # If more than 3 parts, take only the last 3 (database, schema, table)
+    # Handles table names with 4+ parts (e.g., BigQuery INFORMATION_SCHEMA:
+    # `project-name.region-name.INFORMATION_SCHEMA.table_name`) by taking only
+    # the last 3 segments (database, schema, table). Pads with None if fewer than 3.
     full_details: List[Optional[str]] = ([None] * max(0, 3 - len(details))) + details[
         -3:
     ]

--- a/ingestion/src/metadata/utils/logger.py
+++ b/ingestion/src/metadata/utils/logger.py
@@ -13,6 +13,7 @@ Module centralising logger configs
 """
 
 import logging
+import re
 from copy import deepcopy
 from enum import Enum
 from functools import singledispatch
@@ -352,6 +353,11 @@ class StatusWarningHandler(logging.Handler):
             )
         except Exception:  # pylint: disable=broad-except
             self.handleError(record)
+
+
+def sanitize_url_credentials(message: str) -> str:
+    """Mask credentials embedded in URLs (e.g., https://token@host)"""
+    return re.sub(r"https://[^@]+@", "https://****@", message)
 
 
 def redacted_config(config: Dict[str, Union[str, dict]]) -> Dict[str, Union[str, dict]]:

--- a/ingestion/tests/unit/utils/test_logger.py
+++ b/ingestion/tests/unit/utils/test_logger.py
@@ -1,4 +1,4 @@
-from metadata.utils.logger import redacted_config
+from metadata.utils.logger import redacted_config, sanitize_url_credentials
 
 
 def test_safe_config_logger():
@@ -29,3 +29,23 @@ def test_safe_config_logger():
         },
     }
     assert result == expected
+
+
+def test_sanitize_url_credentials():
+    assert (
+        sanitize_url_credentials("https://my_secret_pat@dev.azure.com/org/repo")
+        == "https://****@dev.azure.com/org/repo"
+    )
+    assert (
+        sanitize_url_credentials(
+            "https://x-oauth-basic:token123@github.com/owner/repo.git"
+        )
+        == "https://****@github.com/owner/repo.git"
+    )
+    assert (
+        sanitize_url_credentials(
+            "https://x-token-auth:secret@gitlab.com/owner/repo.git"
+        )
+        == "https://****@gitlab.com/owner/repo.git"
+    )
+    assert sanitize_url_credentials("no url here") == "no url here"


### PR DESCRIPTION
## Summary
- Extracted inline URL credential sanitization to a generic `sanitize_url_credentials()` utility in `logger.py` (alongside existing `redacted_config`)
- Fixed misleading log prefix `GitHubCloneReader::_clone` → `_clone_repo` since the function is shared across GitHub/GitLab/Bitbucket/Azure DevOps
- Added BigQuery INFORMATION_SCHEMA edge case explanation to `split_table_name` comment in `fqn.py`
- Added unit tests for `sanitize_url_credentials`

## Test plan
- [x] Verify `test_sanitize_url_credentials` passes (PAT, oauth-basic, token-auth, and no-URL cases)
- [x] Verify existing `test_clone_repo_error_does_not_leak_credentials` and `test_clone_repo_error_sanitizes_all_credential_formats` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)