### PR TITLE
Db ingestion improvements

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/common_db_source.py
+++ b/ingestion/src/metadata/ingestion/source/database/common_db_source.py
@@ -381,6 +381,30 @@ class CommonDbSourceService(
             for table_name in self.inspector.get_view_names(schema_name) or []
         ]
 
+    def _clear_thread_reflection_cache(self) -> None:
+        """
+        Clear SQLAlchemy reflection cache for the current thread's Inspector.
+
+        Called at schema boundaries so per-(schema, table) cache entries
+        from the prior schema can be reclaimed. SQLAlchemy's info_cache is
+        an unbounded dict populated by @reflection.cache methods
+        (get_schema_columns, get_pk_constraint, get_foreign_keys,
+        get_unique_constraints, get_columns, get_view_definition, ...).
+        On heavy-reflection connectors like Snowflake, one inspector's
+        cache can grow past a gigabyte on a single large database.
+
+        Thread safety: only the current thread's inspector is cleared;
+        other threads may be mid-reflection and touching their cache
+        would race with live reads.
+        """
+        thread_id = self.context.get_current_thread_id()
+        inspector = self._inspector_map.get(thread_id)
+        if inspector is None:
+            return
+        info_cache = getattr(inspector, "info_cache", None)
+        if info_cache is not None:
+            info_cache.clear()
+
     def get_tables_name_and_type(self) -> Optional[Iterable[Tuple[str, str]]]:
         """
         Handle table and views.
@@ -390,6 +414,11 @@ class CommonDbSourceService(
 
         :return: tables or views, depending on config
         """
+        # Reclaim prior-schema reflection cache entries before walking
+        # this schema's tables — bounds Inspector.info_cache growth on
+        # databases with many/wide schemas (see Snowflake's heavy
+        # reflection path via @reflection.cache in snowflake/utils.py).
+        self._clear_thread_reflection_cache()
         schema_name = self.context.get().database_schema
         try:
             if self.source_config.includeTables:

