### PR TITLE
fix for failure to start docker container when running docker compose up

### DIFF
--- a/docker/development/docker-compose-postgres.yml
+++ b/docker/development/docker-compose-postgres.yml
@@ -15,6 +15,7 @@ volumes:
   ingestion-volume-dags:
   ingestion-volume-tmp:
   es-data:
+  db-data-postgres:
 services:
   postgresql:
     build:
@@ -33,7 +34,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-     - ./docker-volume/db-data-postgres:/var/lib/postgresql/data
+     - db-data-postgres:/var/lib/postgresql/data
     networks:
       - local_app_net
     healthcheck:

--- a/docker/development/docker-compose.yml
+++ b/docker/development/docker-compose.yml
@@ -15,6 +15,7 @@ volumes:
   ingestion-volume-dags:
   ingestion-volume-tmp:
   es-data:
+  db-data:
 services:
   mysql:
     build:
@@ -39,7 +40,7 @@ services:
       timeout: 10s
       retries: 10
     volumes:
-     - ./docker-volume/db-data:/var/lib/mysql
+     - db-data:/var/lib/mysql
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:9.3.0

--- a/docker/docker-compose-quickstart/docker-compose-postgres.yml
+++ b/docker/docker-compose-quickstart/docker-compose-postgres.yml
@@ -15,6 +15,7 @@ volumes:
   ingestion-volume-dags:
   ingestion-volume-tmp:
   es-data:
+  db-data-postgres:
 services:
   postgresql:
     container_name: openmetadata_postgresql
@@ -29,7 +30,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-     - ./docker-volume/db-data-postgres:/var/lib/postgresql/data
+     - db-data-postgres:/var/lib/postgresql/data
     
     networks:
       - app_net

--- a/docker/docker-compose-quickstart/docker-compose.yml
+++ b/docker/docker-compose-quickstart/docker-compose.yml
@@ -15,6 +15,7 @@ volumes:
   ingestion-volume-dags:
   ingestion-volume-tmp:
   es-data:
+  db-data:
 services:
   mysql:
     container_name: openmetadata_mysql
@@ -28,7 +29,7 @@ services:
     ports:
       - "3306:3306"
     volumes:
-     - ./docker-volume/db-data:/var/lib/mysql
+     - db-data:/var/lib/mysql
     networks:
       - app_net
     healthcheck:


### PR DESCRIPTION
### Describe your changes:

Fixes <issue-number>

Updated the Docker development compose files so the MySQL and PostgreSQL containers use Docker-managed named volumes for their data directories instead of bind mounts to local host paths.

I worked on this because the SQL containers were failing to start in local environments where the bind-mounted database directories were hosted on filesystems that do not support the permissions and file semantics expected by MySQL/PostgreSQL. In practice, this showed up during local setup when the database containers stayed unhealthy or exited during initialization. Using named volumes makes the setup more reliable across environments, especially with Docker Desktop, WSL, and similar host-mounted filesystem setups.

Changes made:
- Replaced the MySQL data bind mount with a named volume in `docker/development/docker-compose.yml`
- Replaced the PostgreSQL data bind mount with a named volume in `docker/development/docker-compose-postgres.yml`

Tested by:
- validating both compose files with `docker compose -f docker-compose.yml up --detach` and `docker compose -f docker-compose-postgres.yml up --detach`
- reproducing the issue locally with the bind-mounted database path
- confirming the database containers initialize successfully after switching to named volumes

#
### Type of change:
- [x] Bug fix

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas