### PR TITLE
fix(ingestion): validate URL-formatted hostPort and provide clear user-friendly errors

### DIFF
--- a/ingestion/src/metadata/ingestion/connections/builders.py
+++ b/ingestion/src/metadata/ingestion/connections/builders.py
@@ -34,6 +34,7 @@ from metadata.ingestion.connections.headers import inject_query_header_by_conn
 from metadata.ingestion.connections.query_logger import attach_query_tracker
 from metadata.ingestion.connections.secrets import connection_with_options_secrets
 from metadata.utils.constants import BUILDER_PASSWORD_ATTR
+from metadata.utils.host_port_utils import validate_host_port
 from metadata.utils.logger import cli_logger
 
 logger = cli_logger()
@@ -137,6 +138,9 @@ def get_password_secret(connection) -> SecretStr:
     Helper to extract the password secret from the connection object.
     Handles BasicAuth, IamAuth, and falls back to empty SecretStr if not found.
     """
+    if hasattr(connection, "hostPort") and connection.hostPort:
+        validate_host_port(str(connection.hostPort))
+
     password = getattr(connection, BUILDER_PASSWORD_ATTR, None)
 
     if not password:
@@ -180,6 +184,8 @@ def get_connection_url_common(connection) -> str:
     """
     Common method for building the source connection urls
     """
+    if hasattr(connection, "hostPort") and connection.hostPort:
+        validate_host_port(str(connection.hostPort))
 
     url = f"{connection.scheme.value}://"
 

--- a/ingestion/src/metadata/utils/db_utils.py
+++ b/ingestion/src/metadata/utils/db_utils.py
@@ -36,6 +36,7 @@ from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.models import TableView
 from metadata.utils import fqn
 from metadata.utils.execution_time_tracker import calculate_execution_time_generator
+from metadata.utils.host_port_utils import validate_host_port
 from metadata.utils.logger import utils_logger
 
 logger = utils_logger()
@@ -48,6 +49,8 @@ def get_host_from_host_port(uri: str) -> str:
     if uri is like "localhost:9000"
     then return the host "localhost"
     """
+    if uri:
+        validate_host_port(uri)
     return uri.split(":")[0]
 
 

--- a/ingestion/src/metadata/utils/host_port_utils.py
+++ b/ingestion/src/metadata/utils/host_port_utils.py
@@ -1,0 +1,42 @@
+# Copyright 2024 Collate
+# Licensed under the Apache License, Version 2.0
+# See the LICENSE file for details.
+
+"""
+Utility functions for validating hostPort connection strings.
+"""
+
+import re
+
+
+def validate_host_port(host_port: str) -> None:
+    """
+    Validates that the hostPort value is in the correct
+    'host:port' format.
+
+    Raises a clear, user-friendly ValueError if the user
+    mistakenly provides a full URL like 'http://localhost:3306'
+    instead of 'localhost:3306'.
+
+    Args:
+        host_port: The hostPort string to validate.
+
+    Raises:
+        ValueError: If hostPort contains a URL scheme prefix.
+    """
+    if not host_port:
+        raise ValueError(
+            "hostPort cannot be empty. "
+            "Please provide a value in 'host:port' format "
+            "(e.g. 'localhost:3306')."
+        )
+
+    if re.match(r'^https?://', host_port, re.IGNORECASE):
+        raise ValueError(
+            f"Invalid hostPort format: '{host_port}'. "
+            "Please provide the host and port only, "
+            "without any URL scheme. "
+            "Correct format: 'host:port' "
+            "(e.g. 'localhost:3306'). "
+            "Remove 'http://' or 'https://' from the value."
+        )

--- a/ingestion/tests/unit/test_host_port_utils.py
+++ b/ingestion/tests/unit/test_host_port_utils.py
@@ -1,0 +1,92 @@
+# Copyright 2024 Collate
+# Licensed under the Apache License, Version 2.0
+# See the LICENSE file for details.
+
+"""
+Unit tests for host_port_utils.validate_host_port()
+
+Tests both the UI path (builders.py) and 
+CLI path (db_utils.py) validation.
+
+Issue: #24348
+"""
+
+import pytest
+from metadata.utils.host_port_utils import validate_host_port
+
+
+class TestValidateHostPort:
+    """Tests for validate_host_port() function"""
+
+    # ✅ VALID CASES — should pass with no error
+
+    def test_valid_host_and_port(self):
+        """Standard format should pass"""
+        validate_host_port("localhost:3306")
+
+    def test_valid_ip_and_port(self):
+        """IP address format should pass"""
+        validate_host_port("192.168.1.100:5432")
+
+    def test_valid_cloud_host(self):
+        """Cloud database hostname should pass"""
+        validate_host_port(
+            "mydb.cluster-xyz.us-east-1.rds.amazonaws.com:3306"
+        )
+
+    def test_valid_host_only(self):
+        """Host without port should pass"""
+        validate_host_port("localhost")
+
+    def test_valid_azure_host(self):
+        """Azure database hostname should pass"""
+        validate_host_port(
+            "myserver.database.windows.net:1433"
+        )
+
+    # ❌ INVALID CASES — should raise clear ValueError
+
+    def test_http_prefix_raises_error(self):
+        """http:// prefix must raise friendly ValueError"""
+        with pytest.raises(ValueError) as exc_info:
+            validate_host_port("http://localhost:3306")
+        error_msg = str(exc_info.value)
+        assert "http://" in error_msg
+        assert "localhost:3306" in error_msg
+        assert "Remove" in error_msg
+
+    def test_https_prefix_raises_error(self):
+        """https:// prefix must raise friendly ValueError"""
+        with pytest.raises(ValueError) as exc_info:
+            validate_host_port("https://localhost:3306")
+        error_msg = str(exc_info.value)
+        assert "https://" in error_msg
+        assert "Remove" in error_msg
+
+    def test_http_uppercase_raises_error(self):
+        """HTTP:// uppercase must also be caught"""
+        with pytest.raises(ValueError) as exc_info:
+            validate_host_port("HTTP://localhost:3306")
+        assert "Remove" in str(exc_info.value)
+
+    def test_https_cloud_host_raises_error(self):
+        """https:// with cloud host must raise error"""
+        with pytest.raises(ValueError) as exc_info:
+            validate_host_port(
+                "https://mydb.rds.amazonaws.com:3306"
+            )
+        error_msg = str(exc_info.value)
+        assert "https://" in error_msg
+        assert "Remove" in error_msg
+
+    def test_empty_string_raises_error(self):
+        """Empty hostPort must raise friendly ValueError"""
+        with pytest.raises(ValueError) as exc_info:
+            validate_host_port("")
+        assert "empty" in str(exc_info.value).lower()
+
+    def test_error_message_contains_example(self):
+        """Error message must contain correct example"""
+        with pytest.raises(ValueError) as exc_info:
+            validate_host_port("http://localhost:3306")
+        assert "localhost:3306" in str(exc_info.value)


