### PR TITLE
fix tab disabled for ontology explorer

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyExplorer.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyExplorer.tsx
@@ -2069,7 +2069,10 @@ const OntologyExplorer: React.FC<OntologyExplorerProps> = ({
   }, [graphDataToShow, dataSource, explorationMode, t]);
 
   const renderGraphContent = () => {
-    if (loading && !graphDataToShow) {
+    const hasNoVisibleNodes =
+      !graphDataToShow || graphDataToShow.nodes.length === 0;
+
+    if (loading && hasNoVisibleNodes) {
       return (
         <div
           className="tw:absolute tw:inset-0 tw:z-3 tw:flex tw:flex-col tw:items-center tw:justify-center"
@@ -2102,7 +2105,7 @@ const OntologyExplorer: React.FC<OntologyExplorerProps> = ({
       );
     }
 
-    if (!graphDataToShow || graphDataToShow.nodes.length === 0) {
+    if (hasNoVisibleNodes && !loading) {
       const hasActiveFilter =
         withoutOntologyAutocompleteAll(filters.glossaryIds).length > 0 ||
         withoutOntologyAutocompleteAll(filters.relationTypes).length > 0;
@@ -2130,7 +2133,7 @@ const OntologyExplorer: React.FC<OntologyExplorerProps> = ({
         ) : null}
         <div className="tw:relative tw:z-1 tw:h-full tw:w-full tw:min-h-0">
           <OntologyGraph
-            edges={graphDataToShow.edges}
+            edges={graphDataToShow!.edges}
             expandedTermIds={
               explorationMode === 'data' ? expandedTermIds : undefined
             }
@@ -2152,7 +2155,7 @@ const OntologyExplorer: React.FC<OntologyExplorerProps> = ({
                 : undefined
             }
             nodePositions={hierarchyBakedPositions}
-            nodes={graphDataToShow.nodes}
+            nodes={graphDataToShow!.nodes}
             ref={graphRef}
             selectedNodeId={
               explorationMode === 'data' && expandedTermIds.size > 1
@@ -2264,14 +2267,17 @@ const OntologyExplorer: React.FC<OntologyExplorerProps> = ({
                   handleModeChange(key as ExplorationMode);
                 }
               }}>
-              <Tabs.List
-                items={[
-                  { label: t('label.model'), id: 'model' },
-                  { label: t('label.data'), id: 'data' },
-                ]}
-                size="sm"
-                type="button-border"
-              />
+              <Tabs.List size="sm" type="button-border">
+                <Tabs.Item id="model" label={t('label.model')} />
+                <Tabs.Item
+                  className={(state) =>
+                    state.isDisabled ? 'tw:cursor-not-allowed!' : ''
+                  }
+                  id="data"
+                  isDisabled={loading || isLoadingMore}
+                  label={t('label.data')}
+                />
+              </Tabs.List>
               <Tabs.Panel className="tw:hidden" id="model" />
               <Tabs.Panel className="tw:hidden" id="data" />
             </Tabs>

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyExplorer.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyExplorer.tsx
@@ -2123,6 +2123,10 @@ const OntologyExplorer: React.FC<OntologyExplorerProps> = ({
       );
     }
 
+    if (!graphDataToShow) {
+      return null;
+    }
+
     return (
       <>
         {filters.searchQuery.trim() ? (
@@ -2133,7 +2137,7 @@ const OntologyExplorer: React.FC<OntologyExplorerProps> = ({
         ) : null}
         <div className="tw:relative tw:z-1 tw:h-full tw:w-full tw:min-h-0">
           <OntologyGraph
-            edges={graphDataToShow!.edges}
+            edges={graphDataToShow.edges}
             expandedTermIds={
               explorationMode === 'data' ? expandedTermIds : undefined
             }
@@ -2155,7 +2159,7 @@ const OntologyExplorer: React.FC<OntologyExplorerProps> = ({
                 : undefined
             }
             nodePositions={hierarchyBakedPositions}
-            nodes={graphDataToShow!.nodes}
+            nodes={graphDataToShow.nodes}
             ref={graphRef}
             selectedNodeId={
               explorationMode === 'data' && expandedTermIds.size > 1


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:



<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->



<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **Fixed tab disabled state:**
  - Added null guard check for `graphDataToShow` before rendering `OntologyGraph` component
  - Removed non-null assertions (`!`) from `graphDataToShow.edges` and `graphDataToShow.nodes` property accesses

<sub>This will update automatically on new commits.</sub>