### PR TITLE
Playwright: refresh FQN after move in GlossaryHierarchy root-move test

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryHierarchy.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryHierarchy.spec.ts
@@ -61,6 +61,15 @@ test.describe('Glossary Hierarchy', () => {
         glossary.responseData.fullyQualifiedName
       );
 
+      // Refresh responseData so cleanup uses the post-move FQN.
+      // Moving to root rewrites the term's fullyQualifiedName in the DB, and
+      // GlossaryTerm.delete() looks up by name — without this, the finally
+      // block tries to delete by the stale pre-move FQN and 404s.
+      const refreshed = await apiContext.get(
+        `/api/v1/glossaryTerms/${childTerm.responseData.id}`
+      );
+      childTerm.responseData = await refreshed.json();
+
       // Verify term is now at root level (not nested under parent)
       await redirectToHomePage(page);
       await sidebarClick(page, SidebarItem.GLOSSARY);


### PR DESCRIPTION
## Summary

The `Glossary Hierarchy › should move nested term to root level of same glossary` test captures `childTerm.responseData.fullyQualifiedName` at create time. After the UI moves the term to root, the DB FQN is rewritten (`"g"."parent"."child"` → `"g"."child"`) but `responseData` is stale, so the `finally`-block cleanup calls `DELETE /api/v1/glossaryTerms/name/<oldFqn>` and hits `404 Not Found`.

This currently passes on `main` because of a latent backend bug: `GlossaryTermRepository.updateParent` invalidates `CACHE_WITH_ID` but not `CACHE_WITH_NAME`, so the stale-name cache keeps resolving `oldFqn → term id` and the delete silently succeeds by id. Ongoing cache-invalidation work (e.g. PR #27499) evicts that entry, which exposes this test's latent bug — deterministic failure across all 3 retries with "404 Not Found - glossaryTerm instance for ... not found".

Fix: after the move, refetch the term by id so cleanup uses the current FQN.

## Test plan

- [ ] Playwright CI: `Features/Glossary/GlossaryHierarchy.spec.ts` → `should move nested term to root level of same glossary` passes.
- [ ] Verify locally against a build that invalidates `CACHE_WITH_NAME` on rename (reproduces the 404 on current main without this fix).