### PR TITLE
Fixes #26824: correct metadataStatus filtering in column bulk operations

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ColumnRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ColumnRepository.java
@@ -27,6 +27,7 @@ import jakarta.ws.rs.core.UriInfo;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,7 +37,6 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
-import java.util.Collections;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.api.data.BulkColumnUpdatePreview;
@@ -94,78 +94,75 @@ public class ColumnRepository {
     }
   }
 
-public ColumnGridResponse getColumnGridPaginated(
-    SecurityContext securityContext,
-    ColumnAggregator.ColumnAggregationRequest request) throws IOException {
+  public ColumnGridResponse getColumnGridPaginated(
+      SecurityContext securityContext, ColumnAggregator.ColumnAggregationRequest request)
+      throws IOException {
 
-  ColumnGridResponse response = columnAggregator.aggregateColumns(request);
+    ColumnGridResponse response = columnAggregator.aggregateColumns(request);
 
-  List<ColumnGridItem> filtered =
-      response.getColumns() == null
-          ? Collections.emptyList()
-          : response.getColumns().stream()
-              .filter(item -> {
+    List<ColumnGridItem> filtered =
+        response.getColumns() == null
+            ? Collections.emptyList()
+            : response.getColumns().stream()
+                .filter(
+                    item -> {
+                      if (Boolean.TRUE.equals(request.getHasConflicts())
+                          && !Boolean.TRUE.equals(item.getHasVariations())) {
+                        return false;
+                      }
 
-                if (Boolean.TRUE.equals(request.getHasConflicts())
-                    && !Boolean.TRUE.equals(item.getHasVariations())) {
-                  return false;
-                }
+                      if (Boolean.TRUE.equals(request.getHasMissingMetadata())
+                          && !hasMissingMetadata(item)) {
+                        return false;
+                      }
 
-                if (Boolean.TRUE.equals(request.getHasMissingMetadata())
-                    && !hasMissingMetadata(item)) {
-                  return false;
-                }
+                      if (!matchesMetadataStatus(item, request.getMetadataStatus())) {
+                        return false;
+                      }
 
-                if (!matchesMetadataStatus(item, request.getMetadataStatus())) {
-                  return false;
-                }
+                      return true;
+                    })
+                .collect(Collectors.toList());
 
-                return true;
-              })
-              .collect(Collectors.toList());
+    // NOTE: Counts reflect only filtered results for the current page.
+    // Full dataset filtering requires pushing predicates into aggregation layer.
+    // Filtering is applied post-aggregation.
+    // This may result in fewer items than requested page size
+    // and cursor may not perfectly reflect filtered dataset.
+    // Proper fix would require pushing filters into aggregation layer.
+    response.setColumns(filtered);
+    response.setTotalUniqueColumns(filtered.size());
+    response.setTotalOccurrences(
+        filtered.stream()
+            .mapToInt(item -> item.getTotalOccurrences() != null ? item.getTotalOccurrences() : 0)
+            .sum());
 
-  // NOTE: Counts reflect only filtered results for the current page.
-  // Full dataset filtering requires pushing predicates into aggregation layer.
-  // Filtering is applied post-aggregation.
-  // This may result in fewer items than requested page size
-  // and cursor may not perfectly reflect filtered dataset.
-  // Proper fix would require pushing filters into aggregation layer.
-  response.setColumns(filtered);
-  response.setTotalUniqueColumns(filtered.size());
-  response.setTotalOccurrences(
-      filtered.stream()
-          .mapToInt(item -> item.getTotalOccurrences() != null ? item.getTotalOccurrences() : 0)
-          .sum());
-
-  return response;
-}
-
-public static boolean matchesMetadataStatus(
-    ColumnGridItem item, String metadataStatus) {
-
-  if (metadataStatus == null || metadataStatus.isBlank()) {
-    return true;
+    return response;
   }
 
-  String itemStatus =
-      item.getMetadataStatus() != null
-          ? item.getMetadataStatus().value()
-          : "";
+  public static boolean matchesMetadataStatus(ColumnGridItem item, String metadataStatus) {
 
-  return metadataStatus.trim().equalsIgnoreCase(itemStatus);
-}
+    if (metadataStatus == null || metadataStatus.isBlank()) {
+      return true;
+    }
 
-private boolean hasMissingMetadata(ColumnGridItem item) {
-  if (item.getGroups() == null) {
-    return true;
+    String itemStatus = item.getMetadataStatus() != null ? item.getMetadataStatus().value() : "";
+
+    return metadataStatus.trim().equalsIgnoreCase(itemStatus);
   }
 
-  return item.getGroups().stream()
-      .anyMatch(
-          group ->
-              (group.getDescription() == null || group.getDescription().isEmpty())
-                  || (group.getTags() == null || group.getTags().isEmpty()));
-}
+  private boolean hasMissingMetadata(ColumnGridItem item) {
+    if (item.getGroups() == null) {
+      return true;
+    }
+
+    return item.getGroups().stream()
+        .anyMatch(
+            group ->
+                (group.getDescription() == null || group.getDescription().isEmpty())
+                    || (group.getTags() == null || group.getTags().isEmpty()));
+  }
+
   public Column updateColumnByFQN(
       UriInfo uriInfo,
       SecurityContext securityContext,

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ColumnRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ColumnRepository.java
@@ -36,6 +36,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
+import java.util.Collections;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.api.data.BulkColumnUpdatePreview;
@@ -93,44 +94,78 @@ public class ColumnRepository {
     }
   }
 
-  public ColumnGridResponse getColumnGridPaginated(
-      SecurityContext securityContext, ColumnAggregator.ColumnAggregationRequest request)
-      throws IOException {
-    ColumnGridResponse response = columnAggregator.aggregateColumns(request);
+public ColumnGridResponse getColumnGridPaginated(
+    SecurityContext securityContext,
+    ColumnAggregator.ColumnAggregationRequest request) throws IOException {
 
-    if (Boolean.TRUE.equals(request.getHasConflicts())) {
-      response.setColumns(
-          response.getColumns().stream()
-              .filter(ColumnGridItem::getHasVariations)
-              .collect(Collectors.toList()));
-    }
+  ColumnGridResponse response = columnAggregator.aggregateColumns(request);
 
-    if (Boolean.TRUE.equals(request.getHasMissingMetadata())) {
-      response.setColumns(
-          response.getColumns().stream()
-              .filter(this::hasMissingMetadata)
-              .collect(Collectors.toList()));
-    }
+  List<ColumnGridItem> filtered =
+      response.getColumns() == null
+          ? Collections.emptyList()
+          : response.getColumns().stream()
+              .filter(item -> {
 
-    // Filter by INCONSISTENT status (requires post-aggregation filtering)
-    if ("INCONSISTENT".equalsIgnoreCase(request.getMetadataStatus())) {
-      response.setColumns(
-          response.getColumns().stream()
-              .filter(ColumnGridItem::getHasVariations)
-              .collect(Collectors.toList()));
-    }
+                if (Boolean.TRUE.equals(request.getHasConflicts())
+                    && !Boolean.TRUE.equals(item.getHasVariations())) {
+                  return false;
+                }
 
-    return response;
+                if (Boolean.TRUE.equals(request.getHasMissingMetadata())
+                    && !hasMissingMetadata(item)) {
+                  return false;
+                }
+
+                if (!matchesMetadataStatus(item, request.getMetadataStatus())) {
+                  return false;
+                }
+
+                return true;
+              })
+              .collect(Collectors.toList());
+
+  // NOTE: Counts reflect only filtered results for the current page.
+  // Full dataset filtering requires pushing predicates into aggregation layer.
+  // Filtering is applied post-aggregation.
+  // This may result in fewer items than requested page size
+  // and cursor may not perfectly reflect filtered dataset.
+  // Proper fix would require pushing filters into aggregation layer.
+  response.setColumns(filtered);
+  response.setTotalUniqueColumns(filtered.size());
+  response.setTotalOccurrences(
+      filtered.stream()
+          .mapToInt(item -> item.getTotalOccurrences() != null ? item.getTotalOccurrences() : 0)
+          .sum());
+
+  return response;
+}
+
+public static boolean matchesMetadataStatus(
+    ColumnGridItem item, String metadataStatus) {
+
+  if (metadataStatus == null || metadataStatus.isBlank()) {
+    return true;
   }
 
-  private boolean hasMissingMetadata(ColumnGridItem item) {
-    return item.getGroups().stream()
-        .anyMatch(
-            group ->
-                (group.getDescription() == null || group.getDescription().isEmpty())
-                    || (group.getTags() == null || group.getTags().isEmpty()));
+  String itemStatus =
+      item.getMetadataStatus() != null
+          ? item.getMetadataStatus().value()
+          : "";
+
+  return metadataStatus.trim().equalsIgnoreCase(itemStatus);
+}
+
+private boolean hasMissingMetadata(ColumnGridItem item) {
+  if (item.getGroups() == null) {
+    return true;
   }
 
+  return item.getGroups().stream()
+      .anyMatch(
+          group ->
+              (group.getDescription() == null || group.getDescription().isEmpty())
+                  || (group.getTags() == null || group.getTags().isEmpty()));
+}
   public Column updateColumnByFQN(
       UriInfo uriInfo,
       SecurityContext securityContext,

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ColumnRepoTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ColumnRepoTest.java
@@ -1,8 +1,8 @@
 package org.openmetadata.service.jdbi3;
 
-import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.Test;
 import org.openmetadata.schema.api.data.ColumnGridItem;
 import org.openmetadata.schema.api.data.MetadataStatus;
 
@@ -17,11 +17,9 @@ class ColumnRepoTest {
     ColumnGridItem item2 = new ColumnGridItem();
     item2.setMetadataStatus(MetadataStatus.fromValue("INCOMPLETE"));
 
-    boolean result1 =
-        ColumnRepository.matchesMetadataStatus(item1, "COMPLETE");
+    boolean result1 = ColumnRepository.matchesMetadataStatus(item1, "COMPLETE");
 
-    boolean result2 =
-        ColumnRepository.matchesMetadataStatus(item2, "COMPLETE");
+    boolean result2 = ColumnRepository.matchesMetadataStatus(item2, "COMPLETE");
 
     assertTrue(result1);
     assertFalse(result2);
@@ -36,11 +34,9 @@ class ColumnRepoTest {
     ColumnGridItem item2 = new ColumnGridItem();
     item2.setMetadataStatus(MetadataStatus.fromValue("INCOMPLETE"));
 
-    boolean result1 =
-        ColumnRepository.matchesMetadataStatus(item1, "INCOMPLETE");
+    boolean result1 = ColumnRepository.matchesMetadataStatus(item1, "INCOMPLETE");
 
-    boolean result2 =
-        ColumnRepository.matchesMetadataStatus(item2, "INCOMPLETE");
+    boolean result2 = ColumnRepository.matchesMetadataStatus(item2, "INCOMPLETE");
 
     assertFalse(result1);
     assertTrue(result2);
@@ -52,8 +48,7 @@ class ColumnRepoTest {
     ColumnGridItem item = new ColumnGridItem();
     item.setMetadataStatus(MetadataStatus.fromValue("COMPLETE"));
 
-    boolean result =
-        ColumnRepository.matchesMetadataStatus(item, "complete");
+    boolean result = ColumnRepository.matchesMetadataStatus(item, "complete");
 
     assertTrue(result); // case-insensitive check
   }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ColumnRepoTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ColumnRepoTest.java
@@ -1,0 +1,71 @@
+package org.openmetadata.service.jdbi3;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.openmetadata.schema.api.data.ColumnGridItem;
+import org.openmetadata.schema.api.data.MetadataStatus;
+
+class ColumnRepoTest {
+
+  @Test
+  void testMetadataStatusFilterComplete() {
+
+    ColumnGridItem item1 = new ColumnGridItem();
+    item1.setMetadataStatus(MetadataStatus.fromValue("COMPLETE"));
+
+    ColumnGridItem item2 = new ColumnGridItem();
+    item2.setMetadataStatus(MetadataStatus.fromValue("INCOMPLETE"));
+
+    boolean result1 =
+        ColumnRepository.matchesMetadataStatus(item1, "COMPLETE");
+
+    boolean result2 =
+        ColumnRepository.matchesMetadataStatus(item2, "COMPLETE");
+
+    assertTrue(result1);
+    assertFalse(result2);
+  }
+
+  @Test
+  void testMetadataStatusFilterIncomplete() {
+
+    ColumnGridItem item1 = new ColumnGridItem();
+    item1.setMetadataStatus(MetadataStatus.fromValue("COMPLETE"));
+
+    ColumnGridItem item2 = new ColumnGridItem();
+    item2.setMetadataStatus(MetadataStatus.fromValue("INCOMPLETE"));
+
+    boolean result1 =
+        ColumnRepository.matchesMetadataStatus(item1, "INCOMPLETE");
+
+    boolean result2 =
+        ColumnRepository.matchesMetadataStatus(item2, "INCOMPLETE");
+
+    assertFalse(result1);
+    assertTrue(result2);
+  }
+
+  @Test
+  void testMetadataStatusCaseInsensitive() {
+
+    ColumnGridItem item = new ColumnGridItem();
+    item.setMetadataStatus(MetadataStatus.fromValue("COMPLETE"));
+
+    boolean result =
+        ColumnRepository.matchesMetadataStatus(item, "complete");
+
+    assertTrue(result); // case-insensitive check
+  }
+
+  @Test
+  void testMetadataStatusNullOrBlankFilter() {
+
+    ColumnGridItem item = new ColumnGridItem();
+    item.setMetadataStatus(MetadataStatus.fromValue("INCOMPLETE"));
+
+    assertTrue(ColumnRepository.matchesMetadataStatus(item, null));
+    assertTrue(ColumnRepository.matchesMetadataStatus(item, ""));
+    assertTrue(ColumnRepository.matchesMetadataStatus(item, "   "));
+  }
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix


#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x]My PR title is `Fixes #26824: correct metadataStatus filtering in column bulk operations`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
    

--> VIDEO DESCRIBING BUG
https://www.loom.com/share/f875b1484d5f49b680132d1a5e4897bf

----
## Summary by Gitar

- **Refactoring:**
  - Consolidated post-aggregation filtering logic within `getColumnGridPaginated` for improved maintainability.
  - Added `matchesMetadataStatus` helper to centralize status comparison logic.
- **Robustness:**
  - Added null checks in `hasMissingMetadata` to safely handle cases where column groups are undefined.
  - Updated `getColumnGridPaginated` to handle empty column lists gracefully.
- **Testing:**
  - Added `ColumnRepoTest` cases to verify metadata status filtering logic and edge cases.

<sub>This will update automatically on new commits.</sub>