### PR TITLE
Fixes #26305: Implement progressive infinite scroll for Explore dropdowns

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ExploreQuickFilters.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ExploreQuickFilters.spec.ts
@@ -426,4 +426,70 @@ test.describe('Metric search result highlight', () => {
       expect(fullText?.trim()).toBe(metric.entity.name);
     });
   });
+
+  test.afterAll('Cleanup metric entity', async ({ browser }) => {
+    const { apiContext, afterAction } = await createNewPage(browser);
+    await metric.delete(apiContext);
+    await afterAction();
+  });
 });
+
+test.describe(
+  'Quick filter dropdown infinite scroll',
+  { tag: ['@Features', '@Discovery'] },
+  () => {
+    test('should progressively load more options on scroll to bottom', async ({
+      page,
+    }) => {
+      test.slow();
+
+      await test.step('Open the Tag quick filter and capture initial aggregate request with size=50', async () => {
+        const initialAggregateResponse = page.waitForResponse(
+          (response) =>
+            response.url().includes('/api/v1/search/aggregate') &&
+            response.url().includes('field=tags.tagFQN') &&
+            response.url().includes('size=50') &&
+            response.status() === 200
+        );
+
+        await page.getByTestId('search-dropdown-Tag').click();
+        await initialAggregateResponse;
+        await waitForAllLoadersToDisappear(page);
+      });
+
+      await test.step('Scroll to the bottom of the dropdown and verify a second request with size=100', async () => {
+        const scrollContainer = page.getByTestId(
+          'search-dropdown-scroll-container'
+        );
+        await expect(scrollContainer).toBeVisible();
+
+        const nextAggregateResponse = page.waitForResponse(
+          (response) =>
+            response.url().includes('/api/v1/search/aggregate') &&
+            response.url().includes('field=tags.tagFQN') &&
+            response.url().includes('size=100') &&
+            response.status() === 200
+        );
+
+        await scrollContainer.evaluate((el) => {
+          el.scrollTop = el.scrollHeight;
+        });
+
+        await nextAggregateResponse;
+        await waitForAllLoadersToDisappear(page);
+      });
+
+      await clickOutside(page);
+    });
+  }
+);
+
+test.afterAll('Cleanup', async ({ browser }) => {
+  const { apiContext, afterAction } = await createNewPage(browser);
+  await table.delete(apiContext);
+  await domain.delete(apiContext);
+  await tier.delete(apiContext);
+  await tierWithoutAsset.delete(apiContext);
+  await afterAction();
+});
+

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ExploreQuickFilters.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ExploreQuickFilters.spec.ts
@@ -481,15 +481,15 @@ test.describe(
 
       await clickOutside(page);
     });
+
+    test.afterAll('Cleanup', async ({ browser }) => {
+      const { apiContext, afterAction } = await createNewPage(browser);
+      await table.delete(apiContext);
+      await domain.delete(apiContext);
+      await tier.delete(apiContext);
+      await tierWithoutAsset.delete(apiContext);
+      await afterAction();
+    });
   }
 );
-
-test.afterAll('Cleanup', async ({ browser }) => {
-  const { apiContext, afterAction } = await createNewPage(browser);
-  await table.delete(apiContext);
-  await domain.delete(apiContext);
-  await tier.delete(apiContext);
-  await tierWithoutAsset.delete(apiContext);
-  await afterAction();
-});
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx
@@ -39,6 +39,7 @@ import { ExploreQuickFiltersProps } from './ExploreQuickFilters.interface';
 const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
   fields,
   index,
+  aggregations,
   independent = false,
   onFieldValueSelect,
   fieldsWithNullValues = [],
@@ -56,6 +57,7 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
   const { isNLPEnabled } = useSearchStore();
 
   const currentSizeRef = useRef<number>(EXPLORE_QUICK_FILTER_PAGE_SIZE);
