### PR TITLE
fix(playwright): Fix flaky Teams spec 

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Teams.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Teams.spec.ts
@@ -30,6 +30,7 @@ import { TableClass } from '../../support/entity/TableClass';
 import { TeamClass } from '../../support/team/TeamClass';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';
+import { getDefaultAdminAPIContext } from '../../utils/common';
 import {
   descriptionBox,
   descriptionBoxReadOnly,
@@ -138,6 +139,14 @@ test.describe('Teams Page', () => {
   test.beforeAll('Setup pre-requests', async ({ browser }) => {
     const { apiContext, afterAction } = await performAdminLogin(browser);
     await user.create(apiContext);
+    await afterAction();
+  });
+
+  test.afterAll('Cleanup', async ({ browser }) => {
+    const { apiContext, afterAction } = await getDefaultAdminAPIContext(
+      browser
+    );
+    await user.delete(apiContext);
     await afterAction();
   });
 
@@ -881,6 +890,20 @@ test.describe('Teams Page with EditUser Permission', () => {
     await afterAction();
   });
 
+  test.afterAll('Cleanup', async ({ browser }) => {
+    const { apiContext, afterAction } = await getDefaultAdminAPIContext(
+      browser
+    );
+    await user.delete(apiContext);
+    await user2.delete(apiContext);
+    await team2.delete(apiContext);
+    await team.delete(apiContext);
+    await role.delete(apiContext);
+    await policy.delete(apiContext);
+    await editOnlyUser.delete(apiContext);
+    await afterAction();
+  });
+
   test.beforeEach('Visit Home Page', async ({ editOnlyUserPage }) => {
     await redirectToHomePage(editOnlyUserPage);
     await team2.visitTeamPage(editOnlyUserPage);
@@ -1028,6 +1051,19 @@ test.describe('Teams Page with Data Consumer User', () => {
 
     await expect(dataConsumerPage.getByTestId('add-policy')).not.toBeVisible();
   });
+
+  test.afterAll('Cleanup', async ({ browser }) => {
+    const { apiContext, afterAction } = await getDefaultAdminAPIContext(
+      browser
+    );
+    await user.delete(apiContext);
+    await team2.delete(apiContext);
+    await team.delete(apiContext);
+    await role.delete(apiContext);
+    await policy.delete(apiContext);
+    await dataConsumerUser.delete(apiContext);
+    await afterAction();
+  });
 });
 
 test.describe('Teams Page action as Owner of Team', () => {
@@ -1167,5 +1203,23 @@ test.describe('Teams Page action as Owner of Team', () => {
       user,
       userName,
     });
+  });
+
+  test.afterAll('Cleanup', async ({ browser }) => {
+    const { apiContext, afterAction } = await getDefaultAdminAPIContext(
+      browser
+    );
+    await user.delete(apiContext);
+    await dataProduct.delete(apiContext);
+    await domain.delete(apiContext);
+    await teamNoOwner.delete(apiContext);
+    await team4.delete(apiContext);
+    await team3.delete(apiContext);
+    await team2.delete(apiContext);
+    await team.delete(apiContext);
+    await role.delete(apiContext);
+    await policy.delete(apiContext);
+    await ownerUser.delete(apiContext);
+    await afterAction();
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Teams.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Teams.spec.ts
@@ -30,11 +30,11 @@ import { TableClass } from '../../support/entity/TableClass';
 import { TeamClass } from '../../support/team/TeamClass';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';
-import { getDefaultAdminAPIContext } from '../../utils/common';
 import {
   descriptionBox,
   descriptionBoxReadOnly,
   getApiContext,
+  getDefaultAdminAPIContext,
   redirectToHomePage,
   toastNotification,
   uuid,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Teams.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Teams.spec.ts
@@ -99,6 +99,7 @@ const test = base.extend<{
   editOnlyUserPage: Page;
   dataConsumerPage: Page;
   ownerUserPage: Page;
+  scopedUserPage: Page;
 }>({
   editOnlyUserPage: async ({ browser }, use) => {
     const page = await browser.newPage();
@@ -118,6 +119,12 @@ const test = base.extend<{
     await use(page);
     await page.close();
   },
+  scopedUserPage: async ({ browser }, use) => {
+    const page = await browser.newPage();
+    await user.login(page);
+    await use(page);
+    await page.close();
+  },
   page: async ({ browser }, use) => {
     const { page, afterAction } = await performAdminLogin(browser);
     await use(page);
@@ -134,12 +141,6 @@ test.describe('Teams Page', () => {
     await afterAction();
   });
 
-  test.afterAll('Cleanup', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-    await user.delete(apiContext);
-    await afterAction();
-  });
-
   test.beforeEach('Visit Home Page', async ({ page }) => {
     await redirectToHomePage(page);
     const fetchOrganizationResponse = page.waitForResponse(
@@ -149,7 +150,7 @@ test.describe('Teams Page', () => {
     await fetchOrganizationResponse;
   });
 
-  test('Teams Page Flow', async ({ page }) => {
+  test('Teams Page Flow', async ({ page, scopedUserPage }) => {
     await test.step('Create a new team', async () => {
       await checkTeamTabCount(page);
 
@@ -157,7 +158,7 @@ test.describe('Teams Page', () => {
 
       await page.getByTestId('add-team').click();
 
-      const newTeamData = await createTeam(page);
+      const newTeamData = await createTeam(page, true);
 
       teamDetails = {
         ...teamDetails,
@@ -225,16 +226,28 @@ test.describe('Teams Page', () => {
     });
 
     await test.step('Join team should work properly', async () => {
-      await page.locator('[data-testid="users"]').click();
+      const teamPageResponse = scopedUserPage.waitForResponse(
+        (response) =>
+          response.url().includes('/api/v1/teams/name/') &&
+          response.request().method() === 'GET'
+      );
+      await scopedUserPage.goto(
+        `/settings/members/teams/${encodeURIComponent(teamDetails.name ?? '')}`,
+        { waitUntil: 'domcontentloaded' }
+      );
+      await teamPageResponse;
 
-      // Click on join teams button
-      await page.locator('[data-testid="join-teams"]').click();
+      // join-teams is in the page header actions, not inside the users tab
+      await expect(
+        scopedUserPage.locator('[data-testid="join-teams"]')
+      ).toBeVisible();
+      await scopedUserPage.locator('[data-testid="join-teams"]').click();
 
-      await toastNotification(page, 'Team joined successfully!');
+      await toastNotification(scopedUserPage, 'Team joined successfully!');
 
       // Verify leave team button exists
       await expect(
-        page.locator('[data-testid="leave-team-button"]')
+        scopedUserPage.locator('[data-testid="leave-team-button"]')
       ).toBeVisible();
     });
 
@@ -302,24 +315,34 @@ test.describe('Teams Page', () => {
     });
 
     await test.step('Leave team flow should work properly', async () => {
-      await expect(page.locator('[data-testid="team-heading"]')).toContainText(
-        teamDetails?.updatedName ?? ''
+      await scopedUserPage.goto(
+        `/settings/members/teams/${encodeURIComponent(teamDetails.name ?? '')}`,
+        { waitUntil: 'domcontentloaded' }
       );
+      await waitForAllLoadersToDisappear(scopedUserPage);
 
-      // Click on Leave team
-      await page.locator('[data-testid="leave-team-button"]').click();
+      await expect(
+        scopedUserPage.locator('[data-testid="team-heading"]')
+      ).toContainText(teamDetails?.updatedName ?? '');
 
-      const leaveTeamResponse = page.waitForResponse(
+      const leaveTeamResponse = scopedUserPage.waitForResponse(
         (response) =>
           response.url().includes('/api/v1/users/') &&
           response.request().method() === 'PATCH'
       );
+      // Click on Leave team
+      await scopedUserPage.locator('[data-testid="leave-team-button"]').click();
       // Click on confirm button
-      await page.locator('.ant-modal-footer').getByText('Confirm').click();
+      await scopedUserPage
+        .locator('.ant-modal-footer')
+        .getByText('Confirm')
+        .click();
       await leaveTeamResponse;
 
       // Verify that the "Join Teams" button is now visible
-      await expect(page.locator('[data-testid="join-teams"]')).toBeVisible();
+      await expect(
+        scopedUserPage.locator('[data-testid="join-teams"]')
+      ).toBeVisible();
     });
 
     await test.step('Soft Delete Team', async () => {
@@ -863,18 +886,6 @@ test.describe('Teams Page with EditUser Permission', () => {
     await team2.visitTeamPage(editOnlyUserPage);
   });
 
-  test.afterAll('Cleanup', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-    await user.delete(apiContext);
-    await user2.delete(apiContext);
-    await team2.delete(apiContext);
-    await team.delete(apiContext);
-    await role.delete(apiContext);
-    await policy.delete(apiContext);
-    await editOnlyUser.delete(apiContext);
-    await afterAction();
-  });
-
   test('Add and Remove User for Team', async ({ editOnlyUserPage }) => {
     await test.step('Add user in Team from the placeholder', async () => {
       await addUserInTeam(editOnlyUserPage, user);
@@ -1017,17 +1028,6 @@ test.describe('Teams Page with Data Consumer User', () => {
 
     await expect(dataConsumerPage.getByTestId('add-policy')).not.toBeVisible();
   });
-
-  test.afterAll('Cleanup', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-    await user.delete(apiContext);
-    await team2.delete(apiContext);
-    await team.delete(apiContext);
-    await role.delete(apiContext);
-    await policy.delete(apiContext);
-    await dataConsumerUser.delete(apiContext);
-    await afterAction();
-  });
 });
 
 test.describe('Teams Page action as Owner of Team', () => {
@@ -1167,21 +1167,5 @@ test.describe('Teams Page action as Owner of Team', () => {
       user,
       userName,
     });
-  });
-
-  test.afterAll('Cleanup', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-    await user.delete(apiContext);
-    await dataProduct.delete(apiContext);
-    await domain.delete(apiContext);
-    await teamNoOwner.delete(apiContext);
-    await team4.delete(apiContext);
-    await team3.delete(apiContext);
-    await team2.delete(apiContext);
-    await team.delete(apiContext);
-    await role.delete(apiContext);
-    await policy.delete(apiContext);
-    await ownerUser.delete(apiContext);
-    await afterAction();
   });
 });


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

## Why

Two independent flakiness issues in `Teams.spec.ts` when run in parallel:

1. **Join/Leave team PATCH clobber** — the "Join team" and "Leave team" steps both used the shared admin page, PATCHing `/api/v1/users/{adminId}`. Because the admin user is shared across all parallel workers, concurrent PATCH requests (read-modify-write) clobbered each other: one worker's leave was undone by another worker's stale read, so `[data-testid="join-teams"]` never appeared after leaving.

## What

- **Add `scopedUserPage` fixture** — logs in as the scoped `user` (UUID-unique per worker) instead of the shared admin, so join/leave PATCHes target a unique user record per worker with no clobber risk.
- **Create team as joinable** — `createTeam(page, true)` sets `isJoinable: true` so the scoped non-admin user sees the `join-teams` button.
- **Join step**: use `scopedUserPage` with a `waitForResponse` on the teams API instead of `waitForAllLoadersToDisappear`, and remove the spurious `[data-testid="users"]` tab click that was hiding the header join button.
- **Leave step**: use `scopedUserPage` with `waitForResponse` registered before the click (correct race-free pattern).

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->
<img width="1032" height="296" alt="Screenshot 2026-04-11 at 2 15 31 PM" src="https://github.com/user-attachments/assets/38d1495a-fb38-4b2f-848f-043c5ae3f74c" />

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
