### PR TITLE
Fix notification alert sources: add Domain and Data Product, remove deprecated Location

### DIFF
--- a/openmetadata-service/src/main/resources/json/data/EventSubResourceDescriptor.json
+++ b/openmetadata-service/src/main/resources/json/data/EventSubResourceDescriptor.json
@@ -121,18 +121,6 @@
     ]
   },
   {
-    "name" : "location",
-    "supportedFilters" : [
-      "filterByOwnerName",
-      "filterByFqn",
-      "filterByEventType",
-      "filterByUpdaterName",
-      "filterByDomain",
-      "filterByGeneralMetadataEvents",
-      "filterByUpdaterIsBot"
-    ]
-  },
-  {
     "name" : "messagingService",
     "supportedFilters" : [
       "filterByOwnerName",
@@ -300,6 +288,29 @@
       "filterByEventType",
       "filterByUpdaterName",
       "filterByDomain",
+      "filterByUpdaterIsBot"
+    ]
+  },
+  {
+    "name" : "domain",
+    "supportedFilters" : [
+      "filterByOwnerName",
+      "filterByFqn",
+      "filterByEventType",
+      "filterByUpdaterName",
+      "filterByGeneralMetadataEvents",
+      "filterByUpdaterIsBot"
+    ]
+  },
+  {
+    "name" : "dataProduct",
+    "supportedFilters" : [
+      "filterByOwnerName",
+      "filterByFqn",
+      "filterByEventType",
+      "filterByUpdaterName",
+      "filterByDomain",
+      "filterByGeneralMetadataEvents",
       "filterByUpdaterIsBot"
     ]
   }


### PR DESCRIPTION
Fixes #27682

## Summary

The Source dropdown in **Settings → Notifications → Alerts → Create Alert** is populated from `GET /api/v1/events/subscriptions/Notification/resources`, which is backed by `EventSubResourceDescriptor.json`.

This PR updates that descriptor file to:

- **Add `domain`** — with filters: owner, FQN, event type, updater, general metadata events, updater-is-bot. `filterByDomain` is intentionally omitted because the `Domain` entity does not expose a `domains` field (it uses `parent`).
- **Add `dataProduct`** — with the same filter set used for other data assets (chart, dashboard, database, etc.), including `filterByDomain` since Data Products belong to domains.
- **Remove `location`** — this is a deprecated entity type that should not appear as a notification source.

No Java code, no schema enum, no new filter functions are required — every filter referenced already exists in `FilterFunctionsDescriptor.json` and is implemented in `AlertsRuleEvaluator.java`. The registry is reloaded on application startup.

## Verification

- Entity type strings match canonical constants: `Entity.DOMAIN = "domain"`, `Entity.DATA_PRODUCT = "dataProduct"`.
- All filters chosen were checked against the corresponding schemas (`domain.json`, `dataProduct.json`) to ensure the fields they read actually exist on the target entity.

## Test plan

- [x] Start a local server; hit `GET /api/v1/events/subscriptions/Notification/resources` and confirm `domain` and `dataProduct` are present and `location` is absent.
- [x] In the UI, open the Create Alert form and verify `Domain` and `Data Product` appear in the Source dropdown, and `Location` no longer does.
- [x] Create a notification alert with `Data Product` as the source and `filterByDomain` configured; perform an update to a Data Product in the matching domain and verify the alert fires.
- [x] Create a notification alert with `Domain` as the source; update a Domain and verify the alert fires.

----
## Summary by Gitar

- **Miscellaneous:**
  - Included changes from commit `17738ec2` which adds a warning message when searching for terms.

<sub>This will update automatically on new commits.</sub>