### PR TITLE
fix migration: update legacy relatedTerms in glossaryTerm version history after the glossary term realtion changes

### DIFF
--- a/bootstrap/sql/migrations/native/1.13.0/mysql/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.13.0/mysql/postDataMigrationSQLScript.sql
@@ -79,6 +79,8 @@ WHERE NOT EXISTS (
 UPDATE glossary_term_entity
 SET json = JSON_REMOVE(json, '$.relatedTerms')
 WHERE JSON_EXTRACT(json, '$.relatedTerms') IS NOT NULL;
+-- entity_extension version snapshots: handled by Java migration
+-- migrateGlossaryTermVersionRelatedTermsToTermRelation (transforms in place to preserve history).
 
 -- Same fix as above, for version snapshots used by GET /versions/{v}.
 -- Only legacy snapshots: first item has bare `id` (EntityReference) instead of `term` (TermRelation).

--- a/bootstrap/sql/migrations/native/1.13.0/mysql/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.13.0/mysql/postDataMigrationSQLScript.sql
@@ -79,15 +79,9 @@ WHERE NOT EXISTS (
 UPDATE glossary_term_entity
 SET json = JSON_REMOVE(json, '$.relatedTerms')
 WHERE JSON_EXTRACT(json, '$.relatedTerms') IS NOT NULL;
+
 -- entity_extension version snapshots: handled by Java migration
 -- migrateGlossaryTermVersionRelatedTermsToTermRelation (transforms in place to preserve history).
-
--- Same fix as above, for version snapshots used by GET /versions/{v}.
--- Only legacy snapshots: first item has bare `id` (EntityReference) instead of `term` (TermRelation).
-UPDATE entity_extension
-SET json = JSON_REMOVE(json, '$.relatedTerms')
-WHERE extension LIKE 'glossaryTerm.version.%'
-  AND JSON_CONTAINS_PATH(json, 'one', '$.relatedTerms[0].id');
 
 -- Backfill conceptMappings for existing glossary terms
 UPDATE glossary_term_entity

--- a/bootstrap/sql/migrations/native/1.13.0/mysql/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.13.0/mysql/postDataMigrationSQLScript.sql
@@ -80,6 +80,13 @@ UPDATE glossary_term_entity
 SET json = JSON_REMOVE(json, '$.relatedTerms')
 WHERE JSON_EXTRACT(json, '$.relatedTerms') IS NOT NULL;
 
+-- Same fix as above, for version snapshots used by GET /versions/{v}.
+-- Only legacy snapshots: first item has bare `id` (EntityReference) instead of `term` (TermRelation).
+UPDATE entity_extension
+SET json = JSON_REMOVE(json, '$.relatedTerms')
+WHERE extension LIKE 'glossaryTerm.version.%'
+  AND JSON_CONTAINS_PATH(json, 'one', '$.relatedTerms[0].id');
+
 -- Backfill conceptMappings for existing glossary terms
 UPDATE glossary_term_entity
 SET json = JSON_SET(COALESCE(json, '{}'), '$.conceptMappings', JSON_ARRAY())

--- a/bootstrap/sql/migrations/native/1.13.0/postgres/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.13.0/postgres/postDataMigrationSQLScript.sql
@@ -82,12 +82,8 @@ UPDATE glossary_term_entity
 SET json = (json::jsonb - 'relatedTerms')::json
 WHERE jsonb_exists(json::jsonb, 'relatedTerms');
 
--- Same fix as above, for version snapshots used by GET /versions/{v}.
--- Only legacy snapshots: first item has bare `id` (EntityReference) instead of `term` (TermRelation).
-UPDATE entity_extension
-SET json = (json::jsonb - 'relatedTerms')::json
-WHERE extension LIKE 'glossaryTerm.version.%'
-  AND ((json::jsonb)->'relatedTerms'->0) ? 'id';
+-- entity_extension version snapshots: handled by Java migration
+-- migrateGlossaryTermVersionRelatedTermsToTermRelation (transforms in place to preserve history).
 
 -- Backfill conceptMappings for existing glossary terms
 UPDATE glossary_term_entity

--- a/bootstrap/sql/migrations/native/1.13.0/postgres/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.13.0/postgres/postDataMigrationSQLScript.sql
@@ -82,6 +82,13 @@ UPDATE glossary_term_entity
 SET json = (json::jsonb - 'relatedTerms')::json
 WHERE jsonb_exists(json::jsonb, 'relatedTerms');
 
+-- Same fix as above, for version snapshots used by GET /versions/{v}.
+-- Only legacy snapshots: first item has bare `id` (EntityReference) instead of `term` (TermRelation).
+UPDATE entity_extension
+SET json = (json::jsonb - 'relatedTerms')::json
+WHERE extension LIKE 'glossaryTerm.version.%'
+  AND ((json::jsonb)->'relatedTerms'->0) ? 'id';
+
 -- Backfill conceptMappings for existing glossary terms
 UPDATE glossary_term_entity
 SET json = jsonb_set(COALESCE(json::jsonb, '{}'::jsonb), '{conceptMappings}', '[]'::jsonb)

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1130/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1130/Migration.java
@@ -25,5 +25,10 @@ public class Migration extends MigrationProcessImpl {
               + "Webhook authentication may not work correctly until re-saved.",
           e);
     }
+    try {
+      MigrationUtil.migrateGlossaryTermVersionRelatedTermsToTermRelation(handle);
+    } catch (Exception e) {
+      LOG.error("v1130 glossaryTerm version relatedTerms transform failed; re-run to retry.", e);
+    }
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1130/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1130/Migration.java
@@ -25,5 +25,10 @@ public class Migration extends MigrationProcessImpl {
               + "Webhook authentication may not work correctly until re-saved.",
           e);
     }
