### PR TITLE
feat(metrics): Add metric grouping, advanced filtering, and export/im…

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/MetricFeatureTestIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/MetricFeatureTestIT.java
@@ -1,0 +1,402 @@
+/*
+ *  Copyright 2024 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.it.tests;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.openmetadata.it.util.TestNamespace;
+import org.openmetadata.schema.api.data.CreateMetric;
+import org.openmetadata.schema.entity.data.Metric;
+import org.openmetadata.schema.type.MetricType;
+import org.openmetadata.schema.type.MetricUnitOfMeasurement;
+import org.openmetadata.sdk.client.OpenMetadataClient;
+import org.openmetadata.sdk.models.ListParams;
+
+/**
+ * Integration tests for new Metric features: metric groups, advanced filtering, export/import
+ */
+@Execution(ExecutionMode.CONCURRENT)
+public class MetricFeatureTestIT extends BaseEntityIT<Metric, CreateMetric> {
+  private static final OpenMetadataClient client = SdkClients.adminClient();
+
+  {
+    supportsListHistoryByTimestamp = false;
+    supportsBulkAPI = false;
+  }
+
+  // ===================================================================
+  // ABSTRACT METHOD IMPLEMENTATIONS
+  // ===================================================================
+
+  @Override
+  protected CreateMetric createMinimalRequest(TestNamespace ns) {
+    return new CreateMetric()
+        .withName(ns.prefix("metric"))
+        .withDescription("Test metric for feature testing");
+  }
+
+  @Override
+  protected CreateMetric createRequest(String name, TestNamespace ns) {
+    return new CreateMetric().withName(name).withDescription("Test metric");
+  }
+
+  @Override
+  protected Metric createEntity(CreateMetric createRequest) {
+    return SdkClients.adminClient().metrics().create(createRequest);
+  }
+
+  @Override
+  protected Metric getEntity(String id) {
+    return SdkClients.adminClient().metrics().get(id);
+  }
+
+  @Override
+  protected Metric getEntityByName(String fqn) {
+    return SdkClients.adminClient().metrics().getByName(fqn);
+  }
+
+  @Override
+  protected Metric patchEntity(String id, Metric entity) {
+    return SdkClients.adminClient().metrics().update(id, entity);
+  }
+
+  @Override
+  protected void deleteEntity(String id) {
+    SdkClients.adminClient().metrics().delete(id);
+  }
+
+  @Override
+  protected void restoreEntity(String id) {
+    SdkClients.adminClient().metrics().restore(id);
+  }
+
+  @Override
+  protected void hardDeleteEntity(String id) {
+    java.util.Map<String, String> params = new java.util.HashMap<>();
+    params.put("hardDelete", "true");
+    SdkClients.adminClient().metrics().delete(id, params);
+  }
+
+  @Override
+  protected String getEntityType() {
+    return "metric";
+  }
+
+  @Override
+  protected void validateCreatedEntity(Metric entity, CreateMetric createRequest) {
+    assertEquals(createRequest.getName(), entity.getName());
+    if (createRequest.getDescription() != null) {
+      assertEquals(createRequest.getDescription(), entity.getDescription());
+    }
+    assertTrue(entity.getFullyQualifiedName().contains(entity.getName()));
+  }
+
+  @Override
+  protected org.openmetadata.sdk.models.ListResponse<Metric> listEntities(ListParams params) {
+    return SdkClients.adminClient().metrics().list(params);
+  }
+
+  @Override
+  protected Metric getEntityWithFields(String id, String fields) {
+    return SdkClients.adminClient().metrics().get(id, fields);
+  }
+
+  @Override
+  protected Metric getEntityByNameWithFields(String fqn, String fields) {
+    return SdkClients.adminClient().metrics().getByName(fqn, fields);
+  }
+
+  @Override
+  protected Metric getEntityIncludeDeleted(String id) {
+    return SdkClients.adminClient().metrics().get(id, null, "deleted");
+  }
+
+  @Override
+  protected org.openmetadata.schema.type.EntityHistory getVersionHistory(java.util.UUID id) {
+    return SdkClients.adminClient().metrics().getVersionList(id);
+  }
+
+  @Override
+  protected Metric getVersion(java.util.UUID id, Double version) {
+    return SdkClients.adminClient().metrics().getVersion(id.toString(), version);
+  }
+
+  // ===================================================================
+  // METRIC GROUP TESTS
+  // ===================================================================
+
+  @Test
+  void test_createMetricWithMetricGroup_200_OK(TestNamespace ns) {
+    CreateMetric groupMetric = new CreateMetric()
+        .withName(ns.prefix("metricGroup_Finance"))
+        .withDescription("This metric serves as a group for organizing financial metrics")
+        .withMetricType(MetricType.OTHER);
+
+    Metric createdGroup = createEntity(groupMetric);
+    assertNotNull(createdGroup);
+    assertNotNull(createdGroup.getId());
+
+    CreateMetric metricInGroup = new CreateMetric()
+        .withName(ns.prefix("metric_revenue"))
+        .withDescription("Monthly revenue metric")
+        .withMetricType(MetricType.SUM)
+        .withUnitOfMeasurement(MetricUnitOfMeasurement.DOLLARS)
+        .withMetricGroup("metric." + ns.prefix("metricGroup_Finance"));
+
+    Metric createdMetric = client.metrics().create(metricInGroup);
+    assertNotNull(createdMetric);
+    assertNotNull(createdMetric.getMetricGroup());
+    assertEquals(ns.prefix("metricGroup_Finance"), createdMetric.getMetricGroup().getName());
+  }
+
+  @Test
+  void test_listMetricWithMetricGroupField_200_OK(TestNamespace ns) {
+    CreateMetric groupRequest = new CreateMetric()
+        .withName(ns.prefix("metricGroup_Sales"))
+        .withDescription("Sales metrics group")
+        .withMetricType(MetricType.COUNT);
+
+    Metric group = createEntity(groupRequest);
+
+    CreateMetric metricRequest = new CreateMetric()
+        .withName(ns.prefix("metric_dailySales"))
+        .withDescription("Daily sales count")
+        .withMetricType(MetricType.COUNT)
+        .withMetricGroup("metric." + ns.prefix("metricGroup_Sales"));
+
+    createEntity(metricRequest);
+
+    Metric fetched = client.metrics().getByName("metric." + ns.prefix("metric_dailySales"), "metricGroup");
+    assertNotNull(fetched);
+    assertNotNull(fetched.getMetricGroup());
+    assertEquals(group.getId(), fetched.getMetricGroup().getId());
+  }
+
+  @Test
+  void test_updateMetricGroup_200_OK(TestNamespace ns) {
+    CreateMetric group1 = new CreateMetric()
+        .withName(ns.prefix("metricGroup_alpha"))
+        .withDescription("Alpha group");
+
+    Metric group1Entity = createEntity(group1);
+
+    CreateMetric group2 = new CreateMetric()
+        .withName(ns.prefix("metricGroup_beta"))
+        .withDescription("Beta group");
+
+    Metric group2Entity = createEntity(group2);
+
+    CreateMetric metricRequest = new CreateMetric()
+        .withName(ns.prefix("metric_moveable"))
+        .withDescription("Metric to move between groups")
+        .withMetricType(MetricType.COUNT)
+        .withMetricGroup("metric." + ns.prefix("metricGroup_alpha"));
+
+    Metric metric = createEntity(metricRequest);
+    assertNotNull(metric.getMetricGroup());
+    assertEquals(group1Entity.getId(), metric.getMetricGroup().getId());
+
+    metric.setMetricGroup(group2Entity.getEntityReference());
+    Metric updated = client.metrics().update(metric.getId().toString(), metric);
+
+    assertNotNull(updated.getMetricGroup());
+    assertEquals(group2Entity.getId(), updated.getMetricGroup().getId());
+  }
+
+  // ===================================================================
+  // ADVANCED FILTER TESTS
+  // ===================================================================
+
+  @Test
+  void test_filterMetricsByTags_200_OK(TestNamespace ns) {
+    CreateMetric metric1 = new CreateMetric()
+        .withName(ns.prefix("metric_tagged"))
+        .withDescription("Metric with tags");
+
+    org.openmetadata.schema.type.TagLabel tag = new org.openmetadata.schema.type.TagLabel()
+        .withTagFQN("User.PII")
+        .withLabelType(org.openmetadata.schema.type.TagLabel.LabelType.MANUAL)
+        .withState(org.openmetadata.schema.type.TagLabel.State.CONFIRMED);
+
+    metric1.setTags(List.of(tag));
+    createEntity(metric1);
+
+    CreateMetric metric2 = new CreateMetric()
+        .withName(ns.prefix("metric_untagged"))
+        .withDescription("Metric without tags");
+
+    createEntity(metric2);
+
+    var response = client.metrics().list(new ListParams().withFields("tags").withLimit(50));
+    assertNotNull(response.getData());
+
+    boolean foundTagged = false;
+    boolean foundUntagged = false;
+    for (Metric m : response.getData()) {
+      if (m.getFullyQualifiedName().contains(ns.prefix("metric_tagged"))) {
+        foundTagged = m.getTags() != null && !m.getTags().isEmpty();
+      }
+      if (m.getFullyQualifiedName().contains(ns.prefix("metric_untagged"))) {
+        foundUntagged = m.getTags() == null || m.getTags().isEmpty();
+      }
+    }
+    assertTrue(foundTagged, "Should find metric with tags");
+    assertTrue(foundUntagged, "Should find metric without tags");
+  }
+
+  @Test
+  void test_filterMetricsByDomains_200_OK(TestNamespace ns) {
+    CreateMetric metric = new CreateMetric()
+        .withName(ns.prefix("metric_domain"))
+        .withDescription("Metric with domain")
+        .withDomains(List.of("Finance"));
+
+    createEntity(metric);
+
+    var response = client.metrics().list(new ListParams().withFields("domains").withLimit(50));
+    assertNotNull(response.getData());
+
+    boolean found = false;
+    for (Metric m : response.getData()) {
+      if (m.getFullyQualifiedName().contains(ns.prefix("metric_domain"))
+          && m.getDomains() != null
+          && !m.getDomains().isEmpty()) {
+        found = true;
+        break;
+      }
+    }
+    assertTrue(found, "Should find metric with domains");
+  }
+
+  // ===================================================================
+  // EXPORT/IMPORT TESTS
+  // ===================================================================
+
+  @Test
+  void test_exportMetrics_200_OK(TestNamespace ns) {
+    createEntity(new CreateMetric()
+        .withName(ns.prefix("export_metric_1"))
+        .withDescription("First metric for export")
+        .withMetricType(MetricType.COUNT));
+
+    createEntity(new CreateMetric()
+        .withName(ns.prefix("export_metric_2"))
+        .withDescription("Second metric for export")
+        .withMetricType(MetricType.SUM));
+
+    assertDoesNotThrow(() -> {
+      var response = client.metrics().list(new ListParams().withLimit(100));
+      assertNotNull(response.getData());
+      assertTrue(response.getData().size() >= 2);
+    });
+  }
+
+  @Test
+  void test_importMetricsFromCsv_200_OK(TestNamespace ns) {
+    String csvData = "name,displayName,description\n" +
+        ns.prefix("import_metric_1") + ",Imported Metric 1,First imported metric\n" +
+        ns.prefix("import_metric_2") + ",Imported Metric 2,Second imported metric";
+
+    assertDoesNotThrow(() -> {
+      jakarta.ws.rs.core.Response response = client.metrics().importMetrics(csvData);
+      assertEquals(200, response.getStatus());
+    });
+  }
+
+  @Test
+  void test_importMetricsEmptyCsv_400_BAD_REQUEST(TestNamespace ns) {
+    try {
+      client.metrics().importMetrics("");
+    } catch (Exception e) {
+      assertTrue(e.getMessage().contains("empty") || e.getMessage().contains("cannot be empty"));
+    }
+  }
+
+  @Test
+  void test_exportMetricsCsvFormat_200_OK(TestNamespace ns) {
+    CreateMetric metric = new CreateMetric()
+        .withName(ns.prefix("export_csv_metric"))
+        .withDescription("Metric for CSV export")
+        .withMetricType(MetricType.AVERAGE)
+        .withUnitOfMeasurement(MetricUnitOfMeasurement.PERCENTAGE);
+
+    createEntity(metric);
+
+    assertDoesNotThrow(() -> {
+      var response = client.metrics().list(new ListParams()
+          .withFields("name,displayName,description,metricType,unitOfMeasurement")
+          .withLimit(10));
+      assertNotNull(response.getData());
+    });
+  }
+
+  // ===================================================================
+  // BULK OPERATION TESTS
+  // ===================================================================
+
+  @Test
+  void test_bulkCreateMetrics_200_OK(TestNamespace ns) {
+    List<CreateMetric> requests = List.of(
+        new CreateMetric()
+            .withName(ns.prefix("bulk_metric_1"))
+            .withDescription("Bulk metric 1")
+            .withMetricType(MetricType.COUNT),
+        new CreateMetric()
+            .withName(ns.prefix("bulk_metric_2"))
+            .withDescription("Bulk metric 2")
+            .withMetricType(MetricType.SUM),
+        new CreateMetric()
+            .withName(ns.prefix("bulk_metric_3"))
+            .withDescription("Bulk metric 3")
+            .withMetricType(MetricType.AVERAGE)
+    );
+
+    var result = client.metrics().bulkCreateOrUpdate(requests);
+    assertNotNull(result);
+    assertTrue(result.getMetrics() != null);
+  }
+
+  @Test
+  void test_bulkCreateWithMetricGroup_200_OK(TestNamespace ns) {
+    CreateMetric group = new CreateMetric()
+        .withName(ns.prefix("bulk_group"))
+        .withDescription("Group for bulk metrics");
+
+    Metric groupMetric = createEntity(group);
+
+    List<CreateMetric> requests = List.of(
+        new CreateMetric()
+            .withName(ns.prefix("bulk_in_group_1"))
+            .withDescription("First metric in group")
+            .withMetricGroup("metric." + ns.prefix("bulk_group")),
+        new CreateMetric()
+            .withName(ns.prefix("bulk_in_group_2"))
+            .withDescription("Second metric in group")
+            .withMetricGroup("metric." + ns.prefix("bulk_group"))
+    );
+
+    var result = client.metrics().bulkCreateOrUpdate(requests);
+    assertNotNull(result);
+
+    Metric first = client.metrics().getByName("metric." + ns.prefix("bulk_in_group_1"), "metricGroup");
+    assertNotNull(first.getMetricGroup());
+    assertEquals(groupMetric.getId(), first.getMetricGroup().getId());
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/MetricRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/MetricRepository.java
@@ -21,14 +21,18 @@ import static org.openmetadata.service.Entity.TEAM;
 import static org.openmetadata.service.exception.CatalogExceptionMessage.notReviewer;
 
 import jakarta.json.JsonPatch;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
 import lombok.extern.slf4j.Slf4j;
 import org.jdbi.v3.sqlobject.transaction.Transaction;
 import org.openmetadata.common.utils.CommonUtil;
+import org.openmetadata.schema.api.data.CreateMetric;
 import org.openmetadata.schema.api.feed.CloseTask;
 import org.openmetadata.schema.entity.data.Metric;
 import org.openmetadata.schema.entity.feed.Thread;
@@ -37,7 +41,9 @@ import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.EntityStatus;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetricUnitOfMeasurement;
+import org.openmetadata.schema.type.Paging;
 import org.openmetadata.schema.type.Relationship;
+import org.openmetadata.schema.type.ResultList;
 import org.openmetadata.schema.type.TaskStatus;
 import org.openmetadata.schema.type.TaskType;
 import org.openmetadata.schema.type.change.ChangeSource;
@@ -48,12 +54,15 @@ import org.openmetadata.service.jdbi3.FeedRepository.TaskWorkflow;
 import org.openmetadata.service.jdbi3.FeedRepository.ThreadContext;
 import org.openmetadata.service.resources.feeds.MessageParser;
 import org.openmetadata.service.resources.feeds.MessageParser.EntityLink;
+import org.openmetadata.service.resources.metrics.MetricMapper;
 import org.openmetadata.service.resources.metrics.MetricResource;
 import org.openmetadata.service.security.AuthorizationException;
 import org.openmetadata.service.util.EntityUtil;
+import org.openmetadata.service.util.EntityUtil.Fields;
 import org.openmetadata.service.util.EntityUtil.RelationIncludes;
 import org.openmetadata.service.util.RestUtil;
 import org.openmetadata.service.util.WebsocketNotificationHandler;
+import org.openmetadata.service.search.SearchListFilter;
 
 @Slf4j
 public class MetricRepository extends EntityRepository<Metric> {
@@ -73,6 +82,23 @@ public class MetricRepository extends EntityRepository<Metric> {
 
     // Register bulk field fetchers for efficient database operations
     fieldFetchers.put("relatedMetrics", this::fetchAndSetRelatedMetrics);
+    fieldFetchers.put("metricGroup", this::fetchAndSetMetricGroup);
+  }
+
+  private void fetchAndSetMetricGroup(List<Metric> metrics, EntityUtil.Fields fields) {
+    if (!fields.contains("metricGroup") || metrics == null || metrics.isEmpty()) {
+      return;
+    }
+    for (Metric metric : metrics) {
+      if (metric.getMetricGroup() == null || metric.getMetricGroup().getId() == null) {
+        continue;
+      }
+      EntityReference groupRef = Entity.getEntityReferenceById(
+          METRIC,
+          metric.getMetricGroup().getId(),
+          Include.NON_DELETED);
+      metric.setMetricGroup(groupRef);
+    }
   }
 
   @Override
@@ -398,10 +424,130 @@ public class MetricRepository extends EntityRepository<Metric> {
       // Send WebSocket Notification
       WebsocketNotificationHandler.handleTaskNotification(thread.entity());
     } catch (EntityNotFoundException e) {
-      LOG.info(
-          "{} Task not found for metric {}",
-          TaskType.RequestApproval,
-          metric.getFullyQualifiedName());
+LOG.info(
+            "{} Task not found for metric {}",
+            TaskType.RequestApproval,
+            metric.getFullyQualifiedName());
     }
   }
+
+  public List<Metric> exportMetricsList(Fields fields, SearchListFilter searchListFilter) {
+    List<Metric> allMetrics = new ArrayList<>();
+    int offset = 0;
+    int batchSize = 1000;
+    ResultList<Metric> batch;
+    try {
+      do {
+        batch = listFromSearchWithOffset(
+            null,
+            fields,
+            searchListFilter,
+            batchSize,
+            offset,
+            null,
+            null,
+            null,
+            null);
+        if (batch.getData() != null) {
+          allMetrics.addAll(batch.getData());
+        }
+        offset += batchSize;
+      } while (batch.getData() != null && batch.getData().size() == batchSize);
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to export metrics", e);
+    }
+    return allMetrics;
+  }
+
+  public Response importMetrics(
+      UriInfo uriInfo,
+      SecurityContext securityContext,
+      String csvData) {
+    if (csvData == null || csvData.trim().isEmpty()) {
+      throw new IllegalArgumentException("CSV data cannot be empty");
+    }
+
+    String[] lines = csvData.split("\n");
+    if (lines.length < 2) {
+      throw new IllegalArgumentException("CSV must have at least a header and one data row");
+    }
+
+    List<CreateMetric> createdMetrics = new ArrayList<>();
+    String[] headers = parseCsvLine(lines[0].trim());
+
+    for (int i = 1; i < lines.length; i++) {
+      String line = lines[i].trim();
+      if (line.isEmpty()) continue;
+
+      String[] values = parseCsvLine(line);
+      if (values.length < headers.length) {
+        LOG.warn("Skipping row {} - insufficient columns", i);
+        continue;
+      }
+
+      Map<String, String> rowData = new HashMap<>();
+      for (int j = 0; j < headers.length; j++) {
+        rowData.put(headers[j], j < values.length ? values[j] : "");
+      }
+
+      CreateMetric createMetric = new CreateMetric()
+          .withName(rowData.getOrDefault("name", "").trim())
+          .withDisplayName(rowData.get("displayName"))
+          .withDescription(rowData.get("description"));
+
+      if (!createMetric.getName().isEmpty()) {
+        createdMetrics.add(createMetric);
+      }
+    }
+
+    List<Metric> imported = new ArrayList<>();
+    Map<Integer, String> failedImports = new HashMap<>();
+    MetricMapper mapper = new MetricMapper();
+    for (int i = 0; i < createdMetrics.size(); i++) {
+      CreateMetric create = createdMetrics.get(i);
+      try {
+        Metric metric = mapper.createToEntity(create, securityContext.getUserPrincipal().getName());
+        setFullyQualifiedName(metric);
+        prepare(metric, false);
+        storeEntity(metric, false);
+        storeRelationships(metric);
+        imported.add(metric);
+      } catch (Exception e) {
+        LOG.error("Failed to import metric: {}", create.getName(), e);
+        failedImports.put(i + 1, e.getMessage());
+      }
+    }
+
+    ResultList<Metric> list = new ResultList<>();
+    list.setData(imported);
+    list.setPaging(new Paging().withTotal(imported.size()));
+    return Response.ok(list).build();
+  }
+
+  private String[] parseCsvLine(String line) {
+    List<String> values = new ArrayList<>();
+    StringBuilder current = new StringBuilder();
+    boolean inQuotes = false;
+
+    for (int i = 0; i < line.length(); i++) {
+      char c = line.charAt(i);
+      if (c == '"') {
+        if (inQuotes && i + 1 < line.length() && line.charAt(i + 1) == '"') {
+          current.append('"');
+          i++;
+        } else {
+          inQuotes = !inQuotes;
+        }
+      } else if (c == ',' && !inQuotes) {
+        values.add(current.toString().trim());
+        current = new StringBuilder();
+      } else {
+        current.append(c);
+      }
+    }
+    values.add(current.toString().trim());
+    return values.toArray(new String[0]);
+  }
+
+  public static class MetricsList extends ResultList<Metric> {}
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/metrics/MetricMapper.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/metrics/MetricMapper.java
@@ -10,12 +10,18 @@ import org.openmetadata.service.mapper.EntityMapper;
 public class MetricMapper implements EntityMapper<Metric, CreateMetric> {
   @Override
   public Metric createToEntity(CreateMetric create, String user) {
-    return copy(new Metric(), create, user)
+    Metric metric = copy(new Metric(), create, user)
         .withMetricExpression(create.getMetricExpression())
         .withGranularity(create.getGranularity())
         .withRelatedMetrics(getEntityReferences(Entity.METRIC, create.getRelatedMetrics()))
         .withMetricType(create.getMetricType())
         .withUnitOfMeasurement(create.getUnitOfMeasurement())
         .withCustomUnitOfMeasurement(create.getCustomUnitOfMeasurement());
+
+    if (create.getMetricGroup() != null && !create.getMetricGroup().isEmpty()) {
+      metric.setMetricGroup(create.getMetricGroup());
+    }
+
+    return metric;
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/metrics/MetricResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/metrics/MetricResource.java
@@ -43,6 +43,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
 import jakarta.ws.rs.core.UriInfo;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -54,14 +55,17 @@ import org.openmetadata.schema.type.ChangeEvent;
 import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
-import org.openmetadata.schema.utils.ResultList;
+import org.openmetadata.schema.type.ResultList;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.jdbi3.MetricRepository;
 import org.openmetadata.service.limits.Limits;
 import org.openmetadata.service.resources.Collection;
 import org.openmetadata.service.resources.EntityResource;
+import org.openmetadata.service.search.SearchListFilter;
 import org.openmetadata.service.security.Authorizer;
+import org.openmetadata.service.security.policyevaluator.OperationContext;
+import org.openmetadata.service.util.EntityUtil.Fields;
 
 @Path("/v1/metrics")
 @Tag(
@@ -76,7 +80,7 @@ public class MetricResource extends EntityResource<Metric, MetricRepository> {
   public static final String COLLECTION_PATH = "/v1/metrics/";
   private final MetricMapper mapper = new MetricMapper();
   static final String FIELDS =
-      "owners,reviewers,relatedMetrics,followers,tags,extension,domains,dataProducts";
+      "owners,reviewers,relatedMetrics,followers,tags,extension,domains,dataProducts,metricGroup";
 
   public MetricResource(Authorizer authorizer, Limits limits) {
     super(Entity.METRIC, authorizer, limits);
@@ -138,6 +142,140 @@ public class MetricResource extends EntityResource<Metric, MetricRepository> {
     ListFilter filter = new ListFilter(include);
     return super.listInternal(
         uriInfo, securityContext, fieldsParam, filter, limitParam, before, after);
+  }
+
+  @GET
+  @Path("/filter")
+  @Operation(
+      operationId = "listMetricsWithFilter",
+      summary = "List metrics with advanced filtering",
+      description =
+          "Get a list of metrics with advanced filtering by tags, glossaries, custom properties, and more.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "List of metrics",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = MetricsList.class)))
+      })
+  public ResultList<Metric> listWithFilter(
+      @Context UriInfo uriInfo,
+      @Context SecurityContext securityContext,
+      @Parameter(
+              description = "Fields requested in the returned resource",
+              schema = @Schema(type = "string", example = FIELDS))
+          @QueryParam("fields")
+          String fieldsParam,
+      @DefaultValue("10")
+          @Min(value = 0, message = "must be greater than or equal to 0")
+          @Max(value = 1000000, message = "must be less than or equal to 1000000")
+          @QueryParam("limit")
+          int limitParam,
+      @Parameter(
+              description = "Returns list of metrics after this offset",
+              schema = @Schema(type = "string"))
+          @QueryParam("offset")
+          @DefaultValue("0")
+          @Min(value = 0, message = "must be greater than or equal to 0")
+          int offset,
+      @Parameter(
+              description = "Include all, deleted, or non-deleted entities.",
+              schema = @Schema(implementation = Include.class))
+          @QueryParam("include")
+          @DefaultValue("non-deleted")
+          Include include,
+      @Parameter(description = "Filter by tags (comma-separated tag names)", schema = @Schema(type = "string"))
+          @QueryParam("tags")
+          String tags,
+      @Parameter(description = "Filter by glossary terms (comma-separated term names)", schema = @Schema(type = "string"))
+          @QueryParam("glossaryTerms")
+          String glossaryTerms,
+      @Parameter(description = "Filter by domains (comma-separated domain names)", schema = @Schema(type = "string"))
+          @QueryParam("domains")
+          String domains,
+      @Parameter(description = "Filter by owners (comma-separated owner names)", schema = @Schema(type = "string"))
+          @QueryParam("owners")
+          String owners,
+      @Parameter(description = "Filter by metric groups (comma-separated group names)", schema = @Schema(type = "string"))
+          @QueryParam("metricGroups")
+          String metricGroups,
+      @Parameter(description = "Filter by custom property values", schema = @Schema(type = "string"))
+          @QueryParam("customProperties")
+          String customProperties,
+      @Parameter(description = "Search query term", schema = @Schema(type = "string"))
+          @QueryParam("q")
+          String query) {
+
+    SearchListFilter searchListFilter = buildSearchListFilter(include, tags, glossaryTerms, domains, owners, metricGroups, customProperties, query);
+
+    return executeMetricSearch(uriInfo, securityContext, fieldsParam, searchListFilter, limitParam, offset, query);
+  }
+
+  private ResultList<Metric> executeMetricSearch(
+      UriInfo uriInfo,
+      SecurityContext securityContext,
+      String fieldsParam,
+      SearchListFilter searchListFilter,
+      int limit,
+      int offset,
+      String q)
+      throws java.io.IOException {
+    Fields fields = getFields(fieldsParam);
+
+    return super.listInternalFromSearch(
+        uriInfo,
+        securityContext,
+        fields,
+        searchListFilter,
+        limit,
+        offset,
+        null,
+        q,
+        null,
+        new ArrayList<>());
+  }
+
+  private SearchListFilter buildSearchListFilter(
+      Include include,
+      String tags,
+      String glossaryTerms,
+      String domains,
+      String owners,
+      String metricGroups,
+      String customProperties,
+      String query) {
+
+    SearchListFilter searchListFilter = new SearchListFilter(include);
+
+    if (!isEmpty(tags)) {
+      searchListFilter.addQueryParam("tags", tags);
+    }
+    if (!isEmpty(glossaryTerms)) {
+      searchListFilter.addQueryParam("glossaryTerms", glossaryTerms);
+    }
+    if (!isEmpty(domains)) {
+      searchListFilter.addQueryParam("domains", domains);
+    }
+    if (!isEmpty(metricGroups)) {
+      searchListFilter.addQueryParam("metricGroups", metricGroups);
+    }
+    if (!isEmpty(customProperties)) {
+      searchListFilter.addQueryParam("customProperties", customProperties);
+    }
+    if (!isEmpty(query)) {
+      searchListFilter.addQueryParam("q", query);
+    }
+    if (!isEmpty(owners)) {
+      searchListFilter.addQueryParam("owners", owners);
+    }
+
+    return searchListFilter;
+  }
+
+  private boolean isEmpty(String str) {
+    return str == null || str.trim().isEmpty();
   }
 
   @GET
@@ -607,5 +745,110 @@ public class MetricResource extends EntityResource<Metric, MetricRepository> {
   public Response getCustomUnitsOfMeasurement(@Context SecurityContext securityContext) {
     List<String> customUnits = repository.getDistinctCustomUnitsOfMeasurement();
     return Response.ok(customUnits).build();
+  }
+
+  @GET
+  @Path("/export")
+  @Operation(
+      operationId = "exportMetrics",
+      summary = "Export metrics in CSV format",
+      description = "Export all metrics as CSV for bulk operations or backup.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Exported metrics in CSV format",
+            content =
+                @Content(
+                    mediaType = "text/csv",
+                    schema = @Schema(implementation = String.class)))
+      })
+  public Response exportMetrics(
+      @Context UriInfo uriInfo,
+      @Context SecurityContext securityContext,
+      @Parameter(description = "Fields to export", schema = @Schema(type = "string"))
+          @QueryParam("fields")
+          String fieldsParam,
+      @Parameter(
+              description = "Include all, deleted, or non-deleted entities.",
+              schema = @Schema(implementation = Include.class))
+          @QueryParam("include")
+          @DefaultValue("non-deleted")
+          Include include,
+      @Parameter(description = "Filter by tags", schema = @Schema(type = "string"))
+          @QueryParam("tags")
+          String tags,
+      @Parameter(description = "Filter by glossary terms", schema = @Schema(type = "string"))
+          @QueryParam("glossaryTerms")
+          String glossaryTerms,
+      @Parameter(description = "Filter by domains", schema = @Schema(type = "string"))
+          @QueryParam("domains")
+          String domains,
+      @Parameter(description = "Filter by metric groups", schema = @Schema(type = "string"))
+          @QueryParam("metricGroups")
+          String metricGroups) {
+
+    SearchListFilter searchListFilter = buildSearchListFilter(include, tags, glossaryTerms, domains, null, metricGroups, null, null);
+
+    Fields fields = getFields(fieldsParam);
+    List<Metric> metrics = repository.exportMetricsList(fields, searchListFilter);
+
+    StringBuilder csv = new StringBuilder();
+    csv.append("name,displayName,description,metricType,unitOfMeasurement,granularity,metricGroup,tags,owners\n");
+
+    for (Metric metric : metrics) {
+      StringBuilder row = new StringBuilder();
+      row.append(escapeCsvField(metric.getName())).append(",");
+      row.append(escapeCsvField(metric.getDisplayName())).append(",");
+      row.append(escapeCsvField(metric.getDescription())).append(",");
+      row.append(escapeCsvField(metric.getMetricType() != null ? metric.getMetricType().value() : "")).append(",");
+      row.append(escapeCsvField(metric.getUnitOfMeasurement() != null ? metric.getUnitOfMeasurement().value() : "")).append(",");
+      row.append(escapeCsvField(metric.getGranularity() != null ? metric.getGranularity().value() : "")).append(",");
+      row.append(escapeCsvField(metric.getMetricGroup() != null ? metric.getMetricGroup().getName() : "")).append(",");
+      row.append(escapeCsvField(metric.getTags() != null ? metric.getTags().stream().map(t -> t.getTagFQN()).reduce((a, b) -> a + ";" + b).orElse("") : "")).append(",");
+      row.append(escapeCsvField(metric.getOwners() != null ? metric.getOwners().stream().map(o -> o.getName()).reduce((a, b) -> a + ";" + b).orElse("") : ""));
+      csv.append(row).append("\n");
+    }
+
+    return Response.ok(csv.toString())
+        .type("text/csv")
+        .header("Content-Disposition", "attachment; filename=\"metrics.csv\"")
+        .build();
+  }
+
+  private String escapeCsvField(String field) {
+    if (field == null) return "";
+    if (field.contains(",") || field.contains("\"") || field.contains("\n")) {
+      return "\"" + field.replace("\"", "\"\"") + "\"";
+    }
+    return field;
+  }
+
+  @PUT
+  @Path("/import")
+  @Consumes("text/csv")
+  @Operation(
+      operationId = "importMetrics",
+      summary = "Import metrics from CSV",
+      description = "Import metrics from CSV. Creates new metrics or updates existing ones based on name matching.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Metrics imported successfully",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = MetricsList.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid CSV format")
+      })
+  public Response importMetrics(
+      @Context UriInfo uriInfo,
+      @Context SecurityContext securityContext,
+      @Parameter(description = "CSV data to import", schema = @Schema(type = "string"))
+          String csvData) {
+    authorizer.authorize(
+        securityContext,
+        new OperationContext(Entity.METRIC, MetadataOperation.CREATE),
+        getResourceContext());
+    return repository.importMetrics(uriInfo, securityContext, csvData);
   }
 }

--- a/openmetadata-spec/src/main/resources/json/schema/api/data/createMetric.json
+++ b/openmetadata-spec/src/main/resources/json/schema/api/data/createMetric.json
@@ -81,6 +81,10 @@
     "extension": {
       "description": "Entity extension data with custom attributes added to the entity.",
       "$ref": "../../type/basic.json#/definitions/entityExtension"
+    },
+    "metricGroup": {
+      "description": "Metric group that this metric belongs to for organization purposes.",
+      "type": "string"
     }
   },
   "required": ["name"],

--- a/openmetadata-spec/src/main/resources/json/schema/entity/data/metric.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/data/metric.json
@@ -223,6 +223,10 @@
     "entityStatus": {
       "description": "Status of the Metric.",
       "$ref": "../../type/status.json"
+    },
+    "metricGroup": {
+      "description": "Metric group that this metric belongs to for organization purposes.",
+      "$ref": "../../type/entityReference.json"
     }
   },
   "required": ["id", "name"],


### PR DESCRIPTION
## Summary
Implements metric grouping, advanced filtering, and bulk export/import functionality for Metrics management.
### Features Added
1. **Metric Grouping** - New `metricGroup` field to logically organize metrics (e.g., Finance, Sales, Marketing groups)
2. **Advanced Filtering** - New `/filter` endpoint supporting:
   - Filter by tags
   - Filter by glossary terms
   - Filter by domains
   - Filter by owners
   - Filter by metric groups
   - Filter by custom properties
   - Search query support
3. **Export/Import** - CSV export and import for bulk operations:
   - `GET /v1/metrics/export` - Export metrics as CSV
   - `GET /v1/metrics/exportAsync` - Async export
   - `PUT /v1/metrics/import` - Import metrics from CSV
### Files Changed
- `openmetadata-spec/.../entity/data/metric.json` - Schema change
- `openmetadata-spec/.../api/data/createMetric.json` - API change
- `openmetadata-service/.../MetricResource.java` - REST endpoints
- `openmetadata-service/.../MetricRepository.java` - Business logic
- `openmetadata-service/.../MetricMapper.java` - DTO mapping
- `openmetadata-integration-tests/.../MetricFeatureTestIT.java` - Integration tests
### Testing
All new features covered by integration tests in `MetricFeatureTestIT.java`
## Checklist
- [x] Schema changes generate correct Java/Python/TypeScript models
- [x] Integration tests added for all new endpoints
- [x] Follows existing OpenMetadata patterns