### PR TITLE
Fix flaky observability alerts navigation wait (Fixes #3749)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/observabilityAlert.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/observabilityAlert.ts
@@ -48,9 +48,13 @@ export const visitObservabilityAlertPage = async (page: Page) => {
   await waitForAllLoadersToDisappear(page);
 
   // Set up the response promise before navigation
-  const getAlerts = page.waitForResponse(
-    '/api/v1/events/subscriptions?*alertType=Observability*'
-  );
+  const getAlerts = page.waitForResponse((response) => {
+    const url = response.url();
+    return (
+      url.includes('/api/v1/events/subscriptions') &&
+      url.includes('alertType=Observability')
+    );
+  });
 
   // Set up navigation promise before clicking
   const navigationPromise = page.waitForURL('**/observability/alerts');
@@ -58,7 +62,8 @@ export const visitObservabilityAlertPage = async (page: Page) => {
   await sidebarClick(page, SidebarItem.OBSERVABILITY_ALERT);
 
   // Wait for both navigation and API response
-  await Promise.all([navigationPromise, getAlerts]);
+  await navigationPromise;
+  await getAlerts;
 };
 
 export const addExternalDestination = async ({


### PR DESCRIPTION
## Summary
- make the Observability alerts API wait deterministic by switching to a response predicate that matches the subscriptions endpoint and `alertType=Observability`
- avoid race conditions in page loading by awaiting URL navigation first, then waiting for the alerts response
- keep the Playwright helper behavior unchanged while improving reliability

Fixes https://github.com/open-metadata/openmetadata-collate/issues/3749
<img width="787" height="399" alt="Screenshot 2026-04-21 at 3 40 58 PM" src="https://github.com/user-attachments/assets/2d19af7d-fbf4-4b8f-ba8a-fe09d9c2d1c1" />

## Test plan
- [x] Verified the utility change compiles in TypeScript context
- [ ] Run Playwright observability alert scenario end-to-end in CI

Made with [Cursor](https://cursor.com)