### PR TITLE
fix: Skip mark_databases_as_deleted for single-database connectors

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/azuresql/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/azuresql/queries.py
@@ -12,4 +12,4 @@
 SQL Queries used during ingestion
 """
 
-AZURE_SQL_GET_DATABASES = "SELECT name FROM sys.databases order by name"
+AZURE_SQL_GET_DATABASES = "SELECT name FROM master.sys.databases order by name"

--- a/ingestion/src/metadata/ingestion/source/database/azuresql/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/azuresql/queries.py
@@ -12,4 +12,4 @@
 SQL Queries used during ingestion
 """
 
-AZURE_SQL_GET_DATABASES = "SELECT name FROM master.sys.databases order by name"
+AZURE_SQL_GET_DATABASES = "SELECT name FROM sys.databases order by name"

--- a/ingestion/src/metadata/ingestion/source/database/database_service.py
+++ b/ingestion/src/metadata/ingestion/source/database/database_service.py
@@ -54,6 +54,7 @@ from metadata.generated.schema.metadataIngestion.workflow import (
 from metadata.generated.schema.type.entityReferenceList import EntityReferenceList
 from metadata.generated.schema.type.tagLabel import TagLabel
 from metadata.ingestion.api.delete import delete_entity_from_source
+from metadata.ingestion.source.database.multi_db_source import MultiDBSource
 from metadata.ingestion.api.models import Either
 from metadata.ingestion.api.steps import Source
 from metadata.ingestion.api.topology_runner import TopologyRunnerMixin
@@ -817,6 +818,12 @@ class DatabaseServiceSource(
         """
         Use the current inspector to mark databases as deleted
         """
+        if (
+            isinstance(self, MultiDBSource)
+            and self.get_configured_database() is not None
+        ):
+            return
+
         if self.source_config.markDeletedDatabases:
             logger.info(
                 f"Mark Deleted Databases set to True. Processing service [{self.context.get().database_service}]"

--- a/ingestion/tests/unit/topology/database/test_azuresql.py
+++ b/ingestion/tests/unit/topology/database/test_azuresql.py
@@ -112,11 +112,9 @@ class AzuresqlUnitTest(TestCase):
         result = self.azuresql_source.get_configured_database()
         assert result is None
 
-    def test_azure_sql_get_databases_query_uses_sys_databases(self):
-        """Verify the query uses sys.databases without master. prefix
-        (master.sys.databases is not supported on Azure SQL Database)"""
-        assert "master" not in AZURE_SQL_GET_DATABASES
-        assert "sys.databases" in AZURE_SQL_GET_DATABASES
+    def test_azure_sql_get_databases_query(self):
+        """Verify the query fetches from master.sys.databases"""
+        assert "master.sys.databases" in AZURE_SQL_GET_DATABASES
 
     def test_mark_deleted_databases_skipped_single_db(self):
         """When ingestAllDatabases=false, mark_databases_as_deleted should be skipped

--- a/ingestion/tests/unit/topology/database/test_azuresql.py
+++ b/ingestion/tests/unit/topology/database/test_azuresql.py
@@ -1,0 +1,194 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Test Azure SQL using the topology
+"""
+
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from metadata.generated.schema.entity.data.database import Database
+from metadata.generated.schema.entity.services.databaseService import (
+    DatabaseConnection,
+    DatabaseService,
+    DatabaseServiceType,
+)
+from metadata.generated.schema.metadataIngestion.workflow import (
+    OpenMetadataWorkflowConfig,
+)
+from metadata.generated.schema.type.entityReference import EntityReference
+from metadata.ingestion.source.database.azuresql.metadata import AzuresqlSource
+from metadata.ingestion.source.database.azuresql.queries import (
+    AZURE_SQL_GET_DATABASES,
+)
+from metadata.ingestion.source.database.multi_db_source import MultiDBSource
+
+mock_azuresql_config = {
+    "source": {
+        "type": "azuresql",
+        "serviceName": "test_azuresql",
+        "serviceConnection": {
+            "config": {
+                "type": "AzureSQL",
+                "hostPort": "test-server.database.windows.net",
+                "database": "test_db",
+                "username": "testuser",
+                "password": "testpass",
+                "driver": "ODBC Driver 18 for SQL Server",
+            }
+        },
+        "sourceConfig": {"config": {"type": "DatabaseMetadata"}},
+    },
+    "sink": {"type": "metadata-rest", "config": {}},
+    "workflowConfig": {
+        "openMetadataServerConfig": {
+            "hostPort": "http://localhost:8585/api",
+            "authProvider": "openmetadata",
+            "securityConfig": {"jwtToken": "azuresql"},
+        }
+    },
+}
+
+MOCK_DATABASE_SERVICE = DatabaseService(
+    id="85811038-099a-11ed-861d-0242ac120002",
+    name="azuresql_source",
+    connection=DatabaseConnection(),
+    serviceType=DatabaseServiceType.AzureSQL,
+)
+
+MOCK_DATABASE = Database(
+    id="2aaa012e-099a-11ed-861d-0242ac120002",
+    name="test_db",
+    fullyQualifiedName="azuresql_source.test_db",
+    displayName="test_db",
+    description="",
+    service=EntityReference(
+        id="85811038-099a-11ed-861d-0242ac120002",
+        type="databaseService",
+    ),
+)
+
+
+class AzuresqlUnitTest(TestCase):
+    @patch(
+        "metadata.ingestion.source.database.common_db_source.CommonDbSourceService.test_connection"
+    )
+    def __init__(self, methodName, test_connection) -> None:
+        super().__init__(methodName)
+        test_connection.return_value = False
+        self.config = OpenMetadataWorkflowConfig.model_validate(mock_azuresql_config)
+        self.azuresql_source = AzuresqlSource.create(
+            mock_azuresql_config["source"],
+            self.config.workflowConfig.openMetadataServerConfig,
+        )
+        self.azuresql_source.context.get().__dict__[
+            "database_service"
+        ] = MOCK_DATABASE_SERVICE.name.root
+        self.azuresql_source.context.get().__dict__[
+            "database"
+        ] = MOCK_DATABASE.name.root
+
+    def test_azuresql_is_multi_db_source(self):
+        """Verify AzuresqlSource implements MultiDBSource"""
+        assert isinstance(self.azuresql_source, MultiDBSource)
+
+    def test_get_configured_database_single_db(self):
+        """When ingestAllDatabases=false, returns the configured database name"""
+        self.azuresql_source.service_connection.ingestAllDatabases = False
+        result = self.azuresql_source.get_configured_database()
+        assert result == "test_db"
+
+    def test_get_configured_database_all_dbs(self):
+        """When ingestAllDatabases=true, returns None"""
+        self.azuresql_source.service_connection.ingestAllDatabases = True
+        result = self.azuresql_source.get_configured_database()
+        assert result is None
+
+    def test_azure_sql_get_databases_query_uses_sys_databases(self):
+        """Verify the query uses sys.databases without master. prefix
+        (master.sys.databases is not supported on Azure SQL Database)"""
+        assert "master" not in AZURE_SQL_GET_DATABASES
+        assert "sys.databases" in AZURE_SQL_GET_DATABASES
+
+    def test_mark_deleted_databases_skipped_single_db(self):
+        """When ingestAllDatabases=false, mark_databases_as_deleted should be skipped
+        entirely — avoids querying sys.databases on Azure SQL Database which
+        only returns the current database anyway"""
+        mock_source_config = MagicMock()
+        mock_source_config.markDeletedDatabases = True
+        self.azuresql_source.source_config = mock_source_config
+
+        with patch.object(
+            self.azuresql_source, "get_configured_database", return_value="test_db"
+        ):
+            with patch(
+                "metadata.ingestion.source.database.database_service.delete_entity_from_source"
+            ) as mock_delete:
+                result = list(self.azuresql_source.mark_databases_as_deleted())
+
+                assert result == []
+                mock_delete.assert_not_called()
+
+    def test_mark_deleted_databases_runs_when_ingest_all(self):
+        """When ingestAllDatabases=true, mark_databases_as_deleted should proceed"""
+        mock_source_config = MagicMock()
+        mock_source_config.markDeletedDatabases = True
+        self.azuresql_source.source_config = mock_source_config
+
+        self.azuresql_source.context.get().__dict__[
+            "database_service"
+        ] = "test_service"
+        self.azuresql_source.database_entity_source_state = {"test_db_fqn"}
+
+        with patch.object(
+            self.azuresql_source, "get_configured_database", return_value=None
+        ):
+            with patch.object(
+                self.azuresql_source, "_get_filtered_database_names"
+            ) as mock_filtered_dbs:
+                mock_filtered_dbs.return_value = ["test_db"]
+
+                with patch(
+                    "metadata.ingestion.source.database.database_service.delete_entity_from_source"
+                ) as mock_delete:
+                    mock_delete.return_value = iter([])
+
+                    list(self.azuresql_source.mark_databases_as_deleted())
+
+                    mock_delete.assert_called_once()
+
+    def test_mark_deleted_databases_disabled(self):
+        """When markDeletedDatabases=false, nothing happens regardless of ingestAllDatabases"""
+        mock_source_config = MagicMock()
+        mock_source_config.markDeletedDatabases = False
+        self.azuresql_source.source_config = mock_source_config
+
+        with patch.object(
+            self.azuresql_source, "get_configured_database", return_value=None
+        ):
+            with patch(
+                "metadata.ingestion.source.database.database_service.delete_entity_from_source"
+            ) as mock_delete:
+                result = list(self.azuresql_source.mark_databases_as_deleted())
+
+                assert result == []
+                mock_delete.assert_not_called()
+
+    def test_get_database_names_single_db(self):
+        """When ingestAllDatabases=false, yields only the configured database"""
+        self.azuresql_source.config.serviceConnection.root.config.ingestAllDatabases = (
+            False
+        )
+
+        with patch.object(self.azuresql_source, "set_inspector"):
+            names = list(self.azuresql_source.get_database_names())
+
+        assert names == ["test_db"]

--- a/ingestion/tests/unit/topology/database/test_postgres.py
+++ b/ingestion/tests/unit/topology/database/test_postgres.py
@@ -568,37 +568,43 @@ class PostgresUnitTest(TestCase):
         # Mock the database entity source state
         self.postgres_source.database_entity_source_state = {"test_db_fqn"}
 
-        # Mock the _get_filtered_database_names method
+        # Simulate ingestAllDatabases=true so mark_databases_as_deleted is not skipped
         with patch.object(
-            self.postgres_source, "_get_filtered_database_names"
-        ) as mock_filtered_dbs:
-            mock_filtered_dbs.return_value = ["test_db", "another_db"]
+            self.postgres_source, "get_configured_database", return_value=None
+        ):
+            # Mock the _get_filtered_database_names method
+            with patch.object(
+                self.postgres_source, "_get_filtered_database_names"
+            ) as mock_filtered_dbs:
+                mock_filtered_dbs.return_value = ["test_db", "another_db"]
 
-            # Mock the delete_entity_from_source function
-            with patch(
-                "metadata.ingestion.source.database.database_service.delete_entity_from_source"
-            ) as mock_delete:
-                mock_delete.return_value = iter([])
+                # Mock the delete_entity_from_source function
+                with patch(
+                    "metadata.ingestion.source.database.database_service.delete_entity_from_source"
+                ) as mock_delete:
+                    mock_delete.return_value = iter([])
 
-                # Call the method
-                result = list(self.postgres_source.mark_databases_as_deleted())
+                    # Call the method
+                    result = list(self.postgres_source.mark_databases_as_deleted())
 
-                # Verify that delete_entity_from_source was called with correct parameters
-                mock_delete.assert_called_once()
-                call_args = mock_delete.call_args
-                self.assertEqual(call_args[1]["entity_type"], Database)
-                self.assertEqual(call_args[1]["mark_deleted_entity"], True)
-                self.assertEqual(call_args[1]["params"], {"service": "test_service"})
+                    # Verify that delete_entity_from_source was called with correct parameters
+                    mock_delete.assert_called_once()
+                    call_args = mock_delete.call_args
+                    self.assertEqual(call_args[1]["entity_type"], Database)
+                    self.assertEqual(call_args[1]["mark_deleted_entity"], True)
+                    self.assertEqual(
+                        call_args[1]["params"], {"service": "test_service"}
+                    )
 
-                # Verify the entity_source_state contains both processed and filtered databases
-                expected_source_state = {
-                    "test_db_fqn",
-                    "test_service.test_db",
-                    "test_service.another_db",
-                }
-                self.assertEqual(
-                    call_args[1]["entity_source_state"], expected_source_state
-                )
+                    # Verify the entity_source_state contains both processed and filtered databases
+                    expected_source_state = {
+                        "test_db_fqn",
+                        "test_service.test_db",
+                        "test_service.another_db",
+                    }
+                    self.assertEqual(
+                        call_args[1]["entity_source_state"], expected_source_state
+                    )
 
     def test_mark_deleted_databases_disabled(self):
         """Test mark deleted databases when the config is disabled"""
@@ -612,6 +618,51 @@ class PostgresUnitTest(TestCase):
 
         # Verify that no deletion operations are performed
         self.assertEqual(result, [])
+
+    def test_mark_deleted_databases_skipped_when_single_db_configured(self):
+        """Test that mark_databases_as_deleted is skipped when
+        get_configured_database returns a value (ingestAllDatabases=false)"""
+        mock_source_config = MagicMock()
+        mock_source_config.markDeletedDatabases = True
+        self.postgres_source.source_config = mock_source_config
+
+        with patch.object(
+            self.postgres_source, "get_configured_database", return_value="my_database"
+        ):
+            with patch(
+                "metadata.ingestion.source.database.database_service.delete_entity_from_source"
+            ) as mock_delete:
+                result = list(self.postgres_source.mark_databases_as_deleted())
+
+                self.assertEqual(result, [])
+                mock_delete.assert_not_called()
+
+    def test_mark_deleted_databases_runs_when_all_databases_ingested(self):
+        """Test that mark_databases_as_deleted runs when
+        get_configured_database returns None (ingestAllDatabases=true)"""
+        mock_source_config = MagicMock()
+        mock_source_config.markDeletedDatabases = True
+        self.postgres_source.source_config = mock_source_config
+
+        self.postgres_source.context.get().__dict__["database_service"] = "test_service"
+        self.postgres_source.database_entity_source_state = {"test_db_fqn"}
+
+        with patch.object(
+            self.postgres_source, "get_configured_database", return_value=None
+        ):
+            with patch.object(
+                self.postgres_source, "_get_filtered_database_names"
+            ) as mock_filtered_dbs:
+                mock_filtered_dbs.return_value = ["test_db"]
+
+                with patch(
+                    "metadata.ingestion.source.database.database_service.delete_entity_from_source"
+                ) as mock_delete:
+                    mock_delete.return_value = iter([])
+
+                    list(self.postgres_source.mark_databases_as_deleted())
+
+                    mock_delete.assert_called_once()
 
     def test_mark_deleted_schemas_with_schema_filter_pattern(self):
         """Test mark deleted schemas with schema filter pattern applied"""
@@ -675,34 +726,38 @@ class PostgresUnitTest(TestCase):
             "test_service.db2",
         }
 
-        # Mock the _get_filtered_database_names method to return filtered databases
+        # Simulate ingestAllDatabases=true so mark_databases_as_deleted is not skipped
         with patch.object(
-            self.postgres_source, "_get_filtered_database_names"
-        ) as mock_filtered_dbs:
-            mock_filtered_dbs.return_value = ["db1"]
+            self.postgres_source, "get_configured_database", return_value=None
+        ):
+            # Mock the _get_filtered_database_names method to return filtered databases
+            with patch.object(
+                self.postgres_source, "_get_filtered_database_names"
+            ) as mock_filtered_dbs:
+                mock_filtered_dbs.return_value = ["db1"]
 
