### PR TITLE
Backport #26982 to 1.13: add missing nested type to owners field in index mappings

### DIFF
--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/IndexMappingNestedFieldConsistencyTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/IndexMappingNestedFieldConsistencyTest.java
@@ -1,0 +1,102 @@
+package org.openmetadata.service.search;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.search.IndexMapping;
+import org.openmetadata.search.IndexMappingLoader;
+
+class IndexMappingNestedFieldConsistencyTest {
+
+  private static final List<String> LANGUAGES = List.of("en", "jp", "ru", "zh");
+  private static Map<String, JsonNode> allMappings;
+
+  @BeforeAll
+  static void loadAllMappings() throws IOException {
+    IndexMappingLoader.init();
+    IndexMappingLoader loader = IndexMappingLoader.getInstance();
+    allMappings = new HashMap<>();
+    for (Map.Entry<String, IndexMapping> entry : loader.getIndexMapping().entrySet()) {
+      String entity = entry.getKey();
+      IndexMapping indexMapping = entry.getValue();
+      for (String language : LANGUAGES) {
+        String filePath = indexMapping.getIndexMappingFile(language);
+        try (InputStream in =
+            IndexMappingNestedFieldConsistencyTest.class
+                .getClassLoader()
+                .getResourceAsStream(filePath)) {
+          if (in == null) {
+            continue;
+          }
+          String key = entity + "[" + language + "]";
+          allMappings.put(
+              key, JsonUtils.readTree(new String(in.readAllBytes(), StandardCharsets.UTF_8)));
+        }
+      }
+    }
+    assertTrue(allMappings.size() > 1, "Should load more than one index mapping");
+  }
+
+  @Test
+  void ownersFieldMustBeNestedInAllIndices() {
+    List<String> violations = new ArrayList<>();
+    for (Map.Entry<String, JsonNode> entry : allMappings.entrySet()) {
+      String entity = entry.getKey();
+      JsonNode properties = getTopLevelProperties(entry.getValue());
+      assertNotNull(
+          properties,
+          "Index mapping for '" + entity + "' has no properties — mapping file may be malformed.");
+      List<String> paths = new ArrayList<>();
+      findViolations(properties, "owners", "", paths);
+      for (String path : paths) {
+        violations.add(entity + " (" + path + ")");
+      }
+    }
+    assertTrue(
+        violations.isEmpty(),
+        "The 'owners' field must have \"type\": \"nested\" in all index mappings. "
+            + "Missing in: "
+            + violations
+            + ". RBAC nested queries will fail on these indices.");
+  }
+
+  private static void findViolations(
+      JsonNode properties, String fieldName, String currentPath, List<String> violations) {
+    Iterator<String> fieldNames = properties.fieldNames();
+    while (fieldNames.hasNext()) {
+      String name = fieldNames.next();
+      JsonNode fieldNode = properties.get(name);
+      String path = currentPath.isEmpty() ? name : currentPath + "." + name;
+      if (name.equals(fieldName) && fieldNode.has("properties")) {
+        if (!fieldNode.has("type") || !"nested".equals(fieldNode.path("type").asText())) {
+          violations.add(path);
+        }
+      }
+      JsonNode childProps = fieldNode.path("properties");
+      if (!childProps.isMissingNode()) {
+        findViolations(childProps, fieldName, path, violations);
+      }
+    }
+  }
+
+  private static JsonNode getTopLevelProperties(JsonNode root) {
+    JsonNode props = root.path("mappings").path("properties");
+    if (!props.isMissingNode()) {
+      return props;
+    }
+    props = root.path("properties");
+    return props.isMissingNode() ? null : props;
+  }
+}

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/column_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/column_index_mapping.json
@@ -387,6 +387,7 @@
         }
       },
       "owners": {
+        "type": "nested",
         "properties": {
           "id": {
             "type": "keyword",

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/query_cost_record_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/query_cost_record_index_mapping.json
@@ -233,6 +233,7 @@
             "type": "long"
           },
           "owners": {
+            "type": "nested",
             "properties": {
               "id": {
                 "type": "keyword",

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/column_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/column_index_mapping.json
@@ -392,6 +392,7 @@
         }
       },
       "owners": {
+        "type": "nested",
         "properties": {
           "id": {
             "type": "keyword",

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/query_cost_record_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/query_cost_record_index_mapping.json
@@ -210,6 +210,7 @@
             "type": "long"
           },
           "owners": {
+            "type": "nested",
             "properties": {
               "id": {
                 "type": "keyword",

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/security_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/security_service_index_mapping.json
@@ -207,6 +207,7 @@
             }
           },
           "owners": {
+            "type": "nested",
             "properties": {
               "id": {
                 "type": "keyword",

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/column_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/column_index_mapping.json
@@ -406,6 +406,7 @@
         }
       },
       "owners": {
+        "type": "nested",
         "properties": {
           "id": {
             "type": "keyword",

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/query_cost_record_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/query_cost_record_index_mapping.json
@@ -252,6 +252,7 @@
             "type": "long"
           },
           "owners": {
+            "type": "nested",
             "properties": {
               "id": {
                 "type": "keyword",

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/column_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/column_index_mapping.json
@@ -383,6 +383,7 @@
         }
       },
       "owners": {
+        "type": "nested",
         "properties": {
           "id": {
             "type": "keyword",

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/query_cost_record_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/query_cost_record_index_mapping.json
@@ -228,6 +228,7 @@
             "type": "long"
           },
           "owners": {
+            "type": "nested",
             "properties": {
               "id": {
                 "type": "keyword",

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/security_service_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/security_service_index_mapping.json
@@ -201,6 +201,7 @@
             }
           },
           "owners": {
+            "type": "nested",
             "properties": {
               "id": {
                 "type": "keyword",


### PR DESCRIPTION
## Summary

Backport of #26982 to the `1.13` release branch.

Original commit: 1bf85fcc3d7bf92421413be8797d7d473bd5c1d9

### Conflict resolution
The original commit also modified three `mcp_*_index_mapping.json` files that do not exist on `1.13` (MCP index mappings landed only on `main`). Those three files were dropped from this backport; all other index mapping updates and the new `IndexMappingNestedFieldConsistencyTest` are included as-is.

## Test plan
- [ ] CI green on 1.13
- [ ] `IndexMappingNestedFieldConsistencyTest` passes