### PR TITLE
Fixes #27487: Respect conditional entity-level permissions for Glossary Import/Export

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryHeader/GlossaryHeader.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryHeader/GlossaryHeader.component.tsx
@@ -133,12 +133,12 @@ const GlossaryHeader = ({
       permissions?.EditAll ||
       checkPermission(
         Operation.All,
-        ResourceEntity.GLOSSARY_TERM,
+        ResourceEntity.GLOSSARY,
         globalPermissions
       ) ||
       checkPermission(
         Operation.EditAll,
-        ResourceEntity.GLOSSARY_TERM,
+        ResourceEntity.GLOSSARY,
         globalPermissions
       ),
     [globalPermissions, permissions]

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryHeader/GlossaryHeader.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryHeader/GlossaryHeader.component.tsx
@@ -129,19 +129,20 @@ const GlossaryHeader = ({
 
   const importExportPermissions = useMemo(
     () =>
-      permissions?.All ||
-      permissions?.EditAll ||
-      checkPermission(
-        Operation.All,
-        ResourceEntity.GLOSSARY,
-        globalPermissions
-      ) ||
-      checkPermission(
-        Operation.EditAll,
-        ResourceEntity.GLOSSARY,
-        globalPermissions
-      ),
-    [globalPermissions, permissions]
+      isGlossary &&
+      (permissions?.All ||
+        permissions?.EditAll ||
+        checkPermission(
+          Operation.All,
+          ResourceEntity.GLOSSARY,
+          globalPermissions
+        ) ||
+        checkPermission(
+          Operation.EditAll,
+          ResourceEntity.GLOSSARY,
+          globalPermissions
+        )),
+    [globalPermissions, permissions?.All, permissions?.EditAll, isGlossary]
   );
 
   // To fetch the latest glossary data

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryHeader/GlossaryHeader.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryHeader/GlossaryHeader.component.tsx
@@ -129,6 +129,8 @@ const GlossaryHeader = ({
 
   const importExportPermissions = useMemo(
     () =>
+      permissions?.All ||
+      permissions?.EditAll ||
       checkPermission(
         Operation.All,
         ResourceEntity.GLOSSARY_TERM,
@@ -139,7 +141,7 @@ const GlossaryHeader = ({
         ResourceEntity.GLOSSARY_TERM,
         globalPermissions
       ),
-    [globalPermissions]
+    [globalPermissions, permissions]
   );
 
   // To fetch the latest glossary data

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryHeader/GlossaryHeader.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryHeader/GlossaryHeader.test.tsx
@@ -181,6 +181,13 @@ jest.mock('../../Customization/GenericProvider/GenericProvider', () => ({
 }));
 
 describe('GlossaryHeader component', () => {
+  beforeEach(() => {
+    mockGlossaryTermPermission.All = true;
+    mockGlossaryTermPermission.EditAll = true;
+    mockContext.permissions = DEFAULT_ENTITY_PERMISSION;
+    mockContext.type = EntityType.GLOSSARY;
+  });
+
   it('should render name of Glossary', () => {
     render(
       <GlossaryHeader

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryHeader/GlossaryHeader.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryHeader/GlossaryHeader.test.tsx
@@ -240,6 +240,8 @@ describe('GlossaryHeader component', () => {
   it('should not render import and export dropdown menu items if no permission', async () => {
     mockGlossaryTermPermission.All = false;
     mockGlossaryTermPermission.EditAll = false;
+    mockGlossaryPermission.All = false;
+    mockGlossaryPermission.EditAll = false;
     render(
       <GlossaryHeader
         updateVote={mockOnUpdateVote}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryHeader/GlossaryHeader.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryHeader/GlossaryHeader.test.tsx
@@ -33,9 +33,21 @@ const mockGlossaryTermPermission = {
   EditCustomFields: true,
 };
 
+const mockGlossaryPermission = {
+  All: true,
+  Create: true,
+  Delete: true,
+  ViewAll: true,
+  EditAll: true,
+  EditDescription: true,
+  EditDisplayName: true,
+  EditCustomFields: true,
+};
+
 jest.mock('../../../context/PermissionProvider/PermissionProvider', () => ({
   usePermissionProvider: jest.fn().mockImplementation(() => ({
     permissions: {
+      glossary: mockGlossaryPermission,
       glossaryTerm: mockGlossaryTermPermission,
     },
   })),
@@ -184,6 +196,8 @@ describe('GlossaryHeader component', () => {
   beforeEach(() => {
     mockGlossaryTermPermission.All = true;
     mockGlossaryTermPermission.EditAll = true;
+    mockGlossaryPermission.All = true;
+    mockGlossaryPermission.EditAll = true;
     mockContext.permissions = DEFAULT_ENTITY_PERMISSION;
     mockContext.type = EntityType.GLOSSARY;
   });
@@ -240,6 +254,8 @@ describe('GlossaryHeader component', () => {
   it('should render import and export dropdown menu items when global permission is false but contextual entity permission is true', async () => {
     mockGlossaryTermPermission.All = false;
     mockGlossaryTermPermission.EditAll = false;
+    mockGlossaryPermission.All = false;
+    mockGlossaryPermission.EditAll = false;
     mockContext.permissions = { ...DEFAULT_ENTITY_PERMISSION, EditAll: true };
     mockContext.type = EntityType.GLOSSARY;
     render(

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryHeader/GlossaryHeader.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryHeader/GlossaryHeader.test.tsx
@@ -194,6 +194,7 @@ describe('GlossaryHeader component', () => {
   });
 
   it('should render import and export dropdown menu items only for glossary', async () => {
+    mockContext.permissions = { ...DEFAULT_ENTITY_PERMISSION, All: true };
     render(
       <GlossaryHeader
         updateVote={mockOnUpdateVote}
@@ -227,6 +228,27 @@ describe('GlossaryHeader component', () => {
     );
 
     expect(screen.queryByTestId('manage-button')).not.toBeInTheDocument();
+  });
+
+  it('should render import and export dropdown menu items when global permission is false but contextual entity permission is true', async () => {
+    mockGlossaryTermPermission.All = false;
+    mockGlossaryTermPermission.EditAll = false;
+    mockContext.permissions = { ...DEFAULT_ENTITY_PERMISSION, EditAll: true };
+    mockContext.type = EntityType.GLOSSARY;
+    render(
+      <GlossaryHeader
+        updateVote={mockOnUpdateVote}
+        onAddGlossaryTerm={mockOnDelete}
+        onDelete={mockOnDelete}
+      />
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('manage-button'));
+    });
+
+    expect(screen.queryByText('label.import')).toBeInTheDocument();
+    expect(screen.queryByText('label.export')).toBeInTheDocument();
   });
 
   it('should render changeParentHierarchy and style dropdown menu items only for glossaryTerm', async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryHeader/GlossaryHeader.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryHeader/GlossaryHeader.test.tsx
@@ -315,6 +315,8 @@ describe('GlossaryHeader component', () => {
   });
 
   it('should render ChangeParentHierarchy component after clicking dropdown menu item', async () => {
+    mockContext.type = EntityType.GLOSSARY_TERM;
+    mockContext.permissions = { ...DEFAULT_ENTITY_PERMISSION, EditAll: true };
     render(
       <GlossaryHeader
         updateVote={mockOnUpdateVote}
@@ -341,6 +343,8 @@ describe('GlossaryHeader component', () => {
   });
 
   it('should not render ChangeParentHierarchy component after onCancel call', async () => {
+    mockContext.type = EntityType.GLOSSARY_TERM;
+    mockContext.permissions = { ...DEFAULT_ENTITY_PERMISSION, EditAll: true };
     render(
       <GlossaryHeader
         updateVote={mockOnUpdateVote}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryHeader/GlossaryHeader.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryHeader/GlossaryHeader.test.tsx
@@ -228,8 +228,8 @@ describe('GlossaryHeader component', () => {
       fireEvent.click(screen.getByTestId('manage-button'));
     });
 
-    expect(screen.queryByText('label.import')).toBeInTheDocument();
-    expect(screen.queryByText('label.export')).toBeInTheDocument();
+    expect(await screen.findByText('label.import')).toBeInTheDocument();
+    expect(await screen.findByText('label.export')).toBeInTheDocument();
 
     expect(
       screen.queryByText('label.change-parent-entity')
@@ -272,8 +272,8 @@ describe('GlossaryHeader component', () => {
       fireEvent.click(screen.getByTestId('manage-button'));
     });
 
-    expect(screen.queryByText('label.import')).toBeInTheDocument();
-    expect(screen.queryByText('label.export')).toBeInTheDocument();
+    expect(await screen.findByText('label.import')).toBeInTheDocument();
+    expect(await screen.findByText('label.export')).toBeInTheDocument();
   });
 
   it('should render changeParentHierarchy and style dropdown menu items only for glossaryTerm', async () => {


### PR DESCRIPTION
## Description:

Fixes #27487

**What changes did you make and why?**
Fixed a bug where users with conditional `EditAll` permissions (like `isOwner()`) couldn't see the Import/Export buttons in the Glossary. 

Previously, `importExportPermissions` only checked the static global permissions via `checkPermission()`. It ignored the backend-evaluated conditional permissions. I updated the memo to check the local entity-level `permissions` from `useGenericContext()` first, before falling back to the global checks. 

**How did you test your changes?**
* Fixed the mocked context in existing tests so they don't break with the new hook logic.
* Added a specific regression test: `"should render import and export dropdown menu items when global permission is false but contextual entity permission is true"` to guarantee this bug doesn't come back.

**Screen Shot of test Result**
<img width="1462" height="452" alt="image" src="https://github.com/user-attachments/assets/5f40d76b-e1ea-41a3-bae5-cac34d6f8306" />

#
### Type of change:
- [x] Bug fix

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

- [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.

----
## Summary by Gitar

- **Code Refactoring:**
  - Changed `ResourceEntity.GLOSSARY_TERM` to `ResourceEntity.GLOSSARY` in `GlossaryHeader.component.tsx` permission checks.
- **Test Improvements:**
  - Updated `GlossaryHeader.test.tsx` to include `mockGlossaryPermission` and added state resets in `beforeEach` for consistent test execution.

<sub>This will update automatically on new commits.</sub>