### PR TITLE
Fix Parquet Reader to use boto3 client

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/datalake/clients/azure_blob.py
+++ b/ingestion/src/metadata/ingestion/source/database/datalake/clients/azure_blob.py
@@ -13,7 +13,7 @@
 Datalake Azure Blob Client
 """
 from functools import partial
-from typing import Callable, Iterable, Optional, Set
+from typing import Callable, Iterable, Optional, Set, Tuple
 
 from azure.storage.blob import BlobServiceClient
 
@@ -62,7 +62,7 @@ class DatalakeAzureBlobClient(DatalakeBaseClient):
         bucket_name: str,
         prefix: Optional[str],
         skip_cold_storage: bool = False,
-    ) -> Iterable[str]:
+    ) -> Iterable[Tuple[str, Optional[int]]]:
         container_client = self._client.get_container_client(bucket_name)
 
         for file in container_client.list_blobs(name_starts_with=prefix or None):
@@ -74,7 +74,7 @@ class DatalakeAzureBlobClient(DatalakeBaseClient):
                         f"(blob_tier: {blob_tier})"
                     )
                     continue
-            yield file.name
+            yield file.name, getattr(file, "size", None)
 
     def close(self, service_connection):
         self._client.close()

--- a/ingestion/src/metadata/ingestion/source/database/datalake/clients/base.py
+++ b/ingestion/src/metadata/ingestion/source/database/datalake/clients/base.py
@@ -13,18 +13,23 @@
 Datalake Base Client
 """
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Iterable, Optional
+from typing import Any, Callable, Iterable, Optional, Tuple
 
 
 class DatalakeBaseClient(ABC):
     """Base DL client implementation"""
 
-    def __init__(self, client: Any, **kwargs):
+    def __init__(self, client: Any, session: Any = None, **kwargs):
         self._client = client
+        self._session = session
 
     @property
     def client(self) -> Any:
         return self._client
+
+    @property
+    def session(self) -> Any:
+        return self._session
 
     @classmethod
     @abstractmethod
@@ -49,8 +54,8 @@ class DatalakeBaseClient(ABC):
         bucket_name: str,
         prefix: Optional[str],
         skip_cold_storage: bool = False,
-    ) -> Iterable[str]:
-        """Returns the Table names, based on the underlying client."""
+    ) -> Iterable[Tuple[str, Optional[int]]]:
+        """Returns (key, file_size_bytes) tuples. Size may be None if unavailable."""
 
     @abstractmethod
     def close(self, service_connection):

--- a/ingestion/src/metadata/ingestion/source/database/datalake/clients/gcs.py
+++ b/ingestion/src/metadata/ingestion/source/database/datalake/clients/gcs.py
@@ -15,7 +15,7 @@ Datalake GCS Client
 import os
 from copy import deepcopy
 from functools import partial
-from typing import Callable, Iterable, List, Optional, Set
+from typing import Callable, Iterable, List, Optional, Set, Tuple
 
 from google.cloud import storage
 
@@ -117,7 +117,7 @@ class DatalakeGcsClient(DatalakeBaseClient):
         bucket_name: str,
         prefix: Optional[str],
         skip_cold_storage: bool = False,
-    ) -> Iterable[str]:
+    ) -> Iterable[Tuple[str, Optional[int]]]:
         bucket = self._client.get_bucket(bucket_name)
 
         for key in bucket.list_blobs(prefix=prefix):
@@ -129,7 +129,7 @@ class DatalakeGcsClient(DatalakeBaseClient):
                         f"(storage_class: {storage_class})"
                     )
                     continue
-            yield key.name
+            yield key.name, key.size
 
     def close(self, service_connection):
         os.environ.pop("GOOGLE_CLOUD_PROJECT", "")

--- a/ingestion/src/metadata/ingestion/source/database/datalake/clients/s3.py
+++ b/ingestion/src/metadata/ingestion/source/database/datalake/clients/s3.py
@@ -37,7 +37,13 @@ class DatalakeS3Client(DatalakeBaseClient):
 
         aws_client = AWSClient(config.securityConfig)
         session = aws_client.create_session()
-        s3_client = aws_client.get_client(service_name="s3")
+        if config.securityConfig.endPointURL:
+            s3_client = session.client(
+                service_name="s3",
+                endpoint_url=str(config.securityConfig.endPointURL),
+            )
+        else:
+            s3_client = session.client(service_name="s3")
         return cls(client=s3_client, session=session)
 
     def update_client_database(self, config, database_name: str):

--- a/ingestion/src/metadata/ingestion/source/database/datalake/clients/s3.py
+++ b/ingestion/src/metadata/ingestion/source/database/datalake/clients/s3.py
@@ -13,7 +13,7 @@
 Datalake S3 Client
 """
 from functools import partial
-from typing import Callable, Iterable, Optional, Set
+from typing import Callable, Iterable, Optional, Set, Tuple
 
 from metadata.clients.aws_client import AWSClient
 from metadata.generated.schema.entity.services.connections.database.datalake.s3Config import (
@@ -59,7 +59,7 @@ class DatalakeS3Client(DatalakeBaseClient):
         bucket_name: str,
         prefix: Optional[str],
         skip_cold_storage: bool = False,
-    ) -> Iterable[str]:
+    ) -> Iterable[Tuple[str, Optional[int]]]:
         kwargs = {"Bucket": bucket_name}
 
         if prefix:

--- a/ingestion/src/metadata/ingestion/source/database/datalake/clients/s3.py
+++ b/ingestion/src/metadata/ingestion/source/database/datalake/clients/s3.py
@@ -35,8 +35,10 @@ class DatalakeS3Client(DatalakeBaseClient):
         if not config.securityConfig:
             raise RuntimeError("S3Config securityConfig can't be None.")
 
-        s3_client = AWSClient(config.securityConfig).get_client(service_name="s3")
-        return cls(client=s3_client)
+        aws_client = AWSClient(config.securityConfig)
+        session = aws_client.create_session()
+        s3_client = aws_client.get_client(service_name="s3")
+        return cls(client=s3_client, session=session)
 
     def update_client_database(self, config, database_name: str):
         # For the S3 Client we don't need to do anything when changing the database
@@ -76,7 +78,7 @@ class DatalakeS3Client(DatalakeBaseClient):
                         f"(StorageClass: {storage_class}, ArchiveStatus: {archive_status})"
                     )
                     continue
-            yield key["Key"]
+            yield key["Key"], key.get("Size")
 
     def get_folders_prefix(
         self, bucket_name: str, prefix: Optional[str]

--- a/ingestion/src/metadata/ingestion/source/database/datalake/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/datalake/metadata.py
@@ -285,7 +285,7 @@ class DatalakeSource(DatabaseServiceSource):
             table_constraints = None
             data_frame, raw_data = fetch_dataframe_first_chunk(
                 config_source=self.config_source,
-                client=self.client._client,
+                client=self.client.client,
                 file_fqn=DatalakeTableSchemaWrapper(
                     key=table_name,
                     bucket_name=schema_name,
@@ -293,7 +293,7 @@ class DatalakeSource(DatabaseServiceSource):
                     file_size=file_size,
                 ),
                 fetch_raw_data=True,
-                session=getattr(self.client, "_session", None),
+                session=getattr(self.client, "session", None),
             )
             if data_frame:
                 data_frame = next(data_frame)

--- a/ingestion/src/metadata/ingestion/source/database/datalake/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/datalake/metadata.py
@@ -226,7 +226,7 @@ class DatalakeSource(DatabaseServiceSource):
 
     def get_tables_name_and_type(  # pylint: disable=too-many-branches
         self,
-    ) -> Iterable[Tuple[str, TableType, SupportedTypes]]:
+    ) -> Iterable[Tuple[str, TableType, SupportedTypes, Optional[int]]]:
         """
         Handle table and views.
 
@@ -251,7 +251,7 @@ class DatalakeSource(DatabaseServiceSource):
             skip_cold_storage = (
                 getattr(self.service_connection, "skipColdStorage", False) or False
             )
-            for key_name in self.client.get_table_names(
+            for key_name, file_size in self.client.get_table_names(
                 bucket_name, prefix, skip_cold_storage=skip_cold_storage
             ):
                 table_name = self.standardize_table_name(bucket_name, key_name)
@@ -269,17 +269,17 @@ class DatalakeSource(DatabaseServiceSource):
                     )
                     continue
 
-                yield table_name, TableType.Regular, file_extension
+                yield table_name, TableType.Regular, file_extension, file_size
 
     def yield_table(
-        self, table_name_and_type: Tuple[str, TableType, SupportedTypes]
+        self, table_name_and_type: Tuple[str, TableType, SupportedTypes, Optional[int]]
     ) -> Iterable[Either[CreateTableRequest]]:
         """
         From topology.
         Prepare a table request and pass it to the sink.
         Uses first chunk only for schema inference to avoid loading entire file.
         """
-        table_name, table_type, table_extension = table_name_and_type
+        table_name, table_type, table_extension, file_size = table_name_and_type
         schema_name = self.context.get().database_schema
         try:
             table_constraints = None
@@ -290,8 +290,10 @@ class DatalakeSource(DatabaseServiceSource):
                     key=table_name,
                     bucket_name=schema_name,
                     file_extension=table_extension,
+                    file_size=file_size,
                 ),
                 fetch_raw_data=True,
+                session=getattr(self.client, "_session", None),
             )
             if data_frame:
                 data_frame = next(data_frame)

--- a/ingestion/src/metadata/readers/dataframe/avro.py
+++ b/ingestion/src/metadata/readers/dataframe/avro.py
@@ -108,14 +108,11 @@ class AvroDataFrameReader(DataFrameReader):
     @_read_avro_dispatch.register
     def _(self, _: S3Config, key: str, bucket_name: str) -> DatalakeColumnWrapper:
         """Stream Avro from S3 without loading entire file into memory."""
-        import io
-
         schema_response = self.client.get_object(Bucket=bucket_name, Key=key)
         try:
-            schema_buffer = io.BytesIO(schema_response["Body"].read())
+            columns = self._get_avro_columns(schema_response["Body"])
         finally:
             schema_response["Body"].close()
-        columns = self._get_avro_columns(schema_buffer)
 
         def chunk_generator():
             response = self.client.get_object(Bucket=bucket_name, Key=key)

--- a/ingestion/src/metadata/readers/dataframe/avro.py
+++ b/ingestion/src/metadata/readers/dataframe/avro.py
@@ -33,7 +33,6 @@ from metadata.generated.schema.type.schema import DataTypeTopic
 from metadata.readers.dataframe.base import DataFrameReader, FileFormatException
 from metadata.readers.dataframe.models import DatalakeColumnWrapper
 from metadata.readers.file.adls import return_azure_storage_options
-from metadata.readers.file.s3 import return_s3_storage_options
 from metadata.readers.models import ConfigSource
 from metadata.utils.constants import CHUNKSIZE
 from metadata.utils.logger import ingestion_logger
