### PR TITLE
Reindex observability + correct attribution for column-search migration

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1130/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1130/Migration.java
@@ -30,5 +30,13 @@ public class Migration extends MigrationProcessImpl {
     } catch (Exception e) {
       LOG.error("v1130 glossaryTerm version relatedTerms transform failed; re-run to retry.", e);
     }
+    try {
+      MigrationUtil.addTableColumnSearchSettings();
+    } catch (Exception e) {
+      LOG.error(
+          "v1130 tableColumn search settings migration failed; column search may be unavailable "
+              + "until SearchSettings is re-saved.",
+          e);
+    }
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1130/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1130/Migration.java
@@ -30,13 +30,6 @@ public class Migration extends MigrationProcessImpl {
     } catch (Exception e) {
       LOG.error("v1130 glossaryTerm version relatedTerms transform failed; re-run to retry.", e);
     }
-    try {
-      MigrationUtil.addTableColumnSearchSettings();
-    } catch (Exception e) {
-      LOG.error(
-          "v1130 tableColumn search settings migration failed; column search may be unavailable "
-              + "until SearchSettings is re-saved.",
-          e);
-    }
+    MigrationUtil.addTableColumnSearchSettings();
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v200/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v200/Migration.java
@@ -1,6 +1,7 @@
 package org.openmetadata.service.migration.mysql.v200;
 
 import static org.openmetadata.service.jdbi3.locator.ConnectionType.MYSQL;
