### PR TITLE
fix(search): resolve entity-specific aliases to canonical index names

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
@@ -641,13 +641,59 @@ public class SearchRepository {
     return false;
   }
 
+  /**
+   * Resolve the supplied index alias into the actual Elasticsearch / OpenSearch index name to
+   * query. Handles four shapes:
+   *
+   * <ul>
+   *   <li><b>Entity-specific alias</b> (e.g. {@code "table"}): looked up in
+   *       {@code entityIndexMap} and resolved to the canonical {@code *_search_index} name.
+   *       This is the bug fix — without resolving, ES would treat {@code "table"} as an alias
+   *       and expand it to every index that has that alias attached, including
+   *       {@code column_search_index} (because {@code tableColumn} declares {@code "table"} as
+   *       a {@code parentAlias}). Resolving here bypasses ES's alias expansion entirely so a
+   *       query for tables only hits the table index.
+   *   <li><b>Compound alias</b> (e.g. {@code "all"}, {@code "dataAsset"}): no entry in
+   *       {@code entityIndexMap}, no canonical index, so the alias passes through and ES
+   *       resolves it natively across the entities that have registered the alias. This is the
+   *       intended behavior — searching {@code dataAsset} should surface every data-asset
+   *       entity.
+   *   <li><b>Canonical / legacy index name</b> (e.g. {@code "table_search_index"}): not a key
+   *       in {@code entityIndexMap}, falls through to the prefix-and-pass branch, identical to
+   *       the legacy behavior.
+   *   <li><b>Already cluster-prefixed token</b>: idempotent — returned unchanged so that
+   *       internal code paths that hand back a resolved value don't double-prefix.
+   * </ul>
+   *
+   * Comma-separated tokens are resolved independently. Empty tokens (from {@code "table,"} or
+   * {@code ","}) are dropped instead of materializing as a bare cluster prefix; if every token
+   * is empty the original input is returned unchanged so downstream ES surfaces a normal
+   * "unknown index" error instead of an empty-target failure.
+   */
   public String getIndexOrAliasName(String name) {
-    if (clusterAlias == null || clusterAlias.isEmpty()) {
+    if (nullOrEmpty(name)) {
       return name;
     }
-    return Arrays.stream(name.split(","))
-        .map(index -> clusterAlias + INDEX_NAME_SEPARATOR + index.trim())
-        .collect(Collectors.joining(","));
+    String prefix =
+        clusterAlias == null || clusterAlias.isEmpty() ? null : clusterAlias + INDEX_NAME_SEPARATOR;
+    String resolved =
+        Arrays.stream(name.split(","))
+            .map(String::trim)
+            .filter(t -> !t.isEmpty())
+            .map(t -> resolveSingleAliasToken(t, prefix))
+            .collect(Collectors.joining(","));
+    return resolved.isEmpty() ? name : resolved;
+  }
+
+  private String resolveSingleAliasToken(String token, String clusterPrefix) {
+    if (clusterPrefix != null && token.startsWith(clusterPrefix)) {
+      return token;
+    }
+    IndexMapping mapping = entityIndexMap == null ? null : entityIndexMap.get(token);
+    if (mapping != null) {
+      return mapping.getIndexName(clusterAlias);
+    }
+    return clusterPrefix == null ? token : clusterPrefix + token;
   }
 
   private static final Map<String, Set<String>> RBAC_CHILD_TYPES =

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java
@@ -275,6 +275,68 @@ class SearchRepositoryBehaviorTest {
         "table_search_index", repository.getIndexNameWithoutAlias("cluster_table_search_index"));
   }
 