@@ -109,19 +108,21 @@ class AvroDataFrameReader(DataFrameReader):
     @_read_avro_dispatch.register
     def _(self, _: S3Config, key: str, bucket_name: str) -> DatalakeColumnWrapper:
         """Stream Avro from S3 without loading entire file into memory."""
-        from s3fs import S3FileSystem
+        import io
 
-        storage_options = return_s3_storage_options(self.config_source)
-        s3 = S3FileSystem(**storage_options)
-        file_path = f"s3://{bucket_name}/{key}"
-
-        with s3.open(file_path, "rb") as f:
-            columns = self._get_avro_columns(f)
+        schema_response = self.client.get_object(Bucket=bucket_name, Key=key)
+        try:
+            schema_buffer = io.BytesIO(schema_response["Body"].read())
+        finally:
+            schema_response["Body"].close()
+        columns = self._get_avro_columns(schema_buffer)
 
         def chunk_generator():
             response = self.client.get_object(Bucket=bucket_name, Key=key)
-            file_stream = response["Body"]
-            yield from self._stream_avro_records(file_stream)
+            try:
+                yield from self._stream_avro_records(response["Body"])
+            finally:
+                response["Body"].close()
 
         return DatalakeColumnWrapper(
             columns=columns,

--- a/ingestion/src/metadata/readers/dataframe/base.py
+++ b/ingestion/src/metadata/readers/dataframe/base.py
@@ -64,43 +64,44 @@ class DataFrameReader(ABC):
     config_source: ConfigSource
     reader: Reader
 
-    def __init__(self, config_source: ConfigSource, client: Optional[Any]):
+    def __init__(
+        self,
+        config_source: ConfigSource,
+        client: Optional[Any],
+        session: Optional[Any] = None,
+    ):
         self.config_source = config_source
         self.client = client
+        self.session = session
 
         self.reader = get_reader(config_source=config_source, client=client)
 
-    def _get_file_size_mb(self, key: str, bucket_name: str) -> float:
+    def _get_file_size_mb(
+        self, key: str, bucket_name: str, file_size: Optional[int] = None
+    ) -> float:
         """
         Get file size in MB. Returns 0 if unable to determine.
-        Uses efficient HEAD operations from cloud providers.
+        If file_size (bytes) is provided from listing metadata, uses that
+        to avoid a redundant HEAD/info API call.
         """
+        if file_size is not None:
+            return file_size / (1024 * 1024)
         try:
             if isinstance(self.config_source, S3Config):
                 response = self.client.head_object(Bucket=bucket_name, Key=key)
                 return response.get("ContentLength", 0) / (1024 * 1024)
 
             elif isinstance(self.config_source, GCSConfig):
-                from gcsfs import GCSFileSystem
-
-                gcs = GCSFileSystem()
-                file_path = f"gs://{bucket_name}/{key}"
-                file_info = gcs.info(file_path)
-                return file_info.get("size", 0) / (1024 * 1024)
+                bucket = self.client.get_bucket(bucket_name)
+                blob = bucket.get_blob(key)
+                return (blob.size or 0) / (1024 * 1024) if blob else 0
 
             elif isinstance(self.config_source, AzureConfig):
-                from adlfs import AzureBlobFileSystem
-
-                from metadata.readers.file.adls import return_azure_storage_options
-
-                storage_options = return_azure_storage_options(self.config_source)
-                adlfs_fs = AzureBlobFileSystem(
-                    account_name=self.config_source.securityConfig.accountName,
-                    **storage_options,
+                blob_client = self.client.get_blob_client(
+                    container=bucket_name, blob=key
                 )
-                file_path = f"{bucket_name}/{key}"
-                file_info = adlfs_fs.info(file_path)
-                return file_info.get("size", 0) / (1024 * 1024)
+                props = blob_client.get_blob_properties()
+                return (props.size or 0) / (1024 * 1024)
 
             elif isinstance(self.config_source, LocalConfig):
                 import os

--- a/ingestion/src/metadata/readers/dataframe/dsv.py
+++ b/ingestion/src/metadata/readers/dataframe/dsv.py
@@ -34,7 +34,6 @@ from metadata.generated.schema.entity.services.connections.database.datalakeConn
 from metadata.readers.dataframe.base import DataFrameReader, FileFormatException
 from metadata.readers.dataframe.models import DatalakeColumnWrapper
 from metadata.readers.file.adls import AZURE_PATH, return_azure_storage_options
-from metadata.readers.file.s3 import return_s3_storage_options
 from metadata.readers.models import ConfigSource
 from metadata.utils.constants import CHUNKSIZE
 from metadata.utils.logger import ingestion_logger
@@ -173,12 +172,31 @@ class DSVDataFrameReader(DataFrameReader):
 
     @_read_dsv_dispatch.register
     def _(self, _: S3Config, key: str, bucket_name: str) -> DatalakeColumnWrapper:
+        import pandas as pd  # pylint: disable=import-outside-toplevel
+
         compression = "gzip" if key.endswith(".gz") else None
 
-        storage_options = return_s3_storage_options(self.config_source)
-        path = f"s3://{bucket_name}/{key}"
-        return self.read_from_pandas(
-            path=path, storage_options=storage_options, compression=compression
+        def chunk_generator():
+            response = self.client.get_object(Bucket=bucket_name, Key=key)
+            try:
+                with pd.read_csv(
+                    response["Body"],
+                    sep=self.separator,
+                    chunksize=CHUNKSIZE,
+                    compression=compression,
+                    encoding_errors="ignore",
+                    escapechar="\\",
+                ) as reader:
+                    for chunks in reader:
+                        chunks = self._fix_malformed_quoted_chunk(
+                            chunk_list=[chunks], separator=self.separator
+                        )[0]
+                        yield chunks
+            finally:
+                response["Body"].close()
+
+        return DatalakeColumnWrapper(
+            dataframes=chunk_generator, columns=None, raw_data=None
         )
 
     @_read_dsv_dispatch.register

--- a/ingestion/src/metadata/readers/dataframe/dsv.py
+++ b/ingestion/src/metadata/readers/dataframe/dsv.py
@@ -115,9 +115,10 @@ class DSVDataFrameReader(DataFrameReader):
         config_source: ConfigSource,
         client: Optional[Any],
         separator: str = CSV_SEPARATOR,
+        session: Optional[Any] = None,
     ):
         self.separator = separator
-        super().__init__(config_source, client)
+        super().__init__(config_source, client, session=session)
 
     def read_from_pandas(
         self,
@@ -188,10 +189,11 @@ class DSVDataFrameReader(DataFrameReader):
                     escapechar="\\",
                 ) as reader:
                     for chunks in reader:
-                        chunks = self._fix_malformed_quoted_chunk(
+                        fixed = self._fix_malformed_quoted_chunk(
                             chunk_list=[chunks], separator=self.separator
-                        )[0]
-                        yield chunks
+                        )
+                        if fixed:
+                            yield fixed[0]
             finally:
                 response["Body"].close()
 

--- a/ingestion/src/metadata/readers/dataframe/json.py
+++ b/ingestion/src/metadata/readers/dataframe/json.py
@@ -158,7 +158,11 @@ class JSONDataFrameReader(DataFrameReader):
             return False
 
     def _read_json_smart(
-        self, file_obj_getter, key: str, bucket_name: str
+        self,
+        file_obj_getter,
+        key: str,
+        bucket_name: str,
+        file_size: Optional[int] = None,
     ) -> DatalakeColumnWrapper:
         """
         Smart JSON reading with automatic format detection and streaming.
@@ -179,7 +183,7 @@ class JSONDataFrameReader(DataFrameReader):
                 dataframes=chunk_generator, raw_data=None, columns=None
             )
 
-        file_size_mb = self._get_file_size_mb(key, bucket_name)
+        file_size_mb = self._get_file_size_mb(key, bucket_name, file_size=file_size)
         if file_size_mb > (MAX_FILE_SIZE_FOR_PREVIEW / (1024 * 1024)):
             logger.info(
                 f"Large JSON file ({file_size_mb:.2f} MB). Streaming with ijson."
@@ -223,7 +227,9 @@ class JSONDataFrameReader(DataFrameReader):
             finally:
                 response["Body"].close()
 
-        return self._read_json_smart(get_stream, key, bucket_name)
+        return self._read_json_smart(
+            get_stream, key, bucket_name, file_size=self._file_size
+        )
 
     @_read_json_dispatch.register
     def _(self, _: GCSConfig, key: str, bucket_name: str) -> DatalakeColumnWrapper:
@@ -271,7 +277,10 @@ class JSONDataFrameReader(DataFrameReader):
 
         return self._read_json_smart(get_stream, key, bucket_name)
 
-    def _read(self, *, key: str, bucket_name: str, **__) -> DatalakeColumnWrapper:
+    def _read(
+        self, *, key: str, bucket_name: str, file_size: Optional[int] = None, **__
+    ) -> DatalakeColumnWrapper:
+        self._file_size = file_size
         return self._read_json_dispatch(
             self.config_source, key=key, bucket_name=bucket_name
         )

--- a/ingestion/src/metadata/readers/dataframe/models.py
+++ b/ingestion/src/metadata/readers/dataframe/models.py
@@ -59,6 +59,13 @@ class DatalakeTableSchemaWrapper(BaseModel):
         Optional[str],
         Field(None, description="Used for DSV readers to identify the separator"),
     ]
+    file_size: Annotated[
+        Optional[int],
+        Field(
+            None,
+            description="File size in bytes from listing. Avoids redundant HEAD requests.",
+        ),
+    ]
 
 
 class DatalakeTableMetadata(BaseModel):

--- a/ingestion/src/metadata/readers/dataframe/parquet.py
+++ b/ingestion/src/metadata/readers/dataframe/parquet.py
@@ -213,10 +213,12 @@ class ParquetDataFrameReader(DataFrameReader):
 
         kwargs = {}
         if self.session:
-            creds = self.session.get_credentials().get_frozen_credentials()
-            kwargs["key"] = creds.access_key
-            kwargs["secret"] = creds.secret_key
-            kwargs["token"] = creds.token
+            credentials = self.session.get_credentials()
+            if credentials is not None:
+                creds = credentials.get_frozen_credentials()
+                kwargs["key"] = creds.access_key
+                kwargs["secret"] = creds.secret_key
+                kwargs["token"] = creds.token
         elif self.config_source.securityConfig.awsAccessKeyId:
             kwargs["key"] = self.config_source.securityConfig.awsAccessKeyId
             if self.config_source.securityConfig.awsSecretAccessKey:

--- a/ingestion/src/metadata/readers/dataframe/parquet.py
+++ b/ingestion/src/metadata/readers/dataframe/parquet.py
@@ -200,32 +200,68 @@ class ParquetDataFrameReader(DataFrameReader):
                 dataframes=chunk_generator, raw_data=None, columns=None
             )
 
+    def _build_s3fs_filesystem(self):
+        """Build an s3fs filesystem using credentials from the boto3 client.
+
+        Extracts the already-resolved credentials (including AssumeRole,
+        instance profile, ECS task role, etc.) so s3fs uses the same auth
+        as the rest of the connector.
+        """
+        # pylint: disable=import-outside-toplevel
+        from s3fs import S3FileSystem
+
+        creds = self.client._request_signer._credentials.get_frozen_credentials()
+
+        client_kwargs = {}
+        if self.config_source.securityConfig.endPointURL:
+            client_kwargs["endpoint_url"] = str(
+                self.config_source.securityConfig.endPointURL
+            )
+        if self.config_source.securityConfig.awsRegion:
+            client_kwargs["region_name"] = self.config_source.securityConfig.awsRegion
+
+        return S3FileSystem(
+            key=creds.access_key,
+            secret=creds.secret_key,
+            token=creds.token,
+            client_kwargs=client_kwargs if client_kwargs else None,
+        )
+
     @_read_parquet_dispatch.register
     def _(self, _: S3Config, key: str, bucket_name: str) -> DatalakeColumnWrapper:
         # pylint: disable=import-outside-toplevel
-        import io
-
         from pyarrow.parquet import ParquetFile
 
-        def chunk_generator():
-            response = self.client.get_object(Bucket=bucket_name, Key=key)
-            try:
-                buffer = io.BytesIO(response["Body"].read())
-            finally:
-                response["Body"].close()
+        s3_fs = self._build_s3fs_filesystem()
+        file_path = f"{bucket_name}/{key}"
 
-            file_size = buffer.getbuffer().nbytes
-            parquet_file = ParquetFile(buffer)
+        try:
+            file_size = s3_fs.info(file_path)["size"]
+        except Exception as exc:
+            logger.warning(
+                f"Could not determine file size for {file_path}: {exc}. "
+                f"Assuming large file."
+            )
+            file_size = 0
 
-            if self._should_use_chunking(file_size):
+        if self._should_use_chunking(file_size):
+
+            def chunk_generator():
                 logger.info(
                     f"Large parquet file detected ({file_size} bytes > "
                     f"{MAX_FILE_SIZE_FOR_PREVIEW} bytes). "
-                    f"Using batched reading for file: {bucket_name}/{key}"
+                    f"Using batched reading for file: {file_path}"
                 )
-                yield from self._read_parquet_in_batches(parquet_file)
-            else:
-                yield from dataframe_to_chunks(parquet_file.read().to_pandas())
+                with s3_fs.open(file_path) as f:
+                    parquet_file = ParquetFile(f)
+                    yield from self._read_parquet_in_batches(parquet_file)
+
+        else:
+
+            def chunk_generator():
+                with s3_fs.open(file_path) as f:
+                    parquet_file = ParquetFile(f)
+                    yield from dataframe_to_chunks(parquet_file.read().to_pandas())
 
         return DatalakeColumnWrapper(
             dataframes=chunk_generator, raw_data=None, columns=None

--- a/ingestion/src/metadata/readers/dataframe/parquet.py
+++ b/ingestion/src/metadata/readers/dataframe/parquet.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import os
 from functools import singledispatchmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from metadata.generated.schema.entity.services.connections.database.datalake.azureConfig import (
     AzureConfig,
@@ -201,16 +201,22 @@ class ParquetDataFrameReader(DataFrameReader):
             )
 
     def _build_s3fs_filesystem(self):
-        """Build an s3fs filesystem using credentials from the boto3 client.
+        """Build an s3fs filesystem using credentials from the boto3 session.
 
-        Extracts the already-resolved credentials (including AssumeRole,
-        instance profile, ECS task role, etc.) so s3fs uses the same auth
-        as the rest of the connector.
+        Uses the session created by AWSClient which already handles
+        AssumeRole, instance profiles, ECS task roles, etc.
+        Falls back to default credential chain if no session is available
+        (e.g., when called from profiler).
         """
         # pylint: disable=import-outside-toplevel
         from s3fs import S3FileSystem
 
-        creds = self.client._request_signer._credentials.get_frozen_credentials()
+        kwargs = {}
+        if self.session:
+            creds = self.session.get_credentials().get_frozen_credentials()
+            kwargs["key"] = creds.access_key
+            kwargs["secret"] = creds.secret_key
+            kwargs["token"] = creds.token
 
         client_kwargs = {}
         if self.config_source.securityConfig.endPointURL:
@@ -220,12 +226,10 @@ class ParquetDataFrameReader(DataFrameReader):
         if self.config_source.securityConfig.awsRegion:
             client_kwargs["region_name"] = self.config_source.securityConfig.awsRegion
 
-        return S3FileSystem(
-            key=creds.access_key,
-            secret=creds.secret_key,
-            token=creds.token,
-            client_kwargs=client_kwargs if client_kwargs else None,
-        )
+        if client_kwargs:
+            kwargs["client_kwargs"] = client_kwargs
+
+        return S3FileSystem(**kwargs)
 
     @_read_parquet_dispatch.register
     def _(self, _: S3Config, key: str, bucket_name: str) -> DatalakeColumnWrapper:
@@ -234,24 +238,32 @@ class ParquetDataFrameReader(DataFrameReader):
 
         s3_fs = self._build_s3fs_filesystem()
         file_path = f"{bucket_name}/{key}"
+        file_size = getattr(self, "_file_size", None)
 
-        try:
-            file_size = s3_fs.info(file_path)["size"]
-        except Exception as exc:
-            logger.warning(
-                f"Could not determine file size for {file_path}: {exc}. "
-                f"Assuming large file."
-            )
-            file_size = 0
+        if file_size is None:
+            try:
+                file_size = s3_fs.info(file_path)["size"]
+            except Exception as exc:
+                logger.warning(
+                    f"Could not determine file size for {file_path}: {exc}. "
+                    f"Assuming large file."
+                )
+                file_size = 0
 
         if self._should_use_chunking(file_size):
 
             def chunk_generator():
-                logger.info(
-                    f"Large parquet file detected ({file_size} bytes > "
-                    f"{MAX_FILE_SIZE_FOR_PREVIEW} bytes). "
-                    f"Using batched reading for file: {file_path}"
-                )
+                if file_size:
+                    logger.info(
+                        f"Large parquet file detected ({file_size} bytes > "
+                        f"{MAX_FILE_SIZE_FOR_PREVIEW} bytes). "
+                        f"Using batched reading for file: {file_path}"
+                    )
+                else:
+                    logger.info(
+                        f"Unknown file size. "
+                        f"Using batched reading for file: {file_path}"
+                    )
                 with s3_fs.open(file_path) as f:
                     parquet_file = ParquetFile(f)
                     yield from self._read_parquet_in_batches(parquet_file)
@@ -389,7 +401,10 @@ class ParquetDataFrameReader(DataFrameReader):
                 dataframes=chunk_generator, raw_data=None, columns=None
             )
 
-    def _read(self, *, key: str, bucket_name: str, **__) -> DatalakeColumnWrapper:
+    def _read(
+        self, *, key: str, bucket_name: str, file_size: Optional[int] = None, **__
+    ) -> DatalakeColumnWrapper:
+        self._file_size = file_size
         return self._read_parquet_dispatch(
             self.config_source, key=key, bucket_name=bucket_name
         )

--- a/ingestion/src/metadata/readers/dataframe/parquet.py
+++ b/ingestion/src/metadata/readers/dataframe/parquet.py
@@ -217,6 +217,12 @@ class ParquetDataFrameReader(DataFrameReader):
             kwargs["key"] = creds.access_key
             kwargs["secret"] = creds.secret_key
             kwargs["token"] = creds.token
+        elif self.config_source.securityConfig.awsAccessKeyId:
+            kwargs["key"] = self.config_source.securityConfig.awsAccessKeyId
+            kwargs[
+                "secret"
+            ] = self.config_source.securityConfig.awsSecretAccessKey.get_secret_value()
+            kwargs["token"] = self.config_source.securityConfig.awsSessionToken
 
         client_kwargs = {}
         if self.config_source.securityConfig.endPointURL:

--- a/ingestion/src/metadata/readers/dataframe/parquet.py
+++ b/ingestion/src/metadata/readers/dataframe/parquet.py
@@ -219,10 +219,14 @@ class ParquetDataFrameReader(DataFrameReader):
             kwargs["token"] = creds.token
         elif self.config_source.securityConfig.awsAccessKeyId:
             kwargs["key"] = self.config_source.securityConfig.awsAccessKeyId
-            kwargs[
-                "secret"
-            ] = self.config_source.securityConfig.awsSecretAccessKey.get_secret_value()
-            kwargs["token"] = self.config_source.securityConfig.awsSessionToken
+            if self.config_source.securityConfig.awsSecretAccessKey:
+                kwargs[
+                    "secret"
+                ] = (
+                    self.config_source.securityConfig.awsSecretAccessKey.get_secret_value()
+                )
+            if self.config_source.securityConfig.awsSessionToken:
+                kwargs["token"] = self.config_source.securityConfig.awsSessionToken
 
         client_kwargs = {}
         if self.config_source.securityConfig.endPointURL:

--- a/ingestion/src/metadata/readers/dataframe/parquet.py
+++ b/ingestion/src/metadata/readers/dataframe/parquet.py
@@ -203,104 +203,33 @@ class ParquetDataFrameReader(DataFrameReader):
     @_read_parquet_dispatch.register
     def _(self, _: S3Config, key: str, bucket_name: str) -> DatalakeColumnWrapper:
         # pylint: disable=import-outside-toplevel
-        from pyarrow.fs import S3FileSystem
-        from pyarrow.parquet import ParquetDataset, ParquetFile
+        import io
 
-        client_kwargs = {
-            "endpoint_override": (
-                str(self.config_source.securityConfig.endPointURL)
-                if self.config_source.securityConfig.endPointURL
-                else None
-            ),
-            "region": (
-                self.config_source.securityConfig.awsRegion
-                if self.config_source.securityConfig.awsRegion
-                else None
-            ),
-        }
+        from pyarrow.parquet import ParquetFile
 
-        # In order to use S3FileSystem Refreshing mechanism when appropriate we are doing the following:
-        # If both assumeRoleArn and awsAccessKeyId are present, we are setting the credentials as environment variables in order for S3FileSystem to use them as source credentials when assuming the role.
-        if self.config_source.securityConfig.assumeRoleArn:
-            client_kwargs.update(
-                {
-                    "role_arn": self.config_source.securityConfig.assumeRoleArn,
-                    "session_name": self.config_source.securityConfig.assumeRoleSessionName,
-                }
-            )
+        def chunk_generator():
+            response = self.client.get_object(Bucket=bucket_name, Key=key)
+            try:
+                buffer = io.BytesIO(response["Body"].read())
+            finally:
+                response["Body"].close()
 
-            if self.config_source.securityConfig.awsAccessKeyId:
-                os.environ[
-                    "AWS_ACCESS_KEY_ID"
-                ] = self.config_source.securityConfig.awsAccessKeyId
-                os.environ[
-                    "AWS_SECRET_ACCESS_KEY"
-                ] = (
-                    self.config_source.securityConfig.awsSecretAccessKey.get_secret_value()
-                )
-
-                if self.config_source.securityConfig.awsSessionToken:
-                    os.environ[
-                        "AWS_SESSION_TOKEN"
-                    ] = self.config_source.securityConfig.awsSessionToken
-
-        elif self.config_source.securityConfig.awsAccessKeyId:
-            client_kwargs.update(
-                {
-                    "access_key": self.config_source.securityConfig.awsAccessKeyId,
-                    "secret_key": self.config_source.securityConfig.awsSecretAccessKey.get_secret_value(),
-                    "session_token": self.config_source.securityConfig.awsSessionToken,
-                }
-            )
-
-        s3_fs = S3FileSystem(**client_kwargs)
-
-        bucket_uri = f"{bucket_name}/{key}"
-
-        # Check file size to determine reading strategy
-        try:
-            file_info = s3_fs.get_file_info(bucket_uri)
-            file_size = file_info.size if hasattr(file_info, "size") else 0
+            file_size = buffer.getbuffer().nbytes
+            parquet_file = ParquetFile(buffer)
 
             if self._should_use_chunking(file_size):
-                # Use ParquetFile for batched reading of large files
-                def chunk_generator():
-                    logger.info(
-                        f"Large parquet file detected ({file_size} bytes > {MAX_FILE_SIZE_FOR_PREVIEW} bytes). "
-                        f"Using batched reading for file: {bucket_uri}"
-                    )
-                    parquet_file = ParquetFile(bucket_uri, filesystem=s3_fs)
-                    yield from self._read_parquet_in_batches(parquet_file)
-
-                return DatalakeColumnWrapper(
-                    dataframes=chunk_generator, raw_data=None, columns=None
+                logger.info(
+                    f"Large parquet file detected ({file_size} bytes > "
+                    f"{MAX_FILE_SIZE_FOR_PREVIEW} bytes). "
+                    f"Using batched reading for file: {bucket_name}/{key}"
                 )
+                yield from self._read_parquet_in_batches(parquet_file)
             else:
-                # Use ParquetDataset for regular reading of smaller files
-                def chunk_generator():
-                    logger.debug(
-                        f"Reading small parquet file ({file_size} bytes): {bucket_uri}"
-                    )
-                    dataset = ParquetDataset(bucket_uri, filesystem=s3_fs)
-                    yield from dataframe_to_chunks(dataset.read_pandas().to_pandas())
+                yield from dataframe_to_chunks(parquet_file.read().to_pandas())
 
-                return DatalakeColumnWrapper(
-                    dataframes=chunk_generator, raw_data=None, columns=None
-                )
-
-        except Exception as exc:
-            # Fallback to regular reading if size check fails
-            logger.warning(
-                f"Could not determine file size for {bucket_uri}: {exc}. Using regular reading"
-            )
-
-            def chunk_generator():
-                dataset = ParquetDataset(bucket_uri, filesystem=s3_fs)
-                yield from dataframe_to_chunks(dataset.read_pandas().to_pandas())
-
-            return DatalakeColumnWrapper(
-                dataframes=chunk_generator, raw_data=None, columns=None
-            )
+        return DatalakeColumnWrapper(
+            dataframes=chunk_generator, raw_data=None, columns=None
+        )
 
     @_read_parquet_dispatch.register
     def _(self, _: AzureConfig, key: str, bucket_name: str) -> DatalakeColumnWrapper:

--- a/ingestion/src/metadata/readers/dataframe/reader_factory.py
+++ b/ingestion/src/metadata/readers/dataframe/reader_factory.py
@@ -79,6 +79,7 @@ def get_df_reader(
     config_source: ConfigSource,
     client: Optional[Any],
     separator: Optional[str] = None,
+    session: Optional[Any] = None,
 ) -> DataFrameReader:
     """
     Load the File Reader based on the Config Source
@@ -89,11 +90,13 @@ def get_df_reader(
         and separator
     ):
         return get_dsv_reader_by_separator(separator=separator)(
-            config_source=config_source, client=client
+            config_source=config_source, client=client, session=session
         )
 
     if type_.value in DF_READER_MAP:
-        return DF_READER_MAP[type_.value](config_source=config_source, client=client)
+        return DF_READER_MAP[type_.value](
+            config_source=config_source, client=client, session=session
+        )
 
     raise NotImplementedError(
         f"DataFrameReader for [{type_.value}] is not implemented."

--- a/ingestion/src/metadata/utils/datalake/datalake_utils.py
+++ b/ingestion/src/metadata/utils/datalake/datalake_utils.py
@@ -36,6 +36,7 @@ def fetch_dataframe_generator(
     config_source,
     client,
     file_fqn: DatalakeTableSchemaWrapper,
+    session=None,
     **kwargs,
 ) -> Optional[DatalakeColumnWrapper]:
     """Return the datafgrame generator
@@ -65,9 +66,15 @@ def fetch_dataframe_generator(
                 config_source=config_source,
                 client=client,
                 separator=file_fqn.separator,
+                session=session,
             )
             try:
-                return df_reader.read(key=key, bucket_name=bucket_name, **kwargs)
+                return df_reader.read(
+                    key=key,
+                    bucket_name=bucket_name,
+                    file_size=file_fqn.file_size,
+                    **kwargs,
+                )
             except Exception as err:
                 logger.debug(traceback.format_exc())
                 logger.error(
@@ -89,6 +96,7 @@ def fetch_dataframe_first_chunk(
     client,
     file_fqn: DatalakeTableSchemaWrapper,
     fetch_raw_data: bool = False,
+    session=None,
     **kwargs,
 ) -> Optional["DataFrame"]:
     """
@@ -109,10 +117,14 @@ def fetch_dataframe_first_chunk(
                 config_source=config_source,
                 client=client,
                 separator=file_fqn.separator,
+                session=session,
             )
             try:
                 df_wrapper: DatalakeColumnWrapper = df_reader.read_first_chunk(
-                    key=key, bucket_name=bucket_name, **kwargs
+                    key=key,
+                    bucket_name=bucket_name,
+                    file_size=file_fqn.file_size,
+                    **kwargs,
                 )
                 dataframes = df_wrapper.dataframes
                 # Handle callable (generator function) - call it to get the iterator

--- a/ingestion/tests/unit/readers/test_avro_reader.py
+++ b/ingestion/tests/unit/readers/test_avro_reader.py
@@ -77,24 +77,20 @@ class TestAvroReader(unittest.TestCase):
         self.assertEqual(len(columns), 1)
         self.assertEqual(len(columns[0].children), 3)
 
-    @patch("s3fs.S3FileSystem")
-    @patch("metadata.readers.dataframe.avro.return_s3_storage_options")
-    def test_s3_avro_reading(self, mock_storage_opts, mock_s3fs):
-        mock_storage_opts.return_value = {}
-        mock_s3 = Mock()
-        mock_s3fs.return_value = mock_s3
-
-        def create_fresh_file():
-            return self._create_mock_avro_file()
-
-        mock_s3.open.return_value.__enter__ = Mock(
-            side_effect=lambda: create_fresh_file()
-        )
-        mock_s3.open.return_value.__exit__ = Mock(return_value=False)
-
+    def test_s3_avro_reading(self):
+        """Test S3 avro reading uses boto3 client.get_object for both schema and data."""
         mock_client = Mock()
-        mock_response = {"Body": create_fresh_file()}
-        mock_client.get_object.return_value = mock_response
+
+        # get_object is called twice: once for schema, once for data streaming
+        mock_client.get_object.side_effect = [
+            {
+                "Body": Mock(
+                    read=Mock(return_value=self._create_mock_avro_file().read()),
+                    close=Mock(),
+                )
+            },
+            {"Body": self._create_mock_avro_file(), "close": Mock()},
+        ]
 
         config = S3Config(
             securityConfig=AWSCredentials(
@@ -105,11 +101,12 @@ class TestAvroReader(unittest.TestCase):
 
         result = reader._read(key="test.avro", bucket_name="test-bucket")
 
+        self.assertIsNotNone(result.columns)
         self.assertIsNotNone(result.dataframes)
-        dataframes = result.dataframes()
-        self.assertIsNotNone(dataframes)
-        chunks = list(dataframes)
+        chunks = list(result.dataframes())
         self.assertTrue(len(chunks) > 0)
+
+        self.assertEqual(mock_client.get_object.call_count, 2)
 
     @patch("gcsfs.GCSFileSystem")
     def test_gcs_avro_reading(self, mock_gcsfs):

--- a/ingestion/tests/unit/readers/test_avro_reader.py
+++ b/ingestion/tests/unit/readers/test_avro_reader.py
@@ -83,12 +83,7 @@ class TestAvroReader(unittest.TestCase):
 
         # get_object is called twice: once for schema, once for data streaming
         mock_client.get_object.side_effect = [
-            {
-                "Body": Mock(
-                    read=Mock(return_value=self._create_mock_avro_file().read()),
-                    close=Mock(),
-                )
-            },
+            {"Body": self._create_mock_avro_file(), "close": Mock()},
             {"Body": self._create_mock_avro_file(), "close": Mock()},
         ]
 

--- a/ingestion/tests/unit/readers/test_dsv_reader.py
+++ b/ingestion/tests/unit/readers/test_dsv_reader.py
@@ -200,16 +200,12 @@ class TestDSVReader(unittest.TestCase):
 
     def test_s3_csv_reading(self):
         """Test S3 CSV reading uses boto3 client.get_object."""
+        import io
         from unittest.mock import Mock
 
         csv_content = b"id,name\n1,Test\n2,Hello\n"
 
         mock_client = Mock()
-        mock_body = Mock()
-        mock_body.read.return_value = csv_content
-        # StreamingBody is iterable and supports read — use BytesIO to simulate
-        import io
-
         mock_client.get_object.return_value = {
             "Body": io.BytesIO(csv_content),
         }

--- a/ingestion/tests/unit/readers/test_dsv_reader.py
+++ b/ingestion/tests/unit/readers/test_dsv_reader.py
@@ -198,39 +198,39 @@ class TestDSVReader(unittest.TestCase):
         self.assertEqual(len(chunks), 1)
         pd.testing.assert_frame_equal(chunks[0], mock_df)
 
-    @patch("pandas.read_csv")
-    @patch("metadata.readers.dataframe.dsv.return_s3_storage_options")
-    def test_s3_csv_reading(self, mock_storage_opts, mock_read_csv):
-        """Test S3 CSV reading with mocked pandas."""
-        mock_storage_opts.return_value = {}
-        mock_df = pd.DataFrame({"id": [1], "name": ["Test"]})
+    def test_s3_csv_reading(self):
+        """Test S3 CSV reading uses boto3 client.get_object."""
+        from unittest.mock import Mock
 
-        def mock_read_csv_impl(*args, **kwargs):
-            class ChunkReader:
-                def __enter__(self):
-                    return iter([mock_df])
+        csv_content = b"id,name\n1,Test\n2,Hello\n"
 
-                def __exit__(self, *args):
-                    pass
+        mock_client = Mock()
+        mock_body = Mock()
+        mock_body.read.return_value = csv_content
+        # StreamingBody is iterable and supports read — use BytesIO to simulate
+        import io
 
-            return ChunkReader()
-
-        mock_read_csv.side_effect = mock_read_csv_impl
+        mock_client.get_object.return_value = {
+            "Body": io.BytesIO(csv_content),
+        }
 
         config = S3Config(
             securityConfig=AWSCredentials(
                 awsAccessKeyId="test", awsSecretAccessKey="test", awsRegion="us-east-1"
             )
         )
-        reader = CSVDataFrameReader(config, None)
+        reader = CSVDataFrameReader(config, mock_client)
 
         result = reader._read(key="test.csv", bucket_name="test-bucket")
 
         self.assertIsNotNone(result.dataframes)
-        dataframes = result.dataframes()
-        self.assertIsNotNone(dataframes)
-        chunks = list(dataframes)
+        chunks = list(result.dataframes())
         self.assertEqual(len(chunks), 1)
+        self.assertEqual(chunks[0].shape, (2, 2))
+
+        mock_client.get_object.assert_called_once_with(
+            Bucket="test-bucket", Key="test.csv"
+        )
 
     @patch("pandas.read_csv")
     @patch("metadata.readers.dataframe.dsv.return_azure_storage_options")

--- a/ingestion/tests/unit/readers/test_parquet_reader.py
+++ b/ingestion/tests/unit/readers/test_parquet_reader.py
@@ -88,7 +88,7 @@ class TestParquetReader(unittest.TestCase):
         self.assertTrue(len(chunks) > 0)
 
     def _create_s3_reader(self):
-        """Helper to create an S3 ParquetDataFrameReader with a mocked boto3 client."""
+        """Helper to create an S3 ParquetDataFrameReader with a mocked session."""
         from collections import namedtuple
 
         config = S3Config(
@@ -97,13 +97,14 @@ class TestParquetReader(unittest.TestCase):
             )
         )
         mock_client = Mock()
+        mock_session = Mock()
 
         FrozenCreds = namedtuple("FrozenCreds", ["access_key", "secret_key", "token"])
-        mock_client._request_signer._credentials.get_frozen_credentials.return_value = (
-            FrozenCreds(access_key="test", secret_key="test", token=None)
+        mock_session.get_credentials.return_value.get_frozen_credentials.return_value = FrozenCreds(
+            access_key="test", secret_key="test", token=None
         )
 
-        reader = ParquetDataFrameReader(config, mock_client)
+        reader = ParquetDataFrameReader(config, mock_client, session=mock_session)
         return reader, mock_client
 
     @patch("s3fs.S3FileSystem")

--- a/ingestion/tests/unit/readers/test_parquet_reader.py
+++ b/ingestion/tests/unit/readers/test_parquet_reader.py
@@ -87,72 +87,100 @@ class TestParquetReader(unittest.TestCase):
         chunks = list(dataframes)
         self.assertTrue(len(chunks) > 0)
 
-    @patch("pyarrow.fs.S3FileSystem")
-    @patch("pyarrow.parquet.ParquetDataset")
-    def test_s3_small_parquet_file(self, mock_dataset, mock_s3fs):
-        mock_fs = Mock()
-        mock_s3fs.return_value = mock_fs
-
-        mock_file_info = Mock()
-        mock_file_info.size = 1000
-        mock_fs.get_file_info.return_value = mock_file_info
-
-        mock_table = Mock()
-        mock_df = pd.DataFrame({"id": [1], "name": ["Test"]})
-        mock_table.to_pandas.return_value = mock_df
-
-        mock_ds = Mock()
-        mock_ds.read_pandas.return_value = mock_table
-        mock_dataset.return_value = mock_ds
-
+    def _create_s3_reader(self):
+        """Helper to create an S3 ParquetDataFrameReader with a mocked boto3 client."""
         config = S3Config(
             securityConfig=AWSCredentials(
                 awsAccessKeyId="test", awsSecretAccessKey="test", awsRegion="us-east-1"
             )
         )
-        reader = ParquetDataFrameReader(config, None)
+        mock_client = Mock()
+        reader = ParquetDataFrameReader(config, mock_client)
+        return reader, mock_client
+
+    def _mock_s3_response(self, mock_client, parquet_bytes):
+        """Helper to mock a boto3 get_object response with parquet data."""
+        mock_body = Mock()
+        mock_body.read.return_value = parquet_bytes
+        mock_client.get_object.return_value = {"Body": mock_body}
+
+    def test_s3_small_parquet_file(self):
+        """Test S3 parquet reading uses boto3 client.get_object for small files."""
+        reader, mock_client = self._create_s3_reader()
+
+        df = pd.DataFrame({"id": [1, 2, 3], "name": ["Alice", "Bob", "Charlie"]})
+        parquet_bytes = df.to_parquet()
+        self._mock_s3_response(mock_client, parquet_bytes)
 
         result = reader._read(key="test.parquet", bucket_name="test-bucket")
 
         self.assertIsNotNone(result.dataframes)
-        dataframes = result.dataframes()
-        self.assertIsNotNone(dataframes)
-        chunks = list(dataframes)
+        chunks = list(result.dataframes())
         self.assertTrue(len(chunks) > 0)
 
-    @patch("pyarrow.fs.S3FileSystem")
-    @patch("pyarrow.parquet.ParquetFile")
-    def test_s3_large_parquet_file_chunking(self, mock_parquet_file, mock_s3fs):
-        mock_fs = Mock()
-        mock_s3fs.return_value = mock_fs
+        total_rows = sum(len(chunk) for chunk in chunks)
+        self.assertEqual(total_rows, 3)
 
-        mock_file_info = Mock()
-        mock_file_info.size = MAX_FILE_SIZE_FOR_PREVIEW + 1000
-        mock_fs.get_file_info.return_value = mock_file_info
+        mock_client.get_object.assert_called_once_with(
+            Bucket="test-bucket", Key="test.parquet"
+        )
+
+    @patch("pyarrow.parquet.ParquetFile")
+    def test_s3_large_parquet_file_chunking(self, mock_parquet_file_cls):
+        """Test S3 large parquet file triggers batched reading via boto3 client."""
+        reader, mock_client = self._create_s3_reader()
+
+        large_content = b"\x00" * (MAX_FILE_SIZE_FOR_PREVIEW + 1000)
+        self._mock_s3_response(mock_client, large_content)
 
         mock_pf = Mock()
-        mock_parquet_file.return_value = mock_pf
+        mock_parquet_file_cls.return_value = mock_pf
 
         batch_data = pd.DataFrame({"id": [1], "name": ["Test"]})
         mock_batch = Mock()
         mock_batch.to_pandas.return_value = batch_data
-
         mock_pf.iter_batches = Mock(return_value=iter([mock_batch]))
-
-        config = S3Config(
-            securityConfig=AWSCredentials(
-                awsAccessKeyId="test", awsSecretAccessKey="test", awsRegion="us-east-1"
-            )
-        )
-        reader = ParquetDataFrameReader(config, None)
 
         result = reader._read(key="test.parquet", bucket_name="test-bucket")
 
         self.assertIsNotNone(result.dataframes)
-        dataframes = result.dataframes()
-        self.assertIsNotNone(dataframes)
-        chunks = list(dataframes)
+        chunks = list(result.dataframes())
         self.assertTrue(len(chunks) > 0)
+
+        mock_client.get_object.assert_called_once_with(
+            Bucket="test-bucket", Key="test.parquet"
+        )
+
+    def test_s3_get_object_error_propagates(self):
+        """Test that boto3 client errors propagate correctly."""
+        from botocore.exceptions import ClientError
+
+        reader, mock_client = self._create_s3_reader()
+
+        mock_client.get_object.side_effect = ClientError(
+            {"Error": {"Code": "AccessDenied", "Message": "Access Denied"}},
+            "GetObject",
+        )
+
+        result = reader._read(key="test.parquet", bucket_name="test-bucket")
+
+        with self.assertRaises(ClientError):
+            list(result.dataframes())
+
+    def test_s3_response_body_closed(self):
+        """Test that the S3 response body is always closed, even on error."""
+        reader, mock_client = self._create_s3_reader()
+
+        mock_body = Mock()
+        mock_body.read.side_effect = Exception("network error")
+        mock_client.get_object.return_value = {"Body": mock_body}
+
+        result = reader._read(key="test.parquet", bucket_name="test-bucket")
+
+        with self.assertRaises(Exception):
+            list(result.dataframes())
+
+        mock_body.close.assert_called_once()
 
     @patch("gcsfs.GCSFileSystem")
     @patch("pyarrow.parquet.ParquetFile")

--- a/ingestion/tests/unit/readers/test_parquet_reader.py
+++ b/ingestion/tests/unit/readers/test_parquet_reader.py
@@ -14,7 +14,7 @@ Tests for ParquetDataFrameReader S3, GCS, and Local
 """
 import tempfile
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pandas as pd
 
@@ -89,53 +89,67 @@ class TestParquetReader(unittest.TestCase):
 
     def _create_s3_reader(self):
         """Helper to create an S3 ParquetDataFrameReader with a mocked boto3 client."""
+        from collections import namedtuple
+
         config = S3Config(
             securityConfig=AWSCredentials(
                 awsAccessKeyId="test", awsSecretAccessKey="test", awsRegion="us-east-1"
             )
         )
         mock_client = Mock()
+
+        FrozenCreds = namedtuple("FrozenCreds", ["access_key", "secret_key", "token"])
+        mock_client._request_signer._credentials.get_frozen_credentials.return_value = (
+            FrozenCreds(access_key="test", secret_key="test", token=None)
+        )
+
         reader = ParquetDataFrameReader(config, mock_client)
         return reader, mock_client
 
-    def _mock_s3_response(self, mock_client, parquet_bytes):
-        """Helper to mock a boto3 get_object response with parquet data."""
-        mock_body = Mock()
-        mock_body.read.return_value = parquet_bytes
-        mock_client.get_object.return_value = {"Body": mock_body}
+    @patch("s3fs.S3FileSystem")
+    @patch("pyarrow.parquet.ParquetFile")
+    def test_s3_small_parquet_file(self, mock_parquet_file_cls, mock_s3fs):
+        """Test S3 parquet reading uses credentials extracted from boto3 client."""
+        reader, _ = self._create_s3_reader()
 
-    def test_s3_small_parquet_file(self):
-        """Test S3 parquet reading uses boto3 client.get_object for small files."""
-        reader, mock_client = self._create_s3_reader()
+        mock_fs = MagicMock()
+        mock_s3fs.return_value = mock_fs
+        mock_fs.info.return_value = {"size": 1000}
 
-        df = pd.DataFrame({"id": [1, 2, 3], "name": ["Alice", "Bob", "Charlie"]})
-        parquet_bytes = df.to_parquet()
-        self._mock_s3_response(mock_client, parquet_bytes)
+        mock_df = pd.DataFrame({"id": [1, 2, 3], "name": ["Alice", "Bob", "Charlie"]})
+        mock_table = Mock()
+        mock_table.to_pandas.return_value = mock_df
+        mock_pf = Mock()
+        mock_pf.read.return_value = mock_table
+        mock_parquet_file_cls.return_value = mock_pf
 
         result = reader._read(key="test.parquet", bucket_name="test-bucket")
 
         self.assertIsNotNone(result.dataframes)
         chunks = list(result.dataframes())
-        self.assertTrue(len(chunks) > 0)
-
         total_rows = sum(len(chunk) for chunk in chunks)
         self.assertEqual(total_rows, 3)
 
-        mock_client.get_object.assert_called_once_with(
-            Bucket="test-bucket", Key="test.parquet"
+        mock_s3fs.assert_called_once_with(
+            key="test",
+            secret="test",
+            token=None,
+            client_kwargs={"region_name": "us-east-1"},
         )
+        mock_fs.open.assert_called_once_with("test-bucket/test.parquet")
 
+    @patch("s3fs.S3FileSystem")
     @patch("pyarrow.parquet.ParquetFile")
-    def test_s3_large_parquet_file_chunking(self, mock_parquet_file_cls):
-        """Test S3 large parquet file triggers batched reading via boto3 client."""
-        reader, mock_client = self._create_s3_reader()
+    def test_s3_large_parquet_file_chunking(self, mock_parquet_file_cls, mock_s3fs):
+        """Test S3 large parquet file triggers batched reading."""
+        reader, _ = self._create_s3_reader()
 
-        large_content = b"\x00" * (MAX_FILE_SIZE_FOR_PREVIEW + 1000)
-        self._mock_s3_response(mock_client, large_content)
+        mock_fs = MagicMock()
+        mock_s3fs.return_value = mock_fs
+        mock_fs.info.return_value = {"size": MAX_FILE_SIZE_FOR_PREVIEW + 1000}
 
         mock_pf = Mock()
         mock_parquet_file_cls.return_value = mock_pf
-
         batch_data = pd.DataFrame({"id": [1], "name": ["Test"]})
         mock_batch = Mock()
         mock_batch.to_pandas.return_value = batch_data
@@ -147,40 +161,18 @@ class TestParquetReader(unittest.TestCase):
         chunks = list(result.dataframes())
         self.assertTrue(len(chunks) > 0)
 
-        mock_client.get_object.assert_called_once_with(
-            Bucket="test-bucket", Key="test.parquet"
-        )
+    @patch("s3fs.S3FileSystem")
+    def test_s3_file_size_error_falls_back_to_chunking(self, mock_s3fs):
+        """Test that file size check failure falls back to chunked reading."""
+        reader, _ = self._create_s3_reader()
 
-    def test_s3_get_object_error_propagates(self):
-        """Test that boto3 client errors propagate correctly."""
-        from botocore.exceptions import ClientError
-
-        reader, mock_client = self._create_s3_reader()
-
-        mock_client.get_object.side_effect = ClientError(
-            {"Error": {"Code": "AccessDenied", "Message": "Access Denied"}},
-            "GetObject",
-        )
+        mock_fs = MagicMock()
+        mock_s3fs.return_value = mock_fs
+        mock_fs.info.side_effect = Exception("HeadObject failed")
 
         result = reader._read(key="test.parquet", bucket_name="test-bucket")
 
-        with self.assertRaises(ClientError):
-            list(result.dataframes())
-
-    def test_s3_response_body_closed(self):
-        """Test that the S3 response body is always closed, even on error."""
-        reader, mock_client = self._create_s3_reader()
-
-        mock_body = Mock()
-        mock_body.read.side_effect = Exception("network error")
-        mock_client.get_object.return_value = {"Body": mock_body}
-
-        result = reader._read(key="test.parquet", bucket_name="test-bucket")
-
-        with self.assertRaises(Exception):
-            list(result.dataframes())
-
-        mock_body.close.assert_called_once()
+        self.assertIsNotNone(result.dataframes)
 
     @patch("gcsfs.GCSFileSystem")
     @patch("pyarrow.parquet.ParquetFile")

--- a/ingestion/tests/unit/readers/test_s3_n_plus_one.py
+++ b/ingestion/tests/unit/readers/test_s3_n_plus_one.py
@@ -1,0 +1,273 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Tests for N+1 HEAD request elimination.
+
+Problem: list_objects_v2 returns file Size, but readers made separate
+head_object / s3_fs.info() calls per file to determine the size.
+
+Fix: Thread file_size through DatalakeTableSchemaWrapper so readers
+skip the extra API call when size is already known.
+"""
+from collections import namedtuple
+from unittest.mock import MagicMock, Mock, patch
+
+from metadata.generated.schema.entity.services.connections.database.datalake.s3Config import (
+    S3Config,
+)
+from metadata.generated.schema.security.credentials.awsCredentials import AWSCredentials
+from metadata.readers.dataframe.json import JSONDataFrameReader
+from metadata.readers.dataframe.models import DatalakeTableSchemaWrapper
+from metadata.readers.dataframe.parquet import ParquetDataFrameReader
+
+
+def _s3_config():
+    return S3Config(
+        securityConfig=AWSCredentials(
+            awsAccessKeyId="test", awsSecretAccessKey="test", awsRegion="us-east-1"
+        )
+    )
+
+
+def _mock_session():
+    mock_session = Mock()
+    FrozenCreds = namedtuple("FrozenCreds", ["access_key", "secret_key", "token"])
+    mock_session.get_credentials.return_value.get_frozen_credentials.return_value = (
+        FrozenCreds(access_key="test", secret_key="test", token=None)
+    )
+    return mock_session
+
+
+class TestNPlusOneHeadRequests:
+    """Prove that readers still fall back to HEAD/info when file_size is NOT provided."""
+
+    def test_json_reader_calls_head_object_when_no_size(self):
+        """Without file_size, JSON reader falls back to head_object."""
+        mock_client = Mock()
+        mock_client.head_object.return_value = {"ContentLength": 1024}
+
+        json_content = b'[{"id": 1}]'
+
+        def make_body():
+            body = Mock()
+            body.readline.return_value = json_content
+            body.read.return_value = json_content
+            body.__enter__ = Mock(return_value=body)
+            body.__exit__ = Mock(return_value=False)
+            return body
+
+        mock_client.get_object.side_effect = lambda **kw: {"Body": make_body()}
+
+        reader = JSONDataFrameReader(_s3_config(), mock_client)
+
+        try:
+            reader._read(key="data/test.json", bucket_name="bucket")
+        except Exception:
+            pass
+
+        assert mock_client.head_object.call_count == 1
+
+    @patch("s3fs.S3FileSystem")
+    def test_parquet_reader_calls_info_when_no_size(self, mock_s3fs_cls):
+        """Without file_size, parquet reader falls back to s3_fs.info()."""
+        mock_client = Mock()
+        mock_session = _mock_session()
+
+        mock_fs = MagicMock()
+        mock_s3fs_cls.return_value = mock_fs
+        mock_fs.info.return_value = {"size": 1024}
+
+        reader = ParquetDataFrameReader(_s3_config(), mock_client, session=mock_session)
+
+        reader._read(key="data/test.parquet", bucket_name="bucket")
+
+        assert mock_fs.info.call_count == 1
+
+
+class TestFileSizePassthrough:
+    """Verify readers skip HEAD/info when file_size is provided."""
+
+    @patch("s3fs.S3FileSystem")
+    def test_parquet_reader_skips_info_when_size_provided(self, mock_s3fs_cls):
+        """When file_size is passed, parquet reader should NOT call s3_fs.info()."""
+        mock_client = Mock()
+        mock_session = _mock_session()
+
+        mock_fs = MagicMock()
+        mock_s3fs_cls.return_value = mock_fs
+
+        mock_pf = Mock()
+        mock_table = Mock()
+        mock_table.to_pandas.return_value = Mock()
+
+        reader = ParquetDataFrameReader(_s3_config(), mock_client, session=mock_session)
+
+        reader._read(key="data/test.parquet", bucket_name="bucket", file_size=1024)
+
+        mock_fs.info.assert_not_called()
+
+    def test_json_reader_skips_head_when_size_provided(self):
+        """When file_size is passed, JSON reader should NOT call head_object."""
+        mock_client = Mock()
+        mock_client.head_object.return_value = {"ContentLength": 1024}
+
+        json_content = b'[{"id": 1}]'
+
+        def make_body():
+            body = Mock()
+            body.readline.return_value = json_content
+            body.read.return_value = json_content
+            body.__enter__ = Mock(return_value=body)
+            body.__exit__ = Mock(return_value=False)
+            return body
+
+        mock_client.get_object.side_effect = lambda **kw: {"Body": make_body()}
+
+        reader = JSONDataFrameReader(_s3_config(), mock_client)
+
+        try:
+            reader._read(key="data/test.json", bucket_name="bucket", file_size=1024)
+        except Exception:
+            pass
+
+        mock_client.head_object.assert_not_called()
+
+    def test_table_schema_wrapper_accepts_file_size(self):
+        """DatalakeTableSchemaWrapper should accept an optional file_size field."""
+        wrapper = DatalakeTableSchemaWrapper(
+            key="data/test.parquet",
+            bucket_name="bucket",
+            file_size=12345,
+        )
+        assert wrapper.file_size == 12345
+
+    def test_table_schema_wrapper_file_size_defaults_none(self):
+        """file_size should default to None when not provided."""
+        wrapper = DatalakeTableSchemaWrapper(
+            key="data/test.parquet",
+            bucket_name="bucket",
+        )
+        assert wrapper.file_size is None
+
+    @patch("s3fs.S3FileSystem")
+    def test_parquet_reader_works_without_session(self, mock_s3fs_cls):
+        """Parquet reader should not crash when session is None (profiler path)."""
+        mock_client = Mock()
+
+        mock_fs = MagicMock()
+        mock_s3fs_cls.return_value = mock_fs
+        mock_fs.info.return_value = {"size": 1024}
+
+        reader = ParquetDataFrameReader(_s3_config(), mock_client, session=None)
+
+        reader._read(key="data/test.parquet", bucket_name="bucket")
+
+        # Without session, s3fs is created with default credential chain
+        mock_s3fs_cls.assert_called_once()
+        call_kwargs = mock_s3fs_cls.call_args
+        assert "key" not in (call_kwargs.kwargs or {})
+
+    def test_get_table_names_yields_key_and_size(self):
+        """S3 client get_table_names should yield (key, size) tuples."""
+        from metadata.ingestion.source.database.datalake.clients.s3 import (
+            DatalakeS3Client,
+        )
+
+        mock_boto_client = Mock()
+        mock_paginator = Mock()
+        mock_boto_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [
+            {
+                "Contents": [
+                    {"Key": "data/a.parquet", "Size": 100},
+                    {"Key": "data/b.csv", "Size": 200},
+                ]
+            }
+        ]
+
+        client = DatalakeS3Client(client=mock_boto_client)
+        results = list(client.get_table_names("bucket", prefix=None))
+
+        assert results == [("data/a.parquet", 100), ("data/b.csv", 200)]
+
+    def test_gcs_get_file_size_uses_client(self):
+        """GCS _get_file_size_mb should use self.client, not bare GCSFileSystem."""
+        from metadata.generated.schema.entity.services.connections.database.datalake.gcsConfig import (
+            GCSConfig,
+        )
+        from metadata.readers.dataframe.json import JSONDataFrameReader
+
+        mock_client = Mock()
+        mock_blob = Mock()
+        mock_blob.size = 5 * 1024 * 1024  # 5MB
+        mock_bucket = Mock()
+        mock_bucket.get_blob.return_value = mock_blob
+        mock_client.get_bucket.return_value = mock_bucket
+
+        config = GCSConfig()
+        reader = JSONDataFrameReader(config, mock_client)
+
+        result = reader._get_file_size_mb("data/test.json", "test-bucket")
+
+        assert result == 5.0
+        mock_client.get_bucket.assert_called_once_with("test-bucket")
+        mock_bucket.get_blob.assert_called_once_with("data/test.json")
+
+    def test_gcs_get_file_size_handles_missing_blob(self):
+        """GCS _get_file_size_mb should return 0 if blob doesn't exist."""
+        from metadata.generated.schema.entity.services.connections.database.datalake.gcsConfig import (
+            GCSConfig,
+        )
+        from metadata.readers.dataframe.json import JSONDataFrameReader
+
+        mock_client = Mock()
+        mock_bucket = Mock()
+        mock_bucket.get_blob.return_value = None
+        mock_client.get_bucket.return_value = mock_bucket
+
+        config = GCSConfig()
+        reader = JSONDataFrameReader(config, mock_client)
+
+        result = reader._get_file_size_mb("data/missing.json", "test-bucket")
+
+        assert result == 0
+
+    def test_azure_get_file_size_uses_client(self):
+        """Azure _get_file_size_mb should use self.client, not new AzureBlobFileSystem."""
+        from metadata.generated.schema.entity.services.connections.database.datalake.azureConfig import (
+            AzureConfig,
+        )
+        from metadata.generated.schema.security.credentials.azureCredentials import (
+            AzureCredentials,
+        )
+        from metadata.readers.dataframe.json import JSONDataFrameReader
+
+        mock_client = Mock()
+        mock_blob_client = Mock()
+        mock_props = Mock()
+        mock_props.size = 10 * 1024 * 1024  # 10MB
+        mock_blob_client.get_blob_properties.return_value = mock_props
+        mock_client.get_blob_client.return_value = mock_blob_client
+
+        config = AzureConfig(
+            securityConfig=AzureCredentials(
+                accountName="test", clientId="test", tenantId="test"
+            )
+        )
+        reader = JSONDataFrameReader(config, mock_client)
+
+        result = reader._get_file_size_mb("data/test.json", "test-container")
+
+        assert result == 10.0
+        mock_client.get_blob_client.assert_called_once_with(
+            container="test-container", blob="data/test.json"
+        )

--- a/ingestion/tests/unit/readers/test_s3_n_plus_one.py
+++ b/ingestion/tests/unit/readers/test_s3_n_plus_one.py
@@ -160,7 +160,8 @@ class TestFileSizePassthrough:
 
     @patch("s3fs.S3FileSystem")
     def test_parquet_reader_works_without_session(self, mock_s3fs_cls):
-        """Parquet reader should not crash when session is None (profiler path)."""
+        """Parquet reader should not crash when session is None (profiler/storage path).
+        Falls back to credentials from config."""
         mock_client = Mock()
 
         mock_fs = MagicMock()
@@ -171,10 +172,10 @@ class TestFileSizePassthrough:
 
         reader._read(key="data/test.parquet", bucket_name="bucket")
 
-        # Without session, s3fs is created with default credential chain
+        # Without session, s3fs falls back to config credentials
         mock_s3fs_cls.assert_called_once()
-        call_kwargs = mock_s3fs_cls.call_args
-        assert "key" not in (call_kwargs.kwargs or {})
+        call_kwargs = mock_s3fs_cls.call_args.kwargs
+        assert call_kwargs["key"] == "test"
 
     def test_get_table_names_yields_key_and_size(self):
         """S3 client get_table_names should yield (key, size) tuples."""

--- a/ingestion/tests/unit/readers/test_s3_reader_credentials.py
+++ b/ingestion/tests/unit/readers/test_s3_reader_credentials.py
@@ -1,0 +1,158 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Tests that S3 readers use session credentials (not raw config) to access files.
+
+Uses moto to simulate AWS S3, proving that readers work with
+boto3-session-derived credentials — the exact scenario that was broken
+when readers bypassed the boto3 session.
+
+Note: The parquet reader uses s3fs (aiobotocore) which is incompatible
+with moto in this environment. Parquet credential flow is covered by
+unit tests in test_parquet_reader.py with mocked s3fs.
+"""
+import io
+
+import boto3
+import fastavro
+import pytest
+from moto import mock_aws
+
+from metadata.generated.schema.entity.services.connections.database.datalake.s3Config import (
+    S3Config,
+)
+from metadata.generated.schema.security.credentials.awsCredentials import AWSCredentials
+from metadata.readers.dataframe.avro import AvroDataFrameReader
+from metadata.readers.dataframe.dsv import CSVDataFrameReader
+from metadata.readers.dataframe.parquet import ParquetDataFrameReader
+
+BUCKET = "test-bucket"
+REGION = "us-east-1"
+
+
+@pytest.fixture()
+def aws_env(monkeypatch):
+    """Set dummy AWS env vars so moto doesn't fall through to real AWS."""
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+
+
+@pytest.fixture()
+def s3_bucket(aws_env):
+    """Create a mocked S3 bucket with test files."""
+    with mock_aws():
+        s3 = boto3.client("s3", region_name=REGION)
+        s3.create_bucket(Bucket=BUCKET)
+
+        # Upload CSV
+        s3.put_object(
+            Bucket=BUCKET,
+            Key="data/test.csv",
+            Body=b"id,name,score\n1,Alice,9.1\n2,Bob,8.5\n",
+        )
+
+        # Upload Avro
+        avro_schema = {
+            "type": "record",
+            "name": "TestRecord",
+            "fields": [
+                {"name": "id", "type": "int"},
+                {"name": "name", "type": "string"},
+            ],
+        }
+        avro_buf = io.BytesIO()
+        fastavro.writer(avro_buf, avro_schema, [{"id": 1, "name": "Alice"}])
+        s3.put_object(Bucket=BUCKET, Key="data/test.avro", Body=avro_buf.getvalue())
+
+        session = boto3.Session(region_name=REGION)
+        client = session.client("s3", region_name=REGION)
+
+        yield client, session
+
+
+def _config():
+    return S3Config(
+        securityConfig=AWSCredentials(
+            awsAccessKeyId="testing",
+            awsSecretAccessKey="testing",
+            awsRegion=REGION,
+        )
+    )
+
+
+class TestS3ReaderWithBoto3:
+    """Verify CSV and Avro readers work end-to-end with moto-mocked S3."""
+
+    def test_csv_reader_uses_boto3_client(self, s3_bucket):
+        """CSV reader should read via self.client.get_object."""
+        client, session = s3_bucket
+
+        reader = CSVDataFrameReader(_config(), client, session=session)
+        result = reader.read_first_chunk(key="data/test.csv", bucket_name=BUCKET)
+
+        assert result.dataframes is not None
+        chunk = next(result.dataframes())
+        assert len(chunk) == 2
+        assert list(chunk.columns) == ["id", "name", "score"]
+
+    def test_avro_reader_uses_boto3_client(self, s3_bucket):
+        """Avro reader should read via self.client.get_object."""
+        client, session = s3_bucket
+
+        reader = AvroDataFrameReader(_config(), client, session=session)
+        result = reader.read_first_chunk(key="data/test.avro", bucket_name=BUCKET)
+
+        assert result.columns is not None
+        assert result.dataframes is not None
+        chunk = next(result.dataframes())
+        assert len(chunk) == 1
+
+    def test_csv_reader_without_session(self, s3_bucket):
+        """Readers should work when session is None (non-S3 sources)."""
+        client, _ = s3_bucket
+
+        reader = CSVDataFrameReader(_config(), client, session=None)
+        result = reader.read_first_chunk(key="data/test.csv", bucket_name=BUCKET)
+
+        assert result.dataframes is not None
+        chunk = next(result.dataframes())
+        assert len(chunk) == 2
+
+
+class TestParquetSessionCredentialExtraction:
+    """Verify parquet reader extracts credentials from session correctly.
+
+    s3fs (aiobotocore) is not compatible with moto in this environment,
+    so we verify the credential extraction flow rather than end-to-end reads.
+    The actual s3fs read path is covered in test_parquet_reader.py.
+    """
+
+    def test_build_s3fs_uses_session_credentials(self, s3_bucket):
+        """_build_s3fs_filesystem should extract creds from session."""
+        client, session = s3_bucket
+
+        reader = ParquetDataFrameReader(_config(), client, session=session)
+        creds = reader.session.get_credentials().get_frozen_credentials()
+
+        assert creds.access_key is not None
+        assert creds.secret_key is not None
+
+    def test_build_s3fs_passes_region(self, s3_bucket):
+        """s3fs should receive the region from config."""
+        client, session = s3_bucket
+
+        reader = ParquetDataFrameReader(_config(), client, session=session)
+
+        assert reader.config_source.securityConfig.awsRegion == REGION

--- a/ingestion/tests/unit/readers/test_s3_reader_credentials.py
+++ b/ingestion/tests/unit/readers/test_s3_reader_credentials.py
@@ -25,7 +25,9 @@ import io
 import boto3
 import fastavro
 import pytest
-from moto import mock_aws
+
+moto = pytest.importorskip("moto", reason="moto not installed")
+mock_aws = moto.mock_aws
 
 from metadata.generated.schema.entity.services.connections.database.datalake.s3Config import (
     S3Config,

--- a/ingestion/tests/unit/topology/database/test_datalake.py
+++ b/ingestion/tests/unit/topology/database/test_datalake.py
@@ -770,7 +770,7 @@ class DatalakeYieldTableNameTest(TestCase):
             ),
         ):
             results = list(
-                self.source.yield_table((table_name, TableType.Regular, None))
+                self.source.yield_table((table_name, TableType.Regular, None, None))
             )
 
         rights = [r.right for r in results if r.right is not None]

--- a/ingestion/tests/unit/topology/database/test_datalake_azure_blob_client.py
+++ b/ingestion/tests/unit/topology/database/test_datalake_azure_blob_client.py
@@ -350,7 +350,8 @@ class TestDatalakeAzureBlobClientTableMethods(unittest.TestCase):
         mock_container_client.list_blobs.assert_called_once_with(
             name_starts_with="atlas-wind/"
         )
-        self.assertEqual(result, ["atlas-wind/file1.csv", "atlas-wind/file2.csv"])
+        result_keys = [r[0] for r in result]
+        self.assertEqual(result_keys, ["atlas-wind/file1.csv", "atlas-wind/file2.csv"])
 
     def test_get_table_names_with_no_prefix(self):
         """
@@ -380,10 +381,11 @@ class TestDatalakeAzureBlobClientColdStorage(unittest.TestCase):
         self.mock_blob_service_client = MagicMock()
         self.client = DatalakeAzureBlobClient(client=self.mock_blob_service_client)
 
-    def _make_blob(self, name, blob_tier=None):
+    def _make_blob(self, name, blob_tier=None, size=1024):
         blob = MagicMock()
         blob.name = name
         blob.blob_tier = blob_tier
+        blob.size = size
         return blob
 
     def test_get_table_names_skip_cold_storage_filters_cold_tiers(self):
@@ -410,7 +412,8 @@ class TestDatalakeAzureBlobClientColdStorage(unittest.TestCase):
             )
         )
 
-        self.assertEqual(result, ["hot_file.csv", "no_tier_file.csv"])
+        result_keys = [r[0] for r in result]
+        self.assertEqual(result_keys, ["hot_file.csv", "no_tier_file.csv"])
 
     def test_get_table_names_skip_cold_storage_false_returns_all(self):
         """
@@ -433,7 +436,8 @@ class TestDatalakeAzureBlobClientColdStorage(unittest.TestCase):
             )
         )
 
-        self.assertEqual(result, ["hot_file.csv", "archive_file.csv"])
+        result_keys = [r[0] for r in result]
+        self.assertEqual(result_keys, ["hot_file.csv", "archive_file.csv"])
 
     def test_get_table_names_default_skip_cold_storage_is_false(self):
         """
@@ -451,7 +455,8 @@ class TestDatalakeAzureBlobClientColdStorage(unittest.TestCase):
 
         result = list(self.client.get_table_names(bucket_name="container", prefix=None))
 
-        self.assertEqual(result, ["archive_file.csv"])
+        result_keys = [r[0] for r in result]
+        self.assertEqual(result_keys, ["archive_file.csv"])
 
     def test_get_table_names_skip_cold_filters_each_cold_tier(self):
         """

--- a/ingestion/tests/unit/topology/database/test_datalake_gcs_client.py
+++ b/ingestion/tests/unit/topology/database/test_datalake_gcs_client.py
@@ -32,8 +32,8 @@ class TestDatalakeGcsClientColdStorage(unittest.TestCase):
             client=self.mock_gcs_client, temp_credentials_file_path_list=[]
         )
 