-            # Mock the delete_entity_from_source function
-            with patch(
-                "metadata.ingestion.source.database.database_service.delete_entity_from_source"
-            ) as mock_delete:
-                mock_delete.return_value = iter([])
+                # Mock the delete_entity_from_source function
+                with patch(
+                    "metadata.ingestion.source.database.database_service.delete_entity_from_source"
+                ) as mock_delete:
+                    mock_delete.return_value = iter([])
 
-                # Call the method
-                result = list(self.postgres_source.mark_databases_as_deleted())
+                    # Call the method
+                    result = list(self.postgres_source.mark_databases_as_deleted())
 
-                # Verify that delete_entity_from_source was called
-                mock_delete.assert_called_once()
-                call_args = mock_delete.call_args
+                    # Verify that delete_entity_from_source was called
+                    mock_delete.assert_called_once()
+                    call_args = mock_delete.call_args
 
-                # Verify the entity_source_state contains both processed and filtered databases
-                expected_source_state = {
-                    "test_service.db1",
-                    "test_service.db2",
-                    "test_service.db1",
-                }
-                self.assertEqual(
-                    call_args[1]["entity_source_state"], expected_source_state
-                )
+                    # Verify the entity_source_state contains both processed and filtered databases
+                    expected_source_state = {
+                        "test_service.db1",
+                        "test_service.db2",
+                        "test_service.db1",
+                    }
+                    self.assertEqual(
+                        call_args[1]["entity_source_state"], expected_source_state
+                    )
 
     def test_mark_deleted_schemas_empty_source_state(self):
         """Test mark deleted schemas with empty source state"""