+  /**
+   * Bug regression for issue #27761: passing the entity-specific alias {@code "table"} used to
+   * leak into ES alias expansion and surface tableColumn docs (because column_search_index is
+   * registered with {@code "table"} as one of its aliases). Resolving the alias to its canonical
+   * index name here bypasses ES's alias resolution, so the search hits exactly the table index.
+   */
+  @Test
+  void getIndexOrAliasNameResolvesEntitySpecificAliasToCanonicalIndex() {
+    assertEquals("cluster_table_search_index", repository.getIndexOrAliasName("table"));
+    assertEquals("cluster_domain_search_index", repository.getIndexOrAliasName("domain"));
+  }
+
+  /**
+   * Compound aliases like {@code "all"} and {@code "dataAsset"} have no entry in
+   * {@code entityIndexMap} (they're meta-aliases registered against many entities at index
+   * creation time). The resolver passes them through with the cluster prefix so ES expands them
+   * natively — searching {@code dataAsset} should still surface every data-asset entity.
+   */
+  @Test
+  void getIndexOrAliasNamePassesCompoundAliasesThroughForNativeESExpansion() {
+    assertEquals("cluster_dataAsset", repository.getIndexOrAliasName("dataAsset"));
+    assertEquals("cluster_all", repository.getIndexOrAliasName("all"));
+  }
+
+  /**
+   * Defense-in-depth: a token that already carries the cluster prefix must not get prefixed
+   * again. Otherwise multi-tenant deployments would 404 on
+   * {@code cluster_cluster_table_search_index} if any internal code accidentally hands a
+   * resolved value back to this method.
+   */
+  @Test
+  void getIndexOrAliasNameIsIdempotentForAlreadyPrefixedTokens() {
+    assertEquals(
+        "cluster_table_search_index", repository.getIndexOrAliasName("cluster_table_search_index"));
+  }
+
+  /**
+   * Mixed input: each comma-separated token is resolved independently. Entity-specific aliases
+   * resolve to canonical names; compound aliases pass through.
+   */
+  @Test
+  void getIndexOrAliasNameResolvesEachCommaSeparatedTokenIndependently() {
+    assertEquals(
+        "cluster_table_search_index,cluster_dataAsset",
+        repository.getIndexOrAliasName("table,dataAsset"));
+  }
+
+  /**
+   * Stray-comma / empty-token input must not produce bare cluster prefixes such as
+   * {@code "cluster_"}. Empty tokens are dropped; if every token is empty the original string
+   * is returned unchanged so downstream ES surfaces a normal "unknown index" error instead of
+   * a confusing empty-target failure.
+   */
+  @Test
+  void getIndexOrAliasNameDropsEmptyTokensAndPreservesAllEmptyInput() {
+    assertEquals("cluster_table_search_index", repository.getIndexOrAliasName("table,"));
+    assertEquals(
+        "cluster_table_search_index,cluster_domain_search_index",
+        repository.getIndexOrAliasName("table, ,domain"));
+    assertEquals(", ,", repository.getIndexOrAliasName(", ,"));
+  }
+
   @Test
   void indexExistsFallsBackToAliasLookup() {
     when(searchClient.indexExists("cluster_table_search_index")).thenReturn(false);


### PR DESCRIPTION
Closes #27761.

## Problem

When the UI migrated from `index=table_search_index` to `index=table`, every search for tables started returning column docs too. ES alias expansion is bidirectional through the parent/child graph in `indexMapping.json`: `column_search_index` is created with `table` as one of its aliases (because `tableColumn` lists `"table"` in its `parentAliases`), so when ES resolves alias `table` it expands to both `table_search_index` AND `column_search_index`.

Same bleed exists for every alias whose entities also act as a parent for some other entity — `testCase`, `testSuite`, `database`, …

## Fix

One method. `SearchRepository.getIndexOrAliasName(String)` now resolves entity-specific aliases to their canonical `*_search_index` names so we hand ES literal index names and bypass alias expansion entirely.

| Input | Output | Notes |
| --- | --- | --- |
| `"table"` (entity alias) | `"<cluster>_table_search_index"` | **The fix.** Entity-specific alias resolves to canonical, no children leak. |
| `"dataAsset"` / `"all"` (compound) | `"<cluster>_dataAsset"` | Passes through. ES expands natively. UI widgets that span the umbrella keep working. |
| `"table_search_index"` (canonical) | `"<cluster>_table_search_index"` | Legacy callers unchanged. |
| `"<cluster>_table_search_index"` | unchanged | Idempotent — internal code that hands a resolved value back doesn't double-prefix. |
| `"table,"` / `","` | empty tokens dropped | All-empty input preserved so ES surfaces "unknown index" instead of an empty-target failure. |

That's the entire change. No new query params, no schema changes, no method signatures touched. Every existing caller of `getIndexOrAliasName` picks up the new behavior:

- `/v1/search/query`, `/v1/search/export`, `/v1/search/preview`, `/v1/search/nlq/query` — resource layer already pre-resolves via this method.
- `/v1/search/aggregate` (GET + POST), `/v1/search/fieldQuery`, `/v1/search/entityTypeCounts` — ES/OS managers already resolve via this method.

## Why no flag mechanism

A previous draft of this fix (PR #27762, `fix-cluster-aliasing` branch) added `fetchParentsAliases` / `fetchChildAliases` flags so callers could opt into selective expansion. Audit of every caller showed nobody actually needs that — UI sites with `SearchIndex.TABLE` / `TOPIC` / etc. want only that type; UI sites that need mixed entity types use `SearchIndex.ALL` / `SearchIndex.DATA_ASSET` (compound aliases, unchanged by this fix); internal Java callers (RBAC, propagation, `DataInsightSystemChartRepository`) pass entity-specific aliases for entity-specific operations. Adding a flag for a use case nobody has just enlarges the API surface.

## Test plan

- [x] Unit tests in `SearchRepositoryBehaviorTest` pin: entity-alias → canonical resolution; compound-alias passthrough; idempotent already-prefixed token; comma-separated independent resolution; empty-token / all-empty handling; existing `indexNameHelpersRespectClusterAlias` test (canonical-name input) unchanged.
- [ ] Integration smoke against a running stack:
  ```bash
  curl '…/v1/search/query?q=*&index=table&size=20' -H "Authorization: Bearer $TOKEN" \
    | jq '[.hits.hits[]._source.entityType] | unique'
  # Expect: ["table"]   (no "column")
  curl '…/v1/search/query?q=*&index=dataAsset&size=20' -H "Authorization: Bearer $TOKEN" \
    | jq '[.hits.hits[]._source.entityType] | unique'
  # Expect: includes table, topic, dashboard, … (compound alias still works)
  ```
- [ ] Multi-tenant deployment with `clusterAlias` configured: `?index=table` resolves to `<tenant>_table_search_index` exactly once (no double-prefix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)