-    def _make_blob(self, name, storage_class=None):
-        blob = SimpleNamespace(name=name, storage_class=storage_class)
+    def _make_blob(self, name, storage_class=None, size=None):
+        blob = SimpleNamespace(name=name, storage_class=storage_class, size=size)
         return blob
 
     def test_skip_cold_storage_filters_cold_classes(self):
@@ -57,7 +57,10 @@ class TestDatalakeGcsClientColdStorage(unittest.TestCase):
             )
         )
 
-        self.assertEqual(result, ["standard.csv", "nearline.csv"])
+        self.assertEqual(
+            result,
+            [("standard.csv", None), ("nearline.csv", None)],
+        )
 
     def test_skip_cold_storage_false_returns_all(self):
         """
@@ -78,7 +81,10 @@ class TestDatalakeGcsClientColdStorage(unittest.TestCase):
             )
         )
 
-        self.assertEqual(result, ["standard.csv", "archive.csv"])
+        self.assertEqual(
+            result,
+            [("standard.csv", None), ("archive.csv", None)],
+        )
 
     def test_default_skip_cold_storage_is_false(self):
         """
@@ -94,7 +100,7 @@ class TestDatalakeGcsClientColdStorage(unittest.TestCase):
 
         result = list(self.client.get_table_names(bucket_name="my-bucket", prefix=None))
 
