### PR TITLE
test(glossary): make selectActiveGlossary selector robust

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts
@@ -153,7 +153,7 @@ test.describe('Glossary tests', () => {
     await test.step('Approve Glossary Term from Glossary Listing for reviewer user', async () => {
       await redirectToHomePage(page1);
       await sidebarClick(page1, SidebarItem.GLOSSARY);
-      await selectActiveGlossary(page1, glossary1.data.name);
+      await selectActiveGlossary(page1, glossary1.data.displayName);
       await verifyTaskCreated(
         page1,
         glossary1.data.fullyQualifiedName,
@@ -179,7 +179,7 @@ test.describe('Glossary tests', () => {
       await approveGlossaryTermTask(page1, glossary1.data.terms[0].data);
       await redirectToHomePage(page1);
       await sidebarClick(page1, SidebarItem.GLOSSARY);
-      await selectActiveGlossary(page1, glossary1.data.name);
+      await selectActiveGlossary(page1, glossary1.data.displayName);
       await validateGlossaryTerm(
         page1,
         glossary1.data.terms[0].data,
@@ -222,7 +222,7 @@ test.describe('Glossary tests', () => {
     await test.step('Approve Glossary Term from Glossary Listing for reviewer team', async () => {
       await redirectToHomePage(page1);
       await sidebarClick(page1, SidebarItem.GLOSSARY);
-      await selectActiveGlossary(page1, glossary2.data.name);
+      await selectActiveGlossary(page1, glossary2.data.displayName);
 
       await verifyTaskCreated(
         page1,
@@ -234,7 +234,7 @@ test.describe('Glossary tests', () => {
 
       await redirectToHomePage(page1);
       await sidebarClick(page1, SidebarItem.GLOSSARY);
-      await selectActiveGlossary(page1, glossary2.data.name);
+      await selectActiveGlossary(page1, glossary2.data.displayName);
       await validateGlossaryTerm(
         page1,
         glossary2.data.terms[0].data,
@@ -441,7 +441,7 @@ test.describe('Glossary tests', () => {
     await test.step('Approve and Reject Glossary Term', async () => {
       await redirectToHomePage(page1);
       await sidebarClick(page1, SidebarItem.GLOSSARY);
-      await selectActiveGlossary(page1, glossary1.data.name);
+      await selectActiveGlossary(page1, glossary1.data.displayName);
       await verifyTaskCreated(
         page1,
         glossary1.data.fullyQualifiedName,
@@ -454,7 +454,7 @@ test.describe('Glossary tests', () => {
       );
       await redirectToHomePage(page1);
       await sidebarClick(page1, SidebarItem.GLOSSARY);
-      await selectActiveGlossary(page1, glossary1.data.name);
+      await selectActiveGlossary(page1, glossary1.data.displayName);
 
       const taskResolve = page1.waitForResponse('/api/v1/feed/tasks/*/resolve');
       await page1

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/glossary.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/glossary.ts
@@ -63,10 +63,18 @@ export const checkName = async (page: Page, name: string) => {
 
 export const selectActiveGlossary = async (
   page: Page,
-  glossaryName: string,
+  glossaryLabel: string,
   bWaitForResponse = true
 ) => {
-  const menuItem = page.getByRole('menuitem', { name: glossaryName }).first();
+  const sidebar = page.getByTestId('glossary-left-panel');
+  await sidebar.locator('[role="menuitem"]').first().waitFor();
+
+  const menuItem = sidebar.getByRole('menuitem', {
+    name: glossaryLabel,
+    exact: true,
+  });
+  await menuItem.waitFor({ state: 'visible' });
+
   const isSelected = await menuItem.evaluate((element) => {
     return element.classList.contains('ant-menu-item-selected');
   });
@@ -761,7 +769,7 @@ export const createGlossaryTerms = async (
   page: Page,
   glossary: GlossaryData
 ) => {
-  await selectActiveGlossary(page, glossary.name);
+  await selectActiveGlossary(page, glossary.displayName ?? glossary.name);
 
   const termStatus = glossary.reviewers.length > 0 ? 'Draft' : 'Approved';
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/glossary.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/glossary.ts
@@ -267,6 +267,8 @@ export const createGlossary = async (
 
   await page.fill('[data-testid="name"]', glossaryData.name);
 
+  await page.fill('[data-testid="display-name"]', glossaryData.displayName);
+
   await page.locator(descriptionBox).fill(glossaryData.description);
 
   await expect(
@@ -330,7 +332,7 @@ export const verifyGlossaryDetails = async (
   glossaryDetails: GlossaryData
 ) => {
   await page
-    .getByRole('menuitem', { name: glossaryDetails.name })
+    .getByRole('menuitem', { name: glossaryDetails.displayName, exact: true })
     .locator('span')
     .click();
 


### PR DESCRIPTION
## Summary
- Scope `selectActiveGlossary` to `[data-testid="glossary-left-panel"]` and require an exact `name` match so the helper can no longer (a) match a menuitem in another dropdown (the Add-button glossary picker has the same role) or (b) silently mis-click via `.first()` when many glossaries share the `PW % ` prefix.
- Document the parameter as the rendered label (`displayName ?? name`).
- Update `createGlossaryTerms` and the six `Glossary.spec.ts` callers that were passing `glossary.data.name` to pass `glossary.data.displayName` — the menu label is `getEntityName(glossary)` (= `displayName ?? name`), so passing the raw name never matches and the previous substring + `.first()` could mis-click.

## Why
`Glossary tests › Approve and reject glossary term from Glossary Listing` has been failing on 1.12.6. Trace shows the page lands on the wrong (pre-existing) glossary before `validateGlossaryTerm`, then the row-key check times out at 5s. Root cause is the unscoped, non-exact menuitem lookup in `selectActiveGlossary` combined with callers passing the wrong identifier. The same flow exists on `main`, so fixing both here.

## Test plan
- [x] `npx playwright test e2e/Pages/Glossary.spec.ts`
- [x] `npx playwright test e2e/Pages/GlossaryImportExport.spec.ts e2e/Pages/GlossaryFormValidation.spec.ts e2e/Features/Glossary/GlossaryRemoveOperations.spec.ts` (other `selectActiveGlossary` callers — they already pass `displayName`, just verifying the stricter helper doesn't regress them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)