### PR TITLE
test(e2e): instantiate tables in beforeAll (BundleSuiteBulkOperations)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/BundleSuiteBulkOperations.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/BundleSuiteBulkOperations.spec.ts
@@ -30,13 +30,15 @@ import { test } from '../../fixtures/pages';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });
 
-const table1 = new TableClass();
-const table2 = new TableClass();
+let table1: TableClass;
+let table2: TableClass;
 const bundleTestSuite = new BundleTestSuiteClass();
 let bundleSuiteName: string;
 let existingBundleSuiteName: string;
 
 test.beforeAll(async ({ browser }) => {
+  table1 = new TableClass();
+  table2 = new TableClass();
   const { apiContext, afterAction } = await createNewPage(browser);
 
   await table1.create(apiContext);


### PR DESCRIPTION
### Related
https://github.com/open-metadata/openmetadata-collate/issues/3610

### Summary
Moves `TableClass` construction from module scope into `test.beforeAll` in `BundleSuiteBulkOperations.spec.ts`, using `let` + assignment so table fixtures are created in the same lifecycle as the API context used for setup.

### Test plan
- [ ] `yarn eslint` on `BundleSuiteBulkOperations.spec.ts`
- [ ] Targeted Playwright run for `BundleSuiteBulkOperations.spec.ts` if available

Made with [Cursor](https://cursor.com)