### PR TITLE
Fix: Ensure Kubernetes label and pod name length compliance (≤63 chars)

### DIFF
--- a/openmetadata-k8s-operator/src/main/java/org/openmetadata/operator/service/PodManager.java
+++ b/openmetadata-k8s-operator/src/main/java/org/openmetadata/operator/service/PodManager.java
@@ -408,18 +408,17 @@ public class PodManager {
   }
 
   private String normalize(String name) {
-
+    
     int MAX = 63;
 
     if (name.length() <= MAX) return name;
 
-    LOG.warn("Normalizing long name (>63 chars): {}", name);  // Logs 
+    LOG.warn("Normalizing long name (>63 chars): {}", name);
 
-    String hash = Integer.toHexString(name.hashCode());
+    String hash = Integer.toHexString(Math.abs(name.hashCode()));
     int trimLength = MAX - hash.length() - 1;
 
     return name.substring(0, trimLength) + "-" + hash;
-
   }
 
   private String generateMainPodName(OMJobResource omJob) {

--- a/openmetadata-k8s-operator/src/main/java/org/openmetadata/operator/service/PodManager.java
+++ b/openmetadata-k8s-operator/src/main/java/org/openmetadata/operator/service/PodManager.java
@@ -407,12 +407,27 @@ public class PodManager {
     }
   }
 
+  private String normalize(String name) {
+
+    int MAX = 63;
+
+    if (name.length() <= MAX) return name;
+
+    LOG.warn("Normalizing long name (>63 chars): {}", name);  // Logs 
+
+    String hash = Integer.toHexString(name.hashCode());
+    int trimLength = MAX - hash.length() - 1;
+
+    return name.substring(0, trimLength) + "-" + hash;
+
+  }
+
   private String generateMainPodName(OMJobResource omJob) {
-    return omJob.getMetadata().getName() + "-main";
+    return normalize(omJob.getMetadata().getName() + "-main");
   }
 
   private String generateExitHandlerPodName(OMJobResource omJob) {
-    return omJob.getMetadata().getName() + "-exit";
+    return normalize(omJob.getMetadata().getName() + "-exit");
   }
 
   private String determinePipelineStatus(OMJobResource omJob) {

--- a/openmetadata-k8s-operator/src/main/java/org/openmetadata/operator/util/LabelBuilder.java
+++ b/openmetadata-k8s-operator/src/main/java/org/openmetadata/operator/util/LabelBuilder.java
@@ -56,7 +56,7 @@ public class LabelBuilder {
     labels.put(LABEL_APP_NAME, APP_NAME);
     labels.put(LABEL_APP_COMPONENT, COMPONENT_INGESTION);
     labels.put(LABEL_APP_MANAGED_BY, MANAGED_BY_OMJOB_OPERATOR);
-    labels.put(LABEL_OMJOB_NAME, omJob.getMetadata().getName());
+    labels.put(LABEL_OMJOB_NAME, sanitizeLabelValue(omJob.getMetadata().getName()));
 
     // Copy pipeline and run-id from OMJob labels
     String pipelineName = omJob.getPipelineName();
@@ -113,7 +113,7 @@ public class LabelBuilder {
    */
   public static Map<String, String> buildPodSelector(OMJobResource omJob) {
     Map<String, String> selector = new HashMap<>();
-    selector.put(LABEL_OMJOB_NAME, omJob.getMetadata().getName());
+    selector.put(LABEL_OMJOB_NAME, sanitizeLabelValue(omJob.getMetadata().getName()));
     selector.put(LABEL_APP_MANAGED_BY, MANAGED_BY_OMJOB_OPERATOR);
     return selector;
   }

--- a/openmetadata-k8s-operator/src/main/java/org/openmetadata/operator/util/LabelBuilder.java
+++ b/openmetadata-k8s-operator/src/main/java/org/openmetadata/operator/util/LabelBuilder.java
@@ -148,6 +148,12 @@ public class LabelBuilder {
     String sanitized =
         value.replaceAll("[^a-zA-Z0-9\\-_.]", "-").replaceAll("-+", "-").replaceAll("^-|-$", "");
 
-    return sanitized.length() > 63 ? sanitized.substring(0, 63) : sanitized;
+    if (sanitized.length() > 63) {
+      String hash = Integer.toHexString(value.hashCode());
+      int trimLen = 63 - hash.length() - 1;
+      sanitized = sanitized.substring(0, trimLen) + "-" + hash;
+    }
+
+      return sanitized;
   }
 }

--- a/openmetadata-k8s-operator/src/main/java/org/openmetadata/operator/util/LabelBuilder.java
+++ b/openmetadata-k8s-operator/src/main/java/org/openmetadata/operator/util/LabelBuilder.java
@@ -154,6 +154,6 @@ public class LabelBuilder {
       sanitized = sanitized.substring(0, trimLen) + "-" + hash;
     }
 
-      return sanitized;
+    return sanitized;
   }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #27004

Fixed an issue where long OMJob names (>63 chars) cause pod creation failures due to Kubernetes label constraints.

I updated the code to ensure all names used in pod creation and labels stay within the 63 character limit by:

- normalizing pod names with a hash suffix to preserve uniqueness
- using sanitizeLabelValue for label values
- applying the same logic to selectors to keep consistency

#

### Type of change:
- [x] Bug fix

#

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes #27004: Ensure Kubernetes label and pod name length compliance`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 