### PR TITLE
Add k8s-operator unit tests to PR CI

### DIFF
--- a/.github/workflows/openmetadata-service-unit-tests.yml
+++ b/.github/workflows/openmetadata-service-unit-tests.yml
@@ -39,6 +39,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     outputs:
       java: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.java }}
+      k8s-operator: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.k8s-operator }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -59,6 +60,8 @@ jobs:
               - 'pom.xml'
               - 'Makefile'
               - 'bootstrap/**'
+            k8s-operator:
+              - 'openmetadata-k8s-operator/**'
 
   openmetadata-service-unit-tests:
     runs-on: ubuntu-latest
@@ -121,13 +124,58 @@ jobs:
           report_paths: "openmetadata-service/target/surefire-reports/TEST-*.xml"
           check_name: "Test Report (${{ matrix.database }})"
 
+  k8s-operator-unit-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: changes
+    if: ${{ needs.changes.outputs.k8s-operator == 'true' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: "temurin"
+
+      - name: Run k8s-operator unit tests
+        run: |
+          mvn -B clean test -pl openmetadata-k8s-operator -am -DfailIfNoTests=false
+
+      - name: Upload surefire reports
+        if: ${{ failure() && hashFiles('openmetadata-k8s-operator/target/surefire-reports/TEST-*.xml') != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: k8s-operator-surefire-reports
+          path: openmetadata-k8s-operator/target/surefire-reports/
+
+      - name: Publish Test Report
+        if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && hashFiles('openmetadata-k8s-operator/target/surefire-reports/TEST-*.xml') != '' }}
+        uses: scacap/action-surefire-report@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          fail_on_test_failures: true
+          report_paths: "openmetadata-k8s-operator/target/surefire-reports/TEST-*.xml"
+          check_name: "K8s Operator Test Report"
+
   # Single required-check gate for branch protection.
   # Skipped (= "Success") when all test jobs pass or are legitimately skipped.
   # Runs and exits 1 only when a test job fails or is cancelled.
   # Set "OpenMetadata Service Unit Tests / openmetadata-service-unit-tests-status" as the sole required check for this workflow.
   openmetadata-service-unit-tests-status:
     name: openmetadata-service-unit-tests-status
-    needs: [changes, openmetadata-service-unit-tests]
+    needs: [changes, openmetadata-service-unit-tests, k8s-operator-unit-tests]
     if: ${{ failure() || cancelled() }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/openmetadata-service-unit-tests.yml
+++ b/.github/workflows/openmetadata-service-unit-tests.yml
@@ -149,9 +149,13 @@ jobs:
           java-version: "21"
           distribution: "temurin"
 
+      - name: Build k8s-operator dependencies
+        run: |
+          mvn -B clean install -pl openmetadata-k8s-operator -am -DskipTests
+
       - name: Run k8s-operator unit tests
         run: |
-          mvn -B clean test -pl openmetadata-k8s-operator
+          mvn -B test -pl openmetadata-k8s-operator
 
       - name: Upload surefire reports
         if: ${{ failure() && hashFiles('openmetadata-k8s-operator/target/surefire-reports/TEST-*.xml') != '' }}

--- a/.github/workflows/openmetadata-service-unit-tests.yml
+++ b/.github/workflows/openmetadata-service-unit-tests.yml
@@ -39,7 +39,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
     outputs:
       java: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.java }}
-      k8s-operator: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.k8s-operator }}
+      k8s_operator: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.k8s_operator }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -60,8 +60,8 @@ jobs:
               - 'pom.xml'
               - 'Makefile'
               - 'bootstrap/**'
-            k8s-operator:
-              - 'openmetadata-k8s-operator/**'
+            k8s_operator:
+              - 'openmetadata-k8s_operator/**'
 
   openmetadata-service-unit-tests:
     runs-on: ubuntu-latest
