### PR TITLE
test(glossary): fix flaky "Add and Remove Assets" mutex batch

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts
@@ -487,21 +487,12 @@ test.describe('Glossary tests', () => {
     test.slow(true);
 
     const { page, afterAction, apiContext } = await performAdminLogin(browser);
-    const glossary1 = new Glossary();
-    const glossaryTerm1 = new GlossaryTerm(glossary1);
-    const glossaryTerm2 = new GlossaryTerm(glossary1);
-    glossary1.data.mutuallyExclusive = true;
-    glossary1.data.terms = [glossaryTerm1, glossaryTerm2];
-
     const glossary2 = new Glossary();
     const glossaryTerm3 = new GlossaryTerm(glossary2);
     const glossaryTerm4 = new GlossaryTerm(glossary2);
     glossary2.data.terms = [glossaryTerm3, glossaryTerm4];
 
-    await glossary1.create(apiContext);
     await glossary2.create(apiContext);
-    await glossaryTerm1.create(apiContext);
-    await glossaryTerm2.create(apiContext);
     await glossaryTerm3.create(apiContext);
     await glossaryTerm4.create(apiContext);
 
@@ -522,61 +513,6 @@ test.describe('Glossary tests', () => {
         await dashboardEntity.visitEntityPage(page);
 
         // Dashboard Entity Right Panel
-        await page.click(
-          '[data-testid="KnowledgePanel.GlossaryTerms"] [data-testid="glossary-container"] [data-testid="add-tag"]'
-        );
-
-        // Select 1st term
-        await page.click('[data-testid="tag-selector"] #tagsForm_tags');
-
-        const glossaryRequest = page.waitForResponse(
-          `/api/v1/search/query?q=*&index=glossaryTerm&from=0&size=25&deleted=false&track_total_hits=true&getHierarchy=true`
-        );
-        await page.type(
-          '[data-testid="tag-selector"] #tagsForm_tags',
-          glossaryTerm1.data.name
-        );
-        await glossaryRequest;
-
-        await page.getByText(glossaryTerm1.data.displayName).click();
-        await page
-          .locator(
-            `[data-testid="tag-selector"]:has-text("${glossaryTerm1.data.displayName}")`
-          )
-          .waitFor();
-
-        // Select 2nd term
-        await page.click('[data-testid="tag-selector"] #tagsForm_tags');
-
-        const glossaryRequest2 = page.waitForResponse(
-          `/api/v1/search/query?q=*&index=glossaryTerm&from=0&size=25&deleted=false&track_total_hits=true&getHierarchy=true`
-        );
-        await page.type(
-          '[data-testid="tag-selector"] #tagsForm_tags',
-          glossaryTerm2.data.name
-        );
-        await glossaryRequest2;
-
-        await page.getByText(glossaryTerm2.data.displayName).click();
-
-        await page
-          .locator(
-            `[data-testid="tag-selector"]:has-text("${glossaryTerm2.data.displayName}")`
-          )
-          .waitFor();
-
-        const patchRequest = page.waitForResponse(
-          (res) =>
-            res.url().includes('/api/v1/dashboards/') &&
-            res.request().method() === 'PATCH'
-        );
-
-        await expect(page.getByTestId('saveAssociatedTag')).toBeEnabled();
-
-        await page.getByTestId('saveAssociatedTag').click();
-        await patchRequest;
-
-        // Add non mutually exclusive tags
         await page.click(
           '[data-testid="KnowledgePanel.GlossaryTerms"] [data-testid="glossary-container"] [data-testid="add-tag"]'
         );
@@ -718,11 +654,8 @@ test.describe('Glossary tests', () => {
         );
       });
     } finally {
-      await glossaryTerm1.delete(apiContext);
-      await glossaryTerm2.delete(apiContext);
       await glossaryTerm3.delete(apiContext);
       await glossaryTerm4.delete(apiContext);
-      await glossary1.delete(apiContext);
       await glossary2.delete(apiContext);
       await dashboardEntity.delete(apiContext);
       await afterAction();


### PR DESCRIPTION
## Summary

The `Pages/Glossary.spec.ts › Add and Remove Assets` E2E test (shard 6 on CI) is flaky — it times out at 180s on [line 580](openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts#L580) waiting for `[data-testid="add-tag"]` after the first save.

**Root cause.** The test's first batch added two siblings from a `mutuallyExclusive` glossary and relied on the server rejecting the save so the entity's `tags` stayed empty and `add-tag` remained clickable for the next batch. Since #25313, `TreeAsyncSelectList.handleChange` drops mutex siblings client-side once its `/api/v1/glossaries?fields=mutuallyExclusive` fetch resolves, so only one term reaches the server, the save succeeds, `tags` becomes non-empty, and [`TagsContainerV2` swaps `add-tag` for `edit-button`](openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsContainerV2/TagsContainerV2.tsx#L137). The flake is the race between that dropdown fetch and the user's clicks — CI retries (`retries: 2`) masked it at merge time.

**Fix.** Remove the mutex batch and its fixtures. The mutex flow was never actually asserted in this test — it was only used as a side channel to keep `tags` empty. The remaining non-mutex batch plus chart-level tagging and asset-tab verification still cover add/remove-assets end-to-end.

## Verification

- Reproduced the flake locally: 2/2 timeouts on `main` before the fix.
- After the fix: 5/5 passes in 14.3s–23.0s each (previously timing out at 180s).

## Test plan

- [x] Local: `yarn playwright test --project=chromium -g "Add and Remove Assets" --repeat-each=5` — all 5 Glossary iterations pass.
- [ ] CI: confirm shard 6 is green, no retries needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)