### PR TITLE
Fixes #21259: Don't store null secrets in Secrets Manager

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/secrets/ExternalSecretsManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/secrets/ExternalSecretsManager.java
@@ -33,15 +33,20 @@ public abstract class ExternalSecretsManager extends SecretsManager {
   @Override
   protected String storeValue(String fieldName, String value, String secretId, boolean store) {
     String fieldSecretId = buildSecretId(false, secretId, fieldName.toLowerCase(Locale.ROOT));
+    // Issue #21259: a null/empty value means "no credential". Handle this case BEFORE
+    // calling isSecret() — isSecret() invokes startsWith() on the value and would NPE
+    // on null. Returning null here ensures the entity does not carry a stale secret:/
+    // reference to a deleted secret.
+    if (Objects.isNull(value) || value.isEmpty()) {
+      if (store) {
+        upsertSecret(fieldSecretId, value);
+      }
+      return null;
+    }
     // check if value does not start with 'config:' only String can have password annotation
     if (Boolean.FALSE.equals(isSecret(value))) {
       if (store) {
         upsertSecret(fieldSecretId, value);
-      }
-      // Issue #21259: a null/empty value means "no credential" — return null so the
-      // entity does not carry a stale secret:/ reference to a deleted secret.
-      if (Objects.isNull(value) || value.isEmpty()) {
-        return null;
       }
       return SECRET_FIELD_PREFIX + fieldSecretId;
     } else {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/secrets/ExternalSecretsManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/secrets/ExternalSecretsManager.java
@@ -38,6 +38,11 @@ public abstract class ExternalSecretsManager extends SecretsManager {
       if (store) {
         upsertSecret(fieldSecretId, value);
       }
+      // Issue #21259: a null/empty value means "no credential" — return null so the
+      // entity does not carry a stale secret:/ reference to a deleted secret.
+      if (Objects.isNull(value) || value.isEmpty()) {
+        return null;
+      }
       return SECRET_FIELD_PREFIX + fieldSecretId;
     } else {
       return value;
@@ -45,12 +50,22 @@ public abstract class ExternalSecretsManager extends SecretsManager {
   }
 
   public void upsertSecret(String secretName, String secretValue) {
-    String sanitizedValue = cleanNullOrEmpty(secretValue);
+    // Issue #21259: when the value is null/empty, the user's intent is "remove this
+    // credential" — delete the backing secret instead of storing the literal string
+    // "null". This also satisfies the GCP/Kubernetes empty-string rejection constraint
+    // (PR #25224) by simply not calling upsert with an empty value.
+    if (Objects.isNull(secretValue) || secretValue.isEmpty()) {
+      if (existSecret(secretName)) {
+        deleteSecretInternal(secretName);
+        sleep();
+      }
+      return;
+    }
     if (existSecret(secretName)) {
-      updateSecret(secretName, sanitizedValue);
+      updateSecret(secretName, secretValue);
       sleep();
     } else {
-      storeSecret(secretName, sanitizedValue);
+      storeSecret(secretName, secretValue);
       sleep();
     }
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/secrets/SecretsManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/secrets/SecretsManager.java
@@ -411,13 +411,18 @@ public abstract class SecretsManager {
                             fieldName, fernet.decryptIfApplies((String) obj), secretId, store);
                     // get setMethod
                     Method toSet = ReflectionUtil.getToSetMethod(toEncryptObject, obj, fieldName);
-                    // set new value
-                    ReflectionUtil.setValueInMethod(
-                        toEncryptObject,
-                        Fernet.isTokenized(newFieldValue)
-                            ? newFieldValue
-                            : store ? fernet.encrypt(newFieldValue) : newFieldValue,
-                        toSet);
+                    // Issue #21259: storeValue returns null when the user clears the
+                    // password field. Propagate that null through instead of attempting
+                    // to fernet-encrypt it.
+                    String finalValue;
+                    if (newFieldValue == null) {
+                      finalValue = null;
+                    } else if (Fernet.isTokenized(newFieldValue)) {
+                      finalValue = newFieldValue;
+                    } else {
+                      finalValue = store ? fernet.encrypt(newFieldValue) : newFieldValue;
+                    }
+                    ReflectionUtil.setValueInMethod(toEncryptObject, finalValue, toSet);
                   }
                 });
       }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/secrets/ExternalSecretsManagerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/secrets/ExternalSecretsManagerTest.java
@@ -1,9 +1,9 @@
 package org.openmetadata.service.secrets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.openmetadata.schema.api.services.CreateDatabaseService.DatabaseServiceType.Mysql;
 
 import java.util.Map;
@@ -236,10 +236,35 @@ public abstract class ExternalSecretsManagerTest {
                 mysqlConnection, Mysql.value(), "test-empty-password", ServiceType.DATABASE);
 
     assertNotNull(actualConnection, "Encryption should succeed even with empty password");
-    assertFalse(
-        JsonUtils.convertValue(actualConnection.getAuthType(), basicAuth.class)
-            .getPassword()
-            .isEmpty(),
-        "Empty password should be converted to non-empty encrypted value");
+    assertNull(
+        JsonUtils.convertValue(actualConnection.getAuthType(), basicAuth.class).getPassword(),
+        "Issue #21259: Empty password should resolve to null on the entity, "
+            + "not a Fernet-wrapped reference to a 'null' string in the secrets manager");
+  }
+
+  @Test
+  void testIssue21259ClearingPasswordDoesNotStoreNullString() {
+    String serviceName = "bug21259-clear-password";
+
+    Map<String, Map<String, String>> withPassword =
+        Map.of("authType", Map.of("password", "initial-password"));
+    secretsManager.encryptServiceConnectionConfig(
+        withPassword, Mysql.value(), serviceName, ServiceType.DATABASE);
+
+    Map<String, Map<String, String>> clearedPassword =
+        Map.of("authType", Map.of("password", StringUtils.EMPTY));
+    MysqlConnection cleared =
+        (MysqlConnection)
+            secretsManager.encryptServiceConnectionConfig(
+                clearedPassword, Mysql.value(), serviceName, ServiceType.DATABASE);
+
+    String storedPassword =
+        JsonUtils.convertValue(cleared.getAuthType(), basicAuth.class).getPassword();
+    assertNull(
+        storedPassword,
+        "Issue #21259: When a user clears a password field, the entity should "
+            + "carry null, not a stale secret:/ reference to a 'null'-valued secret. "
+            + "The downstream consumer (e.g. Snowflake driver) reads the password "
+            + "verbatim and breaks auth when it gets the literal string 'null'.");
   }
 }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/secrets/ExternalSecretsManagerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/secrets/ExternalSecretsManagerTest.java
