### PR TITLE
PR Title: Fixes #27345: Add usage count column to Classification tags table

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TagResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TagResourceIT.java
@@ -1070,6 +1070,82 @@ public class TagResourceIT extends BaseEntityIT<Tag, CreateTag> {
     }
   }
 
+  @Test
+  void test_tagUsageCountReflectsActualAssets(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    Classification classification = createClassification(ns);
+
+    CreateTag request = new CreateTag();
+    request.setName(ns.shortPrefix("usage_count_tag"));
+    request.setClassification(classification.getFullyQualifiedName());
+    request.setDescription("Tag for usage count verification");
+    Tag tag = createEntity(request);
+
+    Tag initialFetch = client.tags().get(tag.getId().toString(), "usageCount");
+    assertEquals(0, initialFetch.getUsageCount(), "Usage count must be 0 before applying tag");
+
+    org.openmetadata.schema.entity.services.DatabaseService dbService =
+        createDatabaseService(ns, "usage_count_svc");
+    org.openmetadata.schema.entity.data.Database database =
+        createDatabase(ns, dbService.getFullyQualifiedName());
+    org.openmetadata.schema.entity.data.DatabaseSchema schema =
+        createDatabaseSchema(ns, database.getFullyQualifiedName());
+
+    org.openmetadata.schema.type.TagLabel tagLabel =
+        new org.openmetadata.schema.type.TagLabel()
+            .withTagFQN(tag.getFullyQualifiedName())
+            .withSource(org.openmetadata.schema.type.TagLabel.TagSource.CLASSIFICATION)
+            .withLabelType(org.openmetadata.schema.type.TagLabel.LabelType.MANUAL);
+
+    org.openmetadata.schema.api.data.CreateTable createTable =
+        new org.openmetadata.schema.api.data.CreateTable();
+    createTable.setName(ns.shortPrefix("table_one"));
+    createTable.setDatabaseSchema(schema.getFullyQualifiedName());
+    createTable.setColumns(
+        List.of(
+            new org.openmetadata.schema.type.Column()
+                .withName("id")
+                .withDataType(org.openmetadata.schema.type.ColumnDataType.BIGINT)));
+    createTable.setTags(List.of(tagLabel));
+    SdkClients.adminClient().tables().create(createTable);
+
+    Tag afterOneAsset = client.tags().get(tag.getId().toString(), "usageCount");
+    assertEquals(1, afterOneAsset.getUsageCount(), "Usage count must be 1 after tagging one table");
+
+    org.openmetadata.schema.api.data.CreateTable createTable2 =
+        new org.openmetadata.schema.api.data.CreateTable();
+    createTable2.setName(ns.shortPrefix("table_two"));
+    createTable2.setDatabaseSchema(schema.getFullyQualifiedName());
+    createTable2.setColumns(
+        List.of(
+            new org.openmetadata.schema.type.Column()
+                .withName("id")
+                .withDataType(org.openmetadata.schema.type.ColumnDataType.BIGINT)));
+    createTable2.setTags(List.of(tagLabel));
+    SdkClients.adminClient().tables().create(createTable2);
+
+    Tag afterTwoAssets = client.tags().get(tag.getId().toString(), "usageCount");
+    assertEquals(
+        2, afterTwoAssets.getUsageCount(), "Usage count must be 2 after tagging two tables");
+
+    Tag fetchedViaList =
+        client
+            .tags()
+            .list(
+                new ListParams()
+                    .setFields("usageCount")
+                    .setParent(classification.getFullyQualifiedName()))
+            .getData()
+            .stream()
+            .filter(t -> t.getId().equals(tag.getId()))
+            .findFirst()
+            .orElseThrow();
+    assertEquals(
+        2,
+        fetchedViaList.getUsageCount(),
+        "Usage count in list response (batchFetchUsageCounts path) must match");
+  }
+
   private org.openmetadata.schema.entity.services.DatabaseService createDatabaseService(
       TestNamespace ns, String serviceName) {
     org.openmetadata.schema.api.services.CreateDatabaseService createService =

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TagRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TagRepository.java
@@ -743,8 +743,7 @@ public class TagRepository extends EntityRepository<Tag> {
 
     try {
       var results =
-          Entity.getJdbi()
-              .withHandle(handle -> handle.createQuery(query).mapToMap().list());
+          Entity.getJdbi().withHandle(handle -> handle.createQuery(query).mapToMap().list());
 
       return results.stream()
           .filter(row -> row.get("tagFQN") != null)

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TagRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TagRepository.java
@@ -710,15 +710,8 @@ public class TagRepository extends EntityRepository<Tag> {
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
-  private Map<String, Integer> batchFetchUsageCounts(List<Tag> tags) {
-    if (tags == null || tags.isEmpty()) {
-      return Map.of();
-    }
-
-    // Build and execute a single query for all tags
-    var tagFQNs = tags.stream().map(Tag::getFullyQualifiedName).toList();
-
-    // Build UNION query that gets counts for all tags in one go
+  // Package-private for testing
+  String buildUsageCountQuery(List<String> tagFQNs) {
     var queryBuilder = new StringBuilder();
     tagFQNs.forEach(
         tagFQN -> {
@@ -726,22 +719,32 @@ public class TagRepository extends EntityRepository<Tag> {
             queryBuilder.append(" UNION ALL ");
           }
           var escapedFQN = tagFQN.replace("'", "''");
+          var fqnHash = FullyQualifiedName.buildHash(tagFQN).replace("'", "''");
           queryBuilder.append(
               """
           SELECT '%s' as tagFQN,
           COUNT(DISTINCT targetFQNHash) as count
           FROM tag_usage
           WHERE source = %d
-          AND (tagFQNHash = MD5('%s') OR tagFQNHash LIKE CONCAT(MD5('%s'), '.%%'))
+          AND (tagFQNHash = '%s' OR tagFQNHash LIKE CONCAT('%s', '.%%'))
           """
-                  .formatted(
-                      escapedFQN, TagSource.CLASSIFICATION.ordinal(), escapedFQN, escapedFQN));
+                  .formatted(escapedFQN, TagSource.CLASSIFICATION.ordinal(), fqnHash, fqnHash));
         });
+    return queryBuilder.toString();
+  }
+
+  private Map<String, Integer> batchFetchUsageCounts(List<Tag> tags) {
+    if (tags == null || tags.isEmpty()) {
+      return Map.of();
+    }
+
+    var tagFQNs = tags.stream().map(Tag::getFullyQualifiedName).toList();
+    var query = buildUsageCountQuery(tagFQNs);
 
     try {
       var results =
           Entity.getJdbi()
-              .withHandle(handle -> handle.createQuery(queryBuilder.toString()).mapToMap().list());
+              .withHandle(handle -> handle.createQuery(query).mapToMap().list());
 
       return results.stream()
           .filter(row -> row.get("tagFQN") != null)

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TagRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TagRepository.java
@@ -710,27 +710,31 @@ public class TagRepository extends EntityRepository<Tag> {
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
+  record UsageCountQuery(String template, Map<String, Object> bindings) {}
+
   // Package-private for testing
-  String buildUsageCountQuery(List<String> tagFQNs) {
-    var queryBuilder = new StringBuilder();
-    tagFQNs.forEach(
-        tagFQN -> {
-          if (!queryBuilder.isEmpty()) {
-            queryBuilder.append(" UNION ALL ");
-          }
-          var escapedFQN = tagFQN.replace("'", "''");
-          var fqnHash = FullyQualifiedName.buildHash(tagFQN).replace("'", "''");
-          queryBuilder.append(
-              """
-          SELECT '%s' as tagFQN,
+  UsageCountQuery buildUsageCountQuery(List<String> tagFQNs) {
+    var sb = new StringBuilder();
+    Map<String, Object> bindings = new HashMap<>();
+    bindings.put("source", TagSource.CLASSIFICATION.ordinal());
+
+    for (int i = 0; i < tagFQNs.size(); i++) {
+      if (i > 0) {
+        sb.append(" UNION ALL ");
+      }
+      sb.append(
+          """
+          SELECT :tagFQN_%d as tagFQN,
           COUNT(DISTINCT targetFQNHash) as count
           FROM tag_usage
-          WHERE source = %d
-          AND (tagFQNHash = '%s' OR tagFQNHash LIKE CONCAT('%s', '.%%'))
+          WHERE source = :source
+          AND (tagFQNHash = :hash_%d OR tagFQNHash LIKE CONCAT(:hash_%d, '.%%'))
           """
-                  .formatted(escapedFQN, TagSource.CLASSIFICATION.ordinal(), fqnHash, fqnHash));
-        });
-    return queryBuilder.toString();
+              .formatted(i, i, i));
+      bindings.put("tagFQN_" + i, tagFQNs.get(i));
+      bindings.put("hash_" + i, FullyQualifiedName.buildHash(tagFQNs.get(i)));
+    }
+    return new UsageCountQuery(sb.toString(), Collections.unmodifiableMap(bindings));
   }
 
   private Map<String, Integer> batchFetchUsageCounts(List<Tag> tags) {
@@ -739,11 +743,17 @@ public class TagRepository extends EntityRepository<Tag> {
     }
 
     var tagFQNs = tags.stream().map(Tag::getFullyQualifiedName).toList();
-    var query = buildUsageCountQuery(tagFQNs);
 
     try {
+      var usageCountQuery = buildUsageCountQuery(tagFQNs);
       var results =
-          Entity.getJdbi().withHandle(handle -> handle.createQuery(query).mapToMap().list());
+          Entity.getJdbi()
+              .withHandle(
+                  handle -> {
+                    var query = handle.createQuery(usageCountQuery.template());
+                    usageCountQuery.bindings().forEach((k, v) -> query.bind(k, v.toString()));
+                    return query.mapToMap().list();
+                  });
 
       return results.stream()
           .filter(row -> row.get("tagFQN") != null)
@@ -756,7 +766,6 @@ public class TagRepository extends EntityRepository<Tag> {
                   }));
     } catch (Exception e) {
       LOG.error("Error batch fetching usage counts", e);
-      // Fall back to individual queries
       return daoCollection
           .tagUsageDAO()
           .getTagCountsBulk(TagSource.CLASSIFICATION.ordinal(), tagFQNs);

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/TagRepositoryUnitTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/TagRepositoryUnitTest.java
@@ -1,6 +1,7 @@
 package org.openmetadata.service.jdbi3;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -291,47 +292,59 @@ public class TagRepositoryUnitTest {
   }
 
   @Test
-  void test_usageCountQuery_containsCorrectHashNotRawFqn() {
+  void test_usageCountQuery_bindingsContainCorrectHashNotRawFqn() {
     String tagFqn = "PII.Sensitive";
-    String query = realTagRepository.buildUsageCountQuery(List.of(tagFqn));
+    TagRepository.UsageCountQuery result = realTagRepository.buildUsageCountQuery(List.of(tagFqn));
     String expectedHash = FullyQualifiedName.buildHash(tagFqn);
 
-    assertTrue(
-        query.contains(expectedHash), "Query must embed the buildHash result, not the raw FQN");
+    assertEquals(
+        expectedHash, result.bindings().get("hash_0"), "Binding hash_0 must use buildHash result");
     assertTrue(expectedHash.contains("."), "buildHash of a multi-segment FQN must contain '.'");
   }
 
   @Test
-  void test_usageCountQuery_doesNotContainRawFqnAsHash() {
+  void test_usageCountQuery_templateUsesNamedParams() {
     String tagFqn = "PII.Sensitive";
-    String query = realTagRepository.buildUsageCountQuery(List.of(tagFqn));
-
-    // The raw FQN appears once as the SELECT label — but must NOT appear inside tagFQNHash = '...'
-    // (which would be the broken MD5(fqn) pattern — a flat hash with no dot)
+    TagRepository.UsageCountQuery result = realTagRepository.buildUsageCountQuery(List.of(tagFqn));
+    String template = result.template();
     String expectedHash = FullyQualifiedName.buildHash(tagFqn);
-    String brokenPattern = "tagFQNHash = '" + tagFqn + "'";
-    assertTrue(!query.contains(brokenPattern), "Query must not use raw FQN as the hash value");
+
+    assertTrue(template.contains(":hash_0"), "Template must use named param :hash_0, not raw hash");
     assertTrue(
-        query.contains("tagFQNHash = '" + expectedHash + "'"),
-        "Query must use buildHash result for tagFQNHash comparison");
+        template.contains(":tagFQN_0"), "Template must use named param :tagFQN_0, not raw FQN");
+    assertFalse(
+        template.contains("tagFQNHash = '" + tagFqn + "'"),
+        "Template must not embed raw FQN as hash value");
+    assertFalse(
+        template.contains("tagFQNHash = '" + expectedHash + "'"),
+        "Template must use named params, not inline hash literals");
   }
 
   @Test
   void test_usageCountQuery_multipleTagsUnionAll() {
     List<String> tagFqns = List.of("PII.Sensitive", "PII.Personal", "Tier.Tier1");
-    String query = realTagRepository.buildUsageCountQuery(tagFqns);
+    TagRepository.UsageCountQuery result = realTagRepository.buildUsageCountQuery(tagFqns);
+    String template = result.template();
 
-    assertEquals(2, countOccurrences(query, "UNION ALL"), "3 tags must produce 2 UNION ALL joins");
-    for (String fqn : tagFqns) {
-      String hash = FullyQualifiedName.buildHash(fqn);
-      assertTrue(query.contains(hash), "Query must contain the correct hash for: " + fqn);
+    assertEquals(
+        2, countOccurrences(template, "UNION ALL"), "3 tags must produce 2 UNION ALL joins");
+    for (int i = 0; i < tagFqns.size(); i++) {
+      String expectedHash = FullyQualifiedName.buildHash(tagFqns.get(i));
+      assertEquals(
+          expectedHash,
+          result.bindings().get("hash_" + i),
+          "Binding hash_" + i + " must use buildHash result for: " + tagFqns.get(i));
+      assertEquals(
+          tagFqns.get(i),
+          result.bindings().get("tagFQN_" + i),
+          "Binding tagFQN_" + i + " must equal the original FQN");
     }
   }
 
   @Test
-  void test_usageCountQuery_emptyList_returnsEmptyString() {
-    String query = realTagRepository.buildUsageCountQuery(List.of());
-    assertTrue(query.isEmpty(), "Empty tag list must produce empty query string");
+  void test_usageCountQuery_emptyList_returnsEmptyTemplate() {
+    TagRepository.UsageCountQuery result = realTagRepository.buildUsageCountQuery(List.of());
+    assertTrue(result.template().isEmpty(), "Empty tag list must produce empty query template");
   }
 
   private static int countOccurrences(String text, String pattern) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/TagRepositoryUnitTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/TagRepositoryUnitTest.java
@@ -296,7 +296,8 @@ public class TagRepositoryUnitTest {
     String query = realTagRepository.buildUsageCountQuery(List.of(tagFqn));
     String expectedHash = FullyQualifiedName.buildHash(tagFqn);
 
-    assertTrue(query.contains(expectedHash), "Query must embed the buildHash result, not the raw FQN");
+    assertTrue(
+        query.contains(expectedHash), "Query must embed the buildHash result, not the raw FQN");
     assertTrue(expectedHash.contains("."), "buildHash of a multi-segment FQN must contain '.'");
   }
 
@@ -310,7 +311,9 @@ public class TagRepositoryUnitTest {
     String expectedHash = FullyQualifiedName.buildHash(tagFqn);
     String brokenPattern = "tagFQNHash = '" + tagFqn + "'";
     assertTrue(!query.contains(brokenPattern), "Query must not use raw FQN as the hash value");
-    assertTrue(query.contains("tagFQNHash = '" + expectedHash + "'"), "Query must use buildHash result for tagFQNHash comparison");
+    assertTrue(
+        query.contains("tagFQNHash = '" + expectedHash + "'"),
+        "Query must use buildHash result for tagFQNHash comparison");
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/TagRepositoryUnitTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/TagRepositoryUnitTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import java.nio.charset.StandardCharsets;
@@ -19,6 +20,7 @@ import org.openmetadata.schema.type.PredefinedRecognizer;
 import org.openmetadata.schema.type.Recognizer;
 import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.service.exception.BadCursorException;
+import org.openmetadata.service.util.FullyQualifiedName;
 
 public class TagRepositoryUnitTest {
   private static final TagRepository tagRepository;
@@ -267,6 +269,76 @@ public class TagRepositoryUnitTest {
     assertEquals(tag.getRecognizers().get(29), thirdPage.getData().get(9));
     assertNotNull(thirdPage.getPaging().getBefore());
     assertNull(thirdPage.getPaging().getAfter());
+  }
+
+  // ===================================================================
+  // USAGE COUNT QUERY TESTS — verifies batchFetchUsageCounts uses correct hash
+  //
+  // tag_usage.tagFQNHash stores hashes produced by FullyQualifiedName.buildHash:
+  // each FQN segment is hashed individually and joined with ".".
+  // e.g. "PII.Sensitive" → hash("PII") + "." + hash("Sensitive")
+  //
+  // The original bug used MySQL's MD5(fullFqnString) directly in the SQL, which
+  // computes MD5("PII.Sensitive") — a flat 32-char hex string that never matches
+  // any row, returning usageCount = 0 for every tag.
+  // ===================================================================
+
+  private static final TagRepository realTagRepository;
+
+  static {
+    realTagRepository = Mockito.mock(TagRepository.class);
+    when(realTagRepository.buildUsageCountQuery(Mockito.anyList())).thenCallRealMethod();
+  }
+
+  @Test
+  void test_usageCountQuery_containsCorrectHashNotRawFqn() {
+    String tagFqn = "PII.Sensitive";
+    String query = realTagRepository.buildUsageCountQuery(List.of(tagFqn));
+    String expectedHash = FullyQualifiedName.buildHash(tagFqn);
+
+    assertTrue(query.contains(expectedHash), "Query must embed the buildHash result, not the raw FQN");
+    assertTrue(expectedHash.contains("."), "buildHash of a multi-segment FQN must contain '.'");
+  }
+
+  @Test
+  void test_usageCountQuery_doesNotContainRawFqnAsHash() {
+    String tagFqn = "PII.Sensitive";
+    String query = realTagRepository.buildUsageCountQuery(List.of(tagFqn));
+
+    // The raw FQN appears once as the SELECT label — but must NOT appear inside tagFQNHash = '...'
+    // (which would be the broken MD5(fqn) pattern — a flat hash with no dot)
+    String expectedHash = FullyQualifiedName.buildHash(tagFqn);
+    String brokenPattern = "tagFQNHash = '" + tagFqn + "'";
+    assertTrue(!query.contains(brokenPattern), "Query must not use raw FQN as the hash value");
+    assertTrue(query.contains("tagFQNHash = '" + expectedHash + "'"), "Query must use buildHash result for tagFQNHash comparison");
+  }
+
+  @Test
+  void test_usageCountQuery_multipleTagsUnionAll() {
+    List<String> tagFqns = List.of("PII.Sensitive", "PII.Personal", "Tier.Tier1");
+    String query = realTagRepository.buildUsageCountQuery(tagFqns);
+
+    assertEquals(2, countOccurrences(query, "UNION ALL"), "3 tags must produce 2 UNION ALL joins");
+    for (String fqn : tagFqns) {
+      String hash = FullyQualifiedName.buildHash(fqn);
+      assertTrue(query.contains(hash), "Query must contain the correct hash for: " + fqn);
+    }
+  }
+
+  @Test
+  void test_usageCountQuery_emptyList_returnsEmptyString() {
+    String query = realTagRepository.buildUsageCountQuery(List.of());
+    assertTrue(query.isEmpty(), "Empty tag list must produce empty query string");
+  }
+
+  private static int countOccurrences(String text, String pattern) {
+    int count = 0;
+    int idx = 0;
+    while ((idx = text.indexOf(pattern, idx)) != -1) {
+      count++;
+      idx += pattern.length();
+    }
+    return count;
   }
 
   @Test

--- a/openmetadata-ui/src/main/resources/ui/src/components/Classifications/ClassificationDetails/ClassificationDetails.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Classifications/ClassificationDetails/ClassificationDetails.test.tsx
@@ -677,7 +677,10 @@ describe('ClassificationDetails', () => {
         usageCount: 5,
       },
     ];
-    mockGetTags.mockResolvedValueOnce({ data: tagsWithUsage, paging: { total: 1 } });
+    mockGetTags.mockResolvedValueOnce({
+      data: tagsWithUsage,
+      paging: { total: 1 },
+    });
 
     render(
       <MemoryRouter>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Classifications/ClassificationDetails/ClassificationDetails.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Classifications/ClassificationDetails/ClassificationDetails.test.tsx
@@ -648,4 +648,51 @@ describe('ClassificationDetails', () => {
     expect(screen.getByTestId('header')).toBeInTheDocument();
     expect(screen.getByTestId('tags-table')).toBeInTheDocument();
   });
+
+  it('should fetch tags with usageCount field included', async () => {
+    render(
+      <MemoryRouter>
+        <ClassificationDetails {...defaultProps} />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(mockGetTags).toHaveBeenCalled());
+
+    expect(mockGetTags).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fields: expect.stringContaining('usageCount'),
+      })
+    );
+  });
+
+  it('should show usageCount in the table when tags have asset counts', async () => {
+    const tagsWithUsage: Tag[] = [
+      {
+        id: 'tag-3',
+        name: 'Tag3',
+        displayName: 'Tag Three',
+        description: 'Third tag',
+        fullyQualifiedName: 'TestClassification.Tag3',
+        provider: ProviderType.User,
+        usageCount: 5,
+      },
+    ];
+    mockGetTags.mockResolvedValueOnce({ data: tagsWithUsage, paging: { total: 1 } });
+
+    render(
+      <MemoryRouter>
+        <ClassificationDetails {...defaultProps} />
+      </MemoryRouter>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('tag-row-Tag3')).toBeInTheDocument()
+    );
+
+    expect(mockGetTags).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fields: expect.stringContaining('usageCount'),
+      })
+    );
+  });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ClassificationUtils.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ClassificationUtils.test.tsx
@@ -12,8 +12,8 @@
  */
 
 import React from 'react';
-import { EntityField } from '../constants/Feeds.constants';
 import { NO_DATA_PLACEHOLDER } from '../constants/constants';
+import { EntityField } from '../constants/Feeds.constants';
 import { ProviderType } from '../generated/entity/bot';
 import { Classification } from '../generated/entity/classification/classification';
 import { Tag } from '../generated/entity/classification/tag';
@@ -439,7 +439,13 @@ describe('ClassificationUtils', () => {
       const columns = getCommonColumns();
       const usageCountCol = columns.find(
         (col) => (col as { key?: string }).key === 'usageCount'
-      ) as { render?: (val: number, record: Tag, index: number) => React.ReactElement };
+      ) as {
+        render?: (
+          val: number,
+          record: Tag,
+          index: number
+        ) => React.ReactElement;
+      };
 
       const element = usageCountCol.render?.(42, mockTag, 0);
 
@@ -450,7 +456,13 @@ describe('ClassificationUtils', () => {
       const columns = getCommonColumns();
       const usageCountCol = columns.find(
         (col) => (col as { key?: string }).key === 'usageCount'
-      ) as { render?: (val: number, record: Tag, index: number) => React.ReactElement };
+      ) as {
+        render?: (
+          val: number,
+          record: Tag,
+          index: number
+        ) => React.ReactElement;
+      };
 
       const element = usageCountCol.render?.(0, mockTag, 0);
 
@@ -461,7 +473,13 @@ describe('ClassificationUtils', () => {
       const columns = getCommonColumns();
       const usageCountCol = columns.find(
         (col) => (col as { key?: string }).key === 'usageCount'
-      ) as { render?: (val: number, record: Tag, index: number) => React.ReactElement };
+      ) as {
+        render?: (
+          val: number,
+          record: Tag,
+          index: number
+        ) => React.ReactElement;
+      };
 
       const element = usageCountCol.render?.(
         undefined as unknown as number,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ClassificationUtils.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ClassificationUtils.test.tsx
@@ -11,16 +11,49 @@
  *  limitations under the License.
  */
 
+import React from 'react';
 import { EntityField } from '../constants/Feeds.constants';
+import { NO_DATA_PLACEHOLDER } from '../constants/constants';
 import { ProviderType } from '../generated/entity/bot';
 import { Classification } from '../generated/entity/classification/classification';
+import { Tag } from '../generated/entity/classification/tag';
 import { ChangeDescription } from '../generated/entity/type';
-import { getClassificationInfo } from './ClassificationUtils';
+import { getClassificationInfo, getCommonColumns } from './ClassificationUtils';
 import { getEntityVersionByField } from './EntityVersionUtils';
 
-// Mock dependencies
 jest.mock('./EntityVersionUtils', () => ({
   getEntityVersionByField: jest.fn(),
+}));
+
+jest.mock('./i18next/LocalUtil', () => ({
+  t: (key: string) => key,
+}));
+
+jest.mock('./TableColumn.util', () => ({
+  descriptionTableObject: jest.fn(() => [
+    { key: 'description', dataIndex: 'description' },
+  ]),
+}));
+
+jest.mock('./IconUtils', () => ({
+  renderIcon: jest.fn(() => null),
+}));
+
+jest.mock('./RouterUtils', () => ({
+  getClassificationTagPath: jest.fn((fqn: string) => `/tags/${fqn}`),
+  getExplorePath: jest.fn(() => '/explore'),
+}));
+
+jest.mock('./TagsUtils', () => ({
+  getDeleteIcon: jest.fn(() => null),
+}));
+
+jest.mock('@openmetadata/ui-core-components', () => ({
+  Toggle: jest.fn(() => null),
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
 }));
 
 const mockGetEntityVersionByField =
@@ -369,6 +402,74 @@ describe('ClassificationUtils', () => {
         expect(mockGetEntityVersionByField).not.toHaveBeenCalled();
         expect(result.name).toBe('TestClassification');
       });
+    });
+  });
+
+  describe('getCommonColumns', () => {
+    const mockTag: Tag = {
+      id: 'tag-1',
+      name: 'TestTag',
+      description: 'Test tag description',
+      fullyQualifiedName: 'TestClassification.TestTag',
+      provider: ProviderType.User,
+    };
+
+    it('should include usageCount column', () => {
+      const columns = getCommonColumns();
+      const keys = columns.map((col) => (col as { key?: string }).key);
+
+      expect(keys).toContain('usageCount');
+    });
+
+    it('usageCount column should have correct configuration', () => {
+      const columns = getCommonColumns();
+      const usageCountCol = columns.find(
+        (col) => (col as { key?: string }).key === 'usageCount'
+      );
+
+      expect(usageCountCol).toMatchObject({
+        dataIndex: 'usageCount',
+        key: 'usageCount',
+        width: 100,
+        align: 'center',
+      });
+    });
+
+    it('usageCount render should display the count when provided', () => {
+      const columns = getCommonColumns();
+      const usageCountCol = columns.find(
+        (col) => (col as { key?: string }).key === 'usageCount'
+      ) as { render?: (val: number, record: Tag, index: number) => React.ReactElement };
+
+      const element = usageCountCol.render?.(42, mockTag, 0);
+
+      expect(element?.props.children).toBe(42);
+    });
+
+    it('usageCount render should display 0 when usageCount is 0', () => {
+      const columns = getCommonColumns();
+      const usageCountCol = columns.find(
+        (col) => (col as { key?: string }).key === 'usageCount'
+      ) as { render?: (val: number, record: Tag, index: number) => React.ReactElement };
+
+      const element = usageCountCol.render?.(0, mockTag, 0);
+
+      expect(element?.props.children).toBe(0);
+    });
+
+    it('usageCount render should display placeholder when usageCount is undefined', () => {
+      const columns = getCommonColumns();
+      const usageCountCol = columns.find(
+        (col) => (col as { key?: string }).key === 'usageCount'
+      ) as { render?: (val: number, record: Tag, index: number) => React.ReactElement };
+
+      const element = usageCountCol.render?.(
+        undefined as unknown as number,
+        mockTag,
+        0
+      );
+
+      expect(element?.props.children).toBe(NO_DATA_PLACEHOLDER);
     });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ClassificationUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ClassificationUtils.tsx
@@ -145,9 +145,7 @@ export const getCommonColumns = (options?: {
       width: 100,
       align: 'center',
       render: (usageCount: number) => (
-        <Typography.Text>
-          {usageCount ?? NO_DATA_PLACEHOLDER}
-        </Typography.Text>
+        <Typography.Text>{usageCount ?? NO_DATA_PLACEHOLDER}</Typography.Text>
       ),
     }
   );

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ClassificationUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ClassificationUtils.tsx
@@ -137,7 +137,19 @@ export const getCommonColumns = (options?: {
         <Typography.Text>{text || NO_DATA_PLACEHOLDER}</Typography.Text>
       ),
     },
-    ...descriptionTableObject<Tag>({ width: 300 })
+    ...descriptionTableObject<Tag>({ width: 300 }),
+    {
+      title: t('label.asset-plural'),
+      dataIndex: 'usageCount',
+      key: 'usageCount',
+      width: 100,
+      align: 'center',
+      render: (usageCount: number) => (
+        <Typography.Text>
+          {usageCount ?? NO_DATA_PLACEHOLDER}
+        </Typography.Text>
+      ),
+    }
   );
 
   return columns;


### PR DESCRIPTION
  Fixes #27345
                                                                                                                                              
  Added a new "Assets" (usage count) column to the common columns in ClassificationUtils.tsx. This column displays the usageCount field for   
  each tag, showing how many assets are associated with a given classification tag. The column falls back to the NO_DATA_PLACEHOLDER when the 
  value is null/undefined.                                                                                                                    
                                                                                                                                            
  I worked on this because the tags table was missing visibility into how many assets reference each tag, which is useful for understanding   
  tag adoption and cleaning up unused tags.
                                                                                                                                              
  ---                                                                                                                                       
  Type of change:
  - Improvement

  ---
  Checklist:
  - I have read the CONTRIBUTING document.
  - My PR title is Fixes #27345: Add usage count column to Classification tags table
  - I have commented on my code, particularly in hard-to-understand areas.          
  - For JSON Schema changes: I updated the migration scripts or explained why it is not needed.                                               
   
  Improvement checklist:                                                                                                                      
  - I have added tests around the new logic.                                                                                                
  - For connector/ingestion changes: I updated the documentation.                                                                             
                                                                                                                                            
  ---                                                                                                                                         
  Screenshot/Preview: (please add a screenshot of the tags table showing the new "Assets" column)
                                                                                                                                              
  ---                                                                                                                                       
  Files changed:                                                                                                                              
  - openmetadata-ui/src/main/resources/ui/src/utils/ClassificationUtils.tsx — Added usageCount column rendering in getCommonColumns()       

image -
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/bb65c14a-7e0a-4d5f-82d7-6c800c785de7" />

----
## Summary by Gitar

- **Database security:**
  - Refactored `buildUsageCountQuery` in `TagRepository` to use parameterized SQL queries, effectively mitigating potential SQL injection risks.
- **Testing:**
  - Updated `TagRepositoryUnitTest` to validate the new parameter binding structure, ensuring correct usage of hashes and named parameters instead of literal string concatenation.

<sub>This will update automatically on new commits.</sub>