### PR TITLE
test(domains): fix flaky Rename domain with data products attached at domain and subdomain levels

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/domain.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/domain.ts
@@ -1626,7 +1626,9 @@ export const renameDomain = async (page: Page, newName: string) => {
   );
   await page.getByTestId('save-button').click();
   await patchRes;
-  await page.waitForURL((url) => url.pathname.includes(newName));
+  await page.waitForURL((url) =>
+    url.pathname.includes(encodeURIComponent(newName))
+  );
 
   const domainRes = page.waitForResponse('/api/v1/domains/name/*');
   await page.reload();

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/domain.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/domain.ts
@@ -1395,8 +1395,8 @@ export const verifyDataProductsCount = async (
         },
         {
           message: `Wait for data product search index to show ${expectedCount} results for domain "${domainFqn}"`,
-          timeout: 30_000,
-          intervals: [2_000, 3_000, 5_000],
+          timeout: 90_000,
+          intervals: [2_000, 3_000, 5_000, 5_000],
         }
       )
       .toEqual(expectedCount);
@@ -1621,6 +1621,7 @@ export const renameDomain = async (page: Page, newName: string) => {
   const patchRes = page.waitForResponse('/api/v1/domains/*');
   await page.getByTestId('save-button').click();
   await patchRes;
+  await page.waitForURL((url) => url.pathname.includes(newName));
 
   const domainRes = page.waitForResponse('/api/v1/domains/name/*');
   await page.reload();

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/domain.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/domain.ts
@@ -1395,8 +1395,8 @@ export const verifyDataProductsCount = async (
         },
         {
           message: `Wait for data product search index to show ${expectedCount} results for domain "${domainFqn}"`,
-          timeout: 90_000,
-          intervals: [2_000, 3_000, 5_000, 5_000],
+          timeout: 30_000,
+          intervals: [2_000, 3_000, 5_000],
         }
       )
       .toEqual(expectedCount);

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/domain.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/domain.ts
@@ -1618,7 +1618,12 @@ export const renameDomain = async (page: Page, newName: string) => {
   await page.locator('#name').clear();
   await page.locator('#name').fill(newName);
 
-  const patchRes = page.waitForResponse('/api/v1/domains/*');
+  const patchRes = page.waitForResponse(
+    (response) =>
+      response.url().includes('/api/v1/domains/') &&
+      response.request().method() === 'PATCH' &&
+      response.ok()
+  );
   await page.getByTestId('save-button').click();
   await patchRes;
   await page.waitForURL((url) => url.pathname.includes(newName));


### PR DESCRIPTION
## Summary

Stabilize `Domains › Rename domain with data products attached at domain and subdomain levels` (`playwright/e2e/Pages/Domains.spec.ts:1974`).

## Root cause

In `renameDomain` (`playwright/utils/domain.ts`), after the PATCH resolves we immediately call `page.reload()`. The app updates the browser URL to the new FQN asynchronously from React state, so under load the reload can fire while the URL is still the **old** FQN. That reload hits a 404, the app redirects to `/domain` list, and the subsequent `entity-header-name` assertion times out against an empty page.

Seen in CI run `24541920436/1130/1`: first attempt's screenshot shows "No data available" on the domains list at the moment `toContainText` failed (`Domains.spec.ts:2033`).

## Fix

Wait for the URL to reflect the new name before reloading:

```ts
await patchRes;
await page.waitForURL((url) => url.pathname.includes(newName));
```

## Note

There's a second flake surface in the same test — `verifyDataProductsCount` polls the data-product search index for 30s after rename and occasionally sees `0` where it expects `2` (the cascading reindex of `domains.fullyQualifiedName` on child data products is slow under CI load). That's a real backend-timing concern, not a test-logic race, and is left out of this PR intentionally. Worth tracking as a follow-up (either lift the poll budget or investigate whether the reindex cascade can be nudged).

## Test plan

- [ ] Run locally: `npx playwright test Domains.spec.ts -g "Rename domain with data products" --repeat-each=5 --workers=1`
- [ ] Confirm other `renameDomain` callers still pass (the helper change only adds a wait, doesn't remove any step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)