### PR TITLE
Fix issue #27376

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityRightPanel/EntityRightPanel.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityRightPanel/EntityRightPanel.tsx
@@ -92,7 +92,7 @@ const EntityRightPanel = <T extends ExtentionEntitiesKeys>({
     <>
       {beforeSlot}
       <Space className="w-full" direction="vertical" size="large">
-        {showDataProductContainer && (
+        {shouldShowDataProducts && (
           <div data-testid="KnowledgePanel.DataProducts">
             <DataProductsContainer
               newLook
@@ -104,7 +104,7 @@ const EntityRightPanel = <T extends ExtentionEntitiesKeys>({
             />
           </div>
         )}
-
+        {shouldShowTags && (
         <div data-testid="KnowledgePanel.Tags">
           <TagsContainerV2
             newLook
@@ -118,7 +118,8 @@ const EntityRightPanel = <T extends ExtentionEntitiesKeys>({
             onSelectionChange={onTagSelectionChange}
           />
         </div>
-
+               )}
+     {shouldShowGlossaryTerms && (
         <div data-testid="KnowledgePanel.GlossaryTerms">
           <TagsContainerV2
             newLook
@@ -132,6 +133,7 @@ const EntityRightPanel = <T extends ExtentionEntitiesKeys>({
             onSelectionChange={onTagSelectionChange}
           />
         </div>
+               )}
         {KnowledgeArticles && (
           <KnowledgeArticles entityId={entityId} entityType={entityType} />
         )}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityRightPanel/EntityRightPanel.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityRightPanel/EntityRightPanel.tsx
@@ -75,7 +75,19 @@ const EntityRightPanel = <T extends ExtentionEntitiesKeys>({
   }>();
 
   const { domains, dataProducts, id: entityId } = data ?? {};
-
+ const hasClassificationTags = selectedTags.some(
+    (tag) => tag.source === TagSource.Classification
+  );
+  const hasGlossaryTags = selectedTags.some(
+    (tag) => tag.source === TagSource.Glossary
+  );
+ 
+  const shouldShowTags = editTagPermission || hasClassificationTags;
+  const shouldShowGlossaryTerms =
+    editGlossaryTermsPermission || hasGlossaryTags;
+  const shouldShowDataProducts =
+    showDataProductContainer &&
+    (editDataProductPermission || Boolean(dataProducts?.length));
   return (
     <>
       {beforeSlot}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsContainerV2/TagsContainerV2.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsContainerV2/TagsContainerV2.tsx
@@ -493,6 +493,10 @@ const TagsContainerV2 = ({
     setTags(getFilterTags(selectedTags));
   }, [selectedTags]);
 
+  if (newLook && !permission && isEmpty(tags?.[tagType]) && !isEditTags) {
+    return null;
+  }
+  
   if (newLook) {
     return (
       <ExpandableCard


### PR DESCRIPTION
Fixes #27376

This PR fixes the UI inconsistency issue in the right-hand panel of Data Asset pages when using a Custom Persona.

The problem was caused by excessive white space and inconsistent spacing between widgets (Data Products, Tags, Glossary Terms) due to two main issues:

1. **EntityRightPanel spacing issue (Layer 1 fix):**
   - The `Space` component was rendering empty widget wrappers.
   - These empty wrappers still contributed `24px` gaps, leading to large unintended white space.
   - Added conditional rendering to ensure wrapper `<div>`s are only rendered when widgets have meaningful content or user permissions.

2. **Widget-level empty rendering issue (Layer 2 fix):**
   - `TagsContainerV2` and `DataProductsContainer` rendered full `ExpandableCard` shells even when empty.
   - This resulted in visible blank blocks and inconsistent UI spacing under custom personas.
   - Added guards to prevent rendering empty UI shells when no data and no permissions exist.

### Expected behavior:
- Right panel should maintain consistent spacing.
- No unnecessary blank space when widgets are empty.
- Layout should remain aligned regardless of Custom Persona configuration.

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes #27376: UI inconsistency - remove excessive white space in right panel`
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

### Bug fix checklist:
- [x] I have verified the fix removes unnecessary spacing in the right panel.
- [x] I have ensured no UI regression in default persona views.

### Tested with:
-EntityRightPanel.test.tsx




Before(UI spacing between components in custom persona new):
<img width="1096" height="620" alt="Screenshot 2026-04-27 000953" src="https://github.com/user-attachments/assets/31978f56-fb6e-4632-801b-d5782ef4585d" />

After(There is no random spacing in the custom persona):
<img width="1161" height="652" alt="Screenshot 2026-04-27 000850" src="https://github.com/user-attachments/assets/24705106-e1d4-4a79-95ab-014961921086" />

