### PR TITLE
feat(hive): Add partition key detection via DESCRIBE FORMATTED #26712

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/hive/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/metadata.py
@@ -135,7 +135,6 @@ class HiveSource(CommonDbSourceService):
         self._connection_map = {}  # Lazy init as well
         self._inspector_map = {}
 
-
     def get_table_partition_details(
         self,
         table_name: str,
@@ -213,7 +212,6 @@ class HiveSource(CommonDbSourceService):
                 for key in partition_keys
             ]
         )
-
 
     def get_schema_definition(  # pylint: disable=unused-argument
         self, table_type: str, table_name: str, schema_name: str, inspector: Inspector

--- a/ingestion/src/metadata/ingestion/source/database/hive/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/metadata.py
@@ -151,6 +151,7 @@ class HiveSource(CommonDbSourceService):
         is replaced with a MySQL/Postgres metastore engine that cannot
         execute HiveQL DESCRIBE FORMATTED statements.
         """
+        # pylint: disable=unused-argument
         # When metastore connection is configured, self.engine is a
         # MySQL/Postgres engine — DESCRIBE FORMATTED will fail against it.
         # Skip partition detection in this case.
@@ -167,11 +168,13 @@ class HiveSource(CommonDbSourceService):
         in_partition_section = False
 
         try:
+            dialect = getattr(self.engine, "dialect", None)
+            preparer = dialect.identifier_preparer
+            quoted_schema = preparer.quote(schema_name)
+            quoted_table = preparer.quote(table_name)
             with self.engine.connect() as conn:
                 rows = conn.execute(
-                    text(
-                        f"DESCRIBE FORMATTED `{schema_name}`.`{table_name}`"
-                    )
+                    text(f"DESCRIBE FORMATTED {quoted_schema}.{quoted_table}")
                 )
                 for row in rows:
                     col_name = row[0].strip() if row[0] else ""

--- a/ingestion/src/metadata/ingestion/source/database/hive/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/metadata.py
@@ -13,7 +13,7 @@ Hive source methods.
 """
 
 import traceback
-from typing import List, Optional, Tuple, Union  # noqa: UP035
+from typing import Optional, Tuple, Union  # noqa: UP035
 
 from pydantic import ValidationError
 from pyhive.sqlalchemy_hive import HiveDialect
@@ -140,7 +140,7 @@ class HiveSource(CommonDbSourceService):
         table_name: str,
         schema_name: str,
         inspector: Inspector,
-    ) -> Tuple[bool, Optional[TablePartition]]:
+    ) -> tuple[bool, TablePartition | None]:
         """
         Extract partition key columns from DESCRIBE FORMATTED output.
         Returns (True, TablePartition) if partition keys are found,
@@ -163,7 +163,7 @@ class HiveSource(CommonDbSourceService):
             )
             return False, None
 
-        partition_keys: List[str] = []
+        partition_keys: list[str] = []
         in_partition_section = False
 
         try:
@@ -172,9 +172,7 @@ class HiveSource(CommonDbSourceService):
             quoted_schema = preparer.quote(schema_name)
             quoted_table = preparer.quote(table_name)
             with self.engine.connect() as conn:
-                rows = conn.execute(
-                    text(f"DESCRIBE FORMATTED {quoted_schema}.{quoted_table}")
-                )
+                rows = conn.execute(text(f"DESCRIBE FORMATTED {quoted_schema}.{quoted_table}"))
                 for row in rows:
                     col_name = row[0].strip() if row[0] else ""
                     if col_name == "# Partition Information":
@@ -193,10 +191,7 @@ class HiveSource(CommonDbSourceService):
                         partition_keys.append(col_name)
         except Exception as exc:
             logger.debug(traceback.format_exc())
-            logger.warning(
-                f"Failed to get partition details for"
-                f" {schema_name}.{table_name}: {exc}"
-            )
+            logger.warning(f"Failed to get partition details for {schema_name}.{table_name}: {exc}")
             return False, None
 
         if not partition_keys:

--- a/ingestion/src/metadata/ingestion/source/database/hive/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/metadata.py
@@ -168,6 +168,9 @@ class HiveSource(CommonDbSourceService):
 
         try:
             dialect = getattr(self.engine, "dialect", None)
+            if dialect is None:
+                logger.debug(f"Engine has no dialect; skipping partition detection for {schema_name}.{table_name}")
+                return False, None
             preparer = dialect.identifier_preparer
             quoted_schema = preparer.quote(schema_name)
             quoted_table = preparer.quote(table_name)

--- a/ingestion/src/metadata/ingestion/source/database/hive/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/metadata.py
@@ -13,14 +13,19 @@ Hive source methods.
 """
 
 import traceback
