### PR TITLE
test(glossary): fix flaky "Add and Remove Assets" by using edit-button

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts
@@ -490,7 +490,6 @@ test.describe('Glossary tests', () => {
     const glossary1 = new Glossary();
     const glossaryTerm1 = new GlossaryTerm(glossary1);
     const glossaryTerm2 = new GlossaryTerm(glossary1);
-    glossary1.data.mutuallyExclusive = true;
     glossary1.data.terms = [glossaryTerm1, glossaryTerm2];
 
     const glossary2 = new Glossary();
@@ -576,9 +575,8 @@ test.describe('Glossary tests', () => {
         await page.getByTestId('saveAssociatedTag').click();
         await patchRequest;
 
-        // Add non mutually exclusive tags
         await page.click(
-          '[data-testid="KnowledgePanel.GlossaryTerms"] [data-testid="glossary-container"] [data-testid="add-tag"]'
+          '[data-testid="KnowledgePanel.GlossaryTerms"] [data-testid="glossary-container"] [data-testid="edit-button"]'
         );
 
         // Select 1st term
@@ -648,7 +646,7 @@ test.describe('Glossary tests', () => {
           '[data-testid="KnowledgePanel.GlossaryTerms"] [data-testid="glossary-container"] [data-testid="glossary-icon"]'
         );
 
-        expect(await icons.count()).toBe(2);
+        expect(await icons.count()).toBe(4);
 
         // Add Glossary to Dashboard Charts
         await page.click(


### PR DESCRIPTION
## Summary

`Pages/Glossary.spec.ts › Add and Remove Assets` (shard 6 on CI) timed out at 180s on the second `add-tag` click. Root cause is that #25313 (client-side mutex radios in `TreeAsyncSelectList`) drops a mutex sibling before the PATCH, so the save succeeds with one tag instead of being server-rejected. That flips the entity's `tags` from empty to non-empty, and [`TagsContainerV2`](openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsContainerV2/TagsContainerV2.tsx#L137) swaps `add-tag` for `edit-button` whenever tags exist — the test had been implicitly relying on the pre-#25313 rejection to keep `add-tag` rendered.

## Change

- Drop `mutuallyExclusive = true` on `glossary1` (mutex behavior is covered elsewhere; it wasn't asserted by this test — it was only a side-channel to keep `tags` empty).
- Re-open the tag selector for the second batch via `edit-button`.
- Update the final `icons.count` from 2 to 4 — both terms from each of the two glossaries now land on the entity, and `glossary-icon` is rendered per tag (see [TagsV1.component.tsx:83](openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsV1/TagsV1.component.tsx#L83)).

## Verification

- Reproduced the flake on `main`: 2/2 timeouts.
- After fix: 10/10 passes locally at ~15–20s each (was timing out at 180s).

Supersedes #27707 (which removed the batch entirely — this version keeps the multi-glossary tagging coverage).

## Test plan

- [x] Local: `yarn playwright test --project=chromium -g "Add and Remove Assets" --repeat-each=5` (x2 rounds) — Glossary iterations all pass.
- [x] CI: confirm shard 6 is green, no retries needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)