### PR TITLE
test(playwright): mark Data Products suite as slow

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataProducts.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataProducts.spec.ts
@@ -65,6 +65,7 @@ const test = base.extend<{
 
 test.describe('Data Products', () => {
   test.describe.configure({ mode: 'serial' });
+  test.slow();
 
   test.beforeAll('Setup pre-requests', async ({ browser }) => {
     const { apiContext, afterAction } = await performAdminLogin(browser);


### PR DESCRIPTION
## Summary
- Adds `test.slow()` to the Data Products Playwright describe block to triple the per-test timeout, giving the longer-running cases (asset management, 30-fixture pagination) more headroom and reducing flake.

## Test plan
- [ ] `yarn playwright:run playwright/e2e/Pages/DataProducts.spec.ts` passes locally
- [ ] CI Playwright job is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)