-from typing import Optional, Tuple, Union  # noqa: UP035
+from typing import List, Optional, Tuple, Union  # noqa: UP035
 
 from pydantic import ValidationError
 from pyhive.sqlalchemy_hive import HiveDialect
 from sqlalchemy import text
 from sqlalchemy.engine.reflection import Inspector
 
-from metadata.generated.schema.entity.data.table import TableType
+from metadata.generated.schema.entity.data.table import (
+    PartitionColumnDetails,
+    PartitionIntervalTypes,
+    TablePartition,
+    TableType,
+)
 from metadata.generated.schema.entity.services.connections.database.hiveConnection import (
     HiveConnection,
 )
@@ -129,6 +134,83 @@ class HiveSource(CommonDbSourceService):
             self.engine = get_metastore_connection(metastore_conn)
         self._connection_map = {}  # Lazy init as well
         self._inspector_map = {}
+
+
+    def get_table_partition_details(
+        self,
+        table_name: str,
+        schema_name: str,
+        inspector: Inspector,
+    ) -> Tuple[bool, Optional[TablePartition]]:
+        """
+        Extract partition key columns from DESCRIBE FORMATTED output.
+        Returns (True, TablePartition) if partition keys are found,
+        otherwise (False, None).
+
+        Skipped when metastoreConnection is configured because self.engine
+        is replaced with a MySQL/Postgres metastore engine that cannot
+        execute HiveQL DESCRIBE FORMATTED statements.
+        """
+        # When metastore connection is configured, self.engine is a
+        # MySQL/Postgres engine — DESCRIBE FORMATTED will fail against it.
+        # Skip partition detection in this case.
+        metastore_conn = self._get_validated_metastore_connection()
+        if metastore_conn:
+            logger.debug(
+                "Skipping partition key detection for"
+                f" {schema_name}.{table_name}: metastoreConnection"
+                " replaces HiveServer2 engine."
+            )
+            return False, None
+
+        partition_keys: List[str] = []
+        in_partition_section = False
+
+        try:
+            with self.engine.connect() as conn:
+                rows = conn.execute(
+                    text(
+                        f"DESCRIBE FORMATTED `{schema_name}`.`{table_name}`"
+                    )
+                )
+                for row in rows:
+                    col_name = row[0].strip() if row[0] else ""
+                    if col_name == "# Partition Information":
+                        in_partition_section = True
+                        continue
+                    if in_partition_section:
+                        # Exit on blank line or new section header
+                        # AFTER we have already collected at least one key.
+                        # This prevents downstream metadata rows like
+                        # "Database:", "Owner:", "Location:" from being
+                        # collected as partition keys.
+                        if col_name.startswith("#") or not col_name:
+                            if partition_keys:
+                                break
+                            continue
+                        partition_keys.append(col_name)
+        except Exception as exc:
+            logger.debug(traceback.format_exc())
+            logger.warning(
+                f"Failed to get partition details for"
+                f" {schema_name}.{table_name}: {exc}"
+            )
+            return False, None
+
+        if not partition_keys:
+            return False, None
+
+        return True, TablePartition(
+            columns=[
+                PartitionColumnDetails(
+                    columnName=key,
+                    intervalType=PartitionIntervalTypes.COLUMN_VALUE,
+                    interval=None,
+                )
+                for key in partition_keys
+            ]
+        )
+
 
     def get_schema_definition(  # pylint: disable=unused-argument
         self, table_type: str, table_name: str, schema_name: str, inspector: Inspector

--- a/ingestion/tests/unit/topology/database/test_hive.py
+++ b/ingestion/tests/unit/topology/database/test_hive.py
@@ -1172,3 +1172,121 @@ class HiveSourceMetastoreValidationTest(TestCase):
         self.hive.service_connection.metastoreConnection = invalid_dict
         result = self.hive._get_validated_metastore_connection()
         self.assertIsNone(result)
+
+
+class TestHivePartitionDetails(TestCase):
+    """Unit tests for HiveSource.get_table_partition_details"""
+
+    def setUp(self):
+        """
+        Create a minimal HiveSource-like object with mocked internals.
+        Do NOT call HiveSource() constructor — mock only what the method needs:
+        - self.source.engine (Mock)
+        - self.source.connection_config (Mock with metastoreConnection=None)
+        """
+        self.source = Mock()
+        self.source.connection_config.metastoreConnection = None
+        self.source.engine = Mock()
+        # Bind the real method to our mock source
+        self.source.get_table_partition_details = (
+            HiveSource.get_table_partition_details.__get__(self.source)
+        )
+
+    def _make_rows(self, data):
+        """Helper: convert list of tuples into mock row objects."""
+        rows = []
+        for item in data:
+            row = Mock()
+            row.__getitem__ = lambda self, i, _item=item: _item[i]
+            rows.append(row)
+        return rows
+
+    def test_partition_keys_extracted_correctly(self):
+        """Parser extracts year and country, stops before metadata rows."""
+        mock_rows = self._make_rows(
+            [
+                ("col_name", "data_type", "comment"),
+                ("id", "int", ""),
+                ("name", "string", ""),
+                ("# Partition Information", "", ""),
+                ("# col_name", "data_type", "comment"),
+                ("year", "int", ""),
+                ("country", "string", ""),
+                ("# Detailed Table Information", "", ""),
+                ("Database:", "default", ""),
+                ("Owner:", "hadoop", ""),
+            ]
+        )
+        conn_mock = Mock()
+        conn_mock.execute.return_value = mock_rows
+        self.source.engine.connect.return_value.__enter__ = Mock(
+            return_value=conn_mock
+        )
+        self.source.engine.connect.return_value.__exit__ = Mock(return_value=False)
+
+        is_partitioned, partition = self.source.get_table_partition_details(
+            table_name="sales",
+            schema_name="default",
+            inspector=Mock(),
+        )
+
+        self.assertTrue(is_partitioned)
+        self.assertIsNotNone(partition)
+        extracted = [col.columnName for col in partition.columns]
+        self.assertIn("year", extracted)
+        self.assertIn("country", extracted)
+        # Critical: metadata rows must NOT be collected
+        self.assertNotIn("Database:", extracted)
+        self.assertNotIn("Owner:", extracted)
+
+    def test_no_partition_section_returns_false(self):
+        """Tables with no partition section return (False, None)."""
+        mock_rows = self._make_rows(
+            [
+                ("col_name", "data_type", "comment"),
+                ("id", "int", ""),
+                ("name", "string", ""),
+            ]
+        )
+        conn_mock = Mock()
+        conn_mock.execute.return_value = mock_rows
+        self.source.engine.connect.return_value.__enter__ = Mock(
+            return_value=conn_mock
+        )
+        self.source.engine.connect.return_value.__exit__ = Mock(return_value=False)
+
+        is_partitioned, partition = self.source.get_table_partition_details(
+            table_name="simple_table",
+            schema_name="default",
+            inspector=Mock(),
+        )
+
+        self.assertFalse(is_partitioned)
+        self.assertIsNone(partition)
+
+    def test_metastore_connection_skips_detection(self):
+        """When metastoreConnection is set, engine is never called."""
+        with patch.object(self.source, '_get_validated_metastore_connection', return_value=Mock()):
+            is_partitioned, partition = self.source.get_table_partition_details(
+                table_name="any_table",
+                schema_name="any_schema",
+                inspector=Mock(),
+            )
+
+            self.assertFalse(is_partitioned)
+            self.assertIsNone(partition)
+            # Engine must never be touched
+            self.source.engine.connect.assert_not_called()
+
+    def test_engine_exception_returns_false(self):
+        """Engine failure is caught gracefully, returns (False, None)."""
+        self.source.engine.connect.side_effect = Exception("connection failed")
+
+        is_partitioned, partition = self.source.get_table_partition_details(
+            table_name="broken_table",
+            schema_name="default",
+            inspector=Mock(),
+        )
+
+        self.assertFalse(is_partitioned)
+        self.assertIsNone(partition)

--- a/ingestion/tests/unit/topology/database/test_hive.py
+++ b/ingestion/tests/unit/topology/database/test_hive.py
@@ -352,9 +352,15 @@ class HiveUnitTest(TestCase):
         self.thread_id = self.hive.context.get_current_thread_id()
         self.hive._inspector_map[self.thread_id] = types.SimpleNamespace()
 
-        self.hive._inspector_map[self.thread_id].get_pk_constraint = lambda table_name, schema_name: []
-        self.hive._inspector_map[self.thread_id].get_unique_constraints = lambda table_name, schema_name: []
-        self.hive._inspector_map[self.thread_id].get_foreign_keys = lambda table_name, schema_name: []
+        self.hive._inspector_map[self.thread_id].get_pk_constraint = (
+            lambda table_name, schema_name: []
+        )
+        self.hive._inspector_map[self.thread_id].get_unique_constraints = (
+            lambda table_name, schema_name: []
+        )
+        self.hive._inspector_map[self.thread_id].get_foreign_keys = (
+            lambda table_name, schema_name: []
+        )
 
     def test_yield_database(self):
         assert EXPECTED_DATABASE == [either.right for either in self.hive.yield_database(MOCK_DATABASE.name.root)]  # noqa: SIM300
@@ -1219,9 +1225,7 @@ class TestHivePartitionDetails(TestCase):
         )
         conn_mock = Mock()
         conn_mock.execute.return_value = mock_rows
