### PR TITLE
fix(clickhouse): add downstream lineage extraction for MATERIALIZED VIEW TO clause (#26265)

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/clickhouse/lineage.py
+++ b/ingestion/src/metadata/ingestion/source/database/clickhouse/lineage.py
@@ -11,12 +11,16 @@
 """
 Clickhouse lineage module
 """
+from typing import Iterator
+
+from metadata.generated.schema.type.tableQuery import TableQuery
 from metadata.ingestion.source.database.clickhouse.queries import (
     CLICKHOUSE_SQL_STATEMENT,
 )
 from metadata.ingestion.source.database.clickhouse.query_parser import (
     ClickhouseQueryParserSource,
 )
+from metadata.ingestion.source.database.clickhouse.utils import get_mv_to_target_table
 from metadata.ingestion.source.database.lineage_source import LineageSource
 
 
@@ -30,7 +34,7 @@ class ClickhouseLineageSource(ClickhouseQueryParserSource, LineageSource):
 
     filters = """
         and (
-            query_kind='Create' 
+            query_kind='Create'
             or (query_kind='Insert' and query ilike '%%insert%%into%%select%%')
         )
     """
@@ -38,3 +42,24 @@ class ClickhouseLineageSource(ClickhouseQueryParserSource, LineageSource):
     database_field = ""
 
     schema_field = "databases"
+
+    def query_lineage_producer(self) -> Iterator[TableQuery]:
+        """
+        Yield the normal query logs, and — for CREATE MATERIALIZED VIEW ... TO <target>
+        statements — additionally yield a synthetic ``INSERT INTO <target> SELECT * FROM <mv>``
+        so the lineage parser can emit the downstream ``mv -> target`` edge that standard
+        SQL parsers miss from ClickHouse's TO clause.
+        """
+        for table_query in super().query_lineage_producer():
+            yield table_query
+            mv_target = get_mv_to_target_table(table_query.query)
+            if mv_target is None:
+                continue
+            mv_name, target_table = mv_target
+            yield TableQuery(
+                dialect=table_query.dialect,
+                query=f"INSERT INTO {target_table} SELECT * FROM {mv_name}",
+                databaseName=table_query.databaseName,
+                serviceName=table_query.serviceName,
+                databaseSchema=table_query.databaseSchema,
+            )

--- a/ingestion/src/metadata/ingestion/source/database/clickhouse/utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/clickhouse/utils.py
@@ -55,7 +55,7 @@ MATERIALIZED_VIEW_TO_PATTERN = re.compile(
 
 
 def _strip_quotes(identifier: str) -> str:
-    return ".".join(part.strip("`\"") for part in identifier.split("."))
+    return ".".join(part.strip('`"') for part in identifier.split("."))
 
 
 def get_mv_to_target_table(query: str) -> Optional[Tuple[str, str]]:
@@ -71,6 +71,7 @@ def get_mv_to_target_table(query: str) -> Optional[Tuple[str, str]]:
     if not match:
         return None
     return _strip_quotes(match.group("mv")), _strip_quotes(match.group("target"))
+
 
 Map = create_sqlalchemy_type("Map")
 Array = create_sqlalchemy_type("Array")

--- a/ingestion/src/metadata/ingestion/source/database/clickhouse/utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/clickhouse/utils.py
@@ -9,10 +9,13 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """
-Utils module to define overrided sqlalchamy methods 
+Utils module to define overrided sqlalchamy methods
 """
 # pylint: disable=protected-access,unused-argument
 
+
+import re
+from typing import Optional, Tuple
 
 from clickhouse_sqlalchemy.drivers.base import ischema_names
 from clickhouse_sqlalchemy.types import Date
@@ -30,6 +33,44 @@ from metadata.utils.sqlalchemy_utils import (
     get_table_comment_wrapper,
     get_view_definition_wrapper,
 )
+
+_IDENT = r"(?:`[^`]+`|\"[^\"]+\"|[A-Za-z_][\w$]*)"
+_QUALIFIED_IDENT = rf"{_IDENT}(?:\.{_IDENT})?"
+
+MATERIALIZED_VIEW_TO_PATTERN = re.compile(
+    rf"""
+    ^\s*
+    CREATE\s+(?:OR\s+REPLACE\s+)?
+    MATERIALIZED\s+VIEW\s+
+    (?:IF\s+NOT\s+EXISTS\s+)?
+    (?P<mv>{_QUALIFIED_IDENT})
+    (?:\s+ON\s+CLUSTER\s+\S+)?
+    (?:\s+REFRESH\s+.+?)?
+    \s+TO\s+
+    (?P<target>{_QUALIFIED_IDENT})
+    \s+(?:\(|AS\b)
+    """,
+    re.IGNORECASE | re.VERBOSE | re.DOTALL,
+)
+
+
+def _strip_quotes(identifier: str) -> str:
+    return ".".join(part.strip("`\"") for part in identifier.split("."))
+
+
+def get_mv_to_target_table(query: str) -> Optional[Tuple[str, str]]:
+    """Return (mv_name, target_table) for CREATE MATERIALIZED VIEW ... TO <target>.
+
+    Covers both the simple `TO <target>` form and the `REFRESH EVERY ... TO <target>`
+    form. Returns None when the query is not a CREATE MATERIALIZED VIEW with a TO
+    clause (e.g. inline-engine MVs, plain CREATE VIEW, INSERTs, etc.).
+    """
+    if not query:
+        return None
+    match = MATERIALIZED_VIEW_TO_PATTERN.search(query)
+    if not match:
+        return None
+    return _strip_quotes(match.group("mv")), _strip_quotes(match.group("target"))
 
 Map = create_sqlalchemy_type("Map")
 Array = create_sqlalchemy_type("Array")

--- a/ingestion/tests/unit/topology/database/test_clickhouse_utils.py
+++ b/ingestion/tests/unit/topology/database/test_clickhouse_utils.py
@@ -13,7 +13,10 @@
 from clickhouse_sqlalchemy.drivers.base import ischema_names as ch_ischema_names
 from sqlalchemy import types as sqltypes
 
-from metadata.ingestion.source.database.clickhouse.utils import _get_column_type
+from metadata.ingestion.source.database.clickhouse.utils import (
+    _get_column_type,
+    get_mv_to_target_table,
+)
 
 
 class MockDialect:
@@ -134,3 +137,88 @@ class TestClickhouseGeoTypes:
         # All values should be distinct from NullType
         for name, t in types.items():
             assert t is not sqltypes.NullType, f"{name} resolved to NullType"
+
+
+class TestGetMvToTargetTable:
+    """Regression tests for GitHub issue #26265 — missing downstream for
+    ClickHouse MATERIALIZED VIEW ... TO <target> lineage."""
+
+    def test_simple_to_syntax(self):
+        query = (
+            "CREATE MATERIALIZED VIEW mv TO target_table AS SELECT * FROM source_table"
+        )
+        assert get_mv_to_target_table(query) == ("mv", "target_table")
+
+    def test_if_not_exists(self):
+        query = (
+            "CREATE MATERIALIZED VIEW IF NOT EXISTS mv TO target "
+            "AS SELECT * FROM source"
+        )
+        assert get_mv_to_target_table(query) == ("mv", "target")
+
+    def test_or_replace(self):
+        query = (
+            "CREATE OR REPLACE MATERIALIZED VIEW mv TO target "
+            "AS SELECT * FROM source"
+        )
+        assert get_mv_to_target_table(query) == ("mv", "target")
+
+    def test_schema_qualified_names(self):
+        query = (
+            "CREATE MATERIALIZED VIEW db1.mv TO db2.target "
+            "AS SELECT * FROM db1.source"
+        )
+        assert get_mv_to_target_table(query) == ("db1.mv", "db2.target")
+
+    def test_backtick_quoted_identifiers(self):
+        query = (
+            "CREATE MATERIALIZED VIEW `my db`.`mv 1` TO `my db`.`target 1` "
+            "AS SELECT * FROM `my db`.`source 1`"
+        )
+        assert get_mv_to_target_table(query) == ("my db.mv 1", "my db.target 1")
+
+    def test_refresh_every_to_syntax(self):
+        query = (
+            "CREATE MATERIALIZED VIEW mv REFRESH EVERY 1 HOUR TO target "
+            "AS SELECT * FROM source"
+        )
+        assert get_mv_to_target_table(query) == ("mv", "target")
+
+    def test_refresh_every_with_offset_to_syntax(self):
+        query = (
+            "CREATE MATERIALIZED VIEW mv "
+            "REFRESH EVERY 1 DAY OFFSET 1 HOUR RANDOMIZE FOR 10 MINUTE "
+            "TO target AS SELECT * FROM source"
+        )
+        assert get_mv_to_target_table(query) == ("mv", "target")
+
+    def test_on_cluster_to_syntax(self):
+        query = (
+            "CREATE MATERIALIZED VIEW mv ON CLUSTER my_cluster TO target "
+            "AS SELECT * FROM source"
+        )
+        assert get_mv_to_target_table(query) == ("mv", "target")
+
+    def test_case_insensitive(self):
+        query = "create materialized view mv to target as select * from source"
+        assert get_mv_to_target_table(query) == ("mv", "target")
+
+    def test_inline_engine_mv_returns_none(self):
+        """MV defined with inline ENGINE=... (no TO clause) should not match."""
+        query = (
+            "CREATE MATERIALIZED VIEW mv ENGINE = MergeTree() ORDER BY id "
+            "AS SELECT * FROM source"
+        )
+        assert get_mv_to_target_table(query) is None
+
+    def test_plain_view_returns_none(self):
+        query = "CREATE VIEW v AS SELECT * FROM source"
+        assert get_mv_to_target_table(query) is None
+
+    def test_insert_query_returns_none(self):
+        query = "INSERT INTO target SELECT * FROM source"
+        assert get_mv_to_target_table(query) is None
+
+    def test_empty_query_returns_none(self):
+        assert get_mv_to_target_table("") is None
+        assert get_mv_to_target_table(None) is None


### PR DESCRIPTION
# What does this PR do?
This PR adds support for extracting downstream lineage from the `TO` clause in ClickHouse MATERIALIZED VIEW statements.

Previously, the lineage parser only handled upstream lineage from the `FROM` clause, but ignored the target table defined in the `TO` clause. As a result, downstream lineage links were missing.

## Changes made
- Added parsing logic for `TO <schema>.<table>` in MATERIALIZED VIEW
- Registered the target table as a downstream node in lineage graph
- Supported both:
  - Simple `CREATE MATERIALIZED VIEW ... TO ...`
  - `REFRESH EVERY ... TO ...` variant
- Updated lineage extraction flow in ClickHouse utils

## How was this tested?
- Added unit tests covering:
  - MATERIALIZED VIEW with `TO` clause
  - REFRESH-based MATERIALIZED VIEW
- Ran pytest locally → all tests passed
- Verified no regression in existing lineage parsing

## Why is this needed?
This fixes missing downstream lineage for MATERIALIZED VIEW in ClickHouse, improving lineage completeness and correctness.
