### PR TITLE
fix: block dangerous Elasticsearch query types in MCP searchWithDirectQuery

### DIFF
--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
@@ -14,6 +14,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.search.SearchRequest;
@@ -181,6 +183,8 @@ public class SearchMetadataTool implements McpTool {
     if (params.containsKey("queryFilter")) {
       queryFilter = (String) params.get("queryFilter");
       JsonNode queryNode = JsonUtils.getObjectMapper().readTree(queryFilter);
+
+      validateQuerySafety(queryNode);
 
       if (!queryNode.has("query")) {
         ObjectNode queryWrapper = JsonUtils.getObjectMapper().createObjectNode();
@@ -449,5 +453,65 @@ public class SearchMetadataTool implements McpTool {
   @SuppressWarnings("unchecked")
   private static List<Object> safeGetList(Object obj) {
     return (obj instanceof List) ? (List<Object>) obj : null;
+  }
+
+  /**
+   * Elasticsearch query types that allow arbitrary code execution or template expansion.
+   * These must never be allowed in user-supplied query filters as they can bypass
+   * RBAC constraints or cause denial-of-service.
+   *
+   * <ul>
+   *   <li>script — inline or stored scripts (painless/groovy)</li>
+   *   <li>script_score — script-based scoring</li>
+   *   <li>percolator — reverse query matching</li>
+   *   <li>wrapper — base64-encoded queries (can hide nested dangerous types)</li>
+   *   <li>scripted_metric — script-based aggregation (checked at root level)</li>
+   * </ul>
+   */
+  @VisibleForTesting
+  static final Set<String> BLOCKED_QUERY_TYPES =
+      Set.of(
+          "script",
+          "script_score",
+          "percolator",
+          "wrapper",
+          "scripted_metric");
+
+  /**
+   * Recursively validates that a parsed JSON query tree does not contain any blocked
+   * Elasticsearch query types (script, script_score, percolator, wrapper, scripted_metric).
+   *
+   * @param node the parsed JSON query node to validate
+   * @throws IOException if a blocked query type is found
+   */
+  @VisibleForTesting
+  static void validateQuerySafety(JsonNode node) throws IOException {
+    if (node == null || !node.isObject()) {
+      return;
+    }
+
+    for (String blockedType : BLOCKED_QUERY_TYPES) {
+      if (node.has(blockedType)) {
+        throw new IOException(
+            "queryFilter contains blocked query type '" + blockedType + "'. "
+                + "This query type is not allowed for security reasons.");
+      }
+    }
+
+    // Recurse into child objects (bool clauses, nested queries, etc.)
+    var iterator = node.fields();
+    while (iterator.hasNext()) {
+      Map.Entry<String, JsonNode> field = iterator.next();
+      JsonNode child = field.getValue();
+      if (child.isObject()) {
+        validateQuerySafety(child);
+      } else if (child.isArray()) {
+        for (JsonNode element : child) {
+          if (element.isObject()) {
+            validateQuerySafety(element);
+          }
+        }
+      }
+    }
   }
 }

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SearchMetadataTool.java
@@ -15,7 +15,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.search.SearchRequest;
@@ -475,7 +474,9 @@ public class SearchMetadataTool implements McpTool {
           "script_score",
           "percolator",
           "wrapper",
-          "scripted_metric");
+          "scripted_metric",
+          "function_score",
+          "runtime_mappings");
 
   /**
    * Recursively validates that a parsed JSON query tree does not contain any blocked

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SearchMetadataToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SearchMetadataToolTest.java
@@ -2,12 +2,15 @@ package org.openmetadata.mcp.tools;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 import jakarta.ws.rs.core.Response;
+import java.io.IOException;
 import java.security.Principal;
 import java.util.HashMap;
 import java.util.Map;
@@ -18,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.openmetadata.schema.entity.teams.User;
+import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.search.SearchRepository;
 import org.openmetadata.service.security.Authorizer;
@@ -134,5 +138,78 @@ class SearchMetadataToolTest {
       assertEquals(0, result.get("returnedCount"));
       assertNotNull(result.get("results"));
     }
+  }
+
+  // --- Query safety validation tests ---
+
+  @Test
+  void testValidateQuerySafety_blocksScriptQuery() throws Exception {
+    String maliciousQuery =
+        "{\"query\":{\"script\":{\"script\":{\"source\":\"doc['field'].value * 2\"}}}}";
+    JsonNode node = JsonUtils.getObjectMapper().readTree(maliciousQuery);
+
+    IOException ex = assertThrows(IOException.class, () -> SearchMetadataTool.validateQuerySafety(node));
+    assertTrue(ex.getMessage().contains("script"));
+  }
+
+  @Test
+  void testValidateQuerySafety_blocksScriptScoreQuery() throws Exception {
+    String maliciousQuery =
+        "{\"query\":{\"script_score\":{\"query\":{\"match_all\":{}},\"script\":{\"source\":\"1\"}}}}";
+    JsonNode node = JsonUtils.getObjectMapper().readTree(maliciousQuery);
+
+    IOException ex = assertThrows(IOException.class, () -> SearchMetadataTool.validateQuerySafety(node));
+    assertTrue(ex.getMessage().contains("script_score"));
+  }
+
+  @Test
+  void testValidateQuerySafety_blocksWrapperQuery() throws Exception {
+    String maliciousQuery =
+        "{\"query\":{\"wrapper\":{\"query\":\"eyJtYXRjaCI6e319\"}}}";
+    JsonNode node = JsonUtils.getObjectMapper().readTree(maliciousQuery);
+
+    IOException ex = assertThrows(IOException.class, () -> SearchMetadataTool.validateQuerySafety(node));
+    assertTrue(ex.getMessage().contains("wrapper"));
+  }
+
+  @Test
+  void testValidateQuerySafety_blocksNestedScript() throws Exception {
+    // Script hidden inside a bool -> should clause
+    String maliciousQuery =
+        "{\"query\":{\"bool\":{\"should\":[{\"script\":{\"script\":{\"source\":\"painful\"}}}]}}}";
+    JsonNode node = JsonUtils.getObjectMapper().readTree(maliciousQuery);
+
+    IOException ex = assertThrows(IOException.class, () -> SearchMetadataTool.validateQuerySafety(node));
+    assertTrue(ex.getMessage().contains("script"));
+  }
+
+  @Test
+  void testValidateQuerySafety_allowsSafeQuery() throws Exception {
+    String safeQuery =
+        "{\"query\":{\"bool\":{\"must\":[{\"match\":{\"name\":\"test\"}}],\"filter\":[{\"term\":{\"deleted\":false}}]}}}";
+    JsonNode node = JsonUtils.getObjectMapper().readTree(safeQuery);
+
+    // Should not throw
+    SearchMetadataTool.validateQuerySafety(node);
+  }
+
+  @Test
+  void testValidateQuerySafety_blocksPercolatorQuery() throws Exception {
+    String maliciousQuery =
+        "{\"query\":{\"percolator\":{\"field\":\"query\"}}}";
+    JsonNode node = JsonUtils.getObjectMapper().readTree(maliciousQuery);
+
+    IOException ex = assertThrows(IOException.class, () -> SearchMetadataTool.validateQuerySafety(node));
+    assertTrue(ex.getMessage().contains("percolator"));
+  }
+
+  @Test
+  void testValidateQuerySafety_blocksScriptedMetric() throws Exception {
+    String maliciousQuery =
+        "{\"scripted_metric\":{\"init_script\":\"state.transactions = []\"}}";
+    JsonNode node = JsonUtils.getObjectMapper().readTree(maliciousQuery);
+
+    IOException ex = assertThrows(IOException.class, () -> SearchMetadataTool.validateQuerySafety(node));
+    assertTrue(ex.getMessage().contains("scripted_metric"));
   }
 }

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SearchMetadataToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SearchMetadataToolTest.java
@@ -212,4 +212,24 @@ class SearchMetadataToolTest {
     IOException ex = assertThrows(IOException.class, () -> SearchMetadataTool.validateQuerySafety(node));
     assertTrue(ex.getMessage().contains("scripted_metric"));
   }
+
+  @Test
+  void testValidateQuerySafety_blocksFunctionScore() throws Exception {
+    String maliciousQuery =
+        "{\"query\":{\"function_score\":{\"query\":{\"match_all\":{}},\"functions\":[{\"script_score\":{\"script\":{\"source\":\"1\"}}}]}}}";
+    JsonNode node = JsonUtils.getObjectMapper().readTree(maliciousQuery);
+
+    IOException ex = assertThrows(IOException.class, () -> SearchMetadataTool.validateQuerySafety(node));
+    assertTrue(ex.getMessage().contains("function_score"));
+  }
+
+  @Test
+  void testValidateQuerySafety_blocksRuntimeMappings() throws Exception {
+    String maliciousQuery =
+        "{\"runtime_mappings\":{\"evil\":{\"type\":\"long\",\"script\":{\"source\":\"emit(doc['field'].value * 2)\"}}}}";
+    JsonNode node = JsonUtils.getObjectMapper().readTree(maliciousQuery);
+
+    IOException ex = assertThrows(IOException.class, () -> SearchMetadataTool.validateQuerySafety(node));
+    assertTrue(ex.getMessage().contains("runtime_mappings"));
+  }
 }


### PR DESCRIPTION
## Summary

The MCP `searchMetadata` tool accepts a user-controlled `queryFilter` that is parsed as raw JSON and passed directly to Elasticsearch via `Query.of(q -> q.withJson(...))`. While RBAC conditions are applied as filters afterward, the user query itself is not validated for dangerous query types.

This means an authenticated MCP user could craft queries using:
- **`script`** — execute arbitrary Painless/Groovy scripts server-side
- **`script_score`** — script-based scoring with arbitrary code
- **`wrapper`** — base64-encoded queries that can hide nested dangerous types
- **`percolator`** — reverse query matching
- **`scripted_metric`** — script-based aggregation with init/map/combine/reduce scripts

## Fix

Add `validateQuerySafety()` which recursively walks the parsed JSON query tree and rejects any node containing a blocked query type key:

```java
static final Set<String> BLOCKED_QUERY_TYPES =
    Set.of("script", "script_score", "percolator", "wrapper", "scripted_metric");

static void validateQuerySafety(JsonNode node) throws IOException {
    if (node == null || !node.isObject()) return;
    for (String blockedType : BLOCKED_QUERY_TYPES) {
        if (node.has(blockedType)) {
            throw new IOException("queryFilter contains blocked query type

----
## Summary by Gitar

- **Security enhancements:**
  - Added `function_score` and `runtime_mappings` to `BLOCKED_QUERY_TYPES` in `SearchMetadataTool` to prevent potential injection vulnerabilities.
- **Testing:**
  - Added unit tests in `SearchMetadataToolTest` to verify that `function_score` and `runtime_mappings` are correctly rejected.

<sub>This will update automatically on new commits.</sub>