### PR TITLE
Fixes #27418: optimize test case hard-delete relationship cleanup

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
@@ -4503,7 +4503,7 @@ public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
     List<CollectionDAO.EntityRelationshipRecord> relationships =
         Entity.getCollectionDAO()
             .relationshipDAO()
-            .findTo(testCase.getId(), Entity.TEST_CASE, Relationship.RELATED_TO.ordinal());
+            .findTo(testCase.getId(), Entity.TEST_CASE, Relationship.PARENT_OF.ordinal());
 
     assertNotNull(relationships);
     long statusCount =
@@ -4517,13 +4517,14 @@ public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
     // 4. Hard delete the test case
     java.util.Map<String, String> params = new java.util.HashMap<>();
     params.put("hardDelete", "true");
+    params.put("recursive", "true");
     client.testCases().delete(testCase.getId().toString(), params);
 
     // 5. Verify relationships are cleaned up
     List<CollectionDAO.EntityRelationshipRecord> relationshipsAfter =
         Entity.getCollectionDAO()
             .relationshipDAO()
-            .findTo(testCase.getId(), Entity.TEST_CASE, Relationship.RELATED_TO.ordinal());
+            .findTo(testCase.getId(), Entity.TEST_CASE, Relationship.PARENT_OF.ordinal());
 
     long statusCountAfter =
         relationshipsAfter.stream()

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
@@ -40,6 +40,7 @@ import org.openmetadata.schema.type.ApiStatus;
 import org.openmetadata.schema.type.Column;
 import org.openmetadata.schema.type.ColumnDataType;
 import org.openmetadata.schema.type.EntityHistory;
+import org.openmetadata.schema.type.Relationship;
 import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.schema.type.csv.CsvImportResult;
 import org.openmetadata.schema.utils.JsonUtils;
@@ -49,6 +50,8 @@ import org.openmetadata.sdk.models.ListParams;
 import org.openmetadata.sdk.models.ListResponse;
 import org.openmetadata.sdk.network.HttpMethod;
 import org.openmetadata.sdk.network.RequestOptions;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.resources.dqtests.TestCaseResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -4469,5 +4472,74 @@ public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
     // Verify the displayName was actually set
     TestCase updated = getEntity(created.getId().toString());
     assertEquals("Updated Display Name", updated.getDisplayName());
+  }
+
+  @Test
+  void test_testCaseDeleteCleanup(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    Table table = createTable(ns);
+
+    // 1. Create a test case
+    TestCase testCase =
+        TestCaseBuilder.create(client)
+            .name(ns.prefix("delete_cleanup"))
+            .forTable(table)
+            .testDefinition("tableRowCountToEqual")
+            .parameter("value", "100")
+            .create();
+
+    // 2. Create multiple resolution statuses (incidents)
+    for (int i = 0; i < 3; i++) {
+      org.openmetadata.schema.api.tests.CreateTestCaseResolutionStatus status =
+          new org.openmetadata.schema.api.tests.CreateTestCaseResolutionStatus();
+      status.setTestCaseResolutionStatusType(
+          org.openmetadata.schema.tests.type.TestCaseResolutionStatusTypes.Ack);
+      status.setTestCaseReference(testCase.getFullyQualifiedName());
+      client.testCaseResolutionStatuses().create(status);
+    }
+
+    // 3. Verify relationships exist in DB using JDBI
+    // We expect 3 relationships from TestCase TO TestCaseResolutionStatus
+    List<CollectionDAO.EntityRelationshipRecord> relationships =
+        Entity.getCollectionDAO()
+            .relationshipDAO()
+            .findTo(testCase.getId(), Entity.TEST_CASE, Relationship.RELATED_TO.ordinal());
+
+    assertNotNull(relationships);
+    long statusCount =
+        relationships.stream()
+            .filter(r -> r.getType().equals(Entity.TEST_CASE_RESOLUTION_STATUS))
+            .count();
+    assertTrue(
+        statusCount >= 3,
+        "There should be at least 3 relationships to resolution statuses before delete");
+
+    // 4. Hard delete the test case
+    java.util.Map<String, String> params = new java.util.HashMap<>();
+    params.put("hardDelete", "true");
+    client.testCases().delete(testCase.getId().toString(), params);
+
+    // 5. Verify relationships are cleaned up
+    List<CollectionDAO.EntityRelationshipRecord> relationshipsAfter =
+        Entity.getCollectionDAO()
+            .relationshipDAO()
+            .findTo(testCase.getId(), Entity.TEST_CASE, Relationship.RELATED_TO.ordinal());
+
+    long statusCountAfter =
+        relationshipsAfter.stream()
+            .filter(r -> r.getType().equals(Entity.TEST_CASE_RESOLUTION_STATUS))
+            .count();
+    assertEquals(
+        0,
+        statusCountAfter,
+        "All relationships to resolution statuses should be cleaned up after hard delete");
+
+    // 6. Verify time series records still exist (only relationships are deleted)
+    List<String> statusesAfter =
+        Entity.getCollectionDAO()
+            .testCaseResolutionStatusTimeSeriesDao()
+            .listTestCaseResolutionForEntityFQNHash(testCase.getFullyQualifiedName());
+    assertNotNull(statusesAfter);
+    assertEquals(3, statusesAfter.size(), "Time series records should still exist in the database");
   }
 }

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
@@ -4516,7 +4516,7 @@ public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
         "There should be exactly 3 relationships to resolution statuses before delete");
 
     // 4. Hard delete the test case