@@ -754,28 +809,32 @@ class PostgresUnitTest(TestCase):
         # Mock empty database entity source state
         self.postgres_source.database_entity_source_state = set()
 
-        # Mock the _get_filtered_database_names method
+        # Simulate ingestAllDatabases=true so mark_databases_as_deleted is not skipped
         with patch.object(
-            self.postgres_source, "_get_filtered_database_names"
-        ) as mock_filtered_dbs:
-            mock_filtered_dbs.return_value = ["db1"]
+            self.postgres_source, "get_configured_database", return_value=None
+        ):
+            # Mock the _get_filtered_database_names method
+            with patch.object(
+                self.postgres_source, "_get_filtered_database_names"
+            ) as mock_filtered_dbs:
+                mock_filtered_dbs.return_value = ["db1"]
 
-            # Mock the delete_entity_from_source function
-            with patch(
-                "metadata.ingestion.source.database.database_service.delete_entity_from_source"
-            ) as mock_delete:
-                mock_delete.return_value = iter([])
+                # Mock the delete_entity_from_source function
+                with patch(
+                    "metadata.ingestion.source.database.database_service.delete_entity_from_source"
+                ) as mock_delete:
+                    mock_delete.return_value = iter([])
 
-                # Call the method
-                result = list(self.postgres_source.mark_databases_as_deleted())
+                    # Call the method
+                    result = list(self.postgres_source.mark_databases_as_deleted())
 
