### PR TITLE
feat(ui): remove AntD imports from TableV2, fix vertical scroll, add stories

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.interface.ts
@@ -10,6 +10,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+import React from 'react';
+
 export interface FlatRow<T> {
   record: T;
   depth: number;
@@ -24,4 +26,85 @@ export type AriaSelection = 'all' | Set<AriaKey>;
 export interface AriaSortDescriptor {
   column?: AriaKey;
   direction?: 'ascending' | 'descending';
+}
+
+// ─── Local column / table type aliases (mirror antd without importing it) ─────
+
+export type TableSortOrder = 'ascend' | 'descend' | null;
+export type TableDataIndex = string | number | readonly string[];
+export type TableFilterValue = (React.Key | boolean)[];
+
+export interface TableFilterOption {
+  text?: React.ReactNode;
+  value: React.Key | boolean;
+  children?: TableFilterOption[];
+}
+
+export interface TableFilterDropdownProps {
+  prefixCls: string;
+  setSelectedKeys: (keys: React.Key[]) => void;
+  selectedKeys: React.Key[];
+  confirm: () => void;
+  clearFilters?: () => void;
+  filters?: TableFilterOption[];
+  visible: boolean;
+  close: () => void;
+}
+
+export interface TableColumnType<T> {
+  key?: React.Key;
+  dataIndex?: TableDataIndex;
+  title?:
+    | React.ReactNode
+    | ((props: {
+        sortOrder?: TableSortOrder;
+        sortColumn?: TableColumnType<T>;
+        filters?: Record<string, TableFilterValue | null>;
+      }) => React.ReactNode);
+  render?: (
+    value: unknown,
+    record: T,
+    index: number
+  ) => React.ReactNode | { children: React.ReactNode; props?: Record<string, unknown> };
+  sorter?: boolean | ((a: T, b: T) => number);
+  sortOrder?: TableSortOrder;
+  filters?: TableFilterOption[];
+  filterDropdown?:
+    | React.ReactNode
+    | ((props: TableFilterDropdownProps) => React.ReactNode);
+  filterIcon?: React.ReactNode | ((filtered: boolean) => React.ReactNode);
+  onFilter?: (value: React.Key | boolean, record: T) => boolean;
+  onCell?: (
+    record: T,
+    index?: number
+  ) => React.TdHTMLAttributes<HTMLTableCellElement> & Record<string, unknown>;
+  fixed?: boolean | 'left' | 'right';
+  width?: string | number;
+  ellipsis?: boolean | { showTitle?: boolean };
+  align?: 'left' | 'center' | 'right';
+  className?: string;
+}
+
+export type TableColumnsType<T> = TableColumnType<T>[];
+
+export interface TablePaginationConfig {
+  current?: number;
+  pageSize?: number;
+  total?: number;
+  hideOnSinglePage?: boolean;
+  showSizeChanger?: boolean;
+  defaultPageSize?: number;
+  defaultCurrent?: number;
+}
+
+export interface TableSorterResult<T> {
+  column?: TableColumnType<T>;
+  columnKey?: React.Key;
+  field?: React.Key | string[];
+  order?: 'ascend' | 'descend' | null;
+}
+
+export interface TableCurrentDataSource<T> {
+  currentDataSource: T[];
+  action: 'paginate' | 'sort' | 'filter';
 }

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.interface.ts
@@ -65,7 +65,9 @@ export interface TableColumnType<T> {
     value: unknown,
     record: T,
     index: number
-  ) => React.ReactNode | { children: React.ReactNode; props?: Record<string, unknown> };
+  ) =>
+    | React.ReactNode
+    | { children: React.ReactNode; props?: Record<string, unknown> };
   sorter?: boolean | ((a: T, b: T) => number);
   sortOrder?: TableSortOrder;
   filters?: TableFilterOption[];

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.stories.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.stories.tsx
@@ -1,0 +1,248 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * TableV2 stories — usage examples including scrollable behaviour.
+ *
+ * These stories follow the CSF3 format (same as openmetadata-ui-core-components).
+ * They require Storybook to be configured for the main UI, but can also serve
+ * as runnable copy-paste examples and visual regression targets.
+ *
+ * Storybook setup:
+ *   cd openmetadata-ui/src/main/resources/ui
+ *   yarn storybook   (once configured)
+ */
+
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import type { TableColumnsType } from './TableV2.interface';
+
+// ---------------------------------------------------------------------------
+// Sample data
+// ---------------------------------------------------------------------------
+
+interface Column {
+  id: string;
+  name: string;
+  dataType: string;
+  description: string;
+  nullable: boolean;
+  tags: string;
+}
+
+const makeRows = (count: number): Column[] =>
+  Array.from({ length: count }, (_, i) => ({
+    id: String(i + 1),
+    name: `column_${i + 1}`,
+    dataType: ['VARCHAR', 'INTEGER', 'BOOLEAN', 'TIMESTAMP', 'FLOAT'][i % 5],
+    description: `Description for column ${i + 1}. This may be a longer text.`,
+    nullable: i % 3 !== 0,
+    tags: i % 2 === 0 ? 'PII, Sensitive' : 'Public',
+  }));
+
+const SAMPLE_COLUMNS: TableColumnsType<Column> = [
+  {
+    key: 'name',
+    dataIndex: 'name',
+    title: 'Column Name',
+    width: 160,
+    sorter: (a, b) => a.name.localeCompare(b.name),
+  },
+  {
+    key: 'dataType',
+    dataIndex: 'dataType',
+    title: 'Data Type',
+    width: 120,
+  },
+  {
+    key: 'nullable',
+    dataIndex: 'nullable',
+    title: 'Nullable',
+    width: 100,
+    render: (val) => (val ? 'Yes' : 'No'),
+  },
+  {
+    key: 'tags',
+    dataIndex: 'tags',
+    title: 'Tags',
+    width: 180,
+  },
+  {
+    key: 'description',
+    dataIndex: 'description',
+    title: 'Description',
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Minimal stand-alone wrapper that renders TableV2 without OM app providers.
+// Real usage inside the app goes through the full TableV2 component directly.
+// ---------------------------------------------------------------------------
+
+/**
+ * Lightweight demo that renders just the UntitledTable internals.
+ * TableV2 itself requires OM app context (GenericProvider, user store, i18n).
+ * Run `yarn start` in the main UI to see the full component.
+ */
+import {
+  Table as UntitledTable,
+} from '@openmetadata/ui-core-components';
+
+interface DemoTableProps {
+  rows: Column[];
+  /** Vertical scroll — pass a px number to cap the table body height. */
+  scrollY?: number;
+  size?: 'sm' | 'md';
+}
+
+const DemoTable = ({ rows, scrollY, size = 'md' }: DemoTableProps) => (
+  <UntitledTable
+    stickyHeader
+    aria-label="demo-table"
+    containerStyle={
+      scrollY
+        ? {
+            maxHeight: scrollY,
+            overflowX: 'auto',
+            overflowY: 'auto',
+          }
+        : undefined
+    }
+    size={size}>
+    <UntitledTable.Header>
+      {SAMPLE_COLUMNS.map((col) => (
+        <UntitledTable.Head
+          id={String(col.key)}
+          key={String(col.key)}
+          style={col.width ? { width: col.width, minWidth: col.width } : {}}>
+          {col.title as React.ReactNode}
+        </UntitledTable.Head>
+      ))}
+    </UntitledTable.Header>
+    <UntitledTable.Body>
+      {rows.map((row) =>
+        <UntitledTable.Row id={row.id} key={row.id}>
+          {SAMPLE_COLUMNS.map((col) => (
+            <UntitledTable.Cell key={String(col.key)}>
+              {col.render
+                ? (col.render(
+                    (row as Record<string, unknown>)[col.dataIndex as string],
+                    row,
+                    0
+                  ) as React.ReactNode)
+                : String(
+                    (row as Record<string, unknown>)[col.dataIndex as string] ??
+                      ''
+                  )}
+            </UntitledTable.Cell>
+          ))}
+        </UntitledTable.Row>
+      )}
+    </UntitledTable.Body>
+  </UntitledTable>
+);
+
+// ---------------------------------------------------------------------------
+// Meta
+// ---------------------------------------------------------------------------
+
+const meta = {
+  title: 'Components/TableV2',
+  component: DemoTable,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'TableV2 is the Untitled-UI-based drop-in replacement for the legacy Ant Design table. ' +
+          'Stories here use a minimal wrapper; see TableV2.tsx for the full component with ' +
+          'search, column customization, pagination, and sorting.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    scrollY: {
+      control: { type: 'number', min: 100, max: 800, step: 50 },
+      description: 'Vertical scroll threshold in px. Unset = no vertical limit.',
+    },
+    size: {
+      control: 'radio',
+      options: ['sm', 'md'],
+    },
+  },
+} satisfies Meta<typeof DemoTable>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// ---------------------------------------------------------------------------
+// Stories
+// ---------------------------------------------------------------------------
+
+export const Default: Story = {
+  args: {
+    rows: makeRows(5),
+  },
+};
+
+export const ManyRows: Story = {
+  name: 'Many rows (no scroll cap)',
+  args: {
+    rows: makeRows(30),
+  },
+};
+
+/**
+ * Vertical scroll — 30 rows capped at 300 px.
+ * The header is sticky so it stays visible while scrolling.
+ */
+export const VerticalScroll: Story = {
+  name: 'Vertical scroll (scrollY = 300)',
+  args: {
+    rows: makeRows(30),
+    scrollY: 300,
+  },
+};
+
+/**
+ * Small size variant with vertical scroll — common for dense detail panels.
+ */
+export const SmallWithScroll: Story = {
+  name: 'Small size + vertical scroll',
+  args: {
+    rows: makeRows(20),
+    scrollY: 240,
+    size: 'sm',
+  },
+};
+
+/**
+ * Single page of data — no scrollbar appears since content fits.
+ */
+export const FewRowsScrollCapped: Story = {
+  name: 'Few rows — scroll cap but no scrollbar',
+  args: {
+    rows: makeRows(3),
+    scrollY: 300,
+  },
+};
+
+/**
+ * Empty state — verify no scrollbar and the empty message renders correctly.
+ */
+export const Empty: Story = {
+  args: {
+    rows: [],
+  },
+};

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.stories.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.stories.tsx
@@ -23,7 +23,7 @@
  *   yarn storybook   (once configured)
  */
 
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta } from '@storybook/react';
 import React from 'react';
 import type { TableColumnsType } from './TableV2.interface';
 