-        self.source.engine.connect.return_value.__enter__ = Mock(
-            return_value=conn_mock
-        )
+        self.source.engine.connect.return_value.__enter__ = Mock(return_value=conn_mock)
         self.source.engine.connect.return_value.__exit__ = Mock(return_value=False)
 
         is_partitioned, partition = self.source.get_table_partition_details(
@@ -1250,9 +1254,7 @@ class TestHivePartitionDetails(TestCase):
         )
         conn_mock = Mock()
         conn_mock.execute.return_value = mock_rows
-        self.source.engine.connect.return_value.__enter__ = Mock(
-            return_value=conn_mock
-        )
+        self.source.engine.connect.return_value.__enter__ = Mock(return_value=conn_mock)
         self.source.engine.connect.return_value.__exit__ = Mock(return_value=False)
 
         is_partitioned, partition = self.source.get_table_partition_details(

--- a/ingestion/tests/unit/topology/database/test_hive.py
+++ b/ingestion/tests/unit/topology/database/test_hive.py
@@ -352,15 +352,9 @@ class HiveUnitTest(TestCase):
         self.thread_id = self.hive.context.get_current_thread_id()
         self.hive._inspector_map[self.thread_id] = types.SimpleNamespace()
 
-        self.hive._inspector_map[self.thread_id].get_pk_constraint = (
-            lambda table_name, schema_name: []
-        )
-        self.hive._inspector_map[self.thread_id].get_unique_constraints = (
-            lambda table_name, schema_name: []
-        )
-        self.hive._inspector_map[self.thread_id].get_foreign_keys = (
-            lambda table_name, schema_name: []
-        )
+        self.hive._inspector_map[self.thread_id].get_pk_constraint = lambda table_name, schema_name: []
+        self.hive._inspector_map[self.thread_id].get_unique_constraints = lambda table_name, schema_name: []
+        self.hive._inspector_map[self.thread_id].get_foreign_keys = lambda table_name, schema_name: []
 
     def test_yield_database(self):
         assert EXPECTED_DATABASE == [either.right for either in self.hive.yield_database(MOCK_DATABASE.name.root)]  # noqa: SIM300
@@ -1187,16 +1181,14 @@ class TestHivePartitionDetails(TestCase):
         """
         Create a minimal HiveSource-like object with mocked internals.
         Do NOT call HiveSource() constructor — mock only what the method needs:
-        - self.source.engine (Mock)
-        - self.source.service_connection (Mock with metastoreConnection=None)
+        - self.source.engine (MagicMock for context manager support)
+        - self.source._get_validated_metastore_connection returns None
         """
         self.source = Mock()
-        self.source.service_connection.metastoreConnection = None
-        self.source.engine = Mock()
+        self.source._get_validated_metastore_connection.return_value = None
+        self.source.engine = MagicMock()
         # Bind the real method to our mock source
-        self.source.get_table_partition_details = (
-            HiveSource.get_table_partition_details.__get__(self.source)
-        )
+        self.source.get_table_partition_details = HiveSource.get_table_partition_details.__get__(self.source)
 
     def _make_rows(self, data):
         """Helper: convert list of tuples into mock row objects."""
@@ -1225,8 +1217,7 @@ class TestHivePartitionDetails(TestCase):
         )
         conn_mock = Mock()
         conn_mock.execute.return_value = mock_rows
