### PR TITLE
fix(sas): drop logger.info leaking config

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/sas/client.py
+++ b/ingestion/src/metadata/ingestion/source/database/sas/client.py
@@ -168,6 +168,4 @@ class SASClient:
         }
         url = base_url + endpoint
         response = requests.request("POST", url, headers=headers, data=payload, verify=False, timeout=10)
-        text_response = response.json()
-        logger.info(f"this is user: {user}, password: {password}, text: {text_response}")
         return response.json()["access_token"]


### PR DESCRIPTION
## Summary

`SASClient.get_token` logged the cleartext user password at INFO level on every authentication call. Removing the offending `logger.info(...)` line.

## Leak verification

**Static (code flow)**

```
SASClient.__init__(config)
  └─ self.auth_token = self.get_token(
       config.serverHost,
       config.username,
       config.password.get_secret_value()   # ← Pydantic SecretStr → cleartext
     )

SASClient.get_token(self, base_url, user, password):
    ...
    logger.info(f\"this is user: {user}, password: {password}, text: {text_response}\")
                                          ^^^^^^^^^^^^^^^^^^^^
                                          cleartext password interpolated into log message
```

`password.get_secret_value()` returns the raw user-provided password — not a hash, not a token.

**Runtime (repro)**

Patched `requests.request`, instantiated `SASClient` with a fake password `\"Sup3rS3cret!\"`, captured the actual `Ingestion` logger output:

```
INFO metadata.Ingestion this is user: alice, password: Sup3rS3cret!, text: {'access_token': 'fake_token_xyz'}
```

The cleartext password appears verbatim in the log stream every time `SASClient` is instantiated.

**Triggered when:** Every SAS ingestion run hits `__init__` → `get_token` → this log line. Once per worker on startup.

**Compounding factors:**
- `ingestion_logger()` is plain `logging.getLogger(\"Ingestion\")` — no redaction filter. Whatever sink is configured (stdout, file, airflow logs, CloudWatch, OpenSearch indexer) sees the cleartext.
- Logged BEFORE the auth result is checked, so failed-auth attempts also leak.
- The line appears to be leftover dev-debug spam — it serves no production purpose.