### PR DESCRIPTION
## Description

Fixes #24348

Users were accidentally entering full URLs like `http://localhost:3306` 
or `https://mydb.rds.amazonaws.com:3306` in the `hostPort` field instead 
of the expected `host:port` format. This caused Python to throw a cryptic 
low-level error deep in the connection stack:
ValueError: invalid literal for int() with base 10: '//localhost'

This error gave users zero guidance on what went wrong or how to fix it.

---

## Root Cause

`hostPort.split(":")` is used across 10+ locations in the codebase. When 
a user provides `http://localhost:3306`, the split produces `['http', '//localhost', '3306']` 
and `int('//localhost')` throws the cryptic `ValueError` with no actionable message.

---

## Fix

### New file — `ingestion/src/metadata/utils/host_port_utils.py`
- Centralized `validate_host_port()` utility function
- Uses regex to detect `http://` or `https://` prefixes (case-insensitive)
- Raises a clear, actionable `ValueError` with the exact fix spelled out for the user:
Invalid hostPort format: 'http://localhost:3306/'.
Please provide the host and port only, without any URL scheme.
Correct format: 'host:port' (e.g. 'localhost:3306').
Remove 'http://' or 'https://' from the value.

### Modified — `ingestion/src/metadata/ingestion/connections/builders.py`
- Validation added at the start of `get_connection_url_common()` → covers **UI path**
- Validation added at the start of `get_password_secret()` → covers **UI path**

### Modified — `ingestion/src/metadata/utils/db_utils.py`
- Validation added at the start of `get_host_from_host_port()` → covers **CLI path** (`metadata ingest -c conf/pipeline.yaml`)

Both paths now produce the same clear error message regardless of how 
the connector is invoked — through the UI or through the CLI.

---

## Testing

### New file — `ingestion/tests/unit/test_host_port_utils.py`

11 unit tests covering:

| Test | Input | Expected |
|------|-------|----------|
| `test_valid_host_and_port` | `localhost:3306` | ✅ Pass |
| `test_valid_ip_and_port` | `192.168.1.100:5432` | ✅ Pass |
| `test_valid_cloud_host` | `mydb.rds.amazonaws.com:3306` | ✅ Pass |
| `test_valid_host_only` | `localhost` | ✅ Pass |
| `test_valid_azure_host` | `myserver.database.windows.net:1433` | ✅ Pass |
| `test_http_prefix_raises_error` | `http://localhost:3306` | ✅ Raises ValueError |
| `test_https_prefix_raises_error` | `https://localhost:3306` | ✅ Raises ValueError |
| `test_http_uppercase_raises_error` | `HTTP://localhost:3306` | ✅ Raises ValueError |
| `test_https_cloud_host_raises_error` | `https://mydb.rds.amazonaws.com:3306` | ✅ Raises ValueError |
| `test_empty_string_raises_error` | `` (empty) | ✅ Raises ValueError |
| `test_error_message_contains_example` | `http://localhost:3306` | ✅ Message contains fix |

All 11 tests passing ✅

```bash
cd ingestion
python -m pytest tests/unit/test_host_port_utils.py -v
```

---

## Files Changed

| File | Change |
|------|--------|
| `ingestion/src/metadata/utils/host_port_utils.py` | ✨ New |
| `ingestion/tests/unit/test_host_port_utils.py` | ✨ New |
| `ingestion/src/metadata/ingestion/connections/builders.py` | 🔧 Modified |
| `ingestion/src/metadata/utils/db_utils.py` | 🔧 Modified |

---

## Checklist

- [x] Fix covers both UI path and CLI path as requested by @harshach
- [x] Centralized utility — single place to update in future
- [x] User-friendly error message with exact fix instructions
- [x] 11 unit tests added, all passing
- [x] No breaking changes — valid `host:port` values pass through unchanged
- [x] Manually validated both paths end to end