### PR TITLE
feat(mcp): add workflow automation MCP tools for ingestion pipeline management

### DIFF
--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/McpApplicationContext.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/McpApplicationContext.java
@@ -1,0 +1,18 @@
+package org.openmetadata.mcp;
+
+import org.openmetadata.service.OpenMetadataApplicationConfig;
+
+/** Holds application-level singletons needed by MCP tools at runtime. */
+public class McpApplicationContext {
+  private static volatile OpenMetadataApplicationConfig config;
+
+  private McpApplicationContext() {}
+
+  public static void setConfig(OpenMetadataApplicationConfig applicationConfig) {
+    config = applicationConfig;
+  }
+
+  public static OpenMetadataApplicationConfig getConfig() {
+    return config;
+  }
+}

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/McpServer.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/McpServer.java
@@ -287,9 +287,7 @@ public class McpServer implements McpServerProvider {
     return List.of();
   }
 
-  /**
-   * Get base URL from system settings, with fallback to localhost for development.
-   */
+  /** Get base URL from system settings, with fallback to localhost for development. */
   private String getBaseUrlFromSettings() {
     try {
       org.openmetadata.service.jdbi3.SystemRepository systemRepository =
@@ -314,9 +312,9 @@ public class McpServer implements McpServerProvider {
       LOG.warn("Could not get instance URL from SystemSettings, using fallback", e);
     }
     LOG.error(
-        "No base URL configured in MCP settings or system settings. "
-            + "Falling back to http://localhost:8585 — this is only suitable for local development. "
-            + "Configure a proper base URL for production deployments.");
+        "No base URL configured in MCP settings or system settings. Falling back to"
+            + " http://localhost:8585 — this is only suitable for local development. Configure a"
+            + " proper base URL for production deployments.");
     return "http://localhost:8585";
   }
 }

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/McpServer.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/McpServer.java
@@ -61,6 +61,7 @@ public class McpServer implements McpServerProvider {
             SecurityConfigurationManager.getCurrentAuthzConfig());
     this.authorizer = authorizer;
     this.limits = limits;
+    McpApplicationContext.setConfig(config);
     this.environment = environment;
     MutableServletContextHandler contextHandler = environment.getApplicationContext();
     List<McpSchema.Tool> tools = getTools();

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CommonUtils.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CommonUtils.java
@@ -53,4 +53,22 @@ public class CommonUtils {
     }
     return teamsOrUsers;
   }
