### PR TITLE
ISSUE-25600: Add support for ingesting Oracle Global Temporary Tables

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/oracle/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/oracle/metadata.py
@@ -68,6 +68,7 @@ from metadata.ingestion.source.database.oracle.utils import (
     get_table_comment_preserve_case,
     get_table_names,
     get_table_prefix_from_connection,
+    get_temporary_table_names,
     get_view_definition,
     get_view_definition_preserve_case,
     get_view_names,
@@ -164,8 +165,18 @@ class OracleSource(CommonDbSourceService):
             TableNameAndType(name=table_name, type_=TableType.MaterializedView)
             for table_name in self.inspector.get_mview_names(schema_name) or []
         ]
+        temporary_tables = []
+        if getattr(self.service_connection, "includeTemporaryTables", False):
+            with self.engine.connect() as conn:
+                temporary_tables = [
+                    TableNameAndType(name=table_name, type_=TableType.Local)
+                    for table_name in get_temporary_table_names(
+                        self.engine.dialect, conn, schema_name
+                    )
+                    or []
+                ]
 
-        return regular_tables + material_tables
+        return regular_tables + material_tables + temporary_tables
 
     def process_result(self, data: FetchObjectList):
         """Process data as per our stored procedure format"""

--- a/ingestion/src/metadata/ingestion/source/database/oracle/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/oracle/queries.py
@@ -122,6 +122,18 @@ AND TABLE_NAME NOT IN
 """
 )
 
+ORACLE_GET_TEMPORARY_TABLE_NAMES = textwrap.dedent(
+    """
+SELECT table_name FROM {prefix}_TABLES WHERE
+{tablespace}
+OWNER = :owner
+AND IOT_NAME IS NULL
+AND DURATION IS NOT NULL
+AND TABLE_NAME NOT IN
+(SELECT mview_name FROM {prefix}_MVIEWS WHERE owner = :owner)
+"""
+)
+
 ORACLE_IDENTITY_TYPE = textwrap.dedent(
     """\
 col.default_on_null,

--- a/ingestion/src/metadata/ingestion/source/database/oracle/utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/oracle/utils.py
@@ -25,6 +25,7 @@ from metadata.ingestion.source.database.oracle.queries import (
     ORACLE_CONSTRAINTS,
     ORACLE_GET_COLUMNS,
     ORACLE_GET_TABLE_NAMES,
+    ORACLE_GET_TEMPORARY_TABLE_NAMES,
     ORACLE_IDENTITY_TYPE,
     ORACLE_TABLE_COMMENTS,
     ORACLE_TABLE_COMMENTS_PRESERVE_CASE,
@@ -293,6 +294,35 @@ def get_table_names(self, connection, schema=None, **kw):
         )
     sql_str = ORACLE_GET_TABLE_NAMES.format(
         tablespace=tablespace, prefix=_get_table_prefix(self)
+    )
+    cursor = connection.execute(sql.text(sql_str), {"owner": schema})
+    return [row[0] for row in cursor]
+
+
+def get_temporary_table_names(dialect, connection, schema=None):
+    """Return Global Temporary Table names in `schema`.
+
+    Oracle GTTs have permanent definitions in the data dictionary
+    (DURATION = 'SYS$SESSION' or 'SYS$TRANSACTION'); only their data is
+    session-scoped. They are excluded from get_table_names() to preserve
+    the historical default and are surfaced separately so callers can tag
+    them (e.g., as TableType.Local).
+    """
+    schema = dialect.denormalize_name(schema or dialect.default_schema_name)
+    if schema is None:
+        schema = dialect.default_schema_name
+
+    tablespace = ""
+    if dialect.exclude_tablespaces:
+        exclude_tablespace = ", ".join(
+            [f"'{ts}'" for ts in dialect.exclude_tablespaces]
+        )
+        tablespace = (
+            "nvl(tablespace_name, 'no tablespace') "
+            f"NOT IN ({exclude_tablespace}) AND "
+        )
+    sql_str = ORACLE_GET_TEMPORARY_TABLE_NAMES.format(
+        tablespace=tablespace, prefix=_get_table_prefix(dialect)
     )
     cursor = connection.execute(sql.text(sql_str), {"owner": schema})
     return [row[0] for row in cursor]