@@ -124,11 +124,11 @@ jobs:
           report_paths: "openmetadata-service/target/surefire-reports/TEST-*.xml"
           check_name: "Test Report (${{ matrix.database }})"
 
-  k8s-operator-unit-tests:
+  k8s_operator-unit-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: changes
-    if: ${{ needs.changes.outputs.k8s-operator == 'true' }}
+    if: ${{ needs.changes.outputs.k8s_operator == 'true' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -149,24 +149,24 @@ jobs:
           java-version: "21"
           distribution: "temurin"
 
-      - name: Run k8s-operator unit tests
+      - name: Run k8s_operator unit tests
         run: |
-          mvn -B clean test -pl openmetadata-k8s-operator -am
+          mvn -B clean test -pl openmetadata-k8s_operator -am
 
       - name: Upload surefire reports
-        if: ${{ failure() && hashFiles('openmetadata-k8s-operator/target/surefire-reports/TEST-*.xml') != '' }}
+        if: ${{ failure() && hashFiles('openmetadata-k8s_operator/target/surefire-reports/TEST-*.xml') != '' }}
         uses: actions/upload-artifact@v4
         with:
-          name: k8s-operator-surefire-reports
-          path: openmetadata-k8s-operator/target/surefire-reports/
+          name: k8s_operator-surefire-reports
+          path: openmetadata-k8s_operator/target/surefire-reports/
 
       - name: Publish Test Report
-        if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && hashFiles('openmetadata-k8s-operator/target/surefire-reports/TEST-*.xml') != '' }}
+        if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && hashFiles('openmetadata-k8s_operator/target/surefire-reports/TEST-*.xml') != '' }}
         uses: scacap/action-surefire-report@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           fail_on_test_failures: true
-          report_paths: "openmetadata-k8s-operator/target/surefire-reports/TEST-*.xml"
+          report_paths: "openmetadata-k8s_operator/target/surefire-reports/TEST-*.xml"
           check_name: "K8s Operator Test Report"
 
   # Single required-check gate for branch protection.
@@ -175,7 +175,7 @@ jobs:
   # Set "OpenMetadata Service Unit Tests / openmetadata-service-unit-tests-status" as the sole required check for this workflow.
   openmetadata-service-unit-tests-status:
     name: openmetadata-service-unit-tests-status
-    needs: [changes, openmetadata-service-unit-tests, k8s-operator-unit-tests]
+    needs: [changes, openmetadata-service-unit-tests, k8s_operator-unit-tests]
     if: ${{ failure() || cancelled() }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/openmetadata-service-unit-tests.yml
+++ b/.github/workflows/openmetadata-service-unit-tests.yml
@@ -61,7 +61,7 @@ jobs:
               - 'Makefile'
               - 'bootstrap/**'
             k8s_operator:
-              - 'openmetadata-k8s_operator/**'
+              - 'openmetadata-k8s-operator/**'
 
   openmetadata-service-unit-tests:
     runs-on: ubuntu-latest
@@ -149,24 +149,24 @@ jobs:
           java-version: "21"
           distribution: "temurin"
 
-      - name: Run k8s_operator unit tests
+      - name: Run k8s-operator unit tests
         run: |
-          mvn -B clean test -pl openmetadata-k8s_operator -am
+          mvn -B clean test -pl openmetadata-k8s-operator -am
 
       - name: Upload surefire reports
-        if: ${{ failure() && hashFiles('openmetadata-k8s_operator/target/surefire-reports/TEST-*.xml') != '' }}
+        if: ${{ failure() && hashFiles('openmetadata-k8s-operator/target/surefire-reports/TEST-*.xml') != '' }}
         uses: actions/upload-artifact@v4
         with:
-          name: k8s_operator-surefire-reports
-          path: openmetadata-k8s_operator/target/surefire-reports/
+          name: k8s-operator-surefire-reports
+          path: openmetadata-k8s-operator/target/surefire-reports/
 
       - name: Publish Test Report
-        if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && hashFiles('openmetadata-k8s_operator/target/surefire-reports/TEST-*.xml') != '' }}
+        if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && hashFiles('openmetadata-k8s-operator/target/surefire-reports/TEST-*.xml') != '' }}
         uses: scacap/action-surefire-report@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           fail_on_test_failures: true
