### PR TITLE
Chore(UI): fix migration issue

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v200/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v200/Migration.java
@@ -21,7 +21,9 @@ public class Migration extends MigrationProcessImpl {
   public void runDataMigration() {
     addTableColumnSearchSettings();
     migrateSuggestionsToTaskEntity(handle);
-    migrateThreadTasksToTaskEntity(handle);
+    // Causing issues with collate CI, needs to be fixed before enabling this migration
+    // @harshach
+    // migrateThreadTasksToTaskEntity(handle);
     migrateLegacyActivityThreadsToActivityStream(handle);
     backfillAnnouncementRelationships(handle);
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v200/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v200/Migration.java
@@ -4,7 +4,6 @@ import static org.openmetadata.service.migration.utils.v200.MigrationUtil.addTab
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.backfillAnnouncementRelationships;
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.migrateLegacyActivityThreadsToActivityStream;
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.migrateSuggestionsToTaskEntity;
-import static org.openmetadata.service.migration.utils.v200.MigrationUtil.migrateThreadTasksToTaskEntity;
 
 import lombok.SneakyThrows;
 import org.openmetadata.service.migration.api.MigrationProcessImpl;


### PR DESCRIPTION
This pull request makes a small but important change to the MySQL migration process. The migration step for moving thread tasks to the task entity has been temporarily disabled due to issues with the collate CI, and a comment has been added to indicate that this needs to be fixed before re-enabling the migration.

- Migration pipeline update:
  * Temporarily commented out the call to `migrateThreadTasksToTaskEntity(handle)` in the `runDataMigration` method, with a note explaining it is causing issues with collate CI and needs to be fixed before being enabled again.
  cc. @pmbrull @harshach 