### PR TITLE
fix(ingestion): silence basedpyright McpConnection flake

### DIFF
--- a/ingestion/setup.py
+++ b/ingestion/setup.py
@@ -401,7 +401,7 @@ dev = {
     "mypy-boto3-glue",
     "nox",
     "pre-commit",
-    "basedpyright~=1.39.0",
+    "basedpyright==1.39.3",
     # For publishing
     "twine",
     "build",

--- a/ingestion/src/metadata/automations/runner.py
+++ b/ingestion/src/metadata/automations/runner.py
@@ -58,7 +58,7 @@ def _(
 
         host_port_type = type(request.connection.config.hostPort)
         docker_host_port_str = host_port_str.replace("localhost", "host.docker.internal")
-        request.connection.config.hostPort = host_port_type(docker_host_port_str)
+        request.connection.config.hostPort = host_port_type(docker_host_port_str)  # pyright: ignore[reportAttributeAccessIssue]
 
         _ = _test_connection(metadata, request.connection.config, automation_workflow)
 

--- a/ingestion/src/metadata/ingestion/source/api/rest/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/api/rest/metadata.py
@@ -210,7 +210,7 @@ class RestSource(ApiServiceSource):
 
     def _get_fallback_url(self) -> Optional[AnyUrl]:  # noqa: UP045
         """Return openAPISchemaURL if available, otherwise None."""
-        schema_conn = self.config.serviceConnection.root.config.openAPISchemaConnection
+        schema_conn = self.config.serviceConnection.root.config.openAPISchemaConnection  # pyright: ignore[reportAttributeAccessIssue]
         if isinstance(schema_conn, OpenAPISchemaURL):
             return schema_conn.openAPISchemaURL
         return None
@@ -218,7 +218,7 @@ class RestSource(ApiServiceSource):
     def _generate_collection_url(self, collection_name: str) -> Optional[AnyUrl]:  # noqa: UP045
         """generate collection url"""
         try:
-            base_url = self.config.serviceConnection.root.config.docURL
+            base_url = self.config.serviceConnection.root.config.docURL  # pyright: ignore[reportAttributeAccessIssue]
             if not base_url:
                 logger.debug(f"Could not generate collection url for {collection_name} because docURL is not present")
                 return self._get_fallback_url()

--- a/ingestion/src/metadata/ingestion/source/dashboard/mode/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/mode/metadata.py
@@ -62,8 +62,8 @@ class ModeSource(DashboardServiceSource):
         metadata: OpenMetadata,
     ):
         super().__init__(config, metadata)
-        self.workspace_name = config.serviceConnection.root.config.workspaceName
-        self.filter_query_param = config.serviceConnection.root.config.filterQueryParam
+        self.workspace_name = config.serviceConnection.root.config.workspaceName  # pyright: ignore[reportAttributeAccessIssue]
+        self.filter_query_param = config.serviceConnection.root.config.filterQueryParam  # pyright: ignore[reportAttributeAccessIssue]
         self.data_sources = self.client.get_all_data_sources(self.workspace_name)
 
     @classmethod

--- a/ingestion/src/metadata/ingestion/source/dashboard/quicksight/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/quicksight/metadata.py
@@ -91,7 +91,7 @@ class QuicksightSource(DashboardServiceSource):
         super().__init__(config, metadata)
         self.aws_account_id = self.service_connection.awsAccountId
         self.dashboard_url = None
-        self.aws_region = self.config.serviceConnection.root.config.awsConfig.awsRegion
+        self.aws_region = self.config.serviceConnection.root.config.awsConfig.awsRegion  # pyright: ignore[reportAttributeAccessIssue]
         self.default_args = {
             "AwsAccountId": self.aws_account_id,
             "MaxResults": QUICKSIGHT_MAX_RESULTS,

--- a/ingestion/src/metadata/ingestion/source/dashboard/tableau/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/tableau/metadata.py
@@ -1117,6 +1117,6 @@ class TableauSource(DashboardServiceSource):
         """
         Get the proxy url for the tableau server
         """
-        if self.config.serviceConnection.root.config.proxyURL:
-            return str(self.config.serviceConnection.root.config.proxyURL)
+        if self.config.serviceConnection.root.config.proxyURL:  # pyright: ignore[reportAttributeAccessIssue]
+            return str(self.config.serviceConnection.root.config.proxyURL)  # pyright: ignore[reportAttributeAccessIssue]
         return str(self.config.serviceConnection.root.config.hostPort)

--- a/ingestion/src/metadata/ingestion/source/database/azuresql/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/azuresql/metadata.py
@@ -75,8 +75,8 @@ class AzuresqlSource(CommonDbSourceService, MultiDBSource):
         yield from self._execute_database_query(AZURE_SQL_GET_DATABASES)
 
     def get_database_names(self) -> Iterable[str]:
-        if not self.config.serviceConnection.root.config.ingestAllDatabases:
-            configured_db = self.config.serviceConnection.root.config.database
+        if not self.config.serviceConnection.root.config.ingestAllDatabases:  # pyright: ignore[reportAttributeAccessIssue]
+            configured_db = self.config.serviceConnection.root.config.database  # pyright: ignore[reportAttributeAccessIssue]
             self.set_inspector(database_name=configured_db)
             yield configured_db
         else:

--- a/ingestion/src/metadata/ingestion/source/database/cockroach/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/cockroach/metadata.py
@@ -186,8 +186,8 @@ class CockroachSource(CommonDbSourceService, MultiDBSource):
         yield from self._execute_database_query(COCKROACH_GET_DB_NAMES)
 
     def get_database_names(self) -> Iterable[str]:
-        if not self.config.serviceConnection.root.config.ingestAllDatabases:
-            configured_db = self.config.serviceConnection.root.config.database
+        if not self.config.serviceConnection.root.config.ingestAllDatabases:  # pyright: ignore[reportAttributeAccessIssue]
+            configured_db = self.config.serviceConnection.root.config.database  # pyright: ignore[reportAttributeAccessIssue]
             self.set_inspector(database_name=configured_db)
             self.set_schema_description_map()
             yield configured_db

--- a/ingestion/src/metadata/ingestion/source/database/greenplum/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/greenplum/metadata.py
@@ -128,8 +128,8 @@ class GreenplumSource(CommonDbSourceService, MultiDBSource):
         yield from self._execute_database_query(GREENPLUM_GET_DB_NAMES)
 
     def get_database_names(self) -> Iterable[str]:
-        if not self.config.serviceConnection.root.config.ingestAllDatabases:
-            configured_db = self.config.serviceConnection.root.config.database
+        if not self.config.serviceConnection.root.config.ingestAllDatabases:  # pyright: ignore[reportAttributeAccessIssue]
+            configured_db = self.config.serviceConnection.root.config.database  # pyright: ignore[reportAttributeAccessIssue]
             self.set_inspector(database_name=configured_db)
             yield configured_db
         else:

--- a/ingestion/src/metadata/ingestion/source/database/microsoftfabric/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/microsoftfabric/metadata.py
@@ -123,8 +123,8 @@ class MicrosoftFabricSource(CommonDbSourceService, MultiDBSource):
 
         In Microsoft Fabric, each Warehouse and Lakehouse appears as a database.
         """
-        if not self.config.serviceConnection.root.config.ingestAllDatabases:
-            configured_db = self.config.serviceConnection.root.config.database
+        if not self.config.serviceConnection.root.config.ingestAllDatabases:  # pyright: ignore[reportAttributeAccessIssue]
+            configured_db = self.config.serviceConnection.root.config.database  # pyright: ignore[reportAttributeAccessIssue]
             self.set_inspector(database_name=configured_db)
             yield configured_db
         else:

--- a/ingestion/src/metadata/ingestion/source/database/mssql/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/mssql/metadata.py
@@ -190,8 +190,8 @@ class MssqlSource(CommonDbSourceService, MultiDBSource):
         yield from self._execute_database_query(MSSQL_GET_DATABASE)
 
     def get_database_names(self) -> Iterable[str]:
-        if not self.config.serviceConnection.root.config.ingestAllDatabases:
-            configured_db = self.config.serviceConnection.root.config.database
+        if not self.config.serviceConnection.root.config.ingestAllDatabases:  # pyright: ignore[reportAttributeAccessIssue]
+            configured_db = self.config.serviceConnection.root.config.database  # pyright: ignore[reportAttributeAccessIssue]
             self.set_schema_description_map()
             self.set_database_description_map()
             self.set_stored_procedure_description_map()

--- a/ingestion/src/metadata/ingestion/source/database/postgres/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/postgres/metadata.py
@@ -174,8 +174,8 @@ class PostgresSource(CommonDbSourceService, MultiDBSource):
         yield from self._execute_database_query(POSTGRES_GET_DB_NAMES)
 
     def get_database_names(self) -> Iterable[str]:
-        if not self.config.serviceConnection.root.config.ingestAllDatabases:
-            configured_db = self.config.serviceConnection.root.config.database
+        if not self.config.serviceConnection.root.config.ingestAllDatabases:  # pyright: ignore[reportAttributeAccessIssue]
+            configured_db = self.config.serviceConnection.root.config.database  # pyright: ignore[reportAttributeAccessIssue]
             self.set_inspector(database_name=configured_db)
             self.set_schema_description_map()
             yield configured_db

--- a/ingestion/src/metadata/ingestion/source/database/postgres/query_parser.py
+++ b/ingestion/src/metadata/ingestion/source/database/postgres/query_parser.py
@@ -80,7 +80,7 @@ class PostgresQueryParserSource(QueryParserSource, ABC):
             if self.config.sourceConfig.config.queryLogFilePath:
                 yield from super().yield_table_queries_from_logs()
             else:
-                database = self.config.serviceConnection.root.config.database
+                database = self.config.serviceConnection.root.config.database  # pyright: ignore[reportAttributeAccessIssue]
                 if database:
                     self.engine: Engine = get_connection(self.service_connection)
                     yield from self.process_table_query()
@@ -90,7 +90,7 @@ class PostgresQueryParserSource(QueryParserSource, ABC):
                     for res in results:
                         row = list(res)
                         logger.info(f"Ingesting from database: {row[0]}")
-                        self.config.serviceConnection.root.config.database = row[0]
+                        self.config.serviceConnection.root.config.database = row[0]  # pyright: ignore[reportAttributeAccessIssue]
                         self.engine = get_connection(self.service_connection)
                         yield from self.process_table_query()
 

--- a/ingestion/src/metadata/ingestion/source/database/redshift/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/redshift/metadata.py
@@ -279,8 +279,8 @@ class RedshiftSource(ExternalTableLineageMixin, LifeCycleQueryMixin, CommonDbSou
         self.external_location_map = {(database_name, row.schemaname, row.tablename): row.location for row in results}
 
     def get_database_names(self) -> Iterable[str]:
-        if not self.config.serviceConnection.root.config.ingestAllDatabases:
-            configured_db = self.config.serviceConnection.root.config.database
+        if not self.config.serviceConnection.root.config.ingestAllDatabases:  # pyright: ignore[reportAttributeAccessIssue]
+            configured_db = self.config.serviceConnection.root.config.database  # pyright: ignore[reportAttributeAccessIssue]
             self._set_incremental_table_processor(configured_db)
             self.set_external_location_map(configured_db)
             yield configured_db

--- a/ingestion/src/metadata/ingestion/source/database/snowflake/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/metadata.py
@@ -391,7 +391,7 @@ class SnowflakeSource(
             yield row[1]
 
     def get_database_names(self) -> Iterable[str]:
-        configured_db = self.config.serviceConnection.root.config.database
+        configured_db = self.config.serviceConnection.root.config.database  # pyright: ignore[reportAttributeAccessIssue]
         if configured_db:
             self.set_inspector(configured_db)
             self.set_session_query_tag()

--- a/ingestion/src/metadata/ingestion/source/database/timescale/query_parser.py
+++ b/ingestion/src/metadata/ingestion/source/database/timescale/query_parser.py
@@ -80,7 +80,7 @@ class PostgresQueryParserSource(QueryParserSource, ABC):
             if self.config.sourceConfig.config.queryLogFilePath:
                 yield from super().yield_table_queries_from_logs()
             else:
-                database = self.config.serviceConnection.root.config.database
+                database = self.config.serviceConnection.root.config.database  # pyright: ignore[reportAttributeAccessIssue]
                 if database:
                     self.engine: Engine = get_connection(self.service_connection)
                     yield from self.process_table_query()
@@ -90,7 +90,7 @@ class PostgresQueryParserSource(QueryParserSource, ABC):
                     for res in results:
                         row = list(res)
                         logger.info(f"Ingesting from database: {row[0]}")
-                        self.config.serviceConnection.root.config.database = row[0]
+                        self.config.serviceConnection.root.config.database = row[0]  # pyright: ignore[reportAttributeAccessIssue]
                         self.engine = get_connection(self.service_connection)
                         yield from self.process_table_query()
 

--- a/ingestion/src/metadata/ingestion/source/database/vertica/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/vertica/metadata.py
@@ -290,7 +290,7 @@ class VerticaSource(CommonDbSourceService, MultiDBSource):
         yield from self._execute_database_query(VERTICA_LIST_DATABASES)
 
     def get_database_names(self) -> Iterable[str]:
-        configured_db = self.config.serviceConnection.root.config.database
+        configured_db = self.config.serviceConnection.root.config.database  # pyright: ignore[reportAttributeAccessIssue]
         if configured_db:
             self.set_inspector(database_name=configured_db)
             self.set_schema_description_map()

--- a/ingestion/src/metadata/ingestion/source/database/vertica/query_parser.py
+++ b/ingestion/src/metadata/ingestion/source/database/vertica/query_parser.py
@@ -55,7 +55,7 @@ class VerticaQueryParserSource(QueryParserSource, ABC):
         return cls(config, metadata)
 
     def get_table_query(self) -> Iterable[TableQuery]:
-        database = self.config.serviceConnection.root.config.database
+        database = self.config.serviceConnection.root.config.database  # pyright: ignore[reportAttributeAccessIssue]
         if database:
             yield from super().get_table_query()
         else:
@@ -64,6 +64,6 @@ class VerticaQueryParserSource(QueryParserSource, ABC):
             for res in results:
                 row = list(res)
                 logger.info(f"Ingesting from database: {row[0]}")
-                self.config.serviceConnection.root.config.database = row[0]
+                self.config.serviceConnection.root.config.database = row[0]  # pyright: ignore[reportAttributeAccessIssue]
                 self.engine = get_connection(self.service_connection)
                 yield from super().get_table_query()

--- a/ingestion/src/metadata/ingestion/source/security/security_service.py
+++ b/ingestion/src/metadata/ingestion/source/security/security_service.py
@@ -92,7 +92,7 @@ class SecurityServiceSource(TopologyRunnerMixin, Source, ABC):
         config: WorkflowSource,
         metadata: OpenMetadata,
     ):
-        config.serviceConnection.root.config.hostPort = clean_uri(config.serviceConnection.root.config.hostPort)
+        config.serviceConnection.root.config.hostPort = clean_uri(config.serviceConnection.root.config.hostPort)  # pyright: ignore[reportAttributeAccessIssue]
         super().__init__()
         self.config = config
         self.metadata = metadata

--- a/ingestion/src/metadata/profiler/source/database/mssql/profiler_source.py
+++ b/ingestion/src/metadata/profiler/source/database/mssql/profiler_source.py
@@ -65,7 +65,7 @@ class MssqlProfilerSource(ProfilerSource):
         # pylint: disable=import-outside-toplevel
 
         # Get the configured scheme from the source connection
-        scheme = config.source.serviceConnection.root.config.scheme
+        scheme = config.source.serviceConnection.root.config.scheme  # pyright: ignore[reportAttributeAccessIssue]
 
         # Set the appropriate is_disconnect method based on the scheme
         if scheme == MssqlScheme.mssql_pytds:

--- a/ingestion/src/metadata/utils/helpers.py
+++ b/ingestion/src/metadata/utils/helpers.py
@@ -515,7 +515,7 @@ def retry_with_docker_host(config: Optional[WorkflowSource] = None):  # noqa: UP
 
                 host_port_type = type(config.serviceConnection.root.config.hostPort)
                 docker_host_port_str = host_port_str.replace("localhost", "host.docker.internal")
-                config.serviceConnection.root.config.hostPort = host_port_type(docker_host_port_str)
+                config.serviceConnection.root.config.hostPort = host_port_type(docker_host_port_str)  # pyright: ignore[reportAttributeAccessIssue]
                 func(*args, **kwargs)
 
         return wrapper

--- a/ingestion/src/metadata/workflow/ingestion.py
+++ b/ingestion/src/metadata/workflow/ingestion.py
@@ -181,7 +181,7 @@ class IngestionWorkflow(BaseWorkflow, ABC):
             )
 
         try:
-            if not self.config.source.serviceConnection.root.config.supportsProfiler:
+            if not self.config.source.serviceConnection.root.config.supportsProfiler:  # pyright: ignore[reportAttributeAccessIssue]
                 raise AttributeError()  # noqa: TRY301
         except AttributeError:
             if profiler_config_class.model_validate(self.config.processor.model_dump().get("config")).ignoreValidation:
@@ -197,7 +197,7 @@ class IngestionWorkflow(BaseWorkflow, ABC):
         source_type = self.config.source.type.lower()
         try:
             return (
-                import_from_module(self.config.source.serviceConnection.root.config.sourcePythonClass)
+                import_from_module(self.config.source.serviceConnection.root.config.sourcePythonClass)  # pyright: ignore[reportAttributeAccessIssue]
                 if source_type.startswith(CUSTOM_CONNECTOR_PREFIX)
                 else import_source_class(service_type=self.service_type, source_type=source_type)
             )


### PR DESCRIPTION
## Summary

- Pin `basedpyright==1.39.3` (was `~=1.39.0`) to remove patch-version / typeshed drift as a future flake source.
- Add `# pyright: ignore[reportAttributeAccessIssue]` on 35 access / assign sites surfaced by the failing CI run; deletes the diagnostics from each per-file stream so the baseline can no longer drift them.

## Why

CI's `Run Static Checks` step intermittently fails with ~35 `reportAttributeAccessIssue` errors of the form `Cannot access attribute X for class "McpConnection"` (or `CustomDriveConnection`). The errors are not new code — the underlying type holes have always been there — but `basedpyright`'s `--baselinemode=discard` matches baseline entries by per-file diagnostic stream order with no line numbers, so any schema regen that shifts a Union arm's narrowing cascade-misaligns downstream baseline matches and surfaces them as new errors.

Inline ignores are position-stable: they delete the diagnostic from the stream entirely, so they survive future Union ordering shifts. The proper architectural fix (class-level `service_connection: <X>Connection` narrowing on each connector source class, plus long-path → `self.service_connection` refactors) is deferred — when narrowing succeeds, it exposes a second-order cascade of pre-existing Optional-chain issues that need their own audit.

`reportUnnecessaryTypeIgnoreComment` is already disabled in `pyproject.toml` (per the existing comment about cross-platform stub drift), so the ignores are inert on platforms where the union narrowing collapses differently and the errors don't fire (macOS arm64).

The 3 `tableauserverclient` library-export errors at `pipeline/tableaupipeline/client.py:19,21,22` are a separate, unrelated issue (third-party packaging bug); deferred to that PR's owner.

## Test plan

- [x] `ruff check` clean
- [x] `ruff format --check` clean (zero file changes from format pass)
- [x] `basedpyright --baselinefile .basedpyright/baseline.json --baselinemode=discard --pythonplatform Linux` produces an identical 62-error set before and after the changes — zero new errors introduced
- [x] `basedpyright` without baseline reports 0 mentions of `for class "McpConnection"` or `for class "CustomDriveConnection"` on Linux + Darwin platforms
- [ ] CI's `Run Static Checks (3.10)` job passes on this PR