### PR TITLE
fix(e2e): stabilize permanentDeleteUser when user is not soft-deleted

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/user.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/user.ts
@@ -424,6 +424,15 @@ export const permanentDeleteUser = async (
   // Click on delete user button
   await page.click(`[data-testid="delete-user-btn-${username}"]`);
 
+  if (!isUserSoftDeleted) {
+    // Modal opens with soft-delete as default; wait for the form's
+    // initialization effect before switching, otherwise the click races
+    // with setFieldsValue and the selection gets clobbered.
+    await page
+      .locator('[data-testid="soft-delete"].ant-radio-wrapper-checked')
+      .waitFor();
+  }
+
   // Click on hard delete
   await page.click('[data-testid="hard-delete"]');
   await page.fill('[data-testid="confirmation-text-input"]', 'DELETE');


### PR DESCRIPTION
## Summary

`UserCreationWithPersona.spec.ts` → `Create user with persona and verify on profile` times out consistently in nightly on `1.12.6`. Network trace shows the app firing `DELETE /api/v1/users/{id}?hardDelete=false&recursive=false` (soft delete) even though the test clicks the hard-delete radio — so the `waitForResponse('...?hardDelete=true&...')` never resolves and the 60s test timeout hits.

### Why

`DeleteWidgetModal` uses `destroyOnClose`, so its Form remounts with empty state each time the modal opens. A `useEffect([visible])` then seeds `deleteType = SOFT_DELETE` via `form.setFieldsValue`. If Playwright clicks `[data-testid="hard-delete"]` between the Form's mount-render and the effect running, the effect fires *after* the click and overwrites the selection back to `SOFT_DELETE`. On Confirm, the app calls `deleteEntity(..., deleteType === HARD_DELETE)` with `false`.

This only surfaces when `permanentDeleteUser(…, isUserSoftDeleted=false)` is used. Every other caller passes `true`, which triggers a `waitForResponse('/api/v1/users?**include=non-deleted')` on the show-deleted toggle before the modal ever opens, buying enough time for the effect to run. `UserCreationWithPersona.spec.ts` is the only caller that doesn't — hence the consistent failure there while Users / UserDetails / OnlineUsers / PersonaFlow etc. stay green.

### Fix

Test-only change: before clicking hard-delete, wait for `[data-testid="soft-delete"].ant-radio-wrapper-checked` — the signal that `setFieldsValue` has finished seeding the form. The wait is gated on `!isUserSoftDeleted` because when the show-deleted toggle is on, the modal's `allowSoftDelete=false` so there's no soft-delete radio to wait for (and no race — the default is already HARD_DELETE).

Product-side fix (replace the effect with `initialValues` on the Form so the default is set synchronously on mount) belongs on `main`; this PR just unblocks `1.12.6` nightly without touching shipped code.

## Test plan

- [ ] Green CI on `UserCreationWithPersona.spec.ts` across multiple shards
- [ ] `Users.spec.ts`, `UserDetails.spec.ts`, `OnlineUsers.spec.ts`, `PersonaFlow.spec.ts`, `PersonaDeletionUserProfile.spec.ts` still green (they hit the `isUserSoftDeleted=true` branch which is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)