### PR TITLE
Fixes #24559: Add Greenplum 7 partition support

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/greenplum/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/greenplum/metadata.py
@@ -12,6 +12,7 @@
 Greenplum source module
 """
 
+import re
 import traceback
 from collections import namedtuple
 from typing import Iterable, Optional, Tuple  # noqa: UP035
@@ -19,6 +20,7 @@ from typing import Iterable, Optional, Tuple  # noqa: UP035
 from sqlalchemy import sql, text
 from sqlalchemy.dialects.postgresql.base import PGDialect
 from sqlalchemy.engine import Inspector
+from sqlalchemy.exc import SQLAlchemyError
 
 from metadata.generated.schema.entity.data.database import Database
 from metadata.generated.schema.entity.data.table import (
@@ -48,8 +50,11 @@ from metadata.ingestion.source.database.common_pg_mappings import (
 )
 from metadata.ingestion.source.database.greenplum.queries import (
     GREENPLUM_GET_DB_NAMES,
-    GREENPLUM_GET_TABLE_NAMES,
-    GREENPLUM_PARTITION_DETAILS,
+    GREENPLUM_GET_TABLE_NAMES_V6,
+    GREENPLUM_GET_TABLE_NAMES_V7,
+    GREENPLUM_GET_VERSION,
+    GREENPLUM_PARTITION_DETAILS_V6,
+    GREENPLUM_PARTITION_DETAILS_V7,
 )
 from metadata.ingestion.source.database.greenplum.utils import (
     get_column_info,
@@ -92,6 +97,10 @@ class GreenplumSource(CommonDbSourceService, MultiDBSource):
     Database metadata from Greenplum Source
     """
 
