### PR TITLE
Fixes #27060: Fix ON2 bug in deleteChildren and duplicate deletions in TestCaseRepository

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
@@ -777,7 +777,7 @@ public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
                       .withLimit(10)
                       .addFilter("testCaseFQN", fqn);
               org.openmetadata.sdk.models.ListResponse<?> response =
-                  client.testCaseResolutionStatuses().searchList(params);
+                  client.testCaseResolutionStatuses().list(params);
               assertFalse(
                   response.getData().isEmpty(), "Resolution status should exist before delete");
             });
@@ -799,7 +799,7 @@ public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
                       .withLimit(10)
                       .addFilter("testCaseFQN", fqn);
               org.openmetadata.sdk.models.ListResponse<?> response =
-                  client.testCaseResolutionStatuses().searchList(params);
+                  client.testCaseResolutionStatuses().list(params);
               assertTrue(
                   response.getData().isEmpty(), "TestCaseResolutionStatuses should be empty");
             });
@@ -812,10 +812,9 @@ public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
             () -> {
               org.openmetadata.sdk.models.ListParams params =
                   new org.openmetadata.sdk.models.ListParams()
-                      .withLimit(10)
-                      .addFilter("testCaseFQN", fqn);
+                      .withLimit(10);
               org.openmetadata.sdk.models.ListResponse<?> response =
-                  client.testCaseResults().searchList(params);
+                  client.testCaseResults().get(fqn, params);
               assertTrue(response.getData().isEmpty(), "TestCaseResults should be empty");
             });
   }

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
@@ -783,7 +783,10 @@ public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
             });
 
     // Hard delete test case
-    hardDeleteEntity(id);
+    java.util.Map<String, String> params = new java.util.HashMap<>();
+    params.put("hardDelete", "true");
+    params.put("recursive", "true");
+    client.testCases().delete(id, params);
 
     // Verify testcase deleted
     assertThrows(Exception.class, () -> getEntity(id));

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
@@ -783,10 +783,10 @@ public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
             });
 
     // Hard delete test case
-    java.util.Map<String, String> params = new java.util.HashMap<>();
-    params.put("hardDelete", "true");
-    params.put("recursive", "true");
-    client.testCases().delete(id, params);
+    java.util.Map<String, String> deleteParams = new java.util.HashMap<>();
+    deleteParams.put("hardDelete", "true");
+    deleteParams.put("recursive", "true");
+    client.testCases().delete(id, deleteParams);
 
     // Verify testcase deleted
     assertThrows(Exception.class, () -> getEntity(id));

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
@@ -775,7 +775,7 @@ public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
               org.openmetadata.sdk.models.ListParams params =
                   new org.openmetadata.sdk.models.ListParams()
                       .withLimit(10)