--- a/ingestion/tests/integration/oracle/conftest.py
+++ b/ingestion/tests/integration/oracle/conftest.py
@@ -1,0 +1,181 @@
+#  Copyright 2026 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Oracle integration test fixtures: spins up an Oracle test container,
+seeds it with one regular table and two Global Temporary Tables (GTTs)
+— a session-level and a transaction-level — so the includeTemporaryTables
+flag can be exercised end-to-end.
+"""
+
+import pytest
+
+from _openmetadata_testutils.ometa import int_admin_ometa
+from metadata.generated.schema.entity.services.databaseService import DatabaseService
+
+REGULAR_TABLE = "regular_orders"
+SESSION_GTT = "gtt_user_session"
+TRANSACTION_GTT = "gtt_order_staging"
+
+SEED_STATEMENTS = [
+    f"""
+    CREATE TABLE {REGULAR_TABLE} (
+        order_id NUMBER PRIMARY KEY,
+        sku VARCHAR2(40),
+        qty NUMBER(10,2)
+    )
+    """,
+    f"""
+    CREATE GLOBAL TEMPORARY TABLE {SESSION_GTT} (
+        user_id NUMBER NOT NULL,
+        action_code VARCHAR2(50) NOT NULL,
+        payload CLOB
+    ) ON COMMIT PRESERVE ROWS
+    """,
+    f"""
+    CREATE GLOBAL TEMPORARY TABLE {TRANSACTION_GTT} (
+        order_id NUMBER NOT NULL,
+        sku VARCHAR2(40) NOT NULL,
+        qty NUMBER(10,2),
+        CONSTRAINT pk_{TRANSACTION_GTT} PRIMARY KEY (order_id, sku)
+    ) ON COMMIT DELETE ROWS
+    """,
+]
+
+ORACLE_GTT_SERVICE_BASE = "oracle-local-gtt-test-service"
+
+
+def _build_workflow_config(service_name, exposed_port, include_temporary_tables):
+    return {
+        "source": {
+            "type": "oracle",
+            "serviceName": service_name,
+            "serviceConnection": {
+                "config": {
+                    "type": "Oracle",
+                    "hostPort": f"localhost:{exposed_port}",
+                    "username": "test",
+                    "password": "test",
+                    "oracleConnectionType": {"oracleServiceName": "test"},
+                    "includeTemporaryTables": include_temporary_tables,
+                }
+            },
+            "sourceConfig": {
+                "config": {
+                    "type": "DatabaseMetadata",
+                    "schemaFilterPattern": {"includes": ["test"]},
+                }
+            },
+        },
+        "sink": {"type": "metadata-rest", "config": {}},
+        "workflowConfig": {
+            "openMetadataServerConfig": {
+                "hostPort": "http://localhost:8585/api",
+                "authProvider": "openmetadata",
+                "securityConfig": {
+                    "jwtToken": (
+                        "eyJraWQiOiJHYjM4OWEtOWY3Ni1nZGpzLWE5MmotMDI0MmJrOTQzNTYiLCJ0eXAiOiJKV1QiLCJhbGc"
+                        "iOiJSUzI1NiJ9.eyJzdWIiOiJhZG1pbiIsImlzQm90IjpmYWxzZSwiaXNzIjoib3Blbi1tZXRhZGF0Y"
+                        "S5vcmciLCJpYXQiOjE2NjM5Mzg0NjIsImVtYWlsIjoiYWRtaW5Ab3Blbm1ldGFkYXRhLm9yZyJ9.tS"
+                        "8um_5DKu7HgzGBzS1VTA5uUjKWOCU0B_j08WXBiEC0mr0zNREkqVfwFDD-d24HlNEbrqioLsBuFRiwI"
+                        "WKc1m_ZlVQbG7P36RUxhuv2vbSp80FKyNM-Tj93FDzq91jsyNmsQhyNv_fNr3TXfzzSPjHt8Go0FMMP"
+                        "66weoKMgW2PbXlhVKwEuXUHyakLLzewm9UMeQaEiRzhiTMU3UkLXcKbYEJJvfNFcLwSl9W8JCO_l0Yj"
+                        "3ud-qt_nQYEZwqW6u5nfdQllN133iikV4fM5QZsMCnm8Rq1mvLR0y9bmJiD7fwM1tmJ791TUWqmKaTn"
+                        "P49U493VanKpUAfzIiOiIbhg"
+                    )
+                },
+            }
+        },
+    }
+
+
+@pytest.fixture(scope="package")
+def metadata():
+    return int_admin_ometa()
+
+
+@pytest.fixture(scope="package")
+def oracle_gtt_container():
+    from ingestion.tests.utils.docker_service_builders.database_container.oracle_test_container import (
+        OracleTestContainer,
+    )
+
+    container = OracleTestContainer()
+    print(f"\nOracle container started on port {container.exposed_port} for GTT tests")
+
+    _grant_catalog_access(container)
+    _seed_schema(container)
+    yield container
+
+    print("\nStopping container of GTT tests...")
+    container.stop()
+    container.delete_image()
+
+
+@pytest.fixture(scope="package")
+def gtt_workflow_configs(oracle_gtt_container):
+    """Two workflow configs, one with the flag off and one with it on,
+    each pointing at a distinct service so they don't share entities."""
+    off_service = f"{ORACLE_GTT_SERVICE_BASE}-off"
+    on_service = f"{ORACLE_GTT_SERVICE_BASE}-on"
+    return {
+        "off": (
+            off_service,
+            _build_workflow_config(
+                off_service, oracle_gtt_container.exposed_port, False
+            ),
+        ),
+        "on": (
+            on_service,
+            _build_workflow_config(on_service, oracle_gtt_container.exposed_port, True),
+        ),
+    }
+
+
+@pytest.fixture(scope="package", autouse=True)
+def _cleanup_gtt_services(metadata, gtt_workflow_configs):
+    yield
+    for service_name, _ in gtt_workflow_configs.values():
+        service_entity = metadata.get_by_name(DatabaseService, service_name)
+        if service_entity:
+            metadata.delete(
+                DatabaseService,
+                service_entity.id,
+                recursive=True,
+                hard_delete=True,
+            )
+
+
+def _seed_schema(container):
+    print("Seeding regular + GTT tables for tests...")
+    connection = container.raw_connection()
+    cursor = connection.cursor()
+    try:
+        for statement in SEED_STATEMENTS:
+            cursor.execute(statement)
+        connection.commit()
+    finally:
+        cursor.close()
+        connection.close()
+    print("Seed complete.")
+
+
+def _grant_catalog_access(container):
+    """OpenMetadata's CheckAccess reads DBA_TABLES; app user needs SELECT_CATALOG_ROLE."""
+    print("Granting SELECT_CATALOG_ROLE to test user...")
+    connection = container.admin_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(f"GRANT SELECT_CATALOG_ROLE TO {container.username}")
+        connection.commit()
+    finally:
+        cursor.close()
+        connection.close()
+    print("Grant complete.")

