### PR TITLE
Fix: Initialize connectionArguments if null in Unity Catalog

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/connection.py
@@ -99,6 +99,9 @@ def get_sqlalchemy_connection(connection: UnityCatalogConnection) -> Engine:
 
     auth_args = get_auth_config(connection)
 
+    if not connection.connectionArguments:
+        connection.connectionArguments = init_empty_connection_arguments()
+
     original_connection_arguments = connection.connectionArguments
     connection.connectionArguments = deepcopy(original_connection_arguments)
     connection.connectionArguments.root.update(auth_args)


### PR DESCRIPTION
### Describe your changes:

Added a null check to initialize `connectionArguments` before attempting to use it in the Unity Catalog connection setup. This prevents potential `AttributeError` when `connectionArguments` is not provided in the connection configuration.

The fix:
- Checks if `connection.connectionArguments` is `None`
- Initializes it with `init_empty_connection_arguments()` if needed
- Ensures the subsequent deepcopy and update operations have a valid object to work with

### Type of change:
- [x] Bug fix

### Checklist:
- [x] I have read the **CONTRIBUTING** document.

https://claude.ai/code/session_01TXaNbAJVpGe7ejnSGcqcJu