### PR TITLE
chore(ui): add playwright for count comparison

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ExploreAggregationCountsMatching.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ExploreAggregationCountsMatching.spec.ts
@@ -11,8 +11,9 @@
  *  limitations under the License.
  */
 
-import { expect, Page, test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import { redirectToHomePage } from '../../utils/common';
+import { waitForAllLoadersToDisappear } from '../../utils/entity';
 
 // Maps entityType keys from the API aggregation to the explore left-panel tab testid labels.
 // The testid format is `${lowerCase(tabDetail.label)}-tab` (see ExploreUtils.tsx generateTabItems).
@@ -31,135 +32,103 @@ const ENTITY_TYPE_TO_TAB_TESTID: Record<string, string> = {
   chart: 'charts-tab',
   storedProcedure: 'stored procedures-tab',
   tag: 'tags-tab',
-  metrics: 'metrics-tab',
+  metric: 'metrics-tab',
 };
 
 const SEARCH_URL_FRAGMENT = '/api/v1/search/query';
 
-async function runSearchValidation(page: Page): Promise<void> {
-  const apiCountResPromise = page.waitForResponse(
-    'api/v1/search/query?q=customers&index=dataAsset&*'
-  );
+test.describe(
+  'Explore Aggregation Counts Matching',
+  { tag: ['@Discovery'] },
+  () => {
+    test.use({
+      storageState: 'playwright/.auth/admin.json',
+    });
 
-  // Capture the initial table tab search response which fires automatically on load
-  const initialTabSearchResPromise = page.waitForResponse(
-    (response) =>
-      response.url().includes(SEARCH_URL_FRAGMENT) &&
-      response.url().includes('size=15') &&
-      response.url().includes('from=0') &&
-      response.request().method() === 'GET'
-  );
+    test.beforeEach(async ({ page }) => {
+      await redirectToHomePage(page);
+    });
 
-  await page.getByTestId('searchBox').fill('customers');
-  await page.getByTestId('searchBox').press('Enter');
+    test('should verify left panel counts and tab search results for normal search', async ({
+      page,
+    }) => {
+      test.slow();
 
-  const [apiCountRes, initialTabSearchRes] = await Promise.all([
-    apiCountResPromise,
-    initialTabSearchResPromise,
-  ]);
-  const countResponseBody = await apiCountRes.json();
-  const initialTabSearchBody = await initialTabSearchRes.json();
+      const countResPromise = page.waitForResponse(
+        (response) =>
+          response.url().includes(SEARCH_URL_FRAGMENT) &&
+          response.url().includes('q=customers') &&
+          response.url().includes('index=dataAsset') &&
+          response.request().method() === 'GET'
+      );
 
-  // Wait for the explore left panel to appear after search
-  await page.getByTestId('explore-left-panel').waitFor({ state: 'visible' });
+      await page.getByTestId('searchBox').fill('customers');
+      await page.getByTestId('searchBox').press('Enter');
 
-  const aggregations = countResponseBody?.aggregations ?? {};
-  const entityTypeBuckets: Array<{ key: string; doc_count: number }> =
-    (aggregations['entityType'] ?? aggregations['sterms#entityType'])
-      ?.buckets ?? [];
+      const countRes = await countResPromise;
+      const countResponseBody = await countRes.json();
 
-  await test.step('Verify left panel counts match API aggregation', async () => {
-    for (const bucket of entityTypeBuckets) {
-      const tabTestId = ENTITY_TYPE_TO_TAB_TESTID[bucket.key];
+      await expect(page.getByTestId('explore-left-panel')).toBeVisible();
+      await waitForAllLoadersToDisappear(page);
 
-      if (!tabTestId) {
-        continue;
-      }
+      const aggregations = countResponseBody?.aggregations ?? {};
+      const entityTypeBuckets: Array<{ key: string; doc_count: number }> =
+        (aggregations['entityType'] ?? aggregations['sterms#entityType'])
+          ?.buckets ?? [];
 
-      const tabLocator = page.getByTestId(tabTestId);
-      const isTabVisible = await tabLocator.isVisible();
+      await test.step('Verify left panel counts match API aggregation', async () => {
+        for (const bucket of entityTypeBuckets) {
+          const tabTestId = ENTITY_TYPE_TO_TAB_TESTID[bucket.key];
+          if (!tabTestId) {
+            continue;
+          }
 
-      if (!isTabVisible) {
-        continue;
-      }
+          const tabLocator = page.getByTestId(tabTestId);
+          await expect(
+            tabLocator,
+            `Tab "${bucket.key}" should be visible`
+          ).toBeVisible();
 
-      const countLocator = tabLocator.getByTestId('filter-count');
-      const countText = await countLocator.textContent();
-      const displayedCount = parseInt(countText?.trim() ?? '0', 10);
+          await expect(
+            tabLocator.getByTestId('filter-count'),
+            `Left panel count for "${bucket.key}" should match API count`
+          ).toHaveText(String(bucket.doc_count));
+        }
+      });
 
-      expect(
-        displayedCount,
-        `Left panel count for "${bucket.key}" should match API count`
-      ).toBe(bucket.doc_count);
-    }
-  });
+      await test.step('Click each tab and verify search results match aggregation count', async () => {
+        for (const bucket of entityTypeBuckets) {
+          const tabTestId = ENTITY_TYPE_TO_TAB_TESTID[bucket.key];
+          if (!tabTestId) {
+            continue;
+          }
 
-  await test.step('Click each tab and verify search results match entity type', async () => {
-    let isFirstTab = true;
+          const tabLocator = page.getByTestId(tabTestId);
+          await expect(tabLocator).toBeVisible();
 
-    for (const bucket of entityTypeBuckets) {
-      const tabTestId = ENTITY_TYPE_TO_TAB_TESTID[bucket.key];
+          const tabResPromise = page.waitForResponse(
+            (response) =>
+              response.url().includes(SEARCH_URL_FRAGMENT) &&
+              response.url().includes('q=customers') &&
+              response.url().includes('size=15') &&
+              response.url().includes('from=0') &&
+              response.request().method() === 'GET'
+          );
 
-      if (!tabTestId) {
-        continue;
-      }
+          await tabLocator.click();
 
-      const tabLocator = page.getByTestId(tabTestId);
-      const isTabVisible = await tabLocator.isVisible();
+          const tabRes = await tabResPromise;
+          const tabBody = await tabRes.json();
+          const totalHits: number = tabBody?.hits?.total?.value ?? 0;
 
-      if (!isTabVisible) {
-        continue;
-      }
+          await waitForAllLoadersToDisappear(page);
 
-      let tabSearchBody: {
-        hits: {
-          total: { value: number };
-          hits: Array<{ _source: { entityType: string } }>;
-        };
-      };
-
-      if (isFirstTab) {
-        tabSearchBody = initialTabSearchBody;
-        isFirstTab = false;
-      } else {
-        const tabSearchResPromise = page.waitForResponse(
-          (response) =>
-            response.url().includes(SEARCH_URL_FRAGMENT) &&
-            response.url().includes('size=15') &&
-            response.url().includes('from=0') &&
-            response.request().method() === 'GET'
-        );
-
-        await tabLocator.click();
-
-        const tabSearchRes = await tabSearchResPromise;
-        tabSearchBody = await tabSearchRes.json();
-      }
-
-      const totalHits: number = tabSearchBody?.hits?.total?.value ?? 0;
-
-      expect(
-        totalHits,
-        `Tab "${bucket.key}" search total hits should match the aggregation count`
-      ).toBe(bucket.doc_count);
-    }
-  });
-}
-
-test.describe('Explore Aggregation Counts Matching', () => {
-  test.use({
-    storageState: 'playwright/.auth/admin.json',
-  });
-
-  test.beforeEach(async ({ page }) => {
-    await redirectToHomePage(page);
-  });
-
-  test('should verify left panel counts and tab search results for normal search', async ({
-    page,
-  }) => {
-    test.slow();
-
-    await runSearchValidation(page);
-  });
-});
+          expect(
+            totalHits,
+            `Tab "${bucket.key}" search total hits should match aggregation count`
+          ).toBe(bucket.doc_count);
+        }
+      });
+    });
+  }
+);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ExploreAggregationCountsMatching.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ExploreAggregationCountsMatching.spec.ts
@@ -146,20 +146,24 @@ async function runSearchValidation(page: Page): Promise<void> {
   });
 }
 
-test.describe('Explore Aggregation Counts Matching', () => {
-  test.use({
-    storageState: 'playwright/.auth/admin.json',
-  });
+test.describe(
+  'Explore Aggregation Counts Matching',
+  { tag: ['@Discovery'] },
+  () => {
+    test.use({
+      storageState: 'playwright/.auth/admin.json',
+    });
 
-  test.beforeEach(async ({ page }) => {
-    await redirectToHomePage(page);
-  });
+    test.beforeEach(async ({ page }) => {
+      await redirectToHomePage(page);
+    });
 
-  test('should verify left panel counts and tab search results for normal search', async ({
-    page,
-  }) => {
-    test.slow();
+    test('should verify left panel counts and tab search results for normal search', async ({
+      page,
+    }) => {
+      test.slow();
 
-    await runSearchValidation(page);
-  });
-});
+      await runSearchValidation(page);
+    });
+  }
+);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ExploreAggregationCountsMatching.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ExploreAggregationCountsMatching.spec.ts
@@ -11,9 +11,8 @@
  *  limitations under the License.
  */
 
-import { expect, test } from '@playwright/test';
+import { expect, Page, test } from '@playwright/test';
 import { redirectToHomePage } from '../../utils/common';
-import { waitForAllLoadersToDisappear } from '../../utils/entity';
 
 // Maps entityType keys from the API aggregation to the explore left-panel tab testid labels.
 // The testid format is `${lowerCase(tabDetail.label)}-tab` (see ExploreUtils.tsx generateTabItems).
@@ -37,98 +36,130 @@ const ENTITY_TYPE_TO_TAB_TESTID: Record<string, string> = {
 
 const SEARCH_URL_FRAGMENT = '/api/v1/search/query';
 
-test.describe(
-  'Explore Aggregation Counts Matching',
-  { tag: ['@Discovery'] },
-  () => {
-    test.use({
-      storageState: 'playwright/.auth/admin.json',
-    });
+async function runSearchValidation(page: Page): Promise<void> {
+  const apiCountResPromise = page.waitForResponse(
+    'api/v1/search/query?q=customers&index=dataAsset&*'
+  );
 
-    test.beforeEach(async ({ page }) => {
-      await redirectToHomePage(page);
-    });
+  // Capture the initial table tab search response which fires automatically on load
+  const initialTabSearchResPromise = page.waitForResponse(
+    (response) =>
+      response.url().includes(SEARCH_URL_FRAGMENT) &&
+      response.url().includes('size=15') &&
+      response.url().includes('from=0') &&
+      response.request().method() === 'GET'
+  );
 
-    test('should verify left panel counts and tab search results for normal search', async ({
-      page,
-    }) => {
-      test.slow();
+  await page.getByTestId('searchBox').fill('customers');
+  await page.getByTestId('searchBox').press('Enter');
 
-      const countResPromise = page.waitForResponse(
-        (response) =>
-          response.url().includes(SEARCH_URL_FRAGMENT) &&
-          response.url().includes('q=customers') &&
-          response.url().includes('index=dataAsset') &&
-          response.request().method() === 'GET'
-      );
+  const [apiCountRes, initialTabSearchRes] = await Promise.all([
+    apiCountResPromise,
+    initialTabSearchResPromise,
+  ]);
+  const countResponseBody = await apiCountRes.json();
+  const initialTabSearchBody = await initialTabSearchRes.json();
 
-      await page.getByTestId('searchBox').fill('customers');
-      await page.getByTestId('searchBox').press('Enter');
+  // Wait for the explore left panel to appear after search
+  await page.getByTestId('explore-left-panel').waitFor({ state: 'visible' });
 
-      const countRes = await countResPromise;
-      const countResponseBody = await countRes.json();
+  const aggregations = countResponseBody?.aggregations ?? {};
+  const entityTypeBuckets: Array<{ key: string; doc_count: number }> =
+    (aggregations['entityType'] ?? aggregations['sterms#entityType'])
+      ?.buckets ?? [];
 
-      await expect(page.getByTestId('explore-left-panel')).toBeVisible();
-      await waitForAllLoadersToDisappear(page);
+  await test.step('Verify left panel counts match API aggregation', async () => {
+    for (const bucket of entityTypeBuckets) {
+      const tabTestId = ENTITY_TYPE_TO_TAB_TESTID[bucket.key];
 
-      const aggregations = countResponseBody?.aggregations ?? {};
-      const entityTypeBuckets: Array<{ key: string; doc_count: number }> =
-        (aggregations['entityType'] ?? aggregations['sterms#entityType'])
-          ?.buckets ?? [];
+      if (!tabTestId) {
+        continue;
+      }
 
-      await test.step('Verify left panel counts match API aggregation', async () => {
-        for (const bucket of entityTypeBuckets) {
-          const tabTestId = ENTITY_TYPE_TO_TAB_TESTID[bucket.key];
-          if (!tabTestId) {
-            continue;
-          }
+      const tabLocator = page.getByTestId(tabTestId);
+      const isTabVisible = await tabLocator.isVisible();
 
-          const tabLocator = page.getByTestId(tabTestId);
-          await expect(
-            tabLocator,
-            `Tab "${bucket.key}" should be visible`
-          ).toBeVisible();
+      if (!isTabVisible) {
+        continue;
+      }
 
-          await expect(
-            tabLocator.getByTestId('filter-count'),
-            `Left panel count for "${bucket.key}" should match API count`
-          ).toHaveText(String(bucket.doc_count));
-        }
-      });
+      const countLocator = tabLocator.getByTestId('filter-count');
+      const countText = await countLocator.textContent();
+      const displayedCount = parseInt(countText?.trim() ?? '0', 10);
 
-      await test.step('Click each tab and verify search results match aggregation count', async () => {
-        for (const bucket of entityTypeBuckets) {
-          const tabTestId = ENTITY_TYPE_TO_TAB_TESTID[bucket.key];
-          if (!tabTestId) {
-            continue;
-          }
+      expect(
+        displayedCount,
+        `Left panel count for "${bucket.key}" should match API count`
+      ).toBe(bucket.doc_count);
+    }
+  });
 
-          const tabLocator = page.getByTestId(tabTestId);
-          await expect(tabLocator).toBeVisible();
+  await test.step('Click each tab and verify search results match entity type', async () => {
+    let isFirstTab = true;
 
-          const tabResPromise = page.waitForResponse(
-            (response) =>
-              response.url().includes(SEARCH_URL_FRAGMENT) &&
-              response.url().includes('q=customers') &&
-              response.url().includes('size=15') &&
-              response.url().includes('from=0') &&
-              response.request().method() === 'GET'
-          );
+    for (const bucket of entityTypeBuckets) {
+      const tabTestId = ENTITY_TYPE_TO_TAB_TESTID[bucket.key];
 
-          await tabLocator.click();
+      if (!tabTestId) {
+        continue;
+      }
 
-          const tabRes = await tabResPromise;
-          const tabBody = await tabRes.json();
-          const totalHits: number = tabBody?.hits?.total?.value ?? 0;
+      const tabLocator = page.getByTestId(tabTestId);
+      const isTabVisible = await tabLocator.isVisible();
 
-          await waitForAllLoadersToDisappear(page);
+      if (!isTabVisible) {
+        continue;
+      }
 
-          expect(
-            totalHits,
-            `Tab "${bucket.key}" search total hits should match aggregation count`
-          ).toBe(bucket.doc_count);
-        }
-      });
-    });
-  }
-);
+      let tabSearchBody: {
+        hits: {
+          total: { value: number };
+          hits: Array<{ _source: { entityType: string } }>;
+        };
+      };
+
+      if (isFirstTab) {
+        tabSearchBody = initialTabSearchBody;
+        isFirstTab = false;
+      } else {
+        const tabSearchResPromise = page.waitForResponse(
+          (response) =>
+            response.url().includes(SEARCH_URL_FRAGMENT) &&
+            response.url().includes('size=15') &&
+            response.url().includes('from=0') &&
+            response.request().method() === 'GET'
+        );
+
+        await tabLocator.click();
+
+        const tabSearchRes = await tabSearchResPromise;
+        tabSearchBody = await tabSearchRes.json();
+      }
+
+      const totalHits: number = tabSearchBody?.hits?.total?.value ?? 0;
+
+      expect(
+        totalHits,
+        `Tab "${bucket.key}" search total hits should match the aggregation count`
+      ).toBe(bucket.doc_count);
+    }
+  });
+}
+
+test.describe('Explore Aggregation Counts Matching', () => {
+  test.use({
+    storageState: 'playwright/.auth/admin.json',
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await redirectToHomePage(page);
+  });
+
+  test('should verify left panel counts and tab search results for normal search', async ({
+    page,
+  }) => {
+    test.slow();
+
+    await runSearchValidation(page);
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ExploreAggregationCountsMatching.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ExploreAggregationCountsMatching.spec.ts
@@ -1,0 +1,165 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { expect, Page, test } from '@playwright/test';
+import { redirectToHomePage } from '../../utils/common';
+
+// Maps entityType keys from the API aggregation to the explore left-panel tab testid labels.
+// The testid format is `${lowerCase(tabDetail.label)}-tab` (see ExploreUtils.tsx generateTabItems).
+const ENTITY_TYPE_TO_TAB_TESTID: Record<string, string> = {
+  table: 'tables-tab',
+  database: 'databases-tab',
+  databaseSchema: 'database schemas-tab',
+  glossaryTerm: 'glossary terms-tab',
+  dataProduct: 'data products-tab',
+  dashboard: 'dashboards-tab',
+  pipeline: 'pipelines-tab',
+  topic: 'topics-tab',
+  mlmodel: 'ml models-tab',
+  container: 'containers-tab',
+  searchIndex: 'search indexes-tab',
+  chart: 'charts-tab',
+  storedProcedure: 'stored procedures-tab',
+  tag: 'tags-tab',
+  metrics: 'metrics-tab',
+};
+
+const SEARCH_URL_FRAGMENT = '/api/v1/search/query';
+
+async function runSearchValidation(page: Page): Promise<void> {
+  const apiCountResPromise = page.waitForResponse(
+    'api/v1/search/query?q=customers&index=dataAsset&*'
+  );
+
+  // Capture the initial table tab search response which fires automatically on load
+  const initialTabSearchResPromise = page.waitForResponse(
+    (response) =>
+      response.url().includes(SEARCH_URL_FRAGMENT) &&
+      response.url().includes('size=15') &&
+      response.url().includes('from=0') &&
+      response.request().method() === 'GET'
+  );
+
+  await page.getByTestId('searchBox').fill('customers');
+  await page.getByTestId('searchBox').press('Enter');
+
+  const [apiCountRes, initialTabSearchRes] = await Promise.all([
+    apiCountResPromise,
+    initialTabSearchResPromise,
+  ]);
+  const countResponseBody = await apiCountRes.json();
+  const initialTabSearchBody = await initialTabSearchRes.json();
+
+  // Wait for the explore left panel to appear after search
+  await page.getByTestId('explore-left-panel').waitFor({ state: 'visible' });
+
+  const aggregations = countResponseBody?.aggregations ?? {};
+  const entityTypeBuckets: Array<{ key: string; doc_count: number }> =
+    (aggregations['entityType'] ?? aggregations['sterms#entityType'])
+      ?.buckets ?? [];
+
+  await test.step('Verify left panel counts match API aggregation', async () => {
+    for (const bucket of entityTypeBuckets) {
+      const tabTestId = ENTITY_TYPE_TO_TAB_TESTID[bucket.key];
+
+      if (!tabTestId) {
+        continue;
+      }
+
+      const tabLocator = page.getByTestId(tabTestId);
+      const isTabVisible = await tabLocator.isVisible();
+
+      if (!isTabVisible) {
+        continue;
+      }
+
+      const countLocator = tabLocator.getByTestId('filter-count');
+      const countText = await countLocator.textContent();
+      const displayedCount = parseInt(countText?.trim() ?? '0', 10);
+
+      expect(
+        displayedCount,
+        `Left panel count for "${bucket.key}" should match API count`
+      ).toBe(bucket.doc_count);
+    }
+  });
+
+  await test.step('Click each tab and verify search results match entity type', async () => {
+    let isFirstTab = true;
+
+    for (const bucket of entityTypeBuckets) {
+      const tabTestId = ENTITY_TYPE_TO_TAB_TESTID[bucket.key];
+
+      if (!tabTestId) {
+        continue;
+      }
+
+      const tabLocator = page.getByTestId(tabTestId);
+      const isTabVisible = await tabLocator.isVisible();
+
+      if (!isTabVisible) {
+        continue;
+      }
+
+      let tabSearchBody: {
+        hits: {
+          total: { value: number };
+          hits: Array<{ _source: { entityType: string } }>;
+        };
+      };
+
+      if (isFirstTab) {
+        tabSearchBody = initialTabSearchBody;
+        isFirstTab = false;
+      } else {
+        const tabSearchResPromise = page.waitForResponse(
+          (response) =>
+            response.url().includes(SEARCH_URL_FRAGMENT) &&
+            response.url().includes('size=15') &&
+            response.url().includes('from=0') &&
+            response.request().method() === 'GET'
+        );
+
+        await tabLocator.click();
+
+        const tabSearchRes = await tabSearchResPromise;
+        tabSearchBody = await tabSearchRes.json();
+      }
+
+      const totalHits: number = tabSearchBody?.hits?.total?.value ?? 0;
+
+      expect(
+        totalHits,
+        `Tab "${bucket.key}" search total hits should match the aggregation count`
+      ).toBe(bucket.doc_count);
+    }
+  });
+}
+
+test.describe('Explore Aggregation Counts Matching', () => {
+  test.use({
+    storageState: 'playwright/.auth/admin.json',
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await redirectToHomePage(page);
+  });
+
+  test('should verify left panel counts and tab search results for normal search', async ({
+    page,
+  }) => {
+    test.slow();
+
+    await runSearchValidation(page);
+  });
+});


### PR DESCRIPTION
----
## Summary by Gitar

- **Refactored E2E Test:**
  - Encapsulated test logic into a reusable `runSearchValidation` function to improve maintainability.
  - Optimized search response handling by awaiting `apiCountResPromise` and `initialTabSearchResPromise` concurrently.
- **Test Logic Enhancements:**
  - Removed dependency on `waitForAllLoadersToDisappear` in favor of direct API response synchronization and explicit visibility checks.
  - Streamlined tab validation by reusing initial load response data for the first tab check.

<sub>This will update automatically on new commits.</sub>