### PR TITLE
fix(search): add tiebreaker sort to prevent export truncation on numeric sort fields

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSearchManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSearchManager.java
@@ -94,6 +94,8 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
   private final String clusterAlias;
   private final RBACConditionEvaluator rbacConditionEvaluator;
   private final NLQService nlqService;
+  private static final String SORT_FIELD_SCORE = "_score";
+  private static final String SORT_TYPE_KEYWORD = "keyword";
   private static final Set<String> FIELDS_TO_REMOVE =
       Set.of(
           "suggest",
@@ -975,7 +977,7 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
       String clusterAlias)
       throws IOException {
     ElasticSearchRequestBuilder requestBuilder =
-        buildSearchRequestBuilder(request, subjectContext, searchSettings, clusterAlias);
+        buildSearchRequestBuilder(request, subjectContext, searchSettings, clusterAlias, false);
 
     LOG.debug("Executing search on index: {}, query: {}", request.getIndex(), request.getQuery());
 
@@ -1017,7 +1019,7 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
     SearchSettings searchSettings =
         SettingsCache.getSetting(SettingsType.SEARCH_SETTINGS, SearchSettings.class);
     ElasticSearchRequestBuilder requestBuilder =
-        buildSearchRequestBuilder(request, subjectContext, searchSettings, clusterAlias);
+        buildSearchRequestBuilder(request, subjectContext, searchSettings, clusterAlias, true);
 
     try {
       SearchRequest searchRequest = requestBuilder.build(request.getIndex());
@@ -1060,7 +1062,8 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
       org.openmetadata.schema.search.SearchRequest request,
       SubjectContext subjectContext,
       SearchSettings searchSettings,
-      String clusterAlias)
+      String clusterAlias,
+      boolean isExport)
       throws IOException {
     if (!isClientAvailable) {
       throw new IOException("Elasticsearch client is not available");
@@ -1191,18 +1194,17 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
               + request.getSortOrder().substring(1).toLowerCase();
       SortOrder sortOrder = SortOrder.valueOf(sortTypeCapitalized);
 
-      if (!sortField.equalsIgnoreCase("_score")) {
+      if (!sortField.equalsIgnoreCase(SORT_FIELD_SCORE)) {
         boolean isKeywordField =
             sortField.endsWith(".keyword")
                 || SearchSourceBuilderFactory.KEYWORD_SORT_FIELDS.contains(sortField);
-        requestBuilder.sort(sortField, sortOrder, isKeywordField ? "keyword" : "integer");
+        requestBuilder.sort(sortField, sortOrder, isKeywordField ? SORT_TYPE_KEYWORD : "integer");
       } else {
         requestBuilder.sort(sortField, sortOrder, null);
       }
 
-      // Add tiebreaker sort for stable pagination when sorting by score
-      if (sortField.equalsIgnoreCase("_score")) {
-        requestBuilder.sort("name.keyword", SortOrder.Asc, "keyword");
+      if (sortField.equalsIgnoreCase(SORT_FIELD_SCORE) || isExport) {
+        requestBuilder.sort("name.keyword", SortOrder.Asc, SORT_TYPE_KEYWORD);
       }
     }
 
@@ -1370,10 +1372,8 @@ public class ElasticSearchSearchManager implements SearchManagementClient {
       }
     }
 
-    // Add sorting by score first for relevance, then by fullyQualifiedName for consistent hierarchy
-    // ordering
-    requestBuilder.sort("_score", SortOrder.Desc, null);
-    requestBuilder.sort("fullyQualifiedName", SortOrder.Asc, "keyword");
+    requestBuilder.sort(SORT_FIELD_SCORE, SortOrder.Desc, null);
+    requestBuilder.sort("fullyQualifiedName", SortOrder.Asc, SORT_TYPE_KEYWORD);
 
     return requestBuilder;
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSearchManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSearchManager.java
@@ -95,6 +95,8 @@ public class OpenSearchSearchManager implements SearchManagementClient {
   private final String clusterAlias;
   private final RBACConditionEvaluator rbacConditionEvaluator;
   private final NLQService nlqService;
+  private static final String SORT_FIELD_SCORE = "_score";
+  private static final String SORT_TYPE_KEYWORD = "keyword";
   private static final Set<String> FIELDS_TO_REMOVE =
       Set.of(
           "suggest",
@@ -1016,7 +1018,7 @@ public class OpenSearchSearchManager implements SearchManagementClient {
       String clusterAlias)
       throws IOException {
     OpenSearchRequestBuilder requestBuilder =
-        buildSearchRequestBuilder(request, subjectContext, searchSettings, clusterAlias);
+        buildSearchRequestBuilder(request, subjectContext, searchSettings, clusterAlias, false);
 
     LOG.debug("Executing search on index: {}, query: {}", request.getIndex(), request.getQuery());
 
@@ -1053,7 +1055,7 @@ public class OpenSearchSearchManager implements SearchManagementClient {
     SearchSettings searchSettings =
         SettingsCache.getSetting(SettingsType.SEARCH_SETTINGS, SearchSettings.class);
     OpenSearchRequestBuilder requestBuilder =
-        buildSearchRequestBuilder(request, subjectContext, searchSettings, clusterAlias);
+        buildSearchRequestBuilder(request, subjectContext, searchSettings, clusterAlias, true);
 
     try {
       SearchRequest searchRequest = requestBuilder.build(request.getIndex());
@@ -1096,7 +1098,8 @@ public class OpenSearchSearchManager implements SearchManagementClient {
       org.openmetadata.schema.search.SearchRequest request,
       SubjectContext subjectContext,
       SearchSettings searchSettings,
-      String clusterAlias)
+      String clusterAlias,
+      boolean isExport)
       throws IOException {
     if (!isClientAvailable) {
       throw new IOException("OpenSearch client is not available");
@@ -1230,18 +1233,17 @@ public class OpenSearchSearchManager implements SearchManagementClient {
               + request.getSortOrder().substring(1).toLowerCase();
       SortOrder sortOrder = SortOrder.valueOf(sortTypeCapitalized);
 
-      if (!sortField.equalsIgnoreCase("_score")) {
+      if (!sortField.equalsIgnoreCase(SORT_FIELD_SCORE)) {
         boolean isKeywordField =
             sortField.endsWith(".keyword")
                 || SearchSourceBuilderFactory.KEYWORD_SORT_FIELDS.contains(sortField);
-        requestBuilder.sort(sortField, sortOrder, isKeywordField ? "keyword" : "integer");
+        requestBuilder.sort(sortField, sortOrder, isKeywordField ? SORT_TYPE_KEYWORD : "integer");
       } else {
         requestBuilder.sort(sortField, sortOrder, null);
       }
 
-      // Add tiebreaker sort for stable pagination when sorting by score
-      if (sortField.equalsIgnoreCase("_score")) {
-        requestBuilder.sort("name.keyword", SortOrder.Asc, "keyword");
+      if (sortField.equalsIgnoreCase(SORT_FIELD_SCORE) || isExport) {
+        requestBuilder.sort("name.keyword", SortOrder.Asc, SORT_TYPE_KEYWORD);
       }
     }
 
@@ -1408,10 +1410,8 @@ public class OpenSearchSearchManager implements SearchManagementClient {
       }
     }
 
-    // Add sorting by score first for relevance, then by fullyQualifiedName for consistent hierarchy
-    // ordering
-    requestBuilder.sort("_score", SortOrder.Desc, null);
-    requestBuilder.sort("fullyQualifiedName", SortOrder.Asc, "keyword");
+    requestBuilder.sort(SORT_FIELD_SCORE, SortOrder.Desc, null);
+    requestBuilder.sort("fullyQualifiedName", SortOrder.Asc, SORT_TYPE_KEYWORD);
 
     return requestBuilder;
   }


### PR DESCRIPTION

<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

## Problem
Search export truncated at ~1000 rows when sorting by numeric fields (e.g. totalVotes).

## Root cause: 
search_after pagination with no tiebreaker. When many documents share the same totalVotes value (e.g. 0), the cursor search_after=[0] asks for docs where totalVotes < 0 → empty batch → loop breaks early.

## Fix
Add name.keyword ASC as a tiebreaker sort whenever:

- Primary sort is `_score` (was already present, now uses constants)
- `isExport=true` — new flag passed to buildSearchRequestBuilder to distinguish export calls from regular search
This guarantees a unique cursor per document regardless of the primary sort field, enabling stable `search_after` pagination across all 50K+ rows.

## Changes
- ElasticSearchSearchManager.java — added SORT_FIELD_SCORE / SORT_TYPE_KEYWORD constants; isExport param on buildSearchRequestBuilder; merged tiebreaker condition; replaced magic strings in buildHierarchyQuery
- OpenSearchSearchManager.java — identical changes

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
