### PR TITLE
Fixed User spec flakiness

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/support/user/UserClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/user/UserClass.ts
@@ -29,15 +29,14 @@ export type UserData = {
   password: string;
 };
 
-const dataStewardPolicy = new PolicyClass();
-const dataStewardRoles = new RolesClass();
-let dataStewardTeam: TeamClass;
-
 export class UserClass {
   data: UserData;
 
   responseData: UserResponseDataType = {} as UserResponseDataType;
   isUserDataSteward = false;
+  private readonly dataStewardPolicy = new PolicyClass();
+  private readonly dataStewardRoles = new RolesClass();
+  private dataStewardTeam: TeamClass | undefined;
   isAdmin: boolean;
 
   constructor(data?: UserData, isAdmin = false) {
@@ -185,28 +184,28 @@ export class UserClass {
   async setDataStewardRole(apiContext: APIRequestContext) {
     this.isUserDataSteward = true;
     const id = uuid();
-    await dataStewardPolicy.create(apiContext, DATA_STEWARD_RULES);
-    await dataStewardRoles.create(apiContext, [
-      dataStewardPolicy.responseData.name,
+    await this.dataStewardPolicy.create(apiContext, DATA_STEWARD_RULES);
+    await this.dataStewardRoles.create(apiContext, [
+      this.dataStewardPolicy.responseData.name,
     ]);
-    dataStewardTeam = new TeamClass({
+    this.dataStewardTeam = new TeamClass({
       name: `PW%data_steward_team-${id}`,
       displayName: `PW Data Steward Team ${id}`,
       description: 'playwright data steward team description',
       teamType: 'Group',
       users: [this.responseData.id],
-      defaultRoles: dataStewardRoles.responseData.id
-        ? [dataStewardRoles.responseData.id]
+      defaultRoles: this.dataStewardRoles.responseData.id
+        ? [this.dataStewardRoles.responseData.id]
         : [],
     });
-    await dataStewardTeam.create(apiContext);
+    await this.dataStewardTeam.create(apiContext);
   }
 
   async delete(apiContext: APIRequestContext, hardDelete = true) {
     if (this.isUserDataSteward) {
-      await dataStewardPolicy.delete(apiContext);
-      await dataStewardRoles.delete(apiContext);
-      await dataStewardTeam.delete(apiContext);
+      await this.dataStewardPolicy.delete(apiContext);
+      await this.dataStewardRoles.delete(apiContext);
+      await this.dataStewardTeam?.delete(apiContext);
     }
 
     const response = await apiContext.delete(


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes <issue-number>

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

I worked on ... because ...

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **Refactored `UserClass` state management:**
  - Encapsulated global `dataSteward` objects into private class members to prevent cross-test interference and flakiness.
  - Updated `setDataStewardRole` and `delete` methods to use local class instance variables for `PolicyClass`, `RolesClass`, and `TeamClass`.

<sub>This will update automatically on new commits.</sub>