### PR TITLE
[codex] Fix dbt local artifact path matching

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/dbt/dbt_config.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/dbt_config.py
@@ -463,6 +463,12 @@ def _filter_latest_per_project(
     return filtered
 
 
+def _matches_configured_artifact_path(blob: str, config, config_attr: str) -> bool:
+    configured_path = getattr(config, config_attr, None)
+
+    return bool(configured_path) and clean_uri(blob) == clean_uri(configured_path)
+
+
 # pylint: disable=too-many-locals, too-many-branches
 def download_dbt_files(
     blob_grouped_by_directory: Dict, config, client, bucket_name: Optional[str]
@@ -489,18 +495,24 @@ def download_dbt_files(
                 if blob:
                     reader = get_reader(config_source=config, client=client)
                     blob_file_name = os.path.basename(blob)
-                    if DBT_MANIFEST_FILE_NAME == blob_file_name.lower():
-                        logger.debug(f"{DBT_MANIFEST_FILE_NAME} found in {key}")
+                    if _matches_configured_artifact_path(
+                        blob, config, "dbtManifestFilePath"
+                    ) or DBT_MANIFEST_FILE_NAME == blob_file_name.lower():
+                        logger.debug(f"{blob_file_name} found in {key}")
                         dbt_manifest = reader.read(path=blob, **kwargs)
-                    if DBT_CATALOG_FILE_NAME == blob_file_name.lower():
+                    if _matches_configured_artifact_path(
+                        blob, config, "dbtCatalogFilePath"
+                    ) or DBT_CATALOG_FILE_NAME == blob_file_name.lower():
                         try:
-                            logger.debug(f"{DBT_CATALOG_FILE_NAME} found in {key}")
+                            logger.debug(f"{blob_file_name} found in {key}")
                             dbt_catalog = reader.read(path=blob, **kwargs)
                         except Exception as exc:
                             logger.warning(
-                                f"{DBT_CATALOG_FILE_NAME} not found in {key}: {exc}"
+                                f"{blob_file_name} not found in {key}: {exc}"
                             )
-                    if DBT_RUN_RESULTS_FILE_NAME in blob_file_name.lower():
+                    if _matches_configured_artifact_path(
+                        blob, config, "dbtRunResultsFilePath"
+                    ) or DBT_RUN_RESULTS_FILE_NAME in blob_file_name.lower():
                         try:
                             logger.debug(f"{blob_file_name} found in {key}")
                             dbt_run_result = reader.read(path=blob, **kwargs)
@@ -510,8 +522,10 @@ def download_dbt_files(
                             logger.warning(
                                 f"{DBT_RUN_RESULTS_FILE_NAME} not found in {key}: {exc}"
                             )
-                    if DBT_SOURCES_FILE_NAME == blob_file_name.lower():
-                        logger.debug(f"{DBT_SOURCES_FILE_NAME} found in {key}")
+                    if _matches_configured_artifact_path(
+                        blob, config, "dbtSourcesFilePath"
+                    ) or DBT_SOURCES_FILE_NAME == blob_file_name.lower():
+                        logger.debug(f"{blob_file_name} found in {key}")
                         dbt_sources = reader.read(path=blob, **kwargs)
             if not dbt_manifest:
                 raise DBTConfigException(f"Manifest file not found at: {key}")

--- a/ingestion/tests/unit/test_dbt.py
+++ b/ingestion/tests/unit/test_dbt.py
@@ -3156,6 +3156,72 @@ class TestDownloadDbtFiles(TestCase):
             self.assertIsNotNone(result[0].dbt_sources)
 
 
+def test_download_dbt_files_uses_configured_local_artifact_names():
+    from metadata.ingestion.source.database.dbt.dbt_config import download_dbt_files
+
+    manifest_path = "/path/to/dbt/manifest.json.patched"
+    catalog_path = "/path/to/dbt/catalog.json.patched"
+
+    mock_reader = MagicMock()
+    mock_reader.read.side_effect = lambda path, **_: {
+        manifest_path: '{"nodes": {}, "sources": {}}',
+        catalog_path: '{"nodes": {}}',
+    }[path]
+
+    with patch(
+        "metadata.ingestion.source.database.dbt.dbt_config.get_reader",
+        return_value=mock_reader,
+    ):
+        result = list(
+            download_dbt_files(
+                blob_grouped_by_directory={
+                    "/path/to/dbt": [manifest_path, catalog_path]
+                },
+                config=SimpleNamespace(
+                    dbtManifestFilePath=manifest_path,
+                    dbtCatalogFilePath=catalog_path,
+                    dbtRunResultsFilePath=None,
+                    dbtSourcesFilePath=None,
+                ),
+                client=None,
+                bucket_name=None,
+            )
+        )
+
+    assert len(result) == 1
+    assert result[0].dbt_manifest == {"nodes": {}, "sources": {}}
+    assert result[0].dbt_catalog == {"nodes": {}}
+
+
+def test_get_dbt_details_reads_configured_local_artifact_names(tmp_path):
+    from metadata.generated.schema.metadataIngestion.dbtconfig.dbtLocalConfig import (
+        DbtLocalConfig,
+    )
+    from metadata.ingestion.source.database.dbt.dbt_config import get_dbt_details
+
+    manifest_path = tmp_path / "manifest.json.patched"
+    catalog_path = tmp_path / "catalog.json.patched"
+    manifest = {"nodes": {}, "sources": {}}
+    catalog = {"nodes": {}}
+
+    manifest_path.write_text(json.dumps(manifest))
+    catalog_path.write_text(json.dumps(catalog))
+
+    result = list(
+        get_dbt_details(
+            DbtLocalConfig(
+                dbtConfigType="local",
+                dbtManifestFilePath=str(manifest_path),
+                dbtCatalogFilePath=str(catalog_path),
+            )
+        )
+    )
+
+    assert len(result) == 1
+    assert result[0].dbt_manifest == manifest
+    assert result[0].dbt_catalog == catalog
+
+
 class TestGetLatestResult(TestCase):
     """
     Test _get_latest_result picks the most recent result by execute


### PR DESCRIPTION
## Summary

Fix dbt local artifact loading so `dbtManifestFilePath`, `dbtCatalogFilePath`, `dbtRunResultsFilePath`, and `dbtSourcesFilePath` are matched by their configured paths before falling back to the standard dbt artifact filenames.

This lets local dbt ingestion read nonstandard filenames such as `manifest.json.patched` and `catalog.json.patched` instead of ignoring them and reporting `Manifest file not found at: <directory>`.

## Root Cause

`get_dbt_details(DbtLocalConfig)` grouped the exact configured local paths, but `download_dbt_files` classified artifacts only by hardcoded basenames like `manifest.json` and `catalog.json`. Any configured local path with a different basename was present in the group but skipped.

## Validation

Reproduced before the fix with a regression test that failed with:

`DBTConfigException: No valid dbt manifest.json found. Manifest file not found at: /path/to/dbt`

After the fix:

`/tmp/openmetadata-ingestion-dbt-fix/bin/python -m pytest -q tests/unit/test_dbt.py`

Result: `150 passed`
