### PR TITLE
Fixes #26939: Add FQN subtitle to Custom Property entity references

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/PropertyValue.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/PropertyValue.test.tsx
@@ -520,7 +520,9 @@ describe('Test PropertyValue Component', () => {
     expect(
       await screen.findByTestId('entityReference-value')
     ).toBeInTheDocument();
-    expect(screen.getByText('service.schema.entityReferenceName')).toBeInTheDocument();
+    expect(
+      screen.getByText('service.schema.entityReferenceName')
+    ).toBeInTheDocument();
   });
 
   it('should show FQN subtitle for entityReferenceList type', async () => {
@@ -556,12 +558,16 @@ describe('Test PropertyValue Component', () => {
     expect(
       await screen.findByTestId('entityReferenceName1')
     ).toBeInTheDocument();
-    expect(screen.getByText('service.schema.entityReferenceName1')).toBeInTheDocument();
+    expect(
+      screen.getByText('service.schema.entityReferenceName1')
+    ).toBeInTheDocument();
 
     expect(
       await screen.findByTestId('entityReferenceName2')
     ).toBeInTheDocument();
-    expect(screen.getByText('service.schema.entityReferenceName2')).toBeInTheDocument();
+    expect(
+      screen.getByText('service.schema.entityReferenceName2')
+    ).toBeInTheDocument();
   });
 
   it('should not show FQN subtitle when fullyQualifiedName is absent', async () => {
@@ -589,7 +595,7 @@ describe('Test PropertyValue Component', () => {
       await screen.findByTestId('entityReference-value')
     ).toBeInTheDocument();
     expect(screen.getByText('entityReferenceName')).toBeInTheDocument();
-    
+
     // Asserting that the subtitle did not mistakenly render 'undefined' or an empty variable text
     expect(screen.queryByText('undefined')).not.toBeInTheDocument();
   });

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/PropertyValue.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/PropertyValue.test.tsx
@@ -433,9 +433,7 @@ describe('Test PropertyValue Component', () => {
     expect(
       await screen.findByTestId('entityReference-value')
     ).toBeInTheDocument();
-    expect(
-      await screen.findByTestId('entityReference-value')
-    ).toHaveTextContent('entityReferenceName');
+    expect(screen.getByText('entityReferenceName')).toBeInTheDocument();
 
     await act(async () => {
       fireEvent.click(iconElement);
@@ -495,5 +493,104 @@ describe('Test PropertyValue Component', () => {
     expect(
       await screen.findByTestId('entity-reference-select')
     ).toBeInTheDocument();
+  });
+
+  it('should show FQN subtitle for entityReference type', async () => {
+    const extension = {
+      yNumber: {
+        id: 'entityReferenceId',
+        name: 'entityReferenceName',
+        fullyQualifiedName: 'service.schema.entityReferenceName',
+        type: 'entityReference',
+      },
+    };
+    const propertyType = {
+      ...mockData.property.propertyType,
+      name: 'entityReference',
+    };
+    render(
+      <PropertyValue
+        {...mockData}
+        extension={extension}
+        property={{ ...mockData.property, propertyType: propertyType }}
+      />,
+      { wrapper: MemoryRouter }
+    );
+
+    expect(
+      await screen.findByTestId('entityReference-value')
+    ).toBeInTheDocument();
+    expect(screen.getByText('service.schema.entityReferenceName')).toBeInTheDocument();
+  });
+
+  it('should show FQN subtitle for entityReferenceList type', async () => {
+    const extension = {
+      yNumber: [
+        {
+          id: 'entityReferenceId1',
+          name: 'entityReferenceName1',
+          fullyQualifiedName: 'service.schema.entityReferenceName1',
+          type: 'entityReference',
+        },
+        {
+          id: 'entityReferenceId2',
+          name: 'entityReferenceName2',
+          fullyQualifiedName: 'service.schema.entityReferenceName2',
+          type: 'entityReference',
+        },
+      ],
+    };
+    const propertyType = {
+      ...mockData.property.propertyType,
+      name: 'entityReferenceList',
+    };
+    render(
+      <PropertyValue
+        {...mockData}
+        extension={extension}
+        property={{ ...mockData.property, propertyType: propertyType }}
+      />,
+      { wrapper: MemoryRouter }
+    );
+
+    expect(
+      await screen.findByTestId('entityReferenceName1')
+    ).toBeInTheDocument();
+    expect(screen.getByText('service.schema.entityReferenceName1')).toBeInTheDocument();
+
+    expect(
+      await screen.findByTestId('entityReferenceName2')
+    ).toBeInTheDocument();
+    expect(screen.getByText('service.schema.entityReferenceName2')).toBeInTheDocument();
+  });
+
+  it('should not show FQN subtitle when fullyQualifiedName is absent', async () => {
+    const extension = {
+      yNumber: {
+        id: 'entityReferenceId',
+        name: 'entityReferenceName',
+        type: 'entityReference',
+      },
+    };
+    const propertyType = {
+      ...mockData.property.propertyType,
+      name: 'entityReference',
+    };
+    render(
+      <PropertyValue
+        {...mockData}
+        extension={extension}
+        property={{ ...mockData.property, propertyType: propertyType }}
+      />,
+      { wrapper: MemoryRouter }
+    );
+
+    expect(
+      await screen.findByTestId('entityReference-value')
+    ).toBeInTheDocument();
+    expect(screen.getByText('entityReferenceName')).toBeInTheDocument();
+    
+    // Asserting that the subtitle did not mistakenly render 'undefined' or an empty variable text
+    expect(screen.queryByText('undefined')).not.toBeInTheDocument();
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/PropertyValue.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/PropertyValue.tsx
@@ -864,11 +864,20 @@ export const PropertyValue: FC<PropertyValueProps> = ({
           searchClassBase.getEntityIcon(item.type)
         )}
       </div>
-      <Typography.Text
-        className="text-left text-primary truncate w-max-full"
-        ellipsis={{ tooltip: true }}>
-        {getEntityName(item)}
-      </Typography.Text>
+      <div className="d-flex flex-col">
+        <Typography.Text
+          className="text-left text-primary truncate w-max-full"
+          ellipsis={{ tooltip: true }}>
+          {getEntityName(item)}
+        </Typography.Text>
+        {item.fullyQualifiedName && (
+          <Typography.Text
+            className="text-grey-muted text-xs truncate w-max-full"
+            ellipsis={{ tooltip: true }}>
+            {item.fullyQualifiedName}
+          </Typography.Text>
+        )}
+      </div>
     </Link>
   );
 


### PR DESCRIPTION
### Description:

Fixes #26939

I worked on updating the rendering logic inside `CustomPropertyTable/PropertyValue.tsx` to display the `fullyQualifiedName` (FQN) as a secondary, muted subtitle beneath the primary entity name. This resolves an issue where multiple tables/entities sharing the exact same name across different remote systems could not be safely distinguished. The layout now follows the established `getEntityLabel` pattern for UI consistency and falls back safely when the FQN is absent.

All related testing scenarios have successfully passed.

### Test Results
<img width="1368" height="640" alt="image" src="https://github.com/user-attachments/assets/464f8690-3007-4aa8-a321-5183fa861059" />

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.

