### PR TITLE
Fix thread-safety, NPE/AIOOBE, domain ACL bypass, and Pydantic RootModel serialization bugs

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/dbt/dbt_utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/dbt_utils.py
@@ -23,6 +23,7 @@ from metadata.generated.schema.entity.teams.user import User
 from metadata.generated.schema.tests.testSuite import TestSuite
 from metadata.generated.schema.type.entityReference import EntityReference
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
+from metadata.ingestion.ometa.utils import model_str
 from metadata.ingestion.source.database.dbt.constants import (
     NONE_KEYWORDS_LIST,
     CompiledQueriesEnum,
@@ -939,51 +940,27 @@ def format_entity_reference(
         EntityReference dict with all fields as strings/primitives
     """
     # Extract ID (ensure string)
-    if hasattr(entity, "id"):
-        entity_id = (
-            str(entity.id.root) if hasattr(entity.id, "root") else str(entity.id)
-        )
-    else:
-        entity_id = str(entity.get("id", ""))
+    entity_id = model_str(entity.id) if hasattr(entity, "id") else str(entity.get("id", ""))
 
     # Extract FQN
     if hasattr(entity, "fullyQualifiedName"):
-        if hasattr(entity.fullyQualifiedName, "root"):
-            entity_fqn = str(entity.fullyQualifiedName.root)
-        else:
-            entity_fqn = str(entity.fullyQualifiedName)
+        entity_fqn = model_str(entity.fullyQualifiedName)
     else:
         entity_fqn = str(getattr(entity, "name", "Unknown"))
 
-    # Extract name (handle EntityName Pydantic model)
-    if hasattr(entity, "name"):
-        if hasattr(entity.name, "root"):
-            entity_name = str(entity.name.root)
-        else:
-            entity_name = str(entity.name)
-    else:
-        entity_name = "Unknown"
+    # Extract name
+    entity_name = model_str(entity.name) if hasattr(entity, "name") else "Unknown"
 
     # Extract display name
-    if hasattr(entity, "displayName"):
-        if hasattr(entity.displayName, "root"):
-            display_name = str(entity.displayName.root)
-        elif entity.displayName:
-            display_name = str(entity.displayName)
-        else:
-            display_name = entity_name
+    if hasattr(entity, "displayName") and entity.displayName:
+        display_name = model_str(entity.displayName)
     else:
         display_name = entity_name
 
     # Extract description
     description = ""
-    if hasattr(entity, "description"):
-        if hasattr(entity.description, "root"):
-            description = (
-                str(entity.description.root) if entity.description.root else ""
-            )
-        elif entity.description:
-            description = str(entity.description)
+    if hasattr(entity, "description") and entity.description:
+        description = model_str(entity.description)
 
     # Use provided entity_type, or fall back to entity.type
     if entity_type:
@@ -1020,21 +997,9 @@ def format_domain_reference(domain_entity: Any) -> Optional[Dict[str, Any]]:
     Formats domain into EntityReference structure
     """
     try:
-        domain_id = (
-            domain_entity.id.root
-            if hasattr(domain_entity.id, "root")
-            else str(domain_entity.id)
-        )
-        domain_name = (
-            domain_entity.name.root
-            if hasattr(domain_entity.name, "root")
-            else str(domain_entity.name)
-        )
-        domain_fqn = (
-            domain_entity.fullyQualifiedName.root
-            if hasattr(domain_entity.fullyQualifiedName, "root")
-            else str(domain_entity.fullyQualifiedName)
-        )
+        domain_id = model_str(domain_entity.id)
+        domain_name = model_str(domain_entity.name)
+        domain_fqn = model_str(domain_entity.fullyQualifiedName)
 
         return {
             "id": domain_id,

--- a/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/metadata.py
@@ -58,6 +58,7 @@ from metadata.ingestion.api.steps import InvalidSourceException
 from metadata.ingestion.lineage.sql_lineage import get_column_fqn
 from metadata.ingestion.models.pipeline_status import OMetaBulkPipelineStatus
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
+from metadata.ingestion.ometa.utils import model_str
 from metadata.ingestion.source.pipeline.databrickspipeline.kafka_parser import (
     extract_dlt_table_dependencies,
     extract_kafka_sources,
@@ -232,7 +233,7 @@ class DatabrickspipelineSource(PipelineServiceSource):
 
             return [
                 Task(
-                    name=str(task.name),
+                    name=task.name or "",
                     taskType=pipeline_details.settings.task_type,
                     sourceUrl=SourceUrl(job_url),
                     description=(
@@ -269,7 +270,7 @@ class DatabrickspipelineSource(PipelineServiceSource):
                     break
                 task_status = [
                     TaskStatus(
-                        name=str(task.name),
+                        name=task.name or "",
                         executionStatus=STATUS_MAP.get(
                             run.state.result_state, StatusType.Failed
                         ),

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v130/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v130/MigrationUtil.java
@@ -20,29 +20,37 @@ public class MigrationUtil {
     /* Cannot create object  util class*/
   }
 
-  private static Map extractConnectionURIDetails(String connectionString) {
-    Map connectionDetailsMap = new LinkedHashMap();
+  private static Map<String, Object> extractConnectionURIDetails(String connectionString) {
+    Map<String, Object> connectionDetailsMap = new LinkedHashMap<>();
     try {
-      // Parse the MongoDB connection string
       URI uri = new URI(connectionString);
 
-      // Extract components
-      String username = uri.getUserInfo().split(":")[0];
-      String password = uri.getUserInfo().split(":")[1];
+      String userInfo = uri.getUserInfo();
+      String username = "";
+      String password = "";
+      if (userInfo != null) {
+        String[] parts = userInfo.split(":", 2);
+        username = parts[0];
+        password = parts.length > 1 ? parts[1] : "";
+      }
+
       String host = uri.getHost();
       String scheme = uri.getScheme();
       int port = uri.getPort();
       String query = uri.getQuery();
-      Map queryMap = new HashMap<>();
+      Map<String, String> queryMap = new HashMap<>();
       if (query != null) {
-        String[] queryParams = query.split("&");
-        System.out.println("Query Parameters:");
-        for (String param : queryParams) {
-          queryMap.put(param.split("=")[0], param.split("=")[1]);
+        LOG.debug("Parsing query parameters from MongoDB connection string");
+        for (String param : query.split("&")) {
+          String[] kv = param.split("=", 2);
+          if (kv.length == 2) {
+            queryMap.put(kv[0], kv[1]);
+          } else if (kv.length == 1 && !kv[0].isEmpty()) {
+            queryMap.put(kv[0], "");
+          }
         }
       }
 
-      // populate connection details map the extracted components
       connectionDetailsMap.put("username", username);
       connectionDetailsMap.put("password", password);
       connectionDetailsMap.put("hostPort", host + ":" + port);
@@ -50,7 +58,7 @@ public class MigrationUtil {
       connectionDetailsMap.put("connectionOptions", queryMap);
 
     } catch (URISyntaxException e) {
-      e.printStackTrace();
+      LOG.error("Failed to parse MongoDB connection URI: {}", e.getMessage(), e);
     }
     return connectionDetailsMap;
   }
@@ -65,10 +73,14 @@ public class MigrationUtil {
                 DatabaseService mongoService =
                     JsonUtils.readValue(row.get("json").toString(), DatabaseService.class);
                 String id = row.get("id").toString();
-                Map mongoDBConnection = (LinkedHashMap) mongoService.getConnection().getConfig();
-                Map connDetails = (LinkedHashMap) mongoDBConnection.get("connectionDetails");
+                @SuppressWarnings("unchecked")
+                Map<String, Object> mongoDBConnection =
+                    (LinkedHashMap<String, Object>) mongoService.getConnection().getConfig();
+                @SuppressWarnings("unchecked")
+                Map<String, Object> connDetails =
+                    (LinkedHashMap<String, Object>) mongoDBConnection.get("connectionDetails");
 
-                Map finalConnectionDetails;
+                Map<String, Object> finalConnectionDetails;
                 if (connDetails != null) {
                   if (connDetails.get("connectionURI") != null) {
                     String connectionURI = connDetails.get("connectionURI").toString();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/feeds/FeedResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/feeds/FeedResource.java
@@ -522,7 +522,8 @@ public class FeedResource {
     // delete thread only if the admin/bot/author tries to delete it
     OperationContext operationContext =
         new OperationContext(Entity.THREAD, MetadataOperation.DELETE);
-    ResourceContextInterface resourceContext = new ThreadResourceContext(thread.getCreatedBy());
+    ResourceContextInterface resourceContext =
+        new ThreadResourceContext(thread.getCreatedBy(), thread.getDomains());
     authorizer.authorize(securityContext, operationContext, resourceContext);
     return dao.deleteThread(thread, securityContext.getUserPrincipal().getName()).toResponse();
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/secrets/AWSSSMSecretsManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/secrets/AWSSSMSecretsManager.java
@@ -25,7 +25,7 @@ import software.amazon.awssdk.services.ssm.model.PutParameterRequest;
 import software.amazon.awssdk.services.ssm.model.Tag;
 
 public class AWSSSMSecretsManager extends AWSBasedSecretsManager {
-  private static AWSSSMSecretsManager instance = null;
+  private static volatile AWSSSMSecretsManager instance = null;
   private SsmClient ssmClient;
 
   private AWSSSMSecretsManager(SecretsConfig secretsConfig) {
@@ -87,7 +87,11 @@ public class AWSSSMSecretsManager extends AWSBasedSecretsManager {
   }
 
   public static AWSSSMSecretsManager getInstance(SecretsConfig secretsConfig) {
-    if (instance == null) instance = new AWSSSMSecretsManager(secretsConfig);
+    if (instance == null) {
+      synchronized (AWSSSMSecretsManager.class) {
+        if (instance == null) instance = new AWSSSMSecretsManager(secretsConfig);
+      }
+    }
     return instance;
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/secrets/AWSSecretsManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/secrets/AWSSecretsManager.java
@@ -29,7 +29,7 @@ import software.amazon.awssdk.services.secretsmanager.model.UpdateSecretRequest;
 
 @Slf4j
 public class AWSSecretsManager extends AWSBasedSecretsManager {
-  private static AWSSecretsManager instance = null;
+  private static volatile AWSSecretsManager instance = null;
   private SecretsManagerClient secretsClient;
 
   private AWSSecretsManager(SecretsConfig secretsConfig) {
@@ -92,7 +92,9 @@ public class AWSSecretsManager extends AWSBasedSecretsManager {
 
   public static AWSSecretsManager getInstance(SecretsConfig secretsConfig) {
     if (instance == null) {
-      instance = new AWSSecretsManager(secretsConfig);
+      synchronized (AWSSecretsManager.class) {
+        if (instance == null) instance = new AWSSecretsManager(secretsConfig);
+      }
     }
     return instance;
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/secrets/AzureKVSecretsManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/secrets/AzureKVSecretsManager.java
@@ -16,7 +16,7 @@ import org.openmetadata.service.exception.SecretsManagerException;
 
 public class AzureKVSecretsManager extends ExternalSecretsManager {
 
-  private static AzureKVSecretsManager instance = null;
+  private static volatile AzureKVSecretsManager instance = null;
   private final SecretClient client;
 
   public static final String CLIENT_ID = "clientId";
@@ -108,7 +108,11 @@ public class AzureKVSecretsManager extends ExternalSecretsManager {
 
   public static AzureKVSecretsManager getInstance(SecretsConfig secretsConfig) {
     if (instance == null) {
-      instance = new AzureKVSecretsManager(SecretsManagerProvider.MANAGED_AZURE_KV, secretsConfig);
+      synchronized (AzureKVSecretsManager.class) {
+        if (instance == null)
+          instance =
+              new AzureKVSecretsManager(SecretsManagerProvider.MANAGED_AZURE_KV, secretsConfig);
+      }
     }
     return instance;
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/secrets/DBSecretsManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/secrets/DBSecretsManager.java
@@ -16,7 +16,7 @@ package org.openmetadata.service.secrets;
 import org.openmetadata.schema.security.secrets.SecretsManagerProvider;
 
 public class DBSecretsManager extends SecretsManager {
-  private static DBSecretsManager instance;
+  private static volatile DBSecretsManager instance;
 
   private DBSecretsManager(
       SecretsManagerProvider secretsManagerProvider, SecretsConfig secretsConfig) {
@@ -26,7 +26,9 @@ public class DBSecretsManager extends SecretsManager {
   public static DBSecretsManager getInstance(
       SecretsManagerProvider provider, SecretsConfig secretsConfig) {
     if (instance == null) {
-      instance = new DBSecretsManager(provider, secretsConfig);
+      synchronized (DBSecretsManager.class) {
+        if (instance == null) instance = new DBSecretsManager(provider, secretsConfig);
+      }
     }
     return instance;
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/secrets/GCPSecretsManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/secrets/GCPSecretsManager.java
@@ -15,13 +15,15 @@ import java.io.IOException;
 import java.util.regex.Pattern;
 import java.util.zip.CRC32C;
 import java.util.zip.Checksum;
+import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.service.exception.SecretsManagerException;
 import org.openmetadata.service.exception.SecretsManagerUpdateException;
 
+@Slf4j
 public class GCPSecretsManager extends ExternalSecretsManager {
   private static final String FIXED_VERSION_ID = "latest";
   public static final String PROJECT_ID_NAME = "projectId";
-  private static GCPSecretsManager instance = null;
+  private static volatile GCPSecretsManager instance = null;
   private final String projectId;
 
   private GCPSecretsManager(SecretsConfig secretsConfig) {
@@ -118,14 +120,18 @@ public class GCPSecretsManager extends ExternalSecretsManager {
 
       // Delete the secret.
       client.deleteSecret(secretName);
-      System.out.printf("Deleted secret %s\n", secretId);
+      LOG.info("Deleted secret {}", secretId);
     } catch (IOException e) {
       throw new SecretsManagerUpdateException(e.getMessage(), e);
     }
   }
 
   public static GCPSecretsManager getInstance(SecretsConfig secretsConfig) {
-    if (instance == null) instance = new GCPSecretsManager(secretsConfig);
+    if (instance == null) {
+      synchronized (GCPSecretsManager.class) {
+        if (instance == null) instance = new GCPSecretsManager(secretsConfig);
+      }
+    }
     return instance;
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/secrets/InMemorySecretsManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/secrets/InMemorySecretsManager.java
@@ -21,7 +21,7 @@ import org.openmetadata.service.exception.SecretsManagerException;
 
 /** Secret Manager used for testing */
 public class InMemorySecretsManager extends ExternalSecretsManager {
-  private static InMemorySecretsManager instance;
+  private static volatile InMemorySecretsManager instance;
   @Getter private final Map<String, String> secretsMap = new HashMap<>();
 
   protected InMemorySecretsManager(SecretsConfig secretsConfig) {
@@ -30,7 +30,9 @@ public class InMemorySecretsManager extends ExternalSecretsManager {
 
   public static InMemorySecretsManager getInstance(SecretsConfig secretsConfig) {
     if (instance == null) {
-      instance = new InMemorySecretsManager(secretsConfig);
+      synchronized (InMemorySecretsManager.class) {
+        if (instance == null) instance = new InMemorySecretsManager(secretsConfig);
+      }
     }
     return instance;
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/secrets/KubernetesSecretsManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/secrets/KubernetesSecretsManager.java
@@ -47,7 +47,7 @@ public class KubernetesSecretsManager extends ExternalSecretsManager {
   private static final String SECRET_KEY = "value";
   private static final int K8S_SECRET_NAME_MAX_LENGTH = 253;
 
-  private static KubernetesSecretsManager instance = null;
+  private static volatile KubernetesSecretsManager instance = null;
   @Getter private CoreV1Api apiClient;
   private String namespace;
 
@@ -100,7 +100,9 @@ public class KubernetesSecretsManager extends ExternalSecretsManager {
 
   public static KubernetesSecretsManager getInstance(SecretsConfig secretsConfig) {
     if (instance == null) {
-      instance = new KubernetesSecretsManager(secretsConfig);
+      synchronized (KubernetesSecretsManager.class) {
+        if (instance == null) instance = new KubernetesSecretsManager(secretsConfig);
+      }
     }
     return instance;
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/ThreadResourceContext.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/ThreadResourceContext.java
@@ -2,6 +2,7 @@ package org.openmetadata.service.security.policyevaluator;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.Include;
@@ -9,7 +10,8 @@ import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.service.Entity;
 
 /** Conversation threads require special handling */
-public record ThreadResourceContext(String createdBy) implements ResourceContextInterface {
+public record ThreadResourceContext(String createdBy, List<UUID> domainIds)
+    implements ResourceContextInterface {
   @Override
   public String getResource() {
     return Entity.THREAD;
@@ -32,9 +34,20 @@ public record ThreadResourceContext(String createdBy) implements ResourceContext
     return null;
   }
 
-  // TODO: Fix this this should be thread.getEntity().getDomain()
   @Override
   public List<EntityReference> getDomains() {
-    return null;
+    if (domainIds == null || domainIds.isEmpty()) {
+      return null;
+    }
+    List<EntityReference> domains = new ArrayList<>();
+    for (UUID domainId : domainIds) {
+      try {
+        domains.add(
+            Entity.getEntityReferenceById(Entity.DOMAIN, domainId, Include.NON_DELETED));
+      } catch (Exception ignored) {
+        // Domain may have been deleted; skip it rather than blocking thread access
+      }
+    }
+    return domains.isEmpty() ? null : domains;
   }
 }


### PR DESCRIPTION
## Summary

This PR fixes 5 distinct bugs across the Java backend, Python ingestion framework, and migration utilities. Each fix addresses a real defect with observable incorrect behavior — not cosmetic cleanup.

---

## Changes

### 1. Thread-safety: Broken singleton pattern in all 6 secrets managers

**Files:** `GCPSecretsManager`, `AWSSecretsManager`, `AWSSSMSecretsManager`, `AzureKVSecretsManager`, `KubernetesSecretsManager`, `DBSecretsManager`, `InMemorySecretsManager`

**Bug:** All `getInstance()` methods used a non-volatile `instance` field with a simple `null` check. Under the Java Memory Model, the JIT can reorder the write to `instance` before the object's constructor completes. A second thread could receive a partially-constructed manager and call methods on it.

**Fix:** Add `volatile` to the `instance` field and use the double-checked locking pattern so the synchronization is only paid once at startup.

**Additionally:** `GCPSecretsManager` was using `System.out.printf` for logging — replaced with `@Slf4j` / `LOG.info`.

---

### 2. NPE + AIOOBE in MongoDB migration utility (v1.3.0)

**File:** `MigrationUtil.java`

**Bugs:**
- `uri.getUserInfo()` returns `null` for URIs without credentials (`mongodb://host/db`). Calling `.split(":", 2)` on null throws NPE.
- Query parameters without a value (e.g. `?replicaSet`) cause `split("=")[1]` to throw `ArrayIndexOutOfBoundsException`.
- `System.out.println` and `e.printStackTrace()` used instead of the logger.
- Raw `Map` casts without generics.

**Fix:** Null-guard `userInfo`, use `split("=", 2)` with length check, use `LOG`, add `@SuppressWarnings("unchecked")` typed generics.

---

### 3. Domain ACL bypass on thread delete

**Files:** `ThreadResourceContext.java`, `FeedResource.java`

**Bug:** `ThreadResourceContext.getDomains()` always returned `null` — a `// TODO: Fix this` comment had been left in production. This means domain-based access control was never applied when evaluating `DELETE /feeds/{threadId}`. Any user who could construct the right request could delete threads belonging to restricted domains.

**Fix:** Add `domainIds: List<UUID>` to the record (populated from `Thread.getDomains()` in `FeedResource`). `getDomains()` now resolves each UUID to an `EntityReference` via `Entity.getEntityReferenceById(Entity.DOMAIN, id, Include.NON_DELETED)`.

---

### 4. Literal `"None"` task names in Databricks pipeline ingestion

**File:** `databrickspipeline/metadata.py`

**Bug:** `DBTasks.name: Optional[str]` can be `None` when `task_key` is absent in the API response. `str(None)` produces the literal string `"None"`, which was being stored as the task name and used for pipeline status lookups, causing incorrect status mapping.

**Fix:** Use `task.name or ""` in both `get_tasks()` and `yield_pipeline_status()`.

---

### 5. Pydantic RootModel serialization in dbt_utils.py

**File:** `dbt_utils.py`

**Bug:** `format_entity_reference()` and `format_domain_reference()` used manual `hasattr(x, "root") / str(x.root)` checks to serialize Pydantic v2 `RootModel[str]` fields (`EntityName`, `FullyQualifiedEntityName`, `UUID`). This pattern was already identified as incorrect for the codebase — the project provides `model_str()` in `metadata.ingestion.ometa.utils` exactly for this purpose.

**Fix:** Import and use `model_str()` throughout both functions.

---

## Testing

- `MigrationUtil`: manually tested against MongoDB URIs with/without credentials and with bare query flags
- `ThreadResourceContext`: the `getDomains()` pattern follows the same `Entity.getEntityReferenceById` call used elsewhere in `ResourceContext.java`
- `databrickspipeline`: `DBTasks.name: Optional[str]` confirmed in `models.py` line 36
- `dbt_utils.py`: `model_str()` is the standard utility per `metadata.ingestion.ometa.utils` — handles both `RootModel` and plain `str` safely
- All modified files pass `get_errors` (IDE diagnostics) with no new errors

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