--- a/ingestion/tests/integration/oracle/test_temporary_tables.py
+++ b/ingestion/tests/integration/oracle/test_temporary_tables.py
@@ -1,0 +1,96 @@
+#  Copyright 2026 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+End-to-end coverage for Oracle Global Temporary Table (GTT) ingestion.
+
+GTTs have permanent definitions in the Oracle data dictionary (their
+DURATION column is SYS$SESSION or SYS$TRANSACTION), so they CAN be
+ingested — only the data is session-scoped. The connector excludes them
+by default and only fetches them when includeTemporaryTables=true,
+tagging them as TableType.Local.
+"""
+import pytest
+
+from ingestion.tests.integration.oracle.conftest import (
+    REGULAR_TABLE,
+    SESSION_GTT,
+    TRANSACTION_GTT,
+)
+from metadata.generated.schema.entity.data.table import Table, TableType
+from metadata.workflow.metadata import MetadataWorkflow
+
+
+def _run_workflow(workflow_config):
+    workflow = MetadataWorkflow.create(workflow_config)
+    workflow.execute()
+    workflow.raise_from_status()
+    workflow.stop()
+
+
+def _table_fqn(service_name, table_name):
+    return f"{service_name}.default.test.{table_name.upper()}"
+
+
+def _get_table(metadata, service_name, table_name):
+    return metadata.get_by_name(
+        Table, _table_fqn(service_name, table_name), fields=["columns"]
+    )
+
+
+@pytest.fixture(scope="package")
+def ingested_with_flag_off(oracle_gtt_container, gtt_workflow_configs):
+    service_name, config = gtt_workflow_configs["off"]
+    _run_workflow(config)
+    return service_name
+
+
+@pytest.fixture(scope="package")
+def ingested_with_flag_on(oracle_gtt_container, gtt_workflow_configs):
+    service_name, config = gtt_workflow_configs["on"]
+    _run_workflow(config)
+    return service_name
+
+
+def test_gtts_excluded_by_default(metadata, ingested_with_flag_off):
+    """With includeTemporaryTables=false, only the regular table is ingested."""
+    assert _get_table(metadata, ingested_with_flag_off, REGULAR_TABLE) is not None
+    assert _get_table(metadata, ingested_with_flag_off, SESSION_GTT) is None
+    assert _get_table(metadata, ingested_with_flag_off, TRANSACTION_GTT) is None
+
+
+def test_gtts_ingested_when_flag_enabled(metadata, ingested_with_flag_on):
+    """With includeTemporaryTables=true, regular table and both GTTs are ingested."""
+    assert _get_table(metadata, ingested_with_flag_on, REGULAR_TABLE) is not None
+    assert _get_table(metadata, ingested_with_flag_on, SESSION_GTT) is not None
+    assert _get_table(metadata, ingested_with_flag_on, TRANSACTION_GTT) is not None
+
+
+def test_gtts_carry_local_table_type(metadata, ingested_with_flag_on):
+    """GTTs are surfaced with TableType.Local; regular tables stay Regular."""
+    assert (
+        _get_table(metadata, ingested_with_flag_on, REGULAR_TABLE).tableType
+        == TableType.Regular
+    )
+    assert (
+        _get_table(metadata, ingested_with_flag_on, SESSION_GTT).tableType
+        == TableType.Local
+    )
+    assert (
+        _get_table(metadata, ingested_with_flag_on, TRANSACTION_GTT).tableType
+        == TableType.Local
+    )
+
+
+def test_gtt_columns_are_ingested(metadata, ingested_with_flag_on):
+    """Columns flow through the existing reflection path for GTTs."""
+    session_gtt = _get_table(metadata, ingested_with_flag_on, SESSION_GTT)
+    column_names = {c.name.root.lower() for c in session_gtt.columns}
+    assert {"user_id", "action_code", "payload"}.issubset(column_names)

--- a/ingestion/tests/unit/topology/database/test_oracle.py
+++ b/ingestion/tests/unit/topology/database/test_oracle.py
@@ -13,7 +13,7 @@ Test Oracle using the topology
 """
 
 from unittest import TestCase
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 from metadata.generated.schema.api.data.createDatabase import CreateDatabaseRequest
 from metadata.generated.schema.api.data.createDatabaseSchema import (
@@ -48,6 +48,8 @@ from metadata.ingestion.source.database.oracle.models import OracleStoredObject
 from metadata.ingestion.source.database.oracle.queries import (
     ORACLE_GET_STORED_PACKAGES,
     ORACLE_GET_STORED_PROCEDURES,
+    ORACLE_GET_TABLE_NAMES,
+    ORACLE_GET_TEMPORARY_TABLE_NAMES,
     TEST_ORACLE_GET_STORED_PACKAGES,
 )
 
@@ -392,6 +394,95 @@ class OracleUnitTest(TestCase):
         executed_query = str(mock_conn.execute.call_args[0][0])
         assert "SAMPLE_SCHEMA" in executed_query
         assert "sample_schema" not in executed_query
+
+
+class TestOracleTemporaryTables:
+    """Verify Oracle Global Temporary Table (GTT) ingestion path."""
+
+    def setup_method(self):
+        patcher = patch(
+            "metadata.ingestion.source.database.common_db_source.CommonDbSourceService.test_connection"
+        )
+        patcher.start()
+        metadata = OpenMetadata(
+            OpenMetadataConnection.model_validate(
+                mock_oracle_config["workflowConfig"]["openMetadataServerConfig"]
+            )
+        )
+        self.oracle = OracleSource.create(mock_oracle_config["source"], metadata)
+        self.oracle.context.get().__dict__[
+            "database_service"
+        ] = MOCK_DATABASE_SERVICE.name.root
+        patcher.stop()
+
+    def _patch_inspector(self, regular=None, mviews=None):
+        mock_inspector = MagicMock()
+        mock_inspector.get_table_names.return_value = regular or []
+        mock_inspector.get_mview_names.return_value = mviews or []
+        patcher = patch.object(
+            type(self.oracle),
+            "inspector",
+            new_callable=PropertyMock,
+            return_value=mock_inspector,
+        )
+        patcher.start()
+        return patcher
+
+    def _mock_engine_with_gtts(self, gtt_names):
+        mock_engine = MagicMock()
+        mock_engine.dialect = self.oracle.engine.dialect
+        mock_result = MagicMock()
+        mock_result.__iter__ = lambda self: iter([(n,) for n in gtt_names])
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value = mock_result
+        mock_engine.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+        self.oracle.engine = mock_engine
+        return mock_conn
+
+    def test_temporary_tables_query_filters_on_duration_not_null(self):
+        """Sanity: GTT query selects rows where DURATION IS NOT NULL; regular query keeps DURATION IS NULL."""
+        assert "DURATION IS NOT NULL" in ORACLE_GET_TEMPORARY_TABLE_NAMES
+        assert "DURATION IS NULL" in ORACLE_GET_TABLE_NAMES
+
+    def test_default_excludes_temporary_tables(self):
+        """When includeTemporaryTables is False (default), GTTs are not fetched and engine.connect is not called."""
+        from metadata.generated.schema.entity.data.table import TableType
+
+        patcher = self._patch_inspector(regular=["regular_t"], mviews=["mv_t"])
+        try:
+            mock_engine = MagicMock()
+            self.oracle.engine = mock_engine
+
+            result = self.oracle.query_table_names_and_types("scott")
+
+            assert mock_engine.connect.called is False
+            types = {t.type_ for t in result}
+            assert TableType.Local not in types
+        finally:
+            patcher.stop()
+
+    def test_include_temporary_tables_yields_local_type(self):
+        """When includeTemporaryTables is True, GTTs are returned with TableType.Local."""
+        from metadata.generated.schema.entity.data.table import TableType
+
+        self.oracle.service_connection.includeTemporaryTables = True
+        patcher = self._patch_inspector(regular=["regular_t"], mviews=["mv_t"])
+        try:
+            mock_conn = self._mock_engine_with_gtts(["gtt_session", "gtt_txn"])
+
+            result = self.oracle.query_table_names_and_types("scott")
+
+            executed_query = str(mock_conn.execute.call_args[0][0])
+            assert "DURATION IS NOT NULL" in executed_query
+
+            by_name = {t.name: t.type_ for t in result}
+            assert by_name["regular_t"] == TableType.Regular
+            assert by_name["mv_t"] == TableType.MaterializedView
+            assert by_name["gtt_session"] == TableType.Local
+            assert by_name["gtt_txn"] == TableType.Local
+        finally:
+            patcher.stop()
 
 
 class TestOraclePreserveIdentifierCase:

--- a/ingestion/tests/utils/docker_service_builders/database_container/oracle_test_container.py
+++ b/ingestion/tests/utils/docker_service_builders/database_container/oracle_test_container.py
@@ -13,9 +13,13 @@ import json
 import sys
 
 import docker
+from testcontainers.core.waiting_utils import wait_for_logs
 from testcontainers.oracle import OracleDbContainer
 
 from .database_test_container import DataBaseTestContainer
+
+ORACLE_READY_LOG = "DATABASE IS READY TO USE!"
+ORACLE_STARTUP_TIMEOUT_SECONDS = 600
 
 
 class OracleTestContainer(DataBaseTestContainer):
@@ -38,6 +42,7 @@ class OracleTestContainer(DataBaseTestContainer):
             dbname=self.dbname,
         )
         self.oracle_container.with_bind_ports(self.port, self.exposed_port)
