### PR TITLE
fix(ui): Column Profile shows 0% for zero unique, null, and distinct proportions

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ColumnProfileTable/ColumnProfileTable.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ColumnProfileTable/ColumnProfileTable.test.tsx
@@ -10,8 +10,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { ColumnsType } from 'antd/lib/table';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { ColumnsType } from 'antd/lib/table';
 import { act } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { ColumnProfile } from '../../../../../generated/entity/data/table';
@@ -351,7 +351,9 @@ describe('ColumnProfileTable proportion column renders', () => {
         profile: ColumnProfile | undefined
       ) => string;
 
-      expect(renderFn({ [field]: 0.5 } as unknown as ColumnProfile)).toBe('50%');
+      expect(renderFn({ [field]: 0.5 } as unknown as ColumnProfile)).toBe(
+        '50%'
+      );
     }
   );
 
@@ -364,7 +366,9 @@ describe('ColumnProfileTable proportion column renders', () => {
       ) => string;
 
       // 0.001 * 100 = 0.1 → rounds to 0.1%, not 0%
-      expect(renderFn({ [field]: 0.001 } as unknown as ColumnProfile)).toBe('0.1%');
+      expect(renderFn({ [field]: 0.001 } as unknown as ColumnProfile)).toBe(
+        '0.1%'
+      );
     }
   );
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ColumnProfileTable/ColumnProfileTable.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ColumnProfileTable/ColumnProfileTable.test.tsx
@@ -10,24 +10,32 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+import { ColumnsType } from 'antd/lib/table';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { act } from 'react';
 import { MemoryRouter } from 'react-router-dom';
+import { ColumnProfile } from '../../../../../generated/entity/data/table';
 import { MOCK_TABLE } from '../../../../../mocks/TableData.mock';
 import { useTableProfiler } from '../TableProfilerProvider';
 import ColumnProfileTable from './ColumnProfileTable';
 
