### PR TITLE
feat(ingestion): restore connector-audit skill

### DIFF
--- a/.claude/skills/connector-audit
+++ b/.claude/skills/connector-audit
@@ -1,0 +1,1 @@
+../../skills/connector-audit

--- a/skills/connector-audit/SKILL.md
+++ b/skills/connector-audit/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: connector-audit
+description: Deep reliability audit for OpenMetadata connectors — runs 7 investigation prompts (metadata, errors, auth, lineage, scale, synthesis, implementation) against connector standards
+---
+
+# OpenMetadata Connector Reliability Audit
+
+## When to Activate
+
+When a user asks to audit a connector, run a reliability audit, or investigate connector quality in depth.
+
+## STEP 1 — DO THIS FIRST, BEFORE ANYTHING ELSE
+
+When this skill is invoked, your VERY FIRST action — before responding to the user, before summarizing anything, before checking any state — is:
+
+1. List all files in `.claude/audit-results/` (if the directory exists)
+2. List `.claude/connector-audit.json` (if it exists)
+3. Present the file list to the user and ask: *"These files exist from a previous audit. Which should I keep and which should I delete?"*
+4. Wait for the user's answer. Do NOT proceed until they respond.
+
+If no files exist, skip to Step 2.
+
+**NEVER** summarize existing results, say "the audit is complete", or suggest the user doesn't need to run anything. The user invoked the skill — execute it.
+
+## Arguments
+
+- **Connector name** (e.g., `mysql`, `snowflake`, `tableau`): Full 7-prompt audit
+- **`--prompt N`** (e.g., `--prompt 3`): Run a single prompt (1-7) — useful for re-running after fixes
+- **`--prompts N,M`** (e.g., `--prompts 1,4`): Run specific prompts only
+- **`--from N`** (e.g., `--from 6`): Run prompts N through 7 — useful for continuing after P1-P5
+- **`--setup-only`**: Run setup only (writes connector-audit.json)
+- **`--dry-run`**: When used with P7, produce a detailed implementation plan (before/after diffs, tests, risk flags) without actually writing code — for review before execution
+
+## Relationship to connector-review
+
+| | connector-audit | connector-review |
+|---|---|---|
+| **Purpose** | Deep reliability investigation | Breadth check for PRs |
+| **Depth** | 7 focused prompts, hours of analysis | 5 parallel agents, minutes |
+| **Output** | `.claude/audit-results/` (7 reports) | PR comment or local report |
+| **When** | Before major work on a connector | During PR review |
+| **Scope** | Full connector + base classes + shared code | Changed files only |
+
+## Workflow Overview
+
+```
+Setup → P1-P5 (investigation, parallelizable) → P6 (synthesis) → P7 (implementation)
+```
+
+### Phase 1: Setup
+
+After the stale results check (Step 1 above), run the setup prompt to establish connector context. This writes `.claude/connector-audit.json` which all subsequent prompts read.
+
+### Phase 2: Static Pre-Check
+
+Run the static analyzer from the connector-review skill to get a mechanical baseline:
+```bash
+python skills/connector-review/scripts/analyze_connector.py {service_type} {name} --json
+```
+Save the output — prompts reference it to avoid duplicating mechanical checks.
+
+### Phase 3: Investigation (P1-P5)
+
+These 5 prompts are **independent** and can run in any order. For efficiency, dispatch them in parallel:
+- **Pair A**: P1 (Metadata & Ingestion) + P2 (Error Handling)
+- **Pair B**: P3 (Connection & Auth) + P4 (Lineage)
+- **Solo**: P5 (Scale & Performance)
+
+Each prompt:
+1. Reads `.claude/connector-audit.json` for context
+2. Loads connector standards via `/connector-standards`
+3. Investigates its focus area in depth
+4. Presents a summary for user review
+5. Saves its report under `.claude/audit-results/` using the fixed filename for that prompt described in the **Output Structure** section (for example, `01-metadata-ingestion.md` for P1) after user approval
+
+**User review gate**: Each prompt presents findings and asks for confirmation before saving. This catches errors early instead of propagating them to P6.
+
+### Phase 4: Synthesis (P6)
+
+Reads all 5 reports from `.claude/audit-results/`, cross-validates findings, clusters root causes, checks git history, and produces a prioritized implementation plan with PR scoping.
+
+### Phase 5: Implementation (P7)
+
+Reads the P6 plan and implements the fixes — writes code, runs tests, creates commits. With `--dry-run`, produces a detailed plan (before/after diffs, test code, risk flags) without writing code.
+
+## Prompt Files
+
+Each prompt is a self-contained investigation guide in `prompts/`:
+
+| # | File | Focus | Standards |
+|---|---|---|---|
+| 0 | `00-setup.md` | Set target connector, write context file | — |
+| 1 | `01-metadata-ingestion.md` | Metadata coverage by tier, ingestion completeness | Tiers 1-3, Standard 1 |
+| 2 | `02-error-handling.md` | Error handling, fault tolerance, observability | Standards 4, 5, 7 |
+| 3 | `03-connection-auth.md` | Auth methods, test connection, SSL/TLS | Standard 3 |
+| 4 | `04-lineage.md` | SQL dialect, FQN resolution, column lineage | Standard 2 |
+| 5 | `05-scale-performance.md` | Memory patterns, pagination, generators, lookups | Standard 6 |
+| 6 | `06-refactor-plan.md` | Cross-validate, cluster root causes, PR scoping | All standards |
+| 7 | `07-implementation.md` | Implement fixes (or `--dry-run` for plan only) | All standards |
+
+## How to Run
+
+### Full Audit
+
+```
+/connector-audit mysql
+```
+
+1. **Stale results check**: List existing files in `.claude/audit-results/`, ask user what to keep/delete, wait for answer
+2. **Setup**: Ask user for connector name (if not provided), find source directory, write `.claude/connector-audit.json`
+3. **Static pre-check**: Run `analyze_connector.py` for mechanical baseline
+4. **P1-P5**: For each prompt:
+   a. Read the prompt file from `prompts/0N-*.md`
+   b. Follow its instructions — read the actual connector source code, analyze it against the standards, produce findings with file:line references
+   c. Present a summary to the user for review
+   d. Save the report to `.claude/audit-results/` after user approval
+5. **P6**: Read all reports from `.claude/audit-results/`, synthesize, present implementation plan, save after approval
+6. **P7**: Read P6 plan, implement fixes (or `--dry-run` for plan only), save after approval
+
+Each prompt is a detailed investigation guide — it tells you exactly which files to read, what to look for, how to rate findings, and what format to present them in. You must actually read the connector's source code and do the analysis, not summarize previous results.
+
+### Single Prompt
+
+```
+/connector-audit mysql --prompt 3
+```
+
+Verify `.claude/connector-audit.json` exists, then read the prompt file and execute only that investigation.
+
+### Parallel Dispatch
+
+When running the full audit, dispatch P1-P5 using Agent subagents for parallelism:
+- Each agent gets: the prompt content, connector-audit.json values, and the static analyzer output
+- Each agent saves its report independently
+- P6 runs only after all 5 reports exist
+
+**Important**: Each agent must present its summary and get user approval before saving. When running in parallel pairs, present both summaries together.
+
+## Standards Reference
+
+All prompts reference connector standards loaded via `/connector-standards`. The standards live at:
+- `skills/connector-review/standards/` — shared standards (main.md, patterns.md, etc.)
+- `skills/connector-review/standards/source_types/` — per-service-type standards
+
+The static analyzer at `skills/connector-review/scripts/analyze_connector.py` provides mechanical checks that complement the deeper investigation in each prompt.
+
+## Output Structure
+
+```
+.claude/
+├── connector-audit.json          # Connector context (written by Setup)
+└── audit-results/
+    ├── 01-metadata-ingestion.md  # P1 report
+    ├── 02-error-handling.md      # P2 report
+    ├── 03-connection-auth.md     # P3 report
+    ├── 04-lineage.md             # P4 report
+    ├── 05-scale-performance.md   # P5 report
+    ├── 06-refactor-plan.md       # P6 consolidated plan
+    └── 07-implementation.md      # P7 implementation report (or 07-dry-run-implementation.md with --dry-run)
+```
+
+## Report Template
+
+Each prompt report follows the template in `templates/audit-report.md`. Key sections:
+- Header with connector name, prompt number, standards assessed, and rating
+- Findings with file:line references and severity
+- Rating calibration evidence
+- Present & Validate summary for user review
+