-          report_paths: "openmetadata-k8s_operator/target/surefire-reports/TEST-*.xml"
+          report_paths: "openmetadata-k8s-operator/target/surefire-reports/TEST-*.xml"
           check_name: "K8s Operator Test Report"
 
   # Single required-check gate for branch protection.

--- a/.github/workflows/openmetadata-service-unit-tests.yml
+++ b/.github/workflows/openmetadata-service-unit-tests.yml
@@ -151,7 +151,7 @@ jobs:
 
       - name: Run k8s-operator unit tests
         run: |
-          mvn -B clean test -pl openmetadata-k8s-operator -am
+          mvn -B clean test -pl openmetadata-k8s-operator
 
       - name: Upload surefire reports
         if: ${{ failure() && hashFiles('openmetadata-k8s-operator/target/surefire-reports/TEST-*.xml') != '' }}

--- a/.github/workflows/openmetadata-service-unit-tests.yml
+++ b/.github/workflows/openmetadata-service-unit-tests.yml
@@ -151,7 +151,7 @@ jobs:
 
       - name: Run k8s-operator unit tests
         run: |
-          mvn -B clean test -pl openmetadata-k8s-operator -am -DfailIfNoTests=false
+          mvn -B clean test -pl openmetadata-k8s-operator -am
 
       - name: Upload surefire reports
         if: ${{ failure() && hashFiles('openmetadata-k8s-operator/target/surefire-reports/TEST-*.xml') != '' }}

--- a/conf/openmetadata.yaml
+++ b/conf/openmetadata.yaml
@@ -689,8 +689,7 @@ web:
     block: ${WEB_CONF_XSS_PROTECTION_BLOCK:-true}
   csp:
     enabled: ${WEB_CONF_XSS_CSP_ENABLED:-false}
-    policy: >-
-      ${WEB_CONF_XSS_CSP_POLICY:-"default-src 'self'; base-uri 'self'; script-src 'self' 'nonce-__CSP_NONCE__' https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src * 'self' blob: data:; media-src * 'self' blob:; worker-src 'self' blob:; frame-src 'self' https://www.youtube.com; object-src 'none'; connect-src 'self';"}
+    policy: ${WEB_CONF_XSS_CSP_POLICY:-"default-src 'self'; base-uri 'self'; script-src 'self' 'nonce-__CSP_NONCE__' https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src * 'self' blob: data:; media-src * 'self' blob:; worker-src 'self' blob:; frame-src 'self' https://www.youtube.com; object-src 'none'; connect-src 'self';"}
     reportOnlyPolicy: ${WEB_CONF_XSS_CSP_REPORT_ONLY_POLICY:-""}
   referrer-policy:
     enabled: ${WEB_CONF_REFERRER_POLICY_ENABLED:-false}

--- a/conf/openmetadata.yaml
+++ b/conf/openmetadata.yaml
@@ -689,7 +689,8 @@ web:
     block: ${WEB_CONF_XSS_PROTECTION_BLOCK:-true}
   csp:
     enabled: ${WEB_CONF_XSS_CSP_ENABLED:-false}
-    policy: ${WEB_CONF_XSS_CSP_POLICY:-"default-src 'self'; base-uri 'self'; script-src 'self' 'nonce-__CSP_NONCE__' https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src * 'self' blob: data:; media-src * 'self' blob:; worker-src 'self' blob:; frame-src 'self' https://www.youtube.com; object-src 'none'; connect-src 'self';"}
+    policy: >-
+      ${WEB_CONF_XSS_CSP_POLICY:-"default-src 'self'; base-uri 'self'; script-src 'self' 'nonce-__CSP_NONCE__' https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src * 'self' blob: data:; media-src * 'self' blob:; worker-src 'self' blob:; frame-src 'self' https://www.youtube.com; object-src 'none'; connect-src 'self';"}
     reportOnlyPolicy: ${WEB_CONF_XSS_CSP_REPORT_ONLY_POLICY:-""}
   referrer-policy:
     enabled: ${WEB_CONF_REFERRER_POLICY_ENABLED:-false}

