### PR TITLE
Cache audit fixes: tag rename + relationship invalidation, bundle warmup

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/cache/RelationshipCacheInvalidationIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/cache/RelationshipCacheInvalidationIT.java
@@ -1,0 +1,139 @@
+/*
+ *  Copyright 2024 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package org.openmetadata.it.tests.cache;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.openmetadata.it.bootstrap.TestSuiteBootstrap;
+import org.openmetadata.it.factories.DatabaseSchemaTestFactory;
+import org.openmetadata.it.factories.DatabaseServiceTestFactory;
+import org.openmetadata.it.util.SdkClients;
+import org.openmetadata.it.util.TestNamespace;
+import org.openmetadata.it.util.TestNamespaceExtension;
+import org.openmetadata.schema.api.data.CreateTable;
+import org.openmetadata.schema.api.domains.CreateDomain;
+import org.openmetadata.schema.entity.data.DatabaseSchema;
+import org.openmetadata.schema.entity.data.Table;
+import org.openmetadata.schema.entity.domains.Domain;
+import org.openmetadata.schema.entity.services.DatabaseService;
+import org.openmetadata.schema.type.Column;
+import org.openmetadata.schema.type.ColumnDataType;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.sdk.network.HttpMethod;
+import org.openmetadata.sdk.network.RequestOptions;
+
+/**
+ * End-to-end coverage for the inline cache invalidation added to the relationship mutation path
+ * (Bug B in the cache audit). Exercises the round-trip: assign a domain to a table via PATCH,
+ * read it back, remove the domain, read it back. The PATCH path goes through
+ * {@code addRelationship} / {@code deleteRelationship}; without the fix, the source-side bundle
+ * cache (here: the domain's) keeps stale data — pre-fix this manifests as the cached list of
+ * domain-tagged refs not picking up the latest asset assignment.
+ *
+ * <p>Both sides of the relationship are read after each mutation. Assertions check that the
+ * domains field on the table matches the latest state — without the fix the inline mutation path
+ * wouldn't drop the table's bundle and a cache read would surface the previous value.
+ *
+ * <p>Tests are skipped without a Redis cache provider.
+ */
+@ExtendWith(TestNamespaceExtension.class)
+class RelationshipCacheInvalidationIT {
+
+  @BeforeAll
+  static void requireRedis() {
+    Assumptions.assumeTrue(
+        TestSuiteBootstrap.isRedisEnabled(),
+        "Relationship cache invalidation tests require cacheProvider=redis (set by -Pcache-tests"
+            + " or -Ppostgres-os-redis, or pass -DcacheProvider=redis directly)");
+  }
+
+  @Test
+  void addThenRemoveDomain_tableDomainsFieldReflectsLatest(TestNamespace ns) throws Exception {
+    Domain domain = createDomain(ns, "rel_cache_dom");
+    DatabaseService dbService = DatabaseServiceTestFactory.createPostgres(ns);
+    DatabaseSchema schema = DatabaseSchemaTestFactory.createSimple(ns, dbService);
+
+    // Create table without a domain — domains field will be empty.
+    Table table = createTable(ns, schema, "rel_cache_tbl");
+
+    // Warm the cache with a no-domain read.
+    Table beforeAdd = SdkClients.adminClient().tables().get(table.getId().toString(), "domains");
+    assertTrue(
+        beforeAdd.getDomains() == null || beforeAdd.getDomains().isEmpty(),
+        "table should start with no domain");
+
+    // PATCH to add domain — this triggers addRelationship(domain.id, table.id, ...) under the
+    // hood. Without the bug B fix the cached bundle on the table side wouldn't be touched.
+    String addPatch =
+        "[{\"op\":\"add\",\"path\":\"/domains\",\"value\":[{\"id\":\""
+            + domain.getId()
+            + "\",\"type\":\"domain\"}]}]";
+    SdkClients.adminClient()
+        .getHttpClient()
+        .executeForString(
+            HttpMethod.PATCH,
+            "/v1/tables/" + table.getId(),
+            addPatch,
+            RequestOptions.builder().header("Content-Type", "application/json-patch+json").build());
+
+    Table afterAdd = SdkClients.adminClient().tables().get(table.getId().toString(), "domains");
+    List<EntityReference> domainsAfterAdd = afterAdd.getDomains();
+    assertNotNull(domainsAfterAdd, "domains field must hydrate after PATCH");
+    assertEquals(1, domainsAfterAdd.size());
+    assertEquals(domain.getId(), domainsAfterAdd.get(0).getId());
+
+    // PATCH to remove the domain by replacing the field with an empty array.
+    String removePatch = "[{\"op\":\"replace\",\"path\":\"/domains\",\"value\":[]}]";
+    SdkClients.adminClient()
+        .getHttpClient()
+        .executeForString(
+            HttpMethod.PATCH,
+            "/v1/tables/" + table.getId(),
+            removePatch,
+            RequestOptions.builder().header("Content-Type", "application/json-patch+json").build());
+
+    Table afterRemove = SdkClients.adminClient().tables().get(table.getId().toString(), "domains");
+    assertTrue(
+        afterRemove.getDomains() == null || afterRemove.getDomains().isEmpty(),
+        "domains field must reflect removal — bundle cache should be invalidated by the inline"
+            + " deleteRelationship path");
+  }
+
+  // -------------------------- Helpers --------------------------
+
+  private static Domain createDomain(TestNamespace ns, String suffix) {
+    CreateDomain request =
+        new CreateDomain()
+            .withName(ns.prefix(suffix))
+            .withDomainType(CreateDomain.DomainType.AGGREGATE)
+            .withDescription("Domain for relationship cache IT");
+    return SdkClients.adminClient().domains().create(request);
+  }
+
+  private static Table createTable(TestNamespace ns, DatabaseSchema schema, String suffix) {
+    Column column = new Column();
+    column.setName("id");
+    column.setDataType(ColumnDataType.INT);
+
+    CreateTable createTable = new CreateTable();
+    createTable.setName(ns.shortPrefix(suffix));
+    createTable.setDatabaseSchema(schema.getFullyQualifiedName());
+    createTable.setColumns(List.of(column));
+    return SdkClients.adminClient().tables().create(createTable);
+  }
+}

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/cache/RelationshipCacheInvalidationIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/cache/RelationshipCacheInvalidationIT.java
@@ -41,13 +41,11 @@ import org.openmetadata.sdk.network.RequestOptions;
  * End-to-end coverage for the inline cache invalidation added to the relationship mutation path
  * (Bug B in the cache audit). Exercises the round-trip: assign a domain to a table via PATCH,
  * read it back, remove the domain, read it back. The PATCH path goes through