-                # Verify that delete_entity_from_source was called with only filtered databases
-                mock_delete.assert_called_once()
-                call_args = mock_delete.call_args
-                expected_source_state = {"test_service.db1"}
-                self.assertEqual(
-                    call_args[1]["entity_source_state"], expected_source_state
-                )
+                    # Verify that delete_entity_from_source was called with only filtered databases
+                    mock_delete.assert_called_once()
+                    call_args = mock_delete.call_args
+                    expected_source_state = {"test_service.db1"}
+                    self.assertEqual(
+                        call_args[1]["entity_source_state"], expected_source_state
+                    )
 
     def test_mark_deleted_schemas_exception_handling(self):
         """Test mark deleted schemas exception handling"""
@@ -814,15 +873,19 @@ class PostgresUnitTest(TestCase):
         # Mock the database entity source state
         self.postgres_source.database_entity_source_state = {"test_db_fqn"}
 
-        # Mock the _get_filtered_database_names method to raise an exception
+        # Simulate ingestAllDatabases=true so mark_databases_as_deleted is not skipped
         with patch.object(
-            self.postgres_source, "_get_filtered_database_names"
-        ) as mock_filtered_dbs:
-            mock_filtered_dbs.side_effect = Exception("Test exception")
+            self.postgres_source, "get_configured_database", return_value=None
+        ):
+            # Mock the _get_filtered_database_names method to raise an exception
+            with patch.object(
+                self.postgres_source, "_get_filtered_database_names"
+            ) as mock_filtered_dbs:
+                mock_filtered_dbs.side_effect = Exception("Test exception")
 