@@ -94,9 +94,7 @@ const SAMPLE_COLUMNS: TableColumnsType<Column> = [
  * TableV2 itself requires OM app context (GenericProvider, user store, i18n).
  * Run `yarn start` in the main UI to see the full component.
  */
-import {
-  Table as UntitledTable,
-} from '@openmetadata/ui-core-components';
+import { Table as UntitledTable } from '@openmetadata/ui-core-components';
 
 interface DemoTableProps {
   rows: Column[];
@@ -130,7 +128,7 @@ const DemoTable = ({ rows, scrollY, size = 'md' }: DemoTableProps) => (
       ))}
     </UntitledTable.Header>
     <UntitledTable.Body>
-      {rows.map((row) =>
+      {rows.map((row) => (
         <UntitledTable.Row id={row.id} key={row.id}>
           {SAMPLE_COLUMNS.map((col) => (
             <UntitledTable.Cell key={String(col.key)}>
@@ -147,7 +145,7 @@ const DemoTable = ({ rows, scrollY, size = 'md' }: DemoTableProps) => (
             </UntitledTable.Cell>
           ))}
         </UntitledTable.Row>
-      )}
+      ))}
     </UntitledTable.Body>
   </UntitledTable>
 );
@@ -174,7 +172,8 @@ const meta = {
   argTypes: {
     scrollY: {
       control: { type: 'number', min: 100, max: 800, step: 50 },
-      description: 'Vertical scroll threshold in px. Unset = no vertical limit.',
+      description:
+        'Vertical scroll threshold in px. Unset = no vertical limit.',
     },
     size: {
       control: 'radio',

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx
@@ -32,6 +32,10 @@
  * Sorting:
  *  - sorter: (a, b) => number  → applied client-side on full dataset before pagination
  *  - sorter: true              → visual indicator only; parent must handle via onChange
+ *
+ * Scroll:
+ *  - scroll.y → vertical max-height on the table container; header stays sticky
+ *  - scroll.x → horizontal overflow; the inner container scrolls
  */
 
 import {
@@ -40,14 +44,6 @@ import {
   Table as UntitledTable,
 } from '@openmetadata/ui-core-components';
 import { ChevronDown, ChevronRight } from '@untitledui/icons';
-import type { ColumnsType } from 'antd/es/table/interface';
-import type {
-  ColumnType,
-  FilterValue,
-  SorterResult,
-  TableCurrentDataSource,
-  TablePaginationConfig,
-} from 'antd/lib/table/interface';
 import classNames from 'classnames';
 import { isEmpty, isEqual } from 'lodash';
 import React, {
@@ -89,6 +85,11 @@ import type {
   AriaSelection,
   AriaSortDescriptor,
   FlatRow,
+  TableColumnType,
+  TableColumnsType,
+  TableCurrentDataSource,
+  TablePaginationConfig,
+  TableSorterResult,
 } from './TableV2.interface';
 import {
   flattenTreeRows,
@@ -115,7 +116,7 @@ const TableV2 = <T extends object>(
 ) => {
   const { t } = useTranslation();
   const { type } = useGenericContext();
-  const [propsColumns, setPropsColumns] = useState<ColumnsType<T>>([]);
+  const [propsColumns, setPropsColumns] = useState<TableColumnsType<T>>([]);
   const [columnWidths, setColumnWidths] = useState<Record<string, number>>({});
   const [internalCurrentPage, setInternalCurrentPage] = useState(1);
   const [sortState, setSortState] = useState<{
@@ -150,7 +151,7 @@ const TableV2 = <T extends object>(
 
   const entityKey = useMemo(() => entityType ?? type, [type, entityType]);
 
-  const clientPagination = useMemo(() => {
+  const clientPagination = useMemo((): TablePaginationConfig | null => {
     if (rest.pagination === false) {
       return null;
     }
@@ -168,10 +169,10 @@ const TableV2 = <T extends object>(
       return data;
     }
     const col = propsColumns.find((c, idx) => {
-      const key = String(c.key ?? (c as ColumnType<T>).dataIndex ?? idx);
+      const key = String(c.key ?? c.dataIndex ?? idx);
 
       return key === sortState.columnKey;
-    }) as ColumnType<T> | undefined;
+    }) as TableColumnType<T> | undefined;
 
     if (!col?.sorter || typeof col.sorter !== 'function') {
       return data;
@@ -194,8 +195,8 @@ const TableV2 = <T extends object>(
       activeFilters.every(([colKey, selectedKeys]) => {
         const col = propsColumns.find(
           (c, idx) =>
-            String(c.key ?? (c as ColumnType<T>).dataIndex ?? idx) === colKey
-        ) as ColumnType<T> | undefined;
+            String(c.key ?? c.dataIndex ?? idx) === colKey
+        ) as TableColumnType<T> | undefined;
 
         return col?.onFilter
           ? selectedKeys.some((key) =>
@@ -210,9 +211,9 @@ const TableV2 = <T extends object>(
     if (!clientPagination) {
       return filteredDataSource;
     }
-    const start = (internalCurrentPage - 1) * clientPagination.pageSize;
+    const start = (internalCurrentPage - 1) * (clientPagination.pageSize ?? 10);
 
-    return filteredDataSource.slice(start, start + clientPagination.pageSize);
+    return filteredDataSource.slice(start, start + (clientPagination.pageSize ?? 10));
   }, [filteredDataSource, clientPagination, internalCurrentPage]);
 
   const expandedKeys = useMemo<Set<string>>(() => {
@@ -231,22 +232,28 @@ const TableV2 = <T extends object>(
     [rest.staticVisibleColumns, defaultVisibleColumns]
   );
 
-  const scrollStyle = useMemo((): React.CSSProperties => {
-    if (!scroll) {
-      return {};
+  // ─── Scroll container style ───────────────────────────────────────────────
+  // Applied via containerStyle on UntitledTable so that the sticky header
+  // and the scroll container share the same DOM node (required for sticky).
+  const tableContainerStyle = useMemo((): React.CSSProperties | undefined => {
+    if (!scroll?.y) {
+      return undefined;
     }
 
     return {
-      ...(scroll.x ? { overflowX: 'auto' } : {}),
+      maxHeight: scroll.y as string | number,
+      // Explicitly set both axes so the result is independent of Tailwind classes.
+      overflowX: 'auto',
+      overflowY: 'auto',
     };
-  }, [scroll?.x]);
+  }, [scroll?.y]);
 
   // ─── Column customization (identical to Table.tsx) ───────────────────────
 
   const handleMoveItem = useCallback(
     (updatedList: TableColumnDropdownList[]) => {
       setDropdownColumnList(updatedList);
-      setPropsColumns(getReorderedColumns(updatedList, propsColumns));
+      setPropsColumns(getReorderedColumns(updatedList, propsColumns) as TableColumnsType<T>);
     },
     [propsColumns]
   );
@@ -392,12 +399,10 @@ const TableV2 = <T extends object>(
         return;
       }
       const matchedCol = propsColumns.find((c, colIdx) => {
-        const resolvedKey = String(
-          c.key ?? (c as ColumnType<T>).dataIndex ?? colIdx
-        );
+        const resolvedKey = String(c.key ?? c.dataIndex ?? colIdx);
 
         return resolvedKey === descriptor.column;
-      }) as ColumnType<T> | undefined;
+      }) as TableColumnType<T> | undefined;
 
       rest.onChange(
         {
@@ -405,7 +410,7 @@ const TableV2 = <T extends object>(
           pageSize: clientPagination?.pageSize ?? 10,
           total: filteredDataSource.length,
         } as TablePaginationConfig,
-        {} as Record<string, FilterValue | null>,
+        {} as Record<string, (React.Key | boolean)[] | null>,
         {
           column: matchedCol,
           columnKey: String(descriptor.column ?? ''),
@@ -416,7 +421,7 @@ const TableV2 = <T extends object>(
               : descriptor.direction === 'descending'
               ? 'descend'
               : null,
-        } as SorterResult<T>,
+        } as TableSorterResult<T>,
         {
           currentDataSource: (rest.dataSource ?? []) as T[],
           action: 'sort',
@@ -460,9 +465,9 @@ const TableV2 = <T extends object>(
           (rest.staticVisibleColumns ?? []).includes(item.key as string)
       );
 
-      setPropsColumns(getReorderedColumns(dropdownColumnList, filteredColumns));
+      setPropsColumns(getReorderedColumns(dropdownColumnList, filteredColumns) as TableColumnsType<T>);
     } else {
-      setPropsColumns(rest.columns ?? []);
+      setPropsColumns((rest.columns ?? []) as TableColumnsType<T>);
     }
   }, [
     isCustomizeColumnEnable,
@@ -487,8 +492,9 @@ const TableV2 = <T extends object>(
 
   const dataSourceLength = filteredDataSource.length;
   useEffect(() => {
+    const pageSize = clientPagination?.pageSize ?? 10;
     const maxPage = clientPagination
-      ? Math.ceil(dataSourceLength / clientPagination.pageSize) || 1
+      ? Math.ceil(dataSourceLength / pageSize) || 1
       : 1;
     if (internalCurrentPage > maxPage) {
       setInternalCurrentPage(1);
@@ -501,7 +507,7 @@ const TableV2 = <T extends object>(
     if (!rest.expandable) {
       return pagedDataSource.map((record, idx) => {
         const actualIndex = clientPagination
-          ? (internalCurrentPage - 1) * clientPagination.pageSize + idx
+          ? (internalCurrentPage - 1) * (clientPagination.pageSize ?? 10) + idx
           : idx;
 
         return {
@@ -530,6 +536,277 @@ const TableV2 = <T extends object>(
   ]);
 
   // ─── Render ───────────────────────────────────────────────────────────────
+
+  const tableNode = (
+    <UntitledTable
+      stickyHeader
+      aria-label="data-table"
+      className={rest.resizableColumns ? 'tw:table-fixed' : undefined}
+      containerStyle={tableContainerStyle}
+      dragAndDropHooks={dragAndDropHooks}
+      selectedKeys={
+        rest.rowSelection?.selectedRowKeys
+          ? new Set(rest.rowSelection.selectedRowKeys.map(String))
+          : undefined
+      }
+      selectionBehavior={rest.rowSelection ? 'toggle' : undefined}
+      selectionMode={selectionMode}
+      size={rest.size === 'small' ? 'sm' : 'md'}
+      sortDescriptor={
+        sortState.columnKey && sortState.direction
+          ? {
+              column: sortState.columnKey,
+              direction: sortState.direction,
+            }
+          : undefined
+      }
+      onSelectionChange={handleSelectionChange}
+      onSortChange={handleSortChange}>
+      <UntitledTable.Header className="tw:px-2">
+        {propsColumns.map((col, colIdx) => {
+          const colKey = String(col.key ?? col.dataIndex ?? colIdx);
+          const colWidth =
+            columnWidths[colKey] ?? (col.width as number | undefined);
+
+          const stickyStyle = getColumnStickyStyle(col.fixed, 2);
+
+          return (
+            <UntitledTable.Head
+              allowsSorting={!!col.sorter}
+              className="tw:py-2 tw:pl-4 tw:pr-2 tw:text-sm tw:text-tertiary"
+              id={colKey}
+              key={colKey}
+              style={{
+                ...(rest.size === 'small' ? { padding: '8px' } : {}),
+                ...(colWidth !== undefined
+                  ? { width: colWidth, minWidth: colWidth }
+                  : {}),
+                ...(rest.resizableColumns ? { position: 'relative' } : {}),
+                ...stickyStyle,
+              }}>
+              <div className="tw:flex tw:items-center tw:gap-1">
+                {resolveColumnTitle(col, propsColumns)}
+                {Boolean(col.filters || col.filterDropdown) && (
+                  <DialogTrigger
+                    isOpen={openFilterKey === colKey}
+                    onOpenChange={(isOpen) =>
+                      setOpenFilterKey(isOpen ? colKey : null)
+                    }>
+                    <Button
+                      aria-label="filter"
+                      className="tw:ml-1 tw:p-0 tw:bg-transparent tw:border-0 tw:cursor-pointer tw:inline-flex tw:items-center"
+                      color="tertiary">
+                      {typeof col.filterIcon === 'function'
+                        ? col.filterIcon(Boolean(filterState[colKey]?.length))
+                        : col.filterIcon ?? null}
+                    </Button>
+                    <Popover placement="bottom right">
+                      <Dialog className="tw:outline-none">
+                        <div
+                          className="tw:bg-primary tw:shadow-lg tw:ring-1 tw:ring-secondary_alt tw:rounded-lg"
+                          style={{ minWidth: '200px' }}>
+                          {typeof col.filterDropdown === 'function'
+                            ? col.filterDropdown({
+                                prefixCls: 'ant-table-filter-dropdown',
+                                setSelectedKeys: (keys) =>
+                                  setFilterState((prev) => ({
+                                    ...prev,
+                                    [colKey]: keys,
+                                  })),
+                                selectedKeys: filterState[colKey] ?? [],
+                                confirm: () => setOpenFilterKey(null),
+                                clearFilters: () =>
+                                  setFilterState((prev) => {
+                                    const next = { ...prev };
+                                    delete next[colKey];
+
+                                    return next;
+                                  }),
+                                filters: col.filters as TableColumnType<T>['filters'],
+                                visible: true,
+                                close: () => setOpenFilterKey(null),
+                              })
+                            : col.filterDropdown}
+                        </div>
+                      </Dialog>
+                    </Popover>
+                  </DialogTrigger>
+                )}
+              </div>
+              {rest.resizableColumns && (
+                <ColumnResizer
+                  className="tw:absolute tw:right-0 tw:top-1/4 tw:h-1/2 tw:w-2 tw:cursor-col-resize
+                tw:touch-none tw:after:absolute tw:after:left-1/2 tw:after:h-full tw:after:w-px tw:after:-translate-x-1/2 tw:after:content-['']
+                tw:after:bg-[--color-border-secondary] tw:data-[resizing]:after:w-0.5 tw:data-[resizing]:after:bg-[--color-border-brand]"
+                />
+              )}
+            </UntitledTable.Head>
+          );
+        })}
+      </UntitledTable.Header>
+
+      <UntitledTable.Body
+        renderEmptyState={() =>
+          isLoading ? null : (
+            <div className="tw:py-8 tw:text-center tw:text-sm tw:text-fg-tertiary">
+              {(rest.locale?.emptyText as ReactNode) ??
+                t('label.no-data')}
+            </div>
+          )
+        }>
+        {flatRows.map((flatRow) => {
+          const { record, actualIndex, depth, hasChildren, rowKey } =
+            flatRow;
+          const rowHandlers = rest.onRow?.(record, actualIndex) ?? {};
+          const isExpanded = expandedKeys.has(rowKey);
+
+          return (
+            <UntitledTable.Row
+              className={classNames(
+                'tw:group tw:transition-colors tw:hover:bg-secondary tw:data-[selected]:bg-secondary',
+                typeof rest.rowClassName === 'function'
+                  ? rest.rowClassName(record, actualIndex, depth)
+                  : rest.rowClassName
+              )}
+              data-level={depth}
+              data-row-key={rowKey}
+              draggable={
+                dragAndDropHooks
+                  ? undefined
+                  : (rowHandlers.draggable as boolean | undefined)
+              }
+              id={rowKey}
+              key={rowKey}
+              onClick={rowHandlers.onClick}
+              onDoubleClick={rowHandlers.onDoubleClick}
+              onDragEnd={
+                dragAndDropHooks ? undefined : rowHandlers.onDragEnd
+              }
+              onDragEnter={
+                dragAndDropHooks ? undefined : rowHandlers.onDragEnter
+              }
+              onDragLeave={
+                dragAndDropHooks ? undefined : rowHandlers.onDragLeave
+              }
+              onDragOver={
+                dragAndDropHooks ? undefined : rowHandlers.onDragOver
+              }
+              onDragStart={
+                dragAndDropHooks ? undefined : rowHandlers.onDragStart
+              }
+              onDrop={
+                dragAndDropHooks ? undefined : rowHandlers.onDrop
+              }>
+              {propsColumns.map((col, colIdx) => {
+                const cellKey = String(col.key ?? col.dataIndex ?? colIdx);
+                const stickyStyle = getColumnStickyStyle(col.fixed, 1);
+
+                const isFirstColumn = colIdx === 0;
+                const showExpandInCell = rest.expandable && isFirstColumn;
+                const ExpandIcon = rest.expandable?.expandIcon;
+                const cellHandlerProps =
+                  (col.onCell?.(
+                    record,
+                    actualIndex
+                  ) as React.TdHTMLAttributes<HTMLTableCellElement>) ??
+                  {};
+
+                return (
+                  <UntitledTable.Cell
+                    {...cellHandlerProps}
+                    className={classNames(
+                      col.ellipsis && 'tw:overflow-hidden',
+                      rest.cellClassName ??
+                        'tw:py-2 tw:pl-4 tw:pr-2 tw:align-top',
+                      'tw:group-data-[dragging]:opacity-40',
+                      'tw:group-data-[drop-target]:bg-[#e8f4ff] tw:group-data-[drop-target]:outline tw:group-data-[drop-target]:outline-2',
+                      'tw:group-data-[drop-target]:outline-dashed tw:group-data-[drop-target]:outline-[--color-border-brand] tw:group-data-[drop-target]:-outline-offset-2'
+                    )}
+                    key={cellKey}
+                    style={{
+                      ...(rest.size === 'small' && !rest.cellClassName
+                        ? { padding: '8px' }
+                        : {}),
+                      ...(columnWidths[cellKey] !== undefined ||
+                      col.width !== undefined
+                        ? {
+                            width:
+                              columnWidths[cellKey] ??
+                              (col.width as number),
+                            minWidth:
+                              (col.width as number) ?? undefined,
+                          }
+                        : {}),
+                      ...stickyStyle,
+                      ...(showExpandInCell
+                        ? { paddingLeft: `${16 + depth * 12}px` }
+                        : {}),
+                      ...cellHandlerProps.style,
+                    }}>
+                    <div
+                      className={classNames(
+                        'tw:flex tw:items-start tw:gap-1 tw:max-w-full'
+                      )}>
+                      {showExpandInCell && (
+                        <div className="tw:flex-shrink-0">
+                          {hasChildren ? (
+                            ExpandIcon ? (
+                              <ExpandIcon
+                                expandable={hasChildren}
+                                expanded={isExpanded}
+                                prefixCls=""
+                                record={record}
+                                onExpand={(rec, e) => {
+                                  e.stopPropagation();
+                                  handleExpandToggle(rec as T, rowKey);
+                                }}
+                              />
+                            ) : (
+                              <button
+                                aria-expanded={isExpanded}
+                                className="tw:p-0 tw:bg-transparent tw:border-0 tw:cursor-pointer tw:mr-1 tw:inline-flex"
+                                data-testid="expand-icon"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  handleExpandToggle(record, rowKey);
+                                }}>
+                                {isExpanded ? (
+                                  <ChevronDown className="tw:size-4" />
+                                ) : (
+                                  <ChevronRight className="tw:size-4" />
+                                )}
+                              </button>
+                            )
+                          ) : ExpandIcon ? (
+                            <ExpandIcon
+                              expandable={false}
+                              expanded={false}
+                              prefixCls=""
+                              record={record}
+                              onExpand={(_rec, _e) => {}}
+                            />
+                          ) : (
+                            <span className="tw:inline-block tw:w-4 tw:mr-1" />
+                          )}
+                        </div>
+                      )}
+                      {col.ellipsis ? (
+                        <div className="tw:flex-1 tw:min-w-0 tw:truncate">
+                          {resolveCellValue(col, record, actualIndex)}
+                        </div>
+                      ) : (
+                        resolveCellValue(col, record, actualIndex)
+                      )}
+                    </div>
+                  </UntitledTable.Cell>
+                );
+              })}
+            </UntitledTable.Row>
+          );
+        })}
+      </UntitledTable.Body>
+    </UntitledTable>
+  );
 
   return (
     <div
@@ -610,322 +887,22 @@ const TableV2 = <T extends object>(
         </div>
       </div>
 
-      <div
-        className="tw:flex tw:flex-col tw:w-full"
-        data-testid={dataTestId}
-        style={scrollStyle}>
+      <div className="tw:relative" data-testid={dataTestId}>
         {isLoading && (
           <div className="tw:absolute tw:inset-0 tw:z-10 tw:flex tw:items-center tw:justify-center tw:bg-white/60">
             <Loader />
           </div>
         )}
 
-        {(() => {
-          const tableContent = (
-            <UntitledTable
-              stickyHeader
-              aria-label="data-table"
-              className={rest.resizableColumns ? 'tw:table-fixed' : undefined}
-              containerStyle={
-                scroll?.y
-                  ? {
-                      maxHeight: scroll.y as string | number,
-                      overflowY: 'auto',
-                    }
-                  : undefined
-              }
-              dragAndDropHooks={dragAndDropHooks}
-              selectedKeys={
-                rest.rowSelection?.selectedRowKeys
-                  ? new Set(rest.rowSelection.selectedRowKeys.map(String))
-                  : undefined
-              }
-              selectionBehavior={rest.rowSelection ? 'toggle' : undefined}
-              selectionMode={selectionMode}
-              size={rest.size === 'small' ? 'sm' : 'md'}
-              sortDescriptor={
-                sortState.columnKey && sortState.direction
-                  ? {
-                      column: sortState.columnKey,
-                      direction: sortState.direction,
-                    }
-                  : undefined
-              }
-              onSelectionChange={handleSelectionChange}
-              onSortChange={handleSortChange}>
-              <UntitledTable.Header className="tw:px-2">
-                {propsColumns.map((col, colIdx) => {
-                  const colType = col as ColumnType<T>;
-                  const colKey = String(col.key ?? colType.dataIndex ?? colIdx);
-                  const colWidth =
-                    columnWidths[colKey] ??
-                    (colType.width as number | undefined);
-
-                  const stickyStyle = getColumnStickyStyle(colType.fixed, 2);
-
-                  return (
-                    <UntitledTable.Head
-                      allowsSorting={!!colType.sorter}
-                      className="tw:py-2 tw:pl-4 tw:pr-2 tw:text-sm tw:text-tertiary"
-                      id={colKey}
-                      key={colKey}
-                      style={{
-                        ...(rest.size === 'small' ? { padding: '8px' } : {}),
-                        ...(colWidth !== undefined
-                          ? { width: colWidth, minWidth: colWidth }
-                          : {}),
-                        ...(rest.resizableColumns
-                          ? { position: 'relative' }
-                          : {}),
-                        ...stickyStyle,
-                      }}>
-                      <div className="tw:flex tw:items-center tw:gap-1">
-                        {resolveColumnTitle(colType, propsColumns)}
-                        {Boolean(colType.filters || colType.filterDropdown) && (
-                          <DialogTrigger
-                            isOpen={openFilterKey === colKey}
-                            onOpenChange={(isOpen) =>
-                              setOpenFilterKey(isOpen ? colKey : null)
-                            }>
-                            <Button
-                              aria-label="filter"
-                              className="tw:ml-1 tw:p-0 tw:bg-transparent tw:border-0 tw:cursor-pointer tw:inline-flex tw:items-center"
-                              color="tertiary">
-                              {typeof colType.filterIcon === 'function'
-                                ? colType.filterIcon(
-                                    Boolean(filterState[colKey]?.length)
-                                  )
-                                : colType.filterIcon ?? null}
-                            </Button>
-                            <Popover placement="bottom right">
-                              <Dialog className="tw:outline-none">
-                                <div
-                                  className="tw:bg-primary tw:shadow-lg tw:ring-1 tw:ring-secondary_alt tw:rounded-lg"
-                                  style={{ minWidth: '200px' }}>
-                                  {typeof colType.filterDropdown === 'function'
-                                    ? colType.filterDropdown({
-                                        prefixCls: 'ant-table-filter-dropdown',
-                                        setSelectedKeys: (keys) =>
-                                          setFilterState((prev) => ({
-                                            ...prev,
-                                            [colKey]: keys,
-                                          })),
-                                        selectedKeys: filterState[colKey] ?? [],
-                                        confirm: () => setOpenFilterKey(null),
-                                        clearFilters: () =>
-                                          setFilterState((prev) => {
-                                            const next = { ...prev };
-                                            delete next[colKey];
-
-                                            return next;
-                                          }),
-                                        filters: colType.filters,
-                                        visible: true,
-                                        close: () => setOpenFilterKey(null),
-                                      })
-                                    : colType.filterDropdown}
-                                </div>
-                              </Dialog>
-                            </Popover>
-                          </DialogTrigger>
-                        )}
-                      </div>
-                      {rest.resizableColumns && (
-                        <ColumnResizer
-                          className="tw:absolute tw:right-0 tw:top-1/4 tw:h-1/2 tw:w-2 tw:cursor-col-resize 
-                        tw:touch-none tw:after:absolute tw:after:left-1/2 tw:after:h-full tw:after:w-px tw:after:-translate-x-1/2 tw:after:content-[''] 
-                        tw:after:bg-[--color-border-secondary] tw:data-[resizing]:after:w-0.5 tw:data-[resizing]:after:bg-[--color-border-brand]"
-                        />
-                      )}
-                    </UntitledTable.Head>
-                  );
-                })}
-              </UntitledTable.Header>
-
-              <UntitledTable.Body
-                renderEmptyState={() =>
-                  isLoading ? null : (
-                    <div className="tw:py-8 tw:text-center tw:text-sm tw:text-fg-tertiary">
-                      {(rest.locale?.emptyText as ReactNode) ??
-                        t('label.no-data')}
-                    </div>
-                  )
-                }>
-                {flatRows.map((flatRow) => {
-                  const { record, actualIndex, depth, hasChildren, rowKey } =
-                    flatRow;
-                  const rowHandlers = rest.onRow?.(record, actualIndex) ?? {};
-                  const isExpanded = expandedKeys.has(rowKey);
-
-                  return (
-                    <UntitledTable.Row
-                      className={classNames(
-                        'tw:group tw:transition-colors tw:hover:bg-secondary tw:data-[selected]:bg-secondary',
-                        typeof rest.rowClassName === 'function'
-                          ? rest.rowClassName(record, actualIndex, depth)
-                          : rest.rowClassName
-                      )}
-                      data-level={depth}
-                      data-row-key={rowKey}
-                      draggable={
-                        dragAndDropHooks
-                          ? undefined
-                          : (rowHandlers.draggable as boolean | undefined)
-                      }
-                      id={rowKey}
-                      key={rowKey}
-                      onClick={rowHandlers.onClick}
-                      onDoubleClick={rowHandlers.onDoubleClick}
-                      onDragEnd={
-                        dragAndDropHooks ? undefined : rowHandlers.onDragEnd
-                      }
-                      onDragEnter={
-                        dragAndDropHooks ? undefined : rowHandlers.onDragEnter
-                      }
-                      onDragLeave={
-                        dragAndDropHooks ? undefined : rowHandlers.onDragLeave
-                      }
-                      onDragOver={
-                        dragAndDropHooks ? undefined : rowHandlers.onDragOver
-                      }
-                      onDragStart={
-                        dragAndDropHooks ? undefined : rowHandlers.onDragStart
-                      }
-                      onDrop={
-                        dragAndDropHooks ? undefined : rowHandlers.onDrop
-                      }>
-                      {propsColumns.map((col, colIdx) => {
-                        const colType = col as ColumnType<T>;
-                        const cellKey = String(
-                          col.key ?? colType.dataIndex ?? colIdx
-                        );
-                        const stickyStyle = getColumnStickyStyle(
-                          colType.fixed,
-                          1
-                        );
-
-                        const isFirstColumn = colIdx === 0;
-                        const showExpandInCell =
-                          rest.expandable && isFirstColumn;
-                        const ExpandIcon = rest.expandable?.expandIcon;
-                        const cellHandlerProps =
-                          (colType.onCell?.(
-                            record,
-                            actualIndex
-                          ) as React.TdHTMLAttributes<HTMLTableCellElement>) ??
-                          {};
-
-                        return (
-                          <UntitledTable.Cell
-                            {...cellHandlerProps}
-                            className={classNames(
-                              colType.ellipsis && 'tw:overflow-hidden',
-                              rest.cellClassName ??
-                                'tw:py-2 tw:pl-4 tw:pr-2 tw:align-top',
-                              'tw:group-data-[dragging]:opacity-40',
-                              'tw:group-data-[drop-target]:bg-[#e8f4ff] tw:group-data-[drop-target]:outline tw:group-data-[drop-target]:outline-2',
-                              'tw:group-data-[drop-target]:outline-dashed tw:group-data-[drop-target]:outline-[--color-border-brand] tw:group-data-[drop-target]:-outline-offset-2'
-                            )}
-                            key={cellKey}
-                            style={{
-                              ...(rest.size === 'small' && !rest.cellClassName
-                                ? { padding: '8px' }
-                                : {}),
-                              ...(columnWidths[cellKey] !== undefined ||
-                              colType.width !== undefined
-                                ? {
-                                    width:
-                                      columnWidths[cellKey] ??
-                                      (colType.width as number),
-                                    minWidth:
-                                      (colType.width as number) ?? undefined,
-                                  }
-                                : {}),
-                              ...stickyStyle,
-                              ...(showExpandInCell
-                                ? { paddingLeft: `${16 + depth * 12}px` }
-                                : {}),
-                              ...cellHandlerProps.style,
-                            }}>
-                            <div
-                              className={classNames(
-                                'tw:flex tw:items-start tw:gap-1 tw:max-w-full'
-                              )}>
-                              {showExpandInCell && (
-                                <div className="tw:flex-shrink-0">
-                                  {hasChildren ? (
-                                    ExpandIcon ? (
-                                      <ExpandIcon
-                                        expandable={hasChildren}
-                                        expanded={isExpanded}
-                                        prefixCls=""
-                                        record={record}
-                                        onExpand={(rec, e) => {
-                                          e.stopPropagation();
-                                          handleExpandToggle(rec as T, rowKey);
-                                        }}
-                                      />
-                                    ) : (
-                                      <button
-                                        aria-expanded={isExpanded}
-                                        className="tw:p-0 tw:bg-transparent tw:border-0 tw:cursor-pointer tw:mr-1 tw:inline-flex"
-                                        data-testid="expand-icon"
-                                        onClick={(e) => {
-                                          e.stopPropagation();
-                                          handleExpandToggle(record, rowKey);
-                                        }}>
-                                        {isExpanded ? (
-                                          <ChevronDown className="tw:size-4" />
-                                        ) : (
-                                          <ChevronRight className="tw:size-4" />
-                                        )}
-                                      </button>
-                                    )
-                                  ) : ExpandIcon ? (
-                                    <ExpandIcon
-                                      expandable={false}
-                                      expanded={false}
-                                      prefixCls=""
-                                      record={record}
-                                      onExpand={(_rec, _e) => {}}
-                                    />
-                                  ) : (
-                                    <span className="tw:inline-block tw:w-4 tw:mr-1" />
-                                  )}
-                                </div>
-                              )}
-                              {colType.ellipsis ? (
-                                <div className="tw:flex-1 tw:min-w-0 tw:truncate">
-                                  {resolveCellValue(
-                                    colType,
-                                    record,
-                                    actualIndex
-                                  )}
-                                </div>
-                              ) : (
-                                resolveCellValue(colType, record, actualIndex)
-                              )}
-                            </div>
-                          </UntitledTable.Cell>
-                        );
-                      })}
-                    </UntitledTable.Row>
-                  );
-                })}
-              </UntitledTable.Body>
-            </UntitledTable>
-          );
-
-          return rest.resizableColumns ? (
-            <ResizableTableContainer
-              className="tw:overflow-auto tw:relative"
-              onResize={handleColumnResize}>
-              {tableContent}
-            </ResizableTableContainer>
-          ) : (
-            tableContent
-          );
-        })()}
+        {rest.resizableColumns ? (
+          <ResizableTableContainer
+            className="tw:overflow-auto tw:relative"
+            onResize={handleColumnResize}>
+            {tableNode}
+          </ResizableTableContainer>
+        ) : (
+          tableNode
+        )}
       </div>
 
       {customPaginationProps && customPaginationProps.showPagination ? (
@@ -935,13 +912,13 @@ const TableV2 = <T extends object>(
       ) : clientPagination &&
         !(
           clientPagination.hideOnSinglePage &&
-          filteredDataSource.length <= clientPagination.pageSize
+          filteredDataSource.length <= (clientPagination.pageSize ?? 10)
         ) ? (
         <div>
           <NextPrevious
             isNumberBased
             currentPage={internalCurrentPage}
-            pageSize={clientPagination.pageSize}
+            pageSize={clientPagination.pageSize ?? 10}
             paging={{ total: filteredDataSource.length }}
             pagingHandler={({ currentPage }) =>
               setInternalCurrentPage(currentPage)

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx
@@ -85,8 +85,8 @@ import type {
   AriaSelection,
   AriaSortDescriptor,
   FlatRow,
-  TableColumnType,
   TableColumnsType,
+  TableColumnType,
   TableCurrentDataSource,
   TablePaginationConfig,
   TableSorterResult,
@@ -194,8 +194,7 @@ const TableV2 = <T extends object>(
     return sortedDataSource.filter((record) =>
       activeFilters.every(([colKey, selectedKeys]) => {
         const col = propsColumns.find(
-          (c, idx) =>
-            String(c.key ?? c.dataIndex ?? idx) === colKey
+          (c, idx) => String(c.key ?? c.dataIndex ?? idx) === colKey
         ) as TableColumnType<T> | undefined;
 
         return col?.onFilter
@@ -213,7 +212,10 @@ const TableV2 = <T extends object>(
     }
     const start = (internalCurrentPage - 1) * (clientPagination.pageSize ?? 10);
 
-    return filteredDataSource.slice(start, start + (clientPagination.pageSize ?? 10));
+    return filteredDataSource.slice(
+      start,
+      start + (clientPagination.pageSize ?? 10)
+    );
   }, [filteredDataSource, clientPagination, internalCurrentPage]);
 
   const expandedKeys = useMemo<Set<string>>(() => {
@@ -253,7 +255,9 @@ const TableV2 = <T extends object>(
   const handleMoveItem = useCallback(
     (updatedList: TableColumnDropdownList[]) => {
       setDropdownColumnList(updatedList);
-      setPropsColumns(getReorderedColumns(updatedList, propsColumns) as TableColumnsType<T>);
+      setPropsColumns(
+        getReorderedColumns(updatedList, propsColumns) as TableColumnsType<T>
+      );
     },
     [propsColumns]
   );
@@ -465,7 +469,12 @@ const TableV2 = <T extends object>(
           (rest.staticVisibleColumns ?? []).includes(item.key as string)
       );
 
-      setPropsColumns(getReorderedColumns(dropdownColumnList, filteredColumns) as TableColumnsType<T>);
+      setPropsColumns(
+        getReorderedColumns(
+          dropdownColumnList,
+          filteredColumns
+        ) as TableColumnsType<T>
+      );
     } else {
       setPropsColumns((rest.columns ?? []) as TableColumnsType<T>);
     }
@@ -622,7 +631,8 @@ const TableV2 = <T extends object>(
 
                                     return next;
                                   }),
-                                filters: col.filters as TableColumnType<T>['filters'],
+                                filters:
+                                  col.filters as TableColumnType<T>['filters'],
                                 visible: true,
                                 close: () => setOpenFilterKey(null),
                               })
@@ -649,14 +659,12 @@ const TableV2 = <T extends object>(
         renderEmptyState={() =>
           isLoading ? null : (
             <div className="tw:py-8 tw:text-center tw:text-sm tw:text-fg-tertiary">
-              {(rest.locale?.emptyText as ReactNode) ??
-                t('label.no-data')}
+              {(rest.locale?.emptyText as ReactNode) ?? t('label.no-data')}
             </div>
           )
         }>
         {flatRows.map((flatRow) => {
-          const { record, actualIndex, depth, hasChildren, rowKey } =
-            flatRow;
+          const { record, actualIndex, depth, hasChildren, rowKey } = flatRow;
           const rowHandlers = rest.onRow?.(record, actualIndex) ?? {};
           const isExpanded = expandedKeys.has(rowKey);
 
@@ -679,24 +687,18 @@ const TableV2 = <T extends object>(
               key={rowKey}
               onClick={rowHandlers.onClick}
               onDoubleClick={rowHandlers.onDoubleClick}
-              onDragEnd={
-                dragAndDropHooks ? undefined : rowHandlers.onDragEnd
-              }
+              onDragEnd={dragAndDropHooks ? undefined : rowHandlers.onDragEnd}
               onDragEnter={
                 dragAndDropHooks ? undefined : rowHandlers.onDragEnter
               }
               onDragLeave={
                 dragAndDropHooks ? undefined : rowHandlers.onDragLeave
               }
-              onDragOver={
-                dragAndDropHooks ? undefined : rowHandlers.onDragOver
-              }
+              onDragOver={dragAndDropHooks ? undefined : rowHandlers.onDragOver}
               onDragStart={
                 dragAndDropHooks ? undefined : rowHandlers.onDragStart
               }
-              onDrop={
-                dragAndDropHooks ? undefined : rowHandlers.onDrop
-              }>
+              onDrop={dragAndDropHooks ? undefined : rowHandlers.onDrop}>
               {propsColumns.map((col, colIdx) => {
                 const cellKey = String(col.key ?? col.dataIndex ?? colIdx);
                 const stickyStyle = getColumnStickyStyle(col.fixed, 1);
@@ -708,8 +710,7 @@ const TableV2 = <T extends object>(
                   (col.onCell?.(
                     record,
                     actualIndex
-                  ) as React.TdHTMLAttributes<HTMLTableCellElement>) ??
-                  {};
+                  ) as React.TdHTMLAttributes<HTMLTableCellElement>) ?? {};
 
                 return (
                   <UntitledTable.Cell
@@ -731,10 +732,8 @@ const TableV2 = <T extends object>(
                       col.width !== undefined
                         ? {
                             width:
-                              columnWidths[cellKey] ??
-                              (col.width as number),
-                            minWidth:
-                              (col.width as number) ?? undefined,
+                              columnWidths[cellKey] ?? (col.width as number),
+                            minWidth: (col.width as number) ?? undefined,
                           }
                         : {}),
                       ...stickyStyle,

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2Utils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2Utils.ts
@@ -10,15 +10,15 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import type { ColumnsType } from 'antd/es/table/interface';
-import type {
-  ColumnType,
-  FilterValue,
-  SortOrder,
-} from 'antd/lib/table/interface';
 import { isEmpty } from 'lodash';
 import React, { ReactNode } from 'react';
-import type { FlatRow } from './TableV2.interface';
+import type {
+  FlatRow,
+  TableColumnType,
+  TableColumnsType,
+  TableFilterValue,
+  TableSortOrder,
+} from './TableV2.interface';
 
 export function flattenTreeRows<T>(
   data: T[],
@@ -61,7 +61,7 @@ export function flattenTreeRows<T>(
 }
 
 export function resolveCellValue<T>(
-  col: ColumnType<T>,
+  col: TableColumnType<T>,
   record: T,
   index: number
 ): ReactNode {
@@ -94,19 +94,19 @@ export function resolveCellValue<T>(
 }
 
 export function resolveColumnTitle<T>(
-  col: ColumnType<T>,
-  propsColumns: ColumnsType<T>
+  col: TableColumnType<T>,
+  propsColumns: TableColumnsType<T>
 ): ReactNode {
   if (typeof col.title === 'function') {
     const sortedColumn = propsColumns.find(
-      (c) => (c as ColumnType<T>).sortOrder
-    ) as ColumnType<T> | undefined;
+      (c) => (c as TableColumnType<T>).sortOrder
+    ) as TableColumnType<T> | undefined;
 
     return (
       col.title as (props: {
-        sortOrder?: SortOrder;
-        sortColumn?: ColumnType<T>;
-        filters?: Record<string, FilterValue | null>;
+        sortOrder?: TableSortOrder;
+        sortColumn?: TableColumnType<T>;
+        filters?: Record<string, TableFilterValue | null>;
       }) => ReactNode
     )({
       sortOrder: col.sortOrder ?? null,
@@ -124,7 +124,7 @@ export function resolveColumnTitle<T>(
  * to the same side, offsets must be computed by the caller.
  */
 export function getColumnStickyStyle(
-  fixed: ColumnType<unknown>['fixed'],
+  fixed: TableColumnType<unknown>['fixed'],
   zIndex: number
 ): React.CSSProperties {
   if (fixed === 'left') {

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2Utils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2Utils.ts
@@ -14,8 +14,8 @@ import { isEmpty } from 'lodash';
 import React, { ReactNode } from 'react';
 import type {
   FlatRow,
-  TableColumnType,
   TableColumnsType,
+  TableColumnType,
   TableFilterValue,
   TableSortOrder,
 } from './TableV2.interface';


### PR DESCRIPTION
## Summary

- **Remove AntD imports** from `TableV2.tsx` and `TableV2Utils.ts` — these files now depend only on `@openmetadata/ui-core-components` and local types. The public props contract (`TableComponentProps<T>` extending AntD's `TableProps<T>`) is unchanged so no callsites need updating.
- **Fix vertical scroll** — `scroll.y` now works correctly with sticky headers.
- **Add Storybook stories** — six CSF3 stories covering common usage including scrollable behaviour.

## What changed and why

### AntD type aliases (`TableV2.interface.ts`)
Added local type aliases that structurally mirror the antd types that were previously imported directly in the V2 implementation files:

| Local type | Replaces |
|---|---|
| `TableColumnType<T>` | `ColumnType<T>` (antd) |
| `TableColumnsType<T>` | `ColumnsType<T>` (antd) |
| `TablePaginationConfig` | `TablePaginationConfig` (antd) |
| `TableSorterResult<T>` | `SorterResult<T>` (antd) |
| `TableCurrentDataSource<T>` | `TableCurrentDataSource<T>` (antd) |
| `TableSortOrder` | `SortOrder` (antd) |
| `TableFilterValue` | `FilterValue` (antd) |

### Vertical scroll fix (`TableV2.tsx`)
**Root cause**: the previous code passed only `overflowY: 'auto'` via `containerStyle`, relying on the Tailwind `tw:overflow-x-auto` CSS class on the inner `UntitledTable` wrapper div to supply `overflow-x`. Setting one overflow axis via a CSS class and the other via inline style creates a CSS specificity ambiguity and can break the scroll container contract.

**Fix**: `tableContainerStyle` now explicitly sets **both** `overflowX: 'auto'` and `overflowY: 'auto'` alongside `maxHeight` when `scroll.y` is provided. This makes the single inner `div` inside `UntitledTable` the sole scroll container for both axes — which is required for `position: sticky` on the `thead` to work correctly while scrolling vertically.

The redundant outer-div `scrollStyle` (which only set `overflowX`) was also removed, and the loading overlay wrapper was simplified.

### Stories (`TableV2.stories.tsx`)
Six CSF3 stories using a minimal `DemoTable` wrapper (avoids the OM app providers that `TableV2` itself requires):

| Story | Covers |
|---|---|
| `Default` | 5-row baseline |
| `ManyRows` | 30 rows, no height cap |
| `VerticalScroll` | 30 rows, `scrollY=300` — sticky header + scroll bar |
| `SmallWithScroll` | Small size variant + scroll |
| `FewRowsScrollCapped` | Few rows, scroll cap set but no scrollbar rendered |
| `Empty` | Empty-state rendering |

## Test plan
- [ ] Render a table with `scroll={{ y: 400 }}` and enough rows to exceed 400 px — confirm vertical scrollbar appears and header stays sticky
- [ ] Render with `resizableColumns` and `scroll={{ y: 400 }}` — confirm same behaviour inside `ResizableTableContainer`
- [ ] Render without `scroll` prop — confirm no regressions in default layout
- [ ] TypeScript: `npx tsc --noEmit` passes with zero errors in the changed files
- [ ] Existing callers of `TableV2` compile without changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)