### PR TITLE
Fixed the component re-rendering issue which causes the Entity test failure

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataAssetRulesDisabled.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataAssetRulesDisabled.spec.ts
@@ -196,9 +196,9 @@ test.describe(
         ).toBeVisible();
 
         await page
-          .getByTestId('select-owner-tabs')
+          .getByRole('tabpanel', { name: /Users/ })
           .getByTestId('loader')
-          .waitFor({ state: 'detached' });
+          .waitFor({ state: 'hidden' });
 
         await page
           .locator("[data-testid='select-owner-tabs']")
@@ -206,9 +206,9 @@ test.describe(
           .click();
 
         await page
-          .getByTestId('select-owner-tabs')
+          .getByRole('tabpanel', { name: 'Teams' })
           .getByTestId('loader')
-          .waitFor({ state: 'detached' });
+          .waitFor({ state: 'hidden' });
 
         const teamsSearchBar = page.getByTestId(
           'owner-select-teams-search-bar'

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
@@ -245,9 +245,16 @@ export const assignDomain = async (
   await waitForAllLoadersToDisappear(page);
 
   if (checkSelectedDomain) {
-    await expect(page.getByTestId('domain-link')).toContainText(
-      domain.displayName
-    );
+    const hasMultipleDomains = await page
+      .getByTestId('domain-count-button')
+      .isVisible();
+    if (hasMultipleDomains) {
+      await expect(page.getByTestId('domain-count-button')).toBeVisible();
+    } else {
+      await expect(page.getByTestId('domain-link')).toContainText(
+        domain.displayName
+      );
+    }
   }
 };
 
@@ -422,9 +429,17 @@ export const assignDataProduct = async (
   action: 'Add' | 'Edit' = 'Add',
   parentId = 'KnowledgePanel.DataProducts'
 ) => {
-  await expect(page.getByTestId('domain-link')).toContainText(
-    domain.displayName
-  );
+  const hasMultipleDomains = await page
+    .getByTestId('domain-count-button')
+    .isVisible();
+  if (hasMultipleDomains) {
+    await expect(page.getByTestId('domain-count-button')).toBeVisible();
+  } else {
+    await expect(page.getByTestId('domain-link')).toContainText(
+      domain.displayName
+    );
+  }
+
   await page
     .getByTestId(parentId)
     .getByTestId('data-products-container')

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/EntitySelectableList/EntitySelectableList.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/EntitySelectableList/EntitySelectableList.component.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 import { Popover } from 'antd';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { ADD_USER_CONTAINER_HEIGHT } from '../../../constants/constants';
 import { EntityReference } from '../../../generated/entity/data/table';
 import { FocusTrapWithContainer } from '../FocusTrap/FocusTrapWithContainer';
@@ -29,6 +29,11 @@ export const EntitySelectableList = <T,>({
   multiSelect = true,
 }: EntitySelectableListProps<T>) => {
   const [popupVisible, setPopupVisible] = useState(false);
+
+  const selectedItemsAsEntityReferences = useMemo(
+    () => config.toEntityReference(selectedItems),
+    [selectedItems, config.toEntityReference]
+  );
 
   const handleUpdate = async (updateItems: EntityReference[]) => {
     const convertedItems = config.fromEntityReference(updateItems);
@@ -49,7 +54,7 @@ export const EntitySelectableList = <T,>({
               multiSelect={multiSelect}
               searchBarDataTestId={config.searchBarDataTestId}
               searchPlaceholder={config.searchPlaceholder}
-              selectedItems={config.toEntityReference(selectedItems)}
+              selectedItems={selectedItemsAsEntityReferences}
               onCancel={onCancel}
               onUpdate={handleUpdate}
             />


### PR DESCRIPTION

<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:
config.toEntityReference(selectedItems) was called inline in JSX, creating a new array reference on every render. This triggered SelectableList useEffect([selectedItems]) , which reset selectedItemsInternal back from the prop — overwriting the empty Map set by "clear all" before Update was clicked. useMemo stabilizes the reference so the effect only fires when the actual tag data changes.

Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

https://github.com/user-attachments/assets/d8c51ed3-4660-4f4d-9710-5f55cab3e7d0



#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
