### PR TITLE
fix: add missing SecurityConfig init in reIndex/reIndexDI CLI commands

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
@@ -1369,6 +1369,8 @@ public class OpenMetadataOperations implements Callable<Integer> {
           autoTune);
       parseConfig();
       CollectionRegistry.initialize();
+      SettingsCache.initialize(config);
+      initializeSecurityConfig();
       ApplicationHandler.initialize(config);
       CollectionRegistry.getInstance().loadSeedData(jdbi, config, null, null, null, true);
       ApplicationHandler.initialize(config);
@@ -1949,6 +1951,8 @@ public class OpenMetadataOperations implements Callable<Integer> {
           endDate);
       parseConfig();
       CollectionRegistry.initialize();
+      SettingsCache.initialize(config);
+      initializeSecurityConfig();
       ApplicationHandler.initialize(config);
       CollectionRegistry.getInstance().loadSeedData(jdbi, config, null, null, null, true);
       ApplicationHandler.initialize(config);


### PR DESCRIPTION
Fixes #27424

## Summary

- Add `SettingsCache.initialize(config)` and `initializeSecurityConfig()` before `loadSeedData()` in the `reIndex` and `reIndexDI` CLI commands, matching the pattern used by `installApp`/`deleteApp`
- Fixes NPE in `UserRepository.initializeUsers()` caused by null auth config, which also silently strips bot users from their Organization team on every run

## Test plan

- [x] Run `reindexdi --recreate-indexes=true` and verify no NPE in logs
- [x] Verify bot users retain their team membership after reindexing
- [x] Run `reindex` and verify same