### PR TITLE
feat(ui): add font-size support to SelectItem via SelectContext

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/select/select-item.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/select/select-item.tsx
@@ -1,13 +1,14 @@
-import { isValidElement, useContext } from 'react';
+import { Avatar } from '@/components/base/avatar/avatar';
+import { cx } from '@/utils/cx';
+import { isReactComponent } from '@/utils/is-react-component';
+import { fontSizeClass } from '@/utils/tailwindClasses';
 import { Check } from '@untitledui/icons';
+import { isValidElement, useContext } from 'react';
 import type { ListBoxItemProps as AriaListBoxItemProps } from 'react-aria-components';
 import {
   ListBoxItem as AriaListBoxItem,
   Text as AriaText,
 } from 'react-aria-components';
-import { Avatar } from '@/components/base/avatar/avatar';
-import { cx } from '@/utils/cx';
-import { isReactComponent } from '@/utils/is-react-component';
 import type { SelectItemType } from './select';
 import { SelectContext } from './select';
 
@@ -32,7 +33,7 @@ export const SelectItem = ({
   children,
   ...props
 }: SelectItemProps) => {
-  const { size } = useContext(SelectContext);
+  const { fontSize, size } = useContext(SelectContext);
 
   const labelOrChildren =
     label || (typeof children === 'string' ? children : '');
@@ -89,7 +90,8 @@ export const SelectItem = ({
           <div className="tw:flex tw:w-full tw:min-w-0 tw:flex-1 tw:flex-wrap tw:gap-x-2">
             <AriaText
               className={cx(
-                'tw:truncate tw:text-md tw:font-medium tw:whitespace-nowrap tw:text-primary',
+                'tw:truncate tw:whitespace-nowrap tw:text-primary',
+                fontSizeClass[fontSize],
                 state.isDisabled && 'tw:text-disabled'
               )}
               slot="label">
@@ -100,7 +102,8 @@ export const SelectItem = ({
             {supportingText && (
               <AriaText
                 className={cx(
-                  'tw:text-md tw:whitespace-nowrap tw:text-tertiary',
+                  'tw:whitespace-nowrap tw:text-tertiary',
+                  fontSizeClass[fontSize],
                   state.isDisabled && 'tw:text-disabled'
                 )}
                 slot="description">

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/select/select-item.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/select/select-item.tsx
@@ -90,7 +90,7 @@ export const SelectItem = ({
           <div className="tw:flex tw:w-full tw:min-w-0 tw:flex-1 tw:flex-wrap tw:gap-x-2">
             <AriaText
               className={cx(
-                'tw:truncate tw:whitespace-nowrap tw:text-primary',
+                'tw:truncate tw:font-medium tw:whitespace-nowrap tw:text-primary',
                 fontSizeClass[fontSize],
                 state.isDisabled && 'tw:text-disabled'
               )}

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/select/select.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/select/select.tsx
@@ -152,7 +152,11 @@ const SelectValue = ({
   );
 };
 
-export const SelectContext = createContext<{ size: 'sm' | 'md' }>({
+export const SelectContext = createContext<{
+  size: 'sm' | 'md';
+  fontSize: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+}>({
+  fontSize: 'md',
   size: 'sm',
 });
 
@@ -170,7 +174,7 @@ const Select = ({
   ...rest
 }: SelectProps) => {
   return (
-    <SelectContext.Provider value={{ size }}>
+    <SelectContext.Provider value={{ fontSize, size }}>
       <AriaSelect
         {...rest}
         className={(state) =>


### PR DESCRIPTION
### Describe your changes:

Extends fontSize prop support from the Select trigger button down to SelectItem dropdown options, so both the selected value display and the dropdown items use the same configured font size.

Problem
Previously, Select accepted a fontSize prop that only applied to the trigger button (the selected value display). The dropdown SelectItem components used a hardcoded tw:text-md class, so changing fontSize on Select had no effect on the dropdown list items  the two were visually inconsistent.

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->



<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