-        self.assertEqual(result, ["archive.csv"])
+        self.assertEqual(result, [("archive.csv", None)])
 
     def test_skip_cold_storage_handles_no_storage_class(self):
         """
@@ -114,7 +120,7 @@ class TestDatalakeGcsClientColdStorage(unittest.TestCase):
             )
         )
 
-        self.assertEqual(result, ["no_class.csv"])
+        self.assertEqual(result, [("no_class.csv", None)])
 
     def test_skip_cold_storage_filters_each_cold_class(self):
         """
@@ -159,7 +165,7 @@ class TestDatalakeGcsClientColdStorage(unittest.TestCase):
 
         self.assertEqual(
             result,
-            [f"{cls.lower()}.csv" for cls in non_cold_classes],
+            [(f"{cls.lower()}.csv", None) for cls in non_cold_classes],
         )
 
 

--- a/ingestion/tests/unit/topology/database/test_datalake_s3_client.py
+++ b/ingestion/tests/unit/topology/database/test_datalake_s3_client.py
@@ -50,7 +50,10 @@ class TestDatalakeS3ClientColdStorage(unittest.TestCase):
             )
         )
 
-        self.assertEqual(result, ["data/standard.csv", "data/ia.csv"])
+        self.assertEqual(
+            result,
+            [("data/standard.csv", None), ("data/ia.csv", None)],
+        )
 
     @patch("metadata.ingestion.source.database.datalake.clients.s3.list_s3_objects")
     def test_skip_cold_storage_false_returns_all(self, mock_list_s3):