--- a/ingestion/src/metadata/ingestion/source/database/common_db_source.py
+++ b/ingestion/src/metadata/ingestion/source/database/common_db_source.py
@@ -162,9 +162,7 @@ class CommonDbSourceService(
             try:
                 self.engine.dispose()
             except Exception as exc:
-                logger.warning(
-                    f"Failed to dispose previous engine on DB switch: {exc}"
-                )
+                logger.warning(f"Failed to dispose previous engine on DB switch: {exc}")
         logger.info(f"Ingesting from database: {database_name}")
 
         new_service_connection = deepcopy(self.service_connection)

--- a/ingestion/src/metadata/ingestion/source/database/common_db_source.py
+++ b/ingestion/src/metadata/ingestion/source/database/common_db_source.py
@@ -153,6 +153,18 @@ class CommonDbSourceService(
         """
 
         kill_active_connections(self.engine)
+        # Release the previous engine's pool, dialect state, Inspector
+        # info_cache, and any per-engine event listeners that capture `self`
+        # (e.g. SnowflakeSource.set_session_query_tag). Without this, each
+        # database switch leaks ~tens of MB → linear growth on multi-DB
+        # pipelines.
+        if self.engine is not None:
+            try:
+                self.engine.dispose()
+            except Exception as exc:
+                logger.warning(
+                    f"Failed to dispose previous engine on DB switch: {exc}"
+                )
         logger.info(f"Ingesting from database: {database_name}")
 
         new_service_connection = deepcopy(self.service_connection)

--- a/ingestion/src/metadata/ingestion/source/database/snowflake/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/metadata.py
@@ -410,6 +410,7 @@ class SnowflakeSource(
     def get_database_names(self) -> Iterable[str]:
         configured_db = self.config.serviceConnection.root.config.database
         if configured_db:
+            self._reset_per_database_state()
             self.set_inspector(configured_db)
             self.set_session_query_tag()
             self.set_partition_details()
@@ -440,6 +441,7 @@ class SnowflakeSource(
                     continue
 
                 try:
+                    self._reset_per_database_state()
                     self.set_inspector(database_name=new_database)
                     self.set_session_query_tag()
                     self.set_partition_details()
@@ -454,6 +456,26 @@ class SnowflakeSource(
                     logger.warning(
                         f"Error trying to connect to database {new_database}: {exc}"
                     )
+
+    def _reset_per_database_state(self) -> None:
+        # deleted_tables is a process-wide list extended per-schema via
+        # _get_table_names_and_types / _get_stream_names_and_types. Without
+        # this reset, entries from previous databases accumulate across the
+        # run — hundreds of MB of FQN strings in incremental mode with heavy
+        # soft-delete history, and delete-by-name entries get replayed
+        # against the wrong database.
+        #
+        # Safety: runs between database boundaries where all schema-level
+        # workers from the previous DB are already joined (topology_runner
+        # exits the ThreadPoolExecutor context before returning to the
+        # producer generator). .clear() mutates in place rather than
+        # reassigning, so any future code that caches a local reference to
+        # the list sees the cleared state consistently.
+        deleted_tables = self.context.get_global().deleted_tables
+        if deleted_tables is None:
+            self.context.get_global().deleted_tables = []
+        else:
+            deleted_tables.clear()
 
     def __clean_append(self, token: Token, result_list: List) -> None:
         """

--- a/ingestion/tests/unit/topology/database/test_common_db_source.py
+++ b/ingestion/tests/unit/topology/database/test_common_db_source.py
@@ -432,3 +432,96 @@ class TestSetInspectorDisposesOldEngine:
 
         old_engine.dispose.assert_called_once()
         assert mock_source.engine is new_engine
+
+
+class TestSchemaBoundaryReflectionCacheClear:
+    """TDD: clear per-thread Inspector.info_cache at each schema boundary.
+
+    Why: SQLAlchemy's Inspector.info_cache is an unbounded dict populated
+    by @reflection.cache methods (get_schema_columns, get_pk_constraint,
+    get_foreign_keys, get_unique_constraints, get_columns, get_view_definition,
+    get_table_ddl, ...). In Snowflake's heavy reflection path a single wide
+    schema can push one inspector's cache past 1 GB (e.g. 52k tables x 50
+    cols on a single database). Inspectors are retained per-thread in
+    _inspector_map until close(), so without eviction the pod OOMs partway
+    through a large database before any DB-boundary cleanup can fire.
+
+    Clearing at the start of get_tables_name_and_type() is the natural
+    hook — it runs once per schema per thread, so the prior schema's
+    entries are reclaimed before the next schema's entries are written.
+    """
+
+    def test_clear_clears_only_current_thread_inspector(self):
+        """Thread safety: other threads' inspectors must be untouched —
+        they may be actively mid-reflection on their own schemas, and
+        clearing their cache would race with live reads.
+        """
+        import threading
+
+        mock_source = MagicMock()
+        mock_source._clear_thread_reflection_cache = (
+            CommonDbSourceService._clear_thread_reflection_cache.__get__(mock_source)
+        )
+
+        current_thread_id = threading.get_ident()
+        other_thread_id = current_thread_id + 1
+
+        current_inspector = MagicMock()
+        current_inspector.info_cache = {"schema_A_key": "heavy_data"}
+        other_inspector = MagicMock()
+        other_inspector.info_cache = {"schema_B_key": "also_heavy"}
+
+        mock_source._inspector_map = {
+            current_thread_id: current_inspector,
+            other_thread_id: other_inspector,
+        }
+        mock_source.context.get_current_thread_id.return_value = current_thread_id
+
+        mock_source._clear_thread_reflection_cache()
+
+        assert current_inspector.info_cache == {}, (
+            "Current thread's inspector info_cache must be cleared."
+        )
+        assert other_inspector.info_cache == {"schema_B_key": "also_heavy"}, (
+            "Other threads' inspectors must NOT be touched — clearing "
+            "them would race with in-flight reflection reads."
+        )
+
+    def test_clear_is_noop_when_thread_has_no_inspector_yet(self):
+        """First schema after startup (or first schema for a worker thread
+        that has not yet been assigned one) has no inspector — the clear
+        must silently succeed rather than raise.
+        """
+        import threading
+
+        mock_source = MagicMock()
+        mock_source._clear_thread_reflection_cache = (
+            CommonDbSourceService._clear_thread_reflection_cache.__get__(mock_source)
+        )
+
+        mock_source._inspector_map = {}
+        mock_source.context.get_current_thread_id.return_value = threading.get_ident()
+
+        # Must not raise.
+        mock_source._clear_thread_reflection_cache()
+
+    def test_get_tables_name_and_type_clears_cache_at_schema_boundary(self):
+        """Integration: get_tables_name_and_type() is the per-schema hook
+        for the topology — it must call _clear_thread_reflection_cache so
+        the prior schema's cache entries are reclaimed before this schema
+        starts populating its own.
+        """
+        mock_source = MagicMock()
+        mock_source.get_tables_name_and_type = (
+            CommonDbSourceService.get_tables_name_and_type.__get__(mock_source)
+        )
+        # Disable both table and view iteration so we exit the method
+        # immediately after the cache-clear hook — we're not testing
+        # iteration semantics here.
+        mock_source.source_config.includeTables = False
+        mock_source.source_config.includeViews = False
+        mock_source.context.get.return_value = MagicMock(database_schema="schema_X")
+
+        list(mock_source.get_tables_name_and_type() or [])
+
+        mock_source._clear_thread_reflection_cache.assert_called_once()

--- a/ingestion/tests/unit/topology/database/test_common_db_source.py
+++ b/ingestion/tests/unit/topology/database/test_common_db_source.py
@@ -479,9 +479,9 @@ class TestSchemaBoundaryReflectionCacheClear:
 
         mock_source._clear_thread_reflection_cache()
 
-        assert current_inspector.info_cache == {}, (
-            "Current thread's inspector info_cache must be cleared."
-        )
+        assert (
+            current_inspector.info_cache == {}
+        ), "Current thread's inspector info_cache must be cleared."
         assert other_inspector.info_cache == {"schema_B_key": "also_heavy"}, (
             "Other threads' inspectors must NOT be touched — clearing "
             "them would race with in-flight reflection reads."

--- a/ingestion/tests/unit/topology/database/test_common_db_source.py
+++ b/ingestion/tests/unit/topology/database/test_common_db_source.py
@@ -375,9 +375,9 @@ class TestSetInspectorDisposesOldEngine:
             mock_source.set_inspector("next_database")
 
         old_engine.dispose.assert_called_once()
-        assert mock_source.engine is new_engine, (
-            "The new engine must replace the old one after dispose."
-        )
+        assert (
+            mock_source.engine is new_engine
+        ), "The new engine must replace the old one after dispose."
 
     def test_no_dispose_called_when_no_previous_engine(self):
         """First call to set_inspector (before any engine exists) must not

--- a/ingestion/tests/unit/topology/database/test_common_db_source.py
+++ b/ingestion/tests/unit/topology/database/test_common_db_source.py
@@ -334,3 +334,101 @@ class TestNormalizeTableConstraints:
         result = DatabaseServiceSource.normalize_table_constraints(constraints, columns)
         assert result[0].columns is None
         assert result[1].columns == ["id"]
+
+
+class TestSetInspectorDisposesOldEngine:
+    """TDD: set_inspector must dispose the previous engine on each DB switch.
+
+    Why this matters: MultiDBSource connectors (Snowflake, BigQuery, ...) call
+    set_inspector() once per database to point the Inspector at the next DB.
+    Before the fix, the previous engine was simply replaced without calling
+    .dispose(), leaking its QueuePool, dialect metadata, reflection info_cache,
+    and any `event.listens_for(engine, "connect")` closures that capture self
+    (see SnowflakeSource.set_session_query_tag). Across N databases this
+    accumulates linearly — a significant contributor to long-running-pipeline
+    memory growth in production.
+    """
+
+    def test_previous_engine_is_disposed_on_database_switch(self):
+        """When set_inspector is called with a fresh DB, the existing
+        engine (from the previous DB) must have .dispose() invoked before
+        being replaced. Without dispose() the pool's threads, sockets,
+        and cached metadata remain live for the rest of the pipeline.
+        """
+        mock_source = MagicMock()
+        mock_source.set_inspector = CommonDbSourceService.set_inspector.__get__(
+            mock_source
+        )
+
+        old_engine = MagicMock(name="old_engine")
+        mock_source.engine = old_engine
+        mock_source.service_connection = MagicMock()
+
+        new_engine = MagicMock(name="new_engine")
+
+        with patch(
+            "metadata.ingestion.source.database.common_db_source.kill_active_connections"
+        ), patch(
+            "metadata.ingestion.source.database.common_db_source.get_connection",
+            return_value=new_engine,
+        ):
+            mock_source.set_inspector("next_database")
+
+        old_engine.dispose.assert_called_once()
+        assert mock_source.engine is new_engine, (
+            "The new engine must replace the old one after dispose."
+        )
+
+    def test_no_dispose_called_when_no_previous_engine(self):
+        """First call to set_inspector (before any engine exists) must not
+        raise — the dispose guard should only fire when there is a previous
+        engine. Covers fresh-pipeline startup.
+        """
+        mock_source = MagicMock()
+        mock_source.set_inspector = CommonDbSourceService.set_inspector.__get__(
+            mock_source
+        )
+        mock_source.engine = None
+        mock_source.service_connection = MagicMock()
+
+        new_engine = MagicMock(name="new_engine")
+
+        with patch(
+            "metadata.ingestion.source.database.common_db_source.kill_active_connections"
+        ), patch(
+            "metadata.ingestion.source.database.common_db_source.get_connection",
+            return_value=new_engine,
+        ):
+            # Must not raise (e.g. calling .dispose() on None).
+            mock_source.set_inspector("first_database")
+
+        assert mock_source.engine is new_engine
+
+    def test_dispose_failure_does_not_block_new_engine_assignment(self):
+        """If dispose() on the old engine throws (e.g. network glitch during
+        pool teardown), the new engine must still be assigned so ingestion
+        can proceed. Losing a connection on cleanup is acceptable; halting
+        a multi-hour pipeline over it is not.
+        """
+        mock_source = MagicMock()
+        mock_source.set_inspector = CommonDbSourceService.set_inspector.__get__(
+            mock_source
+        )
+
+        old_engine = MagicMock(name="old_engine")
+        old_engine.dispose.side_effect = Exception("simulated teardown error")
+        mock_source.engine = old_engine
+        mock_source.service_connection = MagicMock()
+
+        new_engine = MagicMock(name="new_engine")
+
+        with patch(
+            "metadata.ingestion.source.database.common_db_source.kill_active_connections"
+        ), patch(
+            "metadata.ingestion.source.database.common_db_source.get_connection",
+            return_value=new_engine,
+        ):
+            mock_source.set_inspector("next_database")
+
+        old_engine.dispose.assert_called_once()
+        assert mock_source.engine is new_engine

--- a/ingestion/tests/unit/topology/database/test_snowflake.py
+++ b/ingestion/tests/unit/topology/database/test_snowflake.py
@@ -16,6 +16,7 @@ snowflake unit tests
 from unittest import TestCase
 from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
+import pytest
 import sqlalchemy.types as sqltypes
 
 from metadata.generated.schema.entity.data.table import TableType
@@ -853,3 +854,128 @@ class SnowflakeUnitTest(TestCase):
                 source.schema_tags_map["TEST_SCHEMA"][0],
                 {"tag_name": "TEST_TAG", "tag_value": "123"},
             )
+
+
+class TestSnowflakeDeletedTablesPerDatabaseReset:
+    """TDD: deleted_tables must be scoped to the current database.
+
+    Production context: in incremental mode, ACCOUNT_USAGE.TABLES returns
+    soft-deleted tables historically. Every schema walked calls
+    .extend(...) on a SINGLE process-wide list
+    (self.context.get_global().deleted_tables). Across 39 DBs with 35k
+    ghost tables (the customer footprint), that list reaches hundreds of
+    megabytes of FQN strings and is only consumed at the end of each
+    database by mark_tables_as_deleted — which means entries from
+    previously-processed databases are repeatedly re-emitted as deletes
+    for the CURRENT database, in addition to the memory growth.
+
+    Required post-fix contract:
+      1. When get_database_names yields a new database, deleted_tables is
+         empty at the moment of yield — no carry-over from a prior DB.
+      2. Holds for both single-configured-DB and multi-DB discovery paths.
+      3. Does not affect other per-DB state (partition_details,
+         schema_desc_map, etc. — each of those has its own reset).
+    """
+
+    @pytest.fixture
+    def source(self):
+        return get_snowflake_sources()["not_incremental"]
+
+    def _mock_per_db_setup_methods(self, source):
+        """Patch the setup methods that hit the database so get_database_names
+        can be driven without a real connection.
+        """
+        from contextlib import ExitStack
+
+        stack = ExitStack()
+        for method_name in (
+            "set_inspector",
+            "set_session_query_tag",
+            "set_partition_details",
+            "set_schema_description_map",
+            "set_database_description_map",
+            "set_external_location_map",
+            "set_schema_tags_map",
+            "set_database_tags_map",
+        ):
+            stack.enter_context(
+                patch.object(source, method_name, MagicMock())
+            )
+        return stack
+
+    def test_configured_database_starts_with_empty_deleted_tables(self, source):
+        """Single configured-database path: any stale entries from an
+        earlier run must be cleared before we yield the DB for processing.
+        """
+        # Simulate stale state left over (e.g. from a retry, from init).
+        source.context.get_global().deleted_tables = [
+            "service.prior_db.schema.ghost_1",
+            "service.prior_db.schema.ghost_2",
+        ]
+
+        with self._mock_per_db_setup_methods(source):
+            gen = source.get_database_names()
+            yielded_db = next(gen)
+
+        assert yielded_db == "database"  # from SNOWFLAKE_CONFIGURATION
+        assert source.context.get_global().deleted_tables == [], (
+            "deleted_tables must be empty at the moment the DB is yielded; "
+            f"got {source.context.get_global().deleted_tables!r}"
+        )
+
+    def test_multi_database_yields_reset_between_databases(self, source):
+        """Multi-DB path: fills up deleted_tables while processing DB1
+        (simulating schema walks extending the list), then asserts the
+        list is empty again when DB2 is yielded.
+        """
+        # Remove the configured database so the multi-DB branch is taken.
+        source.config.serviceConnection.root.config.database = None
+        # Bypass the DB-name filter so both DBs pass through.
+        source.source_config.databaseFilterPattern = None
+
+        with self._mock_per_db_setup_methods(source), patch.object(
+            source,
+            "get_database_names_raw",
+            return_value=iter(["DB_ONE", "DB_TWO"]),
+        ), patch(
+            "metadata.ingestion.source.database.snowflake.metadata.fqn.build",
+            side_effect=lambda *a, **kw: f"svc.{kw.get('database_name')}",
+        ), patch(
+            "metadata.ingestion.source.database.snowflake.metadata.filter_by_database",
+            return_value=False,
+        ):
+            gen = source.get_database_names()
+
+            # First DB yielded — list must be empty regardless of prior state.
+            source.context.get_global().deleted_tables = ["leftover_from_setup"]
+            db1 = next(gen)
+            snapshot_at_db1_yield = list(
+                source.context.get_global().deleted_tables
+            )
+
+            # Simulate processing DB1's schemas: schema walks extend the list
+            # with FQNs for soft-deleted tables found in DB1.
+            source.context.get_global().deleted_tables.extend(
+                [
+                    "svc.DB_ONE.schema_a.deleted_table_1",
+                    "svc.DB_ONE.schema_a.deleted_table_2",
+                    "svc.DB_ONE.schema_b.deleted_table_3",
+                ]
+            )
+
+            # Next DB yielded — the DB1 entries must not carry over to DB2.
+            db2 = next(gen)
+            snapshot_at_db2_yield = list(
+                source.context.get_global().deleted_tables
+            )
+
+        assert db1 == "DB_ONE"
+        assert db2 == "DB_TWO"
+        assert snapshot_at_db1_yield == [], (
+            f"Expected empty deleted_tables at DB_ONE yield; got "
+            f"{snapshot_at_db1_yield!r}"
+        )
+        assert snapshot_at_db2_yield == [], (
+            f"Expected empty deleted_tables at DB_TWO yield (DB_ONE's "
+            f"entries must not carry over); got {snapshot_at_db2_yield!r}"
+        )

--- a/ingestion/tests/unit/topology/database/test_snowflake.py
+++ b/ingestion/tests/unit/topology/database/test_snowflake.py
@@ -898,9 +898,7 @@ class TestSnowflakeDeletedTablesPerDatabaseReset:
             "set_schema_tags_map",
             "set_database_tags_map",
         ):
-            stack.enter_context(
-                patch.object(source, method_name, MagicMock())
-            )
+            stack.enter_context(patch.object(source, method_name, MagicMock()))
         return stack
 
     def test_configured_database_starts_with_empty_deleted_tables(self, source):
@@ -949,9 +947,7 @@ class TestSnowflakeDeletedTablesPerDatabaseReset:
             # First DB yielded — list must be empty regardless of prior state.
             source.context.get_global().deleted_tables = ["leftover_from_setup"]
             db1 = next(gen)
-            snapshot_at_db1_yield = list(
-                source.context.get_global().deleted_tables
-            )
+            snapshot_at_db1_yield = list(source.context.get_global().deleted_tables)
 
             # Simulate processing DB1's schemas: schema walks extend the list
             # with FQNs for soft-deleted tables found in DB1.
@@ -965,9 +961,7 @@ class TestSnowflakeDeletedTablesPerDatabaseReset:
 
             # Next DB yielded — the DB1 entries must not carry over to DB2.
             db2 = next(gen)
-            snapshot_at_db2_yield = list(
-                source.context.get_global().deleted_tables
-            )
+            snapshot_at_db2_yield = list(source.context.get_global().deleted_tables)
 
         assert db1 == "DB_ONE"
         assert db2 == "DB_TWO"


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **Memory optimization:**
  - Added `_clear_thread_reflection_cache` to `CommonDbSourceService` to flush SQLAlchemy's unbounded `info_cache` between schema boundaries.
  - Mitigates OOM risks during heavy metadata ingestion for connectors like Snowflake by reclaiming memory per-schema.
- **Testing:**
  - Added `TestSchemaBoundaryReflectionCacheClear` to verify cache clearing logic and ensure thread-safe operation by isolating inspector cache purges.

<sub>This will update automatically on new commits.</sub>