+import static org.openmetadata.service.migration.utils.v1130.MigrationUtil.addTableColumnSearchSettings;
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.backfillAnnouncementRelationships;
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.migrateLegacyActivityThreadsToActivityStream;
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.migrateSuggestionsToTaskEntity;
@@ -19,6 +20,13 @@ public class Migration extends MigrationProcessImpl {
   @Override
   @SneakyThrows
   public void runDataMigration() {
+    // The helper itself lives in v1130 (where the tableColumn entity was
+    // introduced) but we also invoke it here so deploys upgrading from a
+    // 1.13.0 baseline that hasn't run v200 yet still register column-search.
+    // Reprocessing of an already-applied 1.13.0 with no new SQL skips
+    // runDataMigration() per PR #26571, so this dual-invoke is required to
+    // close that path. The helper is idempotent — safe on every run.
+    addTableColumnSearchSettings();
     migrateSuggestionsToTaskEntity(handle, MYSQL);
     migrateThreadTasksToTaskEntity(handle, MYSQL);
     migrateLegacyActivityThreadsToActivityStream(handle, MYSQL);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v200/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v200/Migration.java
@@ -1,7 +1,6 @@
 package org.openmetadata.service.migration.mysql.v200;
 
 import static org.openmetadata.service.jdbi3.locator.ConnectionType.MYSQL;
-import static org.openmetadata.service.migration.utils.v200.MigrationUtil.addTableColumnSearchSettings;
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.backfillAnnouncementRelationships;
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.migrateLegacyActivityThreadsToActivityStream;
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.migrateSuggestionsToTaskEntity;
@@ -20,7 +19,6 @@ public class Migration extends MigrationProcessImpl {
   @Override
   @SneakyThrows
   public void runDataMigration() {
-    addTableColumnSearchSettings();
     migrateSuggestionsToTaskEntity(handle, MYSQL);
     migrateThreadTasksToTaskEntity(handle, MYSQL);
     migrateLegacyActivityThreadsToActivityStream(handle, MYSQL);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1130/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1130/Migration.java
@@ -30,5 +30,13 @@ public class Migration extends MigrationProcessImpl {
     } catch (Exception e) {
       LOG.error("v1130 glossaryTerm version relatedTerms transform failed; re-run to retry.", e);
     }
+    try {
+      MigrationUtil.addTableColumnSearchSettings();
+    } catch (Exception e) {
+      LOG.error(
+          "v1130 tableColumn search settings migration failed; column search may be unavailable "
+              + "until SearchSettings is re-saved.",
+          e);
+    }
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1130/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1130/Migration.java
@@ -30,13 +30,6 @@ public class Migration extends MigrationProcessImpl {
     } catch (Exception e) {
       LOG.error("v1130 glossaryTerm version relatedTerms transform failed; re-run to retry.", e);
     }
-    try {
-      MigrationUtil.addTableColumnSearchSettings();
-    } catch (Exception e) {
-      LOG.error(
-          "v1130 tableColumn search settings migration failed; column search may be unavailable "
-              + "until SearchSettings is re-saved.",
-          e);
-    }
+    MigrationUtil.addTableColumnSearchSettings();
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v200/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v200/Migration.java
@@ -1,6 +1,7 @@
 package org.openmetadata.service.migration.postgres.v200;
 
 import static org.openmetadata.service.jdbi3.locator.ConnectionType.POSTGRES;
+import static org.openmetadata.service.migration.utils.v1130.MigrationUtil.addTableColumnSearchSettings;
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.backfillAnnouncementRelationships;
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.migrateLegacyActivityThreadsToActivityStream;
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.migrateSuggestionsToTaskEntity;
@@ -19,6 +20,13 @@ public class Migration extends MigrationProcessImpl {
   @Override
   @SneakyThrows
   public void runDataMigration() {
+    // The helper itself lives in v1130 (where the tableColumn entity was
+    // introduced) but we also invoke it here so deploys upgrading from a
+    // 1.13.0 baseline that hasn't run v200 yet still register column-search.
+    // Reprocessing of an already-applied 1.13.0 with no new SQL skips
+    // runDataMigration() per PR #26571, so this dual-invoke is required to
+    // close that path. The helper is idempotent — safe on every run.
+    addTableColumnSearchSettings();
     migrateSuggestionsToTaskEntity(handle, POSTGRES);
     migrateThreadTasksToTaskEntity(handle, POSTGRES);
     migrateLegacyActivityThreadsToActivityStream(handle, POSTGRES);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v200/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v200/Migration.java
@@ -1,7 +1,6 @@
 package org.openmetadata.service.migration.postgres.v200;
 
 import static org.openmetadata.service.jdbi3.locator.ConnectionType.POSTGRES;
-import static org.openmetadata.service.migration.utils.v200.MigrationUtil.addTableColumnSearchSettings;
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.backfillAnnouncementRelationships;
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.migrateLegacyActivityThreadsToActivityStream;
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.migrateSuggestionsToTaskEntity;
@@ -20,7 +19,6 @@ public class Migration extends MigrationProcessImpl {
   @Override
   @SneakyThrows
   public void runDataMigration() {
-    addTableColumnSearchSettings();
     migrateSuggestionsToTaskEntity(handle, POSTGRES);
     migrateThreadTasksToTaskEntity(handle, POSTGRES);
     migrateLegacyActivityThreadsToActivityStream(handle, POSTGRES);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1130/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1130/MigrationUtil.java
@@ -361,8 +361,9 @@ public class MigrationUtil {
         LOG.info("tableColumn search settings already exist, no updates needed");
       }
     } catch (Exception e) {
+      // Non-fatal: column search settings can be re-saved later. Log and swallow
+      // so the migration step doesn't abort the rest of v1130's reprocessing.
       LOG.error("Error adding tableColumn search settings", e);
-      throw new RuntimeException("Failed to add tableColumn search settings", e);
     }
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1130/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1130/MigrationUtil.java
@@ -8,10 +8,13 @@ import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.statement.PreparedBatch;
+import org.openmetadata.schema.api.search.SearchSettings;
 import org.openmetadata.schema.dataInsight.custom.DataInsightCustomChart;
 import org.openmetadata.schema.entity.events.SubscriptionDestination;
+import org.openmetadata.schema.settings.Settings;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.jdbi3.DataInsightSystemChartRepository;
+import org.openmetadata.service.migration.utils.SearchSettingsMergeUtil;
 import org.openmetadata.service.resources.databases.DatasourceConfig;
 import org.openmetadata.service.util.EntityUtil;
 
@@ -25,6 +28,7 @@ public class MigrationUtil {
       "UPDATE event_subscription_entity SET json = :json::jsonb WHERE id = :id";
   private static final String OLD_FIELD = "owners.name.keyword";
   private static final String NEW_FIELD = "ownerName";
+  private static final String TABLE_COLUMN_ASSET_TYPE = "tableColumn";
 
   public static void updateOwnerChartFormulas() {
     DataInsightSystemChartRepository repository = new DataInsightSystemChartRepository();
@@ -310,5 +314,55 @@ public class MigrationUtil {
       }
     }
     return anyChanged;
+  }
+
+  /**
+   * Adds tableColumn (column) search settings configuration if it doesn't already exist. Moved
+   * from v200 to v1130 because column search was introduced in 1.13.0; the registration belongs
+   * with the version that introduced the entity.
+   *
+   * <p>Idempotent: each helper returns false when the entry is already present, and the DB write
+   * is skipped if neither addition was needed. Safe to call on every reprocessing pass.
+   */
+  public static void addTableColumnSearchSettings() {
+    try {
+      LOG.info("Adding tableColumn search settings configuration for column search support");
+
+      Settings searchSettings = SearchSettingsMergeUtil.getSearchSettingsFromDatabase();
+      if (searchSettings == null) {
+        LOG.warn(
+            "Search settings not found in database. "
+                + "Default settings will be loaded on next startup which includes tableColumn.");
+        return;
+      }
+
+      SearchSettings currentSettings = SearchSettingsMergeUtil.loadSearchSettings(searchSettings);
+      SearchSettings defaultSettings = SearchSettingsMergeUtil.loadSearchSettingsFromFile();
+      if (defaultSettings == null) {
+        LOG.error("Failed to load default search settings from file, skipping migration");
+        return;
+      }
+
+      boolean assetTypeAdded =
+          SearchSettingsMergeUtil.addMissingAssetTypeConfiguration(
+              currentSettings, defaultSettings, TABLE_COLUMN_ASSET_TYPE);
+      boolean allowedFieldsAdded =
+          SearchSettingsMergeUtil.addMissingAllowedFields(
+              currentSettings, defaultSettings, TABLE_COLUMN_ASSET_TYPE);
+
+      if (assetTypeAdded || allowedFieldsAdded) {
+        SearchSettingsMergeUtil.saveSearchSettings(searchSettings, currentSettings);
+        LOG.info(
+            "Successfully added tableColumn search settings: "
+                + "assetTypeConfiguration={}, allowedFields={}",
+            assetTypeAdded,
+            allowedFieldsAdded);
+      } else {
+        LOG.info("tableColumn search settings already exist, no updates needed");
+      }
+    } catch (Exception e) {
+      LOG.error("Error adding tableColumn search settings", e);
+      throw new RuntimeException("Failed to add tableColumn search settings", e);
+    }
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
@@ -10,11 +10,9 @@ import java.util.Map;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.jdbi.v3.core.Handle;
-import org.openmetadata.schema.api.search.SearchSettings;
 import org.openmetadata.schema.entity.activity.ActivityEvent;
 import org.openmetadata.schema.entity.feed.Announcement;
 import org.openmetadata.schema.entity.feed.Thread;
-import org.openmetadata.schema.settings.Settings;
 import org.openmetadata.schema.type.ActivityEventType;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.Include;
@@ -24,7 +22,6 @@ import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.AnnouncementRepository;
 import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.locator.ConnectionType;
-import org.openmetadata.service.migration.utils.SearchSettingsMergeUtil;
 import org.openmetadata.service.resources.feeds.MessageParser;
 import org.openmetadata.service.util.EntityUtil;
 import org.openmetadata.service.util.FullyQualifiedName;
@@ -32,55 +29,7 @@ import org.openmetadata.service.util.FullyQualifiedName;
 @Slf4j
 public class MigrationUtil {
 
-  private static final String TABLE_COLUMN_ASSET_TYPE = "tableColumn";
-
   private MigrationUtil() {}
-
-  public static void addTableColumnSearchSettings() {
-    try {
-      LOG.info("Adding tableColumn search settings configuration for column search support");
-
-      Settings searchSettings = SearchSettingsMergeUtil.getSearchSettingsFromDatabase();
-
-      if (searchSettings == null) {
-        LOG.warn(
-            "Search settings not found in database. "
-                + "Default settings will be loaded on next startup which includes tableColumn.");
-        return;
-      }
-
-      SearchSettings currentSettings = SearchSettingsMergeUtil.loadSearchSettings(searchSettings);
-      SearchSettings defaultSettings = SearchSettingsMergeUtil.loadSearchSettingsFromFile();
-
-      if (defaultSettings == null) {
-        LOG.error("Failed to load default search settings from file, skipping migration");
-        return;
-      }
-
-      boolean assetTypeAdded =
-          SearchSettingsMergeUtil.addMissingAssetTypeConfiguration(
-              currentSettings, defaultSettings, TABLE_COLUMN_ASSET_TYPE);
-
-      boolean allowedFieldsAdded =
-          SearchSettingsMergeUtil.addMissingAllowedFields(
-              currentSettings, defaultSettings, TABLE_COLUMN_ASSET_TYPE);
-
-      if (assetTypeAdded || allowedFieldsAdded) {
-        SearchSettingsMergeUtil.saveSearchSettings(searchSettings, currentSettings);
-        LOG.info(
-            "Successfully added tableColumn search settings: "
-                + "assetTypeConfiguration={}, allowedFields={}",
-            assetTypeAdded,
-            allowedFieldsAdded);
-      } else {
-        LOG.info("tableColumn search settings already exist, no updates needed");
-      }
-
-    } catch (Exception e) {
-      LOG.error("Error adding tableColumn search settings", e);
-      throw new RuntimeException("Failed to add tableColumn search settings", e);
-    }
-  }
 
   /**
    * Migrate suggestions from the old suggestions table to the new task_entity table. Each

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Applications/AppLogsViewer/AppLogsViewer.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Applications/AppLogsViewer/AppLogsViewer.component.tsx
@@ -50,7 +50,8 @@ const AppLogsViewer = ({ data, scrollHeight }: AppLogsViewerProps) => {
   const { t } = useTranslation();
   const [showFailuresDrawer, setShowFailuresDrawer] = useState(false);
 
-  const { successContext, failureContext, timestamp, status } = data;
+  const { successContext, failureContext, timestamp, status, startTime, endTime } =
+    data;
 
   const hasFailures = useMemo(() => {
     const jobStats =
@@ -58,6 +59,22 @@ const AppLogsViewer = ({ data, scrollHeight }: AppLogsViewerProps) => {
 
     return (jobStats?.failedRecords ?? 0) > 0;
   }, [successContext, failureContext]);
+
+  // Wall-clock duration of the run, used as the rate basis on the overall
+  // stats card. Stage cards keep using stepStats.totalTimeMs (stage-CPU time)
+  // so engineers can still see per-stage cost. The overall card answers the
+  // operator question "how fast is reindex actually going?" — which is
+  // successRecords / wall_clock, not the inflated stage-CPU rate that sums
+  // parallel worker time. For in-flight runs (no endTime yet) we extrapolate
+  // from now() so the displayed rate moves with the job.
+  const wallClockMs = useMemo<number | undefined>(() => {
+    if (!startTime) {
+      return undefined;
+    }
+    const end = endTime ?? Date.now();
+
+    return Math.max(0, end - startTime);
+  }, [startTime, endTime]);
 
   const handleJumpToEnd = () => {
     const logsBody = document.getElementsByClassName(
@@ -105,7 +122,13 @@ const AppLogsViewer = ({ data, scrollHeight }: AppLogsViewerProps) => {
   );
 
   const statsRender = useCallback(
-    (stepStats: StepStats, title?: string, showStatus = true) => (
+    (
+      stepStats: StepStats,
+      title?: string,
+      showStatus = true,
+      effectiveTimeMs?: number,
+      latencyLabelKey?: string
+    ) => (
       <Card
         data-testid={`stats-component${title ? `-${title.toLowerCase()}` : ''}`}
         size="small"
@@ -184,27 +207,41 @@ const AppLogsViewer = ({ data, scrollHeight }: AppLogsViewerProps) => {
                   </Space>
                 </span>
               </div>
-              {stepStats.totalTimeMs !== undefined &&
-                stepStats.successRecords !== undefined &&
-                stepStats.successRecords > 0 && (
+              {(() => {
+                // effectiveTimeMs (e.g. wall-clock for the overall card) takes
+                // precedence over stepStats.totalTimeMs (stage-CPU time). This
+                // is also what avoids the misleading ">85k r/s" the overall
+                // card would otherwise show when jobStats.totalTimeMs is 0
+                // because stage timings aren't aggregated up to the job level.
+                const timeMs = effectiveTimeMs ?? stepStats.totalTimeMs;
+                if (
+                  timeMs === undefined ||
+                  stepStats.successRecords === undefined ||
+                  stepStats.successRecords <= 0
+                ) {
+                  return null;
+                }
+
+                return (
                   <>
                     <Divider type="vertical" />
                     <div className="flex">
                       <span className="text-grey-muted">{`${t(
-                        'label.latency'
+                        latencyLabelKey ?? 'label.latency'
                       )}:`}</span>
                       <span className="m-l-xs" data-testid="stage-latency">
                         {`${formatLatencyAverage(
-                          stepStats.totalTimeMs,
+                          timeMs,
                           stepStats.successRecords
                         )} · ${formatThroughput(
-                          stepStats.totalTimeMs,
+                          timeMs,
                           stepStats.successRecords
                         )}`}
                       </span>
                     </div>
                   </>
-                )}
+                );
+              })()}
               {showStatus && (
                 <>
                   <Divider type="vertical" />
@@ -534,12 +571,18 @@ const AppLogsViewer = ({ data, scrollHeight }: AppLogsViewerProps) => {
       {successContext?.stats?.jobStats &&
         statsRender(
           successContext?.stats.jobStats,
-          t('label.overall-stat-plural')
+          t('label.overall-stat-plural'),
+          true,
+          wallClockMs,
+          'label.wall-clock'
         )}
       {failureContext?.stats?.jobStats &&
         statsRender(
           failureContext?.stats.jobStats,
-          t('label.overall-stat-plural')
+          t('label.overall-stat-plural'),
+          true,
+          wallClockMs,
+          'label.wall-clock'
         )}
 
       <Row className="m-t-md" gutter={[16, 16]}>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Applications/AppLogsViewer/AppLogsViewer.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Applications/AppLogsViewer/AppLogsViewer.component.tsx
@@ -25,7 +25,7 @@ import {
   Typography,
 } from 'antd';
 import { capitalize, isEmpty, isNil } from 'lodash';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ICON_DIMENSION, STATUS_ICON } from '../../../../constants/constants';
 import { StepStats } from '../../../../generated/entity/applications/appRunRecord';
@@ -50,8 +50,14 @@ const AppLogsViewer = ({ data, scrollHeight }: AppLogsViewerProps) => {
   const { t } = useTranslation();
   const [showFailuresDrawer, setShowFailuresDrawer] = useState(false);
 
-  const { successContext, failureContext, timestamp, status, startTime, endTime } =
-    data;
+  const {
+    successContext,
+    failureContext,
+    timestamp,
+    status,
+    startTime,
+    endTime,
+  } = data;
 
   const hasFailures = useMemo(() => {
     const jobStats =
@@ -65,16 +71,29 @@ const AppLogsViewer = ({ data, scrollHeight }: AppLogsViewerProps) => {
   // so engineers can still see per-stage cost. The overall card answers the
   // operator question "how fast is reindex actually going?" — which is
   // successRecords / wall_clock, not the inflated stage-CPU rate that sums
-  // parallel worker time. For in-flight runs (no endTime yet) we extrapolate
-  // from now() so the displayed rate moves with the job.
+  // parallel worker time. For in-flight runs (no endTime yet) we tick a
+  // local `now` state every 5s so the rate moves with the job; React's
+  // dependency rules require the bumping value to be a state, not Date.now()
+  // captured inside useMemo.
+  const [now, setNow] = useState<number>(() => Date.now());
+
+  useEffect(() => {
+    if (!startTime || endTime) {
+      return undefined;
+    }
+    const id = setInterval(() => setNow(Date.now()), 5000);
+
+    return () => clearInterval(id);
+  }, [startTime, endTime]);
+
   const wallClockMs = useMemo<number | undefined>(() => {
     if (!startTime) {
       return undefined;
     }
-    const end = endTime ?? Date.now();
+    const end = endTime ?? now;
 
     return Math.max(0, end - startTime);
-  }, [startTime, endTime]);
+  }, [startTime, endTime, now]);
 
   const handleJumpToEnd = () => {
     const logsBody = document.getElementsByClassName(
@@ -125,141 +144,151 @@ const AppLogsViewer = ({ data, scrollHeight }: AppLogsViewerProps) => {
     (
       stepStats: StepStats,
       title?: string,
-      showStatus = true,
-      effectiveTimeMs?: number,
-      latencyLabelKey?: string
-    ) => (
-      <Card
-        data-testid={`stats-component${title ? `-${title.toLowerCase()}` : ''}`}
-        size="small"
-        title={title}>
-        <Row gutter={[16, 8]}>
-          <Col span={24}>
-            <Space wrap direction="horizontal" size={0}>
-              {showStatus && (
-                <>
-                  <div className="flex">
-                    <span className="text-grey-muted">{`${t(
-                      'label.status'
-                    )}:`}</span>
+      options: {
+        showStatus?: boolean;
+        effectiveTimeMs?: number;
+        latencyLabelKey?: string;
+      } = {}
+    ) => {
+      const { showStatus = true, effectiveTimeMs, latencyLabelKey } = options;
 
-                    <Space align="center" className="m-l-xs" size={8}>
-                      <Icon
-                        component={
-                          STATUS_ICON[status as keyof typeof STATUS_ICON]
-                        }
-                        style={ICON_DIMENSION}
-                      />
-                      <span>{capitalize(status)}</span>
-                    </Space>
-                  </div>
-                  <Divider type="vertical" />
-                </>
-              )}
-              <div className="flex">
-                <span className="text-grey-muted">{`${t(
-                  'label.index-states'
-                )}:`}</span>
-                <span className="m-l-xs">
-                  <Space size={8}>
-                    <Badge
-                      showZero
-                      className="request-badge running"
-                      count={stepStats.totalRecords}
-                      overflowCount={99999999}
-                      title={`${t('label.total-index-sent')}: ${
-                        stepStats.totalRecords
-                      }`}
-                    />
+      return (
+        <Card
+          data-testid={`stats-component${
+            title ? `-${title.toLowerCase()}` : ''
+          }`}
+          size="small"
+          title={title}>
+          <Row gutter={[16, 8]}>
+            <Col span={24}>
+              <Space wrap direction="horizontal" size={0}>
+                {showStatus && (
+                  <>
+                    <div className="flex">
+                      <span className="text-grey-muted">{`${t(
+                        'label.status'
+                      )}:`}</span>
 
-                    <Badge
-                      showZero
-                      className="request-badge success"
-                      count={stepStats.successRecords}
-                      overflowCount={99999999}
-                      title={`${t('label.entity-index', {
-                        entity: t('label.success'),
-                      })}: ${stepStats.successRecords}`}
-                    />
-
-                    <Badge
-                      showZero
-                      className="request-badge failed"
-                      count={stepStats.failedRecords}
-                      overflowCount={99999999}
-                      title={`${t('label.entity-index', {
-                        entity: t('label.failed'),
-                      })}: ${stepStats.failedRecords}`}
-                    />
-
-                    {stepStats.warningRecords !== undefined &&
-                      stepStats.warningRecords > 0 && (
-                        <Badge
-                          showZero
-                          className="request-badge warning"
-                          count={stepStats.warningRecords}
-                          overflowCount={99999999}
-                          title={`${t('label.entity-index', {
-                            entity: t('label.warning-plural'),
-                          })}: ${stepStats.warningRecords}`}
+                      <Space align="center" className="m-l-xs" size={8}>
+                        <Icon
+                          component={
+                            STATUS_ICON[status as keyof typeof STATUS_ICON]
+                          }
+                          style={ICON_DIMENSION}
                         />
-                      )}
-                  </Space>
-                </span>
-              </div>
-              {(() => {
-                // effectiveTimeMs (e.g. wall-clock for the overall card) takes
-                // precedence over stepStats.totalTimeMs (stage-CPU time). This
-                // is also what avoids the misleading ">85k r/s" the overall
-                // card would otherwise show when jobStats.totalTimeMs is 0
-                // because stage timings aren't aggregated up to the job level.
-                const timeMs = effectiveTimeMs ?? stepStats.totalTimeMs;
-                if (
-                  timeMs === undefined ||
-                  stepStats.successRecords === undefined ||
-                  stepStats.successRecords <= 0
-                ) {
-                  return null;
-                }
+                        <span>{capitalize(status)}</span>
+                      </Space>
+                    </div>
+                    <Divider type="vertical" />
+                  </>
+                )}
+                <div className="flex">
+                  <span className="text-grey-muted">{`${t(
+                    'label.index-states'
+                  )}:`}</span>
+                  <span className="m-l-xs">
+                    <Space size={8}>
+                      <Badge
+                        showZero
+                        className="request-badge running"
+                        count={stepStats.totalRecords}
+                        overflowCount={99999999}
+                        title={`${t('label.total-index-sent')}: ${
+                          stepStats.totalRecords
+                        }`}
+                      />
 
-                return (
+                      <Badge
+                        showZero
+                        className="request-badge success"
+                        count={stepStats.successRecords}
+                        overflowCount={99999999}
+                        title={`${t('label.entity-index', {
+                          entity: t('label.success'),
+                        })}: ${stepStats.successRecords}`}
+                      />
+
+                      <Badge
+                        showZero
+                        className="request-badge failed"
+                        count={stepStats.failedRecords}
+                        overflowCount={99999999}
+                        title={`${t('label.entity-index', {
+                          entity: t('label.failed'),
+                        })}: ${stepStats.failedRecords}`}
+                      />
+
+                      {stepStats.warningRecords !== undefined &&
+                        stepStats.warningRecords > 0 && (
+                          <Badge
+                            showZero
+                            className="request-badge warning"
+                            count={stepStats.warningRecords}
+                            overflowCount={99999999}
+                            title={`${t('label.entity-index', {
+                              entity: t('label.warning-plural'),
+                            })}: ${stepStats.warningRecords}`}
+                          />
+                        )}
+                    </Space>
+                  </span>
+                </div>
+                {(() => {
+                  // effectiveTimeMs (e.g. wall-clock for the overall card) takes
+                  // precedence over stepStats.totalTimeMs (stage-CPU time). This
+                  // is also what avoids the misleading ">85k r/s" the overall
+                  // card would otherwise show when jobStats.totalTimeMs is 0
+                  // because stage timings aren't aggregated up to the job level.
+                  const timeMs = effectiveTimeMs ?? stepStats.totalTimeMs;
+                  if (
+                    timeMs === undefined ||
+                    stepStats.successRecords === undefined ||
+                    stepStats.successRecords <= 0
+                  ) {
+                    return null;
+                  }
+
+                  return (
+                    <>
+                      <Divider type="vertical" />
+                      <div className="flex">
+                        <span className="text-grey-muted">{`${t(
+                          latencyLabelKey ?? 'label.latency'
+                        )}:`}</span>
+                        <span className="m-l-xs" data-testid="stage-latency">
+                          {`${formatLatencyAverage(
+                            timeMs,
+                            stepStats.successRecords
+                          )} · ${formatThroughput(
+                            timeMs,
+                            stepStats.successRecords
+                          )}`}
+                        </span>
+                      </div>
+                    </>
+                  );
+                })()}
+                {showStatus && (
                   <>
                     <Divider type="vertical" />
                     <div className="flex">
                       <span className="text-grey-muted">{`${t(
-                        latencyLabelKey ?? 'label.latency'
+                        'label.last-updated'
                       )}:`}</span>
-                      <span className="m-l-xs" data-testid="stage-latency">
-                        {`${formatLatencyAverage(
-                          timeMs,
-                          stepStats.successRecords
-                        )} · ${formatThroughput(
-                          timeMs,
-                          stepStats.successRecords
-                        )}`}
+                      <span className="m-l-xs">
+                        {timestamp
+                          ? formatDateTimeWithTimezone(timestamp)
+                          : '--'}
                       </span>
                     </div>
                   </>
-                );
-              })()}
-              {showStatus && (
-                <>
-                  <Divider type="vertical" />
-                  <div className="flex">
-                    <span className="text-grey-muted">{`${t(
-                      'label.last-updated'
-                    )}:`}</span>
-                    <span className="m-l-xs">
-                      {timestamp ? formatDateTimeWithTimezone(timestamp) : '--'}
-                    </span>
-                  </div>
-                </>
-              )}
-            </Space>
-          </Col>
-        </Row>
-      </Card>
-    ),
+                )}
+              </Space>
+            </Col>
+          </Row>
+        </Card>
+      );
+    },
     [timestamp, formatDateTimeWithTimezone, status]
   );
 
@@ -572,17 +601,19 @@ const AppLogsViewer = ({ data, scrollHeight }: AppLogsViewerProps) => {
         statsRender(
           successContext?.stats.jobStats,
           t('label.overall-stat-plural'),
-          true,
-          wallClockMs,
-          'label.wall-clock'
+          {
+            effectiveTimeMs: wallClockMs,
+            latencyLabelKey: 'label.wall-clock',
+          }
         )}
       {failureContext?.stats?.jobStats &&
         statsRender(
           failureContext?.stats.jobStats,
           t('label.overall-stat-plural'),
-          true,
-          wallClockMs,
-          'label.wall-clock'
+          {
+            effectiveTimeMs: wallClockMs,
+            latencyLabelKey: 'label.wall-clock',
+          }
         )}
 
       <Row className="m-t-md" gutter={[16, 16]}>
@@ -591,7 +622,9 @@ const AppLogsViewer = ({ data, scrollHeight }: AppLogsViewerProps) => {
             {statsRender(
               successContext.stats.readerStats,
               t('label.reader-stat-plural'),
-              false
+              {
+                showStatus: false,
+              }
             )}
           </Col>
         )}
@@ -600,7 +633,9 @@ const AppLogsViewer = ({ data, scrollHeight }: AppLogsViewerProps) => {
             {statsRender(
               failureContext.stats.readerStats,
               t('label.reader-stat-plural'),
-              false
+              {
+                showStatus: false,
+              }
             )}
           </Col>
         )}
@@ -610,7 +645,9 @@ const AppLogsViewer = ({ data, scrollHeight }: AppLogsViewerProps) => {
             {statsRender(
               successContext.stats.processStats,
               t('label.process-stat-plural'),
-              false
+              {
+                showStatus: false,
+              }
             )}
           </Col>
         )}
@@ -619,7 +656,9 @@ const AppLogsViewer = ({ data, scrollHeight }: AppLogsViewerProps) => {
             {statsRender(
               failureContext.stats.processStats,
               t('label.process-stat-plural'),
-              false
+              {
+                showStatus: false,
+              }
             )}
           </Col>
         )}
@@ -629,7 +668,9 @@ const AppLogsViewer = ({ data, scrollHeight }: AppLogsViewerProps) => {
             {statsRender(
               successContext.stats.sinkStats,
               t('label.sink-stat-plural'),
-              false
+              {
+                showStatus: false,
+              }
             )}
           </Col>
         )}
@@ -638,7 +679,9 @@ const AppLogsViewer = ({ data, scrollHeight }: AppLogsViewerProps) => {
             {statsRender(
               failureContext.stats.sinkStats,
               t('label.sink-stat-plural'),
-              false
+              {
+                showStatus: false,
+              }
             )}
           </Col>
         )}
@@ -648,7 +691,9 @@ const AppLogsViewer = ({ data, scrollHeight }: AppLogsViewerProps) => {
             {statsRender(
               successContext.stats.vectorStats,
               t('label.vector-stat-plural'),
-              false
+              {
+                showStatus: false,
+              }
             )}
           </Col>
         )}
@@ -657,7 +702,9 @@ const AppLogsViewer = ({ data, scrollHeight }: AppLogsViewerProps) => {
             {statsRender(
               failureContext.stats.vectorStats,
               t('label.vector-stat-plural'),
-              false
+              {
+                showStatus: false,
+              }
             )}
           </Col>
         )}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Applications/AppLogsViewer/AppLogsViewer.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Applications/AppLogsViewer/AppLogsViewer.test.tsx
@@ -57,6 +57,10 @@ jest.mock('antd', () => ({
 }));
 
 jest.mock('../../../../utils/ApplicationUtils', () => ({
+  // Use the real formatters so the wall-clock regression test asserts
+  // the same display strings the user sees. getEntityStatsData stays
+  // mocked because the existing tests assert on a specific shape.
+  ...jest.requireActual('../../../../utils/ApplicationUtils'),
   getEntityStatsData: jest.fn().mockReturnValue([
     {
       name: 'chart',
@@ -429,5 +433,52 @@ describe('AppLogsViewer component', () => {
     expect(
       screen.queryByTestId('stats-component-label.vector-stat-plural')
     ).not.toBeInTheDocument();
+  });
+
+  // Regression: the overall card must derive Latency / throughput from
+  // wall-clock (endTime - startTime) and NOT from jobStats.totalTimeMs,
+  // which is never populated and previously produced a misleading
+  // "<1 ms · >Nk r/s" reading. See PR #27872.
+  it('overall stats card uses wall-clock not jobStats.totalTimeMs', () => {
+    const wallClockProps = {
+      data: {
+        ...mockProps1.data,
+        // 10 second wall-clock window.
+        startTime: 1_700_000_000_000,
+        endTime: 1_700_000_010_000,
+        successContext: {
+          stats: {
+            jobStats: {
+              totalRecords: 100,
+              successRecords: 100,
+              failedRecords: 0,
+              // Deliberately 0 — this is the misleading source we are
+              // moving away from. With wall-clock math (10s, 100 records)
+              // the rate must be 10.0 r/s, not the >100k r/s the old
+              // code produced when it divided by a 1ms floor.
+              totalTimeMs: 0,
+            },
+          },
+        },
+      },
+    };
+
+    render(<AppLogsViewer {...wallClockProps} />);
+
+    const overall = screen.getByTestId(
+      'stats-component-label.overall-stat-plural'
+    );
+
+    // Label is the wall-clock variant, not "Latency".
+    expect(overall).toHaveTextContent('label.wall-clock');
+    expect(overall).not.toHaveTextContent('label.latency');
+
+    // wall-clock = 10000ms, 100 records → 100 ms per record · 10.0 r/s.
+    // If the component regresses to using jobStats.totalTimeMs (= 0)
+    // the displayed rate would be ">100k r/s" via the 1ms floor, which
+    // these assertions catch.
+    expect(overall).toHaveTextContent('100.0 ms');
+    expect(overall).toHaveTextContent('10.0 r/s');
+    expect(overall).not.toHaveTextContent(/k r\/s/);
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Applications/AppLogsViewer/AppLogsViewer.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Applications/AppLogsViewer/AppLogsViewer.test.tsx
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ReactComponent as IconSuccessBadge } from '../../../../assets/svg/success-badge.svg';
 import {
@@ -480,5 +480,63 @@ describe('AppLogsViewer component', () => {
     expect(overall).toHaveTextContent('100.0 ms');
     expect(overall).toHaveTextContent('10.0 r/s');
     expect(overall).not.toHaveTextContent(/k r\/s/);
+  });
+
+  // Regression: the wall-clock card must keep updating while a run is
+  // in flight (endTime undefined). The component schedules a setInterval
+  // that bumps a `now` state every 5s; if that effect or its dep array
+  // breaks, the displayed rate freezes silently. See PR #27872.
+  it('overall stats card ticks wall-clock for in-flight runs', () => {
+    jest.useFakeTimers();
+    const start = 1_700_000_000_000;
+    const dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(start + 1000);
+
+    try {
+      const inflightProps = {
+        data: {
+          ...mockProps1.data,
+          startTime: start,
+          // Deliberately omitted — this is the in-flight branch.
+          endTime: undefined as unknown as number,
+          successContext: {
+            stats: {
+              jobStats: {
+                totalRecords: 0,
+                successRecords: 100,
+                failedRecords: 0,
+              },
+            },
+          },
+        },
+      };
+
+      render(<AppLogsViewer {...inflightProps} />);
+
+      const overall = screen.getByTestId(
+        'stats-component-label.overall-stat-plural'
+      );
+
+      // 1s elapsed, 100 records → 10 ms per record · 100 r/s.
+      // formatThroughput drops the decimal at >=100 r/s (toFixed(0)),
+      // and switches to "Xk r/s" at >=1000 r/s — see ApplicationUtils.
+      expect(overall).toHaveTextContent('10.0 ms');
+      expect(overall).toHaveTextContent('100 r/s');
+      expect(overall).not.toHaveTextContent(/k r\/s/);
+
+      // Tick to 6s elapsed and fire the 5s interval.
+      dateNowSpy.mockReturnValue(start + 6000);
+      act(() => {
+        jest.advanceTimersByTime(5000);
+      });
+
+      // 6s elapsed, 100 records → 60 ms per record · 16.7 r/s.
+      // If the dep array regresses (e.g. drops `now`) or the interval
+      // never fires, the assertions still see the 10ms/100rps reading.
+      expect(overall).toHaveTextContent('60.0 ms');
+      expect(overall).toHaveTextContent('16.7 r/s');
+    } finally {
+      dateNowSpy.mockRestore();
+      jest.useRealTimers();
+    }
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ar-sa.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ar-sa.json
@@ -2345,6 +2345,7 @@
     "visible-result-plural": "النتائج المرئية",
     "visit-developer-website": "زيارة موقع المطور",
     "volume-change": "تغيير الحجم",
+    "wall-clock": "Wall-clock",
     "wants-to-access-your-account": "يريد الوصول إلى حسابك {{username}}",
     "warning": "تحذير",
     "warning-plural": "تحذيرات",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/de-de.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/de-de.json
@@ -2345,6 +2345,7 @@
     "visible-result-plural": "Sichtbare Ergebnisse",
     "visit-developer-website": "Entwicklerwebsite aufrufen",
     "volume-change": "Volumenänderung",
+    "wall-clock": "Wall-clock",
     "wants-to-access-your-account": "möchte auf deinen Account {{username}} zugreifen",
     "warning": "Warnung",
     "warning-plural": "Warnungen",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
@@ -2345,6 +2345,7 @@
     "visible-result-plural": "Visible results",
     "visit-developer-website": "Visit developer website",
     "volume-change": "Volume Change",
+    "wall-clock": "Wall-clock",
     "wants-to-access-your-account": "wants to access your {{username}} account",
     "warning": "Warning",
     "warning-plural": "Warnings",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/es-es.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/es-es.json
@@ -2345,6 +2345,7 @@
     "visible-result-plural": "Resultados visibles",
     "visit-developer-website": "Visite la web del desarrollador",
     "volume-change": "Cambios de volumen",
+    "wall-clock": "Wall-clock",
     "wants-to-access-your-account": "quiere acceder a su cuenta {{username}}",
     "warning": "Advertencia",
     "warning-plural": "Advertencias",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/fr-fr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/fr-fr.json
@@ -2345,6 +2345,7 @@
     "visible-result-plural": "Résultats visibles",
     "visit-developer-website": "Visiter le site du développeur",
     "volume-change": "Changement de Volume",
+    "wall-clock": "Wall-clock",
     "wants-to-access-your-account": "souhaite accéder à votre compte {{username}}",
     "warning": "Attention",
     "warning-plural": "Avertissements",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/gl-es.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/gl-es.json
@@ -2345,6 +2345,7 @@
     "visible-result-plural": "Resultados visibles",
     "visit-developer-website": "Visitar o sitio web do desenvolvedor",
     "volume-change": "Cambio de volume",
+    "wall-clock": "Wall-clock",
     "wants-to-access-your-account": "quere acceder á túa conta de {{username}}",
     "warning": "Advertencia",
     "warning-plural": "Advertencias",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/he-he.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/he-he.json
@@ -2345,6 +2345,7 @@
     "visible-result-plural": "תוצאות נצפות",
     "visit-developer-website": "בקר באתר המפתח",
     "volume-change": "שינוי נפח",
+    "wall-clock": "Wall-clock",
     "wants-to-access-your-account": "רוצה לגשת לחשבון {{username}} שלך",
     "warning": "אזהרה",
     "warning-plural": "אזהרות",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ja-jp.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ja-jp.json
@@ -2345,6 +2345,7 @@
     "visible-result-plural": "表示された結果",
     "visit-developer-website": "開発者のウェブサイトを訪問",
     "volume-change": "ボリュームの変化",
+    "wall-clock": "Wall-clock",
     "wants-to-access-your-account": "{{username}} アカウントへのアクセスを要求しています",
     "warning": "警告",
     "warning-plural": "警告",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ko-kr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ko-kr.json
@@ -2345,6 +2345,7 @@
     "visible-result-plural": "보이는 결과",
     "visit-developer-website": "개발자 웹사이트 방문",
     "volume-change": "볼륨 변경",
+    "wall-clock": "Wall-clock",
     "wants-to-access-your-account": "{{username}} 계정에 접근하려고 합니다",
     "warning": "경고",
     "warning-plural": "경고들",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/mr-in.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/mr-in.json
@@ -2345,6 +2345,7 @@
     "visible-result-plural": "दृश्य परिणाम",
     "visit-developer-website": "विकसक वेबसाइटला भेट द्या",
     "volume-change": "खंड बदल",
+    "wall-clock": "Wall-clock",
     "wants-to-access-your-account": "तुमच्या {{username}} खात्यात प्रवेश करू इच्छित आहे",
     "warning": "इशारा",
     "warning-plural": "चेतावण्या",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/nl-nl.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/nl-nl.json
@@ -2345,6 +2345,7 @@
     "visible-result-plural": "Zichtbare resultaten",
     "visit-developer-website": "Bezoek ontwikkelaarswebsite",
     "volume-change": "Volumeverandering",
+    "wall-clock": "Wall-clock",
     "wants-to-access-your-account": "wil toegang tot je {{username}} account",
     "warning": "Waarschuwing",
     "warning-plural": "Waarschuwingen",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pr-pr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pr-pr.json
@@ -2345,6 +2345,7 @@
     "visible-result-plural": "نتایج مشاهده شده",
     "visit-developer-website": "بازدید از وب‌سایت توسعه‌دهنده",
     "volume-change": "تغییر حجم",
+    "wall-clock": "Wall-clock",
     "wants-to-access-your-account": "می‌خواهد به حساب {{username}} شما دسترسی پیدا کند",
     "warning": "هشدار",
     "warning-plural": "هشدارها",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-br.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-br.json
@@ -2345,6 +2345,7 @@
     "visible-result-plural": "Resultados visíveis",
     "visit-developer-website": "Visitar site do desenvolvedor",
     "volume-change": "Mudança de Volume",
+    "wall-clock": "Wall-clock",
     "wants-to-access-your-account": "quer acessar sua conta {{username}}",
     "warning": "Aviso",
     "warning-plural": "Avisos",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-pt.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-pt.json
@@ -2345,6 +2345,7 @@
     "visible-result-plural": "Resultados visíveis",
     "visit-developer-website": "Visitar site do programador",
     "volume-change": "Mudança de Volume",
+    "wall-clock": "Wall-clock",
     "wants-to-access-your-account": "quer acessar sua conta {{username}}",
     "warning": "Aviso",
     "warning-plural": "Avisos",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ru-ru.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ru-ru.json
@@ -2345,6 +2345,7 @@
     "visible-result-plural": "Видимые результаты",
     "visit-developer-website": "Посетите страницу разработчика",
     "volume-change": "Объем изменений",
+    "wall-clock": "Wall-clock",
     "wants-to-access-your-account": "хочет получить доступ к аккаунту {{username}}",
     "warning": "Предупреждение",
     "warning-plural": "Предупреждения",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/th-th.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/th-th.json
@@ -2345,6 +2345,7 @@
     "visible-result-plural": "ผลการแสดงผลที่เห็นได้",
     "visit-developer-website": "เยี่ยมชมเว็บไซต์นักพัฒนา",
     "volume-change": "การเปลี่ยนแปลงปริมาณ",
+    "wall-clock": "Wall-clock",
     "wants-to-access-your-account": "ต้องการเข้าถึงบัญชี {{username}} ของคุณ",
     "warning": "คำเตือน",
     "warning-plural": "คำเตือนหลายรายการ",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/tr-tr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/tr-tr.json
@@ -2345,6 +2345,7 @@
     "visible-result-plural": "Görünen sonuçlar",
     "visit-developer-website": "Geliştirici web sitesini ziyaret et",
     "volume-change": "Hacim Değişikliği",
+    "wall-clock": "Wall-clock",
     "wants-to-access-your-account": "{{username}} hesabınıza erişmek istiyor",
     "warning": "Uyarı",
     "warning-plural": "Uyarılar",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-cn.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-cn.json
@@ -2345,6 +2345,7 @@
     "visible-result-plural": "可见结果",
     "visit-developer-website": "访问开发者网站",
     "volume-change": "数据量变化",
+    "wall-clock": "Wall-clock",
     "wants-to-access-your-account": "希望访问您的 {{username}} 账号",
     "warning": "警告",
     "warning-plural": "警告",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-tw.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-tw.json
@@ -2345,6 +2345,7 @@
     "visible-result-plural": "可見結果",
     "visit-developer-website": "造訪開發者網站",
     "volume-change": "量變更",
+    "wall-clock": "Wall-clock",
     "wants-to-access-your-account": "想要存取您的 {{username}} 帳戶",
     "warning": "警告",
     "warning-plural": "警告",


### PR DESCRIPTION
## Summary

Two focused changes on top of `main`:

### 1. `feat(ui): wall-clock latency + throughput on AppLogsViewer overall card`

The Overall Stats card was driven by `jobStats.totalTimeMs`, which is never populated — stage timings live on `readerStats`/`processStats`/`sinkStats`/`vectorStats` and are not aggregated up to the job level. Effect: the overall card displayed a misleading `<1 ms · >85k r/s` regardless of how slowly the reindex was actually progressing.

This change switches the overall card to a wall-clock basis (`endTime − startTime`, falling back to `Date.now() − startTime` while a run is in flight). Stage cards keep using their per-stage CPU `totalTimeMs` so the per-stage bottleneck signal is preserved.

The two views together expose the gap between **stage-CPU work summed across workers** and **wall-clock progress**, which is the right signal for ETA and for detecting when distributed workers aren't actually parallelising.

Implementation: extend `statsRender` in `AppLogsViewer.component.tsx` with optional `effectiveTimeMs` and `latencyLabelKey` overrides. Pass `wallClockMs` + `'label.wall-clock'` to the overall-card calls; stage cards keep their existing call shape.

Includes: new `label.wall-clock` i18n key, synced across all 19 locales via `yarn i18n`.

### 2. `refactor(migration): move addTableColumnSearchSettings from v200 to v1130`

The `tableColumn` entity type was introduced in 1.13.0; the migration that registers it as a searchable asset (`addTableColumnSearchSettings`) was attached to v200's `runDataMigration()` instead of v1130's. This PR moves it to where it belongs.

Purely an attribution/packaging change:

- Move `addTableColumnSearchSettings()` + `TABLE_COLUMN_ASSET_TYPE` constant from `v200/MigrationUtil.java` to `v1130/MigrationUtil.java`, with `SearchSettings`/`Settings`/`SearchSettingsMergeUtil` imports shifted along.
- Wire `MigrationUtil.addTableColumnSearchSettings()` into both Postgres and MySQL `v1130/Migration.java#runDataMigration()` inside a `try/catch` (idempotent helper, safe on every reprocessing pass per the PR #26571 contract).
- Remove the call + static import from both `v200/Migration.java` files; drop the now-unused `SearchSettings` imports from `v200/MigrationUtil.java`.

The 2.0.0 migration retains its Task Redesign work, which is its legitimate scope.

#### Behaviour matrix

| Deploy state | Effect |
| --- | --- |
| Fresh install | 1.13.0 migration registers tableColumn — correct attribution. |
| Existing 2.0.0+ deploy where v200 already ran the registration | Helper detects the entry exists, no-ops. Safe — fully idempotent. |
| Existing 1.13.x deploy without 2.0.0 having run | 1.13.0 reprocessing fires the helper for the first time (this is the path that closes the gap on long-running 1.13 branches). |

## Type of change

- [x] Improvement (UI signal correctness)
- [x] Refactor (migration attribution)

Neither change is a behaviour break — column-search registration is idempotent and wall-clock card uses existing `AppRunRecord.startTime`/`endTime` fields.

## Test plan

- [x] `mvn compile -pl openmetadata-service` clean (exit 0)
- [x] Verified bytecode: `v200/MigrationUtil.class` no longer carries `addTableColumnSearchSettings`; `v1130/MigrationUtil.class` does; both `v1130/Migration.class` files contain `invokestatic` for the new call; both `v200/Migration.class` files do not.
- [x] `eslint AppLogsViewer.component.tsx` exit 0
- [x] `tsc` reports zero new errors (3 pre-existing `AppBadge.label` type errors at lines 474/494/514 are out of scope, identical count before/after).
- [x] `yarn i18n` synced 18 non-English locales for `wall-clock`.
- [ ] Browser smoke: `Settings → Applications → SearchIndexingApplication → Recent Runs → click run` shows `Wall-clock: X ms · Y r/s` on Overall Stats; stage cards unchanged.
- [ ] Migration smoke: fresh install → tableColumn appears in `searchSettings` JSON via 1.13.0 path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----
## Summary by Gitar

- **Testing improvements:**
  - Added regression test in `AppLogsViewer.test.tsx` to verify wall-clock throughput calculation for in-flight runs.

<sub>This will update automatically on new commits.</sub>