@@ -70,7 +73,10 @@ class TestDatalakeS3ClientColdStorage(unittest.TestCase):
             )
         )
 
-        self.assertEqual(result, ["data/standard.csv", "data/glacier.csv"])
+        self.assertEqual(
+            result,
+            [("data/standard.csv", None), ("data/glacier.csv", None)],
+        )
 
     @patch("metadata.ingestion.source.database.datalake.clients.s3.list_s3_objects")
     def test_default_skip_cold_storage_is_false(self, mock_list_s3):
@@ -85,7 +91,7 @@ class TestDatalakeS3ClientColdStorage(unittest.TestCase):
 
         result = list(self.client.get_table_names(bucket_name="my-bucket", prefix=None))
 
-        self.assertEqual(result, ["data/glacier.csv"])
+        self.assertEqual(result, [("data/glacier.csv", None)])
 
     @patch("metadata.ingestion.source.database.datalake.clients.s3.list_s3_objects")
     def test_skip_cold_storage_handles_missing_storage_class(self, mock_list_s3):
@@ -104,7 +110,7 @@ class TestDatalakeS3ClientColdStorage(unittest.TestCase):
             )
         )
 
-        self.assertEqual(result, ["data/no_class.csv"])
+        self.assertEqual(result, [("data/no_class.csv", None)])
 
     @patch("metadata.ingestion.source.database.datalake.clients.s3.list_s3_objects")
     def test_skip_cold_storage_filters_each_cold_class(self, mock_list_s3):
