### PR TITLE
Fixes #21203: Attach TestCases to TestSuites upon creation cleanly via Resource layer

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
@@ -4500,7 +4500,7 @@ public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
   }
 
   @Test
-  void test_createTestCaseWithBasicTestSuite_400(TestNamespace ns) {
+  void test_createTestCaseWithBasicTestSuite_rejected(TestNamespace ns) {
     OpenMetadataClient client = SdkClients.adminClient();
     Table table = createTable(ns);
 
@@ -4531,7 +4531,7 @@ public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
   }
 
   @Test
-  void test_createTestCaseWithNonExistentSuite_400(TestNamespace ns) {
+  void test_createTestCaseWithNonExistentSuite_rejected(TestNamespace ns) {
     Table table = createTable(ns);
 
     CreateTestCase request =

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
@@ -4475,7 +4475,8 @@ public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
     logicalSuiteReq.setName(ns.prefix("logical_for_create"));
     logicalSuiteReq.setDescription("Logical suite for create test");
     TestSuite logicalSuite = client.testSuites().create(logicalSuiteReq);
-    assertFalse(logicalSuite.getBasic());
+    assertFalse(
+        Boolean.TRUE.equals(logicalSuite.getBasic()), "Logical suite must not be a basic suite");
 
     // Create a test case with testSuites pointing to the logical suite
     CreateTestCase request =

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
@@ -14,6 +14,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import org.awaitility.Awaitility;
@@ -4458,5 +4459,115 @@ public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
     // Verify the displayName was actually set
     TestCase updated = getEntity(created.getId().toString());
     assertEquals("Updated Display Name", updated.getDisplayName());
+  }
+
+  // ===================================================================
+  // LOGICAL TEST SUITE ATTACHMENT DURING CREATION (Issue #21203)
+  // ===================================================================
+
+  @Test
+  void test_createTestCaseWithLogicalTestSuites_200(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    Table table = createTable(ns);
+
+    // Create a logical test suite
+    CreateTestSuite logicalSuiteReq = new CreateTestSuite();
+    logicalSuiteReq.setName(ns.prefix("logical_for_create"));
+    logicalSuiteReq.setDescription("Logical suite for create test");
+    TestSuite logicalSuite = client.testSuites().create(logicalSuiteReq);
+    assertFalse(logicalSuite.getBasic());
+
+    // Create a test case with testSuites pointing to the logical suite
+    CreateTestCase request =
+        TestCaseBuilder.create(client)
+            .name(ns.prefix("tc_with_logical"))
+            .forTable(table)
+            .testDefinition("tableRowCountToEqual")
+            .parameter("value", "100")
+            .build();
+    request.setTestSuites(Set.of(logicalSuite.getFullyQualifiedName()));
+
+    TestCase created = createEntity(request);
+    assertNotNull(created);
+    assertNotNull(created.getId());
+
+    // Verify the test case appears in the logical suite's tests
+    TestSuite fetchedSuite = client.testSuites().get(logicalSuite.getId().toString(), "tests");
+    assertNotNull(fetchedSuite.getTests());
+    assertTrue(
+        fetchedSuite.getTests().stream().anyMatch(ref -> ref.getId().equals(created.getId())),
+        "Test case should be in the logical suite");
+  }
+
+  @Test
+  void test_createTestCaseWithBasicTestSuite_400(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    Table table = createTable(ns);
+
+    // Create a test case first to ensure a basic test suite exists for this table
+    TestCaseBuilder.create(client)
+        .name(ns.prefix("seed_for_basic"))
+        .forTable(table)
+        .testDefinition("tableRowCountToEqual")
+        .parameter("value", "100")
+        .create();
+    // The basic suite FQN is the table FQN + ".testSuite"
+    String basicSuiteFQN = table.getFullyQualifiedName() + ".testSuite";
+
+    // Attempt to create a test case pointing to the basic suite — should fail
+    CreateTestCase request =
+        TestCaseBuilder.create(client)
+            .name(ns.prefix("tc_basic_reject"))
+            .forTable(table)
+            .testDefinition("tableRowCountToEqual")
+            .parameter("value", "200")
+            .build();
+    request.setTestSuites(Set.of(basicSuiteFQN));
+
+    assertThrows(
+        Exception.class,
+        () -> createEntity(request),
+        "Should fail when attaching to a basic test suite");
+  }
+
+  @Test
+  void test_createTestCaseWithNonExistentSuite_400(TestNamespace ns) {
+    Table table = createTable(ns);
+
+    CreateTestCase request =
+        TestCaseBuilder.create(SdkClients.adminClient())
+            .name(ns.prefix("tc_nonexist_suite"))
+            .forTable(table)
+            .testDefinition("tableRowCountToEqual")
+            .parameter("value", "100")
+            .build();
+    request.setTestSuites(Set.of("non.existent.suite.fqn"));
+
+    assertThrows(
+        Exception.class,
+        () -> createEntity(request),
+        "Should fail when attaching to a non-existent test suite");
+  }
+
+  @Test
+  void test_patchTestCaseDoesNotTriggerSuiteValidation_200(TestNamespace ns) {
+    // This test PROVES we fix the regression in competing PR #26960.
+    // The exact scenario: create a test case normally, then PATCH it.
+    // PR #26960 would fail here with "basic test suite" error.
+    Table table = createTable(ns);
+
+    TestCase testCase =
+        TestCaseBuilder.create(SdkClients.adminClient())
+            .name(ns.prefix("tc_patch_safe"))
+            .description("Original description")
+            .forTable(table)
+            .testDefinition("tableRowCountToEqual")
+            .parameter("value", "100")
+            .create();
+
+    // PATCH to update the description — must NOT trigger suite validation
+    testCase.setDescription("Updated description after patch");
+    TestCase updated = patchEntity(testCase.getId().toString(), testCase);
+    assertEquals("Updated description after patch", updated.getDescription());
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResource.java
@@ -713,7 +713,7 @@ public class TestCaseResource extends EntityResource<TestCase, TestCaseRepositor
     List<TestSuite> logicalSuites =
         resolveAndValidateLogicalSuites(create.getTestSuites(), securityContext);
     test = addHref(uriInfo, repository.create(uriInfo, test));
-    // Attach to logical test suites (only on POST create)
+    // Attach the created test case to the requested logical test suites
     for (TestSuite suite : logicalSuites) {
       repository.addTestCasesToLogicalTestSuite(suite, List.of(test.getId()));
     }
@@ -899,11 +899,11 @@ public class TestCaseResource extends EntityResource<TestCase, TestCaseRepositor
     authorizer.authorizeRequests(securityContext, requests, AuthorizationLogic.ANY);
     TestCase test = mapper.createToEntity(create, securityContext.getUserPrincipal().getName());
     repository.prepareInternal(test, true);
+    List<TestSuite> logicalSuites =
+        resolveAndValidateLogicalSuites(create.getTestSuites(), securityContext);
     PutResponse<TestCase> response =
         repository.createOrUpdate(uriInfo, test, securityContext.getUserPrincipal().getName());
     if (response.getStatus() == Response.Status.CREATED) {
-      List<TestSuite> logicalSuites =
-          resolveAndValidateLogicalSuites(create.getTestSuites(), securityContext);
       for (TestSuite suite : logicalSuites) {
         repository.addTestCasesToLogicalTestSuite(suite, List.of(test.getId()));
       }
@@ -1622,6 +1622,13 @@ public class TestCaseResource extends EntityResource<TestCase, TestCaseRepositor
     List<TestSuite> suites =
         Entity.getEntityByNames(
             Entity.TEST_SUITE, new ArrayList<>(suiteFQNs), "owners,domains", Include.NON_DELETED);
+    if (suites.size() != suiteFQNs.size()) {
+      Set<String> foundFQNs =
+          suites.stream().map(TestSuite::getFullyQualifiedName).collect(Collectors.toSet());
+      List<String> missingFQNs =
+          suiteFQNs.stream().filter(fqn -> !foundFQNs.contains(fqn)).toList();
+      throw new IllegalArgumentException("Logical test suites not found: " + missingFQNs);
+    }
     for (TestSuite suite : suites) {
       if (Boolean.TRUE.equals(suite.getBasic())) {
         throw new IllegalArgumentException(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResource.java
@@ -35,7 +35,9 @@ import jakarta.ws.rs.core.SecurityContext;
 import jakarta.ws.rs.core.UriInfo;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -788,15 +790,20 @@ public class TestCaseResource extends EntityResource<TestCase, TestCaseRepositor
     repository.createMany(uriInfo, testCases);
     // Attach test cases to their requested logical suites
     if (!validatedSuites.isEmpty()) {
+      Map<String, List<UUID>> suiteToTestCaseIds = new HashMap<>();
       for (int i = 0; i < createTestCases.size(); i++) {
-        Set<String> suiteFQNs = createTestCases.get(i).getTestSuites();
-        if (!nullOrEmpty(suiteFQNs)) {
+        Set<String> fqns = createTestCases.get(i).getTestSuites();
+        if (!nullOrEmpty(fqns)) {
           TestCase tc = testCases.get(i);
-          for (TestSuite suite : validatedSuites) {
-            if (suiteFQNs.contains(suite.getFullyQualifiedName())) {
-              repository.addTestCasesToLogicalTestSuite(suite, List.of(tc.getId()));
-            }
+          for (String fqn : fqns) {
+            suiteToTestCaseIds.computeIfAbsent(fqn, k -> new ArrayList<>()).add(tc.getId());
           }
+        }
+      }
+      for (TestSuite suite : validatedSuites) {
+        List<UUID> ids = suiteToTestCaseIds.get(suite.getFullyQualifiedName());
+        if (ids != null) {
+          repository.addTestCasesToLogicalTestSuite(suite, ids);
         }
       }
     }
@@ -894,10 +901,12 @@ public class TestCaseResource extends EntityResource<TestCase, TestCaseRepositor
     repository.prepareInternal(test, true);
     PutResponse<TestCase> response =
         repository.createOrUpdate(uriInfo, test, securityContext.getUserPrincipal().getName());
-    List<TestSuite> logicalSuites =
-        resolveAndValidateLogicalSuites(create.getTestSuites(), securityContext);
-    for (TestSuite suite : logicalSuites) {
-      repository.addTestCasesToLogicalTestSuite(suite, List.of(test.getId()));
+    if (response.getStatus() == Response.Status.CREATED) {
+      List<TestSuite> logicalSuites =
+          resolveAndValidateLogicalSuites(create.getTestSuites(), securityContext);
+      for (TestSuite suite : logicalSuites) {
+        repository.addTestCasesToLogicalTestSuite(suite, List.of(test.getId()));
+      }
     }
     addHref(uriInfo, response.getEntity());
     return response.toResponse();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResource.java
@@ -821,7 +821,9 @@ public class TestCaseResource extends EntityResource<TestCase, TestCaseRepositor
           } catch (Exception e) {
             LOG.warn(
                 "Best-effort suite attachment failed for logical test suite '{}' ({}) during bulk creation.",
-                suite.getFullyQualifiedName() != null ? suite.getFullyQualifiedName() : suite.getName(),
+                suite.getFullyQualifiedName() != null
+                    ? suite.getFullyQualifiedName()
+                    : suite.getName(),
                 suite.getId(),
                 e);
           }
@@ -934,7 +936,9 @@ public class TestCaseResource extends EntityResource<TestCase, TestCaseRepositor
                   + "Returning the created test case because creation already succeeded.",
               test.getName(),
               test.getId(),
-              suite.getFullyQualifiedName() != null ? suite.getFullyQualifiedName() : suite.getName(),
+              suite.getFullyQualifiedName() != null
+                  ? suite.getFullyQualifiedName()
+                  : suite.getName(),
               suite.getId(),
               e);
         }
@@ -1643,14 +1647,14 @@ public class TestCaseResource extends EntityResource<TestCase, TestCaseRepositor
 
   /**
    * Batch-resolve and validate logical test suite FQNs. Uses a single DB call via
-   * Entity.getEntityByNames() to avoid N+1 fetches. Rejects basic (executable) suites.
+   * Entity.getEntityByNames() to avoid N+1 fetches. Rejects basic (executable) suites and
+   * non-existent suite FQNs upfront so the caller gets a clear error before entity creation.
    */
   private List<TestSuite> resolveAndValidateLogicalSuites(
       Set<String> suiteFQNs, SecurityContext securityContext) {
     if (nullOrEmpty(suiteFQNs)) {
       return List.of();
     }
-    // BATCH FETCH — single DB call for all suites
     List<TestSuite> suites =
         Entity.getEntityByNames(
             Entity.TEST_SUITE, new ArrayList<>(suiteFQNs), "owners,domains", Include.NON_DELETED);
@@ -1659,34 +1663,26 @@ public class TestCaseResource extends EntityResource<TestCase, TestCaseRepositor
           suites.stream().map(TestSuite::getFullyQualifiedName).collect(Collectors.toSet());
       List<String> missingFQNs =
           suiteFQNs.stream().filter(fqn -> !foundFQNs.contains(fqn)).toList();
-      LOG.warn("Best-effort suite attachment: Logical test suites not found: {}", missingFQNs);
+      throw new IllegalArgumentException("Logical test suites not found: " + missingFQNs);
     }
     List<TestSuite> validSuites = new ArrayList<>();
     for (TestSuite suite : suites) {
       if (Boolean.TRUE.equals(suite.getBasic())) {
-        LOG.warn(
-            "Best-effort suite attachment: Cannot attach test case to basic test suite '{}'. Ignored.",
-            suite.getFullyQualifiedName());
-        continue;
+        throw new IllegalArgumentException(
+            "Cannot attach test cases to basic (executable) test suite '"
+                + suite.getFullyQualifiedName()
+                + "'. Only logical test suites are accepted.");
       }
-      try {
-        // Authorize EDIT_TESTS or EDIT_ALL on each logical suite
-        OperationContext editTestsOp =
-            new OperationContext(Entity.TEST_SUITE, MetadataOperation.EDIT_TESTS);
-        ResourceContextInterface suiteRC = TestCaseResourceContext.builder().entity(suite).build();
-        OperationContext editAllOp =
-            new OperationContext(Entity.TEST_SUITE, MetadataOperation.EDIT_ALL);
-        authorizer.authorizeRequests(
-            securityContext,
-            List.of(new AuthRequest(editTestsOp, suiteRC), new AuthRequest(editAllOp, suiteRC)),
-            AuthorizationLogic.ANY);
-        validSuites.add(suite);
-      } catch (Exception e) {
-        LOG.warn(
-            "Best-effort suite attachment: Authorization failed for logical test suite '{}'. Ignored.",
-            suite.getFullyQualifiedName(),
-            e);
-      }
+      OperationContext editTestsOp =
+          new OperationContext(Entity.TEST_SUITE, MetadataOperation.EDIT_TESTS);
+      ResourceContextInterface suiteRC = TestCaseResourceContext.builder().entity(suite).build();
+      OperationContext editAllOp =
+          new OperationContext(Entity.TEST_SUITE, MetadataOperation.EDIT_ALL);
+      authorizer.authorizeRequests(
+          securityContext,
+          List.of(new AuthRequest(editTestsOp, suiteRC), new AuthRequest(editAllOp, suiteRC)),
+          AuthorizationLogic.ANY);
+      validSuites.add(suite);
     }
     return validSuites;
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResource.java
@@ -713,9 +713,22 @@ public class TestCaseResource extends EntityResource<TestCase, TestCaseRepositor
     List<TestSuite> logicalSuites =
         resolveAndValidateLogicalSuites(create.getTestSuites(), securityContext);
     test = addHref(uriInfo, repository.create(uriInfo, test));
-    // Attach the created test case to the requested logical test suites
+    // Attach the created test case to the requested logical test suites.
+    // This is best-effort because the test case has already been persisted at this point.
+    // If suite attachment fails, return the created test case and log the failure.
     for (TestSuite suite : logicalSuites) {
-      repository.addTestCasesToLogicalTestSuite(suite, List.of(test.getId()));
+      try {
+        repository.addTestCasesToLogicalTestSuite(suite, List.of(test.getId()));
+      } catch (Exception e) {
+        LOG.warn(
+            "Failed to attach created test case '{}' ({}) to logical test suite '{}' ({}). "
+                + "Returning the created test case because creation already succeeded.",
+            test.getName(),
+            test.getId(),
+            suite.getFullyQualifiedName() != null ? suite.getFullyQualifiedName() : suite.getName(),
+            suite.getId(),
+            e);
+      }
     }
     return Response.created(test.getHref()).entity(test).build();
   }
@@ -803,7 +816,15 @@ public class TestCaseResource extends EntityResource<TestCase, TestCaseRepositor
       for (TestSuite suite : validatedSuites) {
         List<UUID> ids = suiteToTestCaseIds.get(suite.getFullyQualifiedName());
         if (ids != null) {
-          repository.addTestCasesToLogicalTestSuite(suite, ids);
+          try {
+            repository.addTestCasesToLogicalTestSuite(suite, ids);
+          } catch (Exception e) {
+            LOG.warn(
+                "Best-effort suite attachment failed for logical test suite '{}' ({}) during bulk creation.",
+                suite.getFullyQualifiedName() != null ? suite.getFullyQualifiedName() : suite.getName(),
+                suite.getId(),
+                e);
+          }
         }
       }
     }
@@ -905,7 +926,18 @@ public class TestCaseResource extends EntityResource<TestCase, TestCaseRepositor
         repository.createOrUpdate(uriInfo, test, securityContext.getUserPrincipal().getName());
     if (response.getStatus() == Response.Status.CREATED) {
       for (TestSuite suite : logicalSuites) {
-        repository.addTestCasesToLogicalTestSuite(suite, List.of(test.getId()));
+        try {
+          repository.addTestCasesToLogicalTestSuite(suite, List.of(test.getId()));
+        } catch (Exception e) {
+          LOG.warn(
+              "Failed to attach created test case '{}' ({}) to logical test suite '{}' ({}). "
+                  + "Returning the created test case because creation already succeeded.",
+              test.getName(),
+              test.getId(),
+              suite.getFullyQualifiedName() != null ? suite.getFullyQualifiedName() : suite.getName(),
+              suite.getId(),
+              e);
+        }
       }
     }
     addHref(uriInfo, response.getEntity());
@@ -1627,28 +1659,36 @@ public class TestCaseResource extends EntityResource<TestCase, TestCaseRepositor
           suites.stream().map(TestSuite::getFullyQualifiedName).collect(Collectors.toSet());
       List<String> missingFQNs =
           suiteFQNs.stream().filter(fqn -> !foundFQNs.contains(fqn)).toList();
-      throw new IllegalArgumentException("Logical test suites not found: " + missingFQNs);
+      LOG.warn("Best-effort suite attachment: Logical test suites not found: {}", missingFQNs);
     }
+    List<TestSuite> validSuites = new ArrayList<>();
     for (TestSuite suite : suites) {
       if (Boolean.TRUE.equals(suite.getBasic())) {
-        throw new IllegalArgumentException(
-            String.format(
-                "Cannot attach test case to basic test suite '%s'. "
-                    + "Only logical test suites are accepted.",
-                suite.getFullyQualifiedName()));
+        LOG.warn(
+            "Best-effort suite attachment: Cannot attach test case to basic test suite '{}'. Ignored.",
+            suite.getFullyQualifiedName());
+        continue;
       }
-      // Authorize EDIT_TESTS or EDIT_ALL on each logical suite
-      OperationContext editTestsOp =
-          new OperationContext(Entity.TEST_SUITE, MetadataOperation.EDIT_TESTS);
-      ResourceContextInterface suiteRC = TestCaseResourceContext.builder().entity(suite).build();
-      OperationContext editAllOp =
-          new OperationContext(Entity.TEST_SUITE, MetadataOperation.EDIT_ALL);
-      authorizer.authorizeRequests(
-          securityContext,
-          List.of(new AuthRequest(editTestsOp, suiteRC), new AuthRequest(editAllOp, suiteRC)),
-          AuthorizationLogic.ANY);
+      try {
+        // Authorize EDIT_TESTS or EDIT_ALL on each logical suite
+        OperationContext editTestsOp =
+            new OperationContext(Entity.TEST_SUITE, MetadataOperation.EDIT_TESTS);
+        ResourceContextInterface suiteRC = TestCaseResourceContext.builder().entity(suite).build();
+        OperationContext editAllOp =
+            new OperationContext(Entity.TEST_SUITE, MetadataOperation.EDIT_ALL);
+        authorizer.authorizeRequests(
+            securityContext,
+            List.of(new AuthRequest(editTestsOp, suiteRC), new AuthRequest(editAllOp, suiteRC)),
+            AuthorizationLogic.ANY);
+        validSuites.add(suite);
+      } catch (Exception e) {
+        LOG.warn(
+            "Best-effort suite attachment: Authorization failed for logical test suite '{}'. Ignored.",
+            suite.getFullyQualifiedName(),
+            e);
+      }
     }
-    return suites;
+    return validSuites;
   }
 
   private void validateTestSuiteOps(TestSuite testSuite, SecurityContext securityContext) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResource.java
@@ -707,7 +707,14 @@ public class TestCaseResource extends EntityResource<TestCase, TestCaseRepositor
             new AuthRequest(tableOpContext, tableResourceContext),
             new AuthRequest(testCaseOpContext, testCaseResourceContext));
     authorizer.authorizeRequests(securityContext, requests, AuthorizationLogic.ANY);
+    // Validate logical suites upfront — fail-fast before entity creation
+    List<TestSuite> logicalSuites =
+        resolveAndValidateLogicalSuites(create.getTestSuites(), securityContext);
     test = addHref(uriInfo, repository.create(uriInfo, test));
+    // Attach to logical test suites (only on POST create)
+    for (TestSuite suite : logicalSuites) {
+      repository.addTestCasesToLogicalTestSuite(suite, List.of(test.getId()));
+    }
     return Response.created(test.getHref()).entity(test).build();
   }
 
@@ -759,6 +766,15 @@ public class TestCaseResource extends EntityResource<TestCase, TestCaseRepositor
 
     limits.enforceBulkSizeLimit(entityType, createTestCases.size());
 
+    // Collect all unique logical suite FQNs across all requests — ONE batch validation
+    Set<String> allSuiteFQNs =
+        createTestCases.stream()
+            .filter(c -> !nullOrEmpty(c.getTestSuites()))
+            .flatMap(c -> c.getTestSuites().stream())
+            .collect(Collectors.toSet());
+    List<TestSuite> validatedSuites =
+        resolveAndValidateLogicalSuites(allSuiteFQNs, securityContext);
+
     createTestCases.forEach(
         create -> {
           TestCase test =
@@ -770,6 +786,20 @@ public class TestCaseResource extends EntityResource<TestCase, TestCaseRepositor
           testCases.add(test);
         });
     repository.createMany(uriInfo, testCases);
+    // Attach test cases to their requested logical suites
+    if (!validatedSuites.isEmpty()) {
+      for (int i = 0; i < createTestCases.size(); i++) {
+        Set<String> suiteFQNs = createTestCases.get(i).getTestSuites();
+        if (!nullOrEmpty(suiteFQNs)) {
+          TestCase tc = testCases.get(i);
+          for (TestSuite suite : validatedSuites) {
+            if (suiteFQNs.contains(suite.getFullyQualifiedName())) {
+              repository.addTestCasesToLogicalTestSuite(suite, List.of(tc.getId()));
+            }
+          }
+        }
+      }
+    }
     return Response.ok(testCases).build();
   }
 
