### PR TITLE
fix(workflows): skip PipelineServiceClient initialization during migrate

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/WorkflowHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/WorkflowHandler.java
@@ -95,7 +95,9 @@ public class WorkflowHandler {
       processEngineConfiguration.setDatabaseType(ProcessEngineConfiguration.DATABASE_TYPE_POSTGRES);
     }
 
-    initializeExpressionMap(config);
+    if (!isMigrationContext) {
+      initializeExpressionMap(config);
+    }
     initializeNewProcessEngine(processEngineConfiguration);
   }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/governance/workflows/WorkflowHandlerSchemaUpdateTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/governance/workflows/WorkflowHandlerSchemaUpdateTest.java
@@ -13,6 +13,7 @@
 
 package org.openmetadata.service.governance.workflows;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -83,6 +84,31 @@ class WorkflowHandlerSchemaUpdateTest {
 
       assertTrue(ex.getMessage().contains("openmetadata-ops.sh migrate"));
       assertInstanceOf(FlowableWrongDbException.class, ex.getCause());
+    }
+  }
+
+  @Test
+  void migrationModeDoesNotLoadPipelineServiceClient() {
+    ProcessEngine mockEngine = mock(ProcessEngine.class, RETURNS_DEEP_STUBS);
+
+    try (MockedConstruction<StandaloneProcessEngineConfiguration> ignored =
+            mockConstruction(
+                StandaloneProcessEngineConfiguration.class,
+                (mock, ctx) -> when(mock.buildProcessEngine()).thenReturn(mockEngine));
+        MockedStatic<ProcessEngines> ignoredEngines = mockStatic(ProcessEngines.class);
+        MockedStatic<Entity> entityMock = mockStatic(Entity.class);
+        MockedStatic<PipelineServiceClientFactory> pscMock =
+            mockStatic(PipelineServiceClientFactory.class)) {
+
+      setupEntityMock(entityMock);
+      pscMock
+          .when(() -> PipelineServiceClientFactory.createPipelineServiceClient(any()))
+          .thenThrow(new RuntimeException("pipeline client class not on classpath"));
+
+      assertDoesNotThrow(() -> WorkflowHandler.initialize(buildMockConfig(), true));
+      pscMock.verify(
+          () -> PipelineServiceClientFactory.createPipelineServiceClient(any()),
+          org.mockito.Mockito.never());
     }
   }
 


### PR DESCRIPTION
## Why this change is needed

OpenMetadata uses Flowable as its BPMN workflow engine, which manages its own set of database tables (ACT_RE_*, ACT_HI_*, etc.) completely separate from the Flyway-managed schema.

Before PR #27234, the webserver initialized WorkflowHandler with DB_SCHEMA_UPDATE_TRUE, which meant Flowable ran its DDL (CREATE TABLE, CREATE INDEX, etc.) every time the server started. If the server crashed mid-startup while DDL was half-complete, some tables would be partially created. On the next restart, Flowable would try to run the same DDL again and blow up on "table already exists" errors, leaving the server unable to start at all.

PR #27234 fixed this in three steps. First, it moved the webserver to DB_SCHEMA_UPDATE_FALSE so Flowable never runs DDL at server startup. Second, it moved Flowable schema initialization into the migrate CLI, which is already the designated place for all database schema work. Third, it wrapped Flowable's DDL in an idempotent layer so that re-running migrate would not fail if the schema was already partially applied.

## What the regression was

The migrate CLI now calls WorkflowHandler.initialize(config, true). The WorkflowHandler constructor, regardless of whether it is running in migration or runtime mode, was unconditionally calling initializeExpressionMap, which builds two objects: an IngestionPipelineMapper and a PipelineServiceClient. The PipelineServiceClient is created via reflection using the class name from config.

In the Collate CI environment, the configured PipelineServiceClient class (io.getcollate.clients.pipeline.argo.ArgoServiceClient) is not available on the migrate container's classpath. This caused a ClassNotFoundException wrapped in a PipelineServiceClientException, which propagated out of the migrate command and caused it to exit with code 1. The Flowable schema itself was never the problem and the data migrations had already completed successfully at that point.

## What the fix does

The PipelineServiceClient and IngestionPipelineMapper are only needed at workflow execution time, when Flowable resolves BPMN expression variables like ${PipelineServiceClient} in task definitions. During migration, WorkflowHandler only needs to run Flowable's DDL upgrade and then shut down. No BPMN is ever executed.

The fix guards initializeExpressionMap with if (!isMigrationContext) so that in migration mode the expression map is simply left empty. An empty expression map produces a valid DefaultExpressionManager that Flowable accepts without complaint. The schema upgrade runs and completes, and the migrate command exits cleanly.

This follows the same pattern already used elsewhere in the constructor where isMigrationContext controls setAsyncExecutorActivate and setEnableHistoryCleaning.

## How to reproduce before this fix

```bash
cd /path/to/OpenMetadata
docker compose -f docker/development/docker-compose.yml build --no-cache execute-migrate-all
docker compose -f docker/development/docker-compose.yml up -d mysql
docker rm execute_migrate_all 2>/dev/null
export PIPELINE_SERVICE_CLIENT_CLASS_NAME=io.getcollate.clients.pipeline.argo.ArgoServiceClient
docker compose -f docker/development/docker-compose.yml up execute-migrate-all
```

You will see "Running Flowable schema upgrade." followed immediately by the PipelineServiceClientException and exit code 1. After the fix the same command completes with exit code 0.

## Test coverage

A new test migrationModeDoesNotLoadPipelineServiceClient was added to WorkflowHandlerSchemaUpdateTest. It configures PipelineServiceClientFactory to throw a RuntimeException simulating a missing class, then calls WorkflowHandler.initialize(config, true) and asserts that it completes without throwing and that createPipelineServiceClient was never called.