-    java.util.Map<String, String> params = new java.util.HashMap<>();
+    Map<String, String> params = new HashMap<>();
     params.put("hardDelete", "true");
     params.put("recursive", "true");
     client.testCases().delete(testCase.getId().toString(), params);

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
@@ -4510,9 +4510,10 @@ public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
         relationships.stream()
             .filter(r -> r.getType().equals(Entity.TEST_CASE_RESOLUTION_STATUS))
             .count();
-    assertTrue(
-        statusCount >= 3,
-        "There should be at least 3 relationships to resolution statuses before delete");
+    assertEquals(
+        3,
+        statusCount,
+        "There should be exactly 3 relationships to resolution statuses before delete");
 
     // 4. Hard delete the test case
     java.util.Map<String, String> params = new java.util.HashMap<>();

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
@@ -4544,4 +4544,70 @@ public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
     assertNotNull(statusesAfter);
     assertEquals(3, statusesAfter.size(), "Time series records should still exist in the database");
   }
+
+  @Test
+  void test_testCaseOrphanedRelationshipCleanup(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    Table table = createTable(ns);
+
+    // 1. Create a test case
+    TestCase testCase =
+        TestCaseBuilder.create(client)
+            .name(ns.prefix("orphaned_cleanup"))
+            .forTable(table)
+            .testDefinition("tableRowCountToEqual")
+            .parameter("value", "100")
+            .create();
+
+    // 2. Create resolution statuses (incidents)
+    for (int i = 0; i < 2; i++) {
+      org.openmetadata.schema.api.tests.CreateTestCaseResolutionStatus status =
+          new org.openmetadata.schema.api.tests.CreateTestCaseResolutionStatus();
+      status.setTestCaseResolutionStatusType(
+          org.openmetadata.schema.tests.type.TestCaseResolutionStatusTypes.Ack);
+      status.setTestCaseReference(testCase.getFullyQualifiedName());
+      client.testCaseResolutionStatuses().create(status);
+    }
+
+    // 3. Verify relationships exist
+    List<CollectionDAO.EntityRelationshipRecord> relationships =
+        Entity.getCollectionDAO()
+            .relationshipDAO()
+            .findTo(testCase.getId(), Entity.TEST_CASE, Relationship.PARENT_OF.ordinal());
+    assertEquals(2, relationships.size(), "There should be 2 relationships before orphaning");
+
+    // 4. Manually orphan the relationships by deleting the TestCase via DAO (bypassing normal
+    // delete)
+    Entity.getCollectionDAO().testCaseDAO().delete(testCase.getId());
+
+    // 5. Verify relationships are now orphaned (they still exist because we bypassed normal delete)
+    List<CollectionDAO.EntityRelationshipRecord> orphanedRelationships =
+        Entity.getCollectionDAO()
+            .relationshipDAO()
+            .findTo(testCase.getId(), Entity.TEST_CASE, Relationship.PARENT_OF.ordinal());
+    assertEquals(
+        2, orphanedRelationships.size(), "Relationships should still exist but be orphaned");
+
+    // 6. Run the new cleanup logic (same as what DataRetention app does)
+    Entity.getCollectionDAO()
+        .relationshipDAO()
+        .deleteOrphanedRelationships(
+            Entity.TEST_CASE,
+            Entity.TEST_CASE_RESOLUTION_STATUS,
+            Entity.getCollectionDAO().testCaseDAO().getTableName());
+
+    // 7. Verify relationships are cleaned up
+    List<CollectionDAO.EntityRelationshipRecord> cleanedRelationships =
+        Entity.getCollectionDAO()
+            .relationshipDAO()
+            .findTo(testCase.getId(), Entity.TEST_CASE, Relationship.PARENT_OF.ordinal());
+    assertEquals(0, cleanedRelationships.size(), "Orphaned relationships should be cleaned up");
+
+    // 8. Verify time series records still exist
+    List<String> statusesAfter =
+        Entity.getCollectionDAO()
+            .testCaseResolutionStatusTimeSeriesDao()
+            .listTestCaseResolutionForEntityFQNHash(testCase.getFullyQualifiedName());
+    assertEquals(2, statusesAfter.size(), "Time series records should still exist");
+  }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/Entity.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/Entity.java
@@ -742,6 +742,15 @@ public final class Entity {
 
   public static void deleteEntity(
       String updatedBy, String entityType, UUID entityId, boolean recursive, boolean hardDelete) {
+    if (entityType.equalsIgnoreCase(Entity.TEST_CASE_RESOLUTION_STATUS)
+        || entityType.equalsIgnoreCase(Entity.TEST_CASE_RESULT)) {
+      // TimeSeries entities don't have a standard repository delete flow.
+      // We only want to delete their relationships if they are orphaned.
+      EntityTimeSeriesRepository<?> repository = getEntityTimeSeriesRepository(entityType);
+      // We don't call repository.delete(entityId) here because we want to preserve history.
+      // The relationships will be cleaned up by the caller's relationshipDAO().deleteAll().
+      return;
+    }
     EntityRepository<?> dao = getEntityRepository(entityType);
     try {
       dao.find(entityId, Include.ALL);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/Entity.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/Entity.java
@@ -740,14 +740,22 @@ public final class Entity {
     return listOrEmpty(entityRepository.getAllTags(entity));
   }
 
+  public static boolean isTimeSeriesEntity(String entityType) {
+    return ENTITY_TS_REPOSITORY_MAP.containsKey(entityType);
+  }
+
   public static void deleteEntity(
       String updatedBy, String entityType, UUID entityId, boolean recursive, boolean hardDelete) {
-    if (entityType.equalsIgnoreCase(Entity.TEST_CASE_RESOLUTION_STATUS)
-        || entityType.equalsIgnoreCase(Entity.TEST_CASE_RESULT)) {
-      LOG.debug(
-          "Skipping delete for time-series entity {} with id {} (handled via cleanup)",
-          entityType,
-          entityId);
+    if (isTimeSeriesEntity(entityType)) {
+      if (entityType.equalsIgnoreCase(Entity.TEST_CASE_RESOLUTION_STATUS)
+          || entityType.equalsIgnoreCase(Entity.TEST_CASE_RESULT)) {
+        LOG.debug(
+            "Skipping delete for time-series entity {} with id {} (handled via cleanup)",
+            entityType,
+            entityId);
+        return;
+      }
+      getEntityTimeSeriesRepository(entityType).deleteById(entityId, hardDelete);
       return;
     }
     EntityRepository<?> dao = getEntityRepository(entityType);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/Entity.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/Entity.java
@@ -744,8 +744,10 @@ public final class Entity {
       String updatedBy, String entityType, UUID entityId, boolean recursive, boolean hardDelete) {
     if (entityType.equalsIgnoreCase(Entity.TEST_CASE_RESOLUTION_STATUS)
         || entityType.equalsIgnoreCase(Entity.TEST_CASE_RESULT)) {
-      // TimeSeries entities are cleaned up via entitySpecificCleanup,
-      // not through the standard repository delete flow.
+      LOG.debug(
+          "Skipping delete for time-series entity {} with id {} (handled via cleanup)",
+          entityType,
+          entityId);
       return;
     }
     EntityRepository<?> dao = getEntityRepository(entityType);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/Entity.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/Entity.java
@@ -744,11 +744,8 @@ public final class Entity {
       String updatedBy, String entityType, UUID entityId, boolean recursive, boolean hardDelete) {
     if (entityType.equalsIgnoreCase(Entity.TEST_CASE_RESOLUTION_STATUS)
         || entityType.equalsIgnoreCase(Entity.TEST_CASE_RESULT)) {
-      // TimeSeries entities don't have a standard repository delete flow.
-      // We only want to delete their relationships if they are orphaned.
-      EntityTimeSeriesRepository<?> repository = getEntityTimeSeriesRepository(entityType);
-      // We don't call repository.delete(entityId) here because we want to preserve history.
-      // The relationships will be cleaned up by the caller's relationshipDAO().deleteAll().
+      // TimeSeries entities are cleaned up via entitySpecificCleanup,
+      // not through the standard repository delete flow.
       return;
     }
     EntityRepository<?> dao = getEntityRepository(entityType);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/Entity.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/Entity.java
@@ -744,11 +744,15 @@ public final class Entity {
     return ENTITY_TS_REPOSITORY_MAP.containsKey(entityType);
   }
 
+  public static boolean shouldSkipTimeSeriesDelete(String entityType) {
+    return entityType.equalsIgnoreCase(Entity.TEST_CASE_RESOLUTION_STATUS)
+        || entityType.equalsIgnoreCase(Entity.TEST_CASE_RESULT);
+  }
+
   public static void deleteEntity(
       String updatedBy, String entityType, UUID entityId, boolean recursive, boolean hardDelete) {
     if (isTimeSeriesEntity(entityType)) {
-      if (entityType.equalsIgnoreCase(Entity.TEST_CASE_RESOLUTION_STATUS)
-          || entityType.equalsIgnoreCase(Entity.TEST_CASE_RESULT)) {
+      if (shouldSkipTimeSeriesDelete(entityType)) {
         LOG.debug(
             "Skipping delete for time-series entity {} with id {} (handled via cleanup)",
             entityType,

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dataRetention/DataRetention.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dataRetention/DataRetention.java
@@ -263,7 +263,9 @@ public class DataRetention extends AbstractNativeApplication {
             collectionDAO
                 .relationshipDAO()
                 .deleteOrphanedRelationships(
-                    Entity.TEST_CASE, Entity.TEST_CASE_RESOLUTION_STATUS, "test_case"));
+                    Entity.TEST_CASE,
+                    Entity.TEST_CASE_RESOLUTION_STATUS,
+                    collectionDAO.testCaseDAO().getTableName()));
     LOG.info("TestCaseResolutionStatus orphaned relationships cleanup complete.");
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dataRetention/DataRetention.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dataRetention/DataRetention.java
@@ -239,6 +239,9 @@ public class DataRetention extends AbstractNativeApplication {
           result.getRelationshipResult().getRelationshipsDeleted(),
           result.getHierarchyResult().getTotalBrokenDeleted());
 
+      // Clean up orphaned TestCaseResolutionStatus relationships specifically
+      cleanOrphanedTestCaseResolutionStatusRelationships();
+
     } catch (Exception ex) {
       LOG.error("Failed to clean orphaned relationships and hierarchies", ex);
       internalStatus = AppRunRecord.Status.ACTIVE_ERROR;
@@ -249,6 +252,19 @@ public class DataRetention extends AbstractNativeApplication {
         failureDetails.put("jobStackTrace", ExceptionUtils.getStackTrace(ex));
       }
     }
+  }
+
+  @Transaction
+  private void cleanOrphanedTestCaseResolutionStatusRelationships() {
+    LOG.info("Initiating cleanup for orphaned testCaseResolutionStatus relationships.");
+    executeWithStatsTracking(
+        "orphaned_test_case_resolution_status_relationships",
+        () ->
+            collectionDAO
+                .relationshipDAO()
+                .deleteOrphanedRelationships(
+                    Entity.TEST_CASE, Entity.TEST_CASE_RESOLUTION_STATUS, "test_case"));
+    LOG.info("TestCaseResolutionStatus orphaned relationships cleanup complete.");
   }
 
   private void cleanOrphanedTagUsages() {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -2647,6 +2647,14 @@ public interface CollectionDAO {
     @SqlUpdate("DELETE FROM entity_relationship WHERE toId = :id AND toEntity = :entity")
     void deleteAllTo(@BindUUID("id") UUID id, @Bind("entity") String entity);
 
+    @SqlUpdate(
+        "DELETE FROM entity_relationship WHERE toEntity = :toEntity AND fromEntity = :fromEntity "
+            + "AND fromId NOT IN (SELECT id FROM <table>)")
+    int deleteOrphanedRelationships(
+        @Bind("fromEntity") String fromEntity,
+        @Bind("toEntity") String toEntity,
+        @Define("table") String table);
+
     // Batch deletion methods for improved performance
     @Transaction
     default void batchDeleteRelationships(List<UUID> entityIds, String entityType) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -2649,7 +2649,7 @@ public interface CollectionDAO {
 
     @SqlUpdate(
         "DELETE FROM entity_relationship WHERE toEntity = :toEntity AND fromEntity = :fromEntity "
-            + "AND fromId NOT IN (SELECT id FROM <table>)")
+            + "AND NOT EXISTS (SELECT 1 FROM <table> t WHERE t.id = entity_relationship.fromId)")
     int deleteOrphanedRelationships(
         @Bind("fromEntity") String fromEntity,
         @Bind("toEntity") String toEntity,

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -2600,16 +2600,6 @@ public interface CollectionDAO {
         @Bind("relation") int relation);
 
     @SqlUpdate(
-        "DELETE FROM entity_relationship WHERE fromId = :fromId "
-            + "AND fromEntity = :fromEntity AND toEntity = :toEntity "
-            + "AND relation = :relation")
-    void deleteFrom(
-        @BindUUID("fromId") UUID fromId,
-        @Bind("fromEntity") String fromEntity,
-        @Bind("toEntity") String toEntity,
-        @Bind("relation") int relation);
-
-    @SqlUpdate(
         "DELETE FROM entity_relationship WHERE toId IN (<toIds>) "
             + "AND toEntity = :toEntity AND relation = :relation AND fromEntity = :fromEntity")
     void deleteToMany(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -2647,13 +2647,32 @@ public interface CollectionDAO {
     @SqlUpdate("DELETE FROM entity_relationship WHERE toId = :id AND toEntity = :entity")
     void deleteAllTo(@BindUUID("id") UUID id, @Bind("entity") String entity);
 
+    /**
+     * Delete relationships where the 'from' entity no longer exists in its primary table.
+     *
+     * @param table The table name to check for entity existence. This must be a trusted,
+     *     hard-coded string to prevent SQL injection.
+     */
     @SqlUpdate(
         "DELETE FROM entity_relationship WHERE toEntity = :toEntity AND fromEntity = :fromEntity "
             + "AND NOT EXISTS (SELECT 1 FROM <table> t WHERE t.id = entity_relationship.fromId)")
-    int deleteOrphanedRelationships(
+    int deleteOrphanedRelationshipsInternal(
         @Bind("fromEntity") String fromEntity,
         @Bind("toEntity") String toEntity,
         @Define("table") String table);
+
+    /**
+     * Safe wrapper for deleting orphaned relationships with table name validation.
+     *
+     * @param table Table name to check. Validated against a strict allowlist.
+     */
+    default int deleteOrphanedRelationships(String fromEntity, String toEntity, String table) {
+      // Validate table name against a strict allowlist to prevent SQL injection
+      if (!java.util.Set.of("test_case").contains(table)) {
+        throw new IllegalArgumentException("Invalid table name for relationship cleanup: " + table);
+      }
+      return deleteOrphanedRelationshipsInternal(fromEntity, toEntity, table);
+    }
 
     // Batch deletion methods for improved performance
     @Transaction

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -2600,6 +2600,16 @@ public interface CollectionDAO {
         @Bind("relation") int relation);
 
     @SqlUpdate(
+        "DELETE FROM entity_relationship WHERE fromId = :fromId "
+            + "AND fromEntity = :fromEntity AND toEntity = :toEntity "
+            + "AND relation = :relation")
+    void deleteFrom(
+        @BindUUID("fromId") UUID fromId,
+        @Bind("fromEntity") String fromEntity,
+        @Bind("toEntity") String toEntity,
+        @Bind("relation") int relation);
+
+    @SqlUpdate(
         "DELETE FROM entity_relationship WHERE toId IN (<toIds>) "
             + "AND toEntity = :toEntity AND relation = :relation AND fromEntity = :fromEntity")
     void deleteToMany(
@@ -2653,16 +2663,29 @@ public interface CollectionDAO {
      * @param table The table name to check for entity existence. This must be a trusted,
      *     hard-coded string to prevent SQL injection.
      */
-    @SqlUpdate(
-        "DELETE FROM entity_relationship WHERE toEntity = :toEntity AND fromEntity = :fromEntity "
-            + "AND NOT EXISTS (SELECT 1 FROM <table> t WHERE t.id = entity_relationship.fromId)")
+    @ConnectionAwareSqlUpdate(
+        value =
+            "DELETE FROM entity_relationship WHERE toEntity = :toEntity AND fromEntity = :fromEntity "
+                + "AND NOT EXISTS (SELECT 1 FROM <table> t WHERE t.id = entity_relationship.fromId) "
+                + "LIMIT :limit",
+        connectionType = MYSQL)
+    @ConnectionAwareSqlUpdate(
+        value =
+            "DELETE FROM entity_relationship WHERE ctid IN ( "
+                + "  SELECT ctid FROM entity_relationship "
+                + "  WHERE toEntity = :toEntity AND fromEntity = :fromEntity "
+                + "  AND NOT EXISTS (SELECT 1 FROM <table> t WHERE t.id = entity_relationship.fromId) "
+                + "  LIMIT :limit "
+                + ")",
+        connectionType = POSTGRES)
     int deleteOrphanedRelationshipsInternal(
         @Bind("fromEntity") String fromEntity,
         @Bind("toEntity") String toEntity,
-        @Define("table") String table);
+        @Define("table") String table,
+        @Bind("limit") int limit);
 
     /**
-     * Safe wrapper for deleting orphaned relationships with table name validation.
+     * Safe wrapper for deleting orphaned relationships with table name validation and batching.
      *
      * @param table Table name to check. Validated against a strict allowlist.
      */
@@ -2671,7 +2694,15 @@ public interface CollectionDAO {
       if (!java.util.Set.of("test_case").contains(table)) {
         throw new IllegalArgumentException("Invalid table name for relationship cleanup: " + table);
       }
-      return deleteOrphanedRelationshipsInternal(fromEntity, toEntity, table);
+      int totalDeleted = 0;
+      int deletedInBatch;
+      int batchSize = 1000;
+      do {
+        deletedInBatch =
+            deleteOrphanedRelationshipsInternal(fromEntity, toEntity, table, batchSize);
+        totalDeleted += deletedInBatch;
+      } while (deletedInBatch > 0);
+      return totalDeleted;
     }
 
     // Batch deletion methods for improved performance

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -4380,6 +4380,12 @@ public abstract class EntityRepository<T extends EntityInterface> {
   @Transaction
   private void processDeletionBatch(
       List<UUID> entityIds, String entityType, boolean hardDelete, String updatedBy) {
+    if (entityType.equalsIgnoreCase(Entity.TEST_CASE_RESOLUTION_STATUS)
+        || entityType.equalsIgnoreCase(Entity.TEST_CASE_RESULT)) {
+      LOG.debug(
+          "Skipping batch delete for time-series entity {} (handled via cleanup)", entityType);
+      return;
+    }
 
     LOG.debug("Processing batch of {} {} entities", entityIds.size(), entityType);
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -4380,10 +4380,16 @@ public abstract class EntityRepository<T extends EntityInterface> {
   @Transaction
   private void processDeletionBatch(
       List<UUID> entityIds, String entityType, boolean hardDelete, String updatedBy) {
-    if (entityType.equalsIgnoreCase(Entity.TEST_CASE_RESOLUTION_STATUS)
-        || entityType.equalsIgnoreCase(Entity.TEST_CASE_RESULT)) {
-      LOG.debug(
-          "Skipping batch delete for time-series entity {} (handled via cleanup)", entityType);
+    if (Entity.isTimeSeriesEntity(entityType)) {
+      if (entityType.equalsIgnoreCase(Entity.TEST_CASE_RESOLUTION_STATUS)
+          || entityType.equalsIgnoreCase(Entity.TEST_CASE_RESULT)) {
+        LOG.debug(
+            "Skipping batch delete for time-series entity {} (handled via cleanup)", entityType);
+        return;
+      }
+      for (UUID entityId : entityIds) {
+        Entity.getEntityTimeSeriesRepository(entityType).deleteById(entityId, hardDelete);
+      }
       return;
     }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -4381,8 +4381,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
   private void processDeletionBatch(
       List<UUID> entityIds, String entityType, boolean hardDelete, String updatedBy) {
     if (Entity.isTimeSeriesEntity(entityType)) {
-      if (entityType.equalsIgnoreCase(Entity.TEST_CASE_RESOLUTION_STATUS)
-          || entityType.equalsIgnoreCase(Entity.TEST_CASE_RESULT)) {
+      if (Entity.shouldSkipTimeSeriesDelete(entityType)) {
         LOG.debug(
             "Skipping batch delete for time-series entity {} (handled via cleanup)", entityType);
         return;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityTimeSeriesDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityTimeSeriesDAO.java
@@ -392,10 +392,10 @@ public interface EntityTimeSeriesDAO {
   }
 
   @SqlUpdate(value = "DELETE from <table> WHERE id = :id")
-  void deleteById(@Define("table") String table, @Bind("id") String id);
+  int deleteById(@Define("table") String table, @Bind("id") String id);
 
-  default void deleteById(UUID id) {
-    deleteById(getTimeSeriesTableName(), id.toString());
+  default int deleteById(UUID id) {
+    return deleteById(getTimeSeriesTableName(), id.toString());
   }
 
   /** @deprecated */

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityTimeSeriesRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityTimeSeriesRepository.java
@@ -396,12 +396,8 @@ public abstract class EntityTimeSeriesRepository<T extends EntityTimeSeriesInter
       // soft deleted
       return;
     }
-    T entityRecord = getById(id);
-    if (entityRecord == null) {
-      return;
-    }
-    timeSeriesDao.deleteById(id);
-    if (shouldCleanupRelationshipsOnDelete()) {
+    int deleted = timeSeriesDao.deleteById(id);
+    if (deleted > 0 && shouldCleanupRelationshipsOnDelete()) {
       daoCollection.relationshipDAO().deleteAll(id, entityType);
     }
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityTimeSeriesRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityTimeSeriesRepository.java
@@ -388,6 +388,7 @@ public abstract class EntityTimeSeriesRepository<T extends EntityTimeSeriesInter
     return entityRecord;
   }
 
+  @Transaction
   public void deleteById(UUID id, boolean hardDelete) {
     if (!hardDelete) {
       // time series entities by definition cannot be soft deleted (i.e. they do not have a state,

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityTimeSeriesRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityTimeSeriesRepository.java
@@ -401,7 +401,17 @@ public abstract class EntityTimeSeriesRepository<T extends EntityTimeSeriesInter
       return;
     }
     timeSeriesDao.deleteById(id);
-    daoCollection.relationshipDAO().deleteAll(id, entityType);
+    if (shouldCleanupRelationshipsOnDelete()) {
+      daoCollection.relationshipDAO().deleteAll(id, entityType);
+    }
+  }
+
+  /**
+   * Hook for subclasses to opt into relationship cleanup on entity deletion. Default is false to
+   * avoid unnecessary SQL round-trips for entities without relationships.
+   */
+  protected boolean shouldCleanupRelationshipsOnDelete() {
+    return false;
   }
 
   private Map<String, List<?>> getEntityList(List<String> jsons, boolean skipErrors) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityTimeSeriesRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityTimeSeriesRepository.java
@@ -400,6 +400,7 @@ public abstract class EntityTimeSeriesRepository<T extends EntityTimeSeriesInter
       return;
     }
     timeSeriesDao.deleteById(id);
+    daoCollection.relationshipDAO().deleteAll(id, entityType);
   }
 
   private Map<String, List<?>> getEntityList(List<String> jsons, boolean skipErrors) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
@@ -890,10 +890,6 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
   @Override
   protected void entitySpecificCleanup(TestCase entityInterface) {
     deleteAllTestCaseResults(entityInterface.getFullyQualifiedName());
-    TestCaseResolutionStatusRepository testCaseResolutionStatusRepository =
-        (TestCaseResolutionStatusRepository)
-            Entity.getEntityTimeSeriesRepository(Entity.TEST_CASE_RESOLUTION_STATUS);
-    testCaseResolutionStatusRepository.deleteAllRelationshipsByTestCase(entityInterface.getId());
   }
 
   private void deleteAllTestCaseResults(String fqn) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
@@ -893,8 +893,7 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
     TestCaseResolutionStatusRepository testCaseResolutionStatusRepository =
         (TestCaseResolutionStatusRepository)
             Entity.getEntityTimeSeriesRepository(Entity.TEST_CASE_RESOLUTION_STATUS);
-    testCaseResolutionStatusRepository.deleteAllRelationshipsByTestCase(
-        entityInterface.getFullyQualifiedName());
+    testCaseResolutionStatusRepository.deleteAllRelationshipsByTestCase(entityInterface.getId());
   }
 
   private void deleteAllTestCaseResults(String fqn) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
@@ -890,6 +890,11 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
   @Override
   protected void entitySpecificCleanup(TestCase entityInterface) {
     deleteAllTestCaseResults(entityInterface.getFullyQualifiedName());
+    TestCaseResolutionStatusRepository testCaseResolutionStatusRepository =
+        (TestCaseResolutionStatusRepository)
+            Entity.getEntityTimeSeriesRepository(Entity.TEST_CASE_RESOLUTION_STATUS);
+    testCaseResolutionStatusRepository.deleteAllRelationshipsByTestCase(
+        entityInterface.getFullyQualifiedName());
   }
 
   private void deleteAllTestCaseResults(String fqn) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
@@ -887,30 +887,14 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
     testSuiteRepository.postUpdate(original, testSuite);
   }
 
-  @Transaction
-  @Override
-  protected void deleteChildren(
-      List<CollectionDAO.EntityRelationshipRecord> children, boolean hardDelete, String updatedBy) {
-    if (hardDelete) {
-      for (CollectionDAO.EntityRelationshipRecord entityRelationshipRecord : children) {
-        LOG.info(
-            "Recursively {} deleting {} {}",
-            hardDelete ? "hard" : "soft",
-            entityRelationshipRecord.getType(),
-            entityRelationshipRecord.getId());
-        TestCaseResolutionStatusRepository testCaseResolutionStatusRepository =
-            (TestCaseResolutionStatusRepository)
-                Entity.getEntityTimeSeriesRepository(Entity.TEST_CASE_RESOLUTION_STATUS);
-        for (CollectionDAO.EntityRelationshipRecord child : children) {
-          testCaseResolutionStatusRepository.deleteById(child.getId(), hardDelete);
-        }
-      }
-    }
-  }
-
   @Override
   protected void entitySpecificCleanup(TestCase entityInterface) {
     deleteAllTestCaseResults(entityInterface.getFullyQualifiedName());
+    TestCaseResolutionStatusRepository testCaseResolutionStatusRepository =
+        (TestCaseResolutionStatusRepository)
+            Entity.getEntityTimeSeriesRepository(Entity.TEST_CASE_RESOLUTION_STATUS);
+    testCaseResolutionStatusRepository.deleteAllRelationshipsByTestCase(
+        entityInterface.getFullyQualifiedName());
   }
 
   private void deleteAllTestCaseResults(String fqn) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseResolutionStatusRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseResolutionStatusRepository.java
@@ -228,18 +228,14 @@ public class TestCaseResolutionStatusRepository
     recordEntity.withTestCaseReference(testCaseReference);
   }
 
-  public void deleteAllRelationshipsByTestCase(String testCaseFQN) {
-    List<String> jsons =
-        ((CollectionDAO.TestCaseResolutionStatusTimeSeriesDAO) timeSeriesDao)
-            .listTestCaseResolutionForEntityFQNHash(testCaseFQN);
-    if (jsons.isEmpty()) {
-      return;
-    }
-    List<UUID> statusIds =
-        jsons.stream()
-            .map(json -> JsonUtils.readValue(json, TestCaseResolutionStatus.class).getId())
-            .toList();
-    daoCollection.relationshipDAO().batchDeleteRelationships(statusIds, entityType);
+  public void deleteAllRelationshipsByTestCase(UUID testCaseId) {
+    daoCollection
+        .relationshipDAO()
+        .deleteFrom(
+            testCaseId,
+            Entity.TEST_CASE,
+            Relationship.PARENT_OF.ordinal(),
+            Entity.TEST_CASE_RESOLUTION_STATUS);
   }
 
   @Override
@@ -249,7 +245,7 @@ public class TestCaseResolutionStatusRepository
         recordEntity.getId(),
         Entity.TEST_CASE,
         Entity.TEST_CASE_RESOLUTION_STATUS,
-        Relationship.RELATED_TO,
+        Relationship.PARENT_OF,
         null,
         false);
   }
@@ -257,7 +253,7 @@ public class TestCaseResolutionStatusRepository
   @Override
   protected void setInheritedFields(TestCaseResolutionStatus recordEntity) {
     recordEntity.setTestCaseReference(
-        getFromEntityRef(recordEntity.getId(), Relationship.RELATED_TO, Entity.TEST_CASE, true));
+        getFromEntityRef(recordEntity.getId(), Relationship.PARENT_OF, Entity.TEST_CASE, true));
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseResolutionStatusRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseResolutionStatusRepository.java
@@ -624,4 +624,16 @@ public class TestCaseResolutionStatusRepository
         .max((a, b) -> Long.compare(a.getTimestamp(), b.getTimestamp()))
         .orElse(records.get(records.size() - 1));
   }
+
+  public void deleteAllRelationshipsByTestCase(String testCaseFqn) {
+    EntityReference testCaseRef =
+        getEntityReferenceByName(Entity.TEST_CASE, testCaseFqn, Include.ALL);
+    daoCollection
+        .relationshipDAO()
+        .deleteFrom(
+            testCaseRef.getId(),
+            Entity.TEST_CASE,
+            Entity.TEST_CASE_RESOLUTION_STATUS,
+            Relationship.PARENT_OF.ordinal());
+  }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseResolutionStatusRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseResolutionStatusRepository.java
@@ -228,6 +228,20 @@ public class TestCaseResolutionStatusRepository
     recordEntity.withTestCaseReference(testCaseReference);
   }
 
+  public void deleteAllRelationshipsByTestCase(String testCaseFQN) {
+    List<String> jsons =
+        ((CollectionDAO.TestCaseResolutionStatusTimeSeriesDAO) timeSeriesDao)
+            .listTestCaseResolutionForEntityFQNHash(testCaseFQN);
+    if (jsons.isEmpty()) {
+      return;
+    }
+    List<UUID> statusIds =
+        jsons.stream()
+            .map(json -> JsonUtils.readValue(json, TestCaseResolutionStatus.class).getId())
+            .toList();
+    daoCollection.relationshipDAO().batchDeleteRelationships(statusIds, entityType);
+  }
+
   @Override
   protected void storeRelationship(TestCaseResolutionStatus recordEntity) {
     addRelationship(
@@ -235,7 +249,7 @@ public class TestCaseResolutionStatusRepository
         recordEntity.getId(),
         Entity.TEST_CASE,
         Entity.TEST_CASE_RESOLUTION_STATUS,
-        Relationship.PARENT_OF,
+        Relationship.RELATED_TO,
         null,
         false);
   }
@@ -243,7 +257,7 @@ public class TestCaseResolutionStatusRepository
   @Override
   protected void setInheritedFields(TestCaseResolutionStatus recordEntity) {
     recordEntity.setTestCaseReference(
-        getFromEntityRef(recordEntity.getId(), Relationship.PARENT_OF, Entity.TEST_CASE, true));
+        getFromEntityRef(recordEntity.getId(), Relationship.RELATED_TO, Entity.TEST_CASE, true));
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseResolutionStatusRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseResolutionStatusRepository.java
@@ -62,6 +62,11 @@ public class TestCaseResolutionStatusRepository
   }
 
   @Override
+  protected boolean shouldCleanupRelationshipsOnDelete() {
+    return true;
+  }
+
+  @Override
   protected List<String> getExcludeSearchFields() {
     return List.of("@timestamp", "domains", "testCase", "testSuite", "fqnParts");
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseResolutionStatusRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseResolutionStatusRepository.java
@@ -228,16 +228,6 @@ public class TestCaseResolutionStatusRepository
     recordEntity.withTestCaseReference(testCaseReference);
   }
 
-  public void deleteAllRelationshipsByTestCase(UUID testCaseId) {
-    daoCollection
-        .relationshipDAO()
-        .deleteFrom(
-            testCaseId,
-            Entity.TEST_CASE,
-            Relationship.PARENT_OF.ordinal(),
-            Entity.TEST_CASE_RESOLUTION_STATUS);
-  }
-
   @Override
   protected void storeRelationship(TestCaseResolutionStatus recordEntity) {
     addRelationship(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseResolutionStatusRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseResolutionStatusRepository.java
@@ -625,15 +625,13 @@ public class TestCaseResolutionStatusRepository
         .orElse(records.get(records.size() - 1));
   }
 
-  public void deleteAllRelationshipsByTestCase(String testCaseFqn) {
-    EntityReference testCaseRef =
-        getEntityReferenceByName(Entity.TEST_CASE, testCaseFqn, Include.ALL);
+  public void deleteAllRelationshipsByTestCase(UUID testCaseId) {
     daoCollection
         .relationshipDAO()
         .deleteFrom(
-            testCaseRef.getId(),
+            testCaseId,
             Entity.TEST_CASE,
-            Entity.TEST_CASE_RESOLUTION_STATUS,
-            Relationship.PARENT_OF.ordinal());
+            Relationship.PARENT_OF.ordinal(),
+            Entity.TEST_CASE_RESOLUTION_STATUS);
   }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #27418

**Summary:** Optimized the cleanup of TestCaseResolutionStatus relationships during TestCase hard-deletes. Replaced an inefficient $O(N)$ sequential deletion loop with a single set-based SQL delete.

**Root Cause:** The repository was iterating through each relationship and deleting them one-by-one. This caused significant database round-trip overhead for test cases with large incident histories.

**Changes:**

1. Refactored TestCaseResolutionStatusRepository to use batchDeleteRelationships.
2. Integrated optimized cleanup into the TestCase hard-delete lifecycle.
3. Applied project-wide formatting via spotless.

**How I tested:**

1. **Integration Test:** Added TestCaseResourceIT#test_testCaseDeleteCleanup to verify total relationship cleanup (Passed).
2. **Data Persistence:** Confirmed via SQL that historical time-series records are preserved for audit purposes.
3. **Manual Verification:** Performed a manual hard-delete of a test case with 3+ incidents to ensure no cascading errors.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [X] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [X] My PR title is `Fixes <issue-number>: <short explanation>`
- [X] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **Orphaned relationship cleanup:**
  - Added `deleteOrphanedRelationships` to `CollectionDAO` to identify and remove stale records via batched SQL.
  - Integrated orphaned cleanup into `DataRetention` app to ensure integrity of `TestCase` relationships.
- **Entity infrastructure:**
  - Introduced generic time-series deletion logic in `Entity` and `EntityTimeSeriesRepository` to centralize cleanup tasks.
  - Added `shouldCleanupRelationshipsOnDelete` hook to allow selective relationship purging during time-series entity removal.
- **Integration testing:**
  - Added `test_testCaseDeleteCleanup` and `test_testCaseOrphanedRelationshipCleanup` to verify relationship lifecycle management.

<sub>This will update automatically on new commits.</sub>