### PR TITLE
test: skip WorkflowOssRestrictions tests on AUT

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Workflows/WorkflowOssRestrictions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Workflows/WorkflowOssRestrictions.spec.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { expect, test as base, type Page } from '@playwright/test';
+import { test as base, expect, type Page } from '@playwright/test';
 import { SidebarItem } from '../../../constant/sidebar';
 import { performAdminLogin } from '../../../utils/admin';
 import { clickOutside, redirectToHomePage, uuid } from '../../../utils/common';
@@ -110,544 +110,560 @@ async function openStartNodeSidebar(page: Page) {
   return sidebar;
 }
 
-test.describe('OSS Workflow Capabilities', () => {
-  test.beforeAll('Create test workflow via API', async ({ browser }) => {
-    workflowName = `pw-oss-test-workflow-${uuid()}`;
-    const { apiContext, afterAction } = await performAdminLogin(browser);
+if (process.env.PLAYWRIGHT_IS_OSS) {
+  test.describe('OSS Workflow Capabilities', () => {
+    test.beforeAll('Create test workflow via API', async ({ browser }) => {
+      workflowName = `pw-oss-test-workflow-${uuid()}`;
+      const { apiContext, afterAction } = await performAdminLogin(browser);
 
-    const response = await apiContext.post(
-      '/api/v1/governance/workflowDefinitions',
-      {
-        data: {
-          name: workflowName,
-          description: 'OSS capability test workflow created by Playwright',
-          config: { storeStageStatus: false },
-          trigger: {
-            type: 'eventBasedEntity',
-            config: {
-              entityTypes: ['table'],
-              events: ['Created'],
-              exclude: [],
-              include: [],
-              filter: {},
-            },
-            output: ['relatedEntity', 'updatedBy'],
-          },
-          nodes: [
-            {
-              type: 'startEvent',
-              subType: 'startEvent',
-              name: 'Start',
-              displayName: 'Start',
-            },
-            {
-              type: 'userTask',
-              subType: 'userApprovalTask',
-              name: 'ApprovalTask',
-              displayName: 'Approval Task',
+      const response = await apiContext.post(
+        '/api/v1/governance/workflowDefinitions',
+        {
+          data: {
+            name: workflowName,
+            description: 'OSS capability test workflow created by Playwright',
+            config: { storeStageStatus: false },
+            trigger: {
+              type: 'eventBasedEntity',
               config: {
-                assignees: {
-                  addReviewers: false,
-                  addOwners: false,
-                  candidates: [],
-                },
-                approvalThreshold: 1,
-                rejectionThreshold: 1,
+                entityTypes: ['table'],
+                events: ['Created'],
+                exclude: [],
+                include: [],
+                filter: {},
               },
-              inputNamespaceMap: {
-                relatedEntity: 'global',
+              output: ['relatedEntity', 'updatedBy'],
+            },
+            nodes: [
+              {
+                type: 'startEvent',
+                subType: 'startEvent',
+                name: 'Start',
+                displayName: 'Start',
               },
-            },
-            {
-              type: 'endEvent',
-              subType: 'endEvent',
-              name: 'ApprovedEnd',
-              displayName: 'Approved',
-            },
-            {
-              type: 'endEvent',
-              subType: 'endEvent',
-              name: 'RejectedEnd',
-              displayName: 'Rejected',
-            },
-          ],
-          edges: [
-            { from: 'Start', to: 'ApprovalTask' },
-            { from: 'ApprovalTask', to: 'ApprovedEnd', condition: 'true' },
-            { from: 'ApprovalTask', to: 'RejectedEnd', condition: 'false' },
-          ],
-        },
-      }
-    );
-
-    expect(response.ok()).toBeTruthy();
-    await afterAction();
-  });
-
-  test.afterAll('Delete test workflow via API', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    await apiContext.delete(
-      `/api/v1/governance/workflowDefinitions/name/${encodeURIComponent(
-        workflowName
-      )}`,
-      { params: { hardDelete: true } }
-    );
-
-    await afterAction();
-  });
-
-  test.describe('Workflow listing page', () => {
-    test('create-workflow-button absent on OSS', async ({ page }) => {
-      await redirectToHomePage(page);
-      await navigateToWorkflowsListPage(page);
-
-      await expect(
-        page.getByTestId('create-workflow-button')
-      ).not.toBeVisible();
-    });
-  });
-
-  test.describe('Test workflow — view mode', () => {
-    test('edit-workflow-button visible; delete-workflow-button and run-workflow-button absent', async ({
-      page,
-    }) => {
-      await redirectToHomePage(page);
-      await navigateToWorkflowDetailPage(page, workflowName);
-
-      await expect(page.getByTestId('edit-workflow-button')).toBeVisible();
-      await expect(
-        page.getByTestId('delete-workflow-button')
-      ).not.toBeVisible();
-      await expect(page.getByTestId('run-workflow-button')).not.toBeVisible();
-    });
-
-    test('clicking a node in view mode opens read-only config sidebar (no save or delete buttons)', async ({
-      page,
-    }) => {
-      await redirectToHomePage(page);
-      await navigateToWorkflowDetailPage(page, workflowName);
-
-      const fitViewButton = page.getByTestId('fit-view-button');
-
-      await expect(fitViewButton).toBeVisible();
-      await fitViewButton.click();
-
-      const taskNode = page
-        .locator('.react-flow__node')
-        .filter({ hasNotText: /^Start$/ })
-        .filter({ hasNotText: /^End$/ })
-        .filter({ hasNotText: /^Approved$/ })
-        .filter({ hasNotText: /^Rejected$/ })
-        .first();
-
-      await expect(taskNode).toBeVisible();
-      await taskNode.click();
-
-      const sidebar = page.getByTestId('node-config-sidebar');
-
-      await expect(sidebar).toBeVisible();
-      await waitForAllLoadersToDisappear(page);
-
-      await expect(
-        sidebar.getByTestId('save-node-configuration-button')
-      ).not.toBeVisible();
-      await expect(sidebar.getByTestId('delete-node-button')).not.toBeVisible();
-    });
-  });
-
-  test.describe('Test workflow — edit mode: structural restrictions', () => {
-    test('workflow-node-sidebar (node palette) not rendered in edit mode', async ({
-      page,
-    }) => {
-      await redirectToHomePage(page);
-      await navigateToWorkflowDetailPage(page, workflowName);
-      await enterEditMode(page);
-
-      await expect(page.getByTestId('workflow-node-sidebar')).not.toBeVisible();
-    });
-
-    test('graph canvas contains workflow nodes', async ({ page }) => {
-      await redirectToHomePage(page);
-      await navigateToWorkflowDetailPage(page, workflowName);
-
-      const fitViewButton = page.getByTestId('fit-view-button');
-
-      await expect(fitViewButton).toBeVisible();
-      await fitViewButton.click();
-      await enterEditMode(page);
-
-      await expect(page.locator('.react-flow__node').first()).toBeVisible();
-    });
-  });
-
-  test.describe('Test workflow — edit mode: header controls', () => {
-    test('save, cancel, and validate buttons visible; delete absent in edit mode', async ({
-      page,
-    }) => {
-      await redirectToHomePage(page);
-      await navigateToWorkflowDetailPage(page, workflowName);
-      await enterEditMode(page);
-
-      await expect(page.getByTestId('save-workflow-button')).toBeVisible();
-      await expect(page.getByTestId('cancel-workflow-button')).toBeVisible();
-      await expect(page.getByTestId('test-workflow-button')).toBeVisible();
-      await expect(
-        page.getByTestId('delete-workflow-button')
-      ).not.toBeVisible();
-    });
-
-    test('cancel workflow opens confirmation modal; close-without-saving returns to view mode', async ({
-      page,
-    }) => {
-      await redirectToHomePage(page);
-      await navigateToWorkflowDetailPage(page, workflowName);
-      await enterEditMode(page);
-
-      await page.getByTestId('cancel-workflow-button').click();
-
-      await expect(
-        page.getByTestId('close-without-saving-button')
-      ).toBeVisible();
-      await expect(
-        page.getByTestId('save-workflow-cancel-modal-button')
-      ).toBeVisible();
-
-      await page.getByTestId('close-without-saving-button').click();
-
-      await expect(page.getByTestId('edit-workflow-button')).toBeVisible();
-      await expect(page.getByTestId('save-workflow-button')).not.toBeVisible();
-    });
-  });
-
-  test.describe('Test workflow — edit mode: task node config', () => {
-    test('task node config sidebar opens and save button is enabled', async ({
-      page,
-    }) => {
-      await redirectToHomePage(page);
-      await navigateToWorkflowDetailPage(page, workflowName);
-
-      const sidebar = await openTaskNodeSidebar(page);
-
-      await expect(
-        sidebar.getByTestId('save-node-configuration-button')
-      ).toBeEnabled();
-
-      await sidebar.getByTestId('cancel-workflow-button').click();
-      await expect(sidebar).not.toBeVisible();
-    });
-
-    test('delete-node-button absent in node config sidebar (structural edit blocked)', async ({
-      page,
-    }) => {
-      await redirectToHomePage(page);
-      await navigateToWorkflowDetailPage(page, workflowName);
-
-      const sidebar = await openTaskNodeSidebar(page);
-
-      await expect(sidebar.getByTestId('delete-node-button')).not.toBeVisible();
-    });
-
-    test('save-node-configuration-button closes sidebar (local state update)', async ({
-      page,
-    }) => {
-      await redirectToHomePage(page);
-      await navigateToWorkflowDetailPage(page, workflowName);
-
-      const sidebar = await openTaskNodeSidebar(page);
-
-      await sidebar.getByTestId('save-node-configuration-button').click();
-      await expect(sidebar).not.toBeVisible();
-    });
-
-    test('editing a form field and saving node config then workflow fires PUT API with updated data', async ({
-      page,
-    }) => {
-      await redirectToHomePage(page);
-      await navigateToWorkflowDetailPage(page, workflowName);
-
-      const sidebar = await openTaskNodeSidebar(page);
-
-      const thresholdInput = sidebar
-        .getByTestId('user-approval-approval-threshold-label')
-        .locator('input');
-
-      await expect(thresholdInput).toBeEnabled();
-      await thresholdInput.fill('2');
-
-      await sidebar.getByTestId('save-node-configuration-button').click();
-      await expect(sidebar).not.toBeVisible();
-
-      const saveResponse = page.waitForResponse(
-        (response) =>
-          response.url().includes('/api/v1/governance/workflowDefinitions') &&
-          response.request().method() === 'PUT' &&
-          response.ok()
-      );
-
-      await page.getByTestId('save-workflow-button').click();
-      await saveResponse;
-      await waitForAllLoadersToDisappear(page);
-
-      await expect(page.getByTestId('edit-workflow-button')).toBeVisible();
-    });
-  });
-
-  test.describe('Test workflow — save workflow', () => {
-    test('save-workflow-button fires PUT API and returns to view mode', async ({
-      page,
-    }) => {
-      await redirectToHomePage(page);
-      await navigateToWorkflowDetailPage(page, workflowName);
-      await enterEditMode(page);
-
-      const saveResponse = page.waitForResponse(
-        (response) =>
-          response.url().includes('/api/v1/governance/workflowDefinitions') &&
-          response.request().method() === 'PUT' &&
-          response.ok()
-      );
-
-      await page.getByTestId('save-workflow-button').click();
-      await saveResponse;
-      await waitForAllLoadersToDisappear(page);
-
-      await expect(page.getByTestId('edit-workflow-button')).toBeVisible();
-      await expect(page.getByTestId('save-workflow-button')).not.toBeVisible();
-    });
-  });
-
-  test.describe('Test workflow — start node config (event-based)', () => {
-    test('workflow-name-input is disabled in OSS', async ({ page }) => {
-      await redirectToHomePage(page);
-      await navigateToWorkflowDetailPage(page, workflowName);
-
-      const sidebar = await openStartNodeSidebar(page);
-
-      await expect(
-        sidebar.getByTestId('workflow-name-input').locator('input')
-      ).toBeDisabled();
-    });
-
-    test('workflow-description-input is enabled in OSS', async ({ page }) => {
-      await redirectToHomePage(page);
-      await navigateToWorkflowDetailPage(page, workflowName);
-
-      const sidebar = await openStartNodeSidebar(page);
-
-      await expect(
-        sidebar.getByTestId('workflow-description-input').locator('textarea')
-      ).toBeEnabled();
-    });
-
-    test('data-asset selector is disabled in OSS', async ({ page }) => {
-      await redirectToHomePage(page);
-      await navigateToWorkflowDetailPage(page, workflowName);
-
-      const sidebar = await openStartNodeSidebar(page);
-
-      await expect(
-        sidebar.getByTestId('data-asset').locator('input')
-      ).toBeDisabled();
-    });
-
-    test('trigger-type-select is disabled in OSS', async ({ page }) => {
-      await redirectToHomePage(page);
-      await navigateToWorkflowDetailPage(page, workflowName);
-
-      const sidebar = await openStartNodeSidebar(page);
-
-      await expect(
-        sidebar.getByTestId('trigger-type-select').locator('button').first()
-      ).toBeDisabled();
-    });
-
-    test('event-type-select is disabled in OSS', async ({ page }) => {
-      await redirectToHomePage(page);
-      await navigateToWorkflowDetailPage(page, workflowName);
-
-      const sidebar = await openStartNodeSidebar(page);
-
-      await expect(
-        sidebar.getByTestId('event-type-select').locator('input')
-      ).toBeDisabled();
-    });
-
-    test('exclude-fields-select is enabled in OSS', async ({ page }) => {
-      await redirectToHomePage(page);
-      await navigateToWorkflowDetailPage(page, workflowName);
-
-      const sidebar = await openStartNodeSidebar(page);
-
-      await expect(
-        sidebar.getByTestId('exclude-fields-select').locator('input')
-      ).toBeEnabled();
-    });
-
-    test('include-fields-select is enabled in OSS', async ({ page }) => {
-      await redirectToHomePage(page);
-      await navigateToWorkflowDetailPage(page, workflowName);
-
-      const sidebar = await openStartNodeSidebar(page);
-
-      await expect(
-        sidebar.getByTestId('include-fields-select').locator('input')
-      ).toBeEnabled();
-    });
-
-    test('add-event-filter-button is enabled in OSS', async ({ page }) => {
-      await redirectToHomePage(page);
-      await navigateToWorkflowDetailPage(page, workflowName);
-
-      const sidebar = await openStartNodeSidebar(page);
-
-      await expect(
-        sidebar.getByTestId('add-event-filter-button')
-      ).toBeEnabled();
-    });
-  });
-
-  test.describe('Test workflow — start node config (periodic-batch)', () => {
-    test.beforeAll(
-      'Create periodic-batch test workflow via API',
-      async ({ browser }) => {
-        periodicWorkflowName = `pw-oss-periodic-workflow-${uuid()}`;
-        const { apiContext, afterAction } = await performAdminLogin(browser);
-
-        const response = await apiContext.post(
-          '/api/v1/governance/workflowDefinitions',
-          {
-            data: {
-              name: periodicWorkflowName,
-              description:
-                'OSS periodic-batch capability test workflow created by Playwright',
-              config: { storeStageStatus: false },
-              trigger: {
-                type: 'periodicBatchEntity',
+              {
+                type: 'userTask',
+                subType: 'userApprovalTask',
+                name: 'ApprovalTask',
+                displayName: 'Approval Task',
                 config: {
-                  entityTypes: ['table'],
-                  schedule: {
-                    scheduleTimeline: 'None',
-                    cronExpression: '',
+                  assignees: {
+                    addReviewers: false,
+                    addOwners: false,
+                    candidates: [],
                   },
+                  approvalThreshold: 1,
+                  rejectionThreshold: 1,
                 },
-                output: ['relatedEntity'],
+                inputNamespaceMap: {
+                  relatedEntity: 'global',
+                },
               },
-              nodes: [
-                {
-                  type: 'startEvent',
-                  subType: 'startEvent',
-                  name: 'Start',
-                  displayName: 'Start',
-                },
-                {
-                  type: 'userTask',
-                  subType: 'userApprovalTask',
-                  name: 'ApprovalTask',
-                  displayName: 'Approval Task',
-                  config: {
-                    assignees: {
-                      addReviewers: false,
-                      addOwners: false,
-                      candidates: [],
-                    },
-                    approvalThreshold: 1,
-                    rejectionThreshold: 1,
-                  },
-                  inputNamespaceMap: {
-                    relatedEntity: 'global',
-                  },
-                },
-                {
-                  type: 'endEvent',
-                  subType: 'endEvent',
-                  name: 'ApprovedEnd',
-                  displayName: 'Approved',
-                },
-                {
-                  type: 'endEvent',
-                  subType: 'endEvent',
-                  name: 'RejectedEnd',
-                  displayName: 'Rejected',
-                },
-              ],
-              edges: [
-                { from: 'Start', to: 'ApprovalTask' },
-                { from: 'ApprovalTask', to: 'ApprovedEnd', condition: 'true' },
-                {
-                  from: 'ApprovalTask',
-                  to: 'RejectedEnd',
-                  condition: 'false',
-                },
-              ],
-            },
-          }
-        );
-
-        expect(response.ok()).toBeTruthy();
-        await afterAction();
-      }
-    );
-
-    test.afterAll(
-      'Delete periodic-batch test workflow via API',
-      async ({ browser }) => {
-        const { apiContext, afterAction } = await performAdminLogin(browser);
-
-        await apiContext.delete(
-          `/api/v1/governance/workflowDefinitions/name/${encodeURIComponent(
-            periodicWorkflowName
-          )}`,
-          { params: { hardDelete: true } }
-        );
-
-        await afterAction();
-      }
-    );
-
-    test('schedule-type-select is disabled in OSS', async ({ page }) => {
-      await redirectToHomePage(page);
-      await navigateToWorkflowDetailPage(page, periodicWorkflowName);
-
-      const sidebar = await openStartNodeSidebar(page);
-
-      await expect(
-        sidebar.getByTestId('schedule-type-select').locator('button').first()
-      ).toBeDisabled();
-    });
-
-    test('batch-size-input is enabled in OSS', async ({ page }) => {
-      await redirectToHomePage(page);
-      await navigateToWorkflowDetailPage(page, periodicWorkflowName);
-
-      const sidebar = await openStartNodeSidebar(page);
-
-      await expect(
-        sidebar.getByTestId('batch-size-input').locator('input')
-      ).toBeEnabled();
-    });
-  });
-
-  test.describe('Test workflow — execution history', () => {
-    test('execution history tab loads and API call succeeds', async ({
-      page,
-    }) => {
-      await redirectToHomePage(page);
-      await navigateToWorkflowDetailPage(page, workflowName);
-
-      const historyResponse = page.waitForResponse(
-        (response) =>
-          response.url().includes('/api/v1/governance/workflowInstances') &&
-          response.ok()
+              {
+                type: 'endEvent',
+                subType: 'endEvent',
+                name: 'ApprovedEnd',
+                displayName: 'Approved',
+              },
+              {
+                type: 'endEvent',
+                subType: 'endEvent',
+                name: 'RejectedEnd',
+                displayName: 'Rejected',
+              },
+            ],
+            edges: [
+              { from: 'Start', to: 'ApprovalTask' },
+              { from: 'ApprovalTask', to: 'ApprovedEnd', condition: 'true' },
+              { from: 'ApprovalTask', to: 'RejectedEnd', condition: 'false' },
+            ],
+          },
+        }
       );
 
-      await page.getByTestId('workflow-execution-history').click();
-      await historyResponse;
-      await waitForAllLoadersToDisappear(page);
+      expect(response.ok()).toBeTruthy();
+      await afterAction();
+    });
 
-      await expect(
-        page.getByTestId('workflow-execution-history')
-      ).toBeVisible();
+    test.afterAll('Delete test workflow via API', async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+
+      await apiContext.delete(
+        `/api/v1/governance/workflowDefinitions/name/${encodeURIComponent(
+          workflowName
+        )}`,
+        { params: { hardDelete: true } }
+      );
+
+      await afterAction();
+    });
+
+    test.describe('Workflow listing page', () => {
+      test('create-workflow-button absent on OSS', async ({ page }) => {
+        await redirectToHomePage(page);
+        await navigateToWorkflowsListPage(page);
+
+        await expect(
+          page.getByTestId('create-workflow-button')
+        ).not.toBeVisible();
+      });
+    });
+
+    test.describe('Test workflow — view mode', () => {
+      test('edit-workflow-button visible; delete-workflow-button and run-workflow-button absent', async ({
+        page,
+      }) => {
+        await redirectToHomePage(page);
+        await navigateToWorkflowDetailPage(page, workflowName);
+
+        await expect(page.getByTestId('edit-workflow-button')).toBeVisible();
+        await expect(
+          page.getByTestId('delete-workflow-button')
+        ).not.toBeVisible();
+        await expect(page.getByTestId('run-workflow-button')).not.toBeVisible();
+      });
+
+      test('clicking a node in view mode opens read-only config sidebar (no save or delete buttons)', async ({
+        page,
+      }) => {
+        await redirectToHomePage(page);
+        await navigateToWorkflowDetailPage(page, workflowName);
+
+        const fitViewButton = page.getByTestId('fit-view-button');
+
+        await expect(fitViewButton).toBeVisible();
+        await fitViewButton.click();
+
+        const taskNode = page
+          .locator('.react-flow__node')
+          .filter({ hasNotText: /^Start$/ })
+          .filter({ hasNotText: /^End$/ })
+          .filter({ hasNotText: /^Approved$/ })
+          .filter({ hasNotText: /^Rejected$/ })
+          .first();
+
+        await expect(taskNode).toBeVisible();
+        await taskNode.click();
+
+        const sidebar = page.getByTestId('node-config-sidebar');
+
+        await expect(sidebar).toBeVisible();
+        await waitForAllLoadersToDisappear(page);
+
+        await expect(
+          sidebar.getByTestId('save-node-configuration-button')
+        ).not.toBeVisible();
+        await expect(
+          sidebar.getByTestId('delete-node-button')
+        ).not.toBeVisible();
+      });
+    });
+
+    test.describe('Test workflow — edit mode: structural restrictions', () => {
+      test('workflow-node-sidebar (node palette) not rendered in edit mode', async ({
+        page,
+      }) => {
+        await redirectToHomePage(page);
+        await navigateToWorkflowDetailPage(page, workflowName);
+        await enterEditMode(page);
+
+        await expect(
+          page.getByTestId('workflow-node-sidebar')
+        ).not.toBeVisible();
+      });
+
+      test('graph canvas contains workflow nodes', async ({ page }) => {
+        await redirectToHomePage(page);
+        await navigateToWorkflowDetailPage(page, workflowName);
+
+        const fitViewButton = page.getByTestId('fit-view-button');
+
+        await expect(fitViewButton).toBeVisible();
+        await fitViewButton.click();
+        await enterEditMode(page);
+
+        await expect(page.locator('.react-flow__node').first()).toBeVisible();
+      });
+    });
+
+    test.describe('Test workflow — edit mode: header controls', () => {
+      test('save, cancel, and validate buttons visible; delete absent in edit mode', async ({
+        page,
+      }) => {
+        await redirectToHomePage(page);
+        await navigateToWorkflowDetailPage(page, workflowName);
+        await enterEditMode(page);
+
+        await expect(page.getByTestId('save-workflow-button')).toBeVisible();
+        await expect(page.getByTestId('cancel-workflow-button')).toBeVisible();
+        await expect(page.getByTestId('test-workflow-button')).toBeVisible();
+        await expect(
+          page.getByTestId('delete-workflow-button')
+        ).not.toBeVisible();
+      });
+
+      test('cancel workflow opens confirmation modal; close-without-saving returns to view mode', async ({
+        page,
+      }) => {
+        await redirectToHomePage(page);
+        await navigateToWorkflowDetailPage(page, workflowName);
+        await enterEditMode(page);
+
+        await page.getByTestId('cancel-workflow-button').click();
+
+        await expect(
+          page.getByTestId('close-without-saving-button')
+        ).toBeVisible();
+        await expect(
+          page.getByTestId('save-workflow-cancel-modal-button')
+        ).toBeVisible();
+
+        await page.getByTestId('close-without-saving-button').click();
+
+        await expect(page.getByTestId('edit-workflow-button')).toBeVisible();
+        await expect(
+          page.getByTestId('save-workflow-button')
+        ).not.toBeVisible();
+      });
+    });
+
+    test.describe('Test workflow — edit mode: task node config', () => {
+      test('task node config sidebar opens and save button is enabled', async ({
+        page,
+      }) => {
+        await redirectToHomePage(page);
+        await navigateToWorkflowDetailPage(page, workflowName);
+
+        const sidebar = await openTaskNodeSidebar(page);
+
+        await expect(
+          sidebar.getByTestId('save-node-configuration-button')
+        ).toBeEnabled();
+
+        await sidebar.getByTestId('cancel-workflow-button').click();
+        await expect(sidebar).not.toBeVisible();
+      });
+
+      test('delete-node-button absent in node config sidebar (structural edit blocked)', async ({
+        page,
+      }) => {
+        await redirectToHomePage(page);
+        await navigateToWorkflowDetailPage(page, workflowName);
+
+        const sidebar = await openTaskNodeSidebar(page);
+
+        await expect(
+          sidebar.getByTestId('delete-node-button')
+        ).not.toBeVisible();
+      });
+
+      test('save-node-configuration-button closes sidebar (local state update)', async ({
+        page,
+      }) => {
+        await redirectToHomePage(page);
+        await navigateToWorkflowDetailPage(page, workflowName);
+
+        const sidebar = await openTaskNodeSidebar(page);
+
+        await sidebar.getByTestId('save-node-configuration-button').click();
+        await expect(sidebar).not.toBeVisible();
+      });
+
+      test('editing a form field and saving node config then workflow fires PUT API with updated data', async ({
+        page,
+      }) => {
+        await redirectToHomePage(page);
+        await navigateToWorkflowDetailPage(page, workflowName);
+
+        const sidebar = await openTaskNodeSidebar(page);
+
+        const thresholdInput = sidebar
+          .getByTestId('user-approval-approval-threshold-label')
+          .locator('input');
+
+        await expect(thresholdInput).toBeEnabled();
+        await thresholdInput.fill('2');
+
+        await sidebar.getByTestId('save-node-configuration-button').click();
+        await expect(sidebar).not.toBeVisible();
+
+        const saveResponse = page.waitForResponse(
+          (response) =>
+            response.url().includes('/api/v1/governance/workflowDefinitions') &&
+            response.request().method() === 'PUT' &&
+            response.ok()
+        );
+
+        await page.getByTestId('save-workflow-button').click();
+        await saveResponse;
+        await waitForAllLoadersToDisappear(page);
+
+        await expect(page.getByTestId('edit-workflow-button')).toBeVisible();
+      });
+    });
+
+    test.describe('Test workflow — save workflow', () => {
+      test('save-workflow-button fires PUT API and returns to view mode', async ({
+        page,
+      }) => {
+        await redirectToHomePage(page);
+        await navigateToWorkflowDetailPage(page, workflowName);
+        await enterEditMode(page);
+
+        const saveResponse = page.waitForResponse(
+          (response) =>
+            response.url().includes('/api/v1/governance/workflowDefinitions') &&
+            response.request().method() === 'PUT' &&
+            response.ok()
+        );
+
+        await page.getByTestId('save-workflow-button').click();
+        await saveResponse;
+        await waitForAllLoadersToDisappear(page);
+
+        await expect(page.getByTestId('edit-workflow-button')).toBeVisible();
+        await expect(
+          page.getByTestId('save-workflow-button')
+        ).not.toBeVisible();
+      });
+    });
+
+    test.describe('Test workflow — start node config (event-based)', () => {
+      test('workflow-name-input is disabled in OSS', async ({ page }) => {
+        await redirectToHomePage(page);
+        await navigateToWorkflowDetailPage(page, workflowName);
+
+        const sidebar = await openStartNodeSidebar(page);
+
+        await expect(
+          sidebar.getByTestId('workflow-name-input').locator('input')
+        ).toBeDisabled();
+      });
+
+      test('workflow-description-input is enabled in OSS', async ({ page }) => {
+        await redirectToHomePage(page);
+        await navigateToWorkflowDetailPage(page, workflowName);
+
+        const sidebar = await openStartNodeSidebar(page);
+
+        await expect(
+          sidebar.getByTestId('workflow-description-input').locator('textarea')
+        ).toBeEnabled();
+      });
+
+      test('data-asset selector is disabled in OSS', async ({ page }) => {
+        await redirectToHomePage(page);
+        await navigateToWorkflowDetailPage(page, workflowName);
+
+        const sidebar = await openStartNodeSidebar(page);
+
+        await expect(
+          sidebar.getByTestId('data-asset').locator('input')
+        ).toBeDisabled();
+      });
+
+      test('trigger-type-select is disabled in OSS', async ({ page }) => {
+        await redirectToHomePage(page);
+        await navigateToWorkflowDetailPage(page, workflowName);
+
+        const sidebar = await openStartNodeSidebar(page);
+
+        await expect(
+          sidebar.getByTestId('trigger-type-select').locator('button').first()
+        ).toBeDisabled();
+      });
+
+      test('event-type-select is disabled in OSS', async ({ page }) => {
+        await redirectToHomePage(page);
+        await navigateToWorkflowDetailPage(page, workflowName);
+
+        const sidebar = await openStartNodeSidebar(page);
+
+        await expect(
+          sidebar.getByTestId('event-type-select').locator('input')
+        ).toBeDisabled();
+      });
+
+      test('exclude-fields-select is enabled in OSS', async ({ page }) => {
+        await redirectToHomePage(page);
+        await navigateToWorkflowDetailPage(page, workflowName);
+
+        const sidebar = await openStartNodeSidebar(page);
+
+        await expect(
+          sidebar.getByTestId('exclude-fields-select').locator('input')
+        ).toBeEnabled();
+      });
+
+      test('include-fields-select is enabled in OSS', async ({ page }) => {
+        await redirectToHomePage(page);
+        await navigateToWorkflowDetailPage(page, workflowName);
+
+        const sidebar = await openStartNodeSidebar(page);
+
+        await expect(
+          sidebar.getByTestId('include-fields-select').locator('input')
+        ).toBeEnabled();
+      });
+
+      test('add-event-filter-button is enabled in OSS', async ({ page }) => {
+        await redirectToHomePage(page);
+        await navigateToWorkflowDetailPage(page, workflowName);
+
+        const sidebar = await openStartNodeSidebar(page);
+
+        await expect(
+          sidebar.getByTestId('add-event-filter-button')
+        ).toBeEnabled();
+      });
+    });
+
+    test.describe('Test workflow — start node config (periodic-batch)', () => {
+      test.beforeAll(
+        'Create periodic-batch test workflow via API',
+        async ({ browser }) => {
+          periodicWorkflowName = `pw-oss-periodic-workflow-${uuid()}`;
+          const { apiContext, afterAction } = await performAdminLogin(browser);
+
+          const response = await apiContext.post(
+            '/api/v1/governance/workflowDefinitions',
+            {
+              data: {
+                name: periodicWorkflowName,
+                description:
+                  'OSS periodic-batch capability test workflow created by Playwright',
+                config: { storeStageStatus: false },
+                trigger: {
+                  type: 'periodicBatchEntity',
+                  config: {
+                    entityTypes: ['table'],
+                    schedule: {
+                      scheduleTimeline: 'None',
+                      cronExpression: '',
+                    },
+                  },
+                  output: ['relatedEntity'],
+                },
+                nodes: [
+                  {
+                    type: 'startEvent',
+                    subType: 'startEvent',
+                    name: 'Start',
+                    displayName: 'Start',
+                  },
+                  {
+                    type: 'userTask',
+                    subType: 'userApprovalTask',
+                    name: 'ApprovalTask',
+                    displayName: 'Approval Task',
+                    config: {
+                      assignees: {
+                        addReviewers: false,
+                        addOwners: false,
+                        candidates: [],
+                      },
+                      approvalThreshold: 1,
+                      rejectionThreshold: 1,
+                    },
+                    inputNamespaceMap: {
+                      relatedEntity: 'global',
+                    },
+                  },
+                  {
+                    type: 'endEvent',
+                    subType: 'endEvent',
+                    name: 'ApprovedEnd',
+                    displayName: 'Approved',
+                  },
+                  {
+                    type: 'endEvent',
+                    subType: 'endEvent',
+                    name: 'RejectedEnd',
+                    displayName: 'Rejected',
+                  },
+                ],
+                edges: [
+                  { from: 'Start', to: 'ApprovalTask' },
+                  {
+                    from: 'ApprovalTask',
+                    to: 'ApprovedEnd',
+                    condition: 'true',
+                  },
+                  {
+                    from: 'ApprovalTask',
+                    to: 'RejectedEnd',
+                    condition: 'false',
+                  },
+                ],
+              },
+            }
+          );
+
+          expect(response.ok()).toBeTruthy();
+          await afterAction();
+        }
+      );
+
+      test.afterAll(
+        'Delete periodic-batch test workflow via API',
+        async ({ browser }) => {
+          const { apiContext, afterAction } = await performAdminLogin(browser);
+
+          await apiContext.delete(
+            `/api/v1/governance/workflowDefinitions/name/${encodeURIComponent(
+              periodicWorkflowName
+            )}`,
+            { params: { hardDelete: true } }
+          );
+
+          await afterAction();
+        }
+      );
+
+      test('schedule-type-select is disabled in OSS', async ({ page }) => {
+        await redirectToHomePage(page);
+        await navigateToWorkflowDetailPage(page, periodicWorkflowName);
+
+        const sidebar = await openStartNodeSidebar(page);
+
+        await expect(
+          sidebar.getByTestId('schedule-type-select').locator('button').first()
+        ).toBeDisabled();
+      });
+
+      test('batch-size-input is enabled in OSS', async ({ page }) => {
+        await redirectToHomePage(page);
+        await navigateToWorkflowDetailPage(page, periodicWorkflowName);
+
+        const sidebar = await openStartNodeSidebar(page);
+
+        await expect(
+          sidebar.getByTestId('batch-size-input').locator('input')
+        ).toBeEnabled();
+      });
+    });
+
+    test.describe('Test workflow — execution history', () => {
+      test('execution history tab loads and API call succeeds', async ({
+        page,
+      }) => {
+        await redirectToHomePage(page);
+        await navigateToWorkflowDetailPage(page, workflowName);
+
+        const historyResponse = page.waitForResponse(
+          (response) =>
+            response.url().includes('/api/v1/governance/workflowInstances') &&
+            response.ok()
+        );
+
+        await page.getByTestId('workflow-execution-history').click();
+        await historyResponse;
+        await waitForAllLoadersToDisappear(page);
+
+        await expect(
+          page.getByTestId('workflow-execution-history')
+        ).toBeVisible();
+      });
     });
   });
-});
+}

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Workflows/WorkflowOssRestrictions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Workflows/WorkflowOssRestrictions.spec.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { test as base, expect, type Page } from '@playwright/test';
+import { expect, test as base, type Page } from '@playwright/test';
 import { SidebarItem } from '../../../constant/sidebar';
 import { performAdminLogin } from '../../../utils/admin';
 import { clickOutside, redirectToHomePage, uuid } from '../../../utils/common';


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Wrapped the `WorkflowOssRestrictions` test suite in `if (process.env.PLAYWRIGHT_IS_OSS)` so it only registers and runs when the OSS flag is set
- On AUT (Collate side), the tests are skipped entirely since the workflow restrictions being tested are OSS-specific behaviour that doesn't apply to Collate


## Test plan

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