- * {@code addRelationship} / {@code deleteRelationship}; without the fix, the source-side bundle
- * cache (here: the domain's) keeps stale data — pre-fix this manifests as the cached list of
- * domain-tagged refs not picking up the latest asset assignment.
- *
- * <p>Both sides of the relationship are read after each mutation. Assertions check that the
- * domains field on the table matches the latest state — without the fix the inline mutation path
- * wouldn't drop the table's bundle and a cache read would surface the previous value.
+ * {@code addRelationship} / {@code deleteRelationship}; the assertion is on the *table* side
+ * (the cacheable entity) — without the fix the inline mutation path wouldn't drop the table's
+ * bundle / domains relationship cache, and a cache read would surface the previous {@code
+ * domains} field. Domain itself is in {@code UNCACHED_ENTITY_TYPES}, so its cached refs aren't
+ * the variable being tested here.
  *
  * <p>Tests are skipped without a Redis cache provider.
  */

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/cache/TagRenameCacheIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/cache/TagRenameCacheIT.java
@@ -1,0 +1,152 @@
+/*
+ *  Copyright 2024 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package org.openmetadata.it.tests.cache;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.openmetadata.it.bootstrap.TestSuiteBootstrap;
+import org.openmetadata.it.factories.DatabaseSchemaTestFactory;
+import org.openmetadata.it.factories.DatabaseServiceTestFactory;
+import org.openmetadata.it.util.SdkClients;
+import org.openmetadata.it.util.TestNamespace;
+import org.openmetadata.it.util.TestNamespaceExtension;
+import org.openmetadata.schema.api.classification.CreateClassification;
+import org.openmetadata.schema.api.classification.CreateTag;
+import org.openmetadata.schema.api.data.CreateTable;
+import org.openmetadata.schema.entity.classification.Classification;
+import org.openmetadata.schema.entity.classification.Tag;
+import org.openmetadata.schema.entity.data.DatabaseSchema;
+import org.openmetadata.schema.entity.data.Table;
+import org.openmetadata.schema.entity.services.DatabaseService;
+import org.openmetadata.schema.type.Column;
+import org.openmetadata.schema.type.ColumnDataType;
+import org.openmetadata.schema.type.TagLabel;
+import org.openmetadata.sdk.network.HttpMethod;
+import org.openmetadata.sdk.network.RequestOptions;
+
+/**
+ * End-to-end coverage for the search-based tag-rename cache invalidation (Bug A in the cache
+ * audit). Renames a tag that's applied to a table; verifies the next GET on the table shows the
+ * new tag FQN rather than the cached old one. Without the fix the cached entity bundle keeps the
+ * old tag FQN until TTL expiry (default 48 h).
+ *
+ * <p>Tests are skipped without a Redis cache provider — the bundle/tag caches are no-ops without
+ * one and there is nothing to assert.
+ */
+@ExtendWith(TestNamespaceExtension.class)
+class TagRenameCacheIT {
+
+  @BeforeAll
+  static void requireRedis() {
+    Assumptions.assumeTrue(
+        TestSuiteBootstrap.isRedisEnabled(),
+        "Tag rename cache invalidation tests require cacheProvider=redis (set by -Pcache-tests"
+            + " or -Ppostgres-os-redis, or pass -DcacheProvider=redis directly)");
+  }
+
+  @Test
+  void tagRename_updatesCachedEntityTags(TestNamespace ns) throws Exception {
+    Classification classification = createClassification(ns, "rename_class");
+    Tag tag = createTag(ns, classification, "rename_tag", "Original description");
+    String oldFqn = tag.getFullyQualifiedName();
+
+    DatabaseService dbService = DatabaseServiceTestFactory.createPostgres(ns);
+    DatabaseSchema schema = DatabaseSchemaTestFactory.createSimple(ns, dbService);
+
+    Table table = createTableWithTag(ns, schema, "tag_rename_target", oldFqn);
+
+    // Warm the bundle cache by reading the table once with tags expanded.
+    Table beforeRename = SdkClients.adminClient().tables().get(table.getId().toString(), "tags");
+    assertNotNull(beforeRename.getTags());
+    assertTrue(
+        beforeRename.getTags().stream().anyMatch(t -> oldFqn.equals(t.getTagFQN())),
+        "Pre-rename read should see the original tag FQN");
+
+    String newName = "renamed_" + System.currentTimeMillis();
+    String patch = "[{\"op\":\"replace\",\"path\":\"/name\",\"value\":\"" + newName + "\"}]";
+    SdkClients.adminClient()
+        .getHttpClient()
+        .executeForString(
+            HttpMethod.PATCH,
+            "/v1/tags/" + tag.getId(),
+            patch,
+            RequestOptions.builder().header("Content-Type", "application/json-patch+json").build());
+
+    String newFqn = classification.getFullyQualifiedName() + "." + newName;
+
+    // Search index updates are async — allow a short window for the search-based invalidation
+    // path to enumerate the affected entity, then re-fetch the table. The cached bundle must
+    // have been invalidated; the next GET must hit the DB and surface the new tag FQN.
+    Awaitility.await()
+        .atMost(15, TimeUnit.SECONDS)
+        .pollInterval(500, TimeUnit.MILLISECONDS)
+        .untilAsserted(
+            () -> {
+              Table afterRename =
+                  SdkClients.adminClient().tables().get(table.getId().toString(), "tags");
+              List<TagLabel> tags = afterRename.getTags();
+              assertNotNull(tags);
+              assertFalse(
+                  tags.stream().anyMatch(t -> oldFqn.equals(t.getTagFQN())),
+                  "Cache must not return the stale tag FQN after rename");
+              assertTrue(
+                  tags.stream().anyMatch(t -> newFqn.equals(t.getTagFQN())),
+                  "Post-rename read must show the new tag FQN");
+            });
+  }
+
+  // -------------------------- Helpers --------------------------
+
+  private static Classification createClassification(TestNamespace ns, String suffix) {
+    CreateClassification request = new CreateClassification();
+    request.setName(ns.shortPrefix(suffix));
+    request.setDescription("Classification for cache rename IT");
+    return SdkClients.adminClient().classifications().create(request);
+  }
+
+  private static Tag createTag(
+      TestNamespace ns, Classification classification, String suffix, String description) {
+    CreateTag request = new CreateTag();
+    request.setName(ns.shortPrefix(suffix));
+    request.setClassification(classification.getFullyQualifiedName());
+    request.setDescription(description);
+    return SdkClients.adminClient().tags().create(request);
+  }
+
+  private static Table createTableWithTag(
+      TestNamespace ns, DatabaseSchema schema, String suffix, String tagFqn) {
+    TagLabel tagLabel = new TagLabel();
+    tagLabel.setTagFQN(tagFqn);
+    tagLabel.setSource(TagLabel.TagSource.CLASSIFICATION);
+    tagLabel.setLabelType(TagLabel.LabelType.MANUAL);
+    tagLabel.setState(TagLabel.State.CONFIRMED);
+
+    Column column = new Column();
+    column.setName("id");
+    column.setDataType(ColumnDataType.INT);
+
+    CreateTable createTable = new CreateTable();
+    createTable.setName(ns.shortPrefix(suffix));
+    createTable.setDatabaseSchema(schema.getFullyQualifiedName());
+    createTable.setColumns(List.of(column));
+    createTable.setTags(List.of(tagLabel));
+    return SdkClients.adminClient().tables().create(createTable);
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/cache/CacheWarmupApp.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/cache/CacheWarmupApp.java
@@ -190,17 +190,27 @@ public class CacheWarmupApp extends AbstractNativeApplication {
       if (raw == null) {
         return;
       }
-      Object wb = raw.get("warmBundles");
-      if (wb instanceof Boolean) {
-        warmBundles = (Boolean) wb;
-      }
-      Object dc = raw.get("enableDistributedClaim");
-      if (dc instanceof Boolean) {
-        enableDistributedClaim = (Boolean) dc;
-      }
+      // Accept both native Boolean and string forms — depending on how the config arrives
+      // (typed POJO, raw JSON, YAML env-var override, API string body) the same logical value
+      // can land here as Boolean.TRUE or "true". An instanceof Boolean check would silently
+      // ignore the string form and fall back to JVM system properties, which surprises
+      // operators who set the flag in the UI.
+      warmBundles = parseBooleanFlag(raw.get("warmBundles"), warmBundles);
+      enableDistributedClaim =
+          parseBooleanFlag(raw.get("enableDistributedClaim"), enableDistributedClaim);
     } catch (Exception e) {
       LOG.debug("Could not read warmBundles / enableDistributedClaim from app config", e);
     }
+  }
+
+  private static boolean parseBooleanFlag(Object value, boolean fallback) {
+    if (value == null) {
+      return fallback;
+    }
+    if (value instanceof Boolean) {
+      return (Boolean) value;
+    }
+    return Boolean.parseBoolean(String.valueOf(value));
   }
 
   private void initJobData(JobExecutionContext ctx) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/cache/CacheWarmupApp.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/cache/CacheWarmupApp.java
@@ -17,7 +17,9 @@ import static org.openmetadata.service.apps.scheduler.OmAppJobListener.WEBSOCKET
 import static org.openmetadata.service.socket.WebSocketManager.CACHE_WARMUP_JOB_BROADCAST_CHANNEL;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import java.net.InetAddress;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -39,9 +41,11 @@ import org.openmetadata.schema.system.StepStats;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.apps.AbstractNativeApplication;
+import org.openmetadata.service.cache.BundleWarmupBatcher;
 import org.openmetadata.service.cache.CacheBundle;
 import org.openmetadata.service.cache.CacheConfig;
 import org.openmetadata.service.cache.CacheKeys;
+import org.openmetadata.service.cache.CacheMetrics;
 import org.openmetadata.service.cache.CacheProvider;
 import org.openmetadata.service.exception.AppException;
 import org.openmetadata.service.jdbi3.CollectionDAO;
@@ -80,12 +84,27 @@ import org.quartz.JobExecutionContext;
 public class CacheWarmupApp extends AbstractNativeApplication {
   private static final String ALL = "all";
   private static final int DEFAULT_BATCH_SIZE = 1000;
+  // Per-entity-type checkpoint keys live under their own namespace so we can list/clear them
+  // without colliding with normal cache traffic. TTL is one day — long enough for ops staff to
+  // notice and resume a stuck warmup, short enough that abandoned checkpoints self-clean.
+  private static final String CHECKPOINT_KEY_PREFIX = "om:warmup:checkpoint:";
+  private static final String CLAIM_KEY_PREFIX = "om:warmup:claim:";
+  private static final Duration CHECKPOINT_TTL = Duration.ofDays(1);
+  private static final Duration CLAIM_TTL = Duration.ofMinutes(10);
 
   @Getter private EventPublisherJob jobData;
 
   private CacheProvider cacheProvider;
   private CacheKeys keys;
   private CacheConfig cacheConfig;
+  private BundleWarmupBatcher bundleBatcher;
+  private final String instanceId = generateInstanceId();
+  // Toggle bundle warmup off via -Dom.cache.warmBundles=false at JVM start. Defaults to true so
+  // production deployments get the first-read benefit without config changes.
+  private final boolean warmBundles =
+      Boolean.parseBoolean(System.getProperty("om.cache.warmBundles", "true"));
+  private final boolean enableDistributedClaim =
+      Boolean.parseBoolean(System.getProperty("om.cache.warmup.distributedClaim", "false"));
 
   private JobExecutionContext jobExecutionContext;
   private volatile boolean stopped = false;
@@ -134,6 +153,9 @@ public class CacheWarmupApp extends AbstractNativeApplication {
     cacheConfig = CacheBundle.getCacheConfig();
     if (cacheConfig != null) {
       keys = new CacheKeys(cacheConfig.redis.keyspace);
+    }
+    if (warmBundles && cacheProvider != null && keys != null) {
+      bundleBatcher = new BundleWarmupBatcher(collectionDAO, cacheProvider, keys);
     }
   }
 
@@ -187,12 +209,20 @@ public class CacheWarmupApp extends AbstractNativeApplication {
       jobData.setStatus(EventPublisherJob.Status.STOPPED);
     } else {
       jobData.setStatus(EventPublisherJob.Status.COMPLETED);
+      CacheMetrics metrics = CacheMetrics.getInstance();
+      if (metrics != null) {
+        metrics.recordWarmupCompleted();
+      }
     }
   }
 
   private void warmupEntityType(String entityType, int batchSize, Duration ttl) {
     if (Entity.USER.equals(entityType)) {
       LOG.debug("Skipping user entity type — not cached by design");
+      return;
+    }
+    if (enableDistributedClaim && !claimEntityType(entityType)) {
+      LOG.info("Skipping {} — claimed by another instance", entityType);
       return;
     }
     EntityRepository<?> repository;
@@ -207,8 +237,12 @@ public class CacheWarmupApp extends AbstractNativeApplication {
       return;
     }
 
-    int offset = 0;
+    int offset = readCheckpoint(entityType);
+    if (offset > 0) {
+      LOG.info("Resuming {} warmup from checkpoint offset {}", entityType, offset);
+    }
     int success = 0;
+    int bundlesWritten = 0;
     int failed = 0;
     long start = System.currentTimeMillis();
     while (!stopped) {
@@ -231,6 +265,7 @@ public class CacheWarmupApp extends AbstractNativeApplication {
 
       Map<String, Map<String, String>> hsetBatch = new HashMap<>(page.size() * 2);
       Map<String, String> setBatch = new HashMap<>(page.size());
+      List<EntityInterface> parsedEntities = new ArrayList<>(page.size());
       // Per-page deltas — updateEntityStats adds to the running totals, so passing cumulative
       // counts would double-count entries from earlier pages.
       int pageSuccess = 0;
@@ -245,6 +280,7 @@ public class CacheWarmupApp extends AbstractNativeApplication {
           }
           hsetBatch.put(keys.entity(entityType, entity.getId()), Map.of("base", json));
           setBatch.put(keys.entityByName(entityType, entity.getFullyQualifiedName()), json);
+          parsedEntities.add(entity);
           pageSuccess++;
         } catch (Exception e) {
           pageFailed++;
@@ -256,6 +292,12 @@ public class CacheWarmupApp extends AbstractNativeApplication {
         success += pageSuccess;
         failed += pageFailed;
         updateEntityStats(entityType, pageSuccess, pageFailed);
+        if (bundleBatcher != null && !parsedEntities.isEmpty()) {
+          BundleWarmupBatcher.BatchResult bundleResult =
+              bundleBatcher.warmupBatch(entityType, parsedEntities, ttl);
+          bundlesWritten += bundleResult.success();
+        }
+        writeCheckpoint(entityType, offset + page.size());
       } catch (RuntimeException e) {
         // Redis rejected the batch. Count every row in this page as failed so warmup progress and
         // the WebSocket status reflect the actual state — the cache is not warm for these rows.
@@ -270,7 +312,118 @@ public class CacheWarmupApp extends AbstractNativeApplication {
     }
     long elapsed = System.currentTimeMillis() - start;
     LOG.info(
-        "Warmed {} entities (type={}, failed={}) in {} ms", success, entityType, failed, elapsed);
+        "Warmed {} entities (type={}, failed={}, bundles={}) in {} ms",
+        success,
+        entityType,
+        failed,
+        bundlesWritten,
+        elapsed);
+    if (!stopped) {
+      reportCoverage(entityType, dao, success, bundlesWritten);
+      clearCheckpoint(entityType);
+    }
+    if (enableDistributedClaim) {
+      releaseClaim(entityType);
+    }
+  }
+
+  private boolean claimEntityType(String entityType) {
+    if (cacheProvider == null || !cacheProvider.available()) {
+      return true;
+    }
+    try {
+      return cacheProvider.setIfAbsent(CLAIM_KEY_PREFIX + entityType, instanceId, CLAIM_TTL);
+    } catch (Exception e) {
+      LOG.debug("Claim attempt failed, proceeding without lock for {}", entityType, e);
+      return true;
+    }
+  }
+
+  private void releaseClaim(String entityType) {
+    if (cacheProvider == null || !cacheProvider.available()) {
+      return;
+    }
+    try {
+      cacheProvider.del(CLAIM_KEY_PREFIX + entityType);
+    } catch (Exception e) {
+      LOG.debug("Failed to release claim for {}", entityType, e);
+    }
+  }
+
+  private int readCheckpoint(String entityType) {
+    if (cacheProvider == null || !cacheProvider.available()) {
+      return 0;
+    }
+    try {
+      return cacheProvider.get(CHECKPOINT_KEY_PREFIX + entityType).map(Integer::parseInt).orElse(0);
+    } catch (Exception e) {
+      LOG.debug("Failed to read checkpoint for {}", entityType, e);
+      return 0;
+    }
+  }
+
+  private void writeCheckpoint(String entityType, int offset) {
+    if (cacheProvider == null || !cacheProvider.available()) {
+      return;
+    }
+    try {
+      cacheProvider.set(
+          CHECKPOINT_KEY_PREFIX + entityType, Integer.toString(offset), CHECKPOINT_TTL);
+    } catch (Exception e) {
+      LOG.debug("Failed to write checkpoint for {} at {}", entityType, offset, e);
+    }
+  }
+
+  private void clearCheckpoint(String entityType) {
+    if (cacheProvider == null || !cacheProvider.available()) {
+      return;
+    }
+    try {
+      cacheProvider.del(CHECKPOINT_KEY_PREFIX + entityType);
+    } catch (Exception e) {
+      LOG.debug("Failed to clear checkpoint for {}", entityType, e);
+    }
+  }
+
+  private void reportCoverage(
+      String entityType, EntityDAO<?> dao, int success, int bundlesWritten) {
+    CacheMetrics metrics = CacheMetrics.getInstance();
+    if (metrics == null) {
+      return;
+    }
+    int total;
+    try {
+      total = dao.listTotalCount();
+    } catch (Exception e) {
+      LOG.debug("Failed to fetch total count for coverage metric: {}", entityType, e);
+      return;
+    }
+    if (total <= 0) {
+      return;
+    }
+    double coverage = (double) success / total;
+    metrics.recordCoverage(entityType, coverage);
+    if (coverage < 0.95) {
+      LOG.warn(
+          "Cache coverage below threshold for {}: {}/{} ({}%)",
+          entityType, success, total, Math.round(coverage * 100));
+    }
+    if (bundleBatcher != null) {
+      double bundleCoverage = (double) bundlesWritten / total;
+      metrics.recordBundleCoverage(entityType, bundleCoverage);
+    }
+  }
+
+  private static String generateInstanceId() {
+    try {
+      return InetAddress.getLocalHost().getHostName()
+          + ":"
+          + ProcessHandle.current().pid()
+          + ":"
+          + System.currentTimeMillis();
+    } catch (Exception e) {
+      return "warmup:" + System.currentTimeMillis();
+    }
   }
 
   private Set<String> resolveEntityTypes() {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/cache/CacheWarmupApp.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/cache/CacheWarmupApp.java
@@ -346,12 +346,32 @@ public class CacheWarmupApp extends AbstractNativeApplication {
         success += pageSuccess;
         failed += pageFailed;
         updateEntityStats(entityType, pageSuccess, pageFailed);
+        boolean bundleOk = true;
         if (bundleBatcher != null && !parsedEntities.isEmpty()) {
           BundleWarmupBatcher.BatchResult bundleResult =
               bundleBatcher.warmupBatch(entityType, parsedEntities, ttl);
           bundlesWritten += bundleResult.success();
+          // Whole-page bundle failure (Redis pipeline error / DB tag fetch error) means the
+          // bundles for this page are cold despite the entity JSON being warm. Hold the
+          // checkpoint so the next run retries the page; advance only on partial-or-better
+          // success. This trades an occasional duplicate entity write for not silently leaving
+          // bundle keys stale.
+          if (bundleResult.success() == 0 && bundleResult.failed() > 0) {
+            bundleOk = false;
+            LOG.warn(
+                "Bundle warmup pass failed for {} batch at offset {} ({} rows); holding"
+                    + " checkpoint so the next run retries.",
+                entityType,
+                offset,
+                bundleResult.failed());
+          }
         }
-        writeCheckpoint(entityType, offset + page.size());
+        if (bundleOk) {
+          writeCheckpoint(entityType, offset + page.size());
+        }
+        // Refresh the distributed claim TTL on every successful page — large entity types can
+        // outlast CLAIM_TTL, and without refresh another instance could acquire mid-warm.
+        refreshClaim(entityType);
       } catch (RuntimeException e) {
         // Redis rejected the batch. Count every row in this page as failed so warmup progress and
         // the WebSocket status reflect the actual state — the cache is not warm for these rows.
@@ -390,6 +410,31 @@ public class CacheWarmupApp extends AbstractNativeApplication {
     } catch (Exception e) {
       LOG.debug("Claim attempt failed, proceeding without lock for {}", entityType, e);
       return true;
+    }
+  }
+
+  /**
+   * Refresh the claim TTL after a successful page so a long-running warm doesn't lose the lock
+   * mid-flight. Compare-and-set: GET the current owner; if it's still us, SET with a fresh
+   * TTL. If somebody else now owns it (our TTL expired), don't fight — just stop refreshing.
+   * The warmup itself continues to completion regardless; the worst case is the other instance
+   * does redundant work (Redis writes are idempotent).
+   */
+  private void refreshClaim(String entityType) {
+    if (!enableDistributedClaim
+        || cacheProvider == null
+        || !cacheProvider.available()
+        || claimKeyPrefix == null) {
+      return;
+    }
+    String key = claimKeyPrefix + entityType;
+    try {
+      String owner = cacheProvider.get(key).orElse(null);
+      if (instanceId.equals(owner)) {
+        cacheProvider.set(key, instanceId, CLAIM_TTL);
+      }
+    } catch (Exception e) {
+      LOG.debug("Failed to refresh claim for {}", entityType, e);
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/cache/CacheWarmupApp.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/cache/CacheWarmupApp.java
@@ -75,20 +75,29 @@ import org.quartz.JobExecutionContext;
  *       worst case is redundant SETs of identical JSON.</li>
  * </ul>
  *
- * <p>The more expensive {@code bundle:{<uuid>}:<type>} entries are populated on first read via
- * {@link org.openmetadata.service.cache.CachedReadBundle}; pre-warming the bundle would require
- * full relationship hydration (the thing this app is trying to avoid) and is intentionally not
- * done here.
+ * <p>The {@code bundle:{<uuid>}:<type>} entries are pre-warmed by default via
+ * {@link org.openmetadata.service.cache.BundleWarmupBatcher}, which uses the cheap batched
+ * tag_usage query to populate tags + certification (the parts of the bundle that don't require
+ * full relationship hydration). Relations are left null so the {@link
+ * org.openmetadata.service.cache.CachedReadBundle} read path lazily populates them on first
+ * read. Set {@code warmBundles=false} in the app config (or
+ * {@code -Dom.cache.warmBundles=false} at JVM start) to skip the bundle pass for very large
+ * installs.
+ *
+ * <p>Optional opt-in {@code enableDistributedClaim=true} adds a Redis SETNX-based per-entity-
+ * type claim so multi-instance deployments avoid redundant DB scans. Per-entity-type checkpoints
+ * persist warmup progress across restarts; an aborted run resumes from the last successfully
+ * pipelined offset.
  */
 @Slf4j
 public class CacheWarmupApp extends AbstractNativeApplication {
   private static final String ALL = "all";
   private static final int DEFAULT_BATCH_SIZE = 1000;
-  // Per-entity-type checkpoint keys live under their own namespace so we can list/clear them
-  // without colliding with normal cache traffic. TTL is one day — long enough for ops staff to
-  // notice and resume a stuck warmup, short enough that abandoned checkpoints self-clean.
-  private static final String CHECKPOINT_KEY_PREFIX = "om:warmup:checkpoint:";
-  private static final String CLAIM_KEY_PREFIX = "om:warmup:claim:";
+  // Built per-instance from cacheConfig.redis.keyspace so multi-environment deployments sharing
+  // one Redis with different keyspaces don't collide on warmup metadata. TTL is one day for
+  // checkpoints (long enough for ops staff to notice and resume a stuck warmup, short enough
+  // that abandoned checkpoints self-clean). Claim TTL is short enough to limit the
+  // stop-the-world hold if an instance dies mid-warm.
   private static final Duration CHECKPOINT_TTL = Duration.ofDays(1);
   private static final Duration CLAIM_TTL = Duration.ofMinutes(10);
 
@@ -98,12 +107,15 @@ public class CacheWarmupApp extends AbstractNativeApplication {
   private CacheKeys keys;
   private CacheConfig cacheConfig;
   private BundleWarmupBatcher bundleBatcher;
+  // Set during initCacheComponents from cacheConfig.redis.keyspace.
+  private String checkpointKeyPrefix;
+  private String claimKeyPrefix;
   private final String instanceId = generateInstanceId();
-  // Toggle bundle warmup off via -Dom.cache.warmBundles=false at JVM start. Defaults to true so
-  // production deployments get the first-read benefit without config changes.
-  private final boolean warmBundles =
+  // Read in initJobData from the user-supplied app config (cacheWarmupAppConfig schema). System
+  // properties remain a fallback for cases where the app record isn't editable (e.g. bootstrap).
+  private boolean warmBundles =
       Boolean.parseBoolean(System.getProperty("om.cache.warmBundles", "true"));
-  private final boolean enableDistributedClaim =
+  private boolean enableDistributedClaim =
       Boolean.parseBoolean(System.getProperty("om.cache.warmup.distributedClaim", "false"));
 
   private JobExecutionContext jobExecutionContext;
@@ -120,6 +132,7 @@ public class CacheWarmupApp extends AbstractNativeApplication {
   public void init(App app) {
     super.init(app);
     jobData = JsonUtils.convertValue(app.getAppConfiguration(), EventPublisherJob.class);
+    readAppConfigFlags();
   }
 
   @Override
@@ -153,9 +166,40 @@ public class CacheWarmupApp extends AbstractNativeApplication {
     cacheConfig = CacheBundle.getCacheConfig();
     if (cacheConfig != null) {
       keys = new CacheKeys(cacheConfig.redis.keyspace);
+      String ks = cacheConfig.redis.keyspace == null ? "om:prod" : cacheConfig.redis.keyspace;
+      checkpointKeyPrefix = ks + ":warmup:checkpoint:";
+      claimKeyPrefix = ks + ":warmup:claim:";
     }
     if (warmBundles && cacheProvider != null && keys != null) {
       bundleBatcher = new BundleWarmupBatcher(collectionDAO, cacheProvider, keys);
+    }
+  }
+
+  /**
+   * Pull the user-supplied warmBundles / enableDistributedClaim flags out of the raw app config
+   * map. The runtime parses the same payload as {@link EventPublisherJob}, which doesn't include
+   * these fields, so we read them from the original map rather than trying to extend the
+   * EventPublisherJob schema.
+   */
+  private void readAppConfigFlags() {
+    if (getApp() == null || getApp().getAppConfiguration() == null) {
+      return;
+    }
+    try {
+      Map<?, ?> raw = JsonUtils.convertValue(getApp().getAppConfiguration(), Map.class);
+      if (raw == null) {
+        return;
+      }
+      Object wb = raw.get("warmBundles");
+      if (wb instanceof Boolean) {
+        warmBundles = (Boolean) wb;
+      }
+      Object dc = raw.get("enableDistributedClaim");
+      if (dc instanceof Boolean) {
+        enableDistributedClaim = (Boolean) dc;
+      }
+    } catch (Exception e) {
+      LOG.debug("Could not read warmBundles / enableDistributedClaim from app config", e);
     }
   }
 
@@ -328,34 +372,48 @@ public class CacheWarmupApp extends AbstractNativeApplication {
   }
 
   private boolean claimEntityType(String entityType) {
-    if (cacheProvider == null || !cacheProvider.available()) {
+    if (cacheProvider == null || !cacheProvider.available() || claimKeyPrefix == null) {
       return true;
     }
     try {
-      return cacheProvider.setIfAbsent(CLAIM_KEY_PREFIX + entityType, instanceId, CLAIM_TTL);
+      return cacheProvider.setIfAbsent(claimKeyPrefix + entityType, instanceId, CLAIM_TTL);
     } catch (Exception e) {
       LOG.debug("Claim attempt failed, proceeding without lock for {}", entityType, e);
       return true;
     }
   }
 
+  /**
+   * Compare-and-delete release. If our claim's TTL expired and another instance acquired the key
+   * mid-warm, we must NOT delete their lock. We GET the current owner and only DEL when it
+   * still matches our {@link #instanceId}. This is a non-atomic check (a second instance could
+   * still acquire between our GET and DEL), but the resulting cost is at most one redundant
+   * concurrent warm — the Redis writes are idempotent.
+   */
   private void releaseClaim(String entityType) {
-    if (cacheProvider == null || !cacheProvider.available()) {
+    if (cacheProvider == null || !cacheProvider.available() || claimKeyPrefix == null) {
       return;
     }
+    String key = claimKeyPrefix + entityType;
     try {
-      cacheProvider.del(CLAIM_KEY_PREFIX + entityType);
+      String owner = cacheProvider.get(key).orElse(null);
+      if (instanceId.equals(owner)) {
+        cacheProvider.del(key);
+      } else if (owner != null) {
+        LOG.debug(
+            "Skipping release of claim {} — owner {} != self {}", entityType, owner, instanceId);
+      }
     } catch (Exception e) {
       LOG.debug("Failed to release claim for {}", entityType, e);
     }
   }
 
   private int readCheckpoint(String entityType) {
-    if (cacheProvider == null || !cacheProvider.available()) {
+    if (cacheProvider == null || !cacheProvider.available() || checkpointKeyPrefix == null) {
       return 0;
     }
     try {
-      return cacheProvider.get(CHECKPOINT_KEY_PREFIX + entityType).map(Integer::parseInt).orElse(0);
+      return cacheProvider.get(checkpointKeyPrefix + entityType).map(Integer::parseInt).orElse(0);
     } catch (Exception e) {
       LOG.debug("Failed to read checkpoint for {}", entityType, e);
       return 0;
@@ -363,23 +421,22 @@ public class CacheWarmupApp extends AbstractNativeApplication {
   }
 
   private void writeCheckpoint(String entityType, int offset) {
-    if (cacheProvider == null || !cacheProvider.available()) {
+    if (cacheProvider == null || !cacheProvider.available() || checkpointKeyPrefix == null) {
       return;
     }
     try {
-      cacheProvider.set(
-          CHECKPOINT_KEY_PREFIX + entityType, Integer.toString(offset), CHECKPOINT_TTL);
+      cacheProvider.set(checkpointKeyPrefix + entityType, Integer.toString(offset), CHECKPOINT_TTL);
     } catch (Exception e) {
       LOG.debug("Failed to write checkpoint for {} at {}", entityType, offset, e);
     }
   }
 
   private void clearCheckpoint(String entityType) {
-    if (cacheProvider == null || !cacheProvider.available()) {
+    if (cacheProvider == null || !cacheProvider.available() || checkpointKeyPrefix == null) {
       return;
     }
     try {
-      cacheProvider.del(CHECKPOINT_KEY_PREFIX + entityType);
+      cacheProvider.del(checkpointKeyPrefix + entityType);
     } catch (Exception e) {
       LOG.debug("Failed to clear checkpoint for {}", entityType, e);
     }
@@ -401,17 +458,40 @@ public class CacheWarmupApp extends AbstractNativeApplication {
     if (total <= 0) {
       return;
     }
-    double coverage = (double) success / total;
+    // Prefer the actual Redis key count when the provider supports it — this gives the true
+    // end-state coverage including pages warmed by prior resumed runs. Fall back to the
+    // current-run success count when SCAN is unsupported (negative return). Same reasoning for
+    // the bundle pass below.
+    long entityKeys = scanEntityKeyCount(entityType);
+    double coverage = entityKeys >= 0 ? (double) entityKeys / total : (double) success / total;
     metrics.recordCoverage(entityType, coverage);
     if (coverage < 0.95) {
       LOG.warn(
           "Cache coverage below threshold for {}: {}/{} ({}%)",
-          entityType, success, total, Math.round(coverage * 100));
+          entityType, entityKeys >= 0 ? entityKeys : success, total, Math.round(coverage * 100));
     }
     if (bundleBatcher != null) {
-      double bundleCoverage = (double) bundlesWritten / total;
+      long bundleKeys = scanBundleKeyCount(entityType);
+      double bundleCoverage =
+          bundleKeys >= 0 ? (double) bundleKeys / total : (double) bundlesWritten / total;
       metrics.recordBundleCoverage(entityType, bundleCoverage);
     }
+  }
+
+  private long scanEntityKeyCount(String entityType) {
+    if (cacheProvider == null || cacheConfig == null || !cacheProvider.available()) {
+      return -1L;
+    }
+    return cacheProvider.scanCount(cacheConfig.redis.keyspace + ":e:" + entityType + ":*");
+  }
+
+  private long scanBundleKeyCount(String entityType) {
+    if (cacheProvider == null || cacheConfig == null || !cacheProvider.available()) {
+      return -1L;
+    }
+    // CacheKeys.bundle wraps the id portion in {} for hash-tag colocation:
+    // om:<ks>:bundle:{<id>}:<type> — match all those for this type.
+    return cacheProvider.scanCount(cacheConfig.redis.keyspace + ":bundle:*:" + entityType);
   }
 
   private static String generateInstanceId() {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/cache/BundleWarmupBatcher.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/cache/BundleWarmupBatcher.java
@@ -94,6 +94,7 @@ public class BundleWarmupBatcher {
         bundleKeyValues.put(keys.bundle(entityType, entity.getId()), JsonUtils.pojoToJson(dto));
       } catch (Exception e) {
         failed++;
+        LOG.debug("Bundle warmup row failed: type={} id={}", entityType, entity.getId(), e);
       }
     }
     if (bundleKeyValues.isEmpty()) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/cache/BundleWarmupBatcher.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/cache/BundleWarmupBatcher.java
@@ -1,0 +1,110 @@
+/*
+ *  Copyright 2024 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package org.openmetadata.service.cache;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.schema.EntityInterface;
+import org.openmetadata.schema.type.TagLabel;
+import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.service.jdbi3.CollectionDAO;
+import org.openmetadata.service.util.FullyQualifiedName;
+
+/**
+ * Batched pre-warm for the {@link CachedReadBundle} keys.
+ *
+ * <p>The standard read path's bundle population fans out to ~3 DB queries per entity (TO
+ * relationships, FROM relationships, tag_usage). Doing that during warmup is exactly what
+ * {@link org.openmetadata.service.apps.bundles.cache.CacheWarmupApp} is trying to avoid — it took
+ * hours on modest installs.
+ *
+ * <p>This batcher takes a different tradeoff: it pre-warms only the parts of the bundle that have
+ * cheap batched queries — tags (one batched {@code SELECT ... WHERE targetFQNHash IN (...)}) and
+ * certification (already on the entity JSON we just paged through). Relations are left null so the
+ * read path's lazy populate runs and fills them in on first read. After that first read the bundle
+ * gets re-cached with the full relations map.
+ *
+ * <p>Net benefit: tag and certification reads are warm immediately after warmup, eliminating one of
+ * the three fan-out queries on every first read post-deploy.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class BundleWarmupBatcher {
+  private final CollectionDAO dao;
+  private final CacheProvider cache;
+  private final CacheKeys keys;
+
+  /** Outcome of a batch warmup — caller uses for stats reporting. */
+  public record BatchResult(int success, int failed) {}
+
+  public BatchResult warmupBatch(
+      String entityType, List<? extends EntityInterface> entities, Duration ttl) {
+    if (entities == null || entities.isEmpty()) {
+      return new BatchResult(0, 0);
+    }
+    Map<String, EntityInterface> entitiesByFqnHash = new HashMap<>(entities.size() * 2);
+    List<String> fqnHashes = new ArrayList<>(entities.size());
+    for (EntityInterface entity : entities) {
+      if (entity.getId() == null || entity.getFullyQualifiedName() == null) {
+        continue;
+      }
+      String hash = FullyQualifiedName.buildHash(entity.getFullyQualifiedName());
+      entitiesByFqnHash.put(hash, entity);
+      fqnHashes.add(hash);
+    }
+    if (fqnHashes.isEmpty()) {
+      return new BatchResult(0, 0);
+    }
+
+    Map<String, List<TagLabel>> tagsByFqnHash;
+    try {
+      tagsByFqnHash = dao.tagUsageDAO().getTagsByTargetFQNHashes(fqnHashes);
+    } catch (Exception e) {
+      LOG.warn("Bundle warmup: tag batch fetch failed for type={}", entityType, e);
+      return new BatchResult(0, entities.size());
+    }
+
+    Map<String, String> bundleKeyValues = new HashMap<>(entitiesByFqnHash.size() * 2);
+    int failed = 0;
+    for (Map.Entry<String, EntityInterface> entry : entitiesByFqnHash.entrySet()) {
+      EntityInterface entity = entry.getValue();
+      try {
+        CachedReadBundle.Dto dto = new CachedReadBundle.Dto();
+        // Relations left null on purpose — first read populates via the lazy path. See class
+        // javadoc for the rationale.
+        dto.relations = null;
+        dto.tags = tagsByFqnHash.getOrDefault(entry.getKey(), Collections.emptyList());
+        dto.tagsLoaded = true;
+        dto.certification = entity.getCertification();
+        dto.certificationLoaded = true;
+        bundleKeyValues.put(keys.bundle(entityType, entity.getId()), JsonUtils.pojoToJson(dto));
+      } catch (Exception e) {
+        failed++;
+      }
+    }
+    if (bundleKeyValues.isEmpty()) {
+      return new BatchResult(0, failed);
+    }
+    try {
+      cache.pipelineSet(bundleKeyValues, ttl);
+    } catch (RuntimeException e) {
+      LOG.warn("Bundle warmup: pipelined write failed for type={}", entityType, e);
+      return new BatchResult(0, bundleKeyValues.size() + failed);
+    }
+    return new BatchResult(bundleKeyValues.size(), failed);
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/cache/CacheMetrics.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/cache/CacheMetrics.java
@@ -4,6 +4,8 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.extern.slf4j.Slf4j;
 
@@ -26,6 +28,11 @@ public class CacheMetrics {
   private final AtomicLong warmupEntities = new AtomicLong();
   private final AtomicLong warmupRelationships = new AtomicLong();
   private final AtomicLong warmupTags = new AtomicLong();
+  private final AtomicLong warmupCompletedRuns = new AtomicLong();
+  // Coverage gauges are registered lazily per entity type so we don't need to know the type list
+  // at startup. Holders keep the AtomicLong reference alive so the gauge stays observable.
+  private final Map<String, AtomicLong> coverageGauges = new ConcurrentHashMap<>();
+  private final Map<String, AtomicLong> bundleCoverageGauges = new ConcurrentHashMap<>();
 
   private CacheMetrics(MeterRegistry meterRegistry) {
     this.meterRegistry = meterRegistry;
@@ -94,6 +101,11 @@ public class CacheMetrics {
 
     Gauge.builder("cache.hit.ratio", this, CacheMetrics::getHitRatio)
         .description("Cache hit ratio")
+        .tag("cache", "redis")
+        .register(meterRegistry);
+
+    Gauge.builder("cache.warmup.completed_runs", warmupCompletedRuns, AtomicLong::get)
+        .description("Number of completed warmup runs since process start")
         .tag("cache", "redis")
         .register(meterRegistry);
   }
@@ -170,6 +182,44 @@ public class CacheMetrics {
     warmupEntities.set(entities);
     warmupRelationships.set(relationships);
     warmupTags.set(tags);
+  }
+
+  /**
+   * Record post-warmup coverage for an entity type as the ratio (cached keys / DB row count). A
+   * value below 1.0 indicates cache+DB drift; below ~0.95 signals an unfinished warmup or Redis
+   * outage during warmup. Stored as a percentage 0-100 to keep gauge values intuitive in
+   * dashboards.
+   */
+  public void recordCoverage(String entityType, double ratio) {
+    setOrRegisterCoverageGauge(coverageGauges, "cache.warmup.coverage", entityType, ratio);
+  }
+
+  /** Same as {@link #recordCoverage} but for the bundle pre-warm pass. */
+  public void recordBundleCoverage(String entityType, double ratio) {
+    setOrRegisterCoverageGauge(
+        bundleCoverageGauges, "cache.warmup.bundle.coverage", entityType, ratio);
+  }
+
+  public void recordWarmupCompleted() {
+    warmupCompletedRuns.incrementAndGet();
+  }
+
+  private void setOrRegisterCoverageGauge(
+      Map<String, AtomicLong> holders, String metricName, String entityType, double ratio) {
+    long value = Math.round(Math.max(0.0, Math.min(1.0, ratio)) * 100.0);
+    holders
+        .computeIfAbsent(
+            entityType,
+            type -> {
+              AtomicLong holder = new AtomicLong();
+              Gauge.builder(metricName, holder, AtomicLong::get)
+                  .description("Warmup coverage as percent (cached keys / DB rows)")
+                  .tag("cache", "redis")
+                  .tag("type", type)
+                  .register(meterRegistry);
+              return holder;
+            })
+        .set(value);
   }
 
   private double getHitRatio() {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/cache/CacheProvider.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/cache/CacheProvider.java
@@ -41,6 +41,15 @@ public interface CacheProvider extends AutoCloseable {
 
   Map<String, Object> getStats();
 
+  /**
+   * Count keys matching a glob-style pattern (e.g. {@code "om:prod:e:table:*"}). Implementations
+   * use a server-side SCAN cursor to avoid blocking with KEYS. Default returns -1 for providers
+   * without a scan implementation; callers must treat negative values as "unsupported".
+   */
+  default long scanCount(String pattern) {
+    return -1L;
+  }
+
   @Override
   void close();
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/cache/CacheProvider.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/cache/CacheProvider.java
@@ -45,6 +45,12 @@ public interface CacheProvider extends AutoCloseable {
    * Count keys matching a glob-style pattern (e.g. {@code "om:prod:e:table:*"}). Implementations
    * use a server-side SCAN cursor to avoid blocking with KEYS. Default returns -1 for providers
    * without a scan implementation; callers must treat negative values as "unsupported".
+   *
+   * <p><b>Cost:</b> O(n) over the entire keyspace because Redis SCAN visits every key and applies
+   * the pattern filter server-side. Wall time scales linearly with {@code DBSIZE}, not with the
+   * number of matches. Use sparingly — call it on bounded events (post-warmup, periodic
+   * health-check) rather than on the request path. For large keyspaces consider maintaining a
+   * counter key alongside writes / deletes instead.
    */
   default long scanCount(String pattern) {
     return -1L;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/cache/RedisCacheProvider.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/cache/RedisCacheProvider.java
@@ -432,6 +432,26 @@ public class RedisCacheProvider implements CacheProvider {
   }
 
   @Override
+  public long scanCount(String pattern) {
+    if (!available || pattern == null || pattern.isEmpty()) {
+      return -1L;
+    }
+    try {
+      io.lettuce.core.ScanArgs args = io.lettuce.core.ScanArgs.Builder.matches(pattern).limit(1000);
+      io.lettuce.core.KeyScanCursor<String> cursor = syncCommands.scan(args);
+      long count = cursor.getKeys().size();
+      while (!cursor.isFinished()) {
+        cursor = syncCommands.scan(cursor, args);
+        count += cursor.getKeys().size();
+      }
+      return count;
+    } catch (Exception e) {
+      LOG.warn("scanCount failed for pattern={}", pattern, e);
+      return -1L;
+    }
+  }
+
+  @Override
   public void close() {
     try {
       if (healthChecker != null) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ClassificationRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ClassificationRepository.java
@@ -334,6 +334,10 @@ public class ClassificationRepository extends EntityRepository<Classification> {
       LOG.info("Classification FQN changed from {} to {}", oldFqn, newFqn);
       // Drop cache entries for every tag under this classification BEFORE we rewrite the DB.
       invalidateCacheForRenameCascade(Entity.TAG, oldFqn);
+      // Drop cached entity JSON / bundle for every entity tagged with any tag under this
+      // classification. Tags live in the TAG entity table with FQNs starting with the
+      // classification FQN, so the descendant helper finds them correctly.
+      invalidateCacheForTaggedEntitiesAndDescendants(Entity.TAG, oldFqn);
       daoCollection.tagDAO().updateFqn(oldFqn, newFqn);
       daoCollection
           .tagUsageDAO()

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -120,6 +120,7 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -258,6 +259,7 @@ import org.openmetadata.service.util.RestUtil;
 import org.openmetadata.service.util.RestUtil.DeleteResponse;
 import org.openmetadata.service.util.RestUtil.PatchResponse;
 import org.openmetadata.service.util.RestUtil.PutResponse;
+import org.openmetadata.service.workflows.searchIndex.ReindexingUtil;
 import software.amazon.awssdk.utils.Either;
 
 /**
@@ -2913,6 +2915,20 @@ public abstract class EntityRepository<T extends EntityInterface> {
     if (entityType == null || id == null) {
       return;
     }
+    // Skip every Redis op for entity types that are never cached. Bot/domain/data-product
+    // deletes cascade through many addRelationship/deleteRelationship calls; without this
+    // short-circuit each cascade pays for a pub/sub publish + multiple DELs that touch keys
+    // we never wrote — under heavy parallel load that pushes test budgets like
+    // TaskResourceIT.testDeletingBotCreatorCleansUpOpenSuggestionTasks past their 30 s window.
+    if (!isCacheableEntityType(entityType)) {
+      // Guava L1 still has to be cleared for the rare uncached read path that populates it,
+      // but we skip the Redis hash, relationship, bundle, and pub/sub work entirely.
+      CACHE_WITH_ID.invalidate(new ImmutablePair<>(entityType, id));
+      if (fqn != null) {
+        CACHE_WITH_NAME.invalidate(cacheNameKey(entityType, fqn));
+      }
+      return;
+    }
     CACHE_WITH_ID.invalidate(new ImmutablePair<>(entityType, id));
     if (fqn != null) {
       CACHE_WITH_NAME.invalidate(cacheNameKey(entityType, fqn));
@@ -2953,6 +2969,99 @@ public abstract class EntityRepository<T extends EntityInterface> {
       return;
     }
     invalidateCacheForEntity(record.getType(), record.getId(), extractFqn(record.getJson()));
+  }
+
+  /**
+   * Drop cached entity JSON, bundle, and relationship caches for every entity that carries the
+   * given tag FQN. The {@code tag_usage} table only stores {@code targetFQNHash}, so we cannot
+   * cheaply derive (type, id, fqn) from it; we lean on the search index instead — the same source
+   * the search-side {@code updateClassificationTagByFqnPrefix} reindex uses to find affected
+   * documents. Run this BEFORE the async search reindex starts so the search query still matches
+   * documents by the old tag FQN.
+   *
+   * <p>Recently-tagged entities not yet in search are missed; they fall back to the entity TTL.
+   */
+  public static int invalidateCacheForTaggedEntities(String tagFqn) {
+    if (nullOrEmpty(tagFqn)) {
+      return 0;
+    }
+    int total = 0;
+    int from = 0;
+    while (true) {
+      List<EntityReference> page;
+      try {
+        page =
+            ReindexingUtil.findReferenceInElasticSearchAcrossAllIndexes(
+                "tags.tagFQN", ReindexingUtil.escapeDoubleQuotes(tagFqn), from);
+      } catch (Exception e) {
+        LOG.warn("Search-based cache invalidation failed for tag={}", tagFqn, e);
+        return total;
+      }
+      if (page.isEmpty()) {
+        break;
+      }
+      for (EntityReference ref : page) {
+        invalidateCacheForEntity(ref.getType(), ref.getId(), ref.getFullyQualifiedName());
+        total++;
+      }
+      from += page.size();
+    }
+    if (total > 0) {
+      LOG.info("Invalidated cache for {} entities tagged with: {}", total, tagFqn);
+    }
+    return total;
+  }
+
+  /** Bulk variant — invalidates entities tagged with any of the supplied tag FQNs. */
+  public static int invalidateCacheForTaggedEntities(Collection<String> tagFqns) {
+    if (tagFqns == null || tagFqns.isEmpty()) {
+      return 0;
+    }
+    int total = 0;
+    for (String fqn : tagFqns) {
+      total += invalidateCacheForTaggedEntities(fqn);
+    }
+    if (total > 0) {
+      LOG.info(
+          "Invalidated cache for {} entities across {} renamed tag FQNs", total, tagFqns.size());
+    }
+    return total;
+  }
+
+  /**
+   * Convenience wrapper for tag-like entity renames (Tag, GlossaryTerm) where the rename cascades
+   * to descendants in the same entity table. Enumerates the descendant FQNs from the entity DAO
+   * BEFORE the DB rename rewrites them, then invalidates cached entities tagged with the prefix or
+   * any descendant. For Classification (where children live in a different entity table), enumerate
+   * child tag FQNs at the call site and pass them to {@link
+   * #invalidateCacheForTaggedEntities(Collection)} directly.
+   */
+  public static int invalidateCacheForTaggedEntitiesAndDescendants(
+      String entityType, String oldPrefix) {
+    if (entityType == null || nullOrEmpty(oldPrefix)) {
+      return 0;
+    }
+    List<String> fqns = new ArrayList<>();
+    fqns.add(oldPrefix);
+    try {
+      EntityRepository<?> repo = Entity.getEntityRepository(entityType);
+      if (repo != null && repo.getDao() != null) {
+        List<EntityDAO.EntityIdFqnPair> descendants =
+            repo.getDao().listDescendantIdFqnByPrefix(oldPrefix);
+        for (EntityDAO.EntityIdFqnPair pair : descendants) {
+          if (pair.fqn != null && !pair.fqn.equals(oldPrefix)) {
+            fqns.add(pair.fqn);
+          }
+        }
+      }
+    } catch (Exception e) {
+      LOG.warn(
+          "Failed to enumerate descendants for tagged-entity invalidation: type={} fqn={}",
+          entityType,
+          oldPrefix,
+          e);
+    }
+    return invalidateCacheForTaggedEntities(fqns);
   }
 
   private static String extractFqn(String json) {
@@ -5455,6 +5564,11 @@ public abstract class EntityRepository<T extends EntityInterface> {
               .withRelationshipType(relationship);
       RdfUpdater.addRelationship(reverseRelationship);
     }
+    // Drop cached bundle/owners/domains/container for both sides — relationship just changed and
+    // any cached EntityReference list on either side is now stale. The FQN is unknown here so
+    // by-name eviction is skipped; by-id and bundle eviction is what callers actually need.
+    invalidateCacheForEntity(fromEntity, fromId, null);
+    invalidateCacheForEntity(toEntity, toId, null);
   }
 
   @Transaction
@@ -5463,6 +5577,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
     daoCollection
         .relationshipDAO()
         .bulkInsertToRelationship(fromId, toId, fromEntity, toEntity, relationship.ordinal());
+    invalidateForBulkRelationship(fromId, toId, fromEntity, toEntity);
   }
 
   @Transaction
@@ -5471,6 +5586,18 @@ public abstract class EntityRepository<T extends EntityInterface> {
     daoCollection
         .relationshipDAO()
         .bulkRemoveToRelationship(fromId, toId, fromEntity, toEntity, relationship.ordinal());
+    invalidateForBulkRelationship(fromId, toId, fromEntity, toEntity);
+  }
+
+  private static void invalidateForBulkRelationship(
+      UUID fromId, List<UUID> toIds, String fromEntity, String toEntity) {
+    invalidateCacheForEntity(fromEntity, fromId, null);
+    if (toIds == null) {
+      return;
+    }
+    for (UUID toId : toIds) {
+      invalidateCacheForEntity(toEntity, toId, null);
+    }
   }
 
   public final List<EntityReference> findBoth(
@@ -5771,6 +5898,9 @@ public abstract class EntityRepository<T extends EntityInterface> {
             .withToEntity(toEntityType)
             .withRelationshipType(relationship);
     RdfUpdater.removeRelationship(entityRelationship);
+    // Drop cached bundle/owners/domains/container on both sides — same reason as addRelationship.
+    invalidateCacheForEntity(fromEntityType, fromId, null);
+    invalidateCacheForEntity(toEntityType, toId, null);
   }
 
   public final void deleteTo(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -2979,7 +2979,12 @@ public abstract class EntityRepository<T extends EntityInterface> {
    * documents. Run this BEFORE the async search reindex starts so the search query still matches
    * documents by the old tag FQN.
    *
-   * <p>Recently-tagged entities not yet in search are missed; they fall back to the entity TTL.
+   * <p><b>Consistency tradeoff:</b> coverage is bounded by search-index freshness. Entities
+   * tagged recently enough that the indexer hasn't picked them up are missed and fall back to
+   * the entity TTL (default 48h). On busy clusters with replication lag this can be minutes.
+   * If strict consistency is ever required, a direct {@code tag_usage} table query joined back
+   * to each candidate entity table would be more reliable at the cost of one round-trip per
+   * candidate type.
    */
   public static int invalidateCacheForTaggedEntities(String tagFqn) {
     if (nullOrEmpty(tagFqn)) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
@@ -2184,6 +2184,9 @@ public class GlossaryTermRepository extends EntityRepository<GlossaryTerm> {
       LOG.info("Glossary term FQN changed from {} to {}", oldFqn, newFqn);
       // Drop cache entries for every child term under this renamed term BEFORE the DB rewrite.
       invalidateCacheForRenameCascade(Entity.GLOSSARY_TERM, oldFqn);
+      // Drop cached entity JSON / bundle for every entity tagged with this term (or any
+      // descendant). Done BEFORE the DB rename so the search lookup still matches by old FQN.
+      invalidateCacheForTaggedEntitiesAndDescendants(Entity.GLOSSARY_TERM, oldFqn);
       daoCollection.glossaryTermDAO().updateFqn(oldFqn, newFqn);
       daoCollection.tagUsageDAO().rename(TagSource.GLOSSARY.ordinal(), oldFqn, newFqn);
 
@@ -2250,6 +2253,9 @@ public class GlossaryTermRepository extends EntityRepository<GlossaryTerm> {
 
       // Drop cache entries for every child term under this moved term BEFORE the DB rewrite.
       invalidateCacheForRenameCascade(Entity.GLOSSARY_TERM, oldFqn);
+      // Drop cached entity JSON / bundle for every entity tagged with this term (or any
+      // descendant). Done BEFORE the DB rename so the search lookup still matches by old FQN.
+      invalidateCacheForTaggedEntitiesAndDescendants(Entity.GLOSSARY_TERM, oldFqn);
       daoCollection.glossaryTermDAO().updateFqn(oldFqn, newFqn);
       daoCollection.tagUsageDAO().rename(TagSource.GLOSSARY.ordinal(), oldFqn, newFqn);
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TagRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TagRepository.java
@@ -962,6 +962,9 @@ public class TagRepository extends EntityRepository<Tag> {
         LOG.info("Tag FQN changed from {} to {}", oldFqn, newFqn);
         // Drop cache entries for every child tag under this renamed tag BEFORE the DB rewrite.
         invalidateCacheForRenameCascade(Entity.TAG, oldFqn);
+        // Drop cached entity JSON / bundle for every entity tagged with this tag (or any
+        // descendant). Done BEFORE the DB rename so the search lookup still matches by old FQN.
+        invalidateCacheForTaggedEntitiesAndDescendants(Entity.TAG, oldFqn);
         daoCollection.tagDAO().updateFqn(oldFqn, newFqn);
         daoCollection.tagUsageDAO().rename(TagSource.CLASSIFICATION.ordinal(), oldFqn, newFqn);
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/cache/BundleWarmupBatcherTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/cache/BundleWarmupBatcherTest.java
@@ -1,0 +1,203 @@
+/*
+ *  Copyright 2024 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+package org.openmetadata.service.cache;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.openmetadata.schema.EntityInterface;
+import org.openmetadata.schema.entity.data.Table;
+import org.openmetadata.schema.type.AssetCertification;
+import org.openmetadata.schema.type.TagLabel;
+import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.service.jdbi3.CollectionDAO;
+import org.openmetadata.service.util.FullyQualifiedName;
+
+class BundleWarmupBatcherTest {
+
+  private CollectionDAO dao;
+  private CollectionDAO.TagUsageDAO tagUsageDAO;
+  private CacheProvider cache;
+  private CacheKeys keys;
+  private BundleWarmupBatcher batcher;
+
+  @BeforeEach
+  void setUp() {
+    dao = mock(CollectionDAO.class);
+    tagUsageDAO = mock(CollectionDAO.TagUsageDAO.class);
+    when(dao.tagUsageDAO()).thenReturn(tagUsageDAO);
+    cache = mock(CacheProvider.class);
+    keys = new CacheKeys("om:test");
+    batcher = new BundleWarmupBatcher(dao, cache, keys);
+  }
+
+  @Test
+  void emptyEntitiesShortCircuits() {
+    BundleWarmupBatcher.BatchResult result =
+        batcher.warmupBatch("table", Collections.emptyList(), Duration.ofSeconds(60));
+    assertEquals(0, result.success());
+    assertEquals(0, result.failed());
+    verify(cache, never()).pipelineSet(any(), any());
+    verify(tagUsageDAO, never()).getTagsByTargetFQNHashes(any());
+  }
+
+  @Test
+  void writesBundleKeysWithTagsAndCertification() {
+    Table t1 =
+        new Table()
+            .withId(UUID.randomUUID())
+            .withName("orders")
+            .withFullyQualifiedName("svc.db.schema.orders");
+    Table t2 =
+        new Table()
+            .withId(UUID.randomUUID())
+            .withName("lineitem")
+            .withFullyQualifiedName("svc.db.schema.lineitem");
+    AssetCertification cert =
+        new AssetCertification().withTagLabel(new TagLabel().withTagFQN("Certification.Gold"));
+    t1.withCertification(cert);
+
+    String hash1 = FullyQualifiedName.buildHash(t1.getFullyQualifiedName());
+    String hash2 = FullyQualifiedName.buildHash(t2.getFullyQualifiedName());
+
+    Map<String, List<TagLabel>> tagMap = new HashMap<>();
+    tagMap.put(hash1, List.of(new TagLabel().withTagFQN("PII.Sensitive")));
+    when(tagUsageDAO.getTagsByTargetFQNHashes(any())).thenReturn(tagMap);
+
+    BundleWarmupBatcher.BatchResult result =
+        batcher.warmupBatch("table", List.of(t1, t2), Duration.ofSeconds(60));
+    assertEquals(2, result.success());
+    assertEquals(0, result.failed());
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+    verify(cache, times(1)).pipelineSet(captor.capture(), any(Duration.class));
+    Map<String, String> writes = captor.getValue();
+    assertEquals(2, writes.size());
+
+    String t1Json = writes.get(keys.bundle("table", t1.getId()));
+    assertNotNull(t1Json);
+    CachedReadBundle.Dto t1Dto = JsonUtils.readValue(t1Json, CachedReadBundle.Dto.class);
+    assertNull(t1Dto.relations, "Relations should be left null for lazy populate");
+    assertTrue(t1Dto.tagsLoaded);
+    assertEquals(1, t1Dto.tags.size());
+    assertEquals("PII.Sensitive", t1Dto.tags.get(0).getTagFQN());
+    assertTrue(t1Dto.certificationLoaded);
+    assertNotNull(t1Dto.certification);
+
+    String t2Json = writes.get(keys.bundle("table", t2.getId()));
+    assertNotNull(t2Json);
+    CachedReadBundle.Dto t2Dto = JsonUtils.readValue(t2Json, CachedReadBundle.Dto.class);
+    assertTrue(t2Dto.tagsLoaded);
+    assertTrue(t2Dto.tags.isEmpty(), "Untagged entity should have empty tags list");
+    assertTrue(t2Dto.certificationLoaded);
+    assertNull(t2Dto.certification);
+  }
+
+  @Test
+  void skipsEntitiesMissingIdOrFqn() {
+    Table withoutId = new Table().withName("noId").withFullyQualifiedName("svc.db.schema.noId");
+    Table withoutFqn = new Table().withId(UUID.randomUUID()).withName("noFqn");
+    Table good =
+        new Table()
+            .withId(UUID.randomUUID())
+            .withName("good")
+            .withFullyQualifiedName("svc.db.schema.good");
+
+    when(tagUsageDAO.getTagsByTargetFQNHashes(any())).thenReturn(new HashMap<>());
+
+    BundleWarmupBatcher.BatchResult result =
+        batcher.warmupBatch("table", List.of(withoutId, withoutFqn, good), Duration.ofSeconds(60));
+    assertEquals(1, result.success());
+  }
+
+  @Test
+  void tagFetchFailureMarksAllEntitiesFailed() {
+    Table t1 =
+        new Table()
+            .withId(UUID.randomUUID())
+            .withName("a")
+            .withFullyQualifiedName("svc.db.schema.a");
+    when(tagUsageDAO.getTagsByTargetFQNHashes(any())).thenThrow(new RuntimeException("db down"));
+
+    BundleWarmupBatcher.BatchResult result =
+        batcher.warmupBatch("table", List.of(t1), Duration.ofSeconds(60));
+    assertEquals(0, result.success());
+    assertEquals(1, result.failed());
+    verify(cache, never()).pipelineSet(any(), any());
+  }
+
+  @Test
+  void redisWriteFailureMarksAllEntitiesFailed() {
+    Table t1 =
+        new Table()
+            .withId(UUID.randomUUID())
+            .withName("a")
+            .withFullyQualifiedName("svc.db.schema.a");
+    when(tagUsageDAO.getTagsByTargetFQNHashes(any())).thenReturn(new HashMap<>());
+    org.mockito.Mockito.doThrow(new RuntimeException("pipeline timeout"))
+        .when(cache)
+        .pipelineSet(any(), any());
+
+    BundleWarmupBatcher.BatchResult result =
+        batcher.warmupBatch("table", List.of(t1), Duration.ofSeconds(60));
+    assertEquals(0, result.success());
+    assertTrue(result.failed() >= 1);
+  }
+
+  @Test
+  void usesFqnHashAsTagLookupKey() {
+    Table t1 =
+        new Table()
+            .withId(UUID.randomUUID())
+            .withName("a")
+            .withFullyQualifiedName("svc.db.schema.a");
+    when(tagUsageDAO.getTagsByTargetFQNHashes(any())).thenReturn(new HashMap<>());
+
+    batcher.warmupBatch("table", List.of(t1), Duration.ofSeconds(60));
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<String>> hashesCaptor = ArgumentCaptor.forClass(List.class);
+    verify(tagUsageDAO).getTagsByTargetFQNHashes(hashesCaptor.capture());
+    List<String> hashesPassed = new ArrayList<>(hashesCaptor.getValue());
+    assertEquals(1, hashesPassed.size());
+    assertEquals(FullyQualifiedName.buildHash(t1.getFullyQualifiedName()), hashesPassed.get(0));
+  }
+
+  @Test
+  @SuppressWarnings("unused")
+  /** Sanity: empty list to suppress unused-variable warning on the EntityInterface import. */
+  void typeCompatibility() {
+    List<EntityInterface> empty = Collections.emptyList();
+    BundleWarmupBatcher.BatchResult result =
+        batcher.warmupBatch("table", empty, Duration.ofSeconds(60));
+    assertFalse(result.success() > 0);
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/cache/BundleWarmupBatcherTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/cache/BundleWarmupBatcherTest.java
@@ -11,7 +11,6 @@
 package org.openmetadata.service.cache;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -32,7 +31,6 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.schema.type.AssetCertification;
 import org.openmetadata.schema.type.TagLabel;
@@ -189,15 +187,5 @@ class BundleWarmupBatcherTest {
     List<String> hashesPassed = new ArrayList<>(hashesCaptor.getValue());
     assertEquals(1, hashesPassed.size());
     assertEquals(FullyQualifiedName.buildHash(t1.getFullyQualifiedName()), hashesPassed.get(0));
-  }
-
-  @Test
-  @SuppressWarnings("unused")
-  /** Sanity: empty list to suppress unused-variable warning on the EntityInterface import. */
-  void typeCompatibility() {
-    List<EntityInterface> empty = Collections.emptyList();
-    BundleWarmupBatcher.BatchResult result =
-        batcher.warmupBatch("table", empty, Duration.ofSeconds(60));
-    assertFalse(result.success() > 0);
   }
 }

--- a/openmetadata-spec/src/main/resources/json/schema/entity/applications/configuration/internal/cacheWarmupAppConfig.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/applications/configuration/internal/cacheWarmupAppConfig.json
@@ -33,25 +33,21 @@
       "title": "Batch Size",
       "description": "Number of entities to process in each batch.",
       "type": "integer",
-      "default": 100,
+      "default": 1000,
       "minimum": 10,
       "maximum": 1000
     },
-    "consumerThreads": {
-      "title": "Consumer Threads",
-      "description": "Number of parallel threads for processing entities and warming cache.",
-      "type": "integer",
-      "default": 4,
-      "minimum": 1,
-      "maximum": 10
+    "warmBundles": {
+      "title": "Warm Read Bundles",
+      "description": "Pre-warm the per-entity bundle cache (tags + certification) so the first read after deploy doesn't fan out to the DB. Disable for very large installs.",
+      "type": "boolean",
+      "default": true
     },
-    "queueSize": {
-      "title": "Queue Size",
-      "description": "Internal queue size for entity processing pipeline.",
-      "type": "integer",
-      "default": 1000,
-      "minimum": 100,
-      "maximum": 10000
+    "enableDistributedClaim": {
+      "title": "Enable Distributed Claim",
+      "description": "In multi-instance deployments, claim each entity type via Redis SETNX so only one instance warms it. Disable to let every instance warm independently (idempotent but redundant).",
+      "type": "boolean",
+      "default": false
     },
     "force": {
       "title": "Force Warmup",

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/services/ingestionPipelines/createIngestionPipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/services/ingestionPipelines/createIngestionPipeline.ts
@@ -1104,8 +1104,6 @@ export interface CollateAIAppConfig {
     autoTune?: boolean;
     /**
      * Number of threads to use for reindexing
-     *
-     * Number of parallel threads for processing entities and warming cache.
      */
     consumerThreads?: number;
     /**
@@ -1145,8 +1143,6 @@ export interface CollateAIAppConfig {
     producerThreads?: number;
     /**
      * Queue Size to user internally for reindexing.
-     *
-     * Internal queue size for entity processing pipeline.
      */
     queueSize?: number;
     /**
@@ -1174,9 +1170,20 @@ export interface CollateAIAppConfig {
      */
     useDistributedIndexing?: boolean;
     /**
+     * In multi-instance deployments, claim each entity type via Redis SETNX so only one
+     * instance warms it. Disable to let every instance warm independently (idempotent but
+     * redundant).
+     */
+    enableDistributedClaim?: boolean;
+    /**
      * Force cache warmup even if another instance is detected (use with caution).
      */
     force?: boolean;
+    /**
+     * Pre-warm the per-entity bundle cache (tags + certification) so the first read after
+     * deploy doesn't fan out to the DB. Disable for very large installs.
+     */
+    warmBundles?: boolean;
     /**
      * Enter the retention period for Activity Threads of type = 'Conversation' records in days
      * (e.g., 30 for one month, 60 for two months).

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/applications/app.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/applications/app.ts
@@ -301,8 +301,6 @@ export interface CollateAIAppConfig {
     autoTune?: boolean;
     /**
      * Number of threads to use for reindexing
-     *
-     * Number of parallel threads for processing entities and warming cache.
      */
     consumerThreads?: number;
     /**
@@ -342,8 +340,6 @@ export interface CollateAIAppConfig {
     producerThreads?: number;
     /**
      * Queue Size to user internally for reindexing.
-     *
-     * Internal queue size for entity processing pipeline.
      */
     queueSize?: number;
     /**
@@ -371,9 +367,20 @@ export interface CollateAIAppConfig {
      */
     useDistributedIndexing?: boolean;
     /**
+     * In multi-instance deployments, claim each entity type via Redis SETNX so only one
+     * instance warms it. Disable to let every instance warm independently (idempotent but
+     * redundant).
+     */
+    enableDistributedClaim?: boolean;
+    /**
      * Force cache warmup even if another instance is detected (use with caution).
      */
     force?: boolean;
+    /**
+     * Pre-warm the per-entity bundle cache (tags + certification) so the first read after
+     * deploy doesn't fan out to the DB. Disable for very large installs.
+     */
+    warmBundles?: boolean;
     /**
      * Enter the retention period for Activity Threads of type = 'Conversation' records in days
      * (e.g., 30 for one month, 60 for two months).

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/applications/configuration/internal/cacheWarmupAppConfig.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/applications/configuration/internal/cacheWarmupAppConfig.ts
@@ -19,9 +19,11 @@ export interface CacheWarmupAppConfig {
      */
     batchSize?: number;
     /**
-     * Number of parallel threads for processing entities and warming cache.
+     * In multi-instance deployments, claim each entity type via Redis SETNX so only one
+     * instance warms it. Disable to let every instance warm independently (idempotent but
+     * redundant).
      */
-    consumerThreads?: number;
+    enableDistributedClaim?: boolean;
     /**
      * List of entity types to warm up in cache. Use 'all' to warm up all entity types.
      */
@@ -31,13 +33,14 @@ export interface CacheWarmupAppConfig {
      */
     force?: boolean;
     /**
-     * Internal queue size for entity processing pipeline.
-     */
-    queueSize?: number;
-    /**
      * Application Type
      */
     type?: CacheWarmupType;
+    /**
+     * Pre-warm the per-entity bundle cache (tags + certification) so the first read after
+     * deploy doesn't fan out to the DB. Disable for very large installs.
+     */
+    warmBundles?: boolean;
 }
 
 /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/applications/marketplace/appMarketPlaceDefinition.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/applications/marketplace/appMarketPlaceDefinition.ts
@@ -287,8 +287,6 @@ export interface CollateAIAppConfig {
     autoTune?: boolean;
     /**
      * Number of threads to use for reindexing
-     *
-     * Number of parallel threads for processing entities and warming cache.
      */
     consumerThreads?: number;
     /**
@@ -328,8 +326,6 @@ export interface CollateAIAppConfig {
     producerThreads?: number;
     /**
      * Queue Size to user internally for reindexing.
-     *
-     * Internal queue size for entity processing pipeline.
      */
     queueSize?: number;
     /**
@@ -357,9 +353,20 @@ export interface CollateAIAppConfig {
      */
     useDistributedIndexing?: boolean;
     /**
+     * In multi-instance deployments, claim each entity type via Redis SETNX so only one
+     * instance warms it. Disable to let every instance warm independently (idempotent but
+     * redundant).
+     */
+    enableDistributedClaim?: boolean;
+    /**
      * Force cache warmup even if another instance is detected (use with caution).
      */
     force?: boolean;
+    /**
+     * Pre-warm the per-entity bundle cache (tags + certification) so the first read after
+     * deploy doesn't fan out to the DB. Disable for very large installs.
+     */
+    warmBundles?: boolean;
     /**
      * Enter the retention period for Activity Threads of type = 'Conversation' records in days
      * (e.g., 30 for one month, 60 for two months).

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/applications/marketplace/createAppMarketPlaceDefinitionReq.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/applications/marketplace/createAppMarketPlaceDefinitionReq.ts
@@ -245,8 +245,6 @@ export interface CollateAIAppConfig {
     autoTune?: boolean;
     /**
      * Number of threads to use for reindexing
-     *
-     * Number of parallel threads for processing entities and warming cache.
      */
     consumerThreads?: number;
     /**
@@ -286,8 +284,6 @@ export interface CollateAIAppConfig {
     producerThreads?: number;
     /**
      * Queue Size to user internally for reindexing.
-     *
-     * Internal queue size for entity processing pipeline.
      */
     queueSize?: number;
     /**
@@ -315,9 +311,20 @@ export interface CollateAIAppConfig {
      */
     useDistributedIndexing?: boolean;
     /**
+     * In multi-instance deployments, claim each entity type via Redis SETNX so only one
+     * instance warms it. Disable to let every instance warm independently (idempotent but
+     * redundant).
+     */
+    enableDistributedClaim?: boolean;
+    /**
      * Force cache warmup even if another instance is detected (use with caution).
      */
     force?: boolean;
+    /**
+     * Pre-warm the per-entity bundle cache (tags + certification) so the first read after
+     * deploy doesn't fan out to the DB. Disable for very large installs.
+     */
+    warmBundles?: boolean;
     /**
      * Enter the retention period for Activity Threads of type = 'Conversation' records in days
      * (e.g., 30 for one month, 60 for two months).

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/ingestionPipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/ingestionPipeline.ts
@@ -1695,8 +1695,6 @@ export interface CollateAIAppConfig {
     autoTune?: boolean;
     /**
      * Number of threads to use for reindexing
-     *
-     * Number of parallel threads for processing entities and warming cache.
      */
     consumerThreads?: number;
     /**
@@ -1736,8 +1734,6 @@ export interface CollateAIAppConfig {
     producerThreads?: number;
     /**
      * Queue Size to user internally for reindexing.
-     *
-     * Internal queue size for entity processing pipeline.
      */
     queueSize?: number;
     /**
@@ -1765,9 +1761,20 @@ export interface CollateAIAppConfig {
      */
     useDistributedIndexing?: boolean;
     /**
+     * In multi-instance deployments, claim each entity type via Redis SETNX so only one
+     * instance warms it. Disable to let every instance warm independently (idempotent but
+     * redundant).
+     */
+    enableDistributedClaim?: boolean;
+    /**
      * Force cache warmup even if another instance is detected (use with caution).
      */
     force?: boolean;
+    /**
+     * Pre-warm the per-entity bundle cache (tags + certification) so the first read after
+     * deploy doesn't fan out to the DB. Disable for very large installs.
+     */
+    warmBundles?: boolean;
     /**
      * Enter the retention period for Activity Threads of type = 'Conversation' records in days
      * (e.g., 30 for one month, 60 for two months).

--- a/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/application.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/application.ts
@@ -148,8 +148,6 @@ export interface CollateAIAppConfig {
     autoTune?: boolean;
     /**
      * Number of threads to use for reindexing
-     *
-     * Number of parallel threads for processing entities and warming cache.
      */
     consumerThreads?: number;
     /**
@@ -189,8 +187,6 @@ export interface CollateAIAppConfig {
     producerThreads?: number;
     /**
      * Queue Size to user internally for reindexing.
-     *
-     * Internal queue size for entity processing pipeline.
      */
     queueSize?: number;
     /**
@@ -218,9 +214,20 @@ export interface CollateAIAppConfig {
      */
     useDistributedIndexing?: boolean;
     /**
+     * In multi-instance deployments, claim each entity type via Redis SETNX so only one
+     * instance warms it. Disable to let every instance warm independently (idempotent but
+     * redundant).
+     */
+    enableDistributedClaim?: boolean;
+    /**
      * Force cache warmup even if another instance is detected (use with caution).
      */
     force?: boolean;
+    /**
+     * Pre-warm the per-entity bundle cache (tags + certification) so the first read after
+     * deploy doesn't fan out to the DB. Disable for very large installs.
+     */
+    warmBundles?: boolean;
     /**
      * Enter the retention period for Activity Threads of type = 'Conversation' records in days
      * (e.g., 30 for one month, 60 for two months).

--- a/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/applicationPipeline.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/applicationPipeline.ts
@@ -128,8 +128,6 @@ export interface CollateAIAppConfig {
     autoTune?: boolean;
     /**
      * Number of threads to use for reindexing
-     *
-     * Number of parallel threads for processing entities and warming cache.
      */
     consumerThreads?: number;
     /**
@@ -169,8 +167,6 @@ export interface CollateAIAppConfig {
     producerThreads?: number;
     /**
      * Queue Size to user internally for reindexing.
-     *
-     * Internal queue size for entity processing pipeline.
      */
     queueSize?: number;
     /**
@@ -198,9 +194,20 @@ export interface CollateAIAppConfig {
      */
     useDistributedIndexing?: boolean;
     /**
+     * In multi-instance deployments, claim each entity type via Redis SETNX so only one
+     * instance warms it. Disable to let every instance warm independently (idempotent but
+     * redundant).
+     */
+    enableDistributedClaim?: boolean;
+    /**
      * Force cache warmup even if another instance is detected (use with caution).
      */
     force?: boolean;
+    /**
+     * Pre-warm the per-entity bundle cache (tags + certification) so the first read after
+     * deploy doesn't fan out to the DB. Disable for very large installs.
+     */
+    warmBundles?: boolean;
     /**
      * Enter the retention period for Activity Threads of type = 'Conversation' records in days
      * (e.g., 30 for one month, 60 for two months).

--- a/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/workflow.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/metadataIngestion/workflow.ts
@@ -5981,8 +5981,6 @@ export interface CollateAIAppConfig {
     autoTune?: boolean;
     /**
      * Number of threads to use for reindexing
-     *
-     * Number of parallel threads for processing entities and warming cache.
      */
     consumerThreads?: number;
     /**
@@ -6022,8 +6020,6 @@ export interface CollateAIAppConfig {
     producerThreads?: number;
     /**
      * Queue Size to user internally for reindexing.
-     *
-     * Internal queue size for entity processing pipeline.
      */
     queueSize?: number;
     /**
@@ -6051,9 +6047,20 @@ export interface CollateAIAppConfig {
      */
     useDistributedIndexing?: boolean;
     /**
+     * In multi-instance deployments, claim each entity type via Redis SETNX so only one
+     * instance warms it. Disable to let every instance warm independently (idempotent but
+     * redundant).
+     */
+    enableDistributedClaim?: boolean;
+    /**
      * Force cache warmup even if another instance is detected (use with caution).
      */
     force?: boolean;
+    /**
+     * Pre-warm the per-entity bundle cache (tags + certification) so the first read after
+     * deploy doesn't fan out to the DB. Disable for very large installs.
+     */
+    warmBundles?: boolean;
     /**
      * Enter the retention period for Activity Threads of type = 'Conversation' records in days
      * (e.g., 30 for one month, 60 for two months).


### PR DESCRIPTION
### Describe your changes:

Audited the Redis-backed cache layer and shipped two write-through correctness fixes plus warmup enhancements. **Bug A**: Tag/Glossary/Classification rename now invalidates cached entity JSON for every entity tagged with the renamed tag, using the search index (mirrors the existing `updateClassificationTagByFqnPrefix` fanout pattern). **Bug B**: `addRelationship` / `deleteRelationship` and bulk variants now invalidate the cached bundle on both sides; non-cacheable types (Bot/Domain/DataProduct/Task/etc.) short-circuit so cascade-heavy delete paths don't pay for Redis ops on keys that were never written. **Warmup**: new `BundleWarmupBatcher` pre-warms tags + certification using batched `tag_usage` queries; `CacheWarmupApp` adds checkpoint resume, opt-in `SETNX`-based distributed claim, and per-entity-type `cache.warmup.coverage` gauges. Tests: `BundleWarmupBatcherTest` (mocked unit), `TagRenameCacheIT` and `RelationshipCacheInvalidationIT` (Redis-gated end-to-end).

### Type of change:
- [x] Bug fix
- [x] Improvement

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests that cover the exact scenarios we are fixing.
- [x] For JSON Schema changes: dropped unused `consumerThreads` and `queueSize` fields from `cacheWarmupAppConfig.json` (they were dead config — runtime had already migrated off the producer/consumer queue design); added `warmBundles` and `enableDistributedClaim` flags. No migration needed since the removed fields were never consumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)