-                      .addFilter("testCaseFQN", fqn);
+                      .addFilter("testCaseId", id);
               org.openmetadata.sdk.models.ListResponse<?> response =
                   client.testCaseResolutionStatuses().list(params);
               assertFalse(
@@ -797,7 +797,7 @@ public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
               org.openmetadata.sdk.models.ListParams params =
                   new org.openmetadata.sdk.models.ListParams()
                       .withLimit(10)
-                      .addFilter("testCaseFQN", fqn);
+                      .addFilter("testCaseId", id);
               org.openmetadata.sdk.models.ListResponse<?> response =
                   client.testCaseResolutionStatuses().list(params);
               assertTrue(

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
@@ -734,6 +734,63 @@ public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
   }
 
   @Test
+  void test_testCaseHardDelete_deletes_results_and_resolution_statuses(TestNamespace ns) throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    Table table = createTable(ns);
+
+    TestCase testCase = TestCaseBuilder.create(client)
+            .name(ns.prefix("hard_delete_children"))
+            .forTable(table)
+            .testDefinition("tableRowCountToEqual")
+            .parameter("value", "100")
+            .create();
+
+    String fqn = testCase.getFullyQualifiedName();
+    String id = testCase.getId().toString();
+
+    // Create a test case result (Failed)
+    org.openmetadata.schema.api.tests.CreateTestCaseResult result =
+        new org.openmetadata.schema.api.tests.CreateTestCaseResult();
+    result.setTimestamp(System.currentTimeMillis());
+    result.setTestCaseStatus(org.openmetadata.schema.tests.type.TestCaseStatus.Failed);
+    result.setResult("Failed test");
+    client.testCaseResults().create(fqn, result);
+
+    // Create a resolution status
+    org.openmetadata.schema.api.tests.CreateTestCaseResolutionStatus ackStatus =
+        new org.openmetadata.schema.api.tests.CreateTestCaseResolutionStatus();
+    ackStatus.setTestCaseResolutionStatusType(org.openmetadata.schema.tests.type.TestCaseResolutionStatusTypes.Ack);
+    ackStatus.setTestCaseReference(fqn);
+    client.testCaseResolutionStatuses().create(ackStatus);
+    
+    // Wait for it to be indexed
+    Awaitility.await("Wait for resolution status")
+        .atMost(15, TimeUnit.SECONDS)
+        .pollInterval(500, TimeUnit.MILLISECONDS)
+        .untilAsserted(() -> {
+          org.openmetadata.client.model.ListParams params = new org.openmetadata.client.model.ListParams().withLimit(10).addFilter("testCaseFQN", fqn);
+          org.openmetadata.client.model.ListResponse<?> response = client.testCaseResolutionStatuses().searchList(params);
+          assertTrue(response.getData().size() > 0);
+        });
+
+    // Hard delete test case
+    hardDeleteEntity(id);
+
+    // Verify testcase deleted
+    assertThrows(Exception.class, () -> getEntity(id));
+
+    // Wait and verify resolution statuses are empty
+    Awaitility.await("Verify children are deleted")
+        .atMost(15, TimeUnit.SECONDS)
+        .pollInterval(500, TimeUnit.MILLISECONDS)
+        .untilAsserted(() -> {
+          org.openmetadata.client.model.ListParams params = new org.openmetadata.client.model.ListParams().withLimit(10).addFilter("testCaseFQN", fqn);
+          org.openmetadata.client.model.ListResponse<?> response = client.testCaseResolutionStatuses().searchList(params);
+          assertTrue(response.getData().isEmpty(), "TestCaseResolutionStatuses should be empty");
+        });
+  }
+
+  @Test
   void test_listTestCases_200_OK(TestNamespace ns) {
     OpenMetadataClient client = SdkClients.adminClient();
     Table table = createTable(ns);

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
@@ -768,9 +768,9 @@ public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
         .atMost(15, TimeUnit.SECONDS)
         .pollInterval(500, TimeUnit.MILLISECONDS)
         .untilAsserted(() -> {
-          org.openmetadata.client.model.ListParams params = new org.openmetadata.client.model.ListParams().withLimit(10).addFilter("testCaseFQN", fqn);
-          org.openmetadata.client.model.ListResponse<?> response = client.testCaseResolutionStatuses().searchList(params);
-          assertTrue(response.getData().size() > 0);
+          org.openmetadata.sdk.models.ListParams params = new org.openmetadata.sdk.models.ListParams().withLimit(10).addFilter("testCaseFQN", fqn);
+          org.openmetadata.sdk.models.ListResponse<?> response = client.testCaseResolutionStatuses().searchList(params);
+          assertFalse(response.getData().isEmpty(), "Resolution status should exist before delete");
         });
 
     // Hard delete test case
@@ -780,13 +780,23 @@ public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
     assertThrows(Exception.class, () -> getEntity(id));
 
     // Wait and verify resolution statuses are empty
-    Awaitility.await("Verify children are deleted")
+    Awaitility.await("Verify children resolution statuses are deleted")
         .atMost(15, TimeUnit.SECONDS)
         .pollInterval(500, TimeUnit.MILLISECONDS)
         .untilAsserted(() -> {
-          org.openmetadata.client.model.ListParams params = new org.openmetadata.client.model.ListParams().withLimit(10).addFilter("testCaseFQN", fqn);
-          org.openmetadata.client.model.ListResponse<?> response = client.testCaseResolutionStatuses().searchList(params);
+          org.openmetadata.sdk.models.ListParams params = new org.openmetadata.sdk.models.ListParams().withLimit(10).addFilter("testCaseFQN", fqn);
+          org.openmetadata.sdk.models.ListResponse<?> response = client.testCaseResolutionStatuses().searchList(params);
           assertTrue(response.getData().isEmpty(), "TestCaseResolutionStatuses should be empty");
+        });
+
+    // Wait and verify test case results are empty
+    Awaitility.await("Verify test case results are deleted")
+        .atMost(15, TimeUnit.SECONDS)
+        .pollInterval(500, TimeUnit.MILLISECONDS)
+        .untilAsserted(() -> {
+          org.openmetadata.sdk.models.ListParams params = new org.openmetadata.sdk.models.ListParams().withLimit(10).addFilter("testCaseFQN", fqn);
+          org.openmetadata.sdk.models.ListResponse<?> response = client.testCaseResults().searchList(params);
+          assertTrue(response.getData().isEmpty(), "TestCaseResults should be empty");
         });
   }
 

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
@@ -811,8 +811,7 @@ public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
         .untilAsserted(
             () -> {
               org.openmetadata.sdk.models.ListParams params =
-                  new org.openmetadata.sdk.models.ListParams()
-                      .withLimit(10);
+                  new org.openmetadata.sdk.models.ListParams().withLimit(10);
               org.openmetadata.sdk.models.ListResponse<?> response =
                   client.testCaseResults().get(fqn, params);
               assertTrue(response.getData().isEmpty(), "TestCaseResults should be empty");

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
@@ -734,11 +734,13 @@ public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
   }
 
   @Test
-  void test_testCaseHardDelete_deletes_results_and_resolution_statuses(TestNamespace ns) throws Exception {
+  void test_testCaseHardDelete_deletes_results_and_resolution_statuses(TestNamespace ns)
+      throws Exception {
     OpenMetadataClient client = SdkClients.adminClient();
     Table table = createTable(ns);
 
-    TestCase testCase = TestCaseBuilder.create(client)
+    TestCase testCase =
+        TestCaseBuilder.create(client)
             .name(ns.prefix("hard_delete_children"))
             .forTable(table)
             .testDefinition("tableRowCountToEqual")
@@ -759,19 +761,26 @@ public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
     // Create a resolution status
     org.openmetadata.schema.api.tests.CreateTestCaseResolutionStatus ackStatus =
         new org.openmetadata.schema.api.tests.CreateTestCaseResolutionStatus();
-    ackStatus.setTestCaseResolutionStatusType(org.openmetadata.schema.tests.type.TestCaseResolutionStatusTypes.Ack);
+    ackStatus.setTestCaseResolutionStatusType(
+        org.openmetadata.schema.tests.type.TestCaseResolutionStatusTypes.Ack);
     ackStatus.setTestCaseReference(fqn);
     client.testCaseResolutionStatuses().create(ackStatus);
-    
+
     // Wait for it to be indexed
     Awaitility.await("Wait for resolution status")
         .atMost(15, TimeUnit.SECONDS)
         .pollInterval(500, TimeUnit.MILLISECONDS)
-        .untilAsserted(() -> {
-          org.openmetadata.sdk.models.ListParams params = new org.openmetadata.sdk.models.ListParams().withLimit(10).addFilter("testCaseFQN", fqn);
-          org.openmetadata.sdk.models.ListResponse<?> response = client.testCaseResolutionStatuses().searchList(params);
-          assertFalse(response.getData().isEmpty(), "Resolution status should exist before delete");
-        });
+        .untilAsserted(
+            () -> {
+              org.openmetadata.sdk.models.ListParams params =
+                  new org.openmetadata.sdk.models.ListParams()
+                      .withLimit(10)
+                      .addFilter("testCaseFQN", fqn);
+              org.openmetadata.sdk.models.ListResponse<?> response =
+                  client.testCaseResolutionStatuses().searchList(params);
+              assertFalse(
+                  response.getData().isEmpty(), "Resolution status should exist before delete");
+            });
 
     // Hard delete test case
     hardDeleteEntity(id);
@@ -783,22 +792,32 @@ public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
     Awaitility.await("Verify children resolution statuses are deleted")
         .atMost(15, TimeUnit.SECONDS)
         .pollInterval(500, TimeUnit.MILLISECONDS)
-        .untilAsserted(() -> {
-          org.openmetadata.sdk.models.ListParams params = new org.openmetadata.sdk.models.ListParams().withLimit(10).addFilter("testCaseFQN", fqn);
-          org.openmetadata.sdk.models.ListResponse<?> response = client.testCaseResolutionStatuses().searchList(params);
-          assertTrue(response.getData().isEmpty(), "TestCaseResolutionStatuses should be empty");
-        });
+        .untilAsserted(
+            () -> {
+              org.openmetadata.sdk.models.ListParams params =
+                  new org.openmetadata.sdk.models.ListParams()
+                      .withLimit(10)
+                      .addFilter("testCaseFQN", fqn);
+              org.openmetadata.sdk.models.ListResponse<?> response =
+                  client.testCaseResolutionStatuses().searchList(params);
+              assertTrue(
+                  response.getData().isEmpty(), "TestCaseResolutionStatuses should be empty");
+            });
 
     // Wait and verify test case results are empty
     Awaitility.await("Verify test case results are deleted")
         .atMost(15, TimeUnit.SECONDS)
         .pollInterval(500, TimeUnit.MILLISECONDS)
-        .untilAsserted(() -> {
-          org.openmetadata.sdk.models.ListParams params = new org.openmetadata.sdk.models.ListParams().withLimit(10).addFilter("testCaseFQN", fqn);
-          org.openmetadata.sdk.models.ListResponse<?> response = client.testCaseResults().searchList(params);
-          assertTrue(response.getData().isEmpty(), "TestCaseResults should be empty");
-        });
-  }
+        .untilAsserted(
+            () -> {
+              org.openmetadata.sdk.models.ListParams params =
+                  new org.openmetadata.sdk.models.ListParams()
+                      .withLimit(10)
+                      .addFilter("testCaseFQN", fqn);
+              org.openmetadata.sdk.models.ListResponse<?> response =
+                  client.testCaseResults().searchList(params);
+              assertTrue(response.getData().isEmpty(), "TestCaseResults should be empty");
+            });
 
   @Test
   void test_listTestCases_200_OK(TestNamespace ns) {

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
@@ -818,6 +818,7 @@ public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
                   client.testCaseResults().searchList(params);
               assertTrue(response.getData().isEmpty(), "TestCaseResults should be empty");
             });
+  }
 
   @Test
   void test_listTestCases_200_OK(TestNamespace ns) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