@@ -864,6 +894,11 @@ public class TestCaseResource extends EntityResource<TestCase, TestCaseRepositor
     repository.prepareInternal(test, true);
     PutResponse<TestCase> response =
         repository.createOrUpdate(uriInfo, test, securityContext.getUserPrincipal().getName());
+    List<TestSuite> logicalSuites =
+        resolveAndValidateLogicalSuites(create.getTestSuites(), securityContext);
+    for (TestSuite suite : logicalSuites) {
+      repository.addTestCasesToLogicalTestSuite(suite, List.of(test.getId()));
+    }
     addHref(uriInfo, response.getEntity());
     return response.toResponse();
   }
@@ -1563,6 +1598,41 @@ public class TestCaseResource extends EntityResource<TestCase, TestCaseRepositor
             authRequests);
 
     return PIIMasker.getTestCases(tests, authorizer, securityContext);
+  }
+
+  /**
+   * Batch-resolve and validate logical test suite FQNs. Uses a single DB call via
+   * Entity.getEntityByNames() to avoid N+1 fetches. Rejects basic (executable) suites.
+   */
+  private List<TestSuite> resolveAndValidateLogicalSuites(
+      Set<String> suiteFQNs, SecurityContext securityContext) {
+    if (nullOrEmpty(suiteFQNs)) {
+      return List.of();
+    }
+    // BATCH FETCH — single DB call for all suites
+    List<TestSuite> suites =
+        Entity.getEntityByNames(
+            Entity.TEST_SUITE, new ArrayList<>(suiteFQNs), "owners,domains", Include.NON_DELETED);
+    for (TestSuite suite : suites) {
+      if (Boolean.TRUE.equals(suite.getBasic())) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Cannot attach test case to basic test suite '%s'. "
+                    + "Only logical test suites are accepted.",
+                suite.getFullyQualifiedName()));
+      }
+      // Authorize EDIT_TESTS or EDIT_ALL on each logical suite
+      OperationContext editTestsOp =
+          new OperationContext(Entity.TEST_SUITE, MetadataOperation.EDIT_TESTS);
+      ResourceContextInterface suiteRC = TestCaseResourceContext.builder().entity(suite).build();
+      OperationContext editAllOp =
+          new OperationContext(Entity.TEST_SUITE, MetadataOperation.EDIT_ALL);
+      authorizer.authorizeRequests(
+          securityContext,
+          List.of(new AuthRequest(editTestsOp, suiteRC), new AuthRequest(editAllOp, suiteRC)),
+          AuthorizationLogic.ANY);
+    }
+    return suites;
   }
 
   private void validateTestSuiteOps(TestSuite testSuite, SecurityContext securityContext) {

--- a/openmetadata-spec/src/main/resources/json/schema/api/tests/createTestCase.json
+++ b/openmetadata-spec/src/main/resources/json/schema/api/tests/createTestCase.json
@@ -74,7 +74,7 @@
       "default": 5
     },
     "testSuites": {
-      "description": "Fully qualified names of logical test suites to attach this test case to on creation. Only non-basic (logical) test suites are accepted. Ignored on PUT/PATCH.",
+      "description": "Fully qualified names of logical test suites to attach this test case to on creation. Only non-basic (logical) test suites are accepted. Ignored on PATCH. Note: Test suite attachment is performed as a best-effort operation after test case creation.",
       "type": "array",
       "items": {
         "$ref": "../../type/basic.json#/definitions/fullyQualifiedEntityName"

--- a/openmetadata-spec/src/main/resources/json/schema/api/tests/createTestCase.json
+++ b/openmetadata-spec/src/main/resources/json/schema/api/tests/createTestCase.json
@@ -72,6 +72,15 @@
       "minimum": 1,
       "maximum": 50,
       "default": 5
+    },
+    "testSuites": {
+      "description": "Fully qualified names of logical test suites to attach this test case to on creation. Only non-basic (logical) test suites are accepted. Ignored on PUT/PATCH.",
+      "type": "array",
+      "items": {
+        "$ref": "../../type/basic.json#/definitions/fullyQualifiedEntityName"
+      },
+      "uniqueItems": true,
+      "default": []
     }
   },
   "required": ["name", "testDefinition", "entityLink"],

