### PR TITLE
fix(playwright): make SearchExport tests robust for AUT environments with >200k assets

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchExport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchExport.spec.ts
@@ -27,9 +27,20 @@ const getExportModalContent = (page: Page) =>
 const openExportScopeModal = async (page: Page) => {
   await page.getByTestId('export-search-results-button').click();
   await expect(getExportModalContent(page)).toBeVisible();
-  await expect(
-    getExportModalContent(page).getByRole('button', { name: 'Export' })
-  ).toBeEnabled();
+};
+
+const mockSearchQueryCount = async (page: Page, count = 10) => {
+  await page.route('**/api/v1/search/query?*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        took: 1,
+        hits: { total: { value: count, relation: 'eq' }, hits: [] },
+        aggregations: {},
+      }),
+    });
+  });
 };
 
 test.describe('Search Export', { tag: ['@Features', '@Discovery'] }, () => {
@@ -91,6 +102,7 @@ test.describe('Search Export', { tag: ['@Features', '@Discovery'] }, () => {
   test('All matching assets export calls API with dataAsset index', async ({
     page,
   }) => {
+    await mockSearchQueryCount(page);
     await openExportScopeModal(page);
 
     await test.step('All matching assets radio is pre-selected', async () => {
@@ -190,6 +202,7 @@ test.describe('Search Export', { tag: ['@Features', '@Discovery'] }, () => {
       });
     });
 
+    await mockSearchQueryCount(page);
     await openExportScopeModal(page);
 
     await test.step('Export button becomes disabled and shows loading after click', async () => {
@@ -215,6 +228,7 @@ test.describe('Search Export', { tag: ['@Features', '@Discovery'] }, () => {
       });
     });
 
+    await mockSearchQueryCount(page);
     await openExportScopeModal(page);
 
     await getExportModalContent(page)
@@ -282,6 +296,7 @@ test.describe('Search Export', { tag: ['@Features', '@Discovery'] }, () => {
       });
     });
 
+    await mockSearchQueryCount(page);
     await openExportScopeModal(page);
 
     await test.step('Export button shows loading state while downloading', async () => {


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

## Problem

In AUT environments where the Explore page returns >200,000 total assets, the Export button is disabled by design when "All matching assets" scope is selected. This caused multiple `SearchExport.spec.ts` tests to fail because:

1. `openExportScopeModal` helper asserted `toBeEnabled()` on the Export button unconditionally
2. Tests that click Export with the default "All matching assets" scope had no mock controlling the total count returned when the modal opens

## Root Cause

The Export modal fetches the total asset count via a fresh `searchQuery` call **when the modal opens** (not on page load). In AUT, this returns >200,000, triggering the limit guard and disabling the Export button.

## Fix

- **Removed `toBeEnabled()` from `openExportScopeModal` helper** — the enabled state is environment-dependent and belongs in individual tests, not the shared helper
- **Added `mockSearchQueryCount` helper** — intercepts `**/api/v1/search/query?*` to return a small count (default: 10), ensuring the modal sees a count below the 200k limit
- **Applied `mockSearchQueryCount` to 4 tests** that click Export with the default "All matching assets" scope:
  - `All matching assets export calls API with dataAsset index`
  - `Export button is disabled while export is in progress`
  - `Export API error is shown inside the modal`
  - `Export downloads CSV and closes modal`

Tests using "Visible results" scope are unaffected — switching to that radio always enables the Export button regardless of total count.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
