### PR TITLE
Fixes #24636: use test_metadata.kwargs['model'] to identify primary table for dbt test entity links

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/dbt/dbt_utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/dbt_utils.py
@@ -684,18 +684,53 @@ def get_manifest_column_name(manifest_node) -> Optional[str]:
 
 def generate_entity_link(dbt_test):
     """
-    Method returns entity link
+    Method returns entity link for dbt test cases.
+
+    For test cases with multiple upstream dependencies (e.g., relationship tests),
+    we must identify the primary table being tested. This is explicitly specified in
+    test_metadata.kwargs['model'] for generic tests. Using this explicit reference
+    is more reliable than guessing based on upstream order (fixes issue #24636).
     """
+    import re
+
     manifest_node = dbt_test.get(DbtCommonEnum.MANIFEST_NODE.value)
-    entity_link_list = [
-        entity_link.get_entity_link(
-            Table,
-            fqn=table_fqn,
-            column_name=get_manifest_column_name(manifest_node),
-        )
-        for table_fqn in dbt_test[DbtCommonEnum.UPSTREAM.value]
-    ]
-    return entity_link_list
+    upstream_list = dbt_test.get(DbtCommonEnum.UPSTREAM.value, [])
+
+    if not upstream_list:
+        return []
+
+    primary_table_fqn = None
+
+    # Try to extract the primary table from test_metadata.kwargs['model']
+    # This field contains the main table being tested (order-independent)
+    if hasattr(manifest_node, "test_metadata"):
+        kwargs = getattr(manifest_node.test_metadata, "kwargs", {})
+        if isinstance(kwargs, dict):
+            model_str = kwargs.get("model", "")
+            if model_str:
+                # Extract table name from ref('table_name') pattern
+                match = re.search(r"ref\('([^']+)'\)", str(model_str))
+                if match:
+                    primary_table_name = match.group(1)
+                    # Find the matching FQN in upstream_list
+                    for fqn in upstream_list:
+                        if fqn.endswith(f".{primary_table_name}"):
+                            primary_table_fqn = fqn
+                            break
+
+    # Fallback: use the first upstream table if model field is not available
+    if not primary_table_fqn and upstream_list:
+        primary_table_fqn = upstream_list[0]
+
+    if not primary_table_fqn:
+        return []
+
+    entity_link_str = entity_link.get_entity_link(
+        Table,
+        fqn=primary_table_fqn,
+        column_name=get_manifest_column_name(manifest_node),
+    )
+    return [entity_link_str]
 
 
 def get_dbt_compiled_query(mnode) -> Optional[str]:

--- a/ingestion/src/metadata/ingestion/source/database/dbt/dbt_utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/dbt_utils.py
@@ -691,8 +691,6 @@ def generate_entity_link(dbt_test):
     test_metadata.kwargs['model'] for generic tests. Using this explicit reference
     is more reliable than guessing based on upstream order (fixes issue #24636).
     """
-    import re
-
     manifest_node = dbt_test.get(DbtCommonEnum.MANIFEST_NODE.value)
     upstream_list = dbt_test.get(DbtCommonEnum.UPSTREAM.value, [])
 
@@ -708,8 +706,12 @@ def generate_entity_link(dbt_test):
         if isinstance(kwargs, dict):
             model_str = kwargs.get("model", "")
             if model_str:
-                # Extract table name from ref('table_name') pattern
-                match = re.search(r"ref\('([^']+)'\)", str(model_str))
+                # Extract table name from ref() pattern
+                # Handles: ref('table'), ref("table"), ref('pkg', 'table'), ref("pkg", "table")
+                match = re.search(
+                    r"ref\(['\"](?:[^'\"]+['\"],\s*['\"])?([^'\"]+)['\"]\)",
+                    str(model_str),
+                )
                 if match:
                     primary_table_name = match.group(1)
                     # Find the matching FQN in upstream_list

--- a/ingestion/tests/unit/resources/datasets/manifest_test_node.json
+++ b/ingestion/tests/unit/resources/datasets/manifest_test_node.json
@@ -11,6 +11,87 @@
         "adapter_type": "redshift"
     },
     "nodes": {
+        "test.jaffle_shop.relationships_un_rueckerstattungen_medis_base_PersonNr__ref_un_person_base_": {
+            "test_metadata": {
+                "name": "relationships",
+                "kwargs": {
+                    "column_name": "PersonNr",
+                    "model": "{{ ref('un_rueckerstattungen_medis_base') }}",
+                    "to": "{{ ref('un_person_base') }}",
+                    "field": "PartnerNr"
+                },
+                "namespace": null
+            },
+            "compiled": true,
+            "resource_type": "test",
+            "depends_on": {
+                "macros": [
+                    "macro.dbt.test_relationships"
+                ],
+                "nodes": [
+                    "model.jaffle_shop.un_rueckerstattungen_medis_base",
+                    "model.jaffle_shop.un_person_base"
+                ]
+            },
+            "config": {
+                "enabled": true,
+                "alias": null,
+                "schema": "dbt_test__audit",
+                "database": null,
+                "tags": [],
+                "meta": {},
+                "materialized": "test",
+                "severity": "ERROR",
+                "store_failures": null,
+                "where": null,
+                "limit": null
+            },
+            "database": "dev",
+            "schema": "dbt_test__audit",
+            "fqn": [
+                "jaffle_shop",
+                "relationships_un_rueckerstattungen_medis_base_PersonNr__ref_un_person_base_"
+            ],
+            "unique_id": "test.jaffle_shop.relationships_un_rueckerstattungen_medis_base_PersonNr__ref_un_person_base_",
+            "raw_code": "{{ test_relationships(**_dbt_generic_test_kwargs) }}",
+            "language": "sql",
+            "package_name": "jaffle_shop",
+            "root_path": "/Users/onkarravgan/Desktop/project/jaffle_shop",
+            "path": "relationships_test.sql",
+            "original_file_path": "models/schema.yml",
+            "name": "relationships_un_rueckerstattungen_medis_base_PersonNr__ref_un_person_base_",
+            "alias": "relationships_test",
+            "checksum": {
+                "name": "none",
+                "checksum": ""
+            },
+            "tags": [],
+            "refs": [
+                ["un_rueckerstattungen_medis_base"],
+                ["un_person_base"]
+            ],
+            "sources": [],
+            "metrics": [],
+            "description": "",
+            "columns": {},
+            "meta": {},
+            "docs": {
+                "show": true,
+                "node_color": null
+            },
+            "patch_path": null,
+            "compiled_path": "target/compiled/jaffle_shop/models/schema.yml/relationships_test.sql",
+            "build_path": null,
+            "deferred": false,
+            "unrendered_config": {},
+            "created_at": 1673982251.748683,
+            "compiled_code": "select count(*) from table where PersonNr not in (select PartnerNr from other_table)",
+            "extra_ctes_injected": true,
+            "extra_ctes": [],
+            "relation_name": null,
+            "column_name": "PersonNr",
+            "file_key_name": "models.un_rueckerstattungen_medis_base"
+        },
         "test.jaffle_shop.unique_orders_order_id.fed79b3a6e": {
             "test_metadata": {
                 "name": "unique",

--- a/ingestion/tests/unit/test_dbt.py
+++ b/ingestion/tests/unit/test_dbt.py
@@ -2856,14 +2856,12 @@ class DbtUnitTest(TestCase):
         _, dbt_objects = self.get_dbt_object_files(
             mock_manifest=MOCK_SAMPLE_MANIFEST_TEST_NODE
         )
-        manifest_node = dbt_objects.dbt_manifest.nodes.get(
-            "test.jaffle_shop.unique_orders_order_id.fed79b3a6e"
-        )
 
-        # Test case 1: Relationship test (like from issue #24636)
-        # relationships_un_rueckerstattungen_medis_base_PersonNr__PartnerNr__ref_un_person_base_
-        # For relationship tests, dbt includes both tables in upstream list
-        manifest_node.column_name = "PersonNr"  # Mixed case column
+        # Test case 1: Relationship test with kwargs['model'] extraction (main code path)
+        # This test exercises the primary fix for issue #24636
+        manifest_node = dbt_objects.dbt_manifest.nodes.get(
+            "test.jaffle_shop.relationships_un_rueckerstattungen_medis_base_PersonNr__ref_un_person_base_"
+        )
         dbt_test = {
             "manifest_node": manifest_node,
             "upstream": [
@@ -2877,36 +2875,49 @@ class DbtUnitTest(TestCase):
         self.assertEqual(
             len(result), 1, "Should only create one entity link for primary table"
         )
-        # Link should be to the primary table, not the referenced table
+        # Link should be to the primary table extracted from kwargs['model']
         self.assertIn("un_rueckerstattungen_medis_base", result[0])
         self.assertIn("::columns::PersonNr>", result[0])
         self.assertNotIn("un_person_base", result[0])
 
-        # Test case 2: Unique test with underscore-prefixed mixed-case column
-        # unique_un_abrechnungsposition_cur_dp_AbrechnungspositionHK
-        manifest_node.column_name = (
-            "dp_AbrechnungspositionHK"  # Underscore + mixed case
+        # Test case 2: Verify kwargs['model'] path works with REVERSED upstream order
+        # This proves the fix is order-independent (the bug in #24636)
+        dbt_test_reversed = {
+            "manifest_node": manifest_node,
+            "upstream": [
+                "unity.catalog.schema.un_person_base",  # Referenced table FIRST
+                "unity.catalog.schema.un_rueckerstattungen_medis_base",  # Primary table LAST
+            ],
+            "results": "",
+        }
+        result_reversed = generate_entity_link(dbt_test=dbt_test_reversed)
+        # Should still return the primary table, proving kwargs['model'] extraction works
+        self.assertEqual(
+            len(result_reversed),
+            1,
+            "Should return primary table regardless of upstream order",
         )
-        dbt_test = {
-            "manifest_node": manifest_node,
-            "upstream": ["unity.catalog.schema.un_abrechnungsposition_cur"],
-            "results": "",
-        }
-        result = generate_entity_link(dbt_test=dbt_test)
-        self.assertEqual(len(result), 1)
-        self.assertIn("::columns::dp_AbrechnungspositionHK>", result[0])
+        self.assertIn("un_rueckerstattungen_medis_base", result_reversed[0])
+        self.assertIn("::columns::PersonNr>", result_reversed[0])
+        self.assertNotIn("un_person_base", result_reversed[0])
 
-        # Test case 3: Ensure case sensitivity is preserved
-        manifest_node.column_name = "PartnerNr"
-        dbt_test = {
-            "manifest_node": manifest_node,
-            "upstream": ["unity.catalog.schema.un_person_base"],
+        # Test case 3: Fallback to first upstream when kwargs['model'] is unavailable
+        # This tests the fallback path (lines 720-722)
+        manifest_node_fallback = dbt_objects.dbt_manifest.nodes.get(
+            "test.jaffle_shop.unique_orders_order_id.fed79b3a6e"
+        )
+        dbt_test_fallback = {
+            "manifest_node": manifest_node_fallback,
+            "upstream": [
+                "unity.catalog.schema.un_abrechnungsposition_cur",  # First table
+                "unity.catalog.schema.un_person_base",  # Second table
+            ],
             "results": "",
         }
-        result = generate_entity_link(dbt_test=dbt_test)
-        self.assertEqual(len(result), 1)
-        # Entity link should preserve the exact column name casing
-        self.assertIn("::columns::PartnerNr>", result[0])
+        result_fallback = generate_entity_link(dbt_test=dbt_test_fallback)
+        # Should fall back to first upstream since model pattern doesn't match
+        self.assertEqual(len(result_fallback), 1)
+        self.assertIn("un_abrechnungsposition_cur", result_fallback[0])
 
 
 class TestDownloadDbtFiles(TestCase):

--- a/ingestion/tests/unit/test_dbt.py
+++ b/ingestion/tests/unit/test_dbt.py
@@ -2841,6 +2841,69 @@ class DbtUnitTest(TestCase):
             expected_fqn
         ], f"Expected lineage to resolve via target_schema 'snapshots', got: {result}"
 
+    def test_dbt_entity_link_with_mixed_case_columns_issue_24636(self):
+        """
+        Test for issue #24636: dbt test case ingestion fails with relationship tests.
+
+        Root cause: dbt relationship tests have multiple upstream dependencies, but the
+        order varies by database engine (Snowflake first, Unity Catalog last). Previously,
+        code iterated over ALL upstream tables, causing column validation errors when
+        the referenced table didn't have the same column names.
+
+        Fix: Extract primary table from test_metadata.kwargs['model'] explicitly,
+        which is order-independent and works across all database engines.
+        """
+        _, dbt_objects = self.get_dbt_object_files(
+            mock_manifest=MOCK_SAMPLE_MANIFEST_TEST_NODE
+        )
+        manifest_node = dbt_objects.dbt_manifest.nodes.get(
+            "test.jaffle_shop.unique_orders_order_id.fed79b3a6e"
+        )
+
+        # Test case 1: Relationship test (like from issue #24636)
+        # relationships_un_rueckerstattungen_medis_base_PersonNr__PartnerNr__ref_un_person_base_
+        # For relationship tests, dbt includes both tables in upstream list
+        manifest_node.column_name = "PersonNr"  # Mixed case column
+        dbt_test = {
+            "manifest_node": manifest_node,
+            "upstream": [
+                "unity.catalog.schema.un_rueckerstattungen_medis_base",  # Primary table
+                "unity.catalog.schema.un_person_base",  # Referenced table
+            ],
+            "results": "",
+        }
+        result = generate_entity_link(dbt_test=dbt_test)
+        # Should return only one entity link (for the primary table)
+        self.assertEqual(len(result), 1, "Should only create one entity link for primary table")
+        # Link should be to the primary table, not the referenced table
+        self.assertIn("un_rueckerstattungen_medis_base", result[0])
+        self.assertIn("::columns::PersonNr>", result[0])
+        self.assertNotIn("un_person_base", result[0])
+
+        # Test case 2: Unique test with underscore-prefixed mixed-case column
+        # unique_un_abrechnungsposition_cur_dp_AbrechnungspositionHK
+        manifest_node.column_name = "dp_AbrechnungspositionHK"  # Underscore + mixed case
+        dbt_test = {
+            "manifest_node": manifest_node,
+            "upstream": ["unity.catalog.schema.un_abrechnungsposition_cur"],
+            "results": "",
+        }
+        result = generate_entity_link(dbt_test=dbt_test)
+        self.assertEqual(len(result), 1)
+        self.assertIn("::columns::dp_AbrechnungspositionHK>", result[0])
+
+        # Test case 3: Ensure case sensitivity is preserved
+        manifest_node.column_name = "PartnerNr"
+        dbt_test = {
+            "manifest_node": manifest_node,
+            "upstream": ["unity.catalog.schema.un_person_base"],
+            "results": "",
+        }
+        result = generate_entity_link(dbt_test=dbt_test)
+        self.assertEqual(len(result), 1)
+        # Entity link should preserve the exact column name casing
+        self.assertIn("::columns::PartnerNr>", result[0])
+
 
 class TestDownloadDbtFiles(TestCase):
     """

--- a/ingestion/tests/unit/test_dbt.py
+++ b/ingestion/tests/unit/test_dbt.py
@@ -2874,7 +2874,9 @@ class DbtUnitTest(TestCase):
         }
         result = generate_entity_link(dbt_test=dbt_test)
         # Should return only one entity link (for the primary table)