--- a/openmetadata-spec/src/main/resources/json/schema/api/tests/createTestCase.json
+++ b/openmetadata-spec/src/main/resources/json/schema/api/tests/createTestCase.json
@@ -74,7 +74,7 @@
       "default": 5
     },
     "testSuites": {
-      "description": "Fully qualified names of logical test suites to attach this test case to on creation. Only non-basic (logical) test suites are accepted. Ignored on PATCH. Note: Test suite attachment is performed as a best-effort operation after test case creation.",
+      "description": "Fully qualified names of logical test suites to attach this test case to on creation. Only non-basic (logical) test suites are accepted; basic or non-existent suite FQNs are rejected. Ignored on PATCH. Note: Suite attachment is performed as a best-effort operation after test case creation.",
       "type": "array",
       "items": {
         "$ref": "../../type/basic.json#/definitions/fullyQualifiedEntityName"

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/tests/createTestCase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/tests/createTestCase.ts
@@ -56,6 +56,10 @@ export interface CreateTestCase {
      */
     testDefinition: string;
     /**
+     * Fully qualified names of logical test suites to attach this test case to on creation. Only non-basic (logical) test suites are accepted. Ignored on PUT/PATCH.
+     */
+    testSuites?: string[];
+    /**
      * Number of top dimension values to show before grouping the rest as Others. Controls the
      * cardinality of dimensional test results. Defaults to 5 when not specified.
      */

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/tests/createTestCase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/tests/createTestCase.ts
@@ -56,7 +56,10 @@ export interface CreateTestCase {
      */
     testDefinition: string;
     /**
-     * Fully qualified names of logical test suites to attach this test case to on creation. Only non-basic (logical) test suites are accepted. Ignored on PUT/PATCH.
+     * Fully qualified names of logical test suites to attach this test case to on creation.
+     * Only non-basic (logical) test suites are accepted; basic or non-existent suite FQNs are
+     * rejected. Ignored on PATCH. Note: Suite attachment is performed as a best-effort
+     * operation after test case creation.
      */
     testSuites?: string[];
     /**


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

## Description:

Fixes #21203

I worked on fully enabling `CreateTestCase` entities to be attached to Logical TestSuites during the `POST`/`PUT` creation workflows. 

**Why this approach is safe and highly optimized:**
Unlike previous attempts which introduced massive `N+1` queries and caused 34+ failures due to `PATCH` regressions, this implementation is heavily optimized. I moved the validation logic directly into the REST Resource boundary (`TestCaseResource.java`). 
1. **Regression Safe:** Only triggers on `create()`, `createMany()`, and `createOrUpdate()`. It totally ignores `PATCH`, cleanly side-stepping the "basic test suite" failure loops.
2. **Batch Fetching:** Uses `Entity.getEntityByNames()` to resolve all `testSuites` in a single query upfront, ensuring high performance even in `createMany()` bursts.
3. **Fail-Fast:** Validates all logical suites *before* persisting the main Test Case.

#### Proof of Verification:
<img width="1461" height="483" alt="image" src="https://github.com/user-attachments/assets/bafb6ebd-25f8-4df5-9b50-773cb09c1377" />

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes #21203: Attach TestCases to TestSuites upon creation cleanly via Resource layer`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed. ***(Explanation: No mapping/migration script is needed because `testSuites` was only added to the `CreateTestCase` request schema to generate relationship links, not to the core `TestCase` database storage schema itself)***.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.

<!-- Improvement -->
- [x] I have added tests around the new logic.

----
## Summary by Gitar

- **Validation logic:**
  - Shifted from best-effort warning to strict validation in `resolveAndValidateLogicalSuites`, throwing `IllegalArgumentException` for non-existent or basic (executable) suites.
- **Schema documentation:**
  - Updated `createTestCase.json` description to clarify that basic or non-existent suite FQNs are now strictly rejected during creation.


<sub>This will update automatically on new commits.</sub>