--- a/openmetadata-k8s-operator/pom.xml
+++ b/openmetadata-k8s-operator/pom.xml
@@ -187,6 +187,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.2.5</version>
+                <configuration>
+                    <includes>
+                        <include>**/*Test.java</include>
+                    </includes>
+                </configuration>
             </plugin>
             
             <!-- Failsafe plugin for integration tests -->

--- a/openmetadata-k8s-operator/src/test/java/org/openmetadata/operator/unit/CronOMJobReconcilerTest.java
+++ b/openmetadata-k8s-operator/src/test/java/org/openmetadata/operator/unit/CronOMJobReconcilerTest.java
@@ -17,6 +17,10 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NamespaceableResource;
+import io.fabric8.kubernetes.client.dsl.Resource;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import java.time.Instant;
@@ -36,14 +40,28 @@ import org.openmetadata.operator.model.OMJobSpec;
 class CronOMJobReconcilerTest {
 
   @Mock private Context<CronOMJobResource> context;
+  @Mock private KubernetesClient client;
+  @Mock private MixedOperation mixedOp;
+  @Mock private NamespaceableResource namespaceable;
+  @Mock private Resource resource;
 
   private CronOMJobReconciler reconciler;
   private CronOMJobResource cronOMJob;
 
+  @SuppressWarnings("unchecked")
   @BeforeEach
   void setUp() {
     reconciler = new CronOMJobReconciler();
     cronOMJob = createTestCronOMJob("test-cronjob", "0 * * * *");
+
+    // Stub the client chain so tests that reach the happy path
+    // (time-dependent) don't NPE. Lenient because most tests
+    // return early before calling context.getClient().
+    lenient().when(context.getClient()).thenReturn(client);
+    lenient().when(client.resources(any(Class.class))).thenReturn(mixedOp);
+    lenient().when(mixedOp.inNamespace(any())).thenReturn(mixedOp);
+    lenient().when(mixedOp.resource(any())).thenReturn(namespaceable);
+    lenient().when(namespaceable.create()).thenReturn(null);
   }
 
   @Test

--- a/openmetadata-k8s-operator/src/test/java/org/openmetadata/operator/unit/CronOMJobReconcilerTest.java
+++ b/openmetadata-k8s-operator/src/test/java/org/openmetadata/operator/unit/CronOMJobReconcilerTest.java
@@ -17,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import java.time.Instant;
@@ -37,7 +36,6 @@ import org.openmetadata.operator.model.OMJobSpec;
 class CronOMJobReconcilerTest {
 
   @Mock private Context<CronOMJobResource> context;
-  @Mock private KubernetesClient client;
 
   private CronOMJobReconciler reconciler;
   private CronOMJobResource cronOMJob;
@@ -46,7 +44,6 @@ class CronOMJobReconcilerTest {
   void setUp() {
     reconciler = new CronOMJobReconciler();
     cronOMJob = createTestCronOMJob("test-cronjob", "0 * * * *");
-    when(context.getClient()).thenReturn(client);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Add path-filtered `k8s-operator-unit-tests` job to the service unit tests workflow
- Triggers on PRs touching `openmetadata-k8s-operator/**`
- Follows the same Detect Changes pattern as the existing service tests
- Previously, operator tests only ran during manual release builds (`docker-k8s-operator.yml`)

## Test plan
- [ ] Merge this, then verify the contributor PR #27143 triggers the k8s operator tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)