### PR TITLE
playwright: Fix flaky Online Users Playwright E2E tests

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OnlineUsers.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OnlineUsers.spec.ts
@@ -44,7 +44,9 @@ test.describe('Online Users Feature', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
   test('Should show online users under Settings > Members > Online Users for admins', async ({
     page,
   }) => {
+    const onlineUsersRes = page.waitForResponse('/api/v1/users/online?*');
     await settingClick(page, GlobalSettingOptions.ONLINE_USERS);
+    await onlineUsersRes;
 
     await waitForAllLoadersToDisappear(page);
 
@@ -71,18 +73,11 @@ test.describe('Online Users Feature', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
     ).toBeVisible();
 
     // Check for time filter dropdown (labeled as "Time window:")
-    const timeWindowText = page.getByText('Time window:');
-
-    await expect(timeWindowText).toBeVisible();
-
-    // The dropdown component should be visible (it's an Ant Design Select, not a native select)
-    const timeFilterDropdown = page
-      .locator('.ant-select')
-      .filter({ hasText: /Last \d+ hours/ });
-
-    await expect(timeFilterDropdown).toBeVisible();
+    await expect(page.getByText('Time window:')).toBeVisible();
 
     // Current selection should show "Last 24 hours" by default
+    const timeFilterDropdown = page.getByTestId('time-window-select');
+
     await expect(timeFilterDropdown).toContainText('Last 24 hours');
   });
 
@@ -119,8 +114,13 @@ test.describe('Online Users Feature', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
   });
 
   test('Should not show bots in online users list', async ({ page }) => {
+    const onlineUsersRes = page.waitForResponse('/api/v1/users/online?*');
     await settingClick(page, GlobalSettingOptions.ONLINE_USERS);
+    await onlineUsersRes;
+
     await waitForAllLoadersToDisappear(page);
+
+    await expect(page.getByTestId('online-users-table')).toBeVisible();
 
     // Verify bot users are not shown (ingestion-bot should not be visible)
     const tableRows = page.locator('tbody tr');
@@ -135,14 +135,13 @@ test.describe('Online Users Feature', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
   });
 
   test('Should filter users by time window', async ({ page }) => {
+    const onlineUsersRes = page.waitForResponse('/api/v1/users/online?*');
     await settingClick(page, GlobalSettingOptions.ONLINE_USERS);
+    await onlineUsersRes;
 
     await waitForAllLoadersToDisappear(page);
 
-    // Find the time filter dropdown by looking for the one that contains "Last"
-    const timeFilterDropdown = page
-      .getByTestId('time-window-select')
-      .filter({ hasText: /Last \d+ hours|Last hour|Last \d+ days|All time/ });
+    const timeFilterDropdown = page.getByTestId('time-window-select');
 
     // Verify default filter is "Last 24 hours"
     await expect(timeFilterDropdown).toContainText('Last 24 hours');
@@ -150,32 +149,41 @@ test.describe('Online Users Feature', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
     // Click on the time filter dropdown
     await timeFilterDropdown.click();
 
-    // Verify dropdown options are visible
-    const dropdownOptions = page.locator('.ant-select-dropdown:visible');
+    // Wait for dropdown to fully render
+    await page.locator('.ant-select-dropdown:visible').waitFor({
+      state: 'visible',
+    });
 
-    await expect(dropdownOptions.getByText('Last 5 minutes')).toBeVisible();
-    await expect(dropdownOptions.getByText('Last hour')).toBeVisible();
-    await expect(dropdownOptions.getByText('Last 24 hours')).toBeVisible();
+    await expect(
+      page.locator('.ant-select-dropdown:visible [title="Last 5 minutes"]')
+    ).toBeVisible();
+    await expect(
+      page.locator('.ant-select-dropdown:visible [title="Last hour"]')
+    ).toBeVisible();
+    await expect(
+      page.locator('.ant-select-dropdown:visible [title="Last 24 hours"]')
+    ).toBeVisible();
 
     const onlineRes = page.waitForResponse(
       '/api/v1/users/online?timeWindow=60&*'
     );
 
     // Select a different time window
-    await dropdownOptions.getByText('Last hour').click();
+    await page
+      .locator('.ant-select-dropdown:visible [title="Last hour"]')
+      .click();
     await onlineRes;
 
     // Verify the filter has changed
     await expect(timeFilterDropdown).toContainText('Last hour');
 
     // The table should exist (with or without data)
-    await expect(page.locator('.ant-table')).toBeVisible();
+    await expect(page.getByTestId('online-users-table')).toBeVisible();
   });
 
   test('Non-admin users should not see Online Users page', async ({
     dataConsumerPage,
   }) => {
-    // Use the existing dataConsumer auth
     await redirectToHomePage(dataConsumerPage);
     await sidebarClick(dataConsumerPage, SidebarItem.SETTINGS);
 
@@ -184,11 +192,13 @@ test.describe('Online Users Feature', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
 
     await expect(
       dataConsumerPage.getByTestId('members.online-users')
-    ).not.toBeVisible();
+    ).toBeHidden();
   });
 
   test('Should show correct last activity format', async ({ page }) => {
+    const onlineUsersRes = page.waitForResponse('/api/v1/users/online?*');
     await settingClick(page, GlobalSettingOptions.ONLINE_USERS);
+    await onlineUsersRes;
 
     await waitForAllLoadersToDisappear(page);
     // Check various time formats in the Last Activity column
@@ -238,7 +248,7 @@ test.describe('Online Users Feature', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
 
       // Search for the user to ensure it is visible in the list
       const searchResponse = page.waitForResponse(
-        '/api/v1/search/query?q=*&index=*&from=0&size=*'
+        '/api/v1/search/query?q=*&index=user&from=0&size=*'
       );
       await page.getByTestId('searchbar').fill(displayName);
       await searchResponse;


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

## Summary
- Add `waitForResponse('/api/v1/users/online?*')` before asserting on table content across 4 tests that were missing API response waits, causing race conditions where assertions ran before data loaded
- Replace fragile selectors (`.ant-select`, `.ant-table`, `.ant-select-dropdown:visible` with `getByText`) with stable alternatives (`data-testid`, scoped `[title="..."]` within dropdown portal)
- Narrow overly broad `waitForResponse` pattern from `index=*` to `index=user` in the displayName test to prevent premature resolution from unrelated search API calls

## Changes
1. **Missing API waits**: Tests for admin page view, bots exclusion, time window filter, and activity format now wait for the `/api/v1/users/online` response before asserting
2. **Dropdown selectors**: Use `.ant-select-dropdown:visible [title="..."]` to avoid strict mode violations where both the selected value display and dropdown option share the same `title` attribute
3. **Search response pattern**: `index=*` → `index=user` to match only the user-specific search triggered by the searchbar
4. **Minor cleanup**: Use `data-testid` for table/dropdown references, `toBeHidden()` for non-admin visibility check

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->


https://github.com/user-attachments/assets/1dae7ae8-7d34-4c61-9dce-840b011b45b8


<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