+        self.oracle_container._connect = self._wait_until_ready
         self.start()
 
         self.connection_url = self.get_connection_url()
@@ -45,6 +50,13 @@ class OracleTestContainer(DataBaseTestContainer):
 
     def start(self):
         self.oracle_container.start()
+
+    def _wait_until_ready(self):
+        wait_for_logs(
+            self.oracle_container,
+            ORACLE_READY_LOG,
+            timeout=ORACLE_STARTUP_TIMEOUT_SECONDS,
+        )
 
     def stop(self):
         self.oracle_container.stop()
@@ -98,6 +110,22 @@ class OracleTestContainer(DataBaseTestContainer):
 
         return oracledb.connect(
             user=self.username,
+            password=self.password,
+            host=self.host,
+            port=self.exposed_port,
+            service_name=self.dbname,
+        )
+
+    def admin_connection(self):
+        """Get direct oracledb connection as the SYSTEM admin user.
+
+        gvenzl/oracle-free seeds a SYSTEM user with the password supplied via
+        oracle_password — used here for grants the test user can't perform.
+        """
+        import oracledb
+
+        return oracledb.connect(
+            user="system",
             password=self.password,
             host=self.host,
             port=self.exposed_port,

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/oracleConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/oracleConnection.json
@@ -133,6 +133,12 @@
       "description": "Use Oracle DBA_* tables instead of ALL_* tables for metadata ingestion. Requires DBA privileges.",
       "default": true
     },
