### PR TITLE
fix(ui): remove beta tag from stable services and fix Microsoft Fabric icon

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/constants/ServiceType.constant.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/ServiceType.constant.ts
@@ -176,21 +176,11 @@ export const SERVICE_TYPES_ENUM = {
 };
 
 export const BETA_SERVICES = [
-  PipelineServiceType.OpenLineage,
-  PipelineServiceType.Wherescape,
-  DatabaseServiceType.Cassandra,
-  MetadataServiceType.AlationSink,
-  DatabaseServiceType.Cockroach,
-  SearchServiceType.OpenSearch,
   PipelineServiceType.Ssis,
   DatabaseServiceType.Ssas,
-  DashboardServiceType.ThoughtSpot,
-  SecurityServiceType.Ranger,
   DatabaseServiceType.Epic,
-  DashboardServiceType.Grafana,
   DashboardServiceType.Hex,
   DatabaseServiceType.ServiceNow,
-  DatabaseServiceType.Timescale,
   DatabaseServiceType.Dremio,
   MetadataServiceType.Collibra,
   PipelineServiceType.Mulesoft,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ServiceIconUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ServiceIconUtils.ts
@@ -178,7 +178,7 @@ const SERVICE_ICON_LOADERS: Record<string, string> = {
   iomete: iomete,
   domodatabase: domo,
   customdatabase: databasedefault,
-  microsoftFabric: microsoftFabric,
+  microsoftfabric: microsoftFabric,
 
   // Messaging services
   kafka: kafka,
@@ -221,7 +221,7 @@ const SERVICE_ICON_LOADERS: Record<string, string> = {
   databrickspipeline: databrick,
   gluepipeline: glue,
   custompipeline: pipelinedefault,
-  microsoftFabricPipeline: microsoftFabric,
+  microsoftfabricpipeline: microsoftFabric,
 
   // ML Model services
   mlflow: mlflow,


### PR DESCRIPTION
## Summary
- Remove the Beta tag from services that are now stable: OpenLineage, Wherescape, Cassandra, AlationSink, Cockroach, OpenSearch, ThoughtSpot, Ranger, Grafana, and Timescale.
- Fix Microsoft Fabric and Microsoft Fabric Pipeline icons on the service creation screen. `getServiceIcon` normalizes the key with `toLowerCase()`, but the icon map used camelCase keys (`microsoftFabric`, `microsoftFabricPipeline`), so the lookup missed and the tile fell back to the default database icon. Lowercased the keys to match.

## Test plan
- [x] Open service creation → Database services; confirm the Microsoft Fabric tile shows the Microsoft Fabric logo (not the generic DB cylinder).
- [x] Open service creation → Pipeline services; confirm the Microsoft Fabric Pipeline tile shows the logo.
- [x] Confirm the following no longer display a Beta badge: OpenLineage, Wherescape, Cassandra, AlationSink, Cockroach, OpenSearch, ThoughtSpot, Ranger, Grafana, Timescale.
- [x] Confirm services still expected to be Beta remain marked: SSIS, SSAS, Epic, Hex, ServiceNow, Dremio, Collibra, Mulesoft, Microsoft Fabric, Microsoft Fabric Pipeline, BurstIQ, StarRocks, SFTP, GoogleDrive, Informix, MicrosoftAccess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)