### PR TITLE
fix(test): unflake GlossaryPermissions team-based test

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Permissions/GlossaryPermissions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Permissions/GlossaryPermissions.spec.ts
@@ -393,10 +393,27 @@ test.describe('Glossary Permissions', () => {
     });
 
     // Set up permissions with team as the principal
-    await initializePermissions(page, 'allow', [
+    const { role: teamRole } = await initializePermissions(page, 'allow', [
       'EditDescription',
       'EditOwners',
     ]);
+
+    await apiContext.patch(`/api/v1/teams/${teamId}`, {
+      data: [
+        {
+          op: 'add',
+          path: '/defaultRoles/0',
+          value: {
+            id: teamRole.responseData.id,
+            type: 'role',
+            name: teamRole.responseData.name,
+          },
+        },
+      ],
+      headers: {
+        'Content-Type': 'application/json-patch+json',
+      },
+    });
 
     // Login as test user and verify permissions inherited from team
     await expect(async () => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Permissions/GlossaryPermissions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Permissions/GlossaryPermissions.spec.ts
@@ -354,15 +354,14 @@ test.describe('Glossary Permissions', () => {
   });
 
   // P-11: Team-based permissions work correctly
-  test('Team-based permissions work correctly', async ({
-    testUserPage,
-    page,
-  }) => {
+  test('Team-based permissions work correctly', async ({ browser, page }) => {
     test.slow(true);
 
     const { apiContext } = await getApiContext(page);
 
-    // Create a team and add testUser to it
+    const teamUser = new UserClass();
+    await teamUser.create(apiContext);
+
     const teamName = `TestTeam${Date.now()}`;
     const teamResponse = await apiContext.post('/api/v1/teams', {
       data: {
@@ -375,14 +374,13 @@ test.describe('Glossary Permissions', () => {
     const teamData = await teamResponse.json();
     const teamId = teamData.id;
 
-    // Add user to team
-    await apiContext.patch(`/api/v1/teams/${teamData.id}`, {
+    await apiContext.patch(`/api/v1/teams/${teamId}`, {
       data: [
         {
           op: 'add',
           path: '/users/0',
           value: {
-            id: testUser.responseData.id,
+            id: teamUser.responseData.id,
             type: 'user',
           },
         },
@@ -392,7 +390,6 @@ test.describe('Glossary Permissions', () => {
       },
     });
 
-    // Set up permissions with team as the principal
     const { role: teamRole } = await initializePermissions(page, 'allow', [
       'EditDescription',
       'EditOwners',
@@ -415,24 +412,27 @@ test.describe('Glossary Permissions', () => {
       },
     });
 
-    // Login as test user and verify permissions inherited from team
-    await expect(async () => {
-      await glossary.visitEntityPage(testUserPage);
-      await waitForAllLoadersToDisappear(testUserPage);
+    const teamUserPage = await browser.newPage();
+    try {
+      await teamUser.login(teamUserPage);
 
-      const glossaryHeader = testUserPage.getByTestId(
-        'entity-header-display-name'
-      );
+      await expect(async () => {
+        await glossary.visitEntityPage(teamUserPage);
+        await waitForAllLoadersToDisappear(teamUserPage);
 
-      await expect(glossaryHeader).toBeVisible({ timeout: 5_000 });
-      await expect(glossaryHeader).toContainText(glossary.data.displayName);
-    }).toPass({ timeout: 30_000, intervals: [2_000, 5_000] });
+        const glossaryHeader = teamUserPage.getByTestId(
+          'entity-header-display-name'
+        );
 
-    // Clean up
-    await cleanupPermissions(apiContext);
-
-    if (teamId) {
-      await apiContext.delete(`/api/v1/teams/${teamId}?hardDelete=true`);
+        await expect(glossaryHeader).toBeVisible({ timeout: 5_000 });
+        await expect(glossaryHeader).toContainText(glossary.data.displayName);
+      }).toPass({ timeout: 30_000, intervals: [2_000, 5_000] });
+    } finally {
+      await teamUserPage.close();
     }
+
+    await cleanupPermissions(apiContext);
+    await apiContext.delete(`/api/v1/teams/${teamId}?hardDelete=true`);
+    await teamUser.delete(apiContext);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the flaky `GlossaryPermissions.spec.ts › Team-based permissions work correctly` test (P-11). Symptom: `Timeout 30000ms exceeded while waiting on the predicate`. CI shows ~6/13 nightly runs flaking on this test.

## Root cause

The test name promises to verify team-based permissions, but the setup never attached the new role to the team:

```ts
// Create team, add testUser to it
await apiContext.post('/api/v1/teams', {...});
await apiContext.patch(`/api/v1/teams/${teamId}`, { /* add user */ });

// Create role + policy, but NEVER attach to the team or the user
await initializePermissions(page, 'allow', ['EditDescription', 'EditOwners']);
```

So `testUser`'s effective permissions came only from default Organization rules, which are *conditional* (`isOwner()`, `noOwner()`). The frontend converts `Access.Allow` to `true` and treats `conditionalAllow` as `false` (`getOperationPermissions` in `PermissionsUtils.ts`). The chain that follows:

1. `AdminProtectedRoute` in `GlossaryRouter.tsx` sees `hasPermission=false`.
2. It renders the no-permission `ErrorPlaceHolder` instead of `<GlossaryPage/>`.
3. `GlossaryPage`'s `fetchGlossaryList` never runs, so `/api/v1/glossaries?fields=*` is never called.
4. `visitGlossaryPage`'s unbounded `page.waitForResponse('/api/v1/glossaries?fields=*')` hangs the full 30s `toPass` budget — no time left for `toPass` to retry.

It surfaces as a flake (not a hard fail) because CI's `retries: 2` rescues it about half the time when a fresh fixture login happens to land on a state where conditions evaluate to `Allow`.

## Fix

P-11 now stands fully on its own:

- A dedicated `UserClass` is created, with its own `Page` via `browser.newPage()`. The file-shared `testUser` / `testUserPage` are not touched.
- A team is created, the dedicated user is added to it, and the new role is attached to the team's `defaultRoles`. The user inherits a deterministic `Allow` via team membership — matching the test's stated intent.
- After the assertion, the page, user, team, role, and policy are all torn down inside the test.

Using a dedicated user is deliberate: if cleanup ever fails (network blip, abort), the elevated team+role would otherwise leak into the next test sharing the same worker's `testUser`. With isolation, P-11 cannot pollute any other spec or any other test in the file.

## Local repro (full file × 10 repeats × 4 workers, `retries=0`)

| Run | P-11 pass | P-11 fail | Overall |
|---|---|---|---|
| Before fix | 0/10 | **10/10** | 83/93 |
| After fix | **10/10** | 0/10 | **93/93** |

P-11 was deterministically broken in file context. CI's ~46% flake rate maps to local 100% fail recovered by 2 retries.

## Test plan

- [x] `yarn playwright test playwright/e2e/Features/Permissions/GlossaryPermissions.spec.ts --repeat-each=10 --workers=4 --retries=0` → 93/93 passed
- [ ] Nightly CI run shows P-11 stable