### PR TITLE
Fixes #27130: Stored procedure version view shows empty Code tab

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/StoredProcedureVersion/StoredProcedureVersion.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/StoredProcedureVersion/StoredProcedureVersion.component.tsx
@@ -39,6 +39,7 @@ import DataAssetsVersionHeader from '../../DataAssets/DataAssetsVersionHeader/Da
 import DataProductsContainer from '../../DataProducts/DataProductsContainer/DataProductsContainer.component';
 import EntityVersionTimeLine from '../../Entity/EntityVersionTimeLine/EntityVersionTimeLine';
 import TagsContainerV2 from '../../Tag/TagsContainerV2/TagsContainerV2';
+import { StoredProcedureCodeCard } from '../StoredProcedureCodeCard/StoredProcedureCodeCard';
 import { StoredProcedureVersionProp } from './StoredProcedureVersion.interface';
 
 const StoredProcedureVersion = ({
@@ -131,6 +132,9 @@ const StoredProcedureVersion = ({
                     entityType={EntityType.STORED_PROCEDURE}
                     showActions={false}
                   />
+                </Col>
+                <Col span={24}>
+                  <StoredProcedureCodeCard />
                 </Col>
               </Row>
             </Col>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/StoredProcedureVersion/StoredProcedureVersion.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/StoredProcedureVersion/StoredProcedureVersion.test.tsx
@@ -41,6 +41,12 @@ jest.mock('../../common/EntityDescription/DescriptionV1', () =>
   jest.fn().mockImplementation(() => <div>DescriptionV1</div>)
 );
 
+jest.mock('../StoredProcedureCodeCard/StoredProcedureCodeCard', () => ({
+  StoredProcedureCodeCard: jest
+    .fn()
+    .mockImplementation(() => <div>StoredProcedureCodeCard</div>),
+}));
+
 jest.mock('../../Entity/EntityVersionTimeLine/EntityVersionTimeLine', () =>
   jest.fn().mockImplementation(() => <div>EntityVersionTimeLine</div>)
 );
@@ -76,6 +82,7 @@ describe('StoredProcedureVersion tests', () => {
 
     const dataAssetsVersionHeader = screen.getByText('DataAssetsVersionHeader');
     const description = screen.getByText('DescriptionV1');
+    const codeCard = screen.getByText('StoredProcedureCodeCard');
     const codeTabLabel = screen.getByText('label.code');
     const customPropertyTabLabel = screen.getByText(
       'label.custom-property-plural'
@@ -84,6 +91,7 @@ describe('StoredProcedureVersion tests', () => {
 
     expect(dataAssetsVersionHeader).toBeInTheDocument();
     expect(description).toBeInTheDocument();
+    expect(codeCard).toBeInTheDocument();
     expect(codeTabLabel).toBeInTheDocument();
     expect(customPropertyTabLabel).toBeInTheDocument();
     expect(entityVersionTimeLine).toBeInTheDocument();

--- a/openmetadata-ui/src/main/resources/ui/src/mocks/StoredProcedureVersion.mock.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/mocks/StoredProcedureVersion.mock.ts
@@ -86,7 +86,10 @@ const mockData = {
     previousVersion: 0.1,
   },
   deleted: false,
-  storedProcedureCode: '',
+  storedProcedureCode: {
+    code: 'CREATE OR REPLACE PROCEDURE update_dim_address_table()',
+    language: 'SQL',
+  },
 };
 
 export const storedProcedureVersionMockProps: StoredProcedureVersionProp = {


### PR DESCRIPTION
### Describe your changes:

Fixes #27130

On the stored procedure version view (`/storedProcedure/<fqn>/versions/<version>`), the **Code** tab rendered only the description with no code block, while the current (non-version) details page showed the stored procedure code correctly. This made historical versions appear to have lost their DDL.

The version tab didn't render any code component — it only had `DescriptionV1`. The fix adds the existing `StoredProcedureCodeCard` (already used in `StoredProceduresUtils.tsx` for the main details page) into the version tab's layout. It reads the code via `useGenericContext<StoredProcedure>()`, which is already populated with the version's `currentVersionData` by the surrounding `GenericProvider`, so historical versions resolve their own `storedProcedureCode` correctly.

#### How it was tested
- Created a stored procedure, updated `storedProcedureCode` to bump to v0.2, then opened `/versions/0.1` and `/versions/0.2` — each version now renders its own historical code (v0.1 shows the original DDL, v0.2 shows the updated DDL).
- Verified the non-version details page still renders code correctly (no regression).
- Verified the Custom Properties tab on the version view still renders (no regression).
- Existing Jest test file updated to mock the new child and assert it mounts in the version tab.
- Mock fixture updated so `storedProcedureCode` matches the real `StoredProcedureCodeObject` shape.

#
### Type of change:
- [x] Bug fix

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added a test that covers the exact scenario we are fixing.