--- a/skills/connector-audit/prompts/00-setup.md
+++ b/skills/connector-audit/prompts/00-setup.md
@@ -1,0 +1,30 @@
+# Prompt 0: Setup
+
+Set up the audit context for connector reliability analysis.
+
+---
+
+## Steps
+
+1. **Ask the user** which connector they want to audit (if not provided as an argument).
+
+2. **Find the source directory** under `ingestion/src/metadata/ingestion/source/`. List the service type directories (database, dashboard, pipeline, storage, messaging, search, mlmodel, api) and locate the connector within the correct one.
+
+3. **Determine the service type** from the directory structure.
+
+4. **Write `.claude/connector-audit.json`**:
+   ```json
+   {
+     "connector_name": "<name>",
+     "service_type": "<type>",
+     "source_path": "ingestion/src/metadata/ingestion/source/<type>/<name>/"
+   }
+   ```
+
+5. **Create the `.claude/audit-results/` directory** if it doesn't exist.
+
+6. **Confirm** what you found and what you wrote. Show the user:
+   - Connector name
+   - Service type
+   - Source path
+   - Files found in the connector directory

--- a/skills/connector-audit/prompts/01-metadata-ingestion.md
+++ b/skills/connector-audit/prompts/01-metadata-ingestion.md
@@ -1,0 +1,144 @@
+# Prompt 1: Metadata & Ingestion Completeness
+
+Assess metadata coverage by tier and verify ingestion completeness for the connector.
+
+---
+
+**Context:** Read `.claude/connector-audit.json` for the connector name, service type, and source path. Use these for [CONNECTOR_NAME] and [SERVICE_TYPE] throughout.
+
+Audit this connector for metadata coverage and ingestion completeness.
+
+Load the connector standards with /connector-standards, then analyze against Metadata Tiers 1-3 and the Ingestion Completeness standard.
+
+## Where to look
+
+The connector's metadata extraction is split across MULTIPLE locations. You MUST check ALL of these:
+
+**1. Connector-specific code:**
+- `ingestion/src/metadata/ingestion/source/[SERVICE_TYPE]/[CONNECTOR_NAME]/` — metadata.py, models.py, queries.py
+- `ingestion/src/metadata/ingestion/source/[SERVICE_TYPE]/[CONNECTOR_NAME]/service_spec.py` — registered classes for each pipeline type
+
+**2. Connection schema:**
+- `openmetadata-spec/src/main/resources/json/schema/entity/services/connections/[SERVICE_TYPE]/[connector]Connection.json`
+- Follow `$ref` links to understand available configuration options and metadata types
+
+**3. Service-type base class (CRITICAL — many metadata features live here):**
+Each service type has a shared base class that provides core extraction patterns. Check the one matching your connector:
+- **Database:** `common_db_source.py` (CommonDbSourceService) — table/view extraction, column metadata, descriptions, ownership, tags, yield patterns
+- **Dashboard:** `dashboard_service.py` (DashboardServiceSource) — yield_dashboard, yield_dashboard_chart, data model columns
+- **Pipeline:** `pipeline_service.py` (PipelineServiceSource) — yield_pipeline, yield_pipeline_status, task extraction
+- **Storage:** `storage_service.py` (StorageServiceSource) — yield_create_container_requests
+- **Messaging:** `messaging_service.py` (MessagingServiceSource) — yield_topic, yield_topic_sample_data
+- **Search:** `search_service.py` (SearchServiceSource) — yield_search_index
+- **ML Model:** `mlmodel_service.py` (MlModelServiceSource) — yield_mlmodel
+- **API:** `api_service.py` (ApiServiceSource) — yield_api_collection, yield_api_endpoint
+
+**4. Profiler / Sampler (Tier 3 metadata lives here, NOT in metadata ingestion):**
+- `ingestion/src/metadata/sampler/sqlalchemy/[CONNECTOR_NAME]/` — connector-specific sampler
+- `ingestion/src/metadata/profiler/` — profiler framework
+
+**5. Shared utilities:**
+- `ingestion/src/metadata/utils/filters.py` — schema/table/topic filtering
+- `ingestion/src/metadata/ingestion/models/topology.py` — TopologyRunnerMixin entity iteration
+
+## What to assess
+
+### Part 1: Metadata Coverage by Tier
+
+For EACH metadata type below, determine:
+1. Is it extracted? (yes/no)
+2. Where is it extracted? (file:line)
+3. Source: (a) connector-specific code, (b) inherited from base class, (c) separate pipeline, (d) not supported
+4. Completeness: Does extraction capture ALL available metadata from the source system?
+5. Limitations or gaps
+
+**Tier 1 — Core** (non-negotiable):
+- Entity hierarchy (databases → schemas → tables, dashboards → charts, pipelines → tasks, etc.)
+- Entity types (table, view, materialized view, external table, etc.) — does the connector distinguish all types the source system supports?
+- Column / field metadata (names, data types, constraints, default values)
+- Data Model columns (for dashboard connectors — does it extract column metadata for data models?)
+- Descriptions (entity-level + column-level) — from the source system, not user-added
+- Run status (for pipeline connectors — task success/failure/duration)
+- Table-level lineage — query-log based for databases, cross-service for dashboard/pipeline connectors
+- Column-level lineage — check both connector-specific AND the shared lineage framework
+
+> **Critical:** The connector must ingest **all entity types available from the source system**. If the source distinguishes tables, views, materialized views, external tables, stored procedures, etc., the connector must extract and correctly classify each. Missing entity types means users get an incomplete picture of their data estate. Research the source system's API docs to identify the full set of entity types — don't assume the existing code covers everything.
+
+**Tier 2 — Expected** (customers assume this works):
+- Ownership — does the connector extract owner information from the source system?
+- Tags / Classifications — does the source system have tags/labels? Do we extract them?
+
+**Tier 3 — Differentiator:**
+- Usage statistics — query counts, users, access patterns
+- Profiling — column statistics (min, max, mean, null count, distinct count)
+- Data quality — test results, assertions
+- Sample data — does the sampler pipeline support this connector?
+
+### Part 2: Ingestion Completeness (Standard 1)
+
+For EACH entity type the connector extracts, verify:
+
+1. **Pagination**: Are ALL list operations paginated? Look for:
+   - API calls that fetch lists without pagination tokens
+   - SQL queries with LIMIT but no offset loop
+   - Hard limits (e.g., SHOW TABLES LIMIT 10000) without overflow detection
+
+2. **Silent drops**: Does the connector silently skip entities? Look for:
+   - `continue` without logging
+   - `except: pass` or `except: continue`
+   - Conditions that filter entities without warning logs
+
+3. **Generators**: Are yield patterns used? Look for:
+   - Lists that collect all entities in memory before returning
+   - Missing `yield` in entity iteration methods
+
+4. **Filters**: Are user-configured filters properly applied?
+   - Schema/table/topic filter patterns
+   - Include/exclude logic correctness
+
+5. **Incremental extraction**: Does the connector support incremental ingestion?
+   - Does it check `markDeletedEntities` configuration?
+   - Does it handle soft deletes properly?
+
+## Rating Calibration
+
+**Metadata Coverage** — rate per tier:
+- ✅ Compliant = All metadata types in this tier are extracted completely, with proper source attribution
+- ⚠️ Partial = Most metadata types extracted but some have gaps (e.g., descriptions only at entity level, not column level)
+- ❌ Gaps = Major metadata types in this tier are missing (e.g., no column types, no entity hierarchy)
+- N/A = The source system does not natively provide this metadata type (e.g., MySQL has no native tags/classifications). Do NOT rate as a gap — rate N/A with a brief explanation.
+
+**Ingestion Completeness:**
+- ✅ Compliant = ALL list operations paginated, generators used throughout, no silent drops, filters work correctly. Would handle 10,000+ entities without missing any.
+- ⚠️ Partial = Primary entities paginated but secondary operations have limits (e.g., tags, descriptions fetched without pagination). Some silent drops in edge cases.
+- ❌ Gaps = Major entity types can be silently truncated or dropped. No pagination on primary list operations. Lists collected in memory.
+
+**Optimism traps:**
+- "Pagination exists" — Does it cover ALL operations? Tags, descriptions, ownership, stored procedures, views — not just tables.
+- "The base class handles it" — Check if the connector overrides base class methods and loses pagination or entity extraction.
+- "There's a LIMIT" — A LIMIT without an offset loop means entities beyond the limit are silently lost. Classify as "Not paginated — hard cap" not as "paginated."
+
+**Rating rules:**
+- If any list operation uses a hard cap (LIMIT without pagination/offset loop) where the default value could plausibly be exceeded in production, the Ingestion Completeness rating cannot be ✅. Rate ⚠️ minimum.
+- Before rating ✅ for a metadata type, verify the feature works correctly — not just that code exists. "Code exists that extracts X" is not the same as "X is extracted completely and correctly." If correctness needs deeper testing, rate ⚠️ with a note that the specialized prompt should verify.
+
+**Worked example:** `LIMIT 1000` on a query log table that receives 50K entries/day means 98% of queries are silently dropped at default settings. This is NOT "paginated" and NOT "fine because it's configurable" — most users never change defaults. Rate ⚠️ minimum for Ingestion Completeness and flag in findings.
+
+Present findings as a structured report with:
+1. Metadata coverage table (tier × metadata type × status × source location)
+2. Ingestion Completeness rating with evidence
+3. Specific issues found with file:line references
+4. What's missing compared to what the source system actually provides
+5. **Source system constraints**: List any metadata types rated N/A because the source system does not provide them — so the reader knows what's a connector gap vs a source limitation
+
+## Present & Validate
+
+Before saving, present a summary to the user for review:
+1. **Ratings** — one line per tier/standard with the rating emoji
+2. **Top findings** — the 3-5 most important issues, each with severity and a one-sentence description
+3. **Source system constraints** — anything rated N/A
+4. **Anything you're uncertain about** — flag findings where you're not confident in the severity or root cause
+
+Then ask: *"Ready to save to `.claude/audit-results/01-metadata-ingestion.md`? Any findings to adjust?"*
+
+If the user requests changes, revise and re-present. Once the user confirms, **save the full report** to `.claude/audit-results/01-metadata-ingestion.md` (create the directory if needed) — Prompt 6 reads this file.

