### PR TITLE
fix(ui): unbreak ColumnDetailPanel test suite on 1.12.6

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/ColumnDetailPanel/ColumnDetailPanel.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/ColumnDetailPanel/ColumnDetailPanel.test.tsx
@@ -62,7 +62,8 @@ jest.mock('antd', () => ({
         data-testid={props['data-testid'] || 'button'}
         disabled={disabled}
         onClick={onClick}
-        {...props}>
+        {...props}
+      >
         {children}
       </button>
     )),
@@ -135,33 +136,6 @@ jest.mock('@mui/material', () => ({
   }),
 }));
 
-jest.mock('@mui/material/styles', () => ({
-  ...jest.requireActual('@mui/material/styles'),
-  styled: jest.fn().mockImplementation((component) => {
-    return jest.fn().mockImplementation((props) => {
-      const Component = component;
-
-      return <Component {...props} />;
-    });
-  }),
-  useTheme: jest.fn().mockReturnValue({
-    spacing: (value: number) => `${value * 8}px`,
-    typography: {
-      pxToRem: (value: number) => `${value / 16}rem`,
-    },
-    palette: {
-      allShades: {
-        gray: {
-          50: '#fafafa',
-          100: '#f5f5f5',
-          600: '#757575',
-          900: '#212121',
-        },
-      },
-    },
-  }),
-}));
-
 jest.mock('@mui/icons-material', () => ({
   HelpOutlineIcon: jest
     .fn()
@@ -202,7 +176,8 @@ jest.mock('../../common/DescriptionSection/DescriptionSection', () => ({
             data-testid="update-description"
             onClick={async () => {
               await onDescriptionUpdate('Updated description');
-            }}>
+            }}
+          >
             Update Description
           </button>
         )}
@@ -229,7 +204,8 @@ jest.mock('../../common/TagsSection/TagsSection', () => ({
             } catch {
               // Error is handled by the component
             }
-          }}>
+          }}
+        >
           Update Tags
         </button>
       )}
@@ -256,7 +232,8 @@ jest.mock('../../common/GlossaryTermsSection/GlossaryTermsSection', () => ({
             } catch {
               // Error is handled by the component
             }
-          }}>
+          }}
+        >
           Update Glossary Terms
         </button>
       )}


### PR DESCRIPTION
## Summary

- Remove the `jest.mock('@mui/material/styles', ...)` block from `ColumnDetailPanel.test.tsx` that made the entire suite fail to load on `1.12.6`.
- The mock's `styled` implementation returned `jest.fn().mockImplementation(...)`. Jest mock functions are non-extensible, so when `@mui/x-tree-view/TreeItem` (pulled in transitively via `MUIAsyncTreeSelect -> MUIDomainSelect -> formUtils -> ... -> ColumnDetailPanel`) assigned `TreeItemCheckbox.displayName`, it threw `TypeError: Cannot add property displayName, object is not extensible`.

## Background

- The broken mock was introduced in #24268 (`feat(ui): implement column detail view`) and has always been latent.
- On `main` it was removed in #26396 during the MUI → UntitledUI migration. That PR wasn't backported to `1.12.6`, so this branch still carries the broken mock while also pulling in the x-tree-view chain via `formUtils`, which is what surfaces the error.
- This PR is the minimal targeted fix — just the 26-line mock block. No production-code changes.

## Test plan

- [x] `yarn test --testPathPattern=ColumnDetailPanel.test.tsx` → 16/16 pass locally
- [x] `eslint` on the modified file → clean
- [x] `tsc --noEmit` → no new errors
- [ ] CI `SonarCloud + Jest Coverage` workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)