@@ -40,8 +40,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.SneakyThrows;
@@ -120,9 +118,6 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
   private static final String PATCH_FIELDS =
       "owners,entityLink,testSuite,testSuites,testDefinition,computePassedFailedRowCount,useDynamicAssertion,dimensionColumns,topDimensions";
   public static final String FAILED_ROWS_SAMPLE_EXTENSION = "testCase.failedRowsSample";
-  private final ExecutorService asyncExecutor =
-      Executors.newFixedThreadPool(
-          1, java.lang.Thread.ofPlatform().name("om-test-case-async").factory());
 
   public TestCaseRepository() {
     super(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
@@ -903,18 +903,16 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
   protected void deleteChildren(
       List<CollectionDAO.EntityRelationshipRecord> children, boolean hardDelete, String updatedBy) {
     if (hardDelete) {
+      TestCaseResolutionStatusRepository testCaseResolutionStatusRepository =
+          (TestCaseResolutionStatusRepository)
+              Entity.getEntityTimeSeriesRepository(Entity.TEST_CASE_RESOLUTION_STATUS);
       for (CollectionDAO.EntityRelationshipRecord entityRelationshipRecord : children) {
         LOG.info(
             "Recursively {} deleting {} {}",
             hardDelete ? "hard" : "soft",
             entityRelationshipRecord.getType(),
             entityRelationshipRecord.getId());
-        TestCaseResolutionStatusRepository testCaseResolutionStatusRepository =
-            (TestCaseResolutionStatusRepository)
-                Entity.getEntityTimeSeriesRepository(Entity.TEST_CASE_RESOLUTION_STATUS);
-        for (CollectionDAO.EntityRelationshipRecord child : children) {
-          testCaseResolutionStatusRepository.deleteById(child.getId(), hardDelete);
-        }
+        testCaseResolutionStatusRepository.deleteById(entityRelationshipRecord.getId(), hardDelete);
       }
     }
   }
@@ -928,14 +926,6 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
     TestCaseResultRepository testCaseResultRepository =
         (TestCaseResultRepository) Entity.getEntityTimeSeriesRepository(TEST_CASE_RESULT);
     testCaseResultRepository.deleteAllTestCaseResults(fqn);
-    asyncExecutor.submit(
-        () -> {
-          try {
-            testCaseResultRepository.deleteAllTestCaseResults(fqn);
-          } catch (Exception e) {
-            LOG.error("Error deleting test case results for test case {}", fqn, e);
-          }
-        });
   }
 
   @SneakyThrows

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
@@ -908,8 +908,7 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
               Entity.getEntityTimeSeriesRepository(Entity.TEST_CASE_RESOLUTION_STATUS);
       for (CollectionDAO.EntityRelationshipRecord entityRelationshipRecord : children) {
         LOG.info(
-            "Recursively {} deleting {} {}",
-            hardDelete ? "hard" : "soft",
+            "Recursively hard deleting {} {}",
             entityRelationshipRecord.getType(),
             entityRelationshipRecord.getId());
         testCaseResolutionStatusRepository.deleteById(entityRelationshipRecord.getId(), hardDelete);


### PR DESCRIPTION
### Describe your changes:

Fixes #27060

I worked on this to fix the issue described in #27060 and improve stability.

#
### Type of change:
- [x] Bug fix

#
### High-level design:
N/A — small change.

#
### Tests:

#### Use cases covered
- Verified the issue is resolved.

#### Unit tests
- [x] I added unit tests for the new/changed logic.

#### Backend integration tests
- [ ] Not applicable (no backend API changes).

#### Ingestion integration tests
- [ ] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [ ] Not applicable (no UI changes).

#### Manual testing performed
- Verified locally.

#
### UI screen recording / screenshots:
Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [x] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes test case hard-delete cleanup. The main changes are:

- Deletes each resolution status child once during recursive hard delete.
- Removes the unused duplicate async result-deletion executor.
- Adds an integration test for deleting test results and resolution statuses.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge after a small test style cleanup.

- No blocking issues found in the changed production code.
- The remaining note is limited to Java import style in the new test.

openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java | Fixes the recursive hard-delete loop for test case resolution statuses and removes unused async cleanup state. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java | Adds integration coverage for hard-deleting a test case with results and resolution statuses, with a small Java style cleanup noted. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: remove unused asyncExecutor field a..."](https://github.com/open-metadata/openmetadata/commit/030c8d49ff7cf2d08e3b3df5c3e8728b0cc1a8ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37815478)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->