### PR TITLE
fix(migration): revert webhook authType back to secretKey in v1126 and remove broken v1125 migration

### DIFF
--- a/bootstrap/sql/migrations/native/1.12.6/mysql/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.12.6/mysql/postDataMigrationSQLScript.sql
@@ -1,0 +1,1 @@
+-- Placeholder for 1.12.6 MySQL post data migration SQL script

--- a/bootstrap/sql/migrations/native/1.12.6/mysql/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.12.6/mysql/schemaChanges.sql
@@ -1,0 +1,1 @@
+-- Placeholder for 1.12.6 MySQL schema changes

--- a/bootstrap/sql/migrations/native/1.12.6/postgres/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.12.6/postgres/postDataMigrationSQLScript.sql
@@ -1,0 +1,1 @@
+-- Placeholder for 1.12.6 Postgres post data migration SQL script

--- a/bootstrap/sql/migrations/native/1.12.6/postgres/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.12.6/postgres/schemaChanges.sql
@@ -1,0 +1,1 @@
+-- Placeholder for 1.12.6 Postgres schema changes

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1125/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1125/Migration.java
@@ -18,14 +18,6 @@ public class Migration extends MigrationProcessImpl {
   @SneakyThrows
   public void runDataMigration() {
     try {
-      MigrationUtil.migrateWebhookSecretKeyToAuthType(handle);
-    } catch (Exception e) {
-      LOG.error(
-          "Failed to migrate webhook secretKey to authType in v1125 migration. "
-              + "Webhook authentication may not work correctly until re-saved.",
-          e);
-    }
-    try {
       MigrationUtil.migrateWorkflowDefinitions();
     } catch (Exception e) {
       LOG.error(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1126/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1126/Migration.java
@@ -1,0 +1,25 @@
+package org.openmetadata.service.migration.mysql.v1126;
+
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.service.migration.api.MigrationProcessImpl;
+import org.openmetadata.service.migration.utils.MigrationFile;
+import org.openmetadata.service.migration.utils.v1126.MigrationUtil;
+
+@Slf4j
+public class Migration extends MigrationProcessImpl {
+
+  public Migration(MigrationFile migrationFile) {
+    super(migrationFile);
+  }
+
+  @Override
+  @SneakyThrows
+  public void runDataMigration() {
+    try {
+      MigrationUtil.revertWebhookAuthTypeToSecretKey(handle);
+    } catch (Exception e) {
+      LOG.error("Failed to revert webhook authType to secretKey in v1126 migration.", e);
+    }
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1125/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1125/Migration.java
@@ -18,14 +18,6 @@ public class Migration extends MigrationProcessImpl {
   @SneakyThrows
   public void runDataMigration() {
     try {
-      MigrationUtil.migrateWebhookSecretKeyToAuthType(handle);
-    } catch (Exception e) {
-      LOG.error(
-          "Failed to migrate webhook secretKey to authType in v1125 migration. "
-              + "Webhook authentication may not work correctly until re-saved.",
-          e);
-    }
-    try {
       MigrationUtil.migrateWorkflowDefinitions();
     } catch (Exception e) {
       LOG.error(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1126/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1126/Migration.java
@@ -1,0 +1,25 @@
+package org.openmetadata.service.migration.postgres.v1126;
+
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.service.migration.api.MigrationProcessImpl;
+import org.openmetadata.service.migration.utils.MigrationFile;
+import org.openmetadata.service.migration.utils.v1126.MigrationUtil;
+
+@Slf4j
+public class Migration extends MigrationProcessImpl {
+
+  public Migration(MigrationFile migrationFile) {
+    super(migrationFile);
+  }
+
+  @Override
+  @SneakyThrows
+  public void runDataMigration() {
+    try {
+      MigrationUtil.revertWebhookAuthTypeToSecretKey(handle);
+    } catch (Exception e) {
+      LOG.error("Failed to revert webhook authType to secretKey in v1126 migration.", e);
+    }
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1125/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1125/MigrationUtil.java
@@ -11,7 +11,6 @@ import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.statement.PreparedBatch;
-import org.openmetadata.schema.entity.events.SubscriptionDestination;
 import org.openmetadata.schema.governance.workflows.WorkflowDefinition;
 import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.schema.utils.JsonUtils;
@@ -19,7 +18,6 @@ import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.jdbi3.WorkflowDefinitionRepository;
 import org.openmetadata.service.jdbi3.locator.ConnectionType;
-import org.openmetadata.service.resources.databases.DatasourceConfig;
 import org.openmetadata.service.util.EntityUtil;
 import org.openmetadata.service.util.FullyQualifiedName;
 
@@ -34,74 +32,6 @@ public class MigrationUtil {
       "UPDATE event_subscription_entity SET json = :json::jsonb WHERE id = :id";
   private static final ObjectMapper MAPPER = new ObjectMapper();
   private static final String ADMIN_USER_NAME = "admin";
-
-  public static void migrateWebhookSecretKeyToAuthType(Handle handle) {
-    LOG.info("Starting migration of webhook secretKey to authType");
-
-    List<Map<String, Object>> rows =
-        handle.createQuery("SELECT id, json FROM event_subscription_entity").mapToMap().list();
-
-    int migratedCount = 0;
-    for (Map<String, Object> row : rows) {
-      String id = row.get("id").toString();
-      String jsonStr = row.get("json").toString();
-
-      try {
-        ObjectNode root = (ObjectNode) JsonUtils.readTree(jsonStr);
-        JsonNode destinations = root.get("destinations");
-        if (destinations == null || !destinations.isArray()) {
-          continue;
-        }
-
-        boolean modified = false;
-        for (JsonNode destination : destinations) {
-          String destinationType =
-              destination.get("type") != null
-                  ? destination.get("type").asText().toLowerCase()
-                  : null;
-          if (destinationType == null
-              || !destinationType.equals(
-                  SubscriptionDestination.SubscriptionType.WEBHOOK.value().toLowerCase())) {
-            continue;
-          }
-          JsonNode config = destination.get("config");
-          if (config == null || !config.isObject()) {
-            continue;
-          }
-
-          JsonNode secretKeyNode = config.get("secretKey");
-          if (secretKeyNode == null
-              || secretKeyNode.isNull()
-              || secretKeyNode.asText().trim().isEmpty()) {
-            continue;
-          }
-
-          ObjectNode configObj = (ObjectNode) config;
-          ObjectNode bearerAuth =
-              JsonUtils.getObjectMapper()
-                  .createObjectNode()
-                  .put("type", "bearer")
-                  .put("secretKey", secretKeyNode.asText());
-          configObj.set("authType", bearerAuth);
-          configObj.remove("secretKey");
-          modified = true;
-        }
-
-        if (modified) {
-          String updateSql =
-              Boolean.TRUE.equals(DatasourceConfig.getInstance().isMySQL())
-                  ? UPDATE_EVENT_SUB_MYSQL
-                  : UPDATE_EVENT_SUB_POSTGRESQL;
-          handle.createUpdate(updateSql).bind("json", root.toString()).bind("id", id).execute();
-          migratedCount++;
-        }
-      } catch (Exception e) {
-        LOG.warn("Error migrating event subscription {}: {}", id, e.getMessage());
-      }
-    }
-
-    LOG.info("Migrated {} event subscriptions with secretKey to authType", migratedCount);
-  }
 
   public static void migrateWorkflowDefinitions() {
     LOG.info(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1125/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1125/MigrationUtil.java
@@ -26,10 +26,6 @@ public class MigrationUtil {
 
   private MigrationUtil() {}
 
-  private static final String UPDATE_EVENT_SUB_MYSQL =
-      "UPDATE event_subscription_entity SET json = :json WHERE id = :id";
-  private static final String UPDATE_EVENT_SUB_POSTGRESQL =
-      "UPDATE event_subscription_entity SET json = :json::jsonb WHERE id = :id";
   private static final ObjectMapper MAPPER = new ObjectMapper();
   private static final String ADMIN_USER_NAME = "admin";
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1126/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1126/MigrationUtil.java
@@ -1,0 +1,88 @@
+package org.openmetadata.service.migration.utils.v1126;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.jdbi.v3.core.Handle;
+import org.openmetadata.schema.entity.events.SubscriptionDestination;
+import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.service.resources.databases.DatasourceConfig;
+
+@Slf4j
+public final class MigrationUtil {
+
+  private MigrationUtil() {}
+
+  private static final String UPDATE_MYSQL =
+      "UPDATE event_subscription_entity SET json = :json WHERE id = :id";
+  private static final String UPDATE_POSTGRES =
+      "UPDATE event_subscription_entity SET json = :json::jsonb WHERE id = :id";
+
+  public static void revertWebhookAuthTypeToSecretKey(Handle handle) {
+    LOG.info("Reverting webhook authType back to secretKey");
+    List<Map<String, Object>> rows =
+        handle.createQuery("SELECT id, json FROM event_subscription_entity").mapToMap().list();
+    int revertedCount = 0;
+
+    for (Map<String, Object> row : rows) {
+      String id = row.get("id").toString();
+      String jsonStr = row.get("json").toString();
+
+      try {
+        ObjectNode root = (ObjectNode) JsonUtils.readTree(jsonStr);
+        JsonNode destinations = root.get("destinations");
+        if (destinations == null || !destinations.isArray()) {
+          continue;
+        }
+
+        boolean modified = false;
+        for (JsonNode destination : destinations) {
+          String type =
+              destination.get("type") != null
+                  ? destination.get("type").asText().toLowerCase()
+                  : null;
+          if (!SubscriptionDestination.SubscriptionType.WEBHOOK
+              .value()
+              .toLowerCase()
+              .equals(type)) {
+            continue;
+          }
+
+          JsonNode config = destination.get("config");
+          if (config == null || !config.isObject()) {
+            continue;
+          }
+
+          JsonNode authTypeNode = config.get("authType");
+          if (authTypeNode == null || !authTypeNode.isObject()) {
+            continue;
+          }
+
+          ObjectNode configObj = (ObjectNode) config;
+          String authNodeType = authTypeNode.has("type") ? authTypeNode.get("type").asText() : null;
+
+          if ("bearer".equals(authNodeType) && authTypeNode.has("secretKey")) {
+            configObj.put("secretKey", authTypeNode.get("secretKey").asText());
+          }
+          configObj.remove("authType");
+          modified = true;
+        }
+
+        if (modified) {
+          String updateSql =
+              Boolean.TRUE.equals(DatasourceConfig.getInstance().isMySQL())
+                  ? UPDATE_MYSQL
+                  : UPDATE_POSTGRES;
+          handle.createUpdate(updateSql).bind("json", root.toString()).bind("id", id).execute();
+          revertedCount++;
+        }
+      } catch (Exception e) {
+        LOG.warn("Error reverting event subscription {}: {}", id, e.getMessage());
+      }
+    }
+
+    LOG.info("Reverted {} event subscriptions from authType back to secretKey", revertedCount);
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1126/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1126/MigrationUtil.java
@@ -61,9 +61,14 @@ public final class MigrationUtil {
           }
 
           ObjectNode configObj = (ObjectNode) config;
-          String authNodeType = authTypeNode.has("type") ? authTypeNode.get("type").asText() : null;
+          String authNodeType =
+              authTypeNode.has("type") && !authTypeNode.get("type").isNull()
+                  ? authTypeNode.get("type").asText()
+                  : null;
 
-          if ("bearer".equals(authNodeType) && authTypeNode.has("secretKey")) {
+          if ("bearer".equalsIgnoreCase(authNodeType)
+              && authTypeNode.has("secretKey")
+              && !authTypeNode.get("secretKey").isNull()) {
             configObj.put("secretKey", authTypeNode.get("secretKey").asText());
           } else {
             LOG.warn(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1126/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1126/MigrationUtil.java
@@ -65,6 +65,11 @@ public final class MigrationUtil {
 
           if ("bearer".equals(authNodeType) && authTypeNode.has("secretKey")) {
             configObj.put("secretKey", authTypeNode.get("secretKey").asText());
+          } else {
+            LOG.warn(
+                "Dropping unrecognized authType (type={}) from webhook config for subscription {}",
+                authNodeType,
+                id);
           }
           configObj.remove("authType");
           modified = true;
@@ -79,7 +84,7 @@ public final class MigrationUtil {
           revertedCount++;
         }
       } catch (Exception e) {
-        LOG.warn("Error reverting event subscription {}: {}", id, e.getMessage());
+        LOG.warn("Error reverting event subscription {}", id, e);
       }
     }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/migration/mysql/v1125/MigrationTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/migration/mysql/v1125/MigrationTest.java
@@ -35,7 +35,6 @@ class MigrationTest {
     Migration migration = createMigrationWithHandle(handle);
 
     try (MockedStatic<MigrationUtil> util = mockStatic(MigrationUtil.class)) {
-      util.when(() -> MigrationUtil.migrateWebhookSecretKeyToAuthType(handle)).then(inv -> null);
       util.when(MigrationUtil::migrateWorkflowDefinitions).then(inv -> null);
       util.when(() -> MigrationUtil.migrateCertificationToTagUsage(handle, ConnectionType.MYSQL))
           .then(inv -> null);
@@ -53,7 +52,6 @@ class MigrationTest {
     Migration migration = createMigrationWithHandle(handle);
 
     try (MockedStatic<MigrationUtil> util = mockStatic(MigrationUtil.class)) {
-      util.when(() -> MigrationUtil.migrateWebhookSecretKeyToAuthType(handle)).then(inv -> null);
       util.when(MigrationUtil::migrateWorkflowDefinitions).then(inv -> null);
       util.when(() -> MigrationUtil.migrateCertificationToTagUsage(handle, ConnectionType.MYSQL))
           .thenThrow(new RuntimeException("certification migration failed"));

--- a/openmetadata-service/src/test/java/org/openmetadata/service/migration/postgres/v1125/MigrationTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/migration/postgres/v1125/MigrationTest.java
@@ -35,7 +35,6 @@ class MigrationTest {
     Migration migration = createMigrationWithHandle(handle);
 
     try (MockedStatic<MigrationUtil> util = mockStatic(MigrationUtil.class)) {
-      util.when(() -> MigrationUtil.migrateWebhookSecretKeyToAuthType(handle)).then(inv -> null);
       util.when(MigrationUtil::migrateWorkflowDefinitions).then(inv -> null);
       util.when(() -> MigrationUtil.migrateCertificationToTagUsage(handle, ConnectionType.POSTGRES))
           .then(inv -> null);
@@ -54,7 +53,6 @@ class MigrationTest {
     Migration migration = createMigrationWithHandle(handle);
 
     try (MockedStatic<MigrationUtil> util = mockStatic(MigrationUtil.class)) {
-      util.when(() -> MigrationUtil.migrateWebhookSecretKeyToAuthType(handle)).then(inv -> null);
       util.when(MigrationUtil::migrateWorkflowDefinitions).then(inv -> null);
       util.when(() -> MigrationUtil.migrateCertificationToTagUsage(handle, ConnectionType.POSTGRES))
           .thenThrow(new RuntimeException("certification migration failed"));

--- a/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v1126/MigrationUtilTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v1126/MigrationUtilTest.java
@@ -1,23 +1,32 @@
 package org.openmetadata.service.migration.utils.v1126;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.statement.Update;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.openmetadata.service.resources.databases.DatasourceConfig;
 
 class MigrationUtilTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
 
   private static final String WEBHOOK_WITH_BEARER =
       """
@@ -81,6 +90,13 @@ class MigrationUtilTest {
     return handle;
   }
 
+  private Handle handleWithUpdateCapture(List<Map<String, Object>> rows, Update mockUpdate) {
+    Handle handle = mock(Handle.class, RETURNS_DEEP_STUBS);
+    when(handle.createQuery(any(String.class)).mapToMap().list()).thenReturn(rows);
+    when(handle.createUpdate(any(String.class))).thenReturn(mockUpdate);
+    return handle;
+  }
+
   private Map<String, Object> row(String json) {
     return Map.of("id", UUID.randomUUID().toString(), "json", json);
   }
@@ -113,8 +129,9 @@ class MigrationUtilTest {
   }
 
   @Test
-  void revertWebhookAuthTypeToSecretKeyRevertsBearer() {
-    Handle handle = handleReturningRows(List.of(row(WEBHOOK_WITH_BEARER)));
+  void revertWebhookAuthTypeToSecretKeyRevertsBearer() throws Exception {
+    Update mockUpdate = mock(Update.class, RETURNS_DEEP_STUBS);
+    Handle handle = handleWithUpdateCapture(List.of(row(WEBHOOK_WITH_BEARER)), mockUpdate);
 
     try (MockedStatic<DatasourceConfig> ds = mockStatic(DatasourceConfig.class)) {
       DatasourceConfig mockConfig = mock(DatasourceConfig.class);
@@ -123,13 +140,21 @@ class MigrationUtilTest {
 
       assertDoesNotThrow(() -> MigrationUtil.revertWebhookAuthTypeToSecretKey(handle));
 
-      verify(handle).createUpdate(any());
+      ArgumentCaptor<String> jsonCaptor = ArgumentCaptor.forClass(String.class);
+      verify(mockUpdate).bind(eq("json"), jsonCaptor.capture());
+
+      JsonNode config =
+          MAPPER.readTree(jsonCaptor.getValue()).get("destinations").get(0).get("config");
+      assertEquals("mysecret", config.get("secretKey").asText());
+      assertNull(config.get("authType"));
     }
   }
 
   @Test
-  void revertWebhookAuthTypeToSecretKeyHandlesNonBearerAuthType() {
-    Handle handle = handleReturningRows(List.of(row(WEBHOOK_WITH_NON_BEARER_AUTH_TYPE)));
+  void revertWebhookAuthTypeToSecretKeyHandlesNonBearerAuthType() throws Exception {
+    Update mockUpdate = mock(Update.class, RETURNS_DEEP_STUBS);
+    Handle handle =
+        handleWithUpdateCapture(List.of(row(WEBHOOK_WITH_NON_BEARER_AUTH_TYPE)), mockUpdate);
 
     try (MockedStatic<DatasourceConfig> ds = mockStatic(DatasourceConfig.class)) {
       DatasourceConfig mockConfig = mock(DatasourceConfig.class);
@@ -138,7 +163,13 @@ class MigrationUtilTest {
 
       assertDoesNotThrow(() -> MigrationUtil.revertWebhookAuthTypeToSecretKey(handle));
 
-      verify(handle).createUpdate(any());
+      ArgumentCaptor<String> jsonCaptor = ArgumentCaptor.forClass(String.class);
+      verify(mockUpdate).bind(eq("json"), jsonCaptor.capture());
+
+      JsonNode config =
+          MAPPER.readTree(jsonCaptor.getValue()).get("destinations").get(0).get("config");
+      assertNull(config.get("authType"));
+      assertNull(config.get("secretKey"));
     }
   }
 }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v1126/MigrationUtilTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v1126/MigrationUtilTest.java
@@ -1,0 +1,144 @@
+package org.openmetadata.service.migration.utils.v1126;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.jdbi.v3.core.Handle;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.openmetadata.service.resources.databases.DatasourceConfig;
+
+class MigrationUtilTest {
+
+  private static final String WEBHOOK_WITH_BEARER =
+      """
+      {
+        "destinations": [
+          {
+            "type": "Webhook",
+            "config": {
+              "authType": { "type": "bearer", "secretKey": "mysecret" }
+            }
+          }
+        ]
+      }
+      """;
+
+  private static final String WEBHOOK_WITHOUT_AUTH_TYPE =
+      """
+      {
+        "destinations": [
+          {
+            "type": "Webhook",
+            "config": {
+              "secretKey": "mysecret"
+            }
+          }
+        ]
+      }
+      """;
+
+  private static final String NON_WEBHOOK_DESTINATION =
+      """
+      {
+        "destinations": [
+          {
+            "type": "Slack",
+            "config": {
+              "authType": { "type": "bearer", "secretKey": "mysecret" }
+            }
+          }
+        ]
+      }
+      """;
+
+  private static final String WEBHOOK_WITH_NON_BEARER_AUTH_TYPE =
+      """
+      {
+        "destinations": [
+          {
+            "type": "Webhook",
+            "config": {
+              "authType": { "type": "oAuth2" }
+            }
+          }
+        ]
+      }
+      """;
+
+  private Handle handleReturningRows(List<Map<String, Object>> rows) {
+    Handle handle = mock(Handle.class, RETURNS_DEEP_STUBS);
+    when(handle.createQuery(any(String.class)).mapToMap().list()).thenReturn(rows);
+    return handle;
+  }
+
+  private Map<String, Object> row(String json) {
+    return Map.of("id", UUID.randomUUID().toString(), "json", json);
+  }
+
+  @Test
+  void revertWebhookAuthTypeToSecretKeyIsNoOpWhenNoRows() {
+    Handle handle = handleReturningRows(List.of());
+
+    assertDoesNotThrow(() -> MigrationUtil.revertWebhookAuthTypeToSecretKey(handle));
+
+    verify(handle, never()).createUpdate(any());
+  }
+
+  @Test
+  void revertWebhookAuthTypeToSecretKeyIsNoOpWhenNoAuthType() {
+    Handle handle = handleReturningRows(List.of(row(WEBHOOK_WITHOUT_AUTH_TYPE)));
+
+    assertDoesNotThrow(() -> MigrationUtil.revertWebhookAuthTypeToSecretKey(handle));
+
+    verify(handle, never()).createUpdate(any());
+  }
+
+  @Test
+  void revertWebhookAuthTypeToSecretKeyIsNoOpForNonWebhookDestinations() {
+    Handle handle = handleReturningRows(List.of(row(NON_WEBHOOK_DESTINATION)));
+
+    assertDoesNotThrow(() -> MigrationUtil.revertWebhookAuthTypeToSecretKey(handle));
+
+    verify(handle, never()).createUpdate(any());
+  }
+
+  @Test
+  void revertWebhookAuthTypeToSecretKeyRevertsBearer() {
+    Handle handle = handleReturningRows(List.of(row(WEBHOOK_WITH_BEARER)));
+
+    try (MockedStatic<DatasourceConfig> ds = mockStatic(DatasourceConfig.class)) {
+      DatasourceConfig mockConfig = mock(DatasourceConfig.class);
+      ds.when(DatasourceConfig::getInstance).thenReturn(mockConfig);
+      when(mockConfig.isMySQL()).thenReturn(true);
+
+      assertDoesNotThrow(() -> MigrationUtil.revertWebhookAuthTypeToSecretKey(handle));
+
+      verify(handle).createUpdate(any());
+    }
+  }
+
+  @Test
+  void revertWebhookAuthTypeToSecretKeyHandlesNonBearerAuthType() {
+    Handle handle = handleReturningRows(List.of(row(WEBHOOK_WITH_NON_BEARER_AUTH_TYPE)));
+
+    try (MockedStatic<DatasourceConfig> ds = mockStatic(DatasourceConfig.class)) {
+      DatasourceConfig mockConfig = mock(DatasourceConfig.class);
+      ds.when(DatasourceConfig::getInstance).thenReturn(mockConfig);
+      when(mockConfig.isMySQL()).thenReturn(true);
+
+      assertDoesNotThrow(() -> MigrationUtil.revertWebhookAuthTypeToSecretKey(handle));
+
+      verify(handle).createUpdate(any());
+    }
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v1126/MigrationUtilTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v1126/MigrationUtilTest.java
@@ -129,7 +129,7 @@ class MigrationUtilTest {
   }
 
   @Test
-  void revertWebhookAuthTypeToSecretKeyRevertsBearer() throws Exception {
+  void revertWebhookAuthTypeToSecretKeyRevertsBearerMysql() throws Exception {
     Update mockUpdate = mock(Update.class, RETURNS_DEEP_STUBS);
     Handle handle = handleWithUpdateCapture(List.of(row(WEBHOOK_WITH_BEARER)), mockUpdate);
 
@@ -139,6 +139,39 @@ class MigrationUtilTest {
       when(mockConfig.isMySQL()).thenReturn(true);
 
       assertDoesNotThrow(() -> MigrationUtil.revertWebhookAuthTypeToSecretKey(handle));
+
+      ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+      verify(handle).createUpdate(sqlCaptor.capture());
+      assertEquals(
+          "UPDATE event_subscription_entity SET json = :json WHERE id = :id", sqlCaptor.getValue());
+
+      ArgumentCaptor<String> jsonCaptor = ArgumentCaptor.forClass(String.class);
+      verify(mockUpdate).bind(eq("json"), jsonCaptor.capture());
+
+      JsonNode config =
+          MAPPER.readTree(jsonCaptor.getValue()).get("destinations").get(0).get("config");
+      assertEquals("mysecret", config.get("secretKey").asText());
+      assertNull(config.get("authType"));
+    }
+  }
+
+  @Test
+  void revertWebhookAuthTypeToSecretKeyRevertsBearerPostgres() throws Exception {
+    Update mockUpdate = mock(Update.class, RETURNS_DEEP_STUBS);
+    Handle handle = handleWithUpdateCapture(List.of(row(WEBHOOK_WITH_BEARER)), mockUpdate);
+
+    try (MockedStatic<DatasourceConfig> ds = mockStatic(DatasourceConfig.class)) {
+      DatasourceConfig mockConfig = mock(DatasourceConfig.class);
+      ds.when(DatasourceConfig::getInstance).thenReturn(mockConfig);
+      when(mockConfig.isMySQL()).thenReturn(false);
+
+      assertDoesNotThrow(() -> MigrationUtil.revertWebhookAuthTypeToSecretKey(handle));
+
+      ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+      verify(handle).createUpdate(sqlCaptor.capture());
+      assertEquals(
+          "UPDATE event_subscription_entity SET json = :json::jsonb WHERE id = :id",
+          sqlCaptor.getValue());
 
       ArgumentCaptor<String> jsonCaptor = ArgumentCaptor.forClass(String.class);
       verify(mockUpdate).bind(eq("json"), jsonCaptor.capture());


### PR DESCRIPTION
## Summary
- Removes `migrateWebhookSecretKeyToAuthType` from v1125 migration — this call was incorrectly cherry-picked from the certification refactor branch and rewrote webhook DB data to use `authType`, which Jackson rejects since `Webhook.java` has no such field
- Adds v1126 reverse migration (`revertWebhookAuthTypeToSecretKey`) that restores `secretKey` from the bearer `authType` object back to the top-level config field
- No-op for users who never ran v1125 (e.g. upgrading from 1.12.3 → 1.12.6 directly) — the reverse migration only activates if `authType` is present in webhook config

## Test plan
- [ ] Upgrade from 1.12.5 → 1.12.6: verify webhook event subscriptions are readable and `secretKey` is restored in DB
- [ ] Upgrade from 1.12.3 → 1.12.6: verify v1126 migration is a no-op (no webhook data modified)
- [ ] Verify webhook alerting works end-to-end after migration