-        self.source.engine.connect.return_value.__enter__ = Mock(return_value=conn_mock)
-        self.source.engine.connect.return_value.__exit__ = Mock(return_value=False)
+        self.source.engine.connect.return_value.__enter__.return_value = conn_mock
 
         is_partitioned, partition = self.source.get_table_partition_details(
             table_name="sales",
@@ -1254,8 +1245,7 @@ class TestHivePartitionDetails(TestCase):
         )
         conn_mock = Mock()
         conn_mock.execute.return_value = mock_rows
-        self.source.engine.connect.return_value.__enter__ = Mock(return_value=conn_mock)
-        self.source.engine.connect.return_value.__exit__ = Mock(return_value=False)
+        self.source.engine.connect.return_value.__enter__.return_value = conn_mock
 
         is_partitioned, partition = self.source.get_table_partition_details(
             table_name="simple_table",
@@ -1268,7 +1258,7 @@ class TestHivePartitionDetails(TestCase):
 
     def test_metastore_connection_skips_detection(self):
         """When metastoreConnection is set, engine is never called."""
-        with patch.object(self.source, '_get_validated_metastore_connection', return_value=Mock()):
+        with patch.object(self.source, "_get_validated_metastore_connection", return_value=Mock()):
             is_partitioned, partition = self.source.get_table_partition_details(
                 table_name="any_table",
                 schema_name="any_schema",

--- a/ingestion/tests/unit/topology/database/test_hive.py
+++ b/ingestion/tests/unit/topology/database/test_hive.py
@@ -14,7 +14,7 @@ Test Hive using the topology
 
 import types
 from unittest import TestCase
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 from sqlalchemy.types import INTEGER, VARCHAR, Integer, String
 
@@ -1182,10 +1182,10 @@ class TestHivePartitionDetails(TestCase):
         Create a minimal HiveSource-like object with mocked internals.
         Do NOT call HiveSource() constructor — mock only what the method needs:
         - self.source.engine (Mock)
-        - self.source.connection_config (Mock with metastoreConnection=None)
+        - self.source.service_connection (Mock with metastoreConnection=None)
         """
         self.source = Mock()
-        self.source.connection_config.metastoreConnection = None
+        self.source.service_connection.metastoreConnection = None
         self.source.engine = Mock()
         # Bind the real method to our mock source
         self.source.get_table_partition_details = (
@@ -1196,8 +1196,8 @@ class TestHivePartitionDetails(TestCase):
         """Helper: convert list of tuples into mock row objects."""
         rows = []
         for item in data:
-            row = Mock()
-            row.__getitem__ = lambda self, i, _item=item: _item[i]
+            row = MagicMock()
+            row.__getitem__.side_effect = lambda i, _item=item: _item[i]
             rows.append(row)
         return rows
 


### PR DESCRIPTION
Fixes #26712

### Describe your changes:
Added `get_table_partition_details()` to `HiveSource` to identify Hive partition key columns and expose them as `TablePartition` metadata.

- Runs `DESCRIBE FORMATTED` via HiveServer2 engine to fetch table description
- Parses the `# Partition Information` section to extract partition key column names
- Stops collection when the next section header is encountered — prevents metadata rows like `Database:` and `Owner:` from being included as partition keys
- Guards against `metastoreConnection` — skips engine-based detection when a metastore is configured
- Returns `TablePartition` with `PartitionColumnDetails` using `COLUMN_VALUE` interval type

### Type of change:
- [x] New feature

### Checklist:
- [x] I have read the CONTRIBUTING document.
- [x] My PR title is `feat(hive): Add partition key detection via DESCRIBE FORMATTED #26712`
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

### Tests:
- [x] I have added tests around the new logic.

| Test | Covers |
|---|---|
| `test_partition_keys_extracted_correctly` | Correct extraction, metadata rows excluded |
| `test_no_partition_section_returns_false` | Non-partitioned table returns (False, None) |
| `test_metastore_connection_skips_detection` | Engine never called when metastore configured |
| `test_engine_exception_returns_false` | Graceful failure on engine error |