-            # Call the method and expect it to handle the exception gracefully
-            with self.assertRaises(Exception):
-                list(self.postgres_source.mark_databases_as_deleted())
+                # Call the method and expect it to handle the exception gracefully
+                with self.assertRaises(Exception):
+                    list(self.postgres_source.mark_databases_as_deleted())
 
     def test_mark_deleted_schemas_with_multiple_schemas(self):
         """Test mark deleted schemas with multiple schemas in source state"""
@@ -893,20 +956,24 @@ class PostgresUnitTest(TestCase):
             "test_service.db3",
         }
 
-        # Mock the _get_filtered_database_names method
+        # Simulate ingestAllDatabases=true so mark_databases_as_deleted is not skipped
         with patch.object(
-            self.postgres_source, "_get_filtered_database_names"
-        ) as mock_filtered_dbs:
-            mock_filtered_dbs.return_value = ["db1", "db2"]
+            self.postgres_source, "get_configured_database", return_value=None
+        ):
+            # Mock the _get_filtered_database_names method
+            with patch.object(
+                self.postgres_source, "_get_filtered_database_names"
+            ) as mock_filtered_dbs:
+                mock_filtered_dbs.return_value = ["db1", "db2"]
 
-            # Mock the delete_entity_from_source function
-            with patch(
-                "metadata.ingestion.source.database.database_service.delete_entity_from_source"
-            ) as mock_delete:
-                mock_delete.return_value = iter([])
+                # Mock the delete_entity_from_source function
+                with patch(
+                    "metadata.ingestion.source.database.database_service.delete_entity_from_source"
+                ) as mock_delete:
+                    mock_delete.return_value = iter([])
 