@@ -153,7 +159,7 @@ class TestDatalakeS3ClientColdStorage(unittest.TestCase):
 
         self.assertEqual(
             result,
-            [f"data/{cls.lower()}.csv" for cls in non_cold_classes],
+            [(f"data/{cls.lower()}.csv", None) for cls in non_cold_classes],
         )
 
 


### PR DESCRIPTION
# S3 Datalake Connector — Credential Fix + Performance Optimization

## Problem 1: ACCESS_DENIED reading files from S3

  Symptom: Parquet and CSV files failed with ACCESS_DENIED / Forbidden during schema inference, even though aws s3 cp worked fine with the same credentials.

  Root cause: All S3 file readers (parquet, CSV, avro) bypassed the properly-configured boto3 client and created their own filesystem clients from raw config — missing AssumeRole, instance profiles, ECS task roles, etc.

  Fix: Each reader now uses the boto3 client/session that was already properly configured by AWSClient:

 

## Problem 2: Full file downloaded into memory for parquet

  Symptom: Parquet reader called response["Body"].read() into a BytesIO buffer, loading entire files into memory before reading.

  Fix: Uses s3fs.open() which gives PyArrow a seekable file handle — PyArrow performs ranged reads (footer + needed row groups only), no full download.

## Problem 3: Private boto3 API for credential extraction

  Symptom: Used self.client._request_signer._credentials.get_frozen_credentials() — fragile private API.

  Fix: Session is now stored in DatalakeS3Client and threaded to readers. Uses the public session.get_credentials().get_frozen_credentials() instead. Falls back to default credential chain when session is None (profiler path).

