### PR TITLE
fix: remove /latest/ from METRICS_DOCS URL to fix 404

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/utils/DocumentationLinksClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DocumentationLinksClassBase.ts
@@ -64,7 +64,7 @@ class DocumentationLinksClassBase {
       COLLATE_AI_WIDGET_DOCS: `${this.docsBaseURL}how-to-guides/data-insights/service-insights#generated-data-with-collate-ai-collate-only`,
       MOST_USED_ASSETS_WIDGET_DOCS: `${this.docsBaseURL}how-to-guides/data-insights/service-insights#most-used-assets`,
       MOST_EXPENSIVE_QUERIES_WIDGET_DOCS: `${this.docsBaseURL}how-to-guides/data-insights/service-insights#most-expensive-queries`,
-      METRICS_DOCS: `${this.docsBaseURL}latest/how-to-guides/data-governance/metrics`,
+      METRICS_DOCS: `${this.docsBaseURL}how-to-guides/data-governance/metrics`,
     };
   }
 }


### PR DESCRIPTION
## Summary

**Issue:** Governance -> Metrics page docs link returns 404 (#27436)

**Root Cause:** `METRICS_DOCS` URL used `/latest/` path segment while all other doc links in `DocumentationLinksClassBase.ts` use direct paths without `/latest/`.

**Fix:** Removed `/latest/` from `METRICS_DOCS`:
- Before: `https://docs.open-metadata.org/latest/how-to-guides/data-governance/metrics`
- After: `https://docs.open-metadata.org/how-to-guides/data-governance/metrics`

Fixes: open-metadata/OpenMetadata#27436