### PR TITLE
Feat: Entity auto registration in topology

### DIFF
--- a/ingestion/src/metadata/ingestion/api/topology_runner.py
+++ b/ingestion/src/metadata/ingestion/api/topology_runner.py
@@ -462,6 +462,11 @@ class TopologyRunnerMixin(Generic[C]):
             stage=stage, entity_name=entity_name
         )
 
+        if stage.source_state:
+            source_state_set = getattr(self, stage.source_state, None)
+            if source_state_set is not None:
+                source_state_set.add(entity_fqn)
+
         # If we don't want to write data in OM, we'll return what we fetch from the API.
         # This will be applicable for service entities since we do not want to overwrite the data
         same_fingerprint = False

--- a/ingestion/src/metadata/ingestion/models/topology.py
+++ b/ingestion/src/metadata/ingestion/models/topology.py
@@ -92,6 +92,13 @@ class NodeStage(BaseModel, Generic[T]):
         description="Enable this to get the entity from cached state in the context",
     )
 
+    # Source state tracking for mark-as-deleted
+    source_state: Optional[str] = Field(
+        None,
+        description="Attribute name on the source for tracking entity FQNs seen during ingestion. "
+        "Used by mark_*_as_deleted post-process to identify stale entities.",
+    )
+
 
 class TopologyNode(BaseModel):
     """

--- a/ingestion/src/metadata/ingestion/source/dashboard/dashboard_service.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/dashboard_service.py
@@ -142,6 +142,7 @@ class DashboardServiceTopology(ServiceTopology):
                 consumer=["dashboard_service"],
                 nullable=True,
                 use_cache=True,
+                source_state="datamodel_source_state",
             )
         ],
     )
@@ -174,6 +175,7 @@ class DashboardServiceTopology(ServiceTopology):
                 store_all_in_context=True,
                 clear_context=True,
                 use_cache=True,
+                source_state="datamodel_source_state",
             ),
             NodeStage(
                 type_=Dashboard,
@@ -181,6 +183,7 @@ class DashboardServiceTopology(ServiceTopology):
                 processor="yield_dashboard",
                 consumer=["dashboard_service"],
                 use_cache=True,
+                source_state="dashboard_source_state",
             ),
             NodeStage(
                 type_=AddLineageRequest,


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:


<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

### Auto-registration in the Topology Framework
Problem:
- Every connector must manually call self.register_record_*(request) after yield Either(right=request). If a connector forgets self.register_record_, mark_*_as_deleted sees an empty source state and soft-deletes every entity for that service.

Improvement:
- Add a source_state field to NodeStage that names the attribute on the source where FQNs should be collected. The topology runner auto-registers entity FQNs into this set after a successful yield — no connector code needed.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