+  const isLoadingMoreRef = useRef<boolean>(false);
   const activeFieldRef = useRef<{
     key: string;
     searchIndex?: SearchIndex;
@@ -154,15 +156,27 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
 
     currentSizeRef.current = pageSize;
     searchTextRef.current = '';
+    isLoadingMoreRef.current = false;
     activeFieldRef.current = {
       key,
       searchIndex: fieldSearchIndex,
       searchKey: fieldSearchKey,
     };
 
+    setIsLoadingMore(false);
     setIsOptionsLoading(true);
     setOptions([]);
     setHasMore(false);
+
+    const buckets = aggregations?.[key]?.buckets;
+    if (buckets) {
+      setOptions(uniqWith(getOptionsFromAggregationBucket(buckets), isEqual));
+      setHasMore(buckets.length >= pageSize);
+      setIsOptionsLoading(false);
+
+      return;
+    }
+
     try {
       await fetchAggregationBuckets(
         key,
@@ -230,14 +244,16 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
   };
 
   const handleScrollEnd = useCallback(async () => {
-    if (isLoadingMore || !hasMore || !activeFieldRef.current) {
+    if (isLoadingMoreRef.current || !hasMore || !activeFieldRef.current) {
       return;
     }
+
+    isLoadingMoreRef.current = true;
+    setIsLoadingMore(true);
 
     const nextSize = currentSizeRef.current + pageSize;
     currentSizeRef.current = nextSize;
 
-    setIsLoadingMore(true);
     try {
       await fetchAggregationBuckets(
         activeFieldRef.current.key,
@@ -249,9 +265,10 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
     } catch (error) {
       showErrorToast(error as AxiosError);
     } finally {
+      isLoadingMoreRef.current = false;
       setIsLoadingMore(false);
     }
-  }, [isLoadingMore, hasMore, pageSize, fetchAggregationBuckets]);
+  }, [hasMore, pageSize, fetchAggregationBuckets]);
 
   return (
     <Space wrap className="explore-quick-filters-container" size={[8, 0]}>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx
@@ -15,7 +15,8 @@ import { Space } from 'antd';
 import { AxiosError } from 'axios';
 import { isEqual, uniqWith } from 'lodash';
 import Qs from 'qs';
-import { FC, useCallback, useMemo, useState } from 'react';
+import { FC, useCallback, useMemo, useRef, useState } from 'react';
+import { EXPLORE_QUICK_FILTER_PAGE_SIZE } from '../../constants/explore.constants';
 import { EntityFields } from '../../enums/AdvancedSearch.enum';
 import { SearchIndex } from '../../enums/search.enum';
 import useCustomLocation from '../../hooks/useCustomLocation/useCustomLocation';
@@ -38,7 +39,6 @@ import { ExploreQuickFiltersProps } from './ExploreQuickFilters.interface';
 const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
   fields,
   index,
-  aggregations,
   independent = false,
   onFieldValueSelect,
   fieldsWithNullValues = [],
@@ -50,8 +50,19 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
   const location = useCustomLocation();
   const [options, setOptions] = useState<SearchDropdownOption[]>();
   const [isOptionsLoading, setIsOptionsLoading] = useState<boolean>(false);
+  const [isLoadingMore, setIsLoadingMore] = useState<boolean>(false);
+  const [hasMore, setHasMore] = useState<boolean>(false);
   const { queryFilter } = useAdvanceSearch();
   const { isNLPEnabled } = useSearchStore();
+
+  const currentSizeRef = useRef<number>(EXPLORE_QUICK_FILTER_PAGE_SIZE);
+  const activeFieldRef = useRef<{
+    key: string;
+    searchIndex?: SearchIndex;
+    searchKey?: string;
+  } | null>(null);
+  const searchTextRef = useRef<string>('');
+
   const getStaticOptions = useCallback(
     (key: string) => fields.find((item) => item.key === key)?.options,
     [fields]
@@ -88,43 +99,45 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
     defaultQueryFilter as unknown as QueryFilterInterface
   );
 
-  const fetchDefaultOptions = async (
-    index: SearchIndex | SearchIndex[],
-    key: string,
-    fieldSearchIndex?: SearchIndex,
-    fieldSearchKey?: string
-  ) => {
-    const staticOptions = getStaticOptions(key);
-    if (staticOptions) {
-      setOptions(staticOptions);
+  const pageSize = optionPageSize ?? EXPLORE_QUICK_FILTER_PAGE_SIZE;
 
-      return;
-    }
+  const fetchAggregationBuckets = useCallback(
+    async (
+      key: string,
+      value: string,
+      size: number,
+      fieldSearchIndex?: SearchIndex,
+      fieldSearchKey?: string
+    ) => {
+      const searchIndexToUse = fieldSearchIndex ?? index;
+      const searchKeyToUse = fieldSearchKey ?? key;
 
-    // Use field-specific searchIndex if provided, otherwise use the default index
-    const searchIndexToUse = fieldSearchIndex ?? index;
-    // Use field-specific searchKey if provided, otherwise use the key
-    const searchKeyToUse = fieldSearchKey ?? key;
-
-    let buckets = aggregations?.[key]?.buckets;
-    if (!buckets) {
       const res = await getAggregationOptions(
         searchIndexToUse,
         searchKeyToUse,
-        '',
+        value,
         JSON.stringify(combinedQueryFilter),
         independent,
         showDeleted,
-        optionPageSize,
+        size,
         isNLPEnabled,
         searchText
       );
 
-      buckets = res.data.aggregations[`sterms#${searchKeyToUse}`].buckets;
-    }
+      const buckets =
+        res.data.aggregations[`sterms#${searchKeyToUse}`].buckets;
+      const newOptions = uniqWith(
+        getOptionsFromAggregationBucket(buckets),
+        isEqual
+      );
 
-    setOptions(uniqWith(getOptionsFromAggregationBucket(buckets), isEqual));
-  };
+      setOptions(newOptions);
+      setHasMore(buckets.length >= size);
+
+      return newOptions;
+    },
+    [index, combinedQueryFilter, independent, showDeleted, isNLPEnabled, searchText]
+  );
 
   const getInitialOptions = async (
     key: string,
@@ -134,14 +147,30 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
     const staticOptions = getStaticOptions(key);
     if (staticOptions) {
       setOptions(staticOptions);
+      setHasMore(false);
 
       return;
     }
 
+    currentSizeRef.current = pageSize;
+    searchTextRef.current = '';
+    activeFieldRef.current = {
+      key,
+      searchIndex: fieldSearchIndex,
+      searchKey: fieldSearchKey,
+    };
+
     setIsOptionsLoading(true);
     setOptions([]);
+    setHasMore(false);
     try {
-      await fetchDefaultOptions(index, key, fieldSearchIndex, fieldSearchKey);
+      await fetchAggregationBuckets(
+        key,
+        '',
+        pageSize,
+        fieldSearchIndex,
+        fieldSearchKey
+      );
     } catch (error) {
       showErrorToast(error as AxiosError);
     } finally {
@@ -163,12 +192,22 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
           )
         : staticOptions;
       setOptions(filteredOptions);
+      setHasMore(false);
 
       return;
     }
 
+    currentSizeRef.current = pageSize;
+    searchTextRef.current = value;
+    activeFieldRef.current = {
+      key,
+      searchIndex: fieldSearchIndex,
+      searchKey: fieldSearchKey,
+    };
+
     setIsOptionsLoading(true);
     setOptions([]);
+    setHasMore(false);
     try {
       if (!value) {
         getInitialOptions(key, fieldSearchIndex, fieldSearchKey);
@@ -176,29 +215,43 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
         return;
       }
 
-      const searchIndexToUse = fieldSearchIndex ?? index;
-      const searchKeyToUse = fieldSearchKey ?? key;
-
-      const res = await getAggregationOptions(
-        searchIndexToUse,
-        searchKeyToUse,
+      await fetchAggregationBuckets(
+        key,
         value,
-        JSON.stringify(combinedQueryFilter),
-        independent,
-        showDeleted,
-        undefined,
-        isNLPEnabled,
-        searchText
+        pageSize,
+        fieldSearchIndex,
+        fieldSearchKey
       );
-
-      const buckets = res.data.aggregations[`sterms#${searchKeyToUse}`].buckets;
-      setOptions(uniqWith(getOptionsFromAggregationBucket(buckets), isEqual));
     } catch (error) {
       showErrorToast(error as AxiosError);
     } finally {
       setIsOptionsLoading(false);
     }
   };
+
+  const handleScrollEnd = useCallback(async () => {
+    if (isLoadingMore || !hasMore || !activeFieldRef.current) {
+      return;
+    }
+
+    const nextSize = currentSizeRef.current + pageSize;
+    currentSizeRef.current = nextSize;
+
+    setIsLoadingMore(true);
+    try {
+      await fetchAggregationBuckets(
+        activeFieldRef.current.key,
+        searchTextRef.current,
+        nextSize,
+        activeFieldRef.current.searchIndex,
+        activeFieldRef.current.searchKey
+      );
+    } catch (error) {
+      showErrorToast(error as AxiosError);
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }, [isLoadingMore, hasMore, pageSize, fetchAggregationBuckets]);
 
   return (
     <Space wrap className="explore-quick-filters-container" size={[8, 0]}>
@@ -211,12 +264,14 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
         return (
           <SearchDropdown
             highlight
+            isPaginated
             dropdownClassName={field.dropdownClassName}
             hasNullOption={hasNullOption}
             hideCounts={field.hideCounts ?? false}
             hideSearchBar={field.hideSearchBar ?? false}
             independent={independent}
             index={displayIndex as ExploreSearchIndex}
+            isLoadingMore={isLoadingMore}
             isSuggestionsLoading={isOptionsLoading}
             key={field.key}
             label={translateWithNestedKeys(field.label, field.labelKeyOptions)}
@@ -232,6 +287,7 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
             onGetInitialOptions={(key) =>
               getInitialOptions(key, field.searchIndex, field.searchKey)
             }
+            onScrollEnd={handleScrollEnd}
             onSearch={(value, key) =>
               getFilterOptions(value, key, field.searchIndex, field.searchKey)
             }
@@ -244,3 +300,4 @@ const ExploreQuickFilters: FC<ExploreQuickFiltersProps> = ({
 };
 
 export default ExploreQuickFilters;
+

--- a/openmetadata-ui/src/main/resources/ui/src/components/SearchDropdown/SearchDropdown.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/SearchDropdown/SearchDropdown.interface.ts
@@ -35,6 +35,9 @@ export interface SearchDropdownProps {
   hideSearchBar?: boolean; // Determines if the search bar should be hidden. Default is false
   singleSelect?: boolean; // Enable single-select mode with radio buttons instead of checkboxes
   getPopupContainer?: (triggerNode: HTMLElement) => HTMLElement;
+  isPaginated?: boolean; // Enable infinite scroll with progressive loading
+  onScrollEnd?: () => void; // Callback fired when the user scrolls to the bottom of the options list
+  isLoadingMore?: boolean; // When true, a spinner is rendered at the bottom of the options list
 }
 
 export interface SearchDropdownOption {

--- a/openmetadata-ui/src/main/resources/ui/src/components/SearchDropdown/SearchDropdown.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/SearchDropdown/SearchDropdown.test.tsx
@@ -562,4 +562,147 @@ describe('Search DropDown Component', () => {
       );
     });
   });
+
+  describe('Paginated / Infinite Scroll', () => {
+    const mockOnScrollEnd = jest.fn();
+
+    const paginatedProps: SearchDropdownProps = {
+      ...mockProps,
+      isPaginated: true,
+      onScrollEnd: mockOnScrollEnd,
+      isLoadingMore: false,
+    };
+
+    beforeEach(() => {
+      mockOnScrollEnd.mockClear();
+    });
+
+    it('should render scroll container when isPaginated is true', async () => {
+      render(<SearchDropdown {...paginatedProps} />);
+
+      const container = await screen.findByTestId('search-dropdown-Owner');
+      await act(async () => {
+        fireEvent.click(container);
+      });
+
+      expect(
+        await screen.findByTestId('search-dropdown-scroll-container')
+      ).toBeInTheDocument();
+    });
+
+    it('should NOT render scroll container when isPaginated is false', async () => {
+      render(<SearchDropdown {...mockProps} />);
+
+      const container = await screen.findByTestId('search-dropdown-Owner');
+      await act(async () => {
+        fireEvent.click(container);
+      });
+
+      expect(
+        screen.queryByTestId('search-dropdown-scroll-container')
+      ).not.toBeInTheDocument();
+    });
+
+    it('should call onScrollEnd when scrolled to bottom within threshold', async () => {
+      render(<SearchDropdown {...paginatedProps} />);
+
+      const container = await screen.findByTestId('search-dropdown-Owner');
+      await act(async () => {
+        fireEvent.click(container);
+      });
+
+      const scrollContainer = await screen.findByTestId(
+        'search-dropdown-scroll-container'
+      );
+
+      Object.defineProperty(scrollContainer, 'scrollHeight', {
+        value: 500,
+        writable: true,
+      });
+      Object.defineProperty(scrollContainer, 'clientHeight', {
+        value: 200,
+        writable: true,
+      });
+
+      await act(async () => {
+        fireEvent.scroll(scrollContainer, {
+          target: { scrollTop: 295 },
+        });
+      });
+
+      expect(mockOnScrollEnd).toHaveBeenCalledTimes(1);
+    });
+
+    it('should NOT call onScrollEnd when not scrolled to bottom', async () => {
+      render(<SearchDropdown {...paginatedProps} />);
+
+      const container = await screen.findByTestId('search-dropdown-Owner');
+      await act(async () => {
+        fireEvent.click(container);
+      });
+
+      const scrollContainer = await screen.findByTestId(
+        'search-dropdown-scroll-container'
+      );
+
+      Object.defineProperty(scrollContainer, 'scrollHeight', {
+        value: 500,
+        writable: true,
+      });
+      Object.defineProperty(scrollContainer, 'clientHeight', {
+        value: 200,
+        writable: true,
+      });
+
+      await act(async () => {
+        fireEvent.scroll(scrollContainer, {
+          target: { scrollTop: 100 },
+        });
+      });
+
+      expect(mockOnScrollEnd).not.toHaveBeenCalled();
+    });
+
+    it('should NOT call onScrollEnd when isLoadingMore is true', async () => {
+      render(<SearchDropdown {...paginatedProps} isLoadingMore />);
+
+      const container = await screen.findByTestId('search-dropdown-Owner');
+      await act(async () => {
+        fireEvent.click(container);
+      });
+
+      const scrollContainer = await screen.findByTestId(
+        'search-dropdown-scroll-container'
+      );
+
+      Object.defineProperty(scrollContainer, 'scrollHeight', {
+        value: 500,
+        writable: true,
+      });
+      Object.defineProperty(scrollContainer, 'clientHeight', {
+        value: 200,
+        writable: true,
+      });
+
+      await act(async () => {
+        fireEvent.scroll(scrollContainer, {
+          target: { scrollTop: 295 },
+        });
+      });
+
+      expect(mockOnScrollEnd).not.toHaveBeenCalled();
+    });
+
+    it('should render Loader at bottom when isLoadingMore is true', async () => {
+      render(<SearchDropdown {...paginatedProps} isLoadingMore />);
+
+      const container = await screen.findByTestId('search-dropdown-Owner');
+      await act(async () => {
+        fireEvent.click(container);
+      });
+
+      expect(await screen.findByTestId('loader')).toBeInTheDocument();
+    });
+  });
 });
+

--- a/openmetadata-ui/src/main/resources/ui/src/components/SearchDropdown/SearchDropdown.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/SearchDropdown/SearchDropdown.tsx
@@ -29,7 +29,7 @@ import {
 } from 'antd';
 import classNames from 'classnames';
 import { debounce, isEmpty, isUndefined } from 'lodash';
-import {
+import React, {
   FC,
   ReactNode,
   useCallback,
@@ -75,6 +75,9 @@ const SearchDropdown: FC<SearchDropdownProps> = ({
   hideSearchBar = false,
   singleSelect = false,
   getPopupContainer,
+  isPaginated = false,
+  onScrollEnd,
+  isLoadingMore = false,
 }) => {
   const tabsInfo = searchClassBase.getTabsInfo();
   const { t } = useTranslation();
@@ -238,6 +241,19 @@ const SearchDropdown: FC<SearchDropdownProps> = ({
     );
   }, [isDropDownOpen, selectedKeys]);
 
+  const handleMenuScroll = useCallback(
+    (e: React.UIEvent<HTMLDivElement>) => {
+      if (!isPaginated || !onScrollEnd || isLoadingMore) {
+        return;
+      }
+      const { scrollHeight, scrollTop, clientHeight } = e.currentTarget;
+      if (scrollHeight - (scrollTop + clientHeight) <= 10) {
+        onScrollEnd();
+      }
+    },
+    [isPaginated, onScrollEnd, isLoadingMore]
+  );
+
   const getDropdownBody = useCallback(
     (menuNode: ReactNode) => {
       const entityLabel = index && tabsInfo[index]?.label;
@@ -252,9 +268,30 @@ const SearchDropdown: FC<SearchDropdownProps> = ({
         );
       }
 
-      return options.length > 0 || selectedOptions.length > 0 ? (
-        menuNode
-      ) : (
+      if (options.length > 0 || selectedOptions.length > 0) {
+        return isPaginated ? (
+          <div
+            className="search-dropdown-scroll-container"
+            data-testid="search-dropdown-scroll-container"
+            onScroll={handleMenuScroll}>
+            {menuNode}
+            {isLoadingMore && (
+              <Row
+                align="middle"
+                className="p-y-xss"
+                justify="center">
+                <Col>
+                  <Loader size="small" />
+                </Col>
+              </Row>
+            )}
+          </div>
+        ) : (
+          menuNode
+        );
+      }
+
+      return (
         <Row align="middle" className="m-y-sm" justify="center">
           <Col>
             <Typography.Text className="m-x-sm">
@@ -268,7 +305,16 @@ const SearchDropdown: FC<SearchDropdownProps> = ({
         </Row>
       );
     },
-    [isSuggestionsLoading, options, selectedOptions, index, searchKey]
+    [
+      isSuggestionsLoading,
+      options,
+      selectedOptions,
+      index,
+      searchKey,
+      isPaginated,
+      handleMenuScroll,
+      isLoadingMore,
+    ]
   );
 
   const dropdownCardComponent = useCallback(

--- a/openmetadata-ui/src/main/resources/ui/src/components/SearchDropdown/search-dropdown.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/SearchDropdown/search-dropdown.less
@@ -32,6 +32,18 @@
     }
   }
 
+  .search-dropdown-scroll-container {
+    max-height: 200px;
+    overflow-y: auto;
+    margin-bottom: 8px;
+
+    .ant-dropdown-menu {
+      max-height: none;
+      overflow-y: visible;
+      margin-bottom: 0;
+    }
+  }
+
   .dropdown-option-label {
     max-width: 65vw;
   }

--- a/openmetadata-ui/src/main/resources/ui/src/constants/explore.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/explore.constants.ts
@@ -24,6 +24,8 @@ export const TAG_FQN_KEY = 'tags.tagFQN';
 
 export const MAX_RESULT_HITS = 10000;
 
+export const EXPLORE_QUICK_FILTER_PAGE_SIZE = 50;
+
 export const SUPPORTED_EMPTY_FILTER_FIELDS = [
   EntityFields.OWNERS,
   EntityFields.DOMAINS,

--- a/openmetadata-ui/src/main/resources/ui/src/rest/miscAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/miscAPI.ts
@@ -221,7 +221,8 @@ export const getAggregateFieldOptions = (
   sourceFields?: string,
   deleted = false,
   isNLPEnabled = false,
-  queryText?: string
+  queryText?: string,
+  size?: number
 ) => {
   const withWildCardValue = value
     ? `.*${escapeESReservedCharacters(value)}.*`
@@ -234,6 +235,7 @@ export const getAggregateFieldOptions = (
     sourceFields,
     deleted,
     ...(queryText ? { queryText } : {}),
+    ...(size !== undefined ? { size } : {}),
   };
 
   return APIClient.get<SearchResponse<ExploreSearchIndex>>(

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ExploreUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ExploreUtils.tsx
@@ -382,7 +382,8 @@ export const getAggregationOptions = async (
         undefined,
         deleted,
         isNLPEnabled,
-        queryText
+        queryText,
+        size
       );
 };
 


### PR DESCRIPTION
### Describe your changes:

Fixes #26305

I worked on implementing a progressive infinite scroll mechanism for Explore page quick filters (Tags, Owners) because loading 15,000+ aggregation buckets simultaneously caused severe browser hangs and DOM rendering bottlenecks. 

**What changes did I make?**
* **Progressive Size Increment Strategy:** Because Elasticsearch `terms` aggregations do not natively support offset/cursor-based pagination (`from`/`after`), I implemented a progressive size increment strategy (fetching `size=50`, then `size=100`, etc.) to simulate infinite scrolling.
* **Opt-in Architecture:** Added an `isPaginated` boolean prop to `SearchDropdown` (defaulting to `false`) to ensure we don't break backward compatibility with Domain, Glossary, and Lineage page usages.
* **Clean Event Handling:** Wrapped the `dropdownRender` menu in a scrollable `div` with a pure React `onScroll` listener, completely avoiding fragile `document.querySelector` DOM manipulations.

**How did I test my changes?**
* **Jest Unit Tests:** Added 6 new tests to `SearchDropdown.test.tsx` verifying scroll threshold mathematics, `isLoadingMore` guards, and UI state changes.
* **Playwright E2E Tests:** Added a dedicated test in `ExploreQuickFilters.spec.ts` that intercepts the `/search/aggregate` network request to explicitly verify that `size=50` and `size=100` payloads are requested sequentially upon scrolling.

*(Note: As my local environment is resource-constrained, UI screenshots are omitted, but functionality is strictly verified via the attached Playwright CI tests).*
<img width="1090" height="615" alt="image" src="https://github.com/user-attachments/assets/94ba6f07-160a-4643-83a8-d471fc666e50" />


#
### Type of change:
- [x] Improvement

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes #26305: Implement progressive infinite scroll for Explore dropdowns`
- [x] I have commented on my code, particularly in hard-to-understand areas. 

- [x] I have added tests around the new logic.

---

### 🚀 A Personal Note: WeMakeDevs × OpenMetadata Hackathon Wrap-up
*This PR marks my final contribution for the WeMakeDevs hackathon. Pushing 24 PRs over the last two weeks—ranging from AI Root Cause Analysis engines to Core DB Reliability and Frontend optimizations—has been an incredible engineering gauntlet. I deeply appreciate the maintainers (@harshach, @ulixius9, @Rohit0301 , @PubChimps  and complete collate team) for their rigorous reviews and high standards. The hackathon may be ending, but I will definitely be sticking around the OpenMetadata community. Looking forward to what we build next!*