### PR TITLE
Fix Healthcheck for vector embedding

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SystemRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SystemRepository.java
@@ -106,6 +106,7 @@ import org.openmetadata.service.util.ValidationErrorBuilder.FieldPaths;
 public class SystemRepository {
   private static final String FAILED_TO_UPDATE_SETTINGS = "Failed to Update Settings {}";
   public static final String INTERNAL_SERVER_ERROR_WITH_REASON = "Internal Server Error. Reason :";
+  private static final String VECTOR_EMBEDDING_INDEX_KEY = "vectorEmbedding";
   private final SystemDAO dao;
   private final MigrationValidationClient migrationValidationClient;
 
@@ -822,12 +823,17 @@ public class SystemRepository {
     }
   }
 
-  private List<String> findMissingIndexes(SearchRepository searchRepository) {
+  @VisibleForTesting
+  List<String> findMissingIndexes(SearchRepository searchRepository) {
     List<String> missing = new ArrayList<>();
+    boolean semanticSearchEnabled = searchRepository.isVectorEmbeddingEnabled();
     try {
       Map<String, org.openmetadata.search.IndexMapping> indexMap =
           searchRepository.getEntityIndexMap();
       for (Map.Entry<String, org.openmetadata.search.IndexMapping> entry : indexMap.entrySet()) {
+        if (!semanticSearchEnabled && VECTOR_EMBEDDING_INDEX_KEY.equals(entry.getKey())) {
+          continue;
+        }
         if (!searchRepository.indexExists(entry.getValue())) {
           missing.add(entry.getKey());
         }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/SystemRepositoryMissingIndexesTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/SystemRepositoryMissingIndexesTest.java
@@ -1,0 +1,127 @@
+package org.openmetadata.service.jdbi3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.openmetadata.search.IndexMapping;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.jdbi3.CollectionDAO.SystemDAO;
+import org.openmetadata.service.migration.MigrationValidationClient;
+import org.openmetadata.service.search.SearchRepository;
+
+class SystemRepositoryMissingIndexesTest {
+
+  private MockedStatic<Entity> entityMock;
+  private MockedStatic<MigrationValidationClient> migrationMock;
+  private SearchRepository searchRepository;
+  private SystemRepository systemRepository;
+
+  @BeforeEach
+  void setup() {
+    entityMock = mockStatic(Entity.class);
+    migrationMock = mockStatic(MigrationValidationClient.class);
+
+    CollectionDAO collectionDAO = mock(CollectionDAO.class);
+    SystemDAO systemDAO = mock(SystemDAO.class);
+    when(collectionDAO.systemDAO()).thenReturn(systemDAO);
+    entityMock.when(Entity::getCollectionDAO).thenReturn(collectionDAO);
+
+    MigrationValidationClient migrationClient = mock(MigrationValidationClient.class);
+    migrationMock.when(MigrationValidationClient::getInstance).thenReturn(migrationClient);
+
+    searchRepository = mock(SearchRepository.class);
+    entityMock.when(Entity::getSearchRepository).thenReturn(searchRepository);
+
+    systemRepository = new SystemRepository();
+  }
+
+  @AfterEach
+  void tearDown() {
+    entityMock.close();
+    migrationMock.close();
+  }
+
+  @Test
+  void testVectorEmbeddingIndexSkippedWhenSemanticSearchDisabled() {
+    IndexMapping tableMapping = mock(IndexMapping.class);
+    IndexMapping vectorMapping = mock(IndexMapping.class);
+    Map<String, IndexMapping> indexMap =
+        Map.of("table", tableMapping, "vectorEmbedding", vectorMapping);
+
+    when(searchRepository.isVectorEmbeddingEnabled()).thenReturn(false);
+    when(searchRepository.getEntityIndexMap()).thenReturn(indexMap);
+    when(searchRepository.indexExists(tableMapping)).thenReturn(true);
+    when(searchRepository.indexExists(vectorMapping)).thenReturn(false);
+
+    List<String> missing = systemRepository.findMissingIndexes(searchRepository);
+
+    assertTrue(missing.isEmpty(), "vectorEmbedding should be ignored when semantic search is off");
+  }
+
+  @Test
+  void testVectorEmbeddingIndexReportedMissingWhenSemanticSearchEnabled() {
+    IndexMapping tableMapping = mock(IndexMapping.class);
+    IndexMapping vectorMapping = mock(IndexMapping.class);
+    Map<String, IndexMapping> indexMap =
+        Map.of("table", tableMapping, "vectorEmbedding", vectorMapping);
+
+    when(searchRepository.isVectorEmbeddingEnabled()).thenReturn(true);
+    when(searchRepository.getEntityIndexMap()).thenReturn(indexMap);
+    when(searchRepository.indexExists(tableMapping)).thenReturn(true);
+    when(searchRepository.indexExists(vectorMapping)).thenReturn(false);
+
+    List<String> missing = systemRepository.findMissingIndexes(searchRepository);
+
+    assertEquals(1, missing.size());
+    assertEquals("vectorEmbedding", missing.get(0));
+  }
+
+  @Test
+  void testNonVectorMissingIndexesAlwaysReported() {
+    IndexMapping tableMapping = mock(IndexMapping.class);
+    IndexMapping glossaryMapping = mock(IndexMapping.class);
+    IndexMapping vectorMapping = mock(IndexMapping.class);
+    Map<String, IndexMapping> indexMap =
+        Map.of(
+            "table", tableMapping, "glossary", glossaryMapping, "vectorEmbedding", vectorMapping);
+
+    when(searchRepository.isVectorEmbeddingEnabled()).thenReturn(false);
+    when(searchRepository.getEntityIndexMap()).thenReturn(indexMap);
+    when(searchRepository.indexExists(tableMapping)).thenReturn(true);
+    when(searchRepository.indexExists(glossaryMapping)).thenReturn(false);
+    when(searchRepository.indexExists(vectorMapping)).thenReturn(false);
+
+    List<String> missing = systemRepository.findMissingIndexes(searchRepository);
+
+    assertEquals(1, missing.size());
+    assertEquals("glossary", missing.get(0));
+    assertFalse(missing.contains("vectorEmbedding"));
+  }
+
+  @Test
+  void testAllIndexesPresentReturnsEmpty() {
+    IndexMapping tableMapping = mock(IndexMapping.class);
+    IndexMapping vectorMapping = mock(IndexMapping.class);
+    Map<String, IndexMapping> indexMap =
+        Map.of("table", tableMapping, "vectorEmbedding", vectorMapping);
+
+    when(searchRepository.isVectorEmbeddingEnabled()).thenReturn(true);
+    when(searchRepository.getEntityIndexMap()).thenReturn(indexMap);
+    when(searchRepository.indexExists(tableMapping)).thenReturn(true);
+    when(searchRepository.indexExists(vectorMapping)).thenReturn(true);
+
+    List<String> missing = systemRepository.findMissingIndexes(searchRepository);
+
+    assertTrue(missing.isEmpty());
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/open-metadata/OpenMetadata/issues/27614

----
## Summary by Gitar

- **Logic fix:**
  - Updated `findMissingIndexes` to skip the `vectorEmbedding` index check when semantic search is disabled.
- **Testing:**
  - Added `SystemRepositoryMissingIndexesTest` to verify index validation logic under various semantic search configurations.


<sub>This will update automatically on new commits.</sub>