@@ -243,6 +243,14 @@ public abstract class ExternalSecretsManagerTest {
   }
 
   @Test
+  void testStoreValueWithNullDoesNotThrowNpe() {
+    // Defensive: storeValue must handle null directly — isSecret(null) would NPE,
+    // so the null guard has to come first. (Caught in PR review by Gitar bot.)
+    String result = secretsManager.storeValue("password", null, "test-null-input", true);
+    assertNull(result, "storeValue with null value should return null without throwing");
+  }
+
+  @Test
   void testIssue21259ClearingPasswordDoesNotStoreNullString() {
     String serviceName = "bug21259-clear-password";
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/secrets/KubernetesSecretsManagerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/secrets/KubernetesSecretsManagerTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -261,27 +262,18 @@ class KubernetesSecretsManagerTest {
   }
 
   @Test
-  void testEmptySecretValueShouldBeStoredAsNullString() throws ApiException {
-    ArgumentCaptor<V1Secret> secretCaptor = ArgumentCaptor.forClass(V1Secret.class);
+  void testEmptySecretValueShouldNotBeStored() throws ApiException {
     when(mockApiClient.readNamespacedSecret(anyString(), eq(NAMESPACE))).thenReturn(readRequest);
     when(readRequest.execute()).thenThrow(new ApiException(404, "Not Found"));
 
-    when(mockApiClient.createNamespacedSecret(eq(NAMESPACE), any(V1Secret.class)))
-        .thenReturn(createRequest);
-    when(createRequest.execute()).thenReturn(new V1Secret());
+    String returned = secretsManager.storeValue("field", "", SECRET_ID, true);
 
-    secretsManager.storeValue("field", "", SECRET_ID, true);
-
-    verify(mockApiClient).createNamespacedSecret(eq(NAMESPACE), secretCaptor.capture());
-    verify(createRequest).execute();
-
-    V1Secret createdSecret = secretCaptor.getValue();
-    Map<String, byte[]> data = createdSecret.getData();
-    assert data != null;
-    assertEquals(
-        ExternalSecretsManager.NULL_SECRET_STRING,
-        new String(data.get("value"), StandardCharsets.UTF_8),
-        "Empty string should be stored as 'null' to prevent secrets manager rejection");
+    // Issue #21259: empty value means "no credential" — storeValue must NOT call create,
+    // and must return null so the entity does not carry a stale secret:/ reference.
+    // This also satisfies the original GCP/Kubernetes empty-string rejection constraint
+    // (PR #25224) by simply not upserting an empty value at all.
+    verify(mockApiClient, never()).createNamespacedSecret(eq(NAMESPACE), any(V1Secret.class));
+    assertNull(returned, "storeValue with empty value should return null, not a secret reference");
   }
 
   @Test


### PR DESCRIPTION
## Summary

Closes #21259. Reopened from #27838 (which was based on a fork — switched to upstream branch to match the repo's contribution pattern).

When a user clears a password field on a service backed by an external Secrets Manager (`managed-aws`, GCP, Azure KV, Kubernetes), the previous code stored the literal string `\"null\"` in the secrets backing store instead of removing the secret. Downstream consumers (e.g. the Snowflake driver) then read back the four-character string `\"null\"` as a real password, breaking authentication — most visibly for users who authenticate via private key and never wanted a password configured at all.

This PR fixes the root cause and updates the tests that codified the buggy contract.

## The bug, demonstrated

Before the fix, with `SECRET_MANAGER=managed-aws`:

```bash
# Create a service with a real password, then clear it via the UI (type something, delete it, save).
$ aws secretsmanager get-secret-value \
    --secret-id /<prefix>/<cluster>/database/<service>/authtype/password \
    --query SecretString --output text
null   # ← the literal four ASCII characters, not the JSON null
```

After the fix, the same call returns `ResourceNotFoundException` (the secret has been deleted) and the entity's password field is `null`, not a stale `secret:/` reference.

## Approach

The fix is three small, layered changes — each layer hands a clean null to the next:

1. **`ExternalSecretsManager.upsertSecret()`** — when value is null/empty, the user's intent is *\"remove this credential\"*, so delete the backing secret instead of writing `\"null\"`. This also satisfies the GCP/Kubernetes empty-string rejection constraint from #25224 by simply *not calling* upsert with an empty value.
2. **`ExternalSecretsManager.storeValue()`** — return `null` for null/empty values so the entity does not carry a stale `secret:/` reference to a deleted secret. The null/empty guard sits at the top of the method (above the `isSecret(value)` call) so the function is self-defending against null inputs from any caller.
3. **`SecretsManager.encryptPasswordFields()`** — propagate the `null` returned by `storeValue()` through to the entity field instead of attempting to `fernet.encrypt(null)`.

### Constraint check vs. #25224

#25224 introduced the null→`\"null\"` conversion specifically because GCP and Kubernetes Secrets Manager *reject empty-string upserts*. This PR satisfies that constraint by exclusion: we never call upsert with an empty value because we short-circuit to delete instead. The flipped Kubernetes test (`testEmptySecretValueShouldNotBeStored`, renamed from `testEmptySecretValueShouldBeStoredAsNullString`) verifies `createNamespacedSecret` is never called.

## Tests

- **New**: `testIssue21259ClearingPasswordDoesNotStoreNullString` exercises the exact user scenario (create service with password → clear password → save) and asserts the entity field is `null`, not a Fernet-wrapped `secret:/` reference. Runs against every provider that subclasses `ExternalSecretsManagerTest` (AWS, AWS-SSM, GCP, Kubernetes).
- **New**: `testStoreValueWithNullDoesNotThrowNpe` regression-protects the null-input defensive path.
- **Flipped**: `testEncryptDatabaseConnectionWithEmptyPassword` was asserting the buggy contract; now asserts the corrected one (entity field is null).
- **Flipped & renamed**: `KubernetesSecretsManagerTest.testEmptySecretValueShouldBeStoredAsNullString` → `testEmptySecretValueShouldNotBeStored`. The previous test name itself encoded the bug.

All 83 tests in `*SecretsManager*Test` pass.

## Out of scope (follow-ups)

- **Read-side cleanup of existing dirty data**: customers who already have services with `\"null\"` strings stored in their SM will continue to read those literal `\"null\"` strings until those services are re-saved. A passive read-side wrapper that maps fetched `\"null\"` → `null` (and optionally the existing `migrate-secrets` CLI tool to actively sweep) can land in a separate PR.
- **`cleanNullOrEmpty()` becomes effectively dead code** in the upsert path. Left in place to keep this PR small and reviewable; can be removed in a follow-up.

## Test plan

- [x] `mvn test -pl openmetadata-service -Dtest='*SecretsManager*Test'` (83 tests pass)
- [x] `mvn spotless:apply` (no formatting changes needed)
- [x] Manually reproduced the bug locally with `managed-aws` against AWS SM (output: literal `null`); verified the fix changes the output to `ResourceNotFoundException`
- [ ] Manual regression sanity (set initial password, update password, clear password, recreate service, bot JWT lifecycle, test-connection workflow) — in progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)