### PR TITLE
Fix server-side role search behavior across role selectors

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SSOConfiguration.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SSOConfiguration.spec.ts
@@ -680,6 +680,7 @@ test.describe('SSO Configuration Tests', () => {
       page,
     }) => {
       await selectSSOProvider(page, 'ldap');
+      await page.waitForResponse('/api/v1/roles/search?*');
 
       const addMappingButton = page.getByTestId('add-mapping-btn');
       const ldapGroupInputs = page.locator(
@@ -747,6 +748,7 @@ test.describe('SSO Configuration Tests', () => {
       page,
     }) => {
       await selectSSOProvider(page, 'ldap');
+      await page.waitForResponse('/api/v1/roles/search?*');
 
       const field = page.getByTestId(
         'sso-configuration-form-array-field-template-authReassignRoles'
@@ -760,8 +762,13 @@ test.describe('SSO Configuration Tests', () => {
       // Opening the dropdown shows API-fetched role options
       await field.click();
       await expect(dropdown).toBeVisible();
+      await field.locator('input').fill('');
+      await page.waitForResponse('/api/v1/roles/search?*');
       await expect(dropdown.locator('.ant-select-item-option')).not.toHaveCount(
-        0
+        0,
+        {
+          timeout: 15000,
+        }
       );
 
       // Select the first available role — it appears as a selection tag
@@ -780,15 +787,20 @@ test.describe('SSO Configuration Tests', () => {
       // Typing filters the visible options
       await field.click();
       await field.locator('input').fill('Data');
+      await page.waitForResponse('/api/v1/roles/search?*');
       await expect(
         dropdown.locator(
           '.ant-select-item-option:not(.ant-select-item-option-disabled)'
         )
-      ).not.toHaveCount(0);
+      ).not.toHaveCount(0, { timeout: 15000 });
 
       // Pressing Enter on a non-existent value does not create an arbitrary tag
       await field.locator('input').clear();
+      const missingRoleSearchResponse = page.waitForResponse(
+        '/api/v1/roles/search?*'
+      );
       await field.locator('input').fill('NonExistentRoleXYZ123');
+      await missingRoleSearchResponse;
       await field.locator('input').press('Enter');
       await expect(field.locator('.ant-select-selection-item')).toHaveCount(0);
     });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SSOConfiguration.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SSOConfiguration.spec.ts
@@ -680,7 +680,6 @@ test.describe('SSO Configuration Tests', () => {
       page,
     }) => {
       await selectSSOProvider(page, 'ldap');
-      await page.waitForResponse('/api/v1/roles/search?*');
 
       const addMappingButton = page.getByTestId('add-mapping-btn');
       const ldapGroupInputs = page.locator(
@@ -748,7 +747,6 @@ test.describe('SSO Configuration Tests', () => {
       page,
     }) => {
       await selectSSOProvider(page, 'ldap');
-      await page.waitForResponse('/api/v1/roles/search?*');
 
       const field = page.getByTestId(
         'sso-configuration-form-array-field-template-authReassignRoles'
@@ -762,13 +760,8 @@ test.describe('SSO Configuration Tests', () => {
       // Opening the dropdown shows API-fetched role options
       await field.click();
       await expect(dropdown).toBeVisible();
-      await field.locator('input').fill('');
-      await page.waitForResponse('/api/v1/roles/search?*');
       await expect(dropdown.locator('.ant-select-item-option')).not.toHaveCount(
-        0,
-        {
-          timeout: 15000,
-        }
+        0
       );
 
       // Select the first available role — it appears as a selection tag

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/AddRoleAndAssignToUser.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/AddRoleAndAssignToUser.spec.ts
@@ -79,7 +79,9 @@ test.describe.serial('Add role and assign it to the user', () => {
   test('Create new user and assign new role to him', async ({ page }) => {
     await settingClick(page, GlobalSettingOptions.USERS);
 
+    const initialRolesResponse = page.waitForResponse('/api/v1/roles/search?*');
     await page.click('[data-testid="add-user"]');
+    await initialRolesResponse;
 
     await page.fill('[data-testid="email"]', user.email);
     await page.fill('[data-testid="displayName"]', userDisplayName);
@@ -96,7 +98,9 @@ test.describe.serial('Add role and assign it to the user', () => {
     await page.locator('.ant-select-dropdown').waitFor({
       state: 'visible',
     });
+    const rolesSearchResponse = page.waitForResponse('/api/v1/roles/search?*');
     await page.fill('#roles', roleName);
+    await rolesSearchResponse;
     await page.click(`[title="${roleName}"]`);
 
     await page.keyboard.press('Escape');

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts
@@ -2714,7 +2714,9 @@ test.describe('Domains Rbac', () => {
 
     // Add domain role to the user
     await visitUserProfilePage(page, user1.responseData.name);
+    const initialRolesResponse = page.waitForResponse('/api/v1/roles/search?*');
     await page.getByTestId('edit-roles-button').click();
+    await initialRolesResponse;
 
     await page.locator('[data-testid="user-profile-edit-popover"]').isVisible();
     const rolesCombobox = page.locator('input[role="combobox"]').nth(1);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/UserDetails.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/UserDetails.spec.ts
@@ -501,7 +501,11 @@ test.describe('User with different Roles', () => {
 
     await expect(adminPage.getByTestId('user-profile-roles')).toBeVisible();
 
+    const initialRolesResponse = adminPage.waitForResponse(
+      '/api/v1/roles/search?*'
+    );
     await adminPage.getByTestId('edit-roles-button').click();
+    await initialRolesResponse;
 
     await expect(
       adminPage.getByTestId('profile-edit-roles-select')
@@ -511,6 +515,15 @@ test.describe('User with different Roles', () => {
       state: 'visible',
     });
 
+    await adminPage
+      .getByTestId('profile-edit-roles-select')
+      .locator('input')
+      .fill('Application');
+    await adminPage.waitForResponse('/api/v1/roles/search?*');
+    await adminPage
+      .locator('.ant-select-item-option-content')
+      .getByText('Application bot role', { exact: true })
+      .waitFor({ state: 'visible' });
     await adminPage
       .locator('.ant-select-item-option-content')
       .getByText('Application bot role', { exact: true })

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/user.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/user.ts
@@ -710,7 +710,7 @@ export const addUser = async (
   await waitForAllLoadersToDisappear(page);
   await page.click('[data-testid="add-user"]');
 
-  await page.waitForResponse('/api/v1/roles?default=false&limit=100&fields=');
+  await page.waitForResponse('/api/v1/roles/search?*');
   await page.fill('[data-testid="email"]', email);
 
   await page.fill('[data-testid="displayName"]', name);
@@ -726,7 +726,9 @@ export const addUser = async (
     .getByRole('combobox');
   await expect(rolesCombobox).toBeVisible({ timeout: 120000 });
   await rolesCombobox.click();
+  const rolesSearchResponse = page.waitForResponse('/api/v1/roles/search?*');
   await rolesCombobox.fill(role);
+  await rolesSearchResponse;
   const roleOption = page
     .locator('.ant-select-item-option-content')
     .filter({ hasText: new RegExp(`^${role}$`) })

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Bot/BotDetails/BotDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Bot/BotDetails/BotDetails.component.tsx
@@ -15,7 +15,7 @@ import { CheckOutlined, CloseOutlined } from '@ant-design/icons';
 import { Button, Card, Col, Input, Row, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import { debounce, toLower, uniqBy } from 'lodash';
-import { FC, useCallback, useEffect, useMemo, useState } from 'react';
+import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ReactComponent as IconBotProfile } from '../../../../assets/svg/bot-profile.svg';
 import { TERM_ADMIN } from '../../../../constants/constants';
@@ -49,6 +49,7 @@ const BotDetails: FC<BotsDetailProps> = ({
   const [selectedRoles, setSelectedRoles] = useState<Array<string>>([]);
   const [roles, setRoles] = useState<Array<Role>>([]);
   const [isRolesLoading, setIsRolesLoading] = useState(false);
+  const selectedRolesRef = useRef<string[]>([]);
   const { getResourceLimit, config } = useLimitStore();
 
   const [disableFields, setDisableFields] = useState<string[]>(['token']);
@@ -82,7 +83,7 @@ const BotDetails: FC<BotsDetailProps> = ({
       const data = await searchRoles(query);
       setRoles((prevRoles) => {
         const selectedRoleOptions = prevRoles.filter((role) =>
-          selectedRoles.includes(role.id)
+          selectedRolesRef.current.includes(role.id)
         );
 
         return uniqBy([...selectedRoleOptions, ...data], 'id');
@@ -92,7 +93,7 @@ const BotDetails: FC<BotsDetailProps> = ({
     } finally {
       setIsRolesLoading(false);
     }
-  }, [selectedRoles]);
+  }, []);
 
   const debouncedFetchRoles = useMemo(
     () => debounce(fetchRoles, 300),
@@ -222,6 +223,10 @@ const BotDetails: FC<BotsDetailProps> = ({
       </Row>
     );
   };
+
+  useEffect(() => {
+    selectedRolesRef.current = selectedRoles;
+  }, [selectedRoles]);
 
   useEffect(() => {
     fetchRoles();

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Bot/BotDetails/BotDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Bot/BotDetails/BotDetails.component.tsx
@@ -14,16 +14,16 @@
 import { CheckOutlined, CloseOutlined } from '@ant-design/icons';
 import { Button, Card, Col, Input, Row, Typography } from 'antd';
 import { AxiosError } from 'axios';
-import { toLower } from 'lodash';
-import { FC, useEffect, useMemo, useState } from 'react';
+import { debounce, toLower, uniqBy } from 'lodash';
+import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ReactComponent as IconBotProfile } from '../../../../assets/svg/bot-profile.svg';
-import { PAGE_SIZE_LARGE, TERM_ADMIN } from '../../../../constants/constants';
+import { TERM_ADMIN } from '../../../../constants/constants';
 import { GlobalSettingOptions } from '../../../../constants/GlobalSettings.constants';
 import { useLimitStore } from '../../../../context/LimitsProvider/useLimitsStore';
 import { EntityType } from '../../../../enums/entity.enum';
 import { Role } from '../../../../generated/entity/teams/role';
-import { getAllRoles } from '../../../../rest/rolesAPIV1';
+import { searchRoles } from '../../../../rest/rolesAPIV1';
 import { getEntityName } from '../../../../utils/EntityUtils';
 import { getSettingPath } from '../../../../utils/RouterUtils';
 import { showErrorToast } from '../../../../utils/ToastUtils';
@@ -48,6 +48,7 @@ const BotDetails: FC<BotsDetailProps> = ({
   const [isDisplayNameEdit, setIsDisplayNameEdit] = useState(false);
   const [selectedRoles, setSelectedRoles] = useState<Array<string>>([]);
   const [roles, setRoles] = useState<Array<Role>>([]);
+  const [isRolesLoading, setIsRolesLoading] = useState(false);
   const { getResourceLimit, config } = useLimitStore();
 
   const [disableFields, setDisableFields] = useState<string[]>(['token']);
@@ -74,15 +75,29 @@ const BotDetails: FC<BotsDetailProps> = ({
     }
   };
 
-  const fetchRoles = async () => {
+  const fetchRoles = useCallback(async (query = '') => {
+    setIsRolesLoading(true);
+
     try {
-      const data = await getAllRoles('', false, PAGE_SIZE_LARGE);
-      setRoles(data);
+      const data = await searchRoles(query);
+      setRoles((prevRoles) => {
+        const selectedRoleOptions = prevRoles.filter((role) =>
+          selectedRoles.includes(role.id)
+        );
+
+        return uniqBy([...selectedRoleOptions, ...data], 'id');
+      });
     } catch (err) {
-      setRoles([]);
       showErrorToast(err as AxiosError);
+    } finally {
+      setIsRolesLoading(false);
     }
-  };
+  }, [selectedRoles]);
+
+  const debouncedFetchRoles = useMemo(
+    () => debounce(fetchRoles, 300),
+    [fetchRoles]
+  );
 
   const onDisplayNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setDisplayName(e.target.value);
@@ -190,7 +205,9 @@ const BotDetails: FC<BotsDetailProps> = ({
         </Col>
         <Col span={24}>
           <RolesCard
+            isRolesLoading={isRolesLoading}
             roles={roles}
+            searchRolesOptions={debouncedFetchRoles}
             selectedRoles={selectedRoles}
             setSelectedRoles={(selectedRoles) =>
               setSelectedRoles(selectedRoles)
@@ -212,7 +229,26 @@ const BotDetails: FC<BotsDetailProps> = ({
   }, []);
 
   useEffect(() => {
+    return () => {
+      debouncedFetchRoles.cancel();
+    };
+  }, [debouncedFetchRoles]);
+
+  useEffect(() => {
     prepareSelectedRoles();
+    setRoles((prevRoles) =>
+      uniqBy(
+        [
+          ...prevRoles,
+          ...((botUserData.roles ?? []).map((role) => ({
+            id: role.id,
+            name: role.name ?? '',
+            displayName: role.displayName,
+          })) as Role[]),
+        ],
+        'id'
+      )
+    );
   }, [botUserData]);
 
   return (

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Bot/BotDetails/BotDetails.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Bot/BotDetails/BotDetails.test.tsx
@@ -14,6 +14,7 @@
 import { act, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { OperationPermission } from '../../../../context/PermissionProvider/PermissionProvider.interface';
+import { searchRoles } from '../../../../rest/rolesAPIV1';
 import { getAuthMechanismForBotUser } from '../../../../rest/userAPI';
 import AccessTokenCard from '../../Users/AccessTokenCard/AccessTokenCard.component';
 import BotDetails from './BotDetails.component';
@@ -93,6 +94,10 @@ jest.mock('../../../../utils/PermissionsUtils', () => ({
   checkPermission: jest.fn().mockReturnValue(true),
 }));
 
+jest.mock('../../../../rest/rolesAPIV1', () => ({
+  searchRoles: jest.fn().mockResolvedValue([]),
+}));
+
 const mockGetResourceLimit = jest.fn().mockResolvedValue({
   configuredLimit: { disabledFields: [] },
 });
@@ -146,6 +151,10 @@ jest.mock('../../../../context/LimitsProvider/useLimitsStore', () => ({
 }));
 
 describe('Test BotsDetail Component', () => {
+  beforeEach(() => {
+    (searchRoles as jest.Mock).mockResolvedValue([]);
+  });
+
   it('Should render all child elements', async () => {
     await act(async () => {
       render(<BotDetails {...mockProp} />, {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/CreateUser/CreateUser.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/CreateUser/CreateUser.component.tsx
@@ -24,8 +24,8 @@ import {
   Switch,
 } from 'antd';
 import { AxiosError } from 'axios';
-import { compact, isEmpty, isUndefined, map, trim } from 'lodash';
-import { useEffect, useMemo, useState } from 'react';
+import { compact, debounce, isEmpty, isUndefined, map, trim, uniqBy } from 'lodash';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 import { ReactComponent as IconSync } from '../../../../assets/svg/ic-sync.svg';
@@ -55,8 +55,8 @@ import {
 } from '../../../../interface/FormUtils.interface';
 import { generateRandomPwd } from '../../../../rest/auth-API';
 import { getAllPersonas } from '../../../../rest/PersonaAPI';
+import { searchRoles } from '../../../../rest/rolesAPIV1';
 import { getJWTTokenExpiryOptions } from '../../../../utils/BotsUtils';
-import { handleSearchFilterOption } from '../../../../utils/CommonUtils';
 import {
   getEntityName,
   getEntityReferenceListFromEntities,
@@ -72,7 +72,6 @@ import TeamsSelectable from '../../Team/TeamsSelectable/TeamsSelectable';
 import { CreateUserProps } from './CreateUser.interface';
 
 const CreateUser = ({
-  roles,
   isLoading,
   onCancel,
   onSave,
@@ -92,6 +91,10 @@ const CreateUser = ({
   const [selectedTeams, setSelectedTeams] = useState<
     Array<EntityReference | undefined>
   >([]);
+  const [roleOptions, setRoleOptions] = useState<
+    Array<{ label: string; value: string }>
+  >([]);
+  const [isRolesLoading, setIsRolesLoading] = useState(false);
   const [isPasswordGenerating, setIsPasswordGenerating] = useState(false);
   const { activeDomainEntityRef } = useDomainStore();
   const selectedDomain =
@@ -135,12 +138,33 @@ const CreateUser = ({
   const selectedRoles = Form.useWatch('roles', form);
   const selectedPersonas = Form.useWatch('personas', form);
 
-  const roleOptions = useMemo(() => {
-    return map(roles, (role) => ({
-      label: getEntityName(role),
-      value: role.id,
-    }));
-  }, [roles]);
+  const fetchRoleOptions = useCallback(async (searchText = '') => {
+    setIsRolesLoading(true);
+
+    try {
+      const roles = await searchRoles(searchText);
+      const nextOptions = map(roles, (role) => ({
+        label: getEntityName(role),
+        value: role.id,
+      }));
+
+      setRoleOptions((prevOptions) => {
+        const selectedRoleOptions = prevOptions.filter((option) =>
+          (selectedRoles ?? []).includes(String(option.value))
+        );
+
+        return uniqBy([...selectedRoleOptions, ...nextOptions], 'value');
+      });
+    } catch (error) {
+      showErrorToast(
+        error as AxiosError,
+        t('server.entity-fetch-error', { entity: t('label.role-plural') })
+      );
+      setRoleOptions([]);
+    } finally {
+      setIsRolesLoading(false);
+    }
+  }, [selectedRoles, t]);
 
   const fetchPersonaOptions = async (_searchText: string, page?: number) => {
     try {
@@ -263,6 +287,23 @@ const CreateUser = ({
   useEffect(() => {
     generateRandomPassword();
   }, []);
+
+  useEffect(() => {
+    if (!forceBot && !isAdminPage) {
+      fetchRoleOptions();
+    }
+  }, [forceBot, isAdminPage]);
+
+  const debouncedFetchRoleOptions = useMemo(
+    () => debounce(fetchRoleOptions, 300),
+    [fetchRoleOptions]
+  );
+
+  useEffect(() => {
+    return () => {
+      debouncedFetchRoleOptions.cancel();
+    };
+  }, [debouncedFetchRoleOptions]);
 
   return (
     <Form
@@ -442,14 +483,17 @@ const CreateUser = ({
               <Form.Item label={t('label.role-plural')} name="roles">
                 <Select
                   data-testid="roles-dropdown"
-                  disabled={isEmpty(roles)}
-                  filterOption={handleSearchFilterOption}
+                  disabled={isRolesLoading && isEmpty(roleOptions)}
+                  filterOption={false}
                   getPopupContainer={(triggerNode) => triggerNode.parentElement}
+                  loading={isRolesLoading}
                   mode="multiple"
                   options={roleOptions}
                   placeholder={t('label.please-select-entity', {
                     entity: t('label.role-plural'),
                   })}
+                  showSearch
+                  onSearch={debouncedFetchRoleOptions}
                 />
               </Form.Item>
               <Form.Item label={t('label.persona-plural')} name="personas">

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/CreateUser/CreateUser.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/CreateUser/CreateUser.component.tsx
@@ -24,7 +24,15 @@ import {
   Switch,
 } from 'antd';
 import { AxiosError } from 'axios';
-import { compact, debounce, isEmpty, isUndefined, map, trim, uniqBy } from 'lodash';
+import {
+  compact,
+  debounce,
+  isEmpty,
+  isUndefined,
+  map,
+  trim,
+  uniqBy,
+} from 'lodash';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
@@ -138,33 +146,35 @@ const CreateUser = ({
   const selectedRoles = Form.useWatch('roles', form);
   const selectedPersonas = Form.useWatch('personas', form);
 
-  const fetchRoleOptions = useCallback(async (searchText = '') => {
-    setIsRolesLoading(true);
+  const fetchRoleOptions = useCallback(
+    async (searchText = '') => {
+      setIsRolesLoading(true);
 
-    try {
-      const roles = await searchRoles(searchText);
-      const nextOptions = map(roles, (role) => ({
-        label: getEntityName(role),
-        value: role.id,
-      }));
+      try {
+        const roles = await searchRoles(searchText);
+        const nextOptions = map(roles, (role) => ({
+          label: getEntityName(role),
+          value: role.id,
+        }));
 
-      setRoleOptions((prevOptions) => {
-        const selectedRoleOptions = prevOptions.filter((option) =>
-          (selectedRoles ?? []).includes(String(option.value))
+        setRoleOptions((prevOptions) => {
+          const selectedRoleOptions = prevOptions.filter((option) =>
+            (selectedRoles ?? []).includes(String(option.value))
+          );
+
+          return uniqBy([...selectedRoleOptions, ...nextOptions], 'value');
+        });
+      } catch (error) {
+        showErrorToast(
+          error as AxiosError,
+          t('server.entity-fetch-error', { entity: t('label.role-plural') })
         );
-
-        return uniqBy([...selectedRoleOptions, ...nextOptions], 'value');
-      });
-    } catch (error) {
-      showErrorToast(
-        error as AxiosError,
-        t('server.entity-fetch-error', { entity: t('label.role-plural') })
-      );
-      setRoleOptions([]);
-    } finally {
-      setIsRolesLoading(false);
-    }
-  }, [selectedRoles, t]);
+      } finally {
+        setIsRolesLoading(false);
+      }
+    },
+    [selectedRoles, t]
+  );
 
   const fetchPersonaOptions = async (_searchText: string, page?: number) => {
     try {
@@ -482,6 +492,7 @@ const CreateUser = ({
               </Form.Item>
               <Form.Item label={t('label.role-plural')} name="roles">
                 <Select
+                  showSearch
                   data-testid="roles-dropdown"
                   disabled={isRolesLoading && isEmpty(roleOptions)}
                   filterOption={false}
@@ -492,7 +503,6 @@ const CreateUser = ({
                   placeholder={t('label.please-select-entity', {
                     entity: t('label.role-plural'),
                   })}
-                  showSearch
                   onSearch={debouncedFetchRoleOptions}
                 />
               </Form.Item>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/CreateUser/CreateUser.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/CreateUser/CreateUser.interface.ts
@@ -12,11 +12,9 @@
  */
 
 import { CreateUser } from '../../../../generated/api/teams/createUser';
-import { Role } from '../../../../generated/entity/teams/role';
 
 export interface CreateUserProps {
   isLoading?: boolean;
-  roles: Array<Role>;
   onSave: (data: CreateUser) => void;
   onCancel: () => void;
   forceBot: boolean;

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/CreateUser/CreateUser.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/CreateUser/CreateUser.test.tsx
@@ -17,9 +17,11 @@ import {
   queryByTestId,
   queryByText,
   render,
+  waitFor,
 } from '@testing-library/react';
 import { forwardRef } from 'react';
 import { MemoryRouter, useLocation } from 'react-router-dom';
+import { searchRoles } from '../../../../rest/rolesAPIV1';
 import CreateUser from './CreateUser.component';
 import { CreateUserProps } from './CreateUser.interface';
 
@@ -55,6 +57,10 @@ jest.mock('../../../../rest/auth-API', () => ({
   generateRandomPwd: jest.fn().mockResolvedValue('randomPassword123!'),
 }));
 
+jest.mock('../../../../rest/rolesAPIV1', () => ({
+  searchRoles: jest.fn().mockResolvedValue([]),
+}));
+
 jest.mock('@openmetadata/ui-core-components', () => ({
   Tooltip: jest.fn().mockImplementation(({ children }) => <>{children}</>),
   TooltipTrigger: jest
@@ -83,7 +89,6 @@ jest.mock('../../../common/RichTextEditor/RichTextEditor', () => {
 
 const propsValue: CreateUserProps = {
   isLoading: false,
-  roles: [],
   forceBot: false,
   onSave: jest.fn(),
   onCancel: jest.fn(),
@@ -93,6 +98,10 @@ describe('Test CreateUser component', () => {
   it('CreateUser component should render properly', async () => {
     const { container } = render(<CreateUser {...propsValue} />, {
       wrapper: MemoryRouter,
+    });
+
+    await waitFor(() => {
+      expect(searchRoles).toHaveBeenCalledWith('');
     });
 
     const email = await findByTestId(container, 'email');

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UsersProfile/UserProfileRoles/UserProfileRoles.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UsersProfile/UserProfileRoles/UserProfileRoles.component.tsx
@@ -49,6 +49,7 @@ const UserProfileRoles = ({
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [isRolesLoading, setIsRolesLoading] = useState<boolean>(false);
   const [isDropdownOpen, setIsDropdownOpen] = useState<boolean>(false);
+  const selectedRolesRef = useRef<string[]>([]);
 
   const useRolesOption = useMemo(() => {
     const options = roles?.map((role) => ({
@@ -66,29 +67,32 @@ const UserProfileRoles = ({
     return options;
   }, [roles, isUserAdmin, getEntityName]);
 
-  const fetchRoles = useCallback(async (query = '') => {
-    setIsRolesLoading(true);
+  const fetchRoles = useCallback(
+    async (query = '') => {
+      setIsRolesLoading(true);
 
-    try {
-      const response = await searchRoles(query);
-      setRoles((prevRoles) => {
-        const selectedRoleOptions = prevRoles.filter((role) =>
-          selectedRoles.includes(role.id)
+      try {
+        const response = await searchRoles(query);
+        setRoles((prevRoles) => {
+          const selectedRoleOptions = prevRoles.filter((role) =>
+            selectedRolesRef.current.includes(role.id)
+          );
+
+          return uniqBy([...selectedRoleOptions, ...response], 'id');
+        });
+      } catch (err) {
+        showErrorToast(
+          err as AxiosError,
+          t('server.entity-fetch-error', {
+            entity: t('label.role-plural'),
+          })
         );
-
-        return uniqBy([...selectedRoleOptions, ...response], 'id');
-      });
-    } catch (err) {
-      showErrorToast(
-        err as AxiosError,
-        t('server.entity-fetch-error', {
-          entity: t('label.role-plural'),
-        })
-      );
-    } finally {
-      setIsRolesLoading(false);
-    }
-  }, [selectedRoles, t]);
+      } finally {
+        setIsRolesLoading(false);
+      }
+    },
+    [t]
+  );
 
   const debouncedFetchRoles = useMemo(
     () => debounce(fetchRoles, 300),
@@ -154,6 +158,10 @@ const UserProfileRoles = ({
     setIsRolesEdit(false);
     setUserRoles();
   }, [setUserRoles]);
+
+  useEffect(() => {
+    selectedRolesRef.current = selectedRoles;
+  }, [selectedRoles]);
 
   useEffect(() => {
     setUserRoles();

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UsersProfile/UserProfileRoles/UserProfileRoles.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UsersProfile/UserProfileRoles/UserProfileRoles.component.tsx
@@ -13,7 +13,7 @@
 
 import { Button, Divider, Popover, Select, Tooltip, Typography } from 'antd';
 import { AxiosError } from 'axios';
-import { isEmpty, toLower } from 'lodash';
+import { debounce, toLower, uniqBy } from 'lodash';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ReactComponent as EditIcon } from '../../../../../assets/svg/edit-new.svg';
@@ -21,15 +21,11 @@ import { ReactComponent as ClosePopoverIcon } from '../../../../../assets/svg/ic
 import { ReactComponent as SavePopoverIcon } from '../../../../../assets/svg/ic-popover-save.svg';
 import { ReactComponent as RoleIcon } from '../../../../../assets/svg/ic-roles.svg';
 
-import {
-  PAGE_SIZE_LARGE,
-  TERM_ADMIN,
-} from '../../../../../constants/constants';
+import { TERM_ADMIN } from '../../../../../constants/constants';
 import { EntityType } from '../../../../../enums/entity.enum';
 import { Role } from '../../../../../generated/entity/teams/role';
 import { useAuth } from '../../../../../hooks/authHooks';
-import { getRoles } from '../../../../../rest/rolesAPIV1';
-import { handleSearchFilterOption } from '../../../../../utils/CommonUtils';
+import { searchRoles } from '../../../../../rest/rolesAPIV1';
 import { getEntityName } from '../../../../../utils/EntityUtils';
 import { showErrorToast } from '../../../../../utils/ToastUtils';
 import Chip from '../../../../common/Chip/Chip.component';
@@ -51,6 +47,7 @@ const UserProfileRoles = ({
   const [selectedRoles, setSelectedRoles] = useState<string[]>([]);
   const [roles, setRoles] = useState<Role[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isRolesLoading, setIsRolesLoading] = useState<boolean>(false);
   const [isDropdownOpen, setIsDropdownOpen] = useState<boolean>(false);
 
   const useRolesOption = useMemo(() => {
@@ -69,16 +66,18 @@ const UserProfileRoles = ({
     return options;
   }, [roles, isUserAdmin, getEntityName]);
 
-  const fetchRoles = async () => {
+  const fetchRoles = useCallback(async (query = '') => {
+    setIsRolesLoading(true);
+
     try {
-      const response = await getRoles(
-        '',
-        undefined,
-        undefined,
-        false,
-        PAGE_SIZE_LARGE
-      );
-      setRoles(response.data);
+      const response = await searchRoles(query);
+      setRoles((prevRoles) => {
+        const selectedRoleOptions = prevRoles.filter((role) =>
+          selectedRoles.includes(role.id)
+        );
+
+        return uniqBy([...selectedRoleOptions, ...response], 'id');
+      });
     } catch (err) {
       showErrorToast(
         err as AxiosError,
@@ -86,8 +85,15 @@ const UserProfileRoles = ({
           entity: t('label.role-plural'),
         })
       );
+    } finally {
+      setIsRolesLoading(false);
     }
-  };
+  }, [selectedRoles, t]);
+
+  const debouncedFetchRoles = useMemo(
+    () => debounce(fetchRoles, 300),
+    [fetchRoles]
+  );
 
   const setUserRoles = useCallback(() => {
     const defaultUserRoles = [
@@ -154,10 +160,32 @@ const UserProfileRoles = ({
   }, [setUserRoles]);
 
   useEffect(() => {
-    if (isRolesEdit && isEmpty(roles)) {
+    setRoles((prevRoles) =>
+      uniqBy(
+        [
+          ...(prevRoles ?? []),
+          ...((userRoles ?? []).map((role) => ({
+            id: role.id,
+            name: role.name ?? '',
+            displayName: role.displayName,
+          })) as Role[]),
+        ],
+        'id'
+      )
+    );
+  }, [userRoles]);
+
+  useEffect(() => {
+    if (isRolesEdit) {
       fetchRoles();
     }
-  }, [isRolesEdit, roles]);
+  }, [isRolesEdit]);
+
+  useEffect(() => {
+    return () => {
+      debouncedFetchRoles.cancel();
+    };
+  }, [debouncedFetchRoles]);
 
   useEffect(() => {
     setIsDropdownOpen(isRolesEdit);
@@ -238,8 +266,8 @@ const UserProfileRoles = ({
                     className="w-full"
                     data-testid="profile-edit-roles-select"
                     dropdownMatchSelectWidth={false}
-                    filterOption={handleSearchFilterOption}
-                    loading={isLoading}
+                    filterOption={false}
+                    loading={isRolesLoading}
                     maxTagCount={3}
                     maxTagPlaceholder={(omittedValues) => (
                       <span className="max-tag-text">
@@ -257,6 +285,7 @@ const UserProfileRoles = ({
                     value={selectedRoles}
                     onChange={setSelectedRoles}
                     onDropdownVisibleChange={handleDropdownChange}
+                    onSearch={debouncedFetchRoles}
                   />
                 </div>
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UsersProfile/UserProfileRoles/UserProfileRoles.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/UsersProfile/UserProfileRoles/UserProfileRoles.test.tsx
@@ -20,8 +20,7 @@ import {
 } from '@testing-library/react';
 import { useAuth } from '../../../../../hooks/authHooks';
 import { MOCK_USER_ROLE } from '../../../../../mocks/User.mock';
-import { getRoles } from '../../../../../rest/rolesAPIV1';
-import { mockUserRole } from '../../mocks/User.mocks';
+import { searchRoles } from '../../../../../rest/rolesAPIV1';
 import UserProfileRoles from './UserProfileRoles.component';
 import { UserProfileRolesProps } from './UserProfileRoles.interface';
 
@@ -63,7 +62,7 @@ jest.mock('../../../../../utils/ToastUtils', () => ({
 }));
 
 jest.mock('../../../../../rest/rolesAPIV1', () => ({
-  getRoles: jest.fn().mockImplementation(() => Promise.resolve(mockUserRole)),
+  searchRoles: jest.fn().mockResolvedValue([]),
 }));
 
 describe('Test User Profile Roles Component', () => {
@@ -164,7 +163,7 @@ describe('Test User Profile Roles Component', () => {
 
     fireEvent.click(editButton);
 
-    expect(getRoles).toHaveBeenCalledWith('', undefined, undefined, false, 50);
+    expect(searchRoles).toHaveBeenCalledWith('');
 
     expect(screen.getByTestId('user-profile-edit-popover')).toBeInTheDocument();
   });

--- a/openmetadata-ui/src/main/resources/ui/src/components/SettingsSso/SSOConfigurationForm/SsoRolesSelectField.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/SettingsSso/SSOConfigurationForm/SsoRolesSelectField.test.tsx
@@ -13,12 +13,12 @@
 
 import { FieldProps } from '@rjsf/utils';
 import { render, screen, waitFor } from '@testing-library/react';
-import { getRoles } from '../../../rest/rolesAPIV1';
+import { searchRoles } from '../../../rest/rolesAPIV1';
 import { showErrorToast } from '../../../utils/ToastUtils';
 import SsoRolesSelectField from './SsoRolesSelectField';
 
 jest.mock('../../../rest/rolesAPIV1', () => ({
-  getRoles: jest.fn(),
+  searchRoles: jest.fn(),
 }));
 
 jest.mock('../../../utils/ToastUtils', () => ({
@@ -29,17 +29,14 @@ jest.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
-const mockGetRoles = getRoles as jest.Mock;
+const mockSearchRoles = searchRoles as jest.Mock;
 const mockShowErrorToast = showErrorToast as jest.Mock;
 
-const mockRolesResponse = {
-  data: [
-    { name: 'Admin', displayName: 'Administrator' },
-    { name: 'DataSteward', displayName: 'Data Steward' },
-    { name: 'DataConsumer', displayName: '' },
-  ],
-  paging: { total: 3 },
-};
+const mockRolesResponse = [
+  { name: 'Admin', displayName: 'Administrator' },
+  { name: 'DataSteward', displayName: 'Data Steward' },
+  { name: 'DataConsumer', displayName: '' },
+];
 
 const mockOnChange = jest.fn();
 const mockOnBlur = jest.fn();
@@ -67,7 +64,7 @@ const rolesSelectProps: FieldProps = {
 describe('SsoRolesSelectField', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetRoles.mockResolvedValue(mockRolesResponse);
+    mockSearchRoles.mockResolvedValue(mockRolesResponse);
   });
 
   it('renders the roles select', async () => {
@@ -90,50 +87,42 @@ describe('SsoRolesSelectField', () => {
     });
   });
 
-  it('calls getRoles API on mount with correct arguments', async () => {
+  it('calls searchRoles API on mount with correct arguments', async () => {
     render(<SsoRolesSelectField {...rolesSelectProps} />);
 
     await waitFor(() => {
-      expect(mockGetRoles).toHaveBeenCalledTimes(1);
-      expect(mockGetRoles).toHaveBeenCalledWith(
-        '*',
-        undefined,
-        undefined,
-        true,
-        1000
-      );
+      expect(mockSearchRoles).toHaveBeenCalledTimes(1);
+      expect(mockSearchRoles).toHaveBeenCalledWith('');
     });
   });
 
   it('uses displayName as option label when available', async () => {
-    mockGetRoles.mockResolvedValue({
-      data: [{ name: 'Admin', displayName: 'Administrator' }],
-      paging: { total: 1 },
-    });
+    mockSearchRoles.mockResolvedValue([
+      { name: 'Admin', displayName: 'Administrator' },
+    ]);
 
     render(<SsoRolesSelectField {...rolesSelectProps} />);
 
     await waitFor(() => {
-      expect(mockGetRoles).toHaveBeenCalled();
+      expect(mockSearchRoles).toHaveBeenCalled();
     });
   });
 
   it('falls back to name as option label when displayName is empty', async () => {
-    mockGetRoles.mockResolvedValue({
-      data: [{ name: 'DataConsumer', displayName: '' }],
-      paging: { total: 1 },
-    });
+    mockSearchRoles.mockResolvedValue([
+      { name: 'DataConsumer', displayName: '' },
+    ]);
 
     render(<SsoRolesSelectField {...rolesSelectProps} />);
 
     await waitFor(() => {
-      expect(mockGetRoles).toHaveBeenCalled();
+      expect(mockSearchRoles).toHaveBeenCalled();
     });
   });
 
-  it('shows error toast when getRoles API call fails', async () => {
+  it('shows error toast when searchRoles API call fails', async () => {
     const apiError = new Error('Network error');
-    mockGetRoles.mockRejectedValue(apiError);
+    mockSearchRoles.mockRejectedValue(apiError);
 
     render(<SsoRolesSelectField {...rolesSelectProps} />);
 
@@ -197,7 +186,7 @@ describe('SsoRolesSelectField', () => {
   });
 
   it('renders with empty options list when API returns empty data', async () => {
-    mockGetRoles.mockResolvedValue({ data: [], paging: { total: 0 } });
+    mockSearchRoles.mockResolvedValue([]);
 
     render(<SsoRolesSelectField {...rolesSelectProps} />);
 
@@ -211,12 +200,12 @@ describe('SsoRolesSelectField', () => {
   });
 
   it('renders with empty options and no error toast when API returns null data', async () => {
-    mockGetRoles.mockResolvedValue({ data: null, paging: { total: 0 } });
+    mockSearchRoles.mockResolvedValue(null);
 
     render(<SsoRolesSelectField {...rolesSelectProps} />);
 
     await waitFor(() => {
-      expect(mockGetRoles).toHaveBeenCalled();
+      expect(mockSearchRoles).toHaveBeenCalled();
       expect(mockShowErrorToast).not.toHaveBeenCalled();
     });
   });

--- a/openmetadata-ui/src/main/resources/ui/src/components/SettingsSso/SSOConfigurationForm/SsoRolesSelectField.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/SettingsSso/SSOConfigurationForm/SsoRolesSelectField.tsx
@@ -15,10 +15,10 @@ import { FieldProps } from '@rjsf/utils';
 import { Col, Row, Select, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import classNames from 'classnames';
-import { startCase } from 'lodash';
-import { useCallback, useEffect, useState } from 'react';
+import { debounce, startCase } from 'lodash';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { getRoles } from '../../../rest/rolesAPIV1';
+import { searchRoles } from '../../../rest/rolesAPIV1';
 import { showErrorToast } from '../../../utils/ToastUtils';
 import './sso-configuration-form-array-field-template.less';
 
@@ -30,10 +30,10 @@ const SsoRolesSelectField = (props: FieldProps) => {
   >([]);
 
   useEffect(() => {
-    getRoles('*', undefined, undefined, true, 1000)
-      .then((response) => {
+    searchRoles('')
+      .then((roles) => {
         setRoleOptions(
-          (response.data || []).map((role) => ({
+          (roles ?? []).map((role) => ({
             label: role.displayName || role.name,
             value: role.name,
           }))
@@ -41,6 +41,37 @@ const SsoRolesSelectField = (props: FieldProps) => {
       })
       .catch((error: AxiosError) => showErrorToast(error));
   }, []);
+
+  const debouncedSearchRoles = useMemo(
+    () =>
+      debounce(async (searchText: string) => {
+        try {
+          const results = await searchRoles(searchText);
+          const searchOpts = (results ?? []).map((role) => ({
+            label: role.displayName || role.name,
+            value: role.name,
+          }));
+          const selectedSet = new Set(value || []);
+          const kept = roleOptions.filter((option) =>
+            selectedSet.has(option.value)
+          );
+
+          setRoleOptions([
+            ...kept,
+            ...searchOpts.filter((option) => !selectedSet.has(option.value)),
+          ]);
+        } catch (err) {
+          showErrorToast(err as AxiosError);
+        }
+      }, 300),
+    [roleOptions, value]
+  );
+
+  useEffect(() => {
+    return () => {
+      debouncedSearchRoles.cancel();
+    };
+  }, [debouncedSearchRoles]);
 
   const id = props.idSchema.$id;
   const value: string[] = props.formData ?? [];
@@ -86,9 +117,9 @@ const SsoRolesSelectField = (props: FieldProps) => {
           })}
           data-testid={`sso-configuration-form-array-field-template-${props.name}`}
           disabled={props.disabled}
+          filterOption={false}
           id={id}
           mode="multiple"
-          optionFilterProp="label"
           options={roleOptions}
           placeholder={placeholder}
           status={hasError ? 'error' : undefined}
@@ -96,6 +127,7 @@ const SsoRolesSelectField = (props: FieldProps) => {
           onBlur={handleBlur}
           onChange={handleChange}
           onFocus={handleFocus}
+          onSearch={debouncedSearchRoles}
         />
       </Col>
     </Row>

--- a/openmetadata-ui/src/main/resources/ui/src/components/SettingsSso/SSOConfigurationForm/SsoRolesSelectField.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/SettingsSso/SSOConfigurationForm/SsoRolesSelectField.tsx
@@ -16,7 +16,7 @@ import { Col, Row, Select, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import classNames from 'classnames';
 import { debounce, startCase } from 'lodash';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { searchRoles } from '../../../rest/rolesAPIV1';
 import { showErrorToast } from '../../../utils/ToastUtils';
@@ -28,6 +28,18 @@ const SsoRolesSelectField = (props: FieldProps) => {
   const [roleOptions, setRoleOptions] = useState<
     { label: string; value: string }[]
   >([]);
+  const id = props.idSchema.$id;
+  const value: string[] = props.formData ?? [];
+  const hasError = props.rawErrors && props.rawErrors.length > 0;
+
+  const placeholder =
+    props.uiSchema?.['ui:placeholder'] ?? t('label.select-field');
+  const searchStateRef = useRef({
+    roleOptions: [] as { label: string; value: string }[],
+    value: [] as string[],
+  });
+
+  searchStateRef.current = { roleOptions, value };
 
   useEffect(() => {
     searchRoles('')
@@ -51,7 +63,8 @@ const SsoRolesSelectField = (props: FieldProps) => {
             label: role.displayName || role.name,
             value: role.name,
           }));
-          const selectedSet = new Set(value || []);
+          const { roleOptions, value } = searchStateRef.current;
+          const selectedSet = new Set(value);
           const kept = roleOptions.filter((option) =>
             selectedSet.has(option.value)
           );
@@ -64,7 +77,7 @@ const SsoRolesSelectField = (props: FieldProps) => {
           showErrorToast(err as AxiosError);
         }
       }, 300),
-    [roleOptions, value]
+    []
   );
 
   useEffect(() => {
@@ -72,13 +85,6 @@ const SsoRolesSelectField = (props: FieldProps) => {
       debouncedSearchRoles.cancel();
     };
   }, [debouncedSearchRoles]);
-
-  const id = props.idSchema.$id;
-  const value: string[] = props.formData ?? [];
-  const hasError = props.rawErrors && props.rawErrors.length > 0;
-
-  const placeholder =
-    props.uiSchema?.['ui:placeholder'] ?? t('label.select-field');
 
   const handleChange = useCallback(
     (newValue: string[]) => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Form/JSONSchema/JsonSchemaWidgets/LdapRoleMappingWidget/LdapRoleMappingWidget.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Form/JSONSchema/JsonSchemaWidgets/LdapRoleMappingWidget/LdapRoleMappingWidget.test.tsx
@@ -19,27 +19,24 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react';
-import { getRoles } from '../../../../../../rest/rolesAPIV1';
+import { searchRoles } from '../../../../../../rest/rolesAPIV1';
 import LdapRoleMappingWidget from './LdapRoleMappingWidget';
 
 jest.mock('../../../../../../rest/rolesAPIV1', () => ({
-  getRoles: jest.fn(),
+  searchRoles: jest.fn(),
 }));
 
 jest.mock('../../../../../../utils/ToastUtils', () => ({
   showErrorToast: jest.fn(),
 }));
 
-const mockGetRoles = getRoles as jest.Mock;
+const mockSearchRoles = searchRoles as jest.Mock;
 
-const mockRoles = {
-  data: [
-    { name: 'Admin', displayName: 'Administrator' },
-    { name: 'DataSteward', displayName: 'Data Steward' },
-    { name: 'DataConsumer', displayName: 'Data Consumer' },
-  ],
-  paging: { total: 3 },
-};
+const mockRoles = [
+  { name: 'Admin', displayName: 'Administrator' },
+  { name: 'DataSteward', displayName: 'Data Steward' },
+  { name: 'DataConsumer', displayName: 'Data Consumer' },
+];
 
 const mockOnChange = jest.fn();
 const mockOnFocus = jest.fn();
@@ -65,7 +62,7 @@ const baseProps: WidgetProps = {
 describe('LdapRoleMappingWidget', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetRoles.mockResolvedValue(mockRoles);
+    mockSearchRoles.mockResolvedValue(mockRoles);
   });
 
   describe('Rendering Tests', () => {
@@ -79,13 +76,7 @@ describe('LdapRoleMappingWidget', () => {
       });
 
       expect(screen.queryByText(/label.ldap-group-dn/)).not.toBeInTheDocument();
-      expect(mockGetRoles).toHaveBeenCalledWith(
-        '*',
-        undefined,
-        undefined,
-        true,
-        1000
-      );
+      expect(mockSearchRoles).toHaveBeenCalledWith('');
     });
 
     it('should render with existing mappings', async () => {
@@ -559,18 +550,12 @@ describe('LdapRoleMappingWidget', () => {
       });
 
       await waitFor(() => {
-        expect(mockGetRoles).toHaveBeenCalledWith(
-          '*',
-          undefined,
-          undefined,
-          true,
-          1000
-        );
+        expect(mockSearchRoles).toHaveBeenCalledWith('');
       });
     });
 
     it('should handle API errors', async () => {
-      mockGetRoles.mockRejectedValueOnce(new Error('API Error'));
+      mockSearchRoles.mockRejectedValueOnce(new Error('API Error'));
 
       await act(async () => {
         render(<LdapRoleMappingWidget {...baseProps} />);
@@ -582,7 +567,7 @@ describe('LdapRoleMappingWidget', () => {
     });
 
     it('should show loading state while fetching roles', async () => {
-      mockGetRoles.mockImplementationOnce(() => newPromise);
+      mockSearchRoles.mockImplementationOnce(() => newPromise);
 
       await act(async () => {
         render(<LdapRoleMappingWidget {...baseProps} />);

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Form/JSONSchema/JsonSchemaWidgets/LdapRoleMappingWidget/LdapRoleMappingWidget.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Form/JSONSchema/JsonSchemaWidgets/LdapRoleMappingWidget/LdapRoleMappingWidget.tsx
@@ -23,10 +23,11 @@ import {
   Typography as AntDTypography,
 } from 'antd';
 import { AxiosError } from 'axios';
-import { FC, useCallback, useEffect, useRef, useState } from 'react';
+import { debounce, uniqBy } from 'lodash';
+import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ReactComponent as DeleteIcon } from '../../../../../../assets/svg/ic-delete.svg';
-import { getRoles } from '../../../../../../rest/rolesAPIV1';
+import { searchRoles } from '../../../../../../rest/rolesAPIV1';
 import { showErrorToast } from '../../../../../../utils/ToastUtils';
 import './ldap-role-mapping-widget.less';
 
@@ -53,6 +54,9 @@ const LdapRoleMappingWidget: FC<WidgetProps> = (props) => {
 
   const [mappings, setMappings] = useState<RoleMappingEntry[]>([]);
   const [availableRoles, setAvailableRoles] = useState<RoleOption[]>([]);
+  const [searchResults, setSearchResults] = useState<Map<string, RoleOption[]>>(
+    new Map()
+  );
   const [isLoadingRoles, setIsLoadingRoles] = useState(false);
   const [errors, setErrors] = useState<MappingError>({});
 
@@ -101,8 +105,8 @@ const LdapRoleMappingWidget: FC<WidgetProps> = (props) => {
     const fetchRoles = async () => {
       setIsLoadingRoles(true);
       try {
-        const response = await getRoles('*', undefined, undefined, true, 1000);
-        const roleOptions: RoleOption[] = (response.data || []).map((role) => ({
+        const results = await searchRoles('');
+        const roleOptions: RoleOption[] = results.map((role) => ({
           label: role.displayName || role.name,
           value: role.name,
         }));
@@ -212,6 +216,49 @@ const LdapRoleMappingWidget: FC<WidgetProps> = (props) => {
     [mappings, updateValue]
   );
 
+  const debouncedSearchRoles = useMemo(
+    () =>
+      debounce(async (mappingId: string, searchText: string) => {
+        try {
+          const results = await searchRoles(searchText);
+          setSearchResults((prev) => {
+            const next = new Map(prev);
+            const currentMapping = mappings.find(
+              (mapping) => mapping.id === mappingId
+            );
+            const selectedRoles = new Set(currentMapping?.roles ?? []);
+            const selectedRoleOptions = availableRoles.filter((role) =>
+              selectedRoles.has(role.value)
+            );
+            next.set(
+              mappingId,
+              uniqBy(
+                [
+                  ...selectedRoleOptions,
+                  ...results.map((role) => ({
+                    label: role.displayName || role.name,
+                    value: role.name,
+                  })),
+                ],
+                'value'
+              )
+            );
+
+            return next;
+          });
+        } catch (err) {
+          showErrorToast(err as AxiosError);
+        }
+      }, 300),
+    [availableRoles, mappings]
+  );
+
+  useEffect(() => {
+    return () => {
+      debouncedSearchRoles.cancel();
+    };
+  }, [debouncedSearchRoles]);
+
   return (
     <div className="ldap-role-mapping-widget" data-testid={id}>
       <Space direction="vertical" size="small" style={{ width: '100%' }}>
@@ -266,14 +313,16 @@ const LdapRoleMappingWidget: FC<WidgetProps> = (props) => {
                   className="w-full"
                   data-testid={`roles-select-${mapping.id}`}
                   disabled={disabled || readonly}
+                  filterOption={false}
                   loading={isLoadingRoles}
                   mode="multiple"
-                  options={availableRoles}
+                  options={searchResults.get(mapping.id) ?? availableRoles}
                   placeholder={t('label.select-field', {
                     field: t('label.role-plural'),
                   })}
                   value={mapping.roles}
                   onChange={(roles) => handleRolesChange(mapping.id, roles)}
+                  onSearch={(val) => debouncedSearchRoles(mapping.id, val)}
                 />
               </Grid.Item>
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Form/JSONSchema/JsonSchemaWidgets/LdapRoleMappingWidget/LdapRoleMappingWidget.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Form/JSONSchema/JsonSchemaWidgets/LdapRoleMappingWidget/LdapRoleMappingWidget.tsx
@@ -77,6 +77,12 @@ const LdapRoleMappingWidget: FC<WidgetProps> = (props) => {
   );
 
   const isInitialMount = useRef(true);
+  const searchStateRef = useRef({
+    availableRoles: [] as RoleOption[],
+    mappings: [] as RoleMappingEntry[],
+  });
+
+  searchStateRef.current = { availableRoles, mappings };
 
   useEffect(() => {
     if (isInitialMount.current) {
@@ -223,6 +229,7 @@ const LdapRoleMappingWidget: FC<WidgetProps> = (props) => {
           const results = await searchRoles(searchText);
           setSearchResults((prev) => {
             const next = new Map(prev);
+            const { availableRoles, mappings } = searchStateRef.current;
             const currentMapping = mappings.find(
               (mapping) => mapping.id === mappingId
             );
@@ -250,7 +257,7 @@ const LdapRoleMappingWidget: FC<WidgetProps> = (props) => {
           showErrorToast(err as AxiosError);
         }
       }, 300),
-    [availableRoles, mappings]
+    []
   );
 
   useEffect(() => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/RolesCard/RolesCard.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/RolesCard/RolesCard.component.tsx
@@ -104,6 +104,7 @@ const RolesCard = ({
           {isRolesEdit ? (
             <Space className="w-full" direction="vertical">
               <Select
+                showSearch
                 aria-label="Select roles"
                 className="w-full"
                 defaultValue={selectedRoles}
@@ -113,7 +114,6 @@ const RolesCard = ({
                 mode="multiple"
                 options={userRolesOption}
                 placeholder={`${t('label.role-plural')}...`}
-                showSearch
                 onChange={handleOnRolesChange}
                 onSearch={searchRolesOptions}
               />

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/RolesCard/RolesCard.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/RolesCard/RolesCard.component.tsx
@@ -29,6 +29,8 @@ const RolesCard = ({
   updateUserDetails,
   selectedRoles,
   setSelectedRoles,
+  searchRolesOptions,
+  isRolesLoading,
 }: RolesComponentProps) => {
   const [isRolesEdit, setIsRolesEdit] = useState(false);
 
@@ -105,11 +107,15 @@ const RolesCard = ({
                 aria-label="Select roles"
                 className="w-full"
                 defaultValue={selectedRoles}
+                filterOption={false}
                 id="select-role"
+                loading={isRolesLoading}
                 mode="multiple"
                 options={userRolesOption}
                 placeholder={`${t('label.role-plural')}...`}
+                showSearch
                 onChange={handleOnRolesChange}
+                onSearch={searchRolesOptions}
               />
               <div className="flex justify-end" data-testid="buttons">
                 <Button

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/RolesCard/RolesCard.interfaces.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/RolesCard/RolesCard.interfaces.ts
@@ -20,4 +20,6 @@ export interface RolesComponentProps {
   updateUserDetails: (data: Partial<User>) => Promise<void>;
   selectedRoles: Array<string>;
   setSelectedRoles: (selectedRoles: string[]) => void;
+  searchRolesOptions: (query?: string) => Promise<void>;
+  isRolesLoading: boolean;
 }

--- a/openmetadata-ui/src/main/resources/ui/src/pages/CreateUserPage/CreateUserPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/CreateUserPage/CreateUserPage.component.tsx
@@ -14,20 +14,17 @@
 import { Card } from 'antd';
 import { AxiosError } from 'axios';
 import _ from 'lodash';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import TitleBreadcrumb from '../../components/common/TitleBreadcrumb/TitleBreadcrumb.component';
 import PageLayoutV1 from '../../components/PageLayoutV1/PageLayoutV1';
 import CreateUserComponent from '../../components/Settings/Users/CreateUser/CreateUser.component';
-import { PAGE_SIZE_EXTRA_LARGE } from '../../constants/constants';
 import { GlobalSettingOptions } from '../../constants/GlobalSettings.constants';
 import { useLimitStore } from '../../context/LimitsProvider/useLimitsStore';
 import { CreateUser } from '../../generated/api/teams/createUser';
-import { Role } from '../../generated/entity/teams/role';
 import { useApplicationStore } from '../../hooks/useApplicationStore';
 import { createBot } from '../../rest/botsAPI';
-import { getAllRoles } from '../../rest/rolesAPIV1';
 import {
   createUser,
   createUserWithPut,
@@ -53,7 +50,6 @@ const CreateUserPage = () => {
   const isAdminPage = Boolean(state?.isAdminPage);
   const { setInlineAlertDetails } = useApplicationStore();
   const { getResourceLimit } = useLimitStore();
-  const [roles, setRoles] = useState<Array<Role>>([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
   const { bot } = useRequiredParams<{ bot: string }>();
@@ -154,27 +150,6 @@ const CreateUserPage = () => {
     setIsLoading(false);
   };
 
-  const fetchRoles = async () => {
-    try {
-      const roles = await getAllRoles(
-        '',
-        false,
-        PAGE_SIZE_EXTRA_LARGE // until we implement server-side search, fetch all pages
-      );
-      setRoles(roles);
-    } catch (err) {
-      setRoles([]);
-      showErrorToast(
-        err as AxiosError,
-        t('server.entity-fetch-error', { entity: t('label.role-plural') })
-      );
-    }
-  };
-
-  useEffect(() => {
-    fetchRoles();
-  }, []);
-
   const BREADCRUMB_DETAILS = useMemo(() => {
     if (bot) {
       return {
@@ -222,7 +197,6 @@ const CreateUserPage = () => {
           <CreateUserComponent
             forceBot={Boolean(bot)}
             isLoading={isLoading}
-            roles={roles}
             onCancel={handleCancel}
             onSave={handleAddUserSave}
           />

--- a/openmetadata-ui/src/main/resources/ui/src/rest/rolesAPIV1.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/rolesAPIV1.ts
@@ -184,3 +184,21 @@ export const validateRuleCondition = async (condition: string) => {
    */
   return response;
 };
+
+export const searchRoles = async (
+  query: string,
+  limit = 25
+): Promise<Role[]> => {
+  const response = await APIClient.get<{ data: Role[]; paging: Paging }>(
+    '/roles/search',
+    {
+      params: {
+        q: query || undefined,
+        limit,
+        offset: 0,
+      },
+    },
+  );
+
+  return response.data.data;
+};

--- a/openmetadata-ui/src/main/resources/ui/src/rest/rolesAPIV1.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/rolesAPIV1.ts
@@ -197,7 +197,7 @@ export const searchRoles = async (
         limit,
         offset: 0,
       },
-    },
+    }
   );
 
   return response.data.data;


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #27540 

https://github.com/user-attachments/assets/5388d515-b030-4598-8d30-98079879bee9


<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

### Description

- Adds consistent server-side role search handling for all role-selection dropdowns using the new GET /v1/roles/search API.
- Replaces stale option accumulation with “preserve selected values + replace search results” behavior so filtering works correctly in user, bot, create-user, SSO, and LDAP role selectors.
- Adds debounce to role-search inputs to reduce request spam and align with existing async-search patterns in the UI.
- Adds loading indicators where needed during in-flight role search requests.
- Updates Playwright coverage to explicitly wait for /api/v1/roles/search responses instead of relying only on UI state.


### Included fixes

- UserProfileRoles popover search now filters correctly and keeps selected roles visible.
- BotDetails role search now returns expected filtered results instead of mixing stale options.
- CreateUser role dropdown preserves selected roles while updating search results.
- SsoRolesSelectField and LdapRoleMappingWidget now follow the same selected-value preservation pattern.
- Role-search-related specs/helpers now wait for backend responses during initial load and typed search.

### Problem

- Role-selection dropdowns were moved to server-side search, but several UI flows still handled results incorrectly.
- Search results were being merged into stale/default option lists, so filtered search often appeared broken even when the API returned correct matches.
- Some selectors did not preserve selected roles while refreshing options from search.
- Role search requests were fired on every keystroke without debounce.
- Existing tests/specs often waited only for UI updates and not for the /v1/roles/search network response, which made them brittle after moving to async server-side search.

### Solution

- Standardized role-search handling across role selectors to preserve currently selected values while replacing the rest of the options with the latest backend search results.
- Added debounce to role-search inputs to align with existing async search patterns and reduce unnecessary API calls.
- Added loading indicators for in-flight role search where needed.
- Updated Playwright coverage to explicitly wait for /api/v1/roles/search responses during initial load and typed searches.
- Switched role search consumers to consistently use the new GET /v1/roles/search API.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
