### PR TITLE
fix(test): prevent 409 Conflict in IncidentManagerDateFilter by initializing TableClass in beforeAll

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/IncidentManagerDateFilter.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/IncidentManagerDateFilter.spec.ts
@@ -20,15 +20,18 @@ import { waitForAllLoadersToDisappear } from '../../../utils/entity';
 import { sidebarClick } from '../../../utils/sidebar';
 import { test } from '../../fixtures/pages';
 
-const table = new TableClass();
-
 test.describe(
   'Incident Manager Date Filter',
   { tag: `${DOMAIN_TAGS.OBSERVABILITY}:Incident_Manager` },
   () => {
+    let table: TableClass;
+
     test.beforeAll(async ({ browser }) => {
       test.slow();
       const { apiContext, afterAction } = await performAdminLogin(browser);
+      table = new TableClass();
+
+      await table.create(apiContext);
 
       // Create table and test cases
       await table.createTestCase(apiContext, {


### PR DESCRIPTION
Issue: https://github.com/open-metadata/openmetadata-collate/issues/3610

## Title

fix(test): prevent 409 Conflict in IncidentManagerDateFilter by initializing TableClass in beforeAll

## Description

### Summary

- Move `new TableClass()` instantiation from module scope into `beforeAll` to prevent 409 Conflict / 404 errors on CI test retries

### Root Cause

`new TableClass()` at module scope generates the random table name once at import time. On Playwright retries, `beforeAll` calls `table.create()` again with the same name, causing 409 Conflict (entity already exists) or 404 (stale reference after cleanup).

### Fix

```ts
// Before (409 on retry)
const table = new TableClass();
test.beforeAll(async ({ browser }) => {
  await table.createTestCase(apiContext, ...);
});

// After (safe on retry)
let table: TableClass;
test.beforeAll(async ({ browser }) => {
  table = new TableClass();
  await table.create(apiContext);
  await table.createTestCase(apiContext, ...);
});
```

### Test plan

- [ ] Run `IncidentManagerDateFilter.spec.ts` with retries — no 409/404 on table creation
