### PR TITLE
Add streamDeadlineMinutes to AiPlatform gRPC config    

### DIFF
--- a/openmetadata-spec/src/main/resources/json/schema/configuration/aiPlatformConfiguration.json
+++ b/openmetadata-spec/src/main/resources/json/schema/configuration/aiPlatformConfiguration.json
@@ -27,7 +27,7 @@
           "type": "integer"
         },
         "streamDeadlineMinutes": {
-          "description": "Client-side deadline (minutes) for an AI Platform streaming response. If the stream has not completed within this window the client abandons it and surfaces a timeout. Must be coordinated with any server-side deadline on the AI Platform side; the chat lock sweeper derives its default ceiling as streamDeadlineMinutes + 2. Capped at 60 minutes — longer tasks should use an async job + polling pattern rather than a single long-lived streaming RPC.",
+          "description": "Deadline (minutes) Collate enforces on an AI Platform streaming response. Carried on the gRPC call, so the AI Platform reads it from context and wraps up gracefully. The chat lock sweeper uses streamDeadlineMinutes + 2 as its default stale-lock ceiling (override via COLLATE_CHAT_LOCK_MAX_DURATION_MINUTES). Capped at 60 minutes; for longer tasks prefer async job + polling over a single long-lived stream.",
           "type": "integer",
           "default": 20,
           "minimum": 1,

--- a/openmetadata-spec/src/main/resources/json/schema/configuration/aiPlatformConfiguration.json
+++ b/openmetadata-spec/src/main/resources/json/schema/configuration/aiPlatformConfiguration.json
@@ -27,7 +27,7 @@
           "type": "integer"
         },
         "streamDeadlineMinutes": {
-          "description": "Deadline (minutes) Collate enforces on an AI Platform streaming response. Carried on the gRPC call, so the AI Platform reads it from context and wraps up gracefully. The chat lock sweeper uses streamDeadlineMinutes + 2 as its default stale-lock ceiling (override via COLLATE_CHAT_LOCK_MAX_DURATION_MINUTES). Capped at 60 minutes; for longer tasks prefer async job + polling over a single long-lived stream.",
+          "description": "Deadline (minutes) enforced on a streaming response from the gRPC server.",
           "type": "integer",
           "default": 20,
           "minimum": 1,

--- a/openmetadata-spec/src/main/resources/json/schema/configuration/aiPlatformConfiguration.json
+++ b/openmetadata-spec/src/main/resources/json/schema/configuration/aiPlatformConfiguration.json
@@ -25,6 +25,13 @@
         "keepAliveTimeout": {
           "description": "Keep alive timeout for the gRPC server",
           "type": "integer"
+        },
+        "streamDeadlineMinutes": {
+          "description": "Client-side deadline (minutes) for an AI Platform streaming response. If the stream has not completed within this window the client abandons it and surfaces a timeout. Must be coordinated with any server-side deadline on the AI Platform side; the chat lock sweeper derives its default ceiling as streamDeadlineMinutes + 2. Capped at 60 minutes — longer tasks should use an async job + polling pattern rather than a single long-lived streaming RPC.",
+          "type": "integer",
+          "default": 20,
+          "minimum": 1,
+          "maximum": 60
         }
       },
       "required": ["port"]

--- a/openmetadata-ui/src/main/resources/ui/src/generated/configuration/aiPlatformConfiguration.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/configuration/aiPlatformConfiguration.ts
@@ -88,5 +88,14 @@ export interface GrpcConfiguration {
      * Host for the gRPC server
      */
     port: number;
+    /**
+     * Client-side deadline (minutes) for an AI Platform streaming response. If the stream has
+     * not completed within this window the client abandons it and surfaces a timeout. Must be
+     * coordinated with any server-side deadline on the AI Platform side; the chat lock sweeper
+     * derives its default ceiling as streamDeadlineMinutes + 2. Capped at 60 minutes — longer
+     * tasks should use an async job + polling pattern rather than a single long-lived streaming
+     * RPC.
+     */
+    streamDeadlineMinutes?: number;
     [property: string]: any;
 }

--- a/openmetadata-ui/src/main/resources/ui/src/generated/configuration/aiPlatformConfiguration.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/configuration/aiPlatformConfiguration.ts
@@ -89,12 +89,11 @@ export interface GrpcConfiguration {
      */
     port: number;
     /**
-     * Client-side deadline (minutes) for an AI Platform streaming response. If the stream has
-     * not completed within this window the client abandons it and surfaces a timeout. Must be
-     * coordinated with any server-side deadline on the AI Platform side; the chat lock sweeper
-     * derives its default ceiling as streamDeadlineMinutes + 2. Capped at 60 minutes — longer
-     * tasks should use an async job + polling pattern rather than a single long-lived streaming
-     * RPC.
+     * Deadline (minutes) Collate enforces on an AI Platform streaming response. Carried on the
+     * gRPC call, so the AI Platform reads it from context and wraps up gracefully. The chat
+     * lock sweeper uses streamDeadlineMinutes + 2 as its default stale-lock ceiling (override
+     * via COLLATE_CHAT_LOCK_MAX_DURATION_MINUTES). Capped at 60 minutes; for longer tasks
+     * prefer async job + polling over a single long-lived stream.
      */
     streamDeadlineMinutes?: number;
     [property: string]: any;


### PR DESCRIPTION
Add variable to make GRPC connection limit configurable

----
## Summary by Gitar

- **Documentation update:**
  - Updated the description for `streamDeadlineMinutes` in `aiPlatformConfiguration.json` to clarify the enforced deadline mechanism and lock sweeper behavior.

<sub>This will update automatically on new commits.</sub>