### PR TITLE
fix: Generic DQ test definitions missing for unspecified data types #27718

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -8578,7 +8578,7 @@ public interface CollectionDAO {
         psqlCondition.append("AND entityType=:entityType ");
       }
 
-            if (supportedDataType != null) {
+      if (supportedDataType != null) {
         filter.queryParams.put("supportedDataTypeLike", String.format("%%%s%%", supportedDataType));
         mysqlCondition.append(
             "AND (json_extract(json, '$.supportedDataTypes') = JSON_ARRAY() "
@@ -8652,7 +8652,7 @@ public interface CollectionDAO {
         psqlCondition.append("AND entityType = :entityType ");
       }
 
-            if (supportedDataType != null) {
+      if (supportedDataType != null) {
         filter.queryParams.put("supportedDataTypeLike", String.format("%%%s%%", supportedDataType));
         mysqlCondition.append(
             "AND (json_extract(json, '$.supportedDataTypes') = JSON_ARRAY() "
@@ -8726,7 +8726,7 @@ public interface CollectionDAO {
         psqlCondition.append("AND entityType=:entityType ");
       }
 
-            if (supportedDataType != null) {
+      if (supportedDataType != null) {
         filter.queryParams.put("supportedDataTypeLike", String.format("%%%s%%", supportedDataType));
         mysqlCondition.append(
             "AND (json_extract(json, '$.supportedDataTypes') = JSON_ARRAY() "

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -8543,16 +8543,15 @@ public interface CollectionDAO {
       return TestDefinition.class;
     }
 
+    record SqlConditionPair(StringBuilder mysql, StringBuilder psql, ListFilter filter) {}
+
     default void applyJsonArrayFilter(
-        StringBuilder mysqlCondition,
-        StringBuilder psqlCondition,
-        ListFilter filter,
+        SqlConditionPair conditions,
         String queryParamName,
-        String jsonFieldName,
-        boolean allowEmpty) {
-      String paramValue = filter.getQueryParam(queryParamName);
+        String jsonFieldName) {
+      String paramValue = conditions.filter().getQueryParam(queryParamName);
       if (paramValue != null) {
-        filter.queryParams.put(queryParamName + "Exact", paramValue);
+        conditions.filter().queryParams.put(queryParamName + "Exact", paramValue);
 
         String mysqlBaseCondition =
             String.format(
@@ -8562,19 +8561,35 @@ public interface CollectionDAO {
             String.format(
                 "jsonb_exists(json::jsonb -> '%s', :%sExact)", jsonFieldName, queryParamName);
 
-        if (allowEmpty) {
-          mysqlCondition.append(
-              String.format(
-                  "AND (json_extract(json, '$.%s') = JSON_ARRAY() OR json_extract(json, '$.%s') IS NULL OR %s) ",
-                  jsonFieldName, jsonFieldName, mysqlBaseCondition));
-          psqlCondition.append(
-              String.format(
-                  "AND (json->>'%s' = '[]' OR json->>'%s' IS NULL OR %s) ",
-                  jsonFieldName, jsonFieldName, psqlBaseCondition));
-        } else {
-          mysqlCondition.append(String.format("AND %s ", mysqlBaseCondition));
-          psqlCondition.append(String.format("AND %s ", psqlBaseCondition));
-        }
+        conditions.mysql().append(String.format("AND %s ", mysqlBaseCondition));
+        conditions.psql().append(String.format("AND %s ", psqlBaseCondition));
+      }
+    }
+
+    default void applyJsonArrayFilterWithEmpty(
+        SqlConditionPair conditions,
+        String queryParamName,
+        String jsonFieldName) {
+      String paramValue = conditions.filter().getQueryParam(queryParamName);
+      if (paramValue != null) {
+        conditions.filter().queryParams.put(queryParamName + "Exact", paramValue);
+
+        String mysqlBaseCondition =
+            String.format(
+                "JSON_CONTAINS(json_extract(json, '$.%s'), JSON_ARRAY(:%sExact))",
+                jsonFieldName, queryParamName);
+        String psqlBaseCondition =
+            String.format(
+                "jsonb_exists(json::jsonb -> '%s', :%sExact)", jsonFieldName, queryParamName);
+
+        conditions.mysql().append(
+            String.format(
+                "AND (json_extract(json, '$.%s') = JSON_ARRAY() OR json_extract(json, '$.%s') IS NULL OR %s) ",
+                jsonFieldName, jsonFieldName, mysqlBaseCondition));
+        conditions.psql().append(
+            String.format(
+                "AND (json->>'%s' = '[]' OR json->>'%s' IS NULL OR %s) ",
+                jsonFieldName, jsonFieldName, psqlBaseCondition));
       }
     }
 
@@ -8602,19 +8617,18 @@ public interface CollectionDAO {
       mysqlCondition.append(String.format("%s ", condition));
       psqlCondition.append(String.format("%s ", condition));
 
-      applyJsonArrayFilter(
-          mysqlCondition, psqlCondition, filter, "testPlatform", "testPlatforms", false);
+      SqlConditionPair conditions = new SqlConditionPair(mysqlCondition, psqlCondition, filter);
+
+      applyJsonArrayFilter(conditions, "testPlatform", "testPlatforms");
 
       if (entityType != null) {
         mysqlCondition.append("AND entityType=:entityType ");
         psqlCondition.append("AND entityType=:entityType ");
       }
 
-      applyJsonArrayFilter(
-          mysqlCondition, psqlCondition, filter, "supportedDataType", "supportedDataTypes", true);
+      applyJsonArrayFilterWithEmpty(conditions, "supportedDataType", "supportedDataTypes");
 
-      applyJsonArrayFilter(
-          mysqlCondition, psqlCondition, filter, "supportedService", "supportedServices", true);
+      applyJsonArrayFilterWithEmpty(conditions, "supportedService", "supportedServices");
 
       if (enabled != null) {
         String enabledValue = Boolean.parseBoolean(enabled) ? "TRUE" : "FALSE";
@@ -8655,19 +8669,18 @@ public interface CollectionDAO {
       mysqlCondition.append(String.format("%s ", condition));
       psqlCondition.append(String.format("%s ", condition));
 
-      applyJsonArrayFilter(
-          mysqlCondition, psqlCondition, filter, "testPlatform", "testPlatforms", false);
+      SqlConditionPair conditions = new SqlConditionPair(mysqlCondition, psqlCondition, filter);
+
+      applyJsonArrayFilter(conditions, "testPlatform", "testPlatforms");
 
       if (entityType != null) {
         mysqlCondition.append("AND entityType = :entityType ");
         psqlCondition.append("AND entityType = :entityType ");
       }
 
-      applyJsonArrayFilter(
-          mysqlCondition, psqlCondition, filter, "supportedDataType", "supportedDataTypes", true);
+      applyJsonArrayFilterWithEmpty(conditions, "supportedDataType", "supportedDataTypes");
 
-      applyJsonArrayFilter(
-          mysqlCondition, psqlCondition, filter, "supportedService", "supportedServices", true);
+      applyJsonArrayFilterWithEmpty(conditions, "supportedService", "supportedServices");
 
       if (enabled != null) {
         String enabledValue = Boolean.parseBoolean(enabled) ? "TRUE" : "FALSE";
@@ -8708,19 +8721,18 @@ public interface CollectionDAO {
       mysqlCondition.append(String.format("%s ", condition));
       psqlCondition.append(String.format("%s ", condition));
 
-      applyJsonArrayFilter(
-          mysqlCondition, psqlCondition, filter, "testPlatform", "testPlatforms", false);
+      SqlConditionPair conditions = new SqlConditionPair(mysqlCondition, psqlCondition, filter);
+
+      applyJsonArrayFilter(conditions, "testPlatform", "testPlatforms");
 
       if (entityType != null) {
         mysqlCondition.append("AND entityType=:entityType ");
         psqlCondition.append("AND entityType=:entityType ");
       }
 
-      applyJsonArrayFilter(
-          mysqlCondition, psqlCondition, filter, "supportedDataType", "supportedDataTypes", true);
+      applyJsonArrayFilterWithEmpty(conditions, "supportedDataType", "supportedDataTypes");
 
-      applyJsonArrayFilter(
-          mysqlCondition, psqlCondition, filter, "supportedService", "supportedServices", true);
+      applyJsonArrayFilterWithEmpty(conditions, "supportedService", "supportedServices");
 
       if (enabled != null) {
         String enabledValue = Boolean.parseBoolean(enabled) ? "TRUE" : "FALSE";

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -8543,6 +8543,41 @@ public interface CollectionDAO {
       return TestDefinition.class;
     }
 
+    default void applyJsonArrayFilter(
+        StringBuilder mysqlCondition,
+        StringBuilder psqlCondition,
+        ListFilter filter,
+        String queryParamName,
+        String jsonFieldName,
+        boolean allowEmpty) {
+      String paramValue = filter.getQueryParam(queryParamName);
+      if (paramValue != null) {
+        filter.queryParams.put(queryParamName + "Exact", paramValue);
+
+        String mysqlBaseCondition =
+            String.format(
+                "JSON_CONTAINS(json_extract(json, '$.%s'), JSON_ARRAY(:%sExact))",
+                jsonFieldName, queryParamName);
+        String psqlBaseCondition =
+            String.format(
+                "jsonb_exists(json::jsonb -> '%s', :%sExact)", jsonFieldName, queryParamName);
+
+        if (allowEmpty) {
+          mysqlCondition.append(
+              String.format(
+                  "AND (json_extract(json, '$.%s') = JSON_ARRAY() OR json_extract(json, '$.%s') IS NULL OR %s) ",
+                  jsonFieldName, jsonFieldName, mysqlBaseCondition));
+          psqlCondition.append(
+              String.format(
+                  "AND (json->>'%s' = '[]' OR json->>'%s' IS NULL OR %s) ",
+                  jsonFieldName, jsonFieldName, psqlBaseCondition));
+        } else {
+          mysqlCondition.append(String.format("AND %s ", mysqlBaseCondition));
+          psqlCondition.append(String.format("AND %s ", psqlBaseCondition));
+        }
+      }
+    }
+
     @Override
     default List<String> listBefore(
         ListFilter filter, int limit, String beforeName, String beforeId) {
@@ -8567,40 +8602,19 @@ public interface CollectionDAO {
       mysqlCondition.append(String.format("%s ", condition));
       psqlCondition.append(String.format("%s ", condition));
 
-      if (testPlatform != null) {
-        filter.queryParams.put("testPlatformLike", String.format("%%%s%%", testPlatform));
-        mysqlCondition.append("AND json_extract(json, '$.testPlatforms') LIKE :testPlatformLike ");
-        psqlCondition.append("AND json->>'testPlatforms' LIKE :testPlatformLike ");
-      }
+      applyJsonArrayFilter(
+          mysqlCondition, psqlCondition, filter, "testPlatform", "testPlatforms", false);
 
       if (entityType != null) {
         mysqlCondition.append("AND entityType=:entityType ");
         psqlCondition.append("AND entityType=:entityType ");
       }
 
-      if (supportedDataType != null) {
-        filter.queryParams.put("supportedDataTypeLike", String.format("%%%s%%", supportedDataType));
-        mysqlCondition.append(
-            "AND (json_extract(json, '$.supportedDataTypes') = JSON_ARRAY() "
-                + "OR json_extract(json, '$.supportedDataTypes') IS NULL "
-                + "OR json_extract(json, '$.supportedDataTypes') LIKE :supportedDataTypeLike) ");
-        psqlCondition.append(
-            "AND (json->>'supportedDataTypes' = '[]' "
-                + "OR json->>'supportedDataTypes' IS NULL "
-                + "OR json->>'supportedDataTypes' LIKE :supportedDataTypeLike) ");
-      }
+      applyJsonArrayFilter(
+          mysqlCondition, psqlCondition, filter, "supportedDataType", "supportedDataTypes", true);
 
-      if (supportedService != null) {
-        filter.queryParams.put("supportedServiceLike", String.format("%%%s%%", supportedService));
-        mysqlCondition.append(
-            "AND (json_extract(json, '$.supportedServices') = JSON_ARRAY() "
-                + "OR json_extract(json, '$.supportedServices') IS NULL "
-                + "OR json_extract(json, '$.supportedServices') LIKE :supportedServiceLike) ");
-        psqlCondition.append(
-            "AND (json->>'supportedServices' = '[]' "
-                + "OR json->>'supportedServices' IS NULL "
-                + "OR json->>'supportedServices' LIKE :supportedServiceLike) ");
-      }
+      applyJsonArrayFilter(
+          mysqlCondition, psqlCondition, filter, "supportedService", "supportedServices", true);
 
       if (enabled != null) {
         String enabledValue = Boolean.parseBoolean(enabled) ? "TRUE" : "FALSE";
@@ -8641,40 +8655,19 @@ public interface CollectionDAO {
       mysqlCondition.append(String.format("%s ", condition));
       psqlCondition.append(String.format("%s ", condition));
 
-      if (testPlatform != null) {
-        filter.queryParams.put("testPlatformLike", String.format("%%%s%%", testPlatform));
-        mysqlCondition.append("AND json_extract(json, '$.testPlatforms') LIKE :testPlatformLike ");
-        psqlCondition.append("AND json->>'testPlatforms' LIKE :testPlatformLike ");
-      }
+      applyJsonArrayFilter(
+          mysqlCondition, psqlCondition, filter, "testPlatform", "testPlatforms", false);
 
       if (entityType != null) {
         mysqlCondition.append("AND entityType = :entityType ");
         psqlCondition.append("AND entityType = :entityType ");
       }
 
-      if (supportedDataType != null) {
-        filter.queryParams.put("supportedDataTypeLike", String.format("%%%s%%", supportedDataType));
-        mysqlCondition.append(
-            "AND (json_extract(json, '$.supportedDataTypes') = JSON_ARRAY() "
-                + "OR json_extract(json, '$.supportedDataTypes') IS NULL "
-                + "OR json_extract(json, '$.supportedDataTypes') LIKE :supportedDataTypeLike) ");
-        psqlCondition.append(
-            "AND (json->>'supportedDataTypes' = '[]' "
-                + "OR json->>'supportedDataTypes' IS NULL "
-                + "OR json->>'supportedDataTypes' LIKE :supportedDataTypeLike) ");
-      }
+      applyJsonArrayFilter(
+          mysqlCondition, psqlCondition, filter, "supportedDataType", "supportedDataTypes", true);
 
-      if (supportedService != null) {
-        filter.queryParams.put("supportedServiceLike", String.format("%%%s%%", supportedService));
-        mysqlCondition.append(
-            "AND (json_extract(json, '$.supportedServices') = JSON_ARRAY() "
-                + "OR json_extract(json, '$.supportedServices') IS NULL "
-                + "OR json_extract(json, '$.supportedServices') LIKE :supportedServiceLike) ");
-        psqlCondition.append(
-            "AND (json->>'supportedServices' = '[]' "
-                + "OR json->>'supportedServices' IS NULL "
-                + "OR json->>'supportedServices' LIKE :supportedServiceLike) ");
-      }
+      applyJsonArrayFilter(
+          mysqlCondition, psqlCondition, filter, "supportedService", "supportedServices", true);
 
       if (enabled != null) {
         String enabledValue = Boolean.parseBoolean(enabled) ? "TRUE" : "FALSE";
@@ -8715,40 +8708,19 @@ public interface CollectionDAO {
       mysqlCondition.append(String.format("%s ", condition));
       psqlCondition.append(String.format("%s ", condition));
 
-      if (testPlatform != null) {
-        filter.queryParams.put("testPlatformLike", String.format("%%%s%%", testPlatform));
-        mysqlCondition.append("AND json_extract(json, '$.testPlatforms') LIKE :testPlatformLike ");
-        psqlCondition.append("AND json->>'testPlatforms' LIKE :testPlatformLike ");
-      }
+      applyJsonArrayFilter(
+          mysqlCondition, psqlCondition, filter, "testPlatform", "testPlatforms", false);
 
       if (entityType != null) {
         mysqlCondition.append("AND entityType=:entityType ");
         psqlCondition.append("AND entityType=:entityType ");
       }
 
-      if (supportedDataType != null) {
-        filter.queryParams.put("supportedDataTypeLike", String.format("%%%s%%", supportedDataType));
-        mysqlCondition.append(
-            "AND (json_extract(json, '$.supportedDataTypes') = JSON_ARRAY() "
-                + "OR json_extract(json, '$.supportedDataTypes') IS NULL "
-                + "OR json_extract(json, '$.supportedDataTypes') LIKE :supportedDataTypeLike) ");
-        psqlCondition.append(
-            "AND (json->>'supportedDataTypes' = '[]' "
-                + "OR json->>'supportedDataTypes' IS NULL "
-                + "OR json->>'supportedDataTypes' LIKE :supportedDataTypeLike) ");
-      }
+      applyJsonArrayFilter(
+          mysqlCondition, psqlCondition, filter, "supportedDataType", "supportedDataTypes", true);
 
-      if (supportedService != null) {
-        filter.queryParams.put("supportedServiceLike", String.format("%%%s%%", supportedService));
-        mysqlCondition.append(
-            "AND (json_extract(json, '$.supportedServices') = JSON_ARRAY() "
-                + "OR json_extract(json, '$.supportedServices') IS NULL "
-                + "OR json_extract(json, '$.supportedServices') LIKE :supportedServiceLike) ");
-        psqlCondition.append(
-            "AND (json->>'supportedServices' = '[]' "
-                + "OR json->>'supportedServices' IS NULL "
-                + "OR json->>'supportedServices' LIKE :supportedServiceLike) ");
-      }
+      applyJsonArrayFilter(
+          mysqlCondition, psqlCondition, filter, "supportedService", "supportedServices", true);
 
       if (enabled != null) {
         String enabledValue = Boolean.parseBoolean(enabled) ? "TRUE" : "FALSE";

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -8578,11 +8578,16 @@ public interface CollectionDAO {
         psqlCondition.append("AND entityType=:entityType ");
       }
 
-      if (supportedDataType != null) {
+            if (supportedDataType != null) {
         filter.queryParams.put("supportedDataTypeLike", String.format("%%%s%%", supportedDataType));
         mysqlCondition.append(
-            "AND json_extract(json, '$.supportedDataTypes') LIKE :supportedDataTypeLike ");
-        psqlCondition.append("AND json->>'supportedDataTypes' LIKE :supportedDataTypeLike ");
+            "AND (json_extract(json, '$.supportedDataTypes') = JSON_ARRAY() "
+                + "OR json_extract(json, '$.supportedDataTypes') IS NULL "
+                + "OR json_extract(json, '$.supportedDataTypes') LIKE :supportedDataTypeLike) ");
+        psqlCondition.append(
+            "AND (json->>'supportedDataTypes' = '[]' "
+                + "OR json->>'supportedDataTypes' IS NULL "
+                + "OR json->>'supportedDataTypes' LIKE :supportedDataTypeLike) ");
       }
 
       if (supportedService != null) {
@@ -8647,11 +8652,16 @@ public interface CollectionDAO {
         psqlCondition.append("AND entityType = :entityType ");
       }
 
-      if (supportedDataType != null) {
+            if (supportedDataType != null) {
         filter.queryParams.put("supportedDataTypeLike", String.format("%%%s%%", supportedDataType));
         mysqlCondition.append(
-            "AND json_extract(json, '$.supportedDataTypes') LIKE :supportedDataTypeLike ");
-        psqlCondition.append("AND json->>'supportedDataTypes' LIKE :supportedDataTypeLike ");
+            "AND (json_extract(json, '$.supportedDataTypes') = JSON_ARRAY() "
+                + "OR json_extract(json, '$.supportedDataTypes') IS NULL "
+                + "OR json_extract(json, '$.supportedDataTypes') LIKE :supportedDataTypeLike) ");
+        psqlCondition.append(
+            "AND (json->>'supportedDataTypes' = '[]' "
+                + "OR json->>'supportedDataTypes' IS NULL "
+                + "OR json->>'supportedDataTypes' LIKE :supportedDataTypeLike) ");
       }
 
       if (supportedService != null) {
@@ -8716,11 +8726,16 @@ public interface CollectionDAO {
         psqlCondition.append("AND entityType=:entityType ");
       }
 
-      if (supportedDataType != null) {
+            if (supportedDataType != null) {
         filter.queryParams.put("supportedDataTypeLike", String.format("%%%s%%", supportedDataType));
         mysqlCondition.append(
-            "AND json_extract(json, '$.supportedDataTypes') LIKE :supportedDataTypeLike ");
-        psqlCondition.append("AND json->>'supportedDataTypes' LIKE :supportedDataTypeLike ");
+            "AND (json_extract(json, '$.supportedDataTypes') = JSON_ARRAY() "
+                + "OR json_extract(json, '$.supportedDataTypes') IS NULL "
+                + "OR json_extract(json, '$.supportedDataTypes') LIKE :supportedDataTypeLike) ");
+        psqlCondition.append(
+            "AND (json->>'supportedDataTypes' = '[]' "
+                + "OR json->>'supportedDataTypes' IS NULL "
+                + "OR json->>'supportedDataTypes' LIKE :supportedDataTypeLike) ");
       }
 
       if (supportedService != null) {


### PR DESCRIPTION
### Description
This PR fixes an issue where generic Data Quality (DQ) test definitions (those without explicitly specified supportedDataTypes) were not appearing in the UI when adding test cases to columns. 

The backend filtering logic in CollectionDAO.java was previously using a strict LIKE match on the supportedDataTypes JSON field. If this field was NULL or an empty array [], the match would fail even if the test was intended to be generic.

### Changes
- Modified TestDefinitionDAO.listBefore, listAfter, and listCount in CollectionDAO.java.
- Updated the filtering logic to include tests where supportedDataTypes is NULL or an empty array.
- Ensured compatibility for both MySQL and PostgreSQL.

Fixes #27718

----
## Summary by Gitar

- **Refactoring:**
  - Introduced `SqlConditionPair` record to encapsulate `StringBuilder` conditions and `ListFilter` state.
  - Extracted JSON array filtering logic into cleaner helper methods `applyJsonArrayFilter` and `applyJsonArrayFilterWithEmpty` to reduce code duplication in `CollectionDAO`.


<sub>This will update automatically on new commits.</sub>