+
+  public static int parseLimit(Map<String, Object> params, String key, int defaultValue) {
+    if (!params.containsKey(key)) {
+      return defaultValue;
+    }
+    Object v = params.get(key);
+    if (v instanceof Number n) {
+      return n.intValue();
+    }
+    if (v instanceof String s) {
+      try {
+        return Integer.parseInt(s);
+      } catch (NumberFormatException e) {
+        LOG.warn("Invalid value for '{}': '{}', using default {}", key, s, defaultValue);
+      }
+    }
+    return defaultValue;
+  }
 }

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/DefaultToolContext.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/DefaultToolContext.java
@@ -14,6 +14,10 @@ import org.openmetadata.service.security.auth.CatalogSecurityContext;
 
 @Slf4j
 public class DefaultToolContext {
+  static final String TOOL_LIST_INGESTION_PIPELINES = "list_ingestion_pipelines";
+  static final String TOOL_GET_PIPELINE_STATUS = "get_pipeline_status";
+  static final String TOOL_TRIGGER_INGESTION_PIPELINE = "trigger_ingestion_pipeline";
+
   public DefaultToolContext() {}
 
   /**
@@ -83,13 +87,13 @@ public class DefaultToolContext {
         case "create_metric":
           result = new CreateMetricTool().execute(authorizer, limits, securityContext, params);
           break;
-        case "list_ingestion_pipelines":
+        case TOOL_LIST_INGESTION_PIPELINES:
           result = new ListIngestionPipelinesTool().execute(authorizer, securityContext, params);
           break;
-        case "get_pipeline_status":
+        case TOOL_GET_PIPELINE_STATUS:
           result = new GetPipelineStatusTool().execute(authorizer, securityContext, params);
           break;
-        case "trigger_ingestion_pipeline":
+        case TOOL_TRIGGER_INGESTION_PIPELINE:
           result = new TriggerIngestionPipelineTool().execute(authorizer, securityContext, params);
           break;
         default:

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/DefaultToolContext.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/DefaultToolContext.java
@@ -83,6 +83,15 @@ public class DefaultToolContext {
         case "create_metric":
           result = new CreateMetricTool().execute(authorizer, limits, securityContext, params);
           break;
+        case "list_ingestion_pipelines":
+          result = new ListIngestionPipelinesTool().execute(authorizer, securityContext, params);
+          break;
+        case "get_pipeline_status":
+          result = new GetPipelineStatusTool().execute(authorizer, securityContext, params);
+          break;
+        case "trigger_ingestion_pipeline":
+          result = new TriggerIngestionPipelineTool().execute(authorizer, securityContext, params);
+          break;
         default:
           return McpSchema.CallToolResult.builder()
               .content(

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/DefaultToolContext.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/DefaultToolContext.java
@@ -17,8 +17,8 @@ public class DefaultToolContext {
   public DefaultToolContext() {}
 
   /**
-   * Loads tool definitions from a JSON file located at the specified path.
-   * The JSON file should contain an array of tool definitions under the "tools" key.
+   * Loads tool definitions from a JSON file located at the specified path. The JSON file should
+   * contain an array of tool definitions under the "tools" key.
    *
    * @return List of McpSchema.Tool objects loaded from the JSON file.
    */

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetPipelineStatusTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetPipelineStatusTool.java
@@ -26,20 +26,7 @@ public class GetPipelineStatusTool implements McpTool {
     if (fqn == null || fqn.isBlank()) {
       throw new IllegalArgumentException("Parameter 'fqn' is required");
     }
-
-    int limit = 5;
-    if (params.containsKey("limit")) {
-      Object limitObj = params.get("limit");
-      if (limitObj instanceof Number number) {
-        limit = number.intValue();
-      } else if (limitObj instanceof String s) {
-        try {
-          limit = Integer.parseInt(s);
-        } catch (NumberFormatException ignored) {
-          limit = 5;
-        }
-      }
-    }
+    int limit = CommonUtils.parseLimit(params, "limit", 5);
 
     authorizer.authorize(
         securityContext,

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetPipelineStatusTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetPipelineStatusTool.java
@@ -22,28 +22,35 @@ public class GetPipelineStatusTool implements McpTool {
   public Map<String, Object> execute(
       Authorizer authorizer, CatalogSecurityContext securityContext, Map<String, Object> params)
       throws IOException {
+    String fqn = requireFqn(params);
+    int limit = CommonUtils.parseLimit(params, "limit", 5);
+    authorize(authorizer, securityContext);
+    LOG.info("Getting pipeline status for FQN: {}, limit: {}", fqn, limit);
+    return buildStatusResponse(fqn, limit);
+  }
+
+  private static String requireFqn(Map<String, Object> params) {
     String fqn = (String) params.get("fqn");
     if (fqn == null || fqn.isBlank()) {
       throw new IllegalArgumentException("Parameter 'fqn' is required");
     }
-    int limit = CommonUtils.parseLimit(params, "limit", 5);
+    return fqn;
+  }
 
+  private static void authorize(Authorizer authorizer, CatalogSecurityContext securityContext) {
     authorizer.authorize(
         securityContext,
         new OperationContext(Entity.INGESTION_PIPELINE, MetadataOperation.VIEW_BASIC),
         new ResourceContext<>(Entity.INGESTION_PIPELINE));
+  }
 
-    LOG.info("Getting pipeline status for FQN: {}, limit: {}", fqn, limit);
-
-    IngestionPipelineRepository repository =
+  private static Map<String, Object> buildStatusResponse(String fqn, int limit) throws IOException {
+    IngestionPipelineRepository repo =
         (IngestionPipelineRepository) Entity.getEntityRepository(Entity.INGESTION_PIPELINE);
-
     IngestionPipeline pipeline =
         (IngestionPipeline) Entity.getEntityByName(Entity.INGESTION_PIPELINE, fqn, "", null);
-
-    var latestStatus = repository.getLatestPipelineStatus(pipeline);
-    var recentRuns = repository.listPipelineStatus(fqn, null, null, limit);
-
+    var latestStatus = repo.getLatestPipelineStatus(pipeline);
+    var recentRuns = repo.listPipelineStatus(fqn, null, null, limit);
     Map<String, Object> response = new HashMap<>();
     response.put("fqn", fqn);
     response.put("pipelineName", pipeline.getName());

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetPipelineStatusTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetPipelineStatusTool.java
@@ -1,0 +1,81 @@
+package org.openmetadata.mcp.tools;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.schema.entity.services.ingestionPipelines.IngestionPipeline;
+import org.openmetadata.schema.type.MetadataOperation;
+import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.jdbi3.IngestionPipelineRepository;
+import org.openmetadata.service.limits.Limits;
+import org.openmetadata.service.security.Authorizer;
+import org.openmetadata.service.security.auth.CatalogSecurityContext;
+import org.openmetadata.service.security.policyevaluator.OperationContext;
+import org.openmetadata.service.security.policyevaluator.ResourceContext;
+
+@Slf4j
+public class GetPipelineStatusTool implements McpTool {
+
+  @Override
+  public Map<String, Object> execute(
+      Authorizer authorizer, CatalogSecurityContext securityContext, Map<String, Object> params)
+      throws IOException {
+    String fqn = (String) params.get("fqn");
+    if (fqn == null || fqn.isBlank()) {
+      throw new IllegalArgumentException("Parameter 'fqn' is required");
+    }
+
+    int limit = 5;
+    if (params.containsKey("limit")) {
+      Object limitObj = params.get("limit");
+      if (limitObj instanceof Number number) {
+        limit = number.intValue();
+      } else if (limitObj instanceof String s) {
+        try {
+          limit = Integer.parseInt(s);
+        } catch (NumberFormatException ignored) {
+          limit = 5;
+        }
+      }
+    }
+
+    authorizer.authorize(
+        securityContext,
+        new OperationContext(Entity.INGESTION_PIPELINE, MetadataOperation.VIEW_BASIC),
+        new ResourceContext<>(Entity.INGESTION_PIPELINE));
+
+    LOG.info("Getting pipeline status for FQN: {}, limit: {}", fqn, limit);
+
+    IngestionPipelineRepository repository =
+        (IngestionPipelineRepository) Entity.getEntityRepository(Entity.INGESTION_PIPELINE);
+
+    IngestionPipeline pipeline =
+        (IngestionPipeline) Entity.getEntityByName(Entity.INGESTION_PIPELINE, fqn, "", null);
+
+    var latestStatus = repository.getLatestPipelineStatus(pipeline);
+    var recentRuns = repository.listPipelineStatus(fqn, null, null, limit);
+
+    Map<String, Object> response = new HashMap<>();
+    response.put("fqn", fqn);
+    response.put("pipelineName", pipeline.getName());
+    response.put("pipelineType", pipeline.getPipelineType());
+    response.put("enabled", pipeline.getEnabled());
+    response.put("deployed", pipeline.getDeployed());
+    response.put("latestStatus", latestStatus != null ? JsonUtils.getMap(latestStatus) : null);
+    response.put("recentRuns", JsonUtils.getMap(recentRuns));
+    return response;
+  }
+
+  @Override
+  public Map<String, Object> execute(
+      Authorizer authorizer,
+      Limits limits,
+      CatalogSecurityContext securityContext,
+      Map<String, Object> params)
+      throws IOException {
+    throw new UnsupportedOperationException(
+        "GetPipelineStatusTool does not require limit validation.");
+  }
+}

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/ListIngestionPipelinesTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/ListIngestionPipelinesTool.java
@@ -1,7 +1,6 @@
 package org.openmetadata.mcp.tools;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -34,23 +33,10 @@ public class ListIngestionPipelinesTool implements McpTool {
   public Map<String, Object> execute(
       Authorizer authorizer, CatalogSecurityContext securityContext, Map<String, Object> params)
       throws IOException {
-    String service = params.containsKey("service") ? (String) params.get("service") : null;
-    String pipelineType =
-        params.containsKey("pipelineType") ? (String) params.get("pipelineType") : null;
-    String after = params.containsKey("after") ? (String) params.get("after") : null;
-    int limit = 10;
-    if (params.containsKey("limit")) {
-      Object limitObj = params.get("limit");
-      if (limitObj instanceof Number number) {
-        limit = number.intValue();
-      } else if (limitObj instanceof String s) {
-        try {
-          limit = Integer.parseInt(s);
-        } catch (NumberFormatException ignored) {
-          limit = 10;
-        }
-      }
-    }
+    String service = (String) params.get("service");
+    String pipelineType = (String) params.get("pipelineType");
+    String after = (String) params.get("after");
+    int limit = CommonUtils.parseLimit(params, "limit", 10);
 
     authorizer.authorize(
         securityContext,
@@ -75,10 +61,10 @@ public class ListIngestionPipelinesTool implements McpTool {
     }
 
     var resultList =
-        repository.listAfter(null, repository.getFields("sourceConfig,pipelineType"), filter, limit, after);
+        repository.listAfter(
+            null, repository.getFields("sourceConfig,pipelineType"), filter, limit, after);
 
     Map<String, Object> response = JsonUtils.getMap(resultList);
-    // Strip verbose nested fields from each pipeline entry
     if (response.get("data") instanceof List<?> pipelines) {
       pipelines.forEach(
           p -> {

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/ListIngestionPipelinesTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/ListIngestionPipelinesTool.java
@@ -1,0 +1,105 @@
+package org.openmetadata.mcp.tools;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.schema.type.Include;
+import org.openmetadata.schema.type.MetadataOperation;
+import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.jdbi3.IngestionPipelineRepository;
+import org.openmetadata.service.jdbi3.ListFilter;
+import org.openmetadata.service.limits.Limits;
+import org.openmetadata.service.security.Authorizer;
+import org.openmetadata.service.security.auth.CatalogSecurityContext;
+import org.openmetadata.service.security.policyevaluator.OperationContext;
+import org.openmetadata.service.security.policyevaluator.ResourceContext;
+
+@Slf4j
+public class ListIngestionPipelinesTool implements McpTool {
+
+  private static final List<String> EXCLUDE_FIELDS =
+      List.of(
+          "version",
+          "updatedAt",
+          "updatedBy",
+          "changeDescription",
+          "sourceHash",
+          "openMetadataServerConnection",
+          "airflowConfig");
+
+  @Override
+  public Map<String, Object> execute(
+      Authorizer authorizer, CatalogSecurityContext securityContext, Map<String, Object> params)
+      throws IOException {
+    String service = params.containsKey("service") ? (String) params.get("service") : null;
+    String pipelineType =
+        params.containsKey("pipelineType") ? (String) params.get("pipelineType") : null;
+    String after = params.containsKey("after") ? (String) params.get("after") : null;
+    int limit = 10;
+    if (params.containsKey("limit")) {
+      Object limitObj = params.get("limit");
+      if (limitObj instanceof Number number) {
+        limit = number.intValue();
+      } else if (limitObj instanceof String s) {
+        try {
+          limit = Integer.parseInt(s);
+        } catch (NumberFormatException ignored) {
+          limit = 10;
+        }
+      }
+    }
+
+    authorizer.authorize(
+        securityContext,
+        new OperationContext(Entity.INGESTION_PIPELINE, MetadataOperation.VIEW_BASIC),
+        new ResourceContext<>(Entity.INGESTION_PIPELINE));
+
+    LOG.info(
+        "Listing ingestion pipelines — service: {}, pipelineType: {}, limit: {}",
+        service,
+        pipelineType,
+        limit);
+
+    IngestionPipelineRepository repository =
+        (IngestionPipelineRepository) Entity.getEntityRepository(Entity.INGESTION_PIPELINE);
+
+    ListFilter filter = new ListFilter(Include.NON_DELETED);
+    if (service != null && !service.isBlank()) {
+      filter.addQueryParam("service", service);
+    }
+    if (pipelineType != null && !pipelineType.isBlank()) {
+      filter.addQueryParam("pipelineType", pipelineType);
+    }
+
+    var resultList =
+        repository.listAfter(null, repository.getFields("sourceConfig,pipelineType"), filter, limit, after);
+
+    Map<String, Object> response = JsonUtils.getMap(resultList);
+    // Strip verbose nested fields from each pipeline entry
+    if (response.get("data") instanceof List<?> pipelines) {
+      pipelines.forEach(
+          p -> {
+            if (p instanceof Map<?, ?> pipeline) {
+              @SuppressWarnings("unchecked")
+              Map<String, Object> m = (Map<String, Object>) pipeline;
+              EXCLUDE_FIELDS.forEach(m::remove);
+            }
+          });
+    }
+    return response;
+  }
+
+  @Override
+  public Map<String, Object> execute(
+      Authorizer authorizer,
+      Limits limits,
+      CatalogSecurityContext securityContext,
+      Map<String, Object> params)
+      throws IOException {
+    throw new UnsupportedOperationException(
+        "ListIngestionPipelinesTool does not require limit validation.");
+  }
+}

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/ListIngestionPipelinesTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/ListIngestionPipelinesTool.java
@@ -33,38 +33,47 @@ public class ListIngestionPipelinesTool implements McpTool {
   public Map<String, Object> execute(
       Authorizer authorizer, CatalogSecurityContext securityContext, Map<String, Object> params)
       throws IOException {
-    String service = (String) params.get("service");
-    String pipelineType = (String) params.get("pipelineType");
-    String after = (String) params.get("after");
+    authorize(authorizer, securityContext);
     int limit = CommonUtils.parseLimit(params, "limit", 10);
+    LOG.info(
+        "Listing ingestion pipelines — service: {}, pipelineType: {}, limit: {}",
+        params.get("service"),
+        params.get("pipelineType"),
+        limit);
+    return fetchAndClean(params, limit);
+  }
 
+  private static void authorize(Authorizer authorizer, CatalogSecurityContext securityContext) {
     authorizer.authorize(
         securityContext,
         new OperationContext(Entity.INGESTION_PIPELINE, MetadataOperation.VIEW_BASIC),
         new ResourceContext<>(Entity.INGESTION_PIPELINE));
+  }
 
-    LOG.info(
-        "Listing ingestion pipelines — service: {}, pipelineType: {}, limit: {}",
-        service,
-        pipelineType,
-        limit);
-
-    IngestionPipelineRepository repository =
+  private static Map<String, Object> fetchAndClean(Map<String, Object> params, int limit)
+      throws IOException {
+    IngestionPipelineRepository repo =
         (IngestionPipelineRepository) Entity.getEntityRepository(Entity.INGESTION_PIPELINE);
-
-    ListFilter filter = new ListFilter(Include.NON_DELETED);
-    if (service != null && !service.isBlank()) {
-      filter.addQueryParam("service", service);
-    }
-    if (pipelineType != null && !pipelineType.isBlank()) {
-      filter.addQueryParam("pipelineType", pipelineType);
-    }
-
+    ListFilter filter = buildFilter(params);
+    String after = (String) params.get("after");
     var resultList =
-        repository.listAfter(
-            null, repository.getFields("sourceConfig,pipelineType"), filter, limit, after);
-
+        repo.listAfter(null, repo.getFields("sourceConfig,pipelineType"), filter, limit, after);
     Map<String, Object> response = JsonUtils.getMap(resultList);
+    stripVerboseFields(response);
+    return response;
+  }
+
+  private static ListFilter buildFilter(Map<String, Object> params) {
+    ListFilter filter = new ListFilter(Include.NON_DELETED);
+    String service = (String) params.get("service");
+    String pipelineType = (String) params.get("pipelineType");
+    if (service != null && !service.isBlank()) filter.addQueryParam("service", service);
+    if (pipelineType != null && !pipelineType.isBlank())
+      filter.addQueryParam("pipelineType", pipelineType);
+    return filter;
+  }
+
+  private static void stripVerboseFields(Map<String, Object> response) {
     if (response.get("data") instanceof List<?> pipelines) {
       pipelines.forEach(
           p -> {
@@ -75,7 +84,6 @@ public class ListIngestionPipelinesTool implements McpTool {
             }
           });
     }
-    return response;
   }
 
   @Override

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/TriggerIngestionPipelineTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/TriggerIngestionPipelineTool.java
@@ -40,18 +40,27 @@ public class TriggerIngestionPipelineTool implements McpTool {
     if (pipelineServiceClient == null) {
       return Map.of(
           "error",
-          "Pipeline service client is not configured. Ensure the ingestion infrastructure is set up.",
+          "Pipeline service client is not configured. Ensure the ingestion infrastructure is"
+              + " set up.",
           "fqn",
           fqn);
     }
 
+    IngestionPipeline pipeline =
+        (IngestionPipeline) Entity.getEntityByName(Entity.INGESTION_PIPELINE, fqn, "*", null);
+
+    if (!Boolean.TRUE.equals(pipeline.getDeployed())) {
+      return Map.of(
+          "error",
+          "Pipeline '" + fqn + "' is not deployed. Deploy it first before triggering a run.",
+          "fqn",
+          fqn,
+          "deployed",
+          false);
+    }
+
     LOG.info("Triggering ingestion pipeline: {}", fqn);
 
-    IngestionPipeline pipeline =
-        (IngestionPipeline)
-            Entity.getEntityByName(Entity.INGESTION_PIPELINE, fqn, "*", null);
-
-    // Set the OpenMetadata server connection so the pipeline can call back home
     if (McpApplicationContext.getConfig() != null) {
       pipeline.setOpenMetadataServerConnection(
           new OpenMetadataConnectionBuilder(McpApplicationContext.getConfig()).build());
@@ -61,7 +70,6 @@ public class TriggerIngestionPipelineTool implements McpTool {
     Object service = Entity.getEntity(serviceRef, "ingestionRunner", null);
 
     var response = pipelineServiceClient.runPipeline(pipeline, service);
-
     LOG.info("Trigger response for pipeline {}: {}", fqn, response);
     return JsonUtils.getMap(response);
   }

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/TriggerIngestionPipelineTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/TriggerIngestionPipelineTool.java
@@ -26,7 +26,7 @@ public class TriggerIngestionPipelineTool implements McpTool {
       throws IOException {
     String fqn = requireFqn(params);
     authorize(authorizer, securityContext);
-    PipelineServiceClientInterface client = resolveClient(fqn);
+    PipelineServiceClientInterface client = resolveClient();
     if (client == null) return clientNotConfiguredError(fqn);
     IngestionPipeline pipeline = fetchPipeline(fqn);
     if (!Boolean.TRUE.equals(pipeline.getDeployed())) return notDeployedError(fqn);
@@ -53,7 +53,7 @@ public class TriggerIngestionPipelineTool implements McpTool {
         new ResourceContext<>(Entity.INGESTION_PIPELINE));
   }
 
-  private static PipelineServiceClientInterface resolveClient(String fqn) {
+  private static PipelineServiceClientInterface resolveClient() {
     return PipelineServiceClientFactory.createPipelineServiceClient(null);
   }
 

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/TriggerIngestionPipelineTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/TriggerIngestionPipelineTool.java
@@ -5,7 +5,6 @@ import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.mcp.McpApplicationContext;
 import org.openmetadata.schema.entity.services.ingestionPipelines.IngestionPipeline;
-import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.sdk.PipelineServiceClientInterface;
@@ -25,53 +24,67 @@ public class TriggerIngestionPipelineTool implements McpTool {
   public Map<String, Object> execute(
       Authorizer authorizer, CatalogSecurityContext securityContext, Map<String, Object> params)
       throws IOException {
+    String fqn = requireFqn(params);
+    authorize(authorizer, securityContext);
+    PipelineServiceClientInterface client = resolveClient(fqn);
+    if (client == null) return clientNotConfiguredError(fqn);
+    IngestionPipeline pipeline = fetchPipeline(fqn);
+    if (!Boolean.TRUE.equals(pipeline.getDeployed())) return notDeployedError(fqn);
+    LOG.info("Triggering ingestion pipeline: {}", fqn);
+    setupServerConnection(pipeline);
+    Object service = Entity.getEntity(pipeline.getService(), "ingestionRunner", null);
+    var response = client.runPipeline(pipeline, service);
+    LOG.info("Trigger response for pipeline {}: {}", fqn, response);
+    return JsonUtils.getMap(response);
+  }
+
+  private static String requireFqn(Map<String, Object> params) {
     String fqn = (String) params.get("fqn");
     if (fqn == null || fqn.isBlank()) {
       throw new IllegalArgumentException("Parameter 'fqn' is required");
     }
+    return fqn;
+  }
 
+  private static void authorize(Authorizer authorizer, CatalogSecurityContext securityContext) {
     authorizer.authorize(
         securityContext,
         new OperationContext(Entity.INGESTION_PIPELINE, MetadataOperation.EDIT_ALL),
         new ResourceContext<>(Entity.INGESTION_PIPELINE));
+  }
 
-    PipelineServiceClientInterface pipelineServiceClient =
-        PipelineServiceClientFactory.createPipelineServiceClient(null);
-    if (pipelineServiceClient == null) {
-      return Map.of(
-          "error",
-          "Pipeline service client is not configured. Ensure the ingestion infrastructure is"
-              + " set up.",
-          "fqn",
-          fqn);
-    }
+  private static PipelineServiceClientInterface resolveClient(String fqn) {
+    return PipelineServiceClientFactory.createPipelineServiceClient(null);
+  }
 
-    IngestionPipeline pipeline =
-        (IngestionPipeline) Entity.getEntityByName(Entity.INGESTION_PIPELINE, fqn, "*", null);
+  private static Map<String, Object> clientNotConfiguredError(String fqn) {
+    return Map.of(
+        "error",
+        "Pipeline service client is not configured."
+            + " Ensure the ingestion infrastructure is set up.",
+        "fqn",
+        fqn);
+  }
 
-    if (!Boolean.TRUE.equals(pipeline.getDeployed())) {
-      return Map.of(
-          "error",
-          "Pipeline '" + fqn + "' is not deployed. Deploy it first before triggering a run.",
-          "fqn",
-          fqn,
-          "deployed",
-          false);
-    }
+  private static Map<String, Object> notDeployedError(String fqn) {
+    return Map.of(
+        "error",
+        "Pipeline '" + fqn + "' is not deployed. Deploy it first before triggering a run.",
+        "fqn",
+        fqn,
+        "deployed",
+        false);
+  }
 
-    LOG.info("Triggering ingestion pipeline: {}", fqn);
+  private static IngestionPipeline fetchPipeline(String fqn) throws IOException {
+    return (IngestionPipeline) Entity.getEntityByName(Entity.INGESTION_PIPELINE, fqn, "*", null);
+  }
 
+  private static void setupServerConnection(IngestionPipeline pipeline) {
     if (McpApplicationContext.getConfig() != null) {
       pipeline.setOpenMetadataServerConnection(
           new OpenMetadataConnectionBuilder(McpApplicationContext.getConfig()).build());
     }
-
-    EntityReference serviceRef = pipeline.getService();
-    Object service = Entity.getEntity(serviceRef, "ingestionRunner", null);
-
-    var response = pipelineServiceClient.runPipeline(pipeline, service);
-    LOG.info("Trigger response for pipeline {}: {}", fqn, response);
-    return JsonUtils.getMap(response);
   }
 
   @Override

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/TriggerIngestionPipelineTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/TriggerIngestionPipelineTool.java
@@ -1,0 +1,79 @@
+package org.openmetadata.mcp.tools;
+
+import java.io.IOException;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.mcp.McpApplicationContext;
+import org.openmetadata.schema.entity.services.ingestionPipelines.IngestionPipeline;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.type.MetadataOperation;
+import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.sdk.PipelineServiceClientInterface;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.clients.pipeline.PipelineServiceClientFactory;
+import org.openmetadata.service.limits.Limits;
+import org.openmetadata.service.security.Authorizer;
+import org.openmetadata.service.security.auth.CatalogSecurityContext;
+import org.openmetadata.service.security.policyevaluator.OperationContext;
+import org.openmetadata.service.security.policyevaluator.ResourceContext;
+import org.openmetadata.service.util.OpenMetadataConnectionBuilder;
+
+@Slf4j
+public class TriggerIngestionPipelineTool implements McpTool {
+
+  @Override
+  public Map<String, Object> execute(
+      Authorizer authorizer, CatalogSecurityContext securityContext, Map<String, Object> params)
+      throws IOException {
+    String fqn = (String) params.get("fqn");
+    if (fqn == null || fqn.isBlank()) {
+      throw new IllegalArgumentException("Parameter 'fqn' is required");
+    }
+
+    authorizer.authorize(
+        securityContext,
+        new OperationContext(Entity.INGESTION_PIPELINE, MetadataOperation.EDIT_ALL),
+        new ResourceContext<>(Entity.INGESTION_PIPELINE));
+
+    PipelineServiceClientInterface pipelineServiceClient =
+        PipelineServiceClientFactory.createPipelineServiceClient(null);
+    if (pipelineServiceClient == null) {
+      return Map.of(
+          "error",
+          "Pipeline service client is not configured. Ensure the ingestion infrastructure is set up.",
+          "fqn",
+          fqn);
+    }
+
+    LOG.info("Triggering ingestion pipeline: {}", fqn);
+
+    IngestionPipeline pipeline =
+        (IngestionPipeline)
+            Entity.getEntityByName(Entity.INGESTION_PIPELINE, fqn, "*", null);
+
+    // Set the OpenMetadata server connection so the pipeline can call back home
+    if (McpApplicationContext.getConfig() != null) {
+      pipeline.setOpenMetadataServerConnection(
+          new OpenMetadataConnectionBuilder(McpApplicationContext.getConfig()).build());
+    }
+
+    EntityReference serviceRef = pipeline.getService();
+    Object service = Entity.getEntity(serviceRef, "ingestionRunner", null);
+
+    var response = pipelineServiceClient.runPipeline(pipeline, service);
+
+    LOG.info("Trigger response for pipeline {}: {}", fqn, response);
+    return JsonUtils.getMap(response);
+  }
+
+  @Override
+  public Map<String, Object> execute(
+      Authorizer authorizer,
+      Limits limits,
+      CatalogSecurityContext securityContext,
+      Map<String, Object> params)
+      throws IOException {
+    throw new UnsupportedOperationException(
+        "TriggerIngestionPipelineTool does not require limit validation.");
+  }
+}

--- a/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
+++ b/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
@@ -584,6 +584,65 @@
           "entityType"
         ]
       }
+    },
+    {
+      "name": "list_ingestion_pipelines",
+      "description": "List ingestion pipelines configured in OpenMetadata. Optionally filter by service name or pipeline type (metadata, usage, lineage, profiler, dataInsight, etc.). Returns pipeline names, FQNs, types, and enabled/deployed status. Use 'get_pipeline_status' to check the latest run status of a specific pipeline.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "service": {
+            "type": "string",
+            "description": "Filter pipelines by service name (e.g., 'bigquery_prod', 'snowflake_dw'). Returns only pipelines belonging to this service."
+          },
+          "pipelineType": {
+            "type": "string",
+            "description": "Filter by pipeline type. Values: metadata, usage, lineage, profiler, dataInsight, elasticSearchReindex, dbt, application. Leave empty to return all types."
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Maximum number of pipelines to return. Default: 10. Max recommended: 50.",
+            "default": 10
+          },
+          "after": {
+            "type": "string",
+            "description": "Pagination cursor. Pass the 'after' value from a previous response to retrieve the next page."
+          }
+        }
+      }
+    },
+    {
+      "name": "get_pipeline_status",
+      "description": "Get execution status of a specific ingestion pipeline. Returns the latest run status (success, failed, running, queued) and recent run history. Use 'list_ingestion_pipelines' to find a pipeline's FQN first.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "fqn": {
+            "type": "string",
+            "description": "Fully qualified name of the ingestion pipeline (e.g., 'bigquery_prod.metadata_ingestion'). Use 'list_ingestion_pipelines' or 'search_metadata' to find it."
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Number of recent pipeline runs to return. Default: 5.",
+            "default": 5
+          }
+        },
+        "required": ["fqn"]
+      }
+    },
+    {
+      "name": "trigger_ingestion_pipeline",
+      "description": "Trigger an immediate run of an ingestion pipeline. Use this to kick off metadata, lineage, or profiling ingestion on demand without waiting for the scheduled run. Requires the pipeline to be deployed. Check the pipeline status with 'get_pipeline_status' after triggering to monitor progress.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "fqn": {
+            "type": "string",
+            "description": "Fully qualified name of the ingestion pipeline to trigger (e.g., 'bigquery_prod.metadata_ingestion'). Use 'list_ingestion_pipelines' to find the FQN."
+          }
+        },
+        "required": ["fqn"]
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

Closes part of #26609 — implements the **Workflow Automation** category of new MCP tools.

Adds three new tools to the OpenMetadata MCP server so agents can manage ingestion pipelines conversationally, without switching to the UI or calling REST APIs directly.

### New Tools

| Tool | Description |
|---|---|
| `list_ingestion_pipelines` | List pipelines, optionally filtered by service or pipeline type |
| `get_pipeline_status` | Get latest run status + recent run history for a pipeline |
| `trigger_ingestion_pipeline` | Trigger an immediate run of a deployed pipeline |

### Architecture

```mermaid
sequenceDiagram
    participant Agent as AI Agent / MCP Client
    participant MCP as McpServer
    participant DTC as DefaultToolContext
    participant Repo as IngestionPipelineRepository
    participant PSC as PipelineServiceClient

    Agent->>MCP: call tool (e.g. trigger_ingestion_pipeline)
    MCP->>DTC: callTool(toolName, params)

    alt list_ingestion_pipelines
        DTC->>Repo: listAfter(filter, limit)
        Repo-->>DTC: ResultList<IngestionPipeline>
    else get_pipeline_status
        DTC->>Repo: getLatestPipelineStatus(pipeline)
        DTC->>Repo: listPipelineStatus(fqn, limit)
        Repo-->>DTC: PipelineStatus + history
    else trigger_ingestion_pipeline
        DTC->>Repo: getEntityByName(fqn)
        DTC->>PSC: runPipeline(pipeline, service)
        PSC-->>DTC: PipelineServiceClientResponse
    end

    DTC-->>MCP: Map<String, Object>
    MCP-->>Agent: CallToolResult (JSON)
```

### Files Changed

- **`McpApplicationContext.java`** *(new)* — lightweight static holder for `OpenMetadataApplicationConfig`, populated at MCP server init so tools can access app config without reflection
- **`McpServer.java`** — registers config into `McpApplicationContext` on startup
- **`ListIngestionPipelinesTool.java`** *(new)* — lists ingestion pipelines with service/type filters
- **`GetPipelineStatusTool.java`** *(new)* — fetches latest status + recent run history
- **`TriggerIngestionPipelineTool.java`** *(new)* — triggers a pipeline run via `PipelineServiceClientFactory`
- **`DefaultToolContext.java`** — wires the 3 new tools into the switch router
- **`tools.json`** — adds JSON schema definitions for all 3 tools (LLM-facing descriptions + input schemas)

### Example Agent Interactions

```
"List all ingestion pipelines for the bigquery_prod service"
→ list_ingestion_pipelines { service: "bigquery_prod" }

"What's the status of the last run for bigquery_prod.metadata_ingestion?"
→ get_pipeline_status { fqn: "bigquery_prod.metadata_ingestion" }

"Trigger the metadata ingestion for bigquery_prod right now"
→ trigger_ingestion_pipeline { fqn: "bigquery_prod.metadata_ingestion" }
```

### Checklist
- [x] Follows existing tool patterns (`McpTool` interface, `Entity.getEntityRepository`, auth via `authorizer.authorize`)
- [x] LLM-optimized tool descriptions (verbose fields stripped, context-aware parameter descriptions)
- [x] Authorization enforced (`VIEW_BASIC` for list/status, `EDIT_ALL` for trigger)
- [x] `tools.json` schema updated with input validation and helpful descriptions
- [x] Graceful error when pipeline service client is not configured

----
## Summary by Gitar

- **Refactored tool logic:**
  - Standardized parameter parsing and authorization patterns across `ListIngestionPipelinesTool`, `GetPipelineStatusTool`, and `TriggerIngestionPipelineTool`.
  - Extracted shared execution logic into private helper methods to improve code maintainability.
- **Improved robustness:**
  - Introduced named tool constants in `DefaultToolContext` for safer routing.
  - Added a deployment check in `TriggerIngestionPipelineTool` to prevent triggering non-deployed pipelines.

<sub>This will update automatically on new commits.</sub>