### PR TITLE
Fix restrore entity inherited fields specs

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/RestoreEntityInheritedFields.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/RestoreEntityInheritedFields.spec.ts
@@ -105,9 +105,14 @@ entities.forEach((EntityClass) => {
 
       await entity.visitEntityPage(page);
 
-      await assignDataProduct(page, domain.responseData, [
-        dataProduct.responseData,
-      ]);
+      await assignDataProduct(
+        page,
+        domain.responseData,
+        [dataProduct.responseData],
+        'Add',
+        'KnowledgePanel.DataProducts',
+        true
+      );
 
       // This will delete and restore and ensure both operation are successful
       await softDeleteEntity(

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataContracts.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataContracts.spec.ts
@@ -142,7 +142,8 @@ test.describe('Data Contracts', () => {
     test(`Create Data Contract and validate for ${entityType}`, async ({
       page,
     }) => {
-      test.slow(true);
+      // 12-min timeout so waitForDataContractExecution completes first.
+      test.setTimeout(720_000);
 
       const testClassification = new ClassificationClass();
       const testTag = new TagClass({

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
@@ -436,24 +436,6 @@ export const assignDataProduct = async (
   // to fetch the current state directly from the entity API.
   pollForInheritance = false
 ) => {
-  // Returns the domain display text. When multiple domains are present the
-  // count-button is shown instead of domain-link; returning displayName directly
-  // satisfies the .toContain assertion in both the poll and non-poll paths.
-  const getDomainText = async () => {
-    const hasMultipleDomains = await page
-      .getByTestId('domain-count-button')
-      .isVisible();
-
-    if (hasMultipleDomains) {
-      await expect(page.getByTestId('domain-count-button')).toBeVisible();
-    }
-
-    return page
-      .getByTestId('domain-link')
-      .textContent()
-      .catch(() => null);
-  };
-
   if (pollForInheritance) {
     await expect
       .poll(
@@ -461,19 +443,22 @@ export const assignDataProduct = async (
           await page.reload();
           await waitForAllLoadersToDisappear(page);
 
-          return getDomainText();
+          return page
+            .getByTestId('domain-link')
+            .textContent()
+            .catch(() => null);
         },
         {
           message: `Waiting for inherited domain "${domain.displayName}" to appear on the entity page`,
-          timeout: 30_000,
+          timeout: 60_000,
           intervals: [2_000, 3_000, 5_000],
         }
       )
       .toContain(domain.displayName);
   } else {
-    const domainText = await getDomainText();
-
-    expect(domainText).toContain(domain.displayName);
+    await expect(page.getByTestId('domain-link')).toContainText(
+      domain.displayName
+    );
   }
 
   await page
@@ -537,7 +522,7 @@ export const assignDataProduct = async (
           },
           {
             message: `Waiting for data product "${dataProduct.displayName}" to appear after save`,
-            timeout: 30_000,
+            timeout: 60_000,
             intervals: [2_000, 3_000, 5_000],
           }
         )

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
@@ -436,6 +436,24 @@ export const assignDataProduct = async (
   // to fetch the current state directly from the entity API.
   pollForInheritance = false
 ) => {
+  // Returns the domain display text. When multiple domains are present the
+  // count-button is shown instead of domain-link; returning displayName directly
+  // satisfies the .toContain assertion in both the poll and non-poll paths.
+  const getDomainText = async () => {
+    const hasMultipleDomains = await page
+      .getByTestId('domain-count-button')
+      .isVisible();
+
+    if (hasMultipleDomains) {
+      await expect(page.getByTestId('domain-count-button')).toBeVisible();
+    }
+
+    return page
+      .getByTestId('domain-link')
+      .textContent()
+      .catch(() => null);
+  };
+
   if (pollForInheritance) {
     await expect
       .poll(
@@ -443,18 +461,7 @@ export const assignDataProduct = async (
           await page.reload();
           await waitForAllLoadersToDisappear(page);
 
-          const hasMultipleDomains = await page
-            .getByTestId('domain-count-button')
-            .isVisible();
-
-          if (hasMultipleDomains) {
-            return page.getByTestId('domain-count-button').isVisible();
-          }
-
-          return page
-            .getByTestId('domain-link')
-            .textContent()
-            .catch(() => null);
+          return getDomainText();
         },
         {
           message: `Waiting for inherited domain "${domain.displayName}" to appear on the entity page`,
@@ -464,9 +471,9 @@ export const assignDataProduct = async (
       )
       .toContain(domain.displayName);
   } else {
-    await expect(page.getByTestId('domain-link')).toContainText(
-      domain.displayName
-    );
+    const domainText = await getDomainText();
+
+    expect(domainText).toContain(domain.displayName);
   }
 
   await page

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
@@ -430,13 +430,39 @@ export const assignDataProduct = async (
     fullyQualifiedName?: string;
   }[],
   action: 'Add' | 'Edit' = 'Add',
-  parentId = 'KnowledgePanel.DataProducts'
+  parentId = 'KnowledgePanel.DataProducts',
+  // Set true when the domain is inherited from a parent entity. The search
+  // index is updated asynchronously, so a page reload is needed on each poll
+  // to fetch the current state directly from the entity API.
+  pollForInheritance = false
 ) => {
-  const hasMultipleDomains = await page
-    .getByTestId('domain-count-button')
-    .isVisible();
-  if (hasMultipleDomains) {
-    await expect(page.getByTestId('domain-count-button')).toBeVisible();
+  if (pollForInheritance) {
+    await expect
+      .poll(
+        async () => {
+          await page.reload();
+          await waitForAllLoadersToDisappear(page);
+
+          const hasMultipleDomains = await page
+            .getByTestId('domain-count-button')
+            .isVisible();
+
+          if (hasMultipleDomains) {
+            return page.getByTestId('domain-count-button').isVisible();
+          }
+
+          return page
+            .getByTestId('domain-link')
+            .textContent()
+            .catch(() => null);
+        },
+        {
+          message: `Waiting for inherited domain "${domain.displayName}" to appear on the entity page`,
+          timeout: 30_000,
+          intervals: [2_000, 3_000, 5_000],
+        }
+      )
+      .toContain(domain.displayName);
   } else {
     await expect(page.getByTestId('domain-link')).toContainText(
       domain.displayName
@@ -487,13 +513,38 @@ export const assignDataProduct = async (
     .click();
   await patchReq;
 
-  for (const dataProduct of dataProducts) {
-    await expect(
-      page
-        .getByTestId(parentId)
-        .getByTestId('data-products-list')
-        .getByTestId(`data-product-${dataProduct.fullyQualifiedName}`)
-    ).toBeVisible();
+  if (pollForInheritance) {
+    for (const dataProduct of dataProducts) {
+      await expect
+        .poll(
+          async () => {
+            await page.reload();
+            await waitForAllLoadersToDisappear(page);
+
+            return page
+              .getByTestId(parentId)
+              .getByTestId('data-products-list')
+              .getByTestId(`data-product-${dataProduct.fullyQualifiedName}`)
+              .isVisible()
+              .catch(() => false);
+          },
+          {
+            message: `Waiting for data product "${dataProduct.displayName}" to appear after save`,
+            timeout: 30_000,
+            intervals: [2_000, 3_000, 5_000],
+          }
+        )
+        .toBe(true);
+    }
+  } else {
+    for (const dataProduct of dataProducts) {
+      await expect(
+        page
+          .getByTestId(parentId)
+          .getByTestId('data-products-list')
+          .getByTestId(`data-product-${dataProduct.fullyQualifiedName}`)
+      ).toBeVisible();
+    }
   }
 };
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:
Domain inheritance via parent PATCH is immediate in the entity API but async in the search index. visitEntityPage uses the search box, so in CI the child entity page loads with a stale index document — domain and post-save data product are not yet visible.

Fix: Added pollForInheritance flag to assignDataProduct. When true (only in RestoreEntityInheritedFields.spec.ts), both the domain check and post-save data product check use expect.poll with page.reload() on each retry. page.reload() hits the entity API directly, bypassing the search index, so the committed state is always visible within a few retries.
Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
