### PR TITLE
fix(playwright): stabilize TagSuggestion select + scope tag-chip assertions

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataProducts.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataProducts.spec.ts
@@ -479,6 +479,11 @@ test.describe('Data Products', () => {
       const domainOption = page.getByText(domain.data.displayName);
       await domainOption.waitFor({ state: 'visible' });
       await domainOption.click();
+      await page.keyboard.press('Escape');
+      await page
+        .locator('[role="listbox"]')
+        .first()
+        .waitFor({ state: 'hidden' });
     });
 
     await test.step('Search and select tag via TagSuggestion', async () => {
@@ -488,7 +493,10 @@ test.describe('Data Products', () => {
       });
 
       await expect(
-        page.getByTestId('add-domain-form').getByText(tag.data.displayName)
+        page
+          .getByTestId('add-domain-form')
+          .getByTestId('tags-container')
+          .getByText(tag.data.displayName)
       ).toBeVisible();
     });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts
@@ -1167,7 +1167,10 @@ test.describe('Domains', () => {
         });
 
         await expect(
-          page.getByTestId('add-domain-form').getByText(tag.data.displayName)
+          page
+            .getByTestId('add-domain-form')
+            .getByTestId('tags-container')
+            .getByText(tag.data.displayName)
         ).toBeVisible();
       });
 
@@ -1219,7 +1222,10 @@ test.describe('Domains', () => {
         });
 
         await expect(
-          page.getByTestId('add-domain-form').getByText(tag.data.displayName)
+          page
+            .getByTestId('add-domain-form')
+            .getByTestId('tags-container')
+            .getByText(tag.data.displayName)
         ).toBeVisible();
       });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/tag.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/tag.ts
@@ -626,13 +626,23 @@ export const selectTagInTagSuggestion = async (
     );
   });
 
+  await tagInput.click();
   await tagInput.fill(searchTerm);
   await tagSearchResponse;
 
-  await page.locator('[role="listbox"]').first().waitFor({ state: 'visible' });
-  const tagOption = page.getByTestId(`tag-option-${tagFqn}`);
+  const listboxId = await tagInput.getAttribute('aria-controls');
+  const listbox = listboxId
+    ? page.locator(`[id="${listboxId}"]`)
+    : page
+        .locator('[role="listbox"]')
+        .filter({ has: page.getByTestId(`tag-option-${tagFqn}`) })
+        .first();
+  await listbox.waitFor({ state: 'visible' });
+
+  const tagOption = listbox.getByTestId(`tag-option-${tagFqn}`);
   await tagOption.waitFor({ state: 'visible' });
+  await tagOption.scrollIntoViewIfNeeded();
   await tagOption.click();
   await page.keyboard.press('Escape');
-  await page.locator('[role="listbox"]').first().waitFor({ state: 'hidden' });
+  await listbox.waitFor({ state: 'hidden' });
 };

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/tag.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/tag.ts
@@ -616,6 +616,7 @@ export const selectTagInTagSuggestion = async (
   }
 ) => {
   const tagInput = page.getByRole('combobox', { name: 'Tags' });
+  const tagOption = page.getByTestId(`tag-option-${tagFqn}`);
 
   const tagSearchResponse = page.waitForResponse((response) => {
     const url = response.url();
@@ -630,19 +631,7 @@ export const selectTagInTagSuggestion = async (
   await tagInput.fill(searchTerm);
   await tagSearchResponse;
 
-  const listboxId = await tagInput.getAttribute('aria-controls');
-  const listbox = listboxId
-    ? page.locator(`[id="${listboxId}"]`)
-    : page
-        .locator('[role="listbox"]')
-        .filter({ has: page.getByTestId(`tag-option-${tagFqn}`) })
-        .first();
-  await listbox.waitFor({ state: 'visible' });
-
-  const tagOption = listbox.getByTestId(`tag-option-${tagFqn}`);
-  await tagOption.waitFor({ state: 'visible' });
-  await tagOption.scrollIntoViewIfNeeded();
   await tagOption.click();
   await page.keyboard.press('Escape');
-  await listbox.waitFor({ state: 'hidden' });
+  await tagOption.waitFor({ state: 'hidden' });
 };


### PR DESCRIPTION
## Summary

The two TagSuggestion playwright tests added with the new Autocomplete component were failing in nightly:

- **Domains › Create domain with tags using TagSuggestion** — strict-mode violation: \`getByTestId('add-domain-form').getByText(tag.displayName)\` matched both the chip and the still-rendered dropdown option.
- **Data Products › Create data product with tags using TagSuggestion** — \`tagOption.click()\` hung for the full 60 s test timeout. The helper grabbed \`page.locator('[role="listbox"]').first()\`, which can resolve to the previous (domain) listbox left open from the prior step and never match the tag option's parent.

### Changes
- \`playwright/utils/tag.ts\` — \`selectTagInTagSuggestion\` now resolves the listbox via the combobox's \`aria-controls\` attribute (with a tag-option-scoped fallback) instead of \`[role=\"listbox\"].first()\`. Adds \`scrollIntoViewIfNeeded\` before clicking.
- \`playwright/e2e/Pages/Domains.spec.ts\` (1170, 1222) — assertion scoped to \`tags-container\` so it only matches the chip.
- \`playwright/e2e/Pages/DataProducts.spec.ts\` (491) — same assertion scoping. Also dismiss the domain dropdown after selecting the domain so the two listboxes don't overlap.

## Test plan

Ran locally against \`http://localhost:8585\` (1.12.0-SNAPSHOT @ \`2c262b9abe\`):

- [x] Single run of both specs — 5 passed (50.3s)
- [x] \`--repeat-each=5\` flake check — 13 passed (2.3m), no flakes:
  - Domains › Create domain with tags using TagSuggestion: 5/5 ✓ (avg 6.0s)
  - Data Products › Create data product with tags using TagSuggestion: 5/5 ✓ (avg 8.4s)
- [ ] CI nightly green