### PR TITLE
tests: fix flaky SystemCertificationTags test where Gold tag missing from dropdown after classification re-enable

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SystemCertificationTags.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SystemCertificationTags.spec.ts
@@ -101,9 +101,6 @@ test.describe.serial('System Level Certification Tags', () => {
 
       await closeCertificationDropdown(page);
     } finally {
-      // Re-enable both classification AND individual tags — disabling the
-      // classification can cascade disabled=true to each child tag at the tag
-      // level, and re-enabling the classification alone does NOT undo that.
       await restoreCertificationState(apiContext);
       await afterAction();
     }
@@ -126,10 +123,6 @@ test.describe.serial('System Level Certification Tags', () => {
       }
 
       await closeCertificationDropdown(page);
-
-      // Re-enable classification AND individual tags explicitly so the dropdown
-      // shows all system tags.  Re-enabling classification alone is not enough
-      // because the cascade that disabled the tags is not automatically reversed.
       await restoreCertificationState(apiContext);
 
       await redirectToHomePage(page);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SystemCertificationTags.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SystemCertificationTags.spec.ts
@@ -15,7 +15,7 @@ import { TableClass } from '../../support/entity/TableClass';
 import {
   closeCertificationDropdown,
   openCertificationDropdown,
-  setAllSystemCertificationTagsDisabled,
+  restoreCertificationState,
   setCertificationClassificationDisabled,
   setTagDisabledByFqn,
   SYSTEM_CERTIFICATION_TAGS,
@@ -38,15 +38,13 @@ test.describe.serial('System Level Certification Tags', () => {
   test.beforeAll(async ({ browser }) => {
     const { apiContext, afterAction } = await createNewPage(browser);
     await table.create(apiContext);
-    await setCertificationClassificationDisabled(apiContext, false);
-    await setAllSystemCertificationTagsDisabled(apiContext, false);
+    await restoreCertificationState(apiContext);
     await afterAction();
   });
 
   test.afterAll(async ({ browser }) => {
     const { apiContext, afterAction } = await createNewPage(browser);
-    await setCertificationClassificationDisabled(apiContext, false);
-    await setAllSystemCertificationTagsDisabled(apiContext, false);
+    await restoreCertificationState(apiContext);
     await table.delete(apiContext);
     await afterAction();
   });
@@ -103,7 +101,10 @@ test.describe.serial('System Level Certification Tags', () => {
 
       await closeCertificationDropdown(page);
     } finally {
-      await setCertificationClassificationDisabled(apiContext, false);
+      // Re-enable both classification AND individual tags — disabling the
+      // classification can cascade disabled=true to each child tag at the tag
+      // level, and re-enabling the classification alone does NOT undo that.
+      await restoreCertificationState(apiContext);
       await afterAction();
     }
   });
@@ -126,7 +127,10 @@ test.describe.serial('System Level Certification Tags', () => {
 
       await closeCertificationDropdown(page);
 
-      await setCertificationClassificationDisabled(apiContext, false);
+      // Re-enable classification AND individual tags explicitly so the dropdown
+      // shows all system tags.  Re-enabling classification alone is not enough
+      // because the cascade that disabled the tags is not automatically reversed.
+      await restoreCertificationState(apiContext);
 
       await redirectToHomePage(page);
       await table.visitEntityPage(page);
@@ -138,7 +142,7 @@ test.describe.serial('System Level Certification Tags', () => {
 
       await closeCertificationDropdown(page);
     } finally {
-      await setCertificationClassificationDisabled(apiContext, false);
+      await restoreCertificationState(apiContext);
       await afterAction();
     }
   });

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/certification.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/certification.ts
@@ -56,3 +56,20 @@ export const setAllSystemCertificationTagsDisabled = async (
     await setTagDisabledByFqn(apiContext, tagFqn, disabled);
   }
 };
+
+/**
+ * Restores the Certification classification and all system certification tags
+ * (Gold, Silver, Bronze) to an enabled state.
+ *
+ * Disabling a classification can cascade and mark individual tags as
+ * disabled=true at the tag level. Re-enabling the classification alone does NOT
+ * reverse that cascade. This helper must be used instead of
+ * setCertificationClassificationDisabled(false) in any finally/cleanup block to
+ * guarantee a clean state for subsequent tests.
+ */
+export const restoreCertificationState = async (
+  apiContext: APIRequestContext
+) => {
+  await setCertificationClassificationDisabled(apiContext, false);
+  await setAllSystemCertificationTagsDisabled(apiContext, false);
+};


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:
The certification dropdown calls api call where they have disabled=false filter operates on the individual tag's own disabled field, not just the parent classification's status.
The backend cascades disabled: true down to child tags when a classification is disabled but does NOT reverse this when the classification is re-enabled

Fix:- Restores the Certification classification and all system certification tags (Gold, Silver, Bronze) to an enabled state disabling a classification can cascade and mark individual tags as disabled=true at the tag level. Re-enabling the classification alone does NOT reverse that cascade.

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->


<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
