### PR TITLE
fix(e2e): update glossary playwright specs for TermRelation relatedTerms shape

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryAdvancedOperations.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryAdvancedOperations.spec.ts
@@ -879,8 +879,11 @@ test.describe('Glossary Advanced Operations', () => {
           path: '/relatedTerms',
           value: [
             {
-              id: relatedTerm.responseData.id,
-              type: 'glossaryTerm',
+              relationType: 'relatedTo',
+              term: {
+                id: relatedTerm.responseData.id,
+                type: 'glossaryTerm',
+              },
             },
           ],
         },
@@ -1297,8 +1300,11 @@ test.describe('Glossary Advanced Operations', () => {
           path: '/relatedTerms',
           value: [
             {
-              id: term2.responseData.id,
-              type: 'glossaryTerm',
+              relationType: 'relatedTo',
+              term: {
+                id: term2.responseData.id,
+                type: 'glossaryTerm',
+              },
             },
           ],
         },

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts
@@ -2667,7 +2667,8 @@ test.describe('Glossary tests', () => {
       ).toContain(tagFqn);
       expect(
         (createdTerm.relatedTerms ?? []).map(
-          (t: { fullyQualifiedName: string }) => t.fullyQualifiedName
+          (t: { term: { fullyQualifiedName: string } }) =>
+            t.term.fullyQualifiedName
         )
       ).toContain(relatedTerm.responseData.fullyQualifiedName);
       expect(

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/glossary.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/glossary.ts
@@ -148,10 +148,14 @@ export const setupGlossaryAndTerms = async (page: Page) => {
     op: 'add',
     path: '/relatedTerms/0',
     value: {
-      id: term1.responseData.id,
-      type: 'glossaryTerm',
-      displayName: term1.responseData.displayName,
-      name: term1.responseData.name,
+      relationType: 'relatedTo',
+      term: {
+        id: term1.responseData.id,
+        type: 'glossaryTerm',
+        name: term1.responseData.name,
+        displayName: term1.responseData.displayName,
+        fullyQualifiedName: term1.responseData.fullyQualifiedName,
+      },
     },
   };
 


### PR DESCRIPTION
## Summary

- 4 glossary playwright tests have been failing on `1.13` CI because the `relatedTerms` schema moved from `EntityReference[]` to `TermRelation[]` (each entry is now `{ relationType, term: { ... } }`), but the tests still built and read the old `{ id, type }` shape.
- The backend/schema half of PR #25886 (Glossary relations) was re-applied to `1.13` via commit `2c00efb10a` ("fix conflicts", Apr 17). The playwright test updates from the same PR did not come along, leaving these tests broken on `1.13` ever since.
- Full PR #25886 can't be cherry-picked cleanly onto `1.13` — it was reverted on main and then selectively re-landed piecemeal, and the backend half is already present here; a whole-PR pick would collide heavily. This PR brings over only the minimum playwright-test delta.

## Changes

- [`playwright/utils/glossary.ts`](openmetadata-ui/src/main/resources/ui/playwright/utils/glossary.ts) — `setupGlossaryAndTerms`: wrap the related-term link in `{ relationType: 'relatedTo', term: {...} }`.
- [`playwright/e2e/Features/Glossary/GlossaryAdvancedOperations.spec.ts`](openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryAdvancedOperations.spec.ts) — two PATCH payloads wrapped in the `TermRelation` shape.
- [`playwright/e2e/Pages/Glossary.spec.ts`](openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts) — read `t.term.fullyQualifiedName` instead of `t.fullyQualifiedName`.

## Tests now green

- `GlossaryAdvancedOperations.spec.ts` — `should remove related term`
- `GlossaryAdvancedOperations.spec.ts` — `should show bidirectional related term link`
- `Glossary.spec.ts` — `Create term with related terms, tags and owners during creation`
- `GlossaryVersionPage.spec.ts` — `GlossaryTerm` (via the shared `setupGlossaryAndTerms` helper)

## Test plan

- [x] Verified each failure reproduces locally on `1.13` against the docker stack before the fix.
- [x] Re-ran the 5 targeted test titles locally after the fix — all green:
  ```
  npx playwright test \
    playwright/e2e/Features/Glossary/GlossaryAdvancedOperations.spec.ts \
    playwright/e2e/Pages/Glossary.spec.ts \
    playwright/e2e/VersionPages/GlossaryVersionPage.spec.ts \
    --project=chromium --workers=1 \
    -g 'should remove related term|bidirectional related term link|Create term with related terms, tags and owners during creation|^GlossaryTerm$'
  ```
  → 7 passed (59.3s), including the two setup dependencies.
- [ ] Full `1.13` CI run.