### PR TITLE
Chore(UI): Add test.slow() to customProperties spec to cover for slow responses in AUT runs

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CustomProperties.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CustomProperties.spec.ts
@@ -427,7 +427,9 @@ ALL_ENTITIES.forEach(({ key, makeInstance }) => {
 
     if (makeInstance !== null) {
       test(`Set & Update all CP types on ${entity.name}`, async ({ page }) => {
-        test.slow(true);
+        // 5 minutes timeout since the test handles set->update operation on all
+        // custom property types sequentially
+        test.setTimeout(300000);
         const properties = Object.values(CustomPropertyTypeByName);
 
         await test.step('Set all CP types', async () => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CustomProperties.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CustomProperties.spec.ts
@@ -335,6 +335,7 @@ ALL_ENTITIES.forEach(({ key, makeInstance }) => {
 
     BASIC_PROPERTIES.forEach((property) => {
       test(property, async ({ page }) => {
+        test.slow();
         const propertyName = `cp-${uuid()}-${entity.name}`;
 
         await settingClick(
@@ -607,6 +608,7 @@ ALL_ENTITIES.forEach(({ key, makeInstance }) => {
       test('User visible in right panel when added as entityReferenceList custom property', async ({
         page,
       }) => {
+        test.slow();
         const { apiContext, afterAction } = await getApiContext(page);
         const propertyName =
           mainEntity.customPropertyValue[
@@ -1062,6 +1064,7 @@ ALL_ENTITIES.forEach(({ key, makeInstance }) => {
       test('should show No Data placeholder when hyperlink has no value', async ({
         page,
       }) => {
+        test.slow();
         const propertyName =
           mainEntity.customPropertyValue[CustomPropertyTypeByName.HYPERLINK_CP]
             .property.name;
@@ -1082,6 +1085,7 @@ ALL_ENTITIES.forEach(({ key, makeInstance }) => {
       test('should reject javascript: protocol URLs for XSS protection', async ({
         page,
       }) => {
+        test.slow();
         const propertyName =
           mainEntity.customPropertyValue[CustomPropertyTypeByName.HYPERLINK_CP]
             .property.name;
@@ -1107,6 +1111,7 @@ ALL_ENTITIES.forEach(({ key, makeInstance }) => {
       });
 
       test('should accept valid http and https URLs', async ({ page }) => {
+        test.slow();
         const propertyName =
           mainEntity.customPropertyValue[CustomPropertyTypeByName.HYPERLINK_CP]
             .property.name;
@@ -1146,6 +1151,7 @@ ALL_ENTITIES.forEach(({ key, makeInstance }) => {
       test('should display URL when no display text is provided', async ({
         page,
       }) => {
+        test.slow();
         const propertyName =
           mainEntity.customPropertyValue[CustomPropertyTypeByName.HYPERLINK_CP]
             .property.name;
@@ -2771,6 +2777,7 @@ ALL_ENTITIES.forEach(({ key, makeInstance }) => {
         });
 
         test('Table CP - Name column with all operators', async ({ page }) => {
+          test.slow();
           const value = CP_BASE_VALUES.tableCp.rows[0]['Name'];
           const partialValue = value.substring(1, 4);
           const basePropertyName = propertyNames['table-cp'];
@@ -2865,6 +2872,7 @@ ALL_ENTITIES.forEach(({ key, makeInstance }) => {
         });
 
         test('Table CP - Role column with all operators', async ({ page }) => {
+          test.slow();
           const value = CP_BASE_VALUES.tableCp.rows[0]['Role'];
           const partialValue = value.substring(1, 4);
           const basePropertyName = propertyNames['table-cp'];
@@ -2959,6 +2967,7 @@ ALL_ENTITIES.forEach(({ key, makeInstance }) => {
         });
 
         test('Table CP - Sr No column with all operators', async ({ page }) => {
+          test.slow();
           const value = CP_BASE_VALUES.tableCp.rows[1]['Sr No'];
           const basePropertyName = propertyNames['table-cp'];
           const columnPropertyName = `${basePropertyName} - Sr No`;


### PR DESCRIPTION
This pull request marks several Playwright tests as "slow" in the `CustomProperties.spec.ts` file. This helps the test runner handle potentially long-running tests more gracefully, reducing the chance of false negatives due to timeouts.

The most important changes are:

**Test Stability Improvements:**

* Added `test.slow();` to basic property tests to indicate they may take longer to execute.
* Marked entity reference list custom property tests as slow for better timeout handling.

**Hyperlink Custom Property Tests:**

* Marked multiple hyperlink-related tests as slow, including checks for "No Data" placeholders, XSS protection, valid URL acceptance, and display behavior. [[1]](diffhunk://#diff-6b82542deebc1ccc2bc25602e2f3e2f3fa77093be4f01b2688e8bc6e59e9004cR1067) [[2]](diffhunk://#diff-6b82542deebc1ccc2bc25602e2f3e2f3fa77093be4f01b2688e8bc6e59e9004cR1088) [[3]](diffhunk://#diff-6b82542deebc1ccc2bc25602e2f3e2f3fa77093be4f01b2688e8bc6e59e9004cR1114) [[4]](diffhunk://#diff-6b82542deebc1ccc2bc25602e2f3e2f3fa77093be4f01b2688e8bc6e59e9004cR1154)

**Table Custom Property Tests:**

* Marked table custom property tests (Name, Role, and Sr No columns with all operators) as slow to ensure reliable execution. [[1]](diffhunk://#diff-6b82542deebc1ccc2bc25602e2f3e2f3fa77093be4f01b2688e8bc6e59e9004cR2780) [[2]](diffhunk://#diff-6b82542deebc1ccc2bc25602e2f3e2f3fa77093be4f01b2688e8bc6e59e9004cR2875) [[3]](diffhunk://#diff-6b82542deebc1ccc2bc25602e2f3e2f3fa77093be4f01b2688e8bc6e59e9004cR2970)

----
## Summary by Gitar

- **Test configuration:**
  - Replaced `test.slow(true)` with an explicit 5-minute timeout via `test.setTimeout(300000)` in `CustomProperties.spec.ts`.

<sub>This will update automatically on new commits.</sub>