-                # Call the method
-                result = list(self.postgres_source.mark_databases_as_deleted())
+                    # Call the method
+                    result = list(self.postgres_source.mark_databases_as_deleted())
 
                 # Verify that delete_entity_from_source was called
                 mock_delete.assert_called_once()


### PR DESCRIPTION
## Summary
- Fixed Azure SQL `AZURE_SQL_GET_DATABASES` query to use `sys.databases` instead of `master.sys.databases` — the `master.` prefix is not supported on Azure SQL Database (single database tier), causing `mark_databases_as_deleted` post-process to crash.
- Added a guard in `mark_databases_as_deleted` that skips the entire post-process step when the source is a `MultiDBSource` with `ingestAllDatabases=false`. When only ingesting a single configured database, querying all databases to mark deletions is unnecessary and can fail on platforms like Azure SQL Database.
- Added new Azure SQL topology unit tests and updated existing Postgres tests to cover the new guard behavior.

## Test plan
- [x] All 23 existing Postgres topology tests pass
- [x] All 8 new Azure SQL topology tests pass
- [x] Verified `mark_databases_as_deleted` skips when `get_configured_database()` returns a value (single-db mode)
- [x] Verified `mark_databases_as_deleted` proceeds when `get_configured_database()` returns `None` (all-db mode)
- [x] Verified BigQuery/BigTable behavior unchanged (always returns `None`, so deletion always runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)