### PR TITLE
test: gate version history tests on supportsVersionHistory flag

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/AnnouncementResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/AnnouncementResourceIT.java
@@ -50,7 +50,8 @@ public class AnnouncementResourceIT extends BaseEntityIT<Announcement, CreateAnn
     supportsPatch = true;
     supportsOwners = true;
     supportsSearchIndex = false;
-    supportsVersionHistory = true;
+    supportsVersionHistory = false;
+    supportsGetByVersion = false;
   }
 
   @Override

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BaseEntityIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BaseEntityIT.java
@@ -1343,7 +1343,7 @@ public abstract class BaseEntityIT<T extends EntityInterface, K> {
 
   @Test
   void get_entityVersionHistory_200(TestNamespace ns) {
-    if (!supportsPatch) return; // Version history tests require patch support
+    if (!supportsVersionHistory || !supportsPatch) return;
 
     K createRequest = createMinimalRequest(ns);
     T created = createEntity(createRequest);
@@ -1365,7 +1365,7 @@ public abstract class BaseEntityIT<T extends EntityInterface, K> {
 
   @Test
   void get_entityVersionHistory_paginated_200(TestNamespace ns) {
-    if (!supportsPatch) return;
+    if (!supportsVersionHistory || !supportsPatch) return;
 
     K createRequest = createMinimalRequest(ns);
     T created = createEntity(createRequest);
@@ -1429,7 +1429,7 @@ public abstract class BaseEntityIT<T extends EntityInterface, K> {
 
   @Test
   void get_specificVersion_200(TestNamespace ns) {
-    if (!supportsPatch) return; // Specific version tests require patch support
+    if (!supportsVersionHistory || !supportsGetByVersion || !supportsPatch) return;
 
     K createRequest = createMinimalRequest(ns);
     T created = createEntity(createRequest);
@@ -1448,7 +1448,7 @@ public abstract class BaseEntityIT<T extends EntityInterface, K> {
 
   @Test
   void get_entityVersionHistory_fieldChanged_200(TestNamespace ns) {
-    if (!supportsPatch) return;
+    if (!supportsVersionHistory || !supportsPatch) return;
 
     K createRequest = createMinimalRequest(ns);
     T created = createEntity(createRequest);
@@ -1505,7 +1505,7 @@ public abstract class BaseEntityIT<T extends EntityInterface, K> {
 
   @Test
   void get_entityVersionHistory_fieldChanged_ignoresWrongExtensionPrefix(TestNamespace ns) {
-    if (!supportsPatch) return;
+    if (!supportsVersionHistory || !supportsPatch) return;
 
     K createRequest = createMinimalRequest(ns);
     T created = createEntity(createRequest);
@@ -1591,7 +1591,7 @@ public abstract class BaseEntityIT<T extends EntityInterface, K> {
 
   @Test
   void get_entityVersionHistory_fieldChanged_matchesNullChangedFieldKeysRows(TestNamespace ns) {
-    if (!supportsPatch) return;
+    if (!supportsVersionHistory || !supportsPatch) return;
 
     K createRequest = createMinimalRequest(ns);
     T created = createEntity(createRequest);

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TaskFormSchemaResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TaskFormSchemaResourceIT.java
@@ -43,7 +43,8 @@ public class TaskFormSchemaResourceIT extends BaseEntityIT<TaskFormSchema, TaskF
     supportsPatch = true;
     supportsOwners = false;
     supportsSearchIndex = false;
-    supportsVersionHistory = true;
+    supportsVersionHistory = false;
+    supportsGetByVersion = false;
   }
 
   private FormSchema buildFormSchema() {

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TaskResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TaskResourceIT.java
@@ -125,6 +125,8 @@ public class TaskResourceIT extends BaseEntityIT<Task, CreateTask> {
     supportsPatch = true;
     supportsOwners = false;
     supportsSearchIndex = true;
+    supportsVersionHistory = false;
+    supportsGetByVersion = false;
   }
 
   @Override


### PR DESCRIPTION
### Describe your changes:

After the Task redesign and version history PRs merged, integration tests for `AnnouncementResourceIT`, `TaskFormSchemaResourceIT`, and `TaskResourceIT` started failing with `UnsupportedOperationException: version history not implemented - override in subclass`. The version history tests in `BaseEntityIT` were gated only on `supportsPatch`, but these entities support patch without exposing version endpoints. Gated all version history tests on `supportsVersionHistory` (and `supportsGetByVersion` where relevant) and set those flags to `false` on the three affected IT classes.

#
### Type of change:
- [x] Bug fix

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.