### PR TITLE
fix(rdf): ensure Fuseki dataset before indexing and report failures correctly

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/RdfIndexApp.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/RdfIndexApp.java
@@ -142,6 +142,19 @@ public class RdfIndexApp extends AbstractNativeApplication {
       return;
     }
 
+    try {
+      rdfRepository.ensureStorageReady();
+    } catch (Exception e) {
+      LOG.error("RDF storage is not ready; aborting indexing job", e);
+      updateJobStatus(EventPublisherJob.Status.FAILED);
+      jobData.setFailure(
+          new IndexingError()
+              .withErrorSource(IndexingError.ErrorSource.JOB)
+              .withMessage("RDF storage is not ready: " + e.getMessage()));
+      sendUpdates(jobExecutionContext, true);
+      return;
+    }
+
     String jobName = jobExecutionContext.getJobDetail().getKey().getName();
     if (jobName.equals(ON_DEMAND_JOB)) {
       Map<String, Object> jsonAppConfig = JsonUtils.convertValue(jobData, Map.class);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/distributed/DistributedRdfIndexExecutor.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/distributed/DistributedRdfIndexExecutor.java
@@ -128,6 +128,7 @@ public class DistributedRdfIndexExecutor {
 
   public void joinJob(RdfIndexJob job, EventPublisherJob jobConfiguration)
       throws InterruptedException {
+    RdfRepository.getInstance().ensureStorageReady();
     currentJob = job;
     coordinatorOwnedJob = false;
     stopped.set(false);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfRepository.java
@@ -106,6 +106,13 @@ public class RdfRepository {
     return config.getBaseUri().toString();
   }
 
+  public void ensureStorageReady() {
+    if (!isEnabled()) {
+      return;
+    }
+    storageService.ensureStorageReady();
+  }
+
   public void createOrUpdate(EntityInterface entity) {
     if (!isEnabled()) {
       return;
@@ -147,6 +154,9 @@ public class RdfRepository {
           entity.getEntityReference().getType(),
           entity.getFullyQualifiedName(),
           e);
+      // Rethrow so callers (e.g. RdfBatchProcessor) can count this as a failure instead of
+      // reporting a false success. Entity-hook callers (RdfUpdater) already wrap in try/catch.
+      throw new RuntimeException("Failed to create/update entity in RDF", e);
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/JenaFusekiStorage.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/JenaFusekiStorage.java
@@ -74,8 +74,7 @@ public class JenaFusekiStorage implements RdfStorageInterface {
       this.connection =
           RDFConnectionFuseki.create().destination(endpoint).httpClient(httpClient).build();
     } else {
-      this.connection =
-          RDFConnectionFuseki.create().destination(endpoint).build();
+      this.connection = RDFConnectionFuseki.create().destination(endpoint).build();
     }
     LOG.info("Connected to Apache Jena Fuseki at {}", endpoint);
     loadOntology();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/JenaFusekiStorage.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/JenaFusekiStorage.java
@@ -39,20 +39,26 @@ public class JenaFusekiStorage implements RdfStorageInterface {
 
   private final RDFConnection connection;
   private final String baseUri;
+  private final String endpoint;
+  private final String username;
+  private final String password;
 
   public JenaFusekiStorage(RdfConfiguration config) {
     this.baseUri =
         config.getBaseUri() != null ? config.getBaseUri().toString() : "https://open-metadata.org/";
 
-    String endpoint =
+    this.endpoint =
         config.getRemoteEndpoint() != null && !config.getRemoteEndpoint().toString().isEmpty()
             ? config.getRemoteEndpoint().toString()
             : "http://openmetadata-fuseki:3030/openmetadata";
+    this.username = config.getUsername();
+    this.password = config.getPassword();
 
-    // Ensure the dataset exists before connecting
-    ensureDatasetExists(endpoint, config.getUsername(), config.getPassword());
+    // Best-effort attempt to create the dataset at startup; callers should invoke
+    // ensureStorageReady() before running work to recover from later restarts of the RDF server.
+    ensureDatasetExists(endpoint, username, password);
 
-    if (config.getUsername() != null && config.getPassword() != null) {
+    if (username != null && password != null) {
       java.net.http.HttpClient httpClient =
           java.net.http.HttpClient.newBuilder()
               .authenticator(
@@ -68,9 +74,34 @@ public class JenaFusekiStorage implements RdfStorageInterface {
       this.connection =
           RDFConnectionFuseki.create().destination(endpoint).httpClient(httpClient).build();
     } else {
-      this.connection = RDFConnectionFuseki.create().destination(endpoint).build();
+      this.connection =
+          RDFConnectionFuseki.create().destination(endpoint).build();
     }
     LOG.info("Connected to Apache Jena Fuseki at {}", endpoint);
+    loadOntology();
+  }
+
+  @Override
+  public void ensureStorageReady() {
+    if (testConnection()) {
+      LOG.debug("Fuseki dataset at {} is accessible", endpoint);
+      return;
+    }
+
+    LOG.warn(
+        "Fuseki dataset at {} is not accessible; attempting to (re)create it before running",
+        endpoint);
+    ensureDatasetExists(endpoint, username, password);
+
+    if (!testConnection()) {
+      throw new IllegalStateException(
+          String.format(
+              "RDF storage is not accessible at %s after attempting dataset creation. "
+                  + "Verify the configured RDF endpoint URL, credentials, that the Fuseki dataset "
+                  + "exists, and that the configured user has permission to create it.",
+              endpoint));
+    }
+    LOG.info("Fuseki dataset at {} is now ready", endpoint);
     loadOntology();
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/RdfStorageInterface.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/RdfStorageInterface.java
@@ -75,6 +75,14 @@ public interface RdfStorageInterface {
   boolean testConnection();
 
   /**
+   * Verify the underlying storage is reachable and the configured dataset/graph is accessible,
+   * attempting to create it if missing. Implementations must throw if the storage cannot be
+   * brought to a ready state so callers can surface a clear error instead of silently producing
+   * partial results.
+   */
+  default void ensureStorageReady() {}
+
+  /**
    * Get storage type identifier
    */
   String getStorageType();


### PR DESCRIPTION
## Summary

Two related reliability fixes for the RDF indexing app, discovered debugging a customer instance where the RDF app logged 404/405 errors for every entity yet reported them all as successes.

**Issue 1 — silent data loss when the Fuseki dataset disappears.** `JenaFusekiStorage.ensureDatasetExists()` runs only in the constructor (OM server startup). If the Fuseki dataset is removed later — e.g. Fuseki container restart without pod restart when `FUSEKI_BASE` is on an ephemeral filesystem, admin-API deletion by another process — the RDF connection silently keeps issuing SPARQL calls that come back 404 (query) / 405 (update). The indexing app keeps running and logs thousands of errors, but never recovers.

**Issue 2 — false success counts.** `RdfRepository.createOrUpdate()` caught all exceptions and only logged. `RdfBatchProcessor.processEntities()` wraps the call in `try { ... successCount++; } catch { failedCount++; }`, but because `createOrUpdate` never threw, every failure was counted as a success. App reported `failedRecords: 0` with thousands of server-log errors.

## Changes

- `RdfStorageInterface`: new `default void ensureStorageReady()` (no-op for non-Fuseki implementations).
- `JenaFusekiStorage`: stores endpoint/username/password as fields; implements `ensureStorageReady()` by first running a SPARQL `ASK` (`testConnection()`) — this works even when the Fuseki admin API is disabled — then, on failure, attempting `ensureDatasetExists(...)` and re-verifying. Throws `IllegalStateException` with a clear message pointing at endpoint/credentials/permissions if the dataset still isn't reachable. Also reloads the ontology when we had to (re)create the dataset.
- `RdfRepository`: new `ensureStorageReady()` that delegates to the storage. `createOrUpdate()` now rethrows after logging so callers can count failures.
- `RdfIndexApp.execute()`: calls `rdfRepository.ensureStorageReady()` right after the `isEnabled()` check; on failure, marks the job FAILED with a clear error message and returns, instead of running to completion with partial data.
- `DistributedRdfIndexExecutor.joinJob()`: same call on the participant path, so distributed participants also recover between runs (and fail loudly if they can't).

`RdfUpdater` (the REST-API-path caller) already wraps `createOrUpdate` in try/catch, so user-facing API calls are not affected by the rethrow change.

## Not fixed here

This is app-level idempotency; it does not fix the underlying Fuseki persistence issue that made the dataset disappear in the first place (FUSEKI_BASE/admin-created datasets need to be on a PVC, and the Fuseki container should not be OOMKilled). Those are infra-side fixes that belong outside this PR.

## Test plan

- [ ] RDF indexing with a missing dataset on startup: the app previously produced a knowledge graph partially populated until the dataset reappeared, then silently broke again on the next restart. With this change, either (a) the dataset is auto-recreated and indexing proceeds, or (b) the job FAILS with an `RDF storage is not ready: …` message surfaced in the app run record, instead of silently reporting success.
- [ ] Pre-existing RDF integration tests in `openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/RdfResourceIT.java` continue to pass (default `ensureStorageReady()` no-op doesn't affect in-memory/test-mode paths; Fuseki path only throws on genuine unreachability).
- [ ] With a forced failure injected in `storeEntity`, the batch processor now correctly reports `failedRecords > 0` in the app run stats instead of `0`.