+    def __init__(self, config, metadata):
+        super().__init__(config, metadata)
+        self._greenplum_version: int | None = None
+
     @classmethod
     def create(
         cls,
@@ -105,13 +114,44 @@ class GreenplumSource(CommonDbSourceService, MultiDBSource):
             raise InvalidSourceException(f"Expected GreenplumConnection, but got {connection}")
         return cls(config, metadata)
 
+    def _get_greenplum_major_version(self) -> int:
+        if self._greenplum_version is None:
+            try:
+                with self.engine.connect() as conn:
+                    result = conn.execute(text(GREENPLUM_GET_VERSION))
+                    version_string = result.scalar() or ""
+                match = re.search(r"Greenplum Database (\d+)", version_string)
+                if match:
+                    self._greenplum_version = int(match.group(1))
+                    logger.info("Detected Greenplum major version %d", self._greenplum_version)
+                else:
+                    logger.warning(
+                        "Could not parse Greenplum major version from SELECT version() output, "
+                        "defaulting to 7 to avoid querying removed GP6-specific catalog tables"
+                    )
+                    logger.debug("Full version() output: %s", version_string)
+                    self._greenplum_version = 7
+            except SQLAlchemyError as exc:
+                logger.debug(traceback.format_exc())
+                logger.warning(
+                    "Could not determine Greenplum version (%s), "
+                    "defaulting to 7 to avoid querying removed GP6-specific catalog tables",
+                    exc,
+                )
+                self._greenplum_version = 7
+        return self._greenplum_version
+
+    def _is_v7_or_later(self) -> bool:
+        return self._get_greenplum_major_version() >= 7
+
     def query_table_names_and_types(self, schema_name: str) -> Iterable[TableNameAndType]:
         """
         Overwrite the inspector implementation to handle partitioned
         and foreign types
         """
+        table_names_query = GREENPLUM_GET_TABLE_NAMES_V7 if self._is_v7_or_later() else GREENPLUM_GET_TABLE_NAMES_V6
         result = self.connection.execute(
-            sql.text(GREENPLUM_GET_TABLE_NAMES),
+            sql.text(table_names_query),
             {"schema": schema_name},
         )
 
@@ -158,25 +198,57 @@ class GreenplumSource(CommonDbSourceService, MultiDBSource):
     def get_table_partition_details(
         self, table_name: str, schema_name: str, inspector: Inspector
     ) -> Tuple[bool, Optional[TablePartition]]:  # noqa: UP006, UP045
+        if self._is_v7_or_later():
+            return self._get_table_partition_details_v7(table_name, schema_name)
+        return self._get_table_partition_details_v6(table_name, schema_name)
+
+    def _get_table_partition_details_v6(
+        self, table_name: str, schema_name: str
+    ) -> Tuple[bool, Optional[TablePartition]]:  # noqa: UP006, UP045
         with self.engine.connect() as conn:
             result = conn.execute(
-                text(GREENPLUM_PARTITION_DETAILS.format(table_name=table_name, schema_name=schema_name))
+                text(GREENPLUM_PARTITION_DETAILS_V6),
+                {"table_name": table_name, "schema_name": schema_name},
             ).all()
 
-        if result:
-            partition_details = TablePartition(
-                columns=[
-                    PartitionColumnDetails(
-                        columnName=row.column_name,
-                        intervalType=INTERVAL_TYPE_MAP.get(
-                            result[0].partition_strategy,
-                            PartitionIntervalTypes.COLUMN_VALUE,
-                        ),
-                        interval=None,
-                    )
-                    for row in result
-                    if row.column_name
-                ]
+        return self._build_partition_result(result)
+
+    def _get_table_partition_details_v7(
+        self, table_name: str, schema_name: str
+    ) -> Tuple[bool, Optional[TablePartition]]:  # noqa: UP006, UP045
+        with self.engine.connect() as conn:
+            result = conn.execute(
+                text(GREENPLUM_PARTITION_DETAILS_V7),
+                {"table_name": table_name, "schema_name": schema_name},
+            ).all()
+
+        return self._build_partition_result(result)
+
+    @staticmethod
+    def _build_partition_result(
+        result,
+    ) -> Tuple[bool, Optional[TablePartition]]:  # noqa: UP006, UP045
+        # When a partition key is an expression (not a plain column),
+        # pg_partitioned_table.partattrs / pg_partition.paratts contains 0, so the
+        # join to information_schema.columns yields NULL column_name and the row is
+        # filtered out below. The table is still partitioned; we just cannot surface
+        # the partition-column details yet. Return (True, None) so it is ingested as
+        # TableType.Partitioned rather than TableType.Regular.
+        if not result:
+            return False, None
+        columns = [
+            PartitionColumnDetails(
+                columnName=row.column_name,
+                intervalType=INTERVAL_TYPE_MAP.get(
+                    row.partition_strategy,
+                    PartitionIntervalTypes.COLUMN_VALUE,
+                ),
+                interval=None,
             )
-            return True, partition_details
-        return False, None
+            for row in result
+            if row.column_name
+        ]
+        if not columns:
+            # Partition exists but all keys are expression-based (column_name is NULL).
+            return True, None
+        return True, TablePartition(columns=columns)

--- a/ingestion/src/metadata/ingestion/source/database/greenplum/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/greenplum/queries.py
@@ -16,7 +16,9 @@ import textwrap
 
 # https://www.postgresql.org/docs/current/catalog-pg-class.html
 # r = ordinary table, v = view, m = materialized view, c = composite type, f = foreign table, p = partitioned table,
-GREENPLUM_GET_TABLE_NAMES = """
+
+# Greenplum 6: uses pg_partition_rule to filter out child partitions
+GREENPLUM_GET_TABLE_NAMES_V6 = """
     select c.relname, c.relkind
     from pg_catalog.pg_class c
         left outer join pg_catalog.pg_partition_rule pr on c.oid = pr.parchildrelid
@@ -26,7 +28,15 @@ GREENPLUM_GET_TABLE_NAMES = """
         and n.nspname = :schema
 """
 
-GREENPLUM_PARTITION_DETAILS = textwrap.dedent(
+# Greenplum 7+: uses PostgreSQL-style relispartition to filter out child partitions
+GREENPLUM_GET_TABLE_NAMES_V7 = """
+    SELECT c.relname, c.relkind FROM pg_catalog.pg_class c
+    JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = :schema AND c.relkind in ('r', 'p', 'f') AND c.relispartition = false
+"""
+
+# Greenplum 6: uses pg_partition catalog with parkind/paratts columns
+GREENPLUM_PARTITION_DETAILS_V6 = textwrap.dedent(
     """
     select
         ns.nspname as schema,
@@ -45,7 +55,7 @@ GREENPLUM_PARTITION_DETAILS = textwrap.dedent(
          from
              pg_catalog.pg_partition) pt
     join
-        pg_class par
+        pg_catalog.pg_class par
     on
         par.oid = pt.parrelid
     left join
@@ -56,7 +66,42 @@ GREENPLUM_PARTITION_DETAILS = textwrap.dedent(
         col.table_schema = ns.nspname
         and col.table_name = par.relname
         and ordinal_position = pt.column_index
-    where par.relname='{table_name}' and  ns.nspname='{schema_name}'
+    where par.relname=:table_name and ns.nspname=:schema_name
+    """
+)
+
+# Greenplum 7+: uses PostgreSQL-standard pg_partitioned_table with partstrat/partattrs
+GREENPLUM_PARTITION_DETAILS_V7 = textwrap.dedent(
+    """
+    select
+        ns.nspname as schema,
+        par.relname as table_name,
+        partition_strategy,
+        col.column_name
+    from
+        (select
+             partrelid,
+             partnatts,
+             case partstrat
+                  when 'l' then 'list'
+                  when 'h' then 'hash'
+                  when 'r' then 'range' end as partition_strategy,
+             unnest(partattrs) column_index
+         from
+             pg_catalog.pg_partitioned_table) pt
+    join
+        pg_catalog.pg_class par
+    on
+        par.oid = pt.partrelid
+    join
+        pg_catalog.pg_namespace ns on ns.oid = par.relnamespace
+    left join
+        information_schema.columns col
+    on
+        col.table_schema = ns.nspname
+        and col.table_name = par.relname
+        and ordinal_position = pt.column_index
+     where par.relname=:table_name and ns.nspname=:schema_name
     """
 )
 
@@ -138,4 +183,8 @@ GREENPLUM_SQL_COLUMNS = """
 
 GREENPLUM_GET_SERVER_VERSION = """
 show server_version
+"""
+
+GREENPLUM_GET_VERSION = """
+SELECT version()
 """

--- a/ingestion/tests/unit/topology/database/test_greenplum.py
+++ b/ingestion/tests/unit/topology/database/test_greenplum.py
@@ -13,13 +13,26 @@
 Test Greenplum using the topology
 """
 
+from collections import namedtuple
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+import pytest
+from sqlalchemy.exc import OperationalError
+
+from metadata.generated.schema.entity.data.table import (
+    PartitionColumnDetails,
+    PartitionIntervalTypes,
+    TablePartition,
+)
 from metadata.generated.schema.metadataIngestion.workflow import (
     OpenMetadataWorkflowConfig,
 )
 from metadata.ingestion.source.database.greenplum.metadata import GreenplumSource
+from metadata.ingestion.source.database.greenplum.queries import (
+    GREENPLUM_GET_TABLE_NAMES_V6,
+    GREENPLUM_GET_TABLE_NAMES_V7,
+)
 
 mock_greenplum_config = {
     "source": {
@@ -55,6 +68,8 @@ mock_greenplum_config = {
     },
 }
 
+PartitionRow = namedtuple("PartitionRow", ["schema", "table_name", "partition_strategy", "column_name"])
+
 
 class greenplumUnitTest(TestCase):  # noqa: N801
     @patch("metadata.ingestion.source.database.common_db_source.CommonDbSourceService.test_connection")
@@ -72,3 +87,190 @@ class greenplumUnitTest(TestCase):  # noqa: N801
     def test_close_connection(self, engine, connection):
         connection.return_value = True
         self.greenplum_source.close()
+
+
+@pytest.fixture()
+def greenplum_source():
+    with patch(
+        "metadata.ingestion.source.database.common_db_source.CommonDbSourceService.test_connection"
+    ) as test_connection:
+        test_connection.return_value = False
+        source = GreenplumSource.create(
+            mock_greenplum_config["source"],
+            OpenMetadataWorkflowConfig.model_validate(mock_greenplum_config).workflowConfig.openMetadataServerConfig,
+        )
+        yield source
+
+
+@pytest.fixture()
+def mock_engine_with_version(greenplum_source):
+    def _factory(version_string):
+        mock_engine = MagicMock()
+        mock_conn = MagicMock()
+        mock_engine.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+        mock_conn.execute.return_value.scalar.return_value = version_string
+        greenplum_source.engine = mock_engine
+        greenplum_source._greenplum_version = None
+        return mock_engine, mock_conn
+
+    return _factory
+
+
+def test_version_detection_v6(greenplum_source, mock_engine_with_version):
+    mock_engine_with_version(
+        "PostgreSQL 9.4.26 (Greenplum Database 6.25.3 build dev) on x86_64-pc-linux-gnu compiled by gcc 6.4.0"
+    )
+    assert greenplum_source._get_greenplum_major_version() == 6
+    assert not greenplum_source._is_v7_or_later()
+
+
+def test_version_detection_v7(greenplum_source, mock_engine_with_version):
+    mock_engine_with_version(
+        "PostgreSQL 12.12 (Greenplum Database 7.0.0 build dev) on x86_64-pc-linux-gnu compiled by gcc 12.3.1"
+    )
+    assert greenplum_source._get_greenplum_major_version() == 7
+    assert greenplum_source._is_v7_or_later()
+
+
+def test_version_detection_caches_result(greenplum_source, mock_engine_with_version):
+    mock_engine, _ = mock_engine_with_version(
+        "PostgreSQL 12.12 (Greenplum Database 7.2.0 build dev) on x86_64-pc-linux-gnu"
+    )
+    greenplum_source._get_greenplum_major_version()
+    greenplum_source._get_greenplum_major_version()
+    mock_engine.connect.assert_called_once()
+
+
+def test_version_detection_defaults_to_7_on_error(greenplum_source):
+    mock_engine = MagicMock()
+    mock_engine.connect.side_effect = OperationalError("SELECT version()", {}, Exception("connection error"))
+    greenplum_source.engine = mock_engine
+    greenplum_source._greenplum_version = None
+    assert greenplum_source._get_greenplum_major_version() == 7
+
+
+def test_version_detection_defaults_to_7_on_unparseable(greenplum_source, mock_engine_with_version):
+    mock_engine_with_version("PostgreSQL 14.0 on x86_64-pc-linux-gnu")
+    assert greenplum_source._get_greenplum_major_version() == 7
+
+
+def test_partition_details_v7(greenplum_source):
+    mock_engine = MagicMock()
+    mock_conn = MagicMock()
+    mock_engine.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+    mock_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    mock_conn.execute.return_value.all.return_value = [
+        PartitionRow(schema="public", table_name="sales", partition_strategy="range", column_name="sale_date")
+    ]
+    greenplum_source.engine = mock_engine
+    greenplum_source._greenplum_version = 7
+
+    is_partitioned, partition = greenplum_source.get_table_partition_details("sales", "public", MagicMock())
+
+    assert is_partitioned is True
+    assert partition == TablePartition(
+        columns=[
+            PartitionColumnDetails(
+                columnName="sale_date",
+                intervalType=PartitionIntervalTypes.TIME_UNIT,
+                interval=None,
+            )
+        ]
+    )
+
+
+def test_partition_details_v6(greenplum_source):
+    mock_engine = MagicMock()
+    mock_conn = MagicMock()
+    mock_engine.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+    mock_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    mock_conn.execute.return_value.all.return_value = [
+        PartitionRow(schema="public", table_name="sales", partition_strategy="list", column_name="region")
+    ]
+    greenplum_source.engine = mock_engine
+    greenplum_source._greenplum_version = 6
+
+    is_partitioned, partition = greenplum_source.get_table_partition_details("sales", "public", MagicMock())
+
+    assert is_partitioned is True
+    assert partition == TablePartition(
+        columns=[
+            PartitionColumnDetails(
+                columnName="region",
+                intervalType=PartitionIntervalTypes.COLUMN_VALUE,
+                interval=None,
+            )
+        ]
+    )
+
+
+def test_partition_details_no_results(greenplum_source):
+    mock_engine = MagicMock()
+    mock_conn = MagicMock()
+    mock_engine.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+    mock_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    mock_conn.execute.return_value.all.return_value = []
+    greenplum_source.engine = mock_engine
+    greenplum_source._greenplum_version = 7
+
+    is_partitioned, partition = greenplum_source.get_table_partition_details("not_partitioned", "public", MagicMock())
+
+    assert is_partitioned is False
+    assert partition is None
+
+
+def test_partition_details_expression_key_returns_true_no_columns(greenplum_source):
+    """Expression-based partition keys yield NULL column_name rows; the
+    table should still be reported as partitioned (is_partitioned=True)
+    because a row exists in the partitioning catalog, even though we
+    cannot resolve the column names yet.  partition details are None."""
+    mock_engine = MagicMock()
+    mock_conn = MagicMock()
+    mock_engine.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+    mock_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    mock_conn.execute.return_value.all.return_value = [
+        PartitionRow(schema="public", table_name="sales", partition_strategy="range", column_name=None)
+    ]
+    greenplum_source.engine = mock_engine
+    greenplum_source._greenplum_version = 7
+
+    is_partitioned, partition = greenplum_source.get_table_partition_details("sales", "public", MagicMock())
+
+    assert is_partitioned is True
+    assert partition is None
+
+
+def test_query_table_names_uses_v6_query_for_v6(greenplum_source):
+    mock_connection = MagicMock()
+    mock_connection.execute.return_value = []
+    greenplum_source._greenplum_version = 6
+
+    with patch.object(
+        type(greenplum_source),
+        "connection",
+        new_callable=lambda: property(lambda self: mock_connection),
+    ):
+        list(greenplum_source.query_table_names_and_types("public"))
+
+    executed_sql = str(mock_connection.execute.call_args[0][0])
+    assert executed_sql.strip() == GREENPLUM_GET_TABLE_NAMES_V6.strip()
+    assert "pg_partition_rule" in executed_sql
+
+
+def test_query_table_names_uses_v7_query_for_v7(greenplum_source):
+    mock_connection = MagicMock()
+    mock_connection.execute.return_value = []
+    greenplum_source._greenplum_version = 7
+
+    with patch.object(
+        type(greenplum_source),
+        "connection",
+        new_callable=lambda: property(lambda self: mock_connection),
+    ):
+        list(greenplum_source.query_table_names_and_types("public"))
+
+    executed_sql = str(mock_connection.execute.call_args[0][0])
+    assert executed_sql.strip() == GREENPLUM_GET_TABLE_NAMES_V7.strip()
+    assert "relispartition" in executed_sql
+    assert "pg_partition_rule" not in executed_sql


### PR DESCRIPTION
## PR Description


### Describe your changes:

Fixes #24559

**Problem:**
Greenplum 7 removed the GP-specific catalog tables `pg_partition` and `pg_partition_rule` that the connector relied on for table listing and partition detection. This caused `UndefinedTable` errors when ingesting metadata from GP7 instances.

**Root Cause:**
GP7 adopted PostgreSQL 10+ declarative partitioning, replacing:
- `pg_partition` / `pg_partition_rule` → `pg_partitioned_table` + `relispartition` column in `pg_class`
- `parkind` / `paratts` → `partstrat` / `partattrs`

**Solution:**
Added runtime version detection and dual-path query support:

1. **Version detection** via `SELECT version()` — parses `Greenplum Database X.Y.Z` from the output using regex (note: `SHOW server_version` returns the underlying PostgreSQL version, not Greenplum's, so it cannot be used)
2. **GP6 path** (existing behavior): uses `pg_partition_rule` JOIN for table names, `pg_partition` with `parkind`/`paratts` for partition details
3. **GP7+ path** (new): uses `relispartition = false` for table names, `pg_partitioned_table` with `partstrat`/`partattrs` for partition details
4. **Version caching**: detected version is cached per source instance to avoid repeated queries
5. **Graceful fallback**: defaults to GP7 queries if version detection fails (GP7 is the current release)

**Testing:**
- 9 unit tests (version detection for v6/v7, caching, error fallback, unparseable fallback, partition details for range/list/empty)
- **Tested against real Greenplum 7 database** using Docker (`andruche/greenplum:7`):
  - `SELECT version()` correctly returns `Greenplum Database 7.0.0`
  - Confirmed `pg_partition` and `pg_partition_rule` do NOT exist in GP7
  - Confirmed `pg_partitioned_table` EXISTS in GP7
  - V7 table names query correctly returns only parent tables (filters child partitions)
  - V7 partition details query correctly returns partition strategy and column for both range and list partitioned tables

**Files changed:**
- `ingestion/src/metadata/ingestion/source/database/greenplum/queries.py` — added V7 queries and `SELECT version()` query
- `ingestion/src/metadata/ingestion/source/database/greenplum/metadata.py` — added version detection, query branching, V6/V7 partition detail methods
- `ingestion/tests/unit/topology/database/test_greenplum.py` — added 8 new tests (version detection + partition details)

<!-- Screenshots of Docker GP7 testing attached below -->

#
### Type of change:
- [x] Bug fix

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.

----
## Summary by Gitar

- **Bug fix:**
  - Implemented automatic data-loss prevention by using `errors='replace'` during `datamodel_generation` file operations.
- **Refinement of partition results:**
  - Added `_build_partition_result` helper to handle expression-based partition keys, ensuring tables are correctly marked as partitioned.
- **Robustness improvements:**
  - Added `SQLAlchemyError` handling during version detection to ensure graceful fallback to GP6.
  - Applied explicit `pg_catalog` schema-qualification to partition queries to ensure consistent metadata resolution.

<sub>This will update automatically on new commits.</sub>