### PR TITLE
Fixes #27158: tag_usage Postgres seq-scan (1.12.7 backport)

### DIFF
--- a/bootstrap/sql/migrations/native/1.12.7/mysql/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.12.7/mysql/postDataMigrationSQLScript.sql
@@ -1,0 +1,1 @@
+-- Placeholder for 1.12.7 MySQL post-data migration script

--- a/bootstrap/sql/migrations/native/1.12.7/mysql/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.12.7/mysql/schemaChanges.sql
@@ -1,0 +1,4 @@
+-- Placeholder for 1.12.7 MySQL schema changes
+-- The Postgres-side fix for #27158 has no MySQL counterpart: MySQL's
+-- 1.11.0 indexes were already non-partial (no partial-index syntax in
+-- MySQL), so the regression that hit Postgres did not affect MySQL.

--- a/bootstrap/sql/migrations/native/1.12.7/postgres/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.12.7/postgres/postDataMigrationSQLScript.sql
@@ -1,0 +1,1 @@
+-- Placeholder for 1.12.7 PostgreSQL post-data migration script

--- a/bootstrap/sql/migrations/native/1.12.7/postgres/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.12.7/postgres/schemaChanges.sql
@@ -3,9 +3,11 @@
 -- Fix: add single-col indexes on the `_lower` columns, and drop the
 -- `WHERE state = 1` filter from the partials so changes can't invalidate them.
 
+DROP INDEX CONCURRENTLY IF EXISTS idx_tag_usage_targetfqnhash_lower_pattern;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tag_usage_targetfqnhash_lower_pattern
 ON tag_usage (targetfqnhash_lower text_pattern_ops);
 
+DROP INDEX CONCURRENTLY IF EXISTS idx_tag_usage_tagfqn_lower_pattern;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tag_usage_tagfqn_lower_pattern
 ON tag_usage (tagfqn_lower text_pattern_ops);
 

--- a/bootstrap/sql/migrations/native/1.12.7/postgres/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.12.7/postgres/schemaChanges.sql
@@ -1,0 +1,30 @@
+-- Issue #27158: tag_usage seq-scan on Postgres. #24063 dropped the
+-- `state = 1` predicate that 1.11.0's partial indexes required.
+-- Fix: add single-col indexes on the `_lower` columns, and drop the
+-- `WHERE state = 1` filter from the partials so changes can't invalidate them.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tag_usage_targetfqnhash_lower_pattern
+ON tag_usage (targetfqnhash_lower text_pattern_ops);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tag_usage_tagfqn_lower_pattern
+ON tag_usage (tagfqn_lower text_pattern_ops);
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_tag_usage_target_prefix_covering;
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tag_usage_target_prefix_covering
+ON tag_usage (source, targetfqnhash_lower text_pattern_ops)
+INCLUDE (tagFQN, labelType, state);
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_tag_usage_tagfqn_prefix_covering;
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tag_usage_tagfqn_prefix_covering
+ON tag_usage (source, tagfqn_lower text_pattern_ops)
+INCLUDE (targetFQNHash, labelType, state);
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_tag_usage_join_source;
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_tag_usage_join_source
+ON tag_usage (tagFQNHash, source)
+INCLUDE (targetFQNHash, tagFQN, labelType, state);
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+DROP INDEX CONCURRENTLY IF EXISTS gin_tag_usage_targetfqn_trgm;
+CREATE INDEX CONCURRENTLY IF NOT EXISTS gin_tag_usage_targetfqn_trgm
+ON tag_usage USING GIN (targetFQNHash gin_trgm_ops);


### PR DESCRIPTION
Fixes #27158

Backport of #27745 onto the `1.12.7` release branch so customers on the 1.12.x line get this fix without waiting for 2.0.x.

## Summary

`getTagsInternalByPrefix` parallel seq-scans `tag_usage` on Postgres, causing RDS CPU spikes during ingestion.

**Cause:** 1.11.0 (#23054) added four partial indexes on `tag_usage` filtered `WHERE state = 1`. #24063 then dropped the matching `state = 1` filter from the query (Suggested rows are valid for both classification and glossary derivation), leaving every partial index inapplicable. MySQL was unaffected — its 1.11.0 indexes were never partial (no partial-index syntax).

## Fix

`bootstrap/sql/migrations/native/1.12.7/postgres/schemaChanges.sql`:

1. Add non-partial single-col btrees on `targetfqnhash_lower` and `tagfqn_lower` — mirrors MySQL's `idx_targetfqnhash_lower` / `idx_tagfqn_lower` from 1.11.0.
2. Rebuild the four 1.11.0 partials as non-partial — same shape, same INCLUDE columns; only `WHERE state = 1` removed so future predicate changes can't silently invalidate them.

All DDL is `CONCURRENTLY` and idempotent. No Java/query change. No MySQL change needed.

## Why two PRs

The `1.12.x` migration directories don't exist on `main` — they only live on the `1.12.7` release branch. To ship the fix in both lines we need two parallel PRs:
- #27745 → `main` (2.0.x release line)
- this PR → `1.12.7` (1.12.x release line)

## Verification

50k synthetic rows in local Postgres:

| | Plan | Buffers |
|---|---|---|
| Before | `Seq Scan` (`Rows Removed by Filter: 49010`) | 2274 |
| After | `Bitmap Index Scan on idx_tag_usage_targetfqnhash_lower_pattern` | 1024 |
| Prepared / generic plan | Index still picked; `LIKE LOWER($1)` → range scan | 24 (index only) |

## Test plan

- [x] Reproduced seq scan on a representative dataset
- [x] Verified bitmap index scan after fix (inline + prepared statement)
- [x] Verified rebuilt composite still serves source-filtered queries
- [x] Verified migration idempotency

🤖 Generated with [Claude Code](https://claude.com/claude-code)