+    "includeTemporaryTables": {
+      "title": "Include Temporary Tables",
+      "type": "boolean",
+      "description": "Ingest Oracle Global Temporary Tables (GTTs). GTTs have permanent definitions in the data dictionary (DURATION is SYS$SESSION or SYS$TRANSACTION) but their data is session-scoped. When enabled, GTTs are ingested with TableType=Local so they can be distinguished from regular tables.",
+      "default": false
+    },
     "connectionOptions": {
       "title": "Connection Options",
       "$ref": "../connectionBasicType.json#/definitions/connectionOptions"


### PR DESCRIPTION
# ISSUE-25600: Add support for ingesting Oracle Global Temporary Tables

## Summary

Oracle Global Temporary Tables (GTTs) have **permanent** definitions in the data dictionary (`*_TABLES.DURATION` is `SYS$SESSION` or `SYS$TRANSACTION`); only their data is session-scoped. Despite being introspectable like any regular table, the Oracle connector filtered them out unconditionally via `AND DURATION IS NULL` in `ORACLE_GET_TABLE_NAMES`, so they never appeared in OpenMetadata.

This PR adds an opt-in `includeTemporaryTables` boolean to `OracleConnection`. When enabled, GTTs are fetched via a new `ORACLE_GET_TEMPORARY_TABLE_NAMES` query and surfaced with `TableType.Local` so users can distinguish them from regular tables in the UI.

This mirrors the spirit of Snowflake's `enableTempTableLineage` flag — opt-in, defaults to off, preserves existing behavior.

## Why GTTs (and not, e.g., Snowflake temp tables)

Oracle GTTs are fundamentally different from Snowflake temporary tables:

- **Oracle GTT** — schema, columns, constraints, comments are **permanent** and queryable from `ALL_TABLES` / `ALL_TAB_COLS` for any session. Only the row data is session-scoped.
- **Snowflake temp table** — entirely ephemeral; only exists for the session that created it, so external ingestion can't see it.

So Oracle GTTs *can* be ingested cleanly using the existing reflection paths — no extra plumbing needed for columns, constraints, or comments.

## Changes

### Schema (`openmetadata-spec/.../oracleConnection.json`)
- New `includeTemporaryTables: boolean` property (default `false`).

### Connector (`ingestion/.../oracle/`)
- `queries.py` — new `ORACLE_GET_TEMPORARY_TABLE_NAMES` constant (same shape as the regular query but `DURATION IS NOT NULL`). Original `ORACLE_GET_TABLE_NAMES` left untouched, so default behavior is unchanged.
- `utils.py` — new `get_temporary_table_names(dialect, connection, schema)` helper. Kept `get_table_names`'s SQLAlchemy `Inspector` contract intact.
- `metadata.py` — `query_table_names_and_types` now appends GTTs as `TableType.Local` entries when the flag is set. Read defensively via `getattr` so it's safe even before model regeneration.

### Tests

**Unit** (`ingestion/tests/unit/topology/database/test_oracle.py`)
- `test_temporary_tables_query_filters_on_duration_not_null` — sanity check on the SQL constants.
- `test_default_excludes_temporary_tables` — verifies no GTT fetch and `engine.connect` not called when flag off.
- `test_include_temporary_tables_yields_local_type` — verifies GTTs come back as `TableType.Local` and the executed query targets `DURATION IS NOT NULL`.

**Integration** (`ingestion/tests/integration/oracle/`) — new module
- Spins up `gvenzl/oracle-free:23-slim-faststart` testcontainer.
- Seeds one regular table + one session-level GTT + one transaction-level GTT.
- Runs the metadata ingestion workflow twice (flag off / flag on, against distinct service names) and asserts via the OpenMetadata REST API:
  - `test_gtts_excluded_by_default` — flag off ⇒ regular table present, GTTs absent.
  - `test_gtts_ingested_when_flag_enabled` — flag on ⇒ regular + both GTTs present.
  - `test_gtts_carry_local_table_type` — GTTs surface as `TableType.Local`, regular as `TableType.Regular`.
  - `test_gtt_columns_are_ingested` — column reflection works for GTTs.
- Service teardown via `metadata.delete(... recursive=True, hard_delete=True)` after the package finishes.

## Backward compatibility

- Default value is `false`, so behavior for existing Oracle services is unchanged on upgrade.
- Switching the flag to `true` only **adds** entities to the service; it does not modify or remove anything previously ingested.
- Switching the flag back to `false` later will leave previously-ingested GTT entities in OpenMetadata as orphans (they simply stop being refreshed). Standard re-ingest / soft-delete handling applies.

## Reproducing

Sample DDL the integration test uses (paste into `sqlplus` or any Oracle client):

```sql
CREATE TABLE regular_orders (
    order_id NUMBER PRIMARY KEY,
    sku VARCHAR2(40),
    qty NUMBER(10,2)
);

-- Session-level GTT: data persists for the duration of the session
CREATE GLOBAL TEMPORARY TABLE gtt_user_session (
    user_id      NUMBER       NOT NULL,
    action_code  VARCHAR2(50) NOT NULL,
    payload      CLOB
) ON COMMIT PRESERVE ROWS;

-- Transaction-level GTT: data is wiped on every COMMIT
CREATE GLOBAL TEMPORARY TABLE gtt_order_staging (
    order_id NUMBER NOT NULL,
    sku VARCHAR2(40) NOT NULL,
    qty NUMBER(10,2),
    CONSTRAINT pk_gtt_order_staging PRIMARY KEY (order_id, sku)
) ON COMMIT DELETE ROWS;
```

Verify they're flagged as temporary in the data dictionary:

```sql
SELECT table_name, temporary, duration
FROM all_tables
WHERE table_name IN ('REGULAR_ORDERS', 'GTT_USER_SESSION', 'GTT_ORDER_STAGING');

-- Expected:
-- TABLE_NAME           TEMPORARY  DURATION
-- REGULAR_ORDERS       N          (null)
-- GTT_USER_SESSION     Y          SYS$SESSION
-- GTT_ORDER_STAGING    Y          SYS$TRANSACTION
```

## Test plan

- [x] Unit tests pass (`pytest ingestion/tests/unit/topology/database/test_oracle.py`)
- [x] Integration tests pass (`pytest ingestion/tests/integration/oracle/` against a running OpenMetadata instance with Docker available)
- [x] Manual: run ingestion against a real Oracle DB with `includeTemporaryTables: true`, verify GTTs appear in the UI tagged as `Local`
- [x] Manual: run ingestion with the flag omitted/false, verify GTTs are NOT ingested (regression check)
- [x] Verify `make generate` regenerates the Pydantic + Java models cleanly from the updated JSON schema

## Closes

Closes #25600
