### PR TITLE
fix(e2e): drop redundant table cleanup in DataProducts spec

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataProducts.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataProducts.spec.ts
@@ -198,10 +198,9 @@ test.describe('Data Products', () => {
     });
 
     await test.step('Cleanup test assets', async () => {
-      const { apiContext, afterAction } = await performAdminLogin(
+      const { afterAction } = await performAdminLogin(
         page.context().browser()!
       );
-      await table.delete(apiContext);
       await afterAction();
     });
   });


### PR DESCRIPTION
## Summary
- Remove the unused `apiContext` destructure and redundant `table.delete(apiContext)` call from the DataProducts spec cleanup step. The table is already torn down earlier in the flow, so the extra delete is noise.

## Test plan
- [ ] `yarn playwright:run` passes for `playwright/e2e/Pages/DataProducts.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)