### PR TITLE
fix(conf): quote CSP policy default to restore YAML validity

### DIFF
--- a/conf/openmetadata.yaml
+++ b/conf/openmetadata.yaml
@@ -689,7 +689,7 @@ web:
     block: ${WEB_CONF_XSS_PROTECTION_BLOCK:-true}
   csp:
     enabled: ${WEB_CONF_XSS_CSP_ENABLED:-false}
-    policy: ${WEB_CONF_XSS_CSP_POLICY:-"default-src 'self'; base-uri 'self'; script-src 'self' 'nonce-__CSP_NONCE__' https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src * 'self' blob: data:; media-src * 'self' blob:; worker-src 'self' blob:; frame-src 'self' https://www.youtube.com; object-src 'none'; connect-src 'self';"}
+    policy: "${WEB_CONF_XSS_CSP_POLICY:-\"default-src 'self'; base-uri 'self'; script-src 'self' 'nonce-__CSP_NONCE__' https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src * 'self' blob: data:; media-src * 'self' blob:; worker-src 'self' blob:; frame-src 'self' https://www.youtube.com; object-src 'none'; connect-src 'self';\"}"
     reportOnlyPolicy: ${WEB_CONF_XSS_CSP_REPORT_ONLY_POLICY:-""}
   referrer-policy:
     enabled: ${WEB_CONF_REFERRER_POLICY_ENABLED:-false}


### PR DESCRIPTION
## Summary

- The `validate-json-yaml` workflow has been failing on `main` since #27269. [Line 692](https://github.com/open-metadata/OpenMetadata/blob/main/conf/openmetadata.yaml#L692) of `conf/openmetadata.yaml` uses `${WEB_CONF_XSS_CSP_POLICY:-"..."}` unquoted at the YAML level; the default value contains multiple `:` characters (inside `data:`, `blob:`, URL schemes), which the YAML scanner rejects with `mapping values are not allowed here  in "conf/openmetadata.yaml", line 692, column 285`.
- Wrapping the scalar in double quotes with escaped inner double quotes makes the YAML parse cleanly while preserving the **exact** string passed to Dropwizard's env substitution (verified by loading the file and comparing `csp.policy` before/after).
- Unblocks every PR that merges `main`, including [#27164](https://github.com/open-metadata/OpenMetadata/pull/27164).

## Test plan

- [x] `source env/bin/activate && ./scripts/validate_json_yaml.sh` — passes locally
- [x] Parsed `csp.policy` value is byte-identical to the pre-fix intent (same literal passed to Dropwizard `${VAR:-default}` substitution)
- [x] `Validate JSON/YAML` CI job turns green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)