### PR TITLE
Fix QuickSight dashboards missing data model references

### DIFF
--- a/ingestion/src/metadata/ingestion/source/dashboard/quicksight/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/quicksight/metadata.py
@@ -188,6 +188,17 @@ class QuicksightSource(DashboardServiceSource):
                 )
                 for chart in self.context.get().charts or []
             ],
+            dataModels=[
+                FullyQualifiedEntityName(
+                    fqn.build(
+                        self.metadata,
+                        entity_type=DashboardDataModel,
+                        service_name=self.context.get().dashboard_service,
+                        data_model_name=data_model,
+                    )
+                )
+                for data_model in self.context.get().dataModels or []
+            ],
             service=self.context.get().dashboard_service,
             owners=self.get_owner_ref(dashboard_details=dashboard_details),
         )

--- a/ingestion/tests/unit/topology/dashboard/test_quicksight.py
+++ b/ingestion/tests/unit/topology/dashboard/test_quicksight.py
@@ -109,6 +109,7 @@ EXPECTED_DASHBOARD = CreateDashboardRequest(
     displayName="New Dashboard",
     sourceUrl="https://us-east-2.quicksight.aws.amazon.com/sn/dashboards/552315335",
     charts=[],
+    dataModels=[],
     tags=None,
     owners=None,
     service="quicksight_source_test",
@@ -183,6 +184,23 @@ class QuickSightUnitTest(TestCase):
             if isinstance(result, Either) and result.right:
                 dashboard_list.append(result.right)
         self.assertEqual(EXPECTED_DASHBOARD, dashboard_list[0])
+
+    def test_dashboard_includes_datamodels(self):
+        self.quicksight.context.get().__dict__["dataModels"] = [
+            "dataset-A",
+            "dataset-B",
+        ]
+
+        results = list(
+            self.quicksight.yield_dashboard(DashboardDetail(**MOCK_DASHBOARD_DETAILS))
+        )
+
+        dashboard = next(result.right for result in results if result.right)
+
+        assert dashboard.dataModels == [
+            FullyQualifiedEntityName("quicksight_source_test.model.dataset-A"),
+            FullyQualifiedEntityName("quicksight_source_test.model.dataset-B"),
+        ]
 
     @pytest.mark.order(2)
     def test_dashboard_name(self):


### PR DESCRIPTION
### Describe your changes

QuickSight dashboard ingestion already discovers the datasets used by a dashboard and emits them as `DashboardDataModel` entities, but the dashboard request only populated `charts`. As a result, ingested dashboards had an empty `dataModels` field even when their referenced datasets existed in OpenMetadata.

This change wires the datamodel names already collected in the QuickSight topology context into `CreateDashboardRequest.dataModels`, using the same FQN shape as the ingested dashboard datamodel entities.

### Why this matters

Without this field, QuickSight dashboards are disconnected from their datamodels in lineage and impact analysis. The datamodel to warehouse-table lineage can exist, but the dashboard to datamodel hop is missing.

### Type of change

- [x] Bug fix

### Tests

```bash
/tmp/openmetadata-quicksight-test-venv/bin/python -m pytest -c ingestion/pyproject.toml ingestion/tests/unit/topology/dashboard/test_quicksight.py
```

Result: `10 passed`.
