### PR TITLE
test: fix restore entity field flaky test

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/RestoreEntityInheritedFields.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/RestoreEntityInheritedFields.spec.ts
@@ -104,6 +104,10 @@ entities.forEach((EntityClass) => {
       await redirectToHomePage(page);
 
       await entity.visitEntityPage(page);
+      await expect(page.getByTestId('domain-link')).toContainText(
+        domain.responseData.displayName
+      );
+
       await assignDataProduct(page, domain.responseData, [
         dataProduct.responseData,
       ]);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/RestoreEntityInheritedFields.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/RestoreEntityInheritedFields.spec.ts
@@ -104,9 +104,6 @@ entities.forEach((EntityClass) => {
       await redirectToHomePage(page);
 
       await entity.visitEntityPage(page);
-      await expect(page.getByTestId('domain-link')).toContainText(
-        domain.responseData.displayName
-      );
 
       await assignDataProduct(page, domain.responseData, [
         dataProduct.responseData,

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
@@ -422,6 +422,9 @@ export const assignDataProduct = async (
   action: 'Add' | 'Edit' = 'Add',
   parentId = 'KnowledgePanel.DataProducts'
 ) => {
+  await expect(page.getByTestId('domain-link')).toContainText(
+    domain.displayName
+  );
   await page
     .getByTestId(parentId)
     .getByTestId('data-products-container')


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

The issue is after visiting the entity page the second time, the test immediately calls assignDataProduct without waiting for the inherited domain to be reflected in the UI. The add-data-product button only appears when a domain is present. We need to wait for the domain-link to show the inherited domain before proceeding.

<img width="1512" height="913" alt="Screenshot 2026-04-14 at 11 18 47 AM" src="https://github.com/user-attachments/assets/23933e58-90cd-4e14-8957-dba17f7ea304" />


<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->



<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