-        self.assertEqual(len(result), 1, "Should only create one entity link for primary table")
+        self.assertEqual(
+            len(result), 1, "Should only create one entity link for primary table"
+        )
         # Link should be to the primary table, not the referenced table
         self.assertIn("un_rueckerstattungen_medis_base", result[0])
         self.assertIn("::columns::PersonNr>", result[0])
@@ -2882,7 +2884,9 @@ class DbtUnitTest(TestCase):
 
         # Test case 2: Unique test with underscore-prefixed mixed-case column
         # unique_un_abrechnungsposition_cur_dp_AbrechnungspositionHK
-        manifest_node.column_name = "dp_AbrechnungspositionHK"  # Underscore + mixed case
+        manifest_node.column_name = (
+            "dp_AbrechnungspositionHK"  # Underscore + mixed case
+        )
         dbt_test = {
             "manifest_node": manifest_node,
             "upstream": ["unity.catalog.schema.un_abrechnungsposition_cur"],


### PR DESCRIPTION
Fixes #24636

## Summary
Fix dbt test case ingestion failures for Unity Catalog by using the explicit primary table reference from `test_metadata.kwargs['model']` instead of relying on the order of `depends_on.nodes`.

For dbt relationship tests with multiple upstream dependencies, the order of tables varies by database engine (Snowflake lists main table first; Unity Catalog lists referenced table first). This causes "Invalid column name" errors when the column exists in the primary table but not the referenced table.

## Test Plan
- [x] Added test case `test_dbt_entity_link_with_mixed_case_columns_issue_24636` in `ingestion/tests/unit/test_dbt.py` verifying that relationship tests use only the primary table for entity links
- [x] Verified the fix handles both explicit kwargs['model'] extraction and fallback to first upstream table

## What's Changed
- `ingestion/src/metadata/ingestion/source/database/dbt/dbt_utils.py`: Modified `generate_entity_link()` to extract primary table from `test_metadata.kwargs['model']` using regex pattern matching for `ref('table_name')`
- `ingestion/tests/unit/test_dbt.py`: Added test case to verify entity link generation for relationship tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)