### PR TITLE
test(playwright): initialize domain and data product in beforeAll for RestoreEntityInheritedFields

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/RestoreEntityInheritedFields.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/RestoreEntityInheritedFields.spec.ts
@@ -36,8 +36,8 @@ import {
 } from '../../utils/entity';
 import { test } from '../fixtures/pages';
 
-const domain = new Domain();
-const dataProduct = new DataProduct([domain]);
+let domain: Domain;
+let dataProduct: DataProduct;
 
 const entities = [
   ApiEndpointClass,
@@ -54,6 +54,9 @@ const entities = [
 ] as const;
 
 test.beforeAll('setup test', async ({ browser }) => {
+  domain = new Domain();
+  dataProduct = new DataProduct([domain]);
+
   const { afterAction, apiContext } = await performAdminLogin(browser);
   await domain.create(apiContext);
   await dataProduct.create(apiContext);


### PR DESCRIPTION
## Summary

Moves `Domain` and `DataProduct` construction from module scope into the `test.beforeAll` hook in `RestoreEntityInheritedFields.spec.ts`.

## Why

- Keeps test setup aligned with Playwright’s lifecycle (create resources after the hook runs, alongside `performAdminLogin`).
- Avoids initializing support objects at import time, which can be harder to reason about with parallel workers and retries.

## Changes

- Declare `domain` and `dataProduct` with `let` at module scope.
- Assign `new Domain()` and `new DataProduct([domain])` at the start of the existing `beforeAll('setup test', ...)` block before API create calls.


Made with [Cursor](https://cursor.com)