### PR TITLE
MINOR: regression in export field setter

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DatabaseResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DatabaseResourceIT.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -35,6 +37,7 @@ import org.openmetadata.schema.type.ChangeDescription;
 import org.openmetadata.schema.type.Column;
 import org.openmetadata.schema.type.ColumnDataType;
 import org.openmetadata.schema.type.EntityHistory;
+import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.api.BulkOperationResult;
 import org.openmetadata.schema.type.csv.CsvImportResult;
 import org.openmetadata.sdk.client.OpenMetadataClient;
@@ -42,6 +45,7 @@ import org.openmetadata.sdk.exceptions.InvalidRequestException;
 import org.openmetadata.sdk.fluent.Databases;
 import org.openmetadata.sdk.models.ListParams;
 import org.openmetadata.sdk.models.ListResponse;
+import org.openmetadata.sdk.network.HttpMethod;
 import org.openmetadata.service.util.FullyQualifiedName;
 
 /**
@@ -1701,5 +1705,48 @@ public class DatabaseResourceIT extends BaseEntityIT<Database, CreateDatabase> {
     assertTrue(
         databases.stream().noneMatch(d -> d.getName().startsWith("temp")),
         "Excluded databases should not appear in results");
+  }
+
+  @Test
+  void test_listEntityHistoryByTimestamp_returnsServiceField(TestNamespace ns) throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    long startTs = System.currentTimeMillis();
+
+    CreateDatabase createRequest = createRequest(ns.prefix("history_service_field"), ns);
+    Database database = createEntity(createRequest);
+
+    database.setDescription("Updated for history test - " + System.currentTimeMillis());
+    patchEntity(database.getId().toString(), database);
+
+    long endTs = System.currentTimeMillis();
+    String basePath = getResourcePath() + "history";
+
+    String response =
+        client
+            .getHttpClient()
+            .executeForString(
+                HttpMethod.GET,
+                basePath + "?startTs=" + startTs + "&endTs=" + endTs + "&limit=10",
+                null);
+
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode result = mapper.readTree(response);
+    JsonNode data = result.get("data");
+
+    assertTrue(data.isArray(), "Data should be an array");
+    assertTrue(data.size() > 0, "Should have at least one version in the time range");
+
+    for (JsonNode entityNode : data) {
+      assertTrue(
+          entityNode.has("service") && !entityNode.get("service").isNull(),
+          "Each database version must include the required 'service' field, but got: "
+              + entityNode);
+
+      Database deserialized = mapper.treeToValue(entityNode, Database.class);
+      EntityReference service = deserialized.getService();
+      assertNotNull(service, "Deserialized database must have a non-null service reference");
+      assertNotNull(service.getId(), "Service reference must have an id");
+      assertNotNull(service.getType(), "Service reference must have a type");
+    }
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -2228,6 +2228,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
 
     List<T> entities = JsonUtils.readObjects(jsons, getEntityClass());
     setFieldsInBulk(putFields, entities);
+    hydrateHistoryEntities(entities);
 
     int total = getVersionCountCached(tableName, startTs, endTs, entityType);
 
@@ -2265,14 +2266,14 @@ public abstract class EntityRepository<T extends EntityInterface> {
   }
 
   /**
-   * Hook to hydrate entities returned from {@link #listEntityHistoryByTimestamp(long, long, String,
-   * String, int)}.
+   * Hook called after {@link #setFieldsInBulk} for entities returned from {@link
+   * #listEntityHistoryByTimestamp(long, long, String, String, int)}.
    *
-   * <p>Default behavior is intentionally lightweight: return the historical snapshots as stored in
-   * the extension table and avoid expensive relationship re-hydration for each row.
+   * <p>Subclasses may override to perform additional, entity-specific hydration of history
+   * snapshots without overriding the core field-population logic in {@code setFieldsInBulk}.
    */
   protected void hydrateHistoryEntities(List<T> entities) {
-    // Historical snapshots are already serialized versions; avoid N+1 hydration on /history.
+    // No additional hydration by default.
   }
 
   private String decodeAndValidateCursor(String cursor) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -2227,7 +2227,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
                 fetchLimit);
 
     List<T> entities = JsonUtils.readObjects(jsons, getEntityClass());
-    hydrateHistoryEntities(entities);
+    setFieldsInBulk(putFields, entities);
 
     int total = getVersionCountCached(tableName, startTs, endTs, entityType);
 


### PR DESCRIPTION
### Describe your changes:
Fix regression introduced in entity history where fields are not set anymore

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