+let capturedColumns: ColumnsType<{ profile?: ColumnProfile }> = [];
+
 jest.mock('../../../../common/Table/Table', () =>
-  jest.fn().mockImplementation(({ searchProps }) => (
-    <div>
-      <input
-        data-testid="searchbar"
-        value={searchProps?.value ?? ''}
-        onChange={(e) => searchProps?.onSearch?.(e.target.value)}
-      />
-      <div>Table</div>
-    </div>
-  ))
+  jest.fn().mockImplementation(({ columns, searchProps }) => {
+    capturedColumns = columns ?? [];
+
+    return (
+      <div>
+        <input
+          data-testid="searchbar"
+          value={searchProps?.value ?? ''}
+          onChange={(e) => searchProps?.onSearch?.(e.target.value)}
+        />
+        <div>Table</div>
+      </div>
+    );
+  })
 );
 
 jest.mock('../../../../common/SummaryCard/SummaryCardV1', () =>
@@ -59,7 +67,25 @@ jest.mock(
 jest.mock('../../../../../utils/CommonUtils', () => ({
   formatNumberWithComma: jest.fn(),
   getTableFQNFromColumnFQN: jest.fn().mockImplementation((fqn) => fqn),
-  calculatePercentage: jest.fn().mockReturnValue('50%'),
+  calculatePercentage: jest
+    .fn()
+    .mockImplementation(
+      (
+        numerator: number,
+        denominator: number,
+        precision: number,
+        format: boolean
+      ) => {
+        if (denominator === 0) {
+          return format ? '0%' : 0;
+        }
+        const value = parseFloat(
+          ((numerator / denominator) * 100).toFixed(precision)
+        );
+
+        return format ? `${value}%` : value;
+      }
+    ),
 }));
 
 jest.mock('../../../../../utils/TableUtils', () => ({
@@ -267,4 +293,78 @@ describe('Test ColumnProfileTable component', () => {
       fields: expect.any(String),
     });
   });
+});
+
+describe('ColumnProfileTable proportion column renders', () => {
+  const proportionColumnKeys = [
+    'nullProportion',
+    'uniqueProportion',
+    'distinctProportion',
+  ] as const;
+
+  beforeEach(async () => {
+    cleanup();
+    await act(async () => {
+      render(<ColumnProfileTable />, { wrapper: MemoryRouter });
+    });
+  });
+
+  it.each(proportionColumnKeys)(
+    'should show "0%" instead of "--" when %s is 0',
+    (field) => {
+      const col = capturedColumns.find((c) => c.key === field);
+      const renderFn = col?.render as (
+        profile: ColumnProfile | undefined
+      ) => string;
+
+      expect(renderFn({ [field]: 0 } as unknown as ColumnProfile)).toBe('0%');
+    }
+  );
+
+  it.each(proportionColumnKeys)('should show "--" when %s is null', (field) => {
+    const col = capturedColumns.find((c) => c.key === field);
+    const renderFn = col?.render as (
+      profile: ColumnProfile | undefined
+    ) => string;
+
+    expect(renderFn({ [field]: null } as unknown as ColumnProfile)).toBe('--');
+  });
+
+  it.each(proportionColumnKeys)(
+    'should show "--" when %s is undefined',
+    (field) => {
+      const col = capturedColumns.find((c) => c.key === field);
+      const renderFn = col?.render as (
+        profile: ColumnProfile | undefined
+      ) => string;
+
+      expect(renderFn({} as ColumnProfile)).toBe('--');
+      expect(renderFn(undefined)).toBe('--');
+    }
+  );
+
+  it.each(proportionColumnKeys)(
+    'should show correct percentage for a normal value when %s is 0.5',
+    (field) => {
+      const col = capturedColumns.find((c) => c.key === field);
+      const renderFn = col?.render as (
+        profile: ColumnProfile | undefined
+      ) => string;
+
+      expect(renderFn({ [field]: 0.5 } as unknown as ColumnProfile)).toBe('50%');
+    }
+  );
+
+  it.each(proportionColumnKeys)(
+    'should not round small values (%s = 0.001) to 0%',
+    (field) => {
+      const col = capturedColumns.find((c) => c.key === field);
+      const renderFn = col?.render as (
+        profile: ColumnProfile | undefined
+      ) => string;
+
+      // 0.001 * 100 = 0.1 → rounds to 0.1%, not 0%
+      expect(renderFn({ [field]: 0.001 } as unknown as ColumnProfile)).toBe('0.1%');
+    }
+  );
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ColumnProfileTable/ColumnProfileTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ColumnProfileTable/ColumnProfileTable.tsx
@@ -13,7 +13,7 @@
 
 import { Typography } from '@openmetadata/ui-core-components';
 import { ColumnsType } from 'antd/lib/table';
-import { isEmpty, isUndefined } from 'lodash';
+import { isEmpty, isNil, isUndefined } from 'lodash';
 import Qs from 'qs';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -164,12 +164,10 @@ const ColumnProfileTable = () => {
         dataIndex: 'profile',
         key: 'nullProportion',
         width: 200,
-        render: (profile: ColumnProfile) => {
-          return profile?.nullProportion !== undefined &&
-            profile?.nullProportion !== null
+        render: (profile: ColumnProfile) =>
+          !isNil(profile?.nullProportion)
             ? calculatePercentage(profile.nullProportion, 1, 2, true)
-            : '--';
-        },
+            : '--',
         sorter: (col1, col2) =>
           (col1.profile?.nullProportion || 0) -
           (col2.profile?.nullProportion || 0),
@@ -180,8 +178,7 @@ const ColumnProfileTable = () => {
         key: 'uniqueProportion',
         width: 200,
         render: (profile: ColumnProfile) =>
-          profile?.uniqueProportion !== undefined &&
-          profile?.uniqueProportion !== null
+          !isNil(profile?.uniqueProportion)
             ? calculatePercentage(profile.uniqueProportion, 1, 2, true)
             : '--',
         sorter: (col1, col2) =>
@@ -194,8 +191,7 @@ const ColumnProfileTable = () => {
         key: 'distinctProportion',
         width: 200,
         render: (profile: ColumnProfile) =>
-          profile?.distinctProportion !== undefined &&
-          profile?.distinctProportion !== null
+          !isNil(profile?.distinctProportion)
             ? calculatePercentage(profile.distinctProportion, 1, 2, true)
             : '--',
         sorter: (col1, col2) =>


### PR DESCRIPTION
## Summary

Column Profile was showing `--` for **Unique %**, **Null %**, and **Distinct %** when the API returned a proportion of `0`, because the render logic treated `0` like missing data.

This change uses `isNil()` so only `null` / `undefined` show as `--`, and a real zero shows as `0%`. Unit tests cover the three proportion columns (zero, null, undefined, typical values, and small proportions).

<img width="1508" height="820" alt="Screenshot 2026-04-15 at 5 38 21 PM" src="https://github.com/user-attachments/assets/09e659c0-2a4a-4b7d-8b8d-414d5c9f8073" />


## Related issue

Fixes https://github.com/open-metadata/OpenMetadata/issues/27302


Made with [Cursor](https://cursor.com)