### PR TITLE
refactor: remove stale TODO comments in UserResource.java  Removed outdated TODO comments related to addAuthMechanismToBot method. No functional changes were made.

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java
@@ -1825,7 +1825,6 @@ public class UserResource extends EntityResource<User, UserRepository> {
               original.getAuthenticationMechanism());
       user.setRoles(original.getRoles());
     }
-    // TODO remove this -> Still valid TODO?
     addAuthMechanismToBot(user, create, uriInfo);
     addRolesToBot(user, uriInfo);
     PutResponse<User> response =
@@ -1870,7 +1869,6 @@ public class UserResource extends EntityResource<User, UserRepository> {
     return repository.findToRecords(bot.getId(), Entity.BOT, Relationship.CONTAINS, Entity.USER);
   }
 
-  // TODO remove this -> still valid TODO?
   private void addAuthMechanismToBot(User user, @Valid CreateUser create, UriInfo uriInfo) {
     if (!Boolean.TRUE.equals(user.getIsBot())) {
       throw new IllegalArgumentException(


### PR DESCRIPTION
### Describe your changes:

Fixes #27292

This PR removes stale TODO comments from `UserResource.java` related to the `addAuthMechanismToBot` method.

These TODO comments were no longer relevant since the method is actively used and critical for bot authentication. Keeping them could cause confusion for contributors.

No functional changes were made.

#

### Type of change:

* [ ] Bug fix
* [x] Improvement
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation

#

### Checklist:

* [x] I have read the [**[CONTRIBUTING](https://docs.open-metadata.org/developers/contribute)**](https://docs.open-metadata.org/developers/contribute) document.
* [x] My PR title is `Fixes #27292: Remove stale TODO comments in UserResource.java`
* [ ] I have commented on my code, particularly in hard-to-understand areas.
* [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

### Testing:

Not required, as this change is purely a non-functional cleanup (removal of comments).

### Impact:

* Improves code readability and maintainability
* Removes outdated and misleading comments
* No impact on application behavior