### PR TITLE
fix(migration): align PG v200 migration with MySQL

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v200/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v200/Migration.java
@@ -4,7 +4,6 @@ import static org.openmetadata.service.migration.utils.v200.MigrationUtil.addTab
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.backfillAnnouncementRelationships;
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.migrateLegacyActivityThreadsToActivityStream;
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.migrateSuggestionsToTaskEntity;
-import static org.openmetadata.service.migration.utils.v200.MigrationUtil.migrateThreadTasksToTaskEntity;
 
 import lombok.SneakyThrows;
 import org.openmetadata.service.migration.api.MigrationProcessImpl;
@@ -21,7 +20,9 @@ public class Migration extends MigrationProcessImpl {
   public void runDataMigration() {
     addTableColumnSearchSettings();
     migrateSuggestionsToTaskEntity(handle);
-    migrateThreadTasksToTaskEntity(handle);
+    // Causing issues with collate CI, needs to be fixed before enabling this migration
+    // @harshach
+    // migrateThreadTasksToTaskEntity(handle);
     migrateLegacyActivityThreadsToActivityStream(handle);
     backfillAnnouncementRelationships(handle);
   }


### PR DESCRIPTION
## Summary

- Comments out `migrateThreadTasksToTaskEntity(handle)` in the PostgreSQL v200 migration to match the MySQL fix from #27687.
- The original fix was only applied to MySQL (`openmetadata-service/.../migration/mysql/v200/Migration.java`), so PostgreSQL deployments would still hit the same Collate CI failure.
- Also removes the now-unused static import to keep the file in sync with its MySQL counterpart and pass checkstyle.

After this change, `postgres/v200/Migration.java` is byte-for-byte identical to `mysql/v200/Migration.java` aside from the package declaration.

## Test plan

- [x] `git diff` matches the shape of commit 184eb35a03 (3 insertions, 2 deletions)
- [x] `diff` between postgres and mysql Migration.java (excluding package line) reports no differences
- [x] `mvn spotless:apply` left the file unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)