## Problem 4: N+1 HEAD requests at scale

  Symptom: list_objects_v2 already returns file Size, but readers made separate head_object / s3_fs.info() / GCSFileSystem().info() / AzureBlobFileSystem().info() calls per file. For 100K files = 100K redundant API calls.

  Fix:
  - get_table_names() now yields (key, size) tuples across all 3 cloud providers
  - Size flows through metadata.py → DatalakeTableSchemaWrapper.file_size → readers
  - Readers skip the extra API call when file_size is provided, fall back to HEAD when None

## Problem 5: GCS/Azure _get_file_size_mb created bare filesystem clients

  Symptom: _get_file_size_mb() created GCSFileSystem() without credentials and AzureBlobFileSystem() from raw config — same bypass pattern we fixed for S3.

  Fix: Uses the passed-in self.client for all providers:
  - GCS: self.client.get_bucket().get_blob().size
  - Azure: self.client.get_blob_client().get_blob_properties().size

## Problem 6: DSV IndexError on malformed CSV

  Symptom: _fix_malformed_quoted_chunk can return empty list, and [0] access would crash.

  Fix: Added if fixed: guard before accessing fixed[0].

## Problem 7: Avro loaded full file for schema extraction

  Symptom: io.BytesIO(schema_response["Body"].read()) downloaded the entire avro file just to read the header schema.

  Fix: Passes streaming response["Body"] directly to fastavro.reader() which reads the schema from the header without buffering.

## Problem 8: Misleading log when file size unknown

  Symptom: Log said "Large parquet file detected (0 bytes > 50MB)" when size check failed.

  Fix: Logs "Unknown file size. Using batched reading" when file_size == 0.