+    try {
+      MigrationUtil.migrateGlossaryTermVersionRelatedTermsToTermRelation(handle);
+    } catch (Exception e) {
+      LOG.error("v1130 glossaryTerm version relatedTerms transform failed; re-run to retry.", e);
+    }
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1130/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1130/MigrationUtil.java
@@ -1,11 +1,13 @@
 package org.openmetadata.service.migration.utils.v1130;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.statement.PreparedBatch;
 import org.openmetadata.schema.dataInsight.custom.DataInsightCustomChart;
 import org.openmetadata.schema.entity.events.SubscriptionDestination;
 import org.openmetadata.schema.utils.JsonUtils;
@@ -128,5 +130,185 @@ public class MigrationUtil {
     }
 
     LOG.info("Migrated {} event subscriptions with secretKey to authType", migratedCount);
+  }
+
+  private static final String SELECT_GLOSSARY_VERSIONS_MYSQL =
+      "SELECT id, extension, json FROM entity_extension "
+          + "WHERE extension LIKE 'glossaryTerm.version.%' "
+          + "AND JSON_CONTAINS_PATH(json, 'one', '$.relatedTerms[0].id') "
+          + "AND (id > :id OR (id = :id AND extension > :extension)) "
+          + "ORDER BY id, extension LIMIT :pageSize";
+
+  private static final String SELECT_GLOSSARY_VERSIONS_POSTGRES =
+      "SELECT id, extension, json::text AS json FROM entity_extension "
+          + "WHERE extension LIKE 'glossaryTerm.version.%' "
+          + "AND jsonb_exists((json::jsonb)->'relatedTerms'->0, 'id') "
+          + "AND (id > :id OR (id = :id AND extension > :extension)) "
+          + "ORDER BY id, extension LIMIT :pageSize";
+
+  private static final String UPDATE_VERSION_JSON_MYSQL =
+      "UPDATE entity_extension SET json = :json WHERE id = :id AND extension = :extension";
+
+  private static final String UPDATE_VERSION_JSON_POSTGRES =
+      "UPDATE entity_extension SET json = :json::jsonb WHERE id = :id AND extension = :extension";
+
+  private static final int VERSION_RELATED_TERMS_PAGE_SIZE = 500;
+  private static final String RELATED_TERMS = "relatedTerms";
+  private static final String CHANGE_DESCRIPTION = "changeDescription";
+
+  /**
+   * Wraps legacy {@code EntityReference[]} relatedTerms as {@code TermRelation[]} in
+   * glossaryTerm version snapshots — both top-level and inside changeDescription diff strings.
+   * Version reads bypass entity_relationship rehydration, so a strip would lose history. Idempotent.
+   */
+  public static void migrateGlossaryTermVersionRelatedTermsToTermRelation(Handle handle) {
+    LOG.info("v1130: transforming legacy relatedTerms in glossaryTerm version snapshots");
+    boolean isMySQL = Boolean.TRUE.equals(DatasourceConfig.getInstance().isMySQL());
+    String selectSql = isMySQL ? SELECT_GLOSSARY_VERSIONS_MYSQL : SELECT_GLOSSARY_VERSIONS_POSTGRES;
+    String updateSql = isMySQL ? UPDATE_VERSION_JSON_MYSQL : UPDATE_VERSION_JSON_POSTGRES;
+
+    String cursorId = "";
+    String cursorExtension = "";
+    long totalTransformed = 0;
+    long totalSkipped = 0;
+    int pageNumber = 0;
+    boolean morePages = true;
+
+    while (morePages) {
+      List<Map<String, Object>> rows =
+          handle
+              .createQuery(selectSql)
+              .bind("id", cursorId)
+              .bind("extension", cursorExtension)
+              .bind("pageSize", VERSION_RELATED_TERMS_PAGE_SIZE)
+              .mapToMap()
+              .list();
+
+      if (rows.isEmpty()) {
+        break;
+      }
+      pageNumber++;
+      morePages = rows.size() == VERSION_RELATED_TERMS_PAGE_SIZE;
+
+      PreparedBatch batch = handle.prepareBatch(updateSql);
+      int batchedUpdates = 0;
+      for (Map<String, Object> row : rows) {
+        String id = String.valueOf(row.get("id"));
+        String extension = String.valueOf(row.get("extension"));
+        String jsonStr = String.valueOf(row.get("json"));
+
+        cursorId = id;
+        cursorExtension = extension;
+
+        try {
+          ObjectNode root = (ObjectNode) JsonUtils.readTree(jsonStr);
+          if (transformSnapshot(root)) {
+            batch.bind("id", id).bind("extension", extension).bind("json", root.toString()).add();
+            batchedUpdates++;
+          }
+        } catch (Exception e) {
+          totalSkipped++;
+          LOG.warn(
+              "Skipping malformed glossaryTerm version snapshot id={} extension={}: {}",
+              id,
+              extension,
+              e.getMessage());
+        }
+      }
+
+      if (batchedUpdates > 0) {
+        batch.execute();
+        totalTransformed += batchedUpdates;
+      }
+
+      LOG.info(
+          "v1130 relatedTerms transform: page={} transformed={} skipped={} cursor=({},{})",
+          pageNumber,
+          totalTransformed,
+          totalSkipped,
+          cursorId,
+          cursorExtension);
+    }
+
+    LOG.info(
+        "v1130 relatedTerms transform done: pages={} transformed={} skipped={}",
+        pageNumber,
+        totalTransformed,
+        totalSkipped);
+  }
+
+  private static boolean transformSnapshot(ObjectNode root) {
+    boolean changed = false;
+    ArrayNode wrappedTopLevel = wrapLegacyRelatedTerms(root.get(RELATED_TERMS));
+    if (wrappedTopLevel != null) {
+      root.set(RELATED_TERMS, wrappedTopLevel);
+      changed = true;
+    }
+    JsonNode changeDescription = root.get(CHANGE_DESCRIPTION);
+    if (changeDescription instanceof ObjectNode cd) {
+      changed |= rewriteChangeDescriptionEntries(cd, "fieldsAdded", "newValue");
+      changed |= rewriteChangeDescriptionEntries(cd, "fieldsDeleted", "oldValue");
+      changed |= rewriteChangeDescriptionEntries(cd, "fieldsUpdated", "newValue");
+      changed |= rewriteChangeDescriptionEntries(cd, "fieldsUpdated", "oldValue");
+    }
+    return changed;
+  }
+
+  /** Wraps legacy items as TermRelation; returns null when nothing needs wrapping. */
+  private static ArrayNode wrapLegacyRelatedTerms(JsonNode array) {
+    if (array == null || !array.isArray() || array.isEmpty()) {
+      return null;
+    }
+    ArrayNode wrapped = JsonUtils.getObjectMapper().createArrayNode();
+    boolean changed = false;
+    for (JsonNode item : array) {
+      if (isWrappedTermRelation(item)) {
+        wrapped.add(item);
+      } else {
+        ObjectNode tr = JsonUtils.getObjectMapper().createObjectNode();
+        tr.set("term", item);
+        tr.put("relationType", "relatedTo");
+        wrapped.add(tr);
+        changed = true;
+      }
+    }
+    return changed ? wrapped : null;
+  }
+
+  private static boolean isWrappedTermRelation(JsonNode item) {
+    return item != null && item.isObject() && item.has("term");
+  }
+
+  /** Rewrites legacy relatedTerms items inside changeDescription diff JSON strings. */
+  private static boolean rewriteChangeDescriptionEntries(
+      ObjectNode changeDescription, String bucket, String valueField) {
+    JsonNode entries = changeDescription.get(bucket);
+    if (entries == null || !entries.isArray()) {
+      return false;
+    }
+    boolean anyChanged = false;
+    for (JsonNode entry : entries) {
+      if (!(entry instanceof ObjectNode entryObj)) {
+        continue;
+      }
+      JsonNode nameNode = entryObj.get("name");
+      if (nameNode == null || !RELATED_TERMS.equals(nameNode.asText())) {
+        continue;
+      }
+      JsonNode valueNode = entryObj.get(valueField);
+      if (valueNode == null || !valueNode.isTextual() || valueNode.asText().isEmpty()) {
+        continue;
+      }
+      try {
+        JsonNode parsed = JsonUtils.readTree(valueNode.asText());
+        ArrayNode wrapped = wrapLegacyRelatedTerms(parsed);
+        if (wrapped != null) {
+          entryObj.put(valueField, wrapped.toString());
+          anyChanged = true;
+        }
+      } catch (Exception ignored) {
+      }
+    }
+    return anyChanged;
   }
 }


