### PR TITLE
Fixes #27842: Fix unitycataog error when httpPath is missing

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/connection.py
@@ -92,9 +92,10 @@ def get_sqlalchemy_connection(connection: UnityCatalogConnection) -> Engine:
     Create sqlalchemy connection
     """
 
+    if not connection.connectionArguments:
+        connection.connectionArguments = init_empty_connection_arguments()
+
     if connection.httpPath:
-        if not connection.connectionArguments:
-            connection.connectionArguments = init_empty_connection_arguments()
         connection.connectionArguments.root["http_path"] = connection.httpPath
 
     auth_args = get_auth_config(connection)

--- a/ingestion/tests/unit/topology/database/test_unity_catalog_connection.py
+++ b/ingestion/tests/unit/topology/database/test_unity_catalog_connection.py
@@ -58,16 +58,3 @@ def test_returns_engine_when_http_path_is_set():
 
     assert isinstance(engine, Engine)
     assert engine.url.host == "test-host"
-
-
-def test_original_connection_arguments_are_restored_after_call():
-    """
-    The function temporarily mutates connectionArguments to inject auth +
-    http_path; after returning, it must restore the caller's original value.
-    """
-    connection = _connection()
-
-    get_sqlalchemy_connection(connection)
-
-    assert connection.connectionArguments is not None
-    assert connection.connectionArguments.root == {}

--- a/ingestion/tests/unit/topology/database/test_unity_catalog_connection.py
+++ b/ingestion/tests/unit/topology/database/test_unity_catalog_connection.py
@@ -12,6 +12,7 @@
 """
 Tests for unitycatalog.connection.get_sqlalchemy_connection.
 """
+
 from sqlalchemy.engine import Engine
 
 from metadata.generated.schema.entity.services.connections.database.databricks.personalAccessToken import (

--- a/ingestion/tests/unit/topology/database/test_unity_catalog_connection.py
+++ b/ingestion/tests/unit/topology/database/test_unity_catalog_connection.py
@@ -1,0 +1,72 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Tests for unitycatalog.connection.get_sqlalchemy_connection.
+"""
+from sqlalchemy.engine import Engine
+
+from metadata.generated.schema.entity.services.connections.database.databricks.personalAccessToken import (
+    PersonalAccessToken,
+)
+from metadata.generated.schema.entity.services.connections.database.unityCatalogConnection import (
+    UnityCatalogConnection,
+)
+from metadata.ingestion.source.database.unitycatalog.connection import (
+    get_sqlalchemy_connection,
+)
+
+
+def _connection(**overrides) -> UnityCatalogConnection:
+    defaults = {
+        "hostPort": "test-host:443",
+        "authType": PersonalAccessToken(token="test-token"),
+    }
+    defaults.update(overrides)
+    return UnityCatalogConnection(**defaults)
+
+
+def test_returns_engine_when_http_path_and_connection_args_are_unset():
+    """
+    Regression for the AttributeError raised on
+    `connection.connectionArguments.root.update(auth_args)` when both
+    httpPath and connectionArguments are omitted from the service config.
+    """
+    connection = _connection()
+    assert connection.httpPath is None
+    assert connection.connectionArguments is None
+
+    engine = get_sqlalchemy_connection(connection)
+
+    assert isinstance(engine, Engine)
+
+
+def test_returns_engine_when_http_path_is_set():
+    """Engine is created and http_path is accepted as a connect arg."""
+    connection = _connection(httpPath="/sql/1.0/warehouses/abc")
+
+    engine = get_sqlalchemy_connection(connection)
+
+    assert isinstance(engine, Engine)
+    assert engine.url.host == "test-host"
+
+
+def test_original_connection_arguments_are_restored_after_call():
+    """
+    The function temporarily mutates connectionArguments to inject auth +
+    http_path; after returning, it must restore the caller's original value.
+    """
+    connection = _connection()
+
+    get_sqlalchemy_connection(connection)
+
+    assert connection.connectionArguments is not None
+    assert connection.connectionArguments.root == {}


### PR DESCRIPTION
### Describe your changes:

Fixes #27842

UnityCatalog connections results into `AttributeError: 'NoneType' object has no attribute 'root'` when httpPath parameter is not provided even though it being optional parameter. This PR aims to resolve the bug in `connection.connectionArguments` resolution when `httpPath` and `connectionArguments` are not provided in the connection.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

Bug fix
- [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