--- a/skills/connector-audit/prompts/02-error-handling.md
+++ b/skills/connector-audit/prompts/02-error-handling.md
@@ -1,0 +1,143 @@
+# Prompt 2: Error Handling & Resilience
+
+Audit error handling (Error Clarity), fault tolerance, and observability across the connector.
+
+---
+
+**Context:** Read `.claude/connector-audit.json` for the connector name, service type, and source path. Use these for [CONNECTOR_NAME] and [SERVICE_TYPE] throughout.
+
+Audit this connector for error handling, fault tolerance, and observability.
+
+Load the connector standards with /connector-standards, then analyze against these 3 reliability standards:
+- **Error Clarity** (Standard 4)
+- **Fault Tolerance** (Standard 5)
+- **Observability** (Standard 7)
+
+## Where to look
+
+**1. Connector-specific code:**
+- `ingestion/src/metadata/ingestion/source/[SERVICE_TYPE]/[CONNECTOR_NAME]/` — ALL .py files
+- Focus especially on: metadata.py (entity extraction), connection.py (connection handling), lineage.py (lineage extraction)
+
+**2. Service-type base class:**
+- **Database:** `common_db_source.py` — error handling in yield_table, yield_view, set_inspector
+- **Dashboard:** `dashboard_service.py` — error handling in yield_dashboard, yield_dashboard_chart
+- **Pipeline:** `pipeline_service.py` — error handling in yield_pipeline, yield_pipeline_status
+- Check ALL methods the connector inherits or overrides
+
+**3. Connection handling:**
+- `ingestion/src/metadata/ingestion/source/[SERVICE_TYPE]/[CONNECTOR_NAME]/connection.py`
+- `ingestion/src/metadata/ingestion/connections/builders.py` — shared connection building
+- **Token lifecycle (CRITICAL for IAM/OAuth/temporary credentials):** Trace end-to-end — where is the token generated? Where stored? Is there a refresh mechanism? Check BOTH `connection.py` AND `builders.py` (IAM tokens are often generated in shared code). Check ALL auth types, not just the first one you find.
+
+**4. Shared utilities:**
+- `ingestion/src/metadata/utils/helpers.py` — retry utilities
+- `ingestion/src/metadata/ingestion/api/models.py` — Either pattern definition
+
+## What to assess
+
+### Standard 4: Error Clarity
+
+**Classify EVERY try/except block** in the connector-specific code as:
+- ✅ Good: Uses Either pattern with entity name + operation + stack trace
+- ⚠️ Acceptable: Logs at WARNING/ERROR with enough context to debug
+- ❌ Bad: bare except, except:pass, except:continue, swallowed exceptions, debug-level for operational failures
+
+Present as a table: | File:Line | Exception handling | Classification | Issue |
+
+**Check specifically for:**
+1. **Either pattern usage**: Are per-entity errors wrapped in `Either(left=StackTraceError(...))`?
+2. **Error context**: Does every error message include the entity name and operation that failed?
+3. **Exception specificity**: Are exceptions caught by type (OperationalError, TimeoutError) or with bare `except Exception`?
+4. **Silent drops**: Any `except: continue` or `except: pass` that drops entities without logging?
+5. **Error propagation**: Are connection-level errors properly distinguished from entity-level errors?
+
+**After classifying existing try/except blocks**, scan for code paths that SHOULD have error handling but don't:
+- Any raw SQL execution (via `conn.execute()`, `text()`) NOT inside a try/except
+- Any external API call NOT inside a try/except
+- Any file I/O NOT inside a try/except
+These missing handlers are often higher severity than poorly-written existing ones.
+
+### Standard 5: Fault Tolerance
+
+**Check for:**
+1. **Retry logic**: Are API calls and queries retried on transient failures (HTTP 429, 503, connection reset)?
+   - Connection pool retry (reconnecting dropped connections) does NOT count as query retry
+   - Look for `@retry`, `tenacity`, `backoff`, or manual retry loops
+   - What's the retry strategy? (exponential backoff, fixed delay, no backoff)
+
+2. **Timeouts**: Are there per-operation timeouts?
+   - Check SQLAlchemy engine creation for `connect_args` timeout settings
+   - Check HTTP client configurations for request timeouts
+   - A framework default of 300s per query × many queries = hours is NOT meaningful
+
+3. **Token refresh**: For connectors with OAuth or temporary credentials:
+   - Are tokens refreshed during long-running ingestion?
+   - What happens when a token expires mid-ingestion?
+
+4. **Resource cleanup**: Are connections, cursors, file handles cleaned up on failure?
+   - Look for try/finally patterns or context managers
+   - Check for connection/engine leaks (creating new engines without closing old ones)
+
+5. **Graceful degradation**: When a non-critical operation fails (e.g., fetching tags), does the connector continue with core extraction?
+
+### Standard 7: Observability
+
+**Check for:**
+1. **Log levels**: Are operational failures logged at WARNING or ERROR? (not DEBUG). Is routine progress logged at INFO? Are verbose details at DEBUG?
+
+2. **Silent fallbacks**: Any pattern where the code catches an exception and returns a default value WITHOUT logging?
+
+3. **Progress logging**: Can an operator tell from the logs which entity is being processed, how many were processed/skipped/failed, and why an entity was skipped?
+
+4. **Failure attribution**: When ingestion partially fails, can you tell from the logs WHICH entities failed and WHY?
+
+5. **Sensitive data**: Are credentials, tokens, or connection strings accidentally logged?
+
+## Rating Calibration
+
+**Error Clarity:**
+- ✅ Compliant = Every entity extraction wrapped in Either pattern, all exceptions caught with specific types, error messages include entity name + operation, no silent drops
+- ⚠️ Partial = Either pattern used for primary entities but not everywhere, some generic exception handling, most errors have context
+- ❌ Gaps = Widespread bare except/pass/continue, missing Either pattern on primary entity extraction, errors lack context
+
+**Fault Tolerance:**
+- ✅ Compliant = Transient errors retried with backoff, per-operation timeouts, token refresh handled, proper cleanup in finally blocks
+- ⚠️ Partial = Per-entity isolation exists (one entity failing doesn't stop others), but no query-level retry, no explicit timeouts
+- ❌ Gaps = No retry at any level, no timeouts, token expiry crashes ingestion, resource leaks on failure
+
+**Fault Tolerance optimism traps:**
+- "The connection pool retries" — Connection pool reconnection is NOT the same as retrying a failed query or API call
+- "Per-entity isolation" — Good, but not sufficient alone. What about transient API failures that affect ALL entities?
+- "There's a timeout in the engine config" — Is it per-query or per-connection? What's the actual value?
+
+**Observability:**
+- ✅ Compliant = All failures logged at WARNING+, progress visible at INFO, no silent fallbacks, failure attribution clear
+- ⚠️ Partial = Most failures logged but some at wrong level, some silent fallbacks exist, partial progress logging
+- ❌ Gaps = Operational failures at DEBUG, widespread silent fallbacks, no way to tell from logs what went wrong
+
+Present findings in TWO sections:
+
+**Section A — Connector-specific issues** (files under the connector directory):
+1. Try/except classification table (EVERY block in connector-specific code)
+2. Per-standard rating with evidence (file:line references)
+3. Specific issues found, ordered by severity
+4. Recommended fixes
+
+**Section B — Inherited base class issues** (shared code that affects this connector):
+1. Base class issues that affect this connector, labeled with which other connectors share the same issue
+2. Clearly mark whether a fix would be connector-specific or shared
+
+**Source system constraints**: Note any limitations that are inherent to the source system (e.g., no native retry mechanism) vs connector implementation gaps.
+
+## Present & Validate
+
+Before saving, present a summary to the user for review:
+1. **Ratings** — one line per standard (Error Clarity, Fault Tolerance, Observability) with the rating
+2. **Top findings** — the 3-5 most important issues, each with severity and a one-sentence description
+3. **Section A vs B split** — how many issues are connector-specific vs inherited
+4. **Anything you're uncertain about** — flag findings where you're not confident
+
+Then ask: *"Ready to save to `.claude/audit-results/02-error-handling.md`? Any findings to adjust?"*
+
+If the user requests changes, revise and re-present. Once the user confirms, **save the full report** to `.claude/audit-results/02-error-handling.md` (create the directory if needed) — Prompt 6 reads this file.

--- a/skills/connector-audit/prompts/03-connection-auth.md
+++ b/skills/connector-audit/prompts/03-connection-auth.md
@@ -1,0 +1,111 @@
+# Prompt 3: Connection & Auth
+
+Review connection setup, auth method coverage, and test connection validation.
+
+---
+
+**Context:** Read `.claude/connector-audit.json` for the connector name, service type, and source path. Use these for [CONNECTOR_NAME] and [SERVICE_TYPE] throughout.
+
+Audit this connector for connection setup and authentication.
+
+Load the connector standards with /connector-standards, then analyze against the Connection Setup standard (Standard 3).
+
+## Where to look
+
+**1. Connection implementation:**
+- `ingestion/src/metadata/ingestion/source/[SERVICE_TYPE]/[CONNECTOR_NAME]/connection.py` — get_connection(), test_connection()
+- `ingestion/src/metadata/ingestion/connections/builders.py` — shared connection URL building, get_connection_url_common()
+
+**2. Connection schema (CRITICAL — defines what auth methods we support):**
+- `openmetadata-spec/src/main/resources/json/schema/entity/services/connections/[SERVICE_TYPE]/[connector]Connection.json`
+- Follow ALL `$ref` links to auth type schemas (e.g., in `connections/`, `security/credentials/`)
+- Check `authType` field and its `oneOf` variants — this defines which auth methods users can configure
+
+**Token lifecycle (CRITICAL for temporary credentials):** For EACH temporary credential auth type (IAM, OAuth, Azure AD, etc.), trace the full lifecycle: where is the token generated? Where stored? What is its expiration time? Is there a refresh mechanism? Check BOTH `connection.py` AND `builders.py` — IAM tokens may be generated in shared code, not the connector.
+
+**3. Test connection steps:**
+- `ingestion/src/metadata/ingestion/source/[SERVICE_TYPE]/[CONNECTOR_NAME]/connection.py` — test_connection_steps()
+- Each step should validate real access, not just connectivity
+
+**4. Source system documentation:**
+- Research the official auth methods the source system supports
+- Compare against what our schema offers
+
+## What to assess
+
+### Auth Method Coverage
+
+1. **Research the source system's official auth methods** — check their documentation for:
+   - Username/password (basic auth)
+   - OAuth 2.0 / SSO
+   - API keys / tokens
+   - Service accounts / service principals
+   - IAM roles (AWS, GCP, Azure)
+   - Key pair authentication
+   - Kerberos / LDAP
+   - Certificate-based auth
+
+2. **Map our schema's auth support** — from the JSON schema:
+   - What `authType` variants exist?
+   - Which fields does each variant expose?
+   - Are field types correct (SecretStr for passwords, proper enums)?
+
+3. **Present as a comparison table:**
+   | Auth Method | Source System | Our Schema | Status | Notes |
+
+### Test Connection Validation
+
+For each step in `test_connection_steps()`:
+1. What does it actually validate? (connectivity only, or real access?)
+2. Does it test with the configured auth method?
+3. Does it validate read permissions (e.g., can list schemas/tables)?
+4. Are errors specific and actionable?
+
+### Error Message Quality
+
+Check connection error handling for:
+1. **Specificity**: Does the error tell the user WHAT went wrong? (auth failure vs network vs permissions)
+2. **Actionability**: Does the error tell the user HOW to fix it?
+3. **Context**: Does the error include relevant details? (username, host, auth method)
+4. **No credential leaks**: Are passwords/tokens excluded from error messages and logs?
+
+### SSL/TLS Support
+
+1. Is SSL/TLS configurable in the schema?
+2. Can users provide custom CA certificates?
+3. Is there a `verifySSL` option?
+4. Does the connection implementation actually use these settings?
+
+**Dead code check:** Before concluding a config field (like `sslConfig`) is dead code, trace the full initialization path — including `__init__`, shared utilities like `ssl_manager.py`, and any pre-engine setup hooks. A field may be consumed by shared infrastructure (e.g., `SSLManager.setup_ssl()` injecting values into `connectionArguments`) rather than by connector-specific code in `connection.py`.
+
+## Rating Calibration
+
+**Connection Setup:**
+- ✅ Compliant = All major auth methods the source system supports are in our schema, test_connection validates real access with specific error messages, SSL/TLS is configurable, schema fields properly typed
+- ⚠️ Partial = Primary auth method works (e.g., username/password), but missing modern methods (OAuth, SSO, IAM). Test connection checks connectivity but not full access. Error messages exist but are generic.
+- ❌ Gaps = Missing auth methods customers commonly use, test_connection is superficial or broken, errors are generic "Connection failed" with no guidance
+
+**Optimism traps:**
+- "We support BasicAuth" — Most source systems support 3-5 auth methods. BasicAuth alone is ⚠️ at best if OAuth/IAM/SSO are available.
+- "test_connection passes" — Does it test with a real query or just open a socket? A successful TCP connection doesn't mean the user has read permissions.
+- "SSL is supported" — Is it configurable? Can users provide custom CA certs? Or is it just a boolean flag that defaults to off?
+- "The schema has all the fields" — Are they the right types? Is `password` a SecretStr? Are descriptions helpful?
+
+Present findings as:
+1. Auth method comparison table (source system vs our schema)
+2. Test connection step analysis
+3. Connection Setup rating with evidence
+4. Specific issues found with file:line references
+5. Recommended fixes prioritized by customer impact
+
+## Present & Validate
+
+Before saving, present a summary to the user for review:
+1. **Rating** — Connection Setup standard rating with one-line justification
+2. **Auth coverage** — how many of the source system's auth methods we support (X of Y)
+3. **Top findings** — the 3-5 most important issues, each with severity and a one-sentence description
+4. **Anything you're uncertain about** — flag findings where you're not confident (e.g., "I believe SSL is wired through the base class but could not fully verify")
+
+Then ask: *"Ready to save to `.claude/audit-results/03-connection-auth.md`? Any findings to adjust?"*
+
+If the user requests changes, revise and re-present. Once the user confirms, **save the full report** to `.claude/audit-results/03-connection-auth.md` (create the directory if needed) — Prompt 6 reads this file.

--- a/skills/connector-audit/prompts/04-lineage.md
+++ b/skills/connector-audit/prompts/04-lineage.md
@@ -1,0 +1,133 @@
+# Prompt 4: Lineage Accuracy
+
+Review lineage extraction for SQL dialect, FQN resolution, column-level lineage, and cross-service resolution.
+
+---
+
+**Context:** Read `.claude/connector-audit.json` for the connector name, service type, and source path. Use these for [CONNECTOR_NAME] and [SERVICE_TYPE] throughout.
+
+Audit this connector for lineage accuracy.
+
+Load the connector standards with /connector-standards, then analyze against the Lineage Accuracy standard (Standard 2).
+
+## Where to look
+
+Lineage in OpenMetadata is split across MULTIPLE layers. You MUST check ALL of these:
+
+**1. Connector-specific lineage:**
+- `ingestion/src/metadata/ingestion/source/[SERVICE_TYPE]/[CONNECTOR_NAME]/lineage.py` — connector-specific lineage extraction (if exists)
+- `ingestion/src/metadata/ingestion/source/[SERVICE_TYPE]/[CONNECTOR_NAME]/queries.py` — SQL queries for extracting query logs (if exists)
+- `ingestion/src/metadata/ingestion/source/[SERVICE_TYPE]/[CONNECTOR_NAME]/models.py` — lineage-related models
+
+**2. Service-type base class lineage methods:**
+- **Database:** `lineage_source.py` (LineageSource) — yield_table_lineage, yield_procedure_lineage
+- **Database:** `query_parser_source.py` (QueryParserSource) — query log processing
+- **Dashboard:** `dashboard_service.py` — yield_dashboard_lineage_details (dashboard → table)
+- **Pipeline:** `pipeline_service.py` — yield_pipeline_lineage (pipeline → table)
+
+**3. Shared lineage framework (CRITICAL — column-level lineage lives here):**
+- `ingestion/src/metadata/ingestion/lineage/parser.py` — LineageParser, column-level extraction
+- `ingestion/src/metadata/ingestion/lineage/sql_lineage.py` — FQN resolution, get_lineage_by_query, multi-service search
+- `ingestion/src/metadata/ingestion/lineage/lineage_processors.py` — cross-database lineage, service_names expansion
+
+**4. Pipeline configuration:**
+- `openmetadata-spec/.../metadataIngestion/databaseServiceQueryLineagePipeline.json` — processCrossDatabaseLineage toggle, service names config
+
+**5. Service spec:**
+- `[CONNECTOR_NAME]/service_spec.py` — which classes are registered for the lineage pipeline type
+
+## What to assess
+
+### SQL Dialect Configuration
+
+1. Is the correct SQL dialect set for this connector's SQL parsing?
+2. Where is the dialect configured? (connector-specific or inherited?)
+3. Does the dialect handle connector-specific syntax? (e.g., Snowflake's FLATTEN, BigQuery's UNNEST, Redshift's COPY)
+
+### Query Source
+
+1. Where do query logs come from? (system tables, API, audit logs)
+2. Is there a time window filter? Does it use `get_start_and_end()` properly?
+3. Is there a result limit? What happens when there are more queries than the limit?
+4. Are DDL statements (CREATE VIEW AS, CREATE TABLE AS SELECT) captured in addition to DML?
+
+### Table-Level Lineage
+
+For EACH lineage path the connector supports, verify:
+1. **FQN resolution**: Are table references resolved to full database.schema.table format?
+2. **Case normalization**: Does the connector handle case-sensitivity correctly for this source system?
+3. **Cross-database references**: Are references to tables in other databases/schemas resolved?
+4. **Temporary/intermediate tables**: Are temp tables filtered out or resolved correctly?
+5. **View lineage**: Are views resolved to their underlying tables?
+
+### Column-Level Lineage
+
+Column-level lineage is often inherited from the shared framework — verify it actually works for this connector:
+1. **SELECT \***: Does column lineage resolve when queries use SELECT \*?
+2. **Aliases**: Are column aliases tracked correctly? (SELECT a AS b)
+3. **Expressions**: Are computed columns (SELECT a + b AS c) tracked to their source columns?
+4. **Subqueries**: Does column lineage work through subqueries and CTEs?
+5. **UNIONs**: Are column mappings preserved across UNION branches?
+6. **Functions**: Are columns inside functions (COALESCE, CASE, CAST) tracked?
+
+### Cross-Service Lineage
+
+**For database connectors:**
+- Is `processCrossDatabaseLineage` supported? Check pipeline config JSON.
+- Does the connector override `yield_cross_database_lineage()`?
+- How are `service_names` expanded in lineage_processors.py?
+
+**For dashboard connectors:**
+- Does `yield_dashboard_lineage_details()` resolve to the correct database tables?
+- Are data source connections mapped to the right database service?
+- Does it handle dashboards that query multiple databases?
+
+**For pipeline connectors:**
+- Does `yield_pipeline_lineage()` resolve input/output datasets to table FQNs?
+- Are task-level lineage edges created (task → input table, task → output table)?
+
+### Edge Cases
+
+Check how the connector handles:
+1. **CTEs (WITH clauses)**: Are intermediate CTE references resolved or do they create phantom entities?
+2. **Temp tables**: Are they filtered, resolved, or do they pollute lineage?
+3. **Dynamic SQL**: Is it detected? Skipped? Does it create incorrect lineage?
+4. **View chains**: A → view_1 → view_2 → table — is the full chain resolved?
+5. **Stored procedures**: Is the stored procedure lineage mixin registered for this connector? Does it work?
+6. **Schema changes**: If a table moves schemas, does lineage break?
+
+## Rating Calibration
+
+**Lineage Accuracy:**
+- ✅ Compliant = Correct SQL dialect configured, FQNs resolve correctly across databases/schemas, column-level lineage works for standard queries, cross-service lineage resolves to correct entities, edge cases handled or gracefully skipped with logging
+- ⚠️ Partial = Table-level lineage works for common queries, but column-level has gaps (SELECT \*, complex expressions), cross-service partially resolves, some edge cases create incorrect lineage
+- ❌ Gaps = Wrong or missing dialect, FQNs don't resolve (wrong database/schema), column-level lineage broken or absent, cross-service lineage not implemented
+- N/A = The source system fundamentally cannot provide the data for this lineage type (e.g., no execution history table, no audit log). Rate N/A regardless of whether connector code exists. Do NOT rate as ❌. Note: static analysis of definitions (e.g., parsing procedure body SQL) IS implementable and can be rated ⚠️ if missing, but runtime lineage without a source system data source is N/A.
+
+**Optimism traps:**
+- "Lineage exists" — Table-level only? Column-level may be completely broken even when table-level works fine.
+- "FQNs resolve" — Within the same database only? Cross-schema and cross-database resolution is a different code path.
+- "The shared parser handles it" — Which SQL dialect is configured? A generic parser may mangle connector-specific syntax (LATERAL FLATTEN, PIVOT, QUALIFY).
+- "Column lineage is inherited" — Does the inherited code actually work for this connector's query patterns? Test with SELECT \*, aliases, and expressions.
+- "Stored procedure lineage works" — Is the StoredProcedureLineageMixin registered in service_spec.py? Many connectors inherit it but never register the pipeline.
+
+Present findings as:
+1. Lineage path inventory (which lineage types are supported, where implemented)
+2. Per-path assessment (table-level, column-level, cross-service)
+3. Rating with evidence (file:line references)
+4. Specific issues found, ordered by severity
+5. What the source system provides that we don't extract
+6. **Source system constraints**: List lineage types rated N/A because the source system fundamentally cannot provide the data — so the reader knows what's a connector gap vs an impossible ask
+
+## Present & Validate
+
+Before saving, present a summary to the user for review:
+1. **Rating** — Lineage Accuracy standard rating
+2. **Lineage path inventory** — which lineage types work, which are broken, which are N/A
+3. **Top findings** — the 3-5 most important issues, each with severity and a one-sentence description
+4. **Source system constraints** — lineage types rated N/A
+5. **Anything you're uncertain about** — flag findings where you're not confident
+
+Then ask: *"Ready to save to `.claude/audit-results/04-lineage.md`? Any findings to adjust?"*
+
+If the user requests changes, revise and re-present. Once the user confirms, **save the full report** to `.claude/audit-results/04-lineage.md` (create the directory if needed) — Prompt 6 reads this file.

--- a/skills/connector-audit/prompts/05-scale-performance.md
+++ b/skills/connector-audit/prompts/05-scale-performance.md
@@ -1,0 +1,134 @@
+# Prompt 5: Scale & Performance
+
+Audit memory patterns, pagination, generator usage, lookup complexity, and connection management.
+
+---
+
+**Context:** Read `.claude/connector-audit.json` for the connector name, service type, and source path. Use these for [CONNECTOR_NAME] and [SERVICE_TYPE] throughout.
+
+Audit this connector for scale and performance.
+
+Load the connector standards with /connector-standards, then analyze against the Scale standard (Standard 6).
+
+## Where to look
+
+**1. Connector-specific code:**
+- `ingestion/src/metadata/ingestion/source/[SERVICE_TYPE]/[CONNECTOR_NAME]/` — ALL .py files
+- Focus on: metadata.py (entity iteration), queries.py (SQL queries), lineage.py (query log processing), models.py (data structures)
+
+**2. Service-type base class and topology runner:**
+- **Database:** `common_db_source.py` (CommonDbSourceService) — entity iteration, inspector management, per-schema processing
+- **Dashboard:** `dashboard_service.py` — dashboard/chart iteration patterns
+- **Pipeline:** `pipeline_service.py` — pipeline/task iteration patterns
+- `ingestion/src/metadata/ingestion/models/topology.py` — TopologyRunnerMixin, how entities are yielded and processed
+- Check if the connector overrides base class methods and introduces performance issues
+
+**3. Connection management:**
+- `ingestion/src/metadata/ingestion/source/[SERVICE_TYPE]/[CONNECTOR_NAME]/connection.py` — engine creation, connection pooling
+- `ingestion/src/metadata/ingestion/connections/builders.py` — shared engine creation patterns (QueuePool, max_overflow)
+
+**4. Lineage processing (often the most memory-intensive):**
+- `ingestion/src/metadata/ingestion/lineage/parser.py` — query parsing memory usage
+- `ingestion/src/metadata/ingestion/lineage/sql_lineage.py` — lineage graph construction
+- Check if query logs are streamed or loaded entirely into memory
+
+## What to assess
+
+### Memory Patterns
+
+**Classify EVERY data collection** in the connector-specific code as:
+- ✅ Bounded: Fixed-size or capped (e.g., configuration dicts, enum lookups)
+- ⚠️ Linear: Grows with data volume but proportionally (e.g., one entry per table — manageable at 10K)
+- ❌ Unbounded: Grows without limit or accumulates across iterations (e.g., collecting all query logs in a list, caching all column metadata in a dict that's never cleared)
+
+Present as a table: | File:Line | Data Structure | Growth Pattern | Classification | Risk at Scale |
+
+**Check specifically for:**
+1. Lists that collect all results before processing (should use generators)
+2. Dicts/caches that grow per-entity and are never cleared between schemas/databases
+3. File reads without size checks (reading entire query log files into memory)
+4. String concatenation in loops (building large SQL strings)
+
+### Pagination Completeness
+
+For EVERY API call or SQL query that fetches a list of entities:
+1. Is it paginated? (page token, offset/limit, cursor)
+2. What's the page size? Is it configurable?
+3. What happens when there are more results than the page/limit?
+4. Are there hard limits (e.g., LIMIT 10000) without overflow detection?
+
+Present as a table: | File:Line | Operation | Paginated? | Page Size | Overflow Handling |
+
+### Generator Usage
+
+1. Are `yield` patterns used for ALL entity iteration methods?
+2. Are there methods that collect entities in a list then return the list?
+3. Does the topology runner process entities as they're yielded, or does it collect them first?
+4. Are secondary operations (tags, descriptions, ownership) also streamed?
+
+### Lookup Complexity
+
+1. Are there O(n×m) patterns? (nested loops where both n and m grow with data volume)
+2. Could any nested lookups be replaced with pre-built dicts?
+3. Are there repeated API calls inside loops that could be batched?
+
+**Common patterns to check:**
+- Looking up column metadata by iterating all columns for each table (should index by table name)
+- Searching for lineage matches by scanning all entities (should use FQN dict)
+- Fetching tags/descriptions per-entity when batch APIs exist
+
+### Connection Management
+
+1. **Pooling**: Is a connection pool used? What are the pool settings? (pool_size, max_overflow)
+2. **Engine creation**: Is a new engine created per-schema or per-database? (Should be shared or disposed properly)
+3. **Cursor management**: Are cursors closed after use? Are there server-side cursors for large result sets?
+4. **Connection leaks**: Any code paths where connections are acquired but not released on error?
+
+### Scale Scenarios
+
+Think about what happens when this connector runs against:
+- **10,000 tables** with 100 columns each → 1M column metadata objects
+- **500 dashboards** with 50 charts each → 25K chart objects
+- **1,000,000 query log entries** → lineage parsing memory and time
+- **200ms network latency** per API call → multiply by number of sequential API calls
+- **100 schemas** in one database → per-schema operations multiply
+
+For each scenario, identify:
+1. Which code paths become bottlenecks?
+2. Where does memory grow proportionally?
+3. Where do sequential API calls become time bottlenecks?
+4. Are there any operations that are O(n²) or worse?
+
+## Rating Calibration
+
+**Scale:**
+- ✅ Compliant = All list operations use generators, pagination on every API/SQL list call, bounded caches, no O(n×m) lookups, connection pool properly managed, would handle 10K+ entities without memory issues or excessive time
+- ⚠️ Partial = Primary entity iteration uses generators, but secondary operations (tags, descriptions, lineage) collect in memory. Pagination on main operations but not all. Some O(n×m) patterns in non-critical paths.
+- ❌ Gaps = Primary entity lists collected in memory, no pagination on key operations, unbounded caches, O(n×m) lookups in hot paths, connection leaks or per-schema engine creation without cleanup
+
+**Optimism traps:**
+- "It uses generators" — For primary entity iteration only? Secondary operations (fetching tags, descriptions, column metadata, lineage per table) may still collect everything in memory.
+- "Connection pool handles it" — Does the connector create new engines per schema or per database? A pool per schema × 100 schemas = 100 pools.
+- "Results are paginated" — But are paginated results collected into a list before processing? Pagination that loads all pages into memory before yielding defeats the purpose.
+- "There's a LIMIT" — A LIMIT/TOP without an offset loop or cursor continuation is NOT pagination. It is a hard cap that silently drops data. Classify as "Not paginated — hard cap" in the pagination table. If the default value could plausibly be exceeded in production (e.g., 1000 queries on a system doing 50K/day), this directly degrades the Scale rating — rate ⚠️ minimum.
+- "It's fine for test data" — Test environments have 10 tables. Production has 10,000. What's O(n) at 10 is still O(n) at 10,000 — but the constant matters when n is large.
+- "The base class is efficient" — Does the connector override base class methods? Overrides may lose generator patterns, add unbounded caches, or introduce O(n×m) lookups.
+
+Present findings as:
+1. Memory pattern classification table (EVERY collection in connector code)
+2. Pagination completeness table (EVERY list operation)
+3. Rating with evidence (file:line references)
+4. Specific issues found, ordered by severity
+5. Scale scenario analysis (what breaks first at 10x, 100x, 1000x)
+
+## Present & Validate
+
+Before saving, present a summary to the user for review:
+1. **Rating** — Scale standard rating
+2. **Top findings** — the 3-5 most important issues, each with severity and a one-sentence description
+3. **What breaks first** — the single biggest bottleneck at scale
+4. **Anything you're uncertain about** — flag findings where you're not confident
+
+Then ask: *"Ready to save to `.claude/audit-results/05-scale-performance.md`? Any findings to adjust?"*
+
+If the user requests changes, revise and re-present. Once the user confirms, **save the full report** to `.claude/audit-results/05-scale-performance.md` (create the directory if needed) — Prompt 6 reads this file.

--- a/skills/connector-audit/prompts/06-refactor-plan.md
+++ b/skills/connector-audit/prompts/06-refactor-plan.md
@@ -1,0 +1,92 @@
+# Prompt 6: Refactor Assessment
+
+Consolidate findings from all parallel audits, cluster root causes, and produce a prioritized implementation plan.
+
+---
+
+**Context:** Read `.claude/connector-audit.json` for the connector name, service type, and source path. Use these for [CONNECTOR_NAME] and [SERVICE_TYPE] throughout.
+
+Consolidate all audit results for this connector and decide the implementation approach.
+
+## Input: Audit Results
+
+Read **all `.md` files** from `.claude/audit-results/` (excluding any previous `06-refactor-plan.md` or `07-*.md`). The core prompts produce files `01` through `05`, but additional reports may exist from standalone prompts run outside the skill. Include every report found.
+
+List the files you found and their focus area before proceeding.
+
+For each finding across all reports, capture: what's wrong, where (file:line), severity (❌/⚠️), which standard it violates, and **which Metadata Tier (1/2/3) it affects** — Tier 1 gaps are critical, Tier 3 gaps can wait.
+
+## Analysis
+
+### 0. Cross-Prompt Validation
+
+Before clustering, scan ALL reports for **contradictions**:
+- Does one report list a feature as working while another found it broken? (e.g., SSL found unwired in connection audit but assumed working in scale audit)
+- Do two reports give conflicting severity ratings for the same code path?
+- Flag and resolve contradictions before proceeding.
+
+**File coverage check**: List every file in the connector directory. For each file, verify that at least one prompt analyzed it substantively. If a connector-specific file was only mentioned in passing or not covered by any prompt, flag the gap — it may contain issues no prompt caught.
+
+### 1. Root Cause Clustering
+
+Group issues that share a common root cause. Ask:
+- Do multiple findings trace back to the same code pattern? (e.g., missing Either pattern in 10 places = 1 root cause)
+- Are issues caused by a wrong architectural choice? (e.g., wrong base class, missing mixin)
+- Could a single shared-code change fix issues across this connector AND others?
+
+### 2. Git History Check
+
+Before proposing refactors, check:
+- `git log --oneline -20 -- ingestion/src/metadata/ingestion/source/[SERVICE_TYPE]/[CONNECTOR_NAME]/`
+- Is this connector actively being modified? By whom?
+- Are there open PRs touching the same files? (check with `gh pr list`)
+- Avoid refactoring code that's in active development — coordinate or wait.
+
+### 3. Classify Each Finding
+
+For each issue (or issue cluster), classify using this decision framework:
+
+| Situation | Approach | Risk |
+|-----------|----------|------|
+| Bug in one connector, clean code around it | **Fix in place** | Low |
+| Same bug in 3+ connectors | **Fix in shared base class** | Medium — needs broader testing |
+| Code works but is hard to follow | **Refactor only if touching it anyway** | Low if isolated |
+| Connector duplicates logic from another connector | **Extract shared logic, then fix** | Medium |
+| Wrong base class or missing mixin | **Refactor first, then address standards** | High — architectural change |
+| Missing feature identified during audit | **New feature** — scope separately | Varies |
+
+### 4. Effort & Risk Estimation
+
+For each classified item, estimate:
+- **Effort**: S (< 1 hour), M (1-4 hours), L (4+ hours)
+- **Risk**: Low (isolated to this connector), Medium (touches shared code), High (architectural change)
+- **Testing**: What tests need to run? (unit only, integration, manual verification)
+
+### 5. PR Scoping
+
+Decide how to split work into PRs:
+- **One PR per concern** — don't mix bug fixes with refactors, don't mix connector-specific with shared changes
+- **Shared code changes first** — if a base class fix resolves issues in multiple connectors, do that PR first
+- **Order by dependency** — if fix B depends on refactor A, refactor A goes first
+
+## Output
+
+Present as:
+1. **Consolidated findings table**: | # | Finding | Severity | Standard | Tier | File:Line | Root Cause Cluster |
+2. **Source system constraints**: List items rated N/A across any audit because the source system cannot provide the data — these are not bugs and should not appear in the implementation plan
+3. **Implementation plan**: Ordered list of work items, each with: approach (fix/extract/refactor/new), effort, risk, PR scope, testing strategy
+4. **Recommended PR sequence**: Which PRs to create and in what order
+5. **Deferred items**: Anything that should be tracked but not fixed now (with reason)
+
+## Present & Validate
+
+Before saving, present a summary to the user for review:
+1. **Cross-prompt contradictions** — any contradictions found and how you resolved them
+2. **Findings count** — total findings, how many HIGH/MEDIUM/LOW, how many root cause clusters
+3. **Recommended PR sequence** — the PR list with effort and risk per PR
+4. **Source system constraints** — items rated N/A (confirming these are NOT in the implementation plan)
+5. **Deferred items** — what you're recommending to skip and why
+
+Then ask: *"Ready to save to `.claude/audit-results/06-refactor-plan.md`? Any changes to the plan?"*
+
+If the user requests changes (e.g., different PR grouping, different severity, items to add/remove), revise and re-present. Once the user confirms, **save the full plan** to `.claude/audit-results/06-refactor-plan.md` — Prompt 7 reads this file.

--- a/skills/connector-audit/prompts/07-implementation.md
+++ b/skills/connector-audit/prompts/07-implementation.md
@@ -1,0 +1,127 @@
+# Prompt 7: Implementation
+
+Execute the refactor plan — implement fixes, write tests, and prepare the PR.
+
+Supports `--dry-run` mode: produce a detailed plan (before/after diffs, tests, risk flags, commit messages) without writing code.
+
+---
+
+**Context:** Read `.claude/connector-audit.json` for the connector name, service type, and source path. Use these for [CONNECTOR_NAME] and [SERVICE_TYPE] throughout.
+
+## Mode Selection
+
+- **Default (no flag)**: Implement the fixes — write code, run tests, create commits.
+- **`--dry-run`**: Produce a detailed implementation plan only — exact before/after code diffs, complete test code, risk flags with mitigations, and commit messages. Do NOT write any code or create commits. Save the plan to `.claude/audit-results/07-dry-run-implementation.md`.
+
+Read the implementation plan from `.claude/audit-results/06-refactor-plan.md`.
+
+**Follow the refactor plan's PR structure and work item ordering exactly.** If you disagree with the plan's approach for a specific item, explain why before changing it. If you **drop** an optional item from the plan, note the omission and explain why.
+
+Load the connector standards with /connector-standards, then follow the workflow below.
+
+## Implementation Workflow
+
+### Before Starting
+
+1. **Verify you're in a worktree**: Check `git branch` — you should be on `task/[connector]-reliability`
+2. **Run existing tests**: Run the connector's existing tests BEFORE making any changes to establish a baseline:
+   `cd ingestion && python -m pytest tests/unit/[relevant_test_files] -v`
+3. **Note any pre-existing failures**: Don't fix unrelated test failures in this PR
+
+### For Each Fix (in priority order)
+
+**Priority 1: ❌ Gaps** (broken or missing functionality)
+**Priority 2: ⚠️ Partial** (improvements to existing functionality)
+
+For each item in the implementation plan:
+1. **Explain** the change before making it — what you're changing, why, and what the expected behavior is
+2. **Implement** the change — keep it minimal and focused
+3. **Separate concerns**: Bug fixes and refactors go in separate commits, even if they touch the same file
+4. **Test**: Write **complete, runnable test code** for any behavioral change — no placeholder comments or pseudocode. Use pytest style (plain `assert`, no TestCase). Include imports, fixtures, and assertions.
+5. **Lint**: Run `make py_format` and `make lint` in the ingestion directory after changes
+
+### Commit Strategy
+
+- **One logical change per commit** — don't bundle unrelated fixes
+- **Commit message format**: `fix([connector]): [what]` or `refactor([connector]): [what]`
+- **Shared code changes get their own commits**: If you modify `common_db_source.py` or `builders.py`, that's a separate commit from connector-specific changes
+
+### Multi-Connector Fixes
+
+If a fix applies to multiple connectors (e.g., a pattern found in the shared base class):
+- Fix it ONCE in the shared code for this connector's PR
+- Note which other connectors benefit from the shared fix
+- Note which other connectors need connector-specific follow-up
+- Do NOT fix other connectors in this PR — each connector gets its own PR
+
+### After Implementation
+
+1. **Run full test suite** for this connector:
+   `cd ingestion && python -m pytest tests/unit/[relevant_test_files] -v`
+2. **Run linter and formatter**:
+   `cd ingestion && make py_format && make lint`
+3. **Verify no regressions**: Compare test results with the baseline from before your changes
+4. **Propose rating updates**: List which standard ratings would change based on post-fix state (e.g., which standards move from ⚠️ to ✅), with justification for each change.
+
+## What NOT to Do
+
+- Do NOT change code that is working correctly just to match a style preference
+- Do NOT add comments to code you didn't change
+- Do NOT refactor code unrelated to the findings
+- Do NOT fix issues in other connectors in this PR
+- Do NOT skip tests — if you can't test a change, flag it for manual verification
+
+## After All Fixes
+
+### If `--dry-run`: Present the Plan
+
+For each work item in the refactor plan, produce:
+1. **Before/after code diffs** — exact code with file paths and line numbers
+2. **Complete test code** — runnable pytest code, not pseudocode
+3. **Risk flags** — with proposed verification steps or mitigations
+4. **Commit message** — following the `fix([connector]): [what]` format
+
+Present a summary:
+1. **PR-by-PR overview** — for each PR: what changes, which files, any disagreements with the plan
+2. **Items where you diverged from the plan** — explain why
+3. **Test coverage** — what tests you would add and what they validate
+4. **Risk flags** — anything that needs manual verification
+
+Ask: *"Ready to save to `.claude/audit-results/07-dry-run-implementation.md`? Any changes?"*
+
+Save after user approval.
+
+### If implementing (default): After All Fixes
+
+Once all fixes are implemented, tested, and passing:
+
+1. **Show before/after summary**:
+   ```
+   Before: 5.8/10 — 3 blockers, 6 warnings, 4 suggestions
+   After:  8.6/10 — 0 blockers, 1 warning, 2 suggestions
+   ```
+   List each finding and its resolution:
+   ```
+   #1 HIGH   SSL config not wired to driver   → FIXED: added ssl_args extraction in connection.py
+   #2 HIGH   IAM token no refresh              → FIXED: added pool event listener for token regen
+   #3 MEDIUM hostPort not validated for IAM    → FIXED: added format validation with clear error
+   ```
+
+2. **Run the static analyzer** to verify fixes:
+   ```bash
+   python skills/connector-review/scripts/analyze_connector.py {service_type} {name}
+   ```
+
+3. **Propose rating updates** — list which standard ratings would change and why:
+   ```
+   Connection Setup: ⚠️ → ✅ (SSL wired, all auth methods tested)
+   Fault Tolerance: ❌ → ⚠️ (token refresh added, still no query retry)
+   ```
+
+4. **Save implementation report** to `.claude/audit-results/07-implementation.md` with:
+   - PR-by-PR overview (what changed, which files, test results)
+   - Items where you diverged from the plan (and why)
+   - Remaining items deferred (and why)
+   - Risk flags with verification steps
+
+Ask: *"Ready to save the implementation report to `.claude/audit-results/07-implementation.md`?"*

--- a/skills/connector-audit/templates/audit-report.md
+++ b/skills/connector-audit/templates/audit-report.md
@@ -1,0 +1,65 @@
+# Audit {PROMPT_NUMBER} — {PROMPT_TITLE}: {CONNECTOR_NAME} Connector
+
+**Connector**: {CONNECTOR_NAME}
+**Service type**: {SERVICE_TYPE}
+**Source path**: `ingestion/src/metadata/ingestion/source/{SERVICE_TYPE}/{CONNECTOR_NAME}/`
+**Rating**: **{RATING}**
+
+---
+
+## 1. {FIRST_SECTION_TITLE}
+
+<!-- Primary analysis section — varies by prompt -->
+<!-- Use tables with file:line references for all findings -->
+
+| # | Severity | Finding | File | Line(s) |
+|---|----------|---------|------|---------|
+| 1 | {HIGH/MEDIUM/LOW} | {Description} | `{file_path}` | {lines} |
+
+---
+
+## 2. {SECOND_SECTION_TITLE}
+
+<!-- Secondary analysis section -->
+
+---
+
+## 3. Rating Justification
+
+### Rating: {RATING}
+
+**What works well**:
+- {Positive finding with file:line reference}
+
+**What needs fixing**:
+- **{Issue}** — {description with file:line reference}
+
+---
+
+## 4. Issues Summary
+
+| # | Severity | Issue | File | Line(s) |
+|---|----------|-------|------|---------|
+| 1 | HIGH | {Description} | `{file_path}` | {lines} |
+| 2 | MEDIUM | {Description} | `{file_path}` | {lines} |
+
+---
+
+## 5. Recommended Fixes (Prioritized by Customer Impact)
+
+### P0 — {Most critical fix}
+
+{Description of the fix with code examples if helpful}
+
+### P1 — {Next priority fix}
+
+{Description}
+
+---
+
+## 6. Source System Constraints
+
+<!-- Items rated N/A because the source system cannot provide the data -->
+<!-- These are NOT connector bugs — they clarify what's impossible vs what's missing -->
+
+- **{Metadata type}**: N/A — {reason the source system cannot provide this}


### PR DESCRIPTION
## Summary

Restores the `connector-audit` skill (11 files, +1149 lines) originally added by #26992 on 2026-04-05 and inadvertently deleted by #25894 (`task_redesign`) on 2026-04-23.

## Root cause

`task_redesign` was opened 2026-02-16 and squash-merged 2026-04-23 without rebasing. Its squash diff, computed against the old merge-base, marked every post-2026-02-16 addition it didn't touch as `removed` — including all 11 `connector-audit` files. GitHub's PR API confirms `"status": "removed"` for each file.

## Recovery

Files restored via `git checkout 38b5ce35f7 -- skills/connector-audit .claude/skills/connector-audit` (original merge commit of #26992). No content changes.

## Prevention

Consider enabling "Require branches to be up to date before merging" in branch protection to block stale-branch clobbers on long-running PRs.