### PR TITLE
feat(queryRunner): raise maxResultSize upper bound to 10000

### DIFF
--- a/openmetadata-spec/src/main/resources/json/schema/entity/automations/queryRunnerRequest.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/automations/queryRunnerRequest.json
@@ -58,7 +58,7 @@
       "description": "RUNTIME FIELD - Automatically injected by backend from admin QueryRunnerConfig.querySettings.maxResultSize. This is NOT user-configurable in the request. The backend fetches this value from the service's QueryRunnerConfig and injects it here for enforcement by the Python workflow. If query has LIMIT exceeding this value, an error is raised. If query has no LIMIT, one is automatically injected.",
       "type": "integer",
       "minimum": 1,
-      "maximum": 50000,
+      "maximum": 10000,
       "default": null
     },
     "credentialSourceType": {

--- a/openmetadata-spec/src/main/resources/json/schema/entity/automations/queryRunnerRequest.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/automations/queryRunnerRequest.json
@@ -58,7 +58,7 @@
       "description": "RUNTIME FIELD - Automatically injected by backend from admin QueryRunnerConfig.querySettings.maxResultSize. This is NOT user-configurable in the request. The backend fetches this value from the service's QueryRunnerConfig and injects it here for enforcement by the Python workflow. If query has LIMIT exceeding this value, an error is raised. If query has no LIMIT, one is automatically injected.",
       "type": "integer",
       "minimum": 1,
-      "maximum": 100000,
+      "maximum": 50000,
       "default": null
     },
     "credentialSourceType": {

--- a/openmetadata-spec/src/main/resources/json/schema/entity/automations/queryRunnerRequest.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/automations/queryRunnerRequest.json
@@ -58,7 +58,7 @@
       "description": "RUNTIME FIELD - Automatically injected by backend from admin QueryRunnerConfig.querySettings.maxResultSize. This is NOT user-configurable in the request. The backend fetches this value from the service's QueryRunnerConfig and injects it here for enforcement by the Python workflow. If query has LIMIT exceeding this value, an error is raised. If query has no LIMIT, one is automatically injected.",
       "type": "integer",
       "minimum": 1,
-      "maximum": 1000,
+      "maximum": 100000,
       "default": null
     },
     "credentialSourceType": {


### PR DESCRIPTION
fixes https://github.com/open-metadata/ai-platform/issues/555

## Summary

- Raises `QueryRunnerRequest.maxResultSize` schema maximum from `1000` to `10000`.
- Default (`100` on the companion Collate config) and minimum (`1`) unchanged.
- No code changes — enforcement in the Python workflow (`query_runner_utils.validate_and_enforce_query_limit`) and backend injection from `QueryRunnerConfig.querySettings.maxResultSize` already respect whatever integer the schema allows.

## Motivation

The previous `1000` cap forced admins to pick a conservative row ceiling for Query Runner / SQL Studio executions even when their ingestion runner could comfortably return larger result sets. Widening the maximum to `10000` gives operators a meaningful, conservative bump while keeping payload sizes predictable through the batch workflow transport (Argo response → REST body → UI/LLM).

## Why this schema matters (and why Collate needs a matching PR)

The Query Runner feature has its ceiling enforced at two schema boundaries:

| Schema | Repo | Role |
|---|---|---|
| `QueryRunnerConfig.querySettings.maxResultSize` | Collate (entity) | Persistent admin config — stored in the DB, set via the config form, has a default |
| `QueryRunnerRequest.maxResultSize` (this PR) | OSS (automations) | Ephemeral workflow trigger payload — built per-execution, carries the value into the Python runner, discarded after |

The field appears in both because the Python runner doesn't read the Collate DB — the value has to be packed into the OSS-owned `automations` request envelope for the generic runner to consume it. Bounds in both are defense-in-depth: widening only one doesn't help — injection would still be capped by the other.

So this OSS PR is the transport-side half. The Collate-side PR raises the admin-config ceiling and updates the help docs: https://github.com/open-metadata/openmetadata-collate/pull/3696

Both need to merge for the higher ceiling to be usable end-to-end.

## Test plan

- [ ] `mvn -pl openmetadata-spec clean install` regenerates the Java model with the new bound.
- [ ] `make generate` regenerates the Pydantic model and `QueryRunnerRequest(maxResultSize=10000)` validates; `QueryRunnerRequest(maxResultSize=10001)` fails with a validation error.
- [ ] Admin UI form (on Collate after the companion merge) accepts `maxResultSize` values up to `10000` without client-side rejection.
- [ ] Query Runner end-to-end: configure a service with `maxResultSize = 5000`, execute a query without `LIMIT`, verify the Python workflow injects `LIMIT 5000` and returns successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)