### PR DESCRIPTION
## Summary

Fixes #27802 .Extends PR #26586. That fix cleaned `glossary_term_entity` of legacy `relatedTerms` data but missed the version history in `entity_extension`, so `GET /glossaryTerms/{id}/versions/{v}` still 500s on any pre-1.13 term with non-empty `relatedTerms`:

```
UnrecognizedPropertyException: Unrecognized field "id" (class TermRelation)
```

## What this PR does

Adds a Java migration `migrateGlossaryTermVersionRelatedTermsToTermRelation` (v1130) that **transforms** each legacy `EntityReference[]` item into the new `TermRelation[]` shape — `{ "term": <ref>, "relationType": "relatedTo" }` — at:

1. the top-level `relatedTerms` field of each `entity_extension` version history, and
2. the JSON value strings inside `changeDescription.fieldsAdded[*].newValue` and `fieldsDeleted[*].oldValue`, so version-history diffs continue to render strikethrough/green for related-term changes.

The earlier draft of this PR did a SQL strip; that has been replaced with the Java migration. The SQL files now contain a comment pointer to the Java migration.

## Why transform instead of strip

Version reads (`EntityRepository.getVersion`) deserialize the snapshot JSON directly — no `entity_relationship` rehydration, no `setFields` repopulation. A strip would silently lose every related-term that ever existed at any historical version. The transform preserves that history exactly.

The live-row strip in `glossary_term_entity` (from #26586) stays as-is; that read path *does* rehydrate from `entity_relationship`.

## Scale

Designed for tables with 10M+ rows:
- Pre-filters at SQL using `extension_index` + JSON-side legacy-shape predicate (`relatedTerms[0].id` exists in mysql / `jsonb_exists` in postgres). Continuous-migration cost on a fully-transformed install: a single short-circuiting index scan, no JSON evaluation, no Java parsing.
- Keyset pagination on PK `(id, extension)` — no OFFSET cost.
- `PreparedBatch` updates (1 round-trip per 500 rows).
- Per-row try/catch isolates malformed snapshots; cursor advances even on caught errors so a poison-pill row can't loop forever.
- Idempotent: re-runs on already-transformed rows do shape-detection-then-skip with zero DB writes.

## Test plan

- [x] Seeded a 1.12.7 install with 500 glossary terms across glossary → root → child → grandchild levels, 3 update passes each, ~1500 version history(s) in legacy `EntityReference[]` shape (script: `scripts/seed_legacy_related_terms_v1130.py`).
- [x] Upgraded to 1.13.0; migration ran cleanly: `pages=3 transformed=1285 skipped=0` with zero failures.
- [x] Verified zero data loss in DB: items per snapshot match pre-migration counts; every wrapped item has `term` + `relationType: "relatedTo"`; `term` sub-objects preserve `id`, `name`, `fullyQualifiedName`, `type`, `description`, `displayName`, `deleted`.
- [x] `GET /glossaryTerms/{id}/versions/{v}` returns 200 with `TermRelation[]` shape across root, child, and grandchild terms.
- [x] Version-history UI renders correctly with strikethrough/green diff annotations for related-term changes on covered snapshots.