### PR TITLE
fix(apps): route app logs through streamable log storage when enabled

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/apps/AppResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/apps/AppResource.java
@@ -48,6 +48,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.ServiceEntityInterface;
 import org.openmetadata.schema.api.data.RestoreEntity;
@@ -542,7 +543,13 @@ public class AppResource extends EntityResource<App, AppRepository> {
                       + "If not provided, returns logs for the latest run.",
               schema = @Schema(type = "string"))
           @QueryParam("runId")
-          String runId) {
+          String runId,
+      @Parameter(
+              description = "Maximum number of lines to return (only applies to streamable logs)",
+              schema = @Schema(type = "integer"))
+          @QueryParam("limit")
+          @DefaultValue("1000")
+          int limit) {
     App installation = repository.getByName(uriInfo, name, repository.getFields("id,pipelines"));
     if (installation.getAppType().equals(AppType.Internal)) {
       AppRunRecord latestRun = repository.getLatestAppRunsOptional(installation).orElse(null);
@@ -557,14 +564,61 @@ public class AppResource extends EntityResource<App, AppRepository> {
             (IngestionPipelineRepository) Entity.getEntityRepository(Entity.INGESTION_PIPELINE);
         IngestionPipeline ingestionPipeline =
             ingestionPipelineRepository.get(
-                uriInfo, pipelineRef.getId(), ingestionPipelineRepository.getFields(FIELD_OWNERS));
-        return Response.ok(
-                pipelineServiceClient.getIngestionLogs(ingestionPipeline, after, runId),
-                MediaType.APPLICATION_JSON_TYPE)
-            .build();
+                uriInfo,
+                pipelineRef.getId(),
+                ingestionPipelineRepository.getFields(
+                    FIELD_OWNERS + ",pipelineStatuses,ingestionRunner"));
+        Map<String, String> lastLogs =
+            getAppLastLogs(ingestionPipelineRepository, ingestionPipeline, after, runId, limit);
+        return Response.ok(lastLogs, MediaType.APPLICATION_JSON_TYPE).build();
       }
     }
     throw new BadRequestException("Failed to Get Logs for the Installation.");
+  }
+
+  private Map<String, String> getAppLastLogs(
+      IngestionPipelineRepository ingestionPipelineRepository,
+      IngestionPipeline ingestionPipeline,
+      String after,
+      String runId,
+      int limit) {
+    boolean useStreamableLogs =
+        Boolean.TRUE.equals(ingestionPipeline.getEnableStreamableLogs())
+            || (ingestionPipeline.getIngestionRunner() != null
+                && ingestionPipelineRepository.isIngestionRunnerStreamableLogsEnabled(
+                    ingestionPipeline.getIngestionRunner()));
+    if (useStreamableLogs) {
+      String effectiveRunId =
+          !nullOrEmpty(runId)
+              ? runId
+              : (ingestionPipeline.getPipelineStatuses() != null
+                  ? ingestionPipeline.getPipelineStatuses().getRunId()
+                  : null);
+      if (!nullOrEmpty(effectiveRunId)) {
+        UUID runUuid;
+        try {
+          runUuid = UUID.fromString(effectiveRunId);
+        } catch (IllegalArgumentException e) {
+          throw new BadRequestException("Invalid runId format: " + effectiveRunId);
+        }
+        Map<String, Object> raw =
+            ingestionPipelineRepository.getLogs(
+                ingestionPipeline.getFullyQualifiedName(), runUuid, after, limit);
+        Map<String, String> lastLogs =
+            raw.entrySet().stream()
+                .filter(e -> e.getValue() != null)
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().toString()));
+        Object logs = lastLogs.remove("logs");
+        if (logs != null) {
+          lastLogs.put(
+              PipelineServiceClientInterface.TYPE_TO_TASK.get(
+                  ingestionPipeline.getPipelineType().toString()),
+              logs.toString());
+        }
+        return lastLogs;
+      }
+    }
+    return pipelineServiceClient.getIngestionLogs(ingestionPipeline, after, runId);
   }
 
   @GET


### PR DESCRIPTION
Fixes #27381

## Summary

- `AppResource.getLastLogs` now mirrors `IngestionPipelineResource.getLastIngestionLogs`: checks `enableStreamableLogs` on the pipeline and its ingestion runner, and when enabled reads from `IngestionPipelineRepository.getLogs(fqn, runId, after, limit)` (which picks S3 or the default log store). Falls back to `pipelineServiceClient.getIngestionLogs(pipeline, after, runId)` when streamable logs are not configured.
- Adds an optional `limit` query param (default `1000`) matching the sibling endpoint; only applied on the streamable-logs branch.
- Reuses the existing `runId` query param so per-run log retrieval now also works over S3-backed storage (falls back to the latest run's `runId` when not supplied).
- No schema, UI, or API-shape changes — response body remains `Map<String,String>`. Non-S3 deployments are unaffected.

## Test plan

Configure `PIPELINE_SERVICE_CLIENT_LOG_TYPE=s3` with a bucket/prefix, run an external App, and verify `GET /api/v1/apps/name/{app}/logs` returns log content from S3; unset the config and confirm the non-streamable path still works.