### PR TITLE
ISSUE-26552: Add support for UDF ingestion in BigQuery stored procedures

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/bigquery/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/bigquery/queries.py
@@ -101,7 +101,7 @@ SELECT
   routine_definition as definition,
   external_language as language
 FROM `{database_name}`.`{schema_name}`.INFORMATION_SCHEMA.ROUTINES
-WHERE routine_type in ('PROCEDURE', 'TABLE FUNCTION')
+WHERE routine_type in ('PROCEDURE', 'TABLE FUNCTION', 'FUNCTION')
   AND routine_catalog = '{database_name}'
   AND routine_schema = '{schema_name}'
     """
@@ -114,7 +114,7 @@ SELECT
   routine_definition as definition,
   external_language as language
 FROM `{database_name}`.`region-{region}`.INFORMATION_SCHEMA.ROUTINES
-WHERE routine_type in ('PROCEDURE', 'TABLE FUNCTION')
+WHERE routine_type in ('PROCEDURE', 'TABLE FUNCTION', 'FUNCTION')
   AND routine_catalog = '{database_name}'
   AND routine_schema = '{schema_name}'
     """

--- a/ingestion/tests/unit/topology/database/test_bigquery.py
+++ b/ingestion/tests/unit/topology/database/test_bigquery.py
@@ -56,6 +56,10 @@ from metadata.ingestion.api.parser import parse_workflow_config_gracefully
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.database.bigquery.lineage import BigqueryLineageSource
 from metadata.ingestion.source.database.bigquery.metadata import BigquerySource
+from metadata.ingestion.source.database.bigquery.queries import (
+    BIGQUERY_GET_STORED_PROCEDURES,
+    BIGQUERY_GET_STORED_PROCEDURES_BY_REGION,
+)
 
 mock_bq_config = {
     "source": {
@@ -663,6 +667,63 @@ class BigqueryUnitTest(TestCase):
 
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].name, "sp_include")
+
+    def test_stored_procedures_queries_include_function_routine_type(self):
+        """
+        BigQuery routines include user-defined FUNCTIONs in addition to
+        PROCEDURE and TABLE FUNCTION. Both query constants must filter on
+        all three routine_types so user-defined functions are ingested.
+        """
+        for query in (
+            BIGQUERY_GET_STORED_PROCEDURES,
+            BIGQUERY_GET_STORED_PROCEDURES_BY_REGION,
+        ):
+            assert "'PROCEDURE'" in query
+            assert "'TABLE FUNCTION'" in query
+            assert "'FUNCTION'" in query
+
+    def test_get_stored_procedures_ingests_user_defined_functions(self):
+        """
+        User-defined functions (routine_type = FUNCTION) returned by the
+        INFORMATION_SCHEMA.ROUTINES query are yielded alongside procedures
+        and table functions.
+        """
+        self.bq_source.source_config.includeStoredProcedures = True
+        self.bq_source.source_config.storedProcedureFilterPattern = None
+        self.bq_source.context.get().__dict__["database"] = MOCK_DB_NAME
+        self.bq_source.context.get().__dict__[
+            "database_schema"
+        ] = MOCK_DATABASE_SCHEMA.name.root
+
+        proc_row = {"name": "my_proc", "definition": "BEGIN END", "language": "SQL"}
+        table_fn_row = {
+            "name": "my_table_fn",
+            "definition": "SELECT 1",
+            "language": "SQL",
+        }
+        udf_row = {
+            "name": "my_udf",
+            "definition": "RETURN x + 1",
+            "language": "SQL",
+        }
+
+        mock_engine = MagicMock()
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.all.return_value = [
+            proc_row,
+            table_fn_row,
+            udf_row,
+        ]
+        mock_engine.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+        self.bq_source.engine = mock_engine
+
+        results = list(self.bq_source.get_stored_procedures())
+
+        names = {r.name for r in results}
+        assert names == {"my_proc", "my_table_fn", "my_udf"}
+        query_str = str(mock_conn.execute.call_args[0][0])
+        assert "'FUNCTION'" in query_str
 
     @patch("metadata.utils.credentials.auth.default")
     def test_usage_location_passed_to_client_and_engine(self, mock_auth_default):


### PR DESCRIPTION
## Describe your changes

BigQuery's `INFORMATION_SCHEMA.ROUTINES` view exposes three `routine_type` values: `PROCEDURE`, `TABLE FUNCTION`, and `FUNCTION` (user-defined functions / UDFs). The stored procedure ingestion query was filtering on only `PROCEDURE` and `TABLE FUNCTION`, so UDFs — which many BigQuery users rely on heavily — were silently skipped.

This PR adds `'FUNCTION'` to the `routine_type` filter in both the dataset-scoped and region-scoped stored procedure queries, so user-defined functions are ingested alongside procedures and table functions.

This is the dataset that I used for testing
```
CREATE OR REPLACE FUNCTION my_dataset.get_loyalty_tier(
  total_spend FLOAT64,
  tenure_months INT64
)
RETURNS STRING
AS (
  CASE
    WHEN total_spend >= 10000 AND tenure_months >= 24 THEN 'Platinum'
    WHEN total_spend >= 5000 AND tenure_months >= 12 THEN 'Gold'
    WHEN total_spend >= 1000 AND tenure_months >= 6 THEN 'Silver'
    ELSE 'Bronze'
  END
)
```

proof of ingestion working for this UDF
<img width="1721" height="1292" alt="image" src="https://github.com/user-attachments/assets/e4ed516d-cb95-498c-9e10-97c39dcc7d54" />


### Changes
- `ingestion/src/metadata/ingestion/source/database/bigquery/queries.py`
  - Added `'FUNCTION'` to the `routine_type IN (...)` clause in `BIGQUERY_GET_STORED_PROCEDURES`
  - Added `'FUNCTION'` to the `routine_type IN (...)` clause in `BIGQUERY_GET_STORED_PROCEDURES_BY_REGION`
- `ingestion/tests/unit/topology/database/test_bigquery.py`
  - `test_stored_procedures_queries_include_function_routine_type` — asserts both query constants filter on `PROCEDURE`, `TABLE FUNCTION`, and `FUNCTION`
  - `test_get_stored_procedures_ingests_user_defined_functions` — mocks a routines result containing a procedure, a table function, and a UDF, and verifies all three are yielded by `get_stored_procedures()`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Issue
Closes #26552

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective / that my feature works
- [x] New and existing unit tests pass locally with my changes
