### PR TITLE
Containers: FQN-driven hierarchy listings + cascade-delete orphan fix

### DIFF
--- a/bootstrap/sql/migrations/native/1.13.0/mysql/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.13.0/mysql/schemaChanges.sql
@@ -307,7 +307,7 @@ ALTER TABLE search_index_server_stats
   ADD COLUMN sinkTimeMs BIGINT NOT NULL DEFAULT 0,
   ADD COLUMN vectorTimeMs BIGINT NOT NULL DEFAULT 0;
 
--- The Postgres counterpart to this file adds a `varchar_pattern_ops` index
+-- The Postgres counterpart to this file adds a `text_pattern_ops` index
 -- on `fqnHash` for every entity table to make `?service=` / `?database=` /
 -- `?databaseSchema=` / `?parent=` listings (which compile to
 -- `fqnHash LIKE 'prefix%'`) index-driven instead of seq-scan-driven on RDS.

--- a/bootstrap/sql/migrations/native/1.13.0/postgres/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.13.0/postgres/schemaChanges.sql
@@ -337,12 +337,22 @@ ALTER TABLE search_index_server_stats
 -- RDS). Neither qualifies the planner to use the index for `LIKE 'prefix%'`,
 -- so count(*) and the page query degrade to a parallel seq scan over the
 -- JSONB heap — observed at ~3s on a ~580k-row storage_container_entity table
--- even with ANALYZE / VACUUM tuned. A `varchar_pattern_ops` index supports
--- LIKE-prefix lookups regardless of column collation, dropping cold count(*)
--- on a service-filtered listing from seconds to tens of milliseconds.
--- `varchar_pattern_ops` matches the actual column type (`VARCHAR(768)` /
--- `VARCHAR(256)`); `text_pattern_ops` would also work via implicit casting
--- but the type-matched opclass is the canonical choice.
+-- even with ANALYZE / VACUUM tuned. A pattern-ops index supports LIKE-prefix
+-- lookups regardless of column collation, dropping cold count(*) on a
+-- service-filtered listing from seconds to tens of milliseconds.
+--
+-- Why `text_pattern_ops` and not `varchar_pattern_ops`:
+-- `fqnHash` is declared `VARCHAR(768)` / `VARCHAR(256)`, so on paper
+-- `varchar_pattern_ops` is the type-matched choice. In practice the planner
+-- normalizes `varchar LIKE text` (which is what every JDBC `setString` call
+-- and any `encode(...)`-derived RHS produces) by casting the column to text:
+-- the resulting filter expression is `(fqnhash)::text ~~ ...`. The
+-- `varchar_pattern_ops` opclass does NOT match that cast expression — the
+-- index is silently unused and the table seq-scans. `text_pattern_ops`
+-- matches `(varchar_col)::text ~~ ...` and gets picked up. Confirmed via
+-- EXPLAIN ANALYZE on a 580k-row storage_container_entity: the same query
+-- drops from ~470ms cold (Parallel Seq Scan) to <1ms (Index Scan) after
+-- recreating the index with `text_pattern_ops`.
 --
 -- Built CONCURRENTLY so the migration does not take a write lock on these
 -- tables (matches the 1.11.0 `idx_tag_usage_*` pattern). Each statement runs
@@ -382,48 +392,48 @@ ALTER TABLE search_index_server_stats
 -- `CHARACTER SET ascii COLLATE ascii_bin`, a binary collation that already
 -- permits prefix scans on the unique index. This pass is Postgres-only.
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_chart_entity_fqnhash_pattern
-    ON chart_entity (fqnHash varchar_pattern_ops);
+    ON chart_entity (fqnHash text_pattern_ops);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_dashboard_entity_fqnhash_pattern
-    ON dashboard_entity (fqnHash varchar_pattern_ops);
+    ON dashboard_entity (fqnHash text_pattern_ops);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_dashboard_data_model_entity_fqnhash_pattern
-    ON dashboard_data_model_entity (fqnHash varchar_pattern_ops);
+    ON dashboard_data_model_entity (fqnHash text_pattern_ops);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_database_entity_fqnhash_pattern
-    ON database_entity (fqnHash varchar_pattern_ops);
+    ON database_entity (fqnHash text_pattern_ops);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_database_schema_entity_fqnhash_pattern
-    ON database_schema_entity (fqnHash varchar_pattern_ops);
+    ON database_schema_entity (fqnHash text_pattern_ops);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_glossary_term_entity_fqnhash_pattern
-    ON glossary_term_entity (fqnHash varchar_pattern_ops);
+    ON glossary_term_entity (fqnHash text_pattern_ops);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_ingestion_pipeline_entity_fqnhash_pattern
-    ON ingestion_pipeline_entity (fqnHash varchar_pattern_ops);
+    ON ingestion_pipeline_entity (fqnHash text_pattern_ops);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_metric_entity_fqnhash_pattern
-    ON metric_entity (fqnHash varchar_pattern_ops);
+    ON metric_entity (fqnHash text_pattern_ops);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_ml_model_entity_fqnhash_pattern
-    ON ml_model_entity (fqnHash varchar_pattern_ops);
+    ON ml_model_entity (fqnHash text_pattern_ops);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_policy_entity_fqnhash_pattern
-    ON policy_entity (fqnHash varchar_pattern_ops);
+    ON policy_entity (fqnHash text_pattern_ops);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_query_entity_fqnhash_pattern
-    ON query_entity (fqnHash varchar_pattern_ops);
+    ON query_entity (fqnHash text_pattern_ops);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_report_entity_fqnhash_pattern
-    ON report_entity (fqnHash varchar_pattern_ops);
+    ON report_entity (fqnHash text_pattern_ops);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_search_index_entity_fqnhash_pattern
-    ON search_index_entity (fqnHash varchar_pattern_ops);
+    ON search_index_entity (fqnHash text_pattern_ops);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_storage_container_entity_fqnhash_pattern
-    ON storage_container_entity (fqnHash varchar_pattern_ops);
+    ON storage_container_entity (fqnHash text_pattern_ops);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_table_entity_fqnhash_pattern
-    ON table_entity (fqnHash varchar_pattern_ops);
+    ON table_entity (fqnHash text_pattern_ops);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_test_case_fqnhash_pattern
-    ON test_case (fqnHash varchar_pattern_ops);
+    ON test_case (fqnHash text_pattern_ops);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_topic_entity_fqnhash_pattern
-    ON topic_entity (fqnHash varchar_pattern_ops);
+    ON topic_entity (fqnHash text_pattern_ops);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_api_collection_entity_fqnhash_pattern
-    ON api_collection_entity (fqnHash varchar_pattern_ops);
+    ON api_collection_entity (fqnHash text_pattern_ops);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_api_endpoint_entity_fqnhash_pattern
-    ON api_endpoint_entity (fqnHash varchar_pattern_ops);
+    ON api_endpoint_entity (fqnHash text_pattern_ops);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_directory_entity_fqnhash_pattern
-    ON directory_entity (fqnHash varchar_pattern_ops);
+    ON directory_entity (fqnHash text_pattern_ops);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_file_entity_fqnhash_pattern
-    ON file_entity (fqnHash varchar_pattern_ops);
+    ON file_entity (fqnHash text_pattern_ops);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_spreadsheet_entity_fqnhash_pattern
-    ON spreadsheet_entity (fqnHash varchar_pattern_ops);
+    ON spreadsheet_entity (fqnHash text_pattern_ops);
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_worksheet_entity_fqnhash_pattern
-    ON worksheet_entity (fqnHash varchar_pattern_ops);
+    ON worksheet_entity (fqnHash text_pattern_ops);

--- a/bootstrap/sql/migrations/native/1.13.0/postgres/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.13.0/postgres/schemaChanges.sql
@@ -359,16 +359,23 @@ ALTER TABLE search_index_server_stats
 -- outside an implicit transaction, which the OpenMetadata native migration
 -- runner already supports — see 1.11.0/postgres/schemaChanges.sql.
 --
+-- Recreate, not "create if missing": the original 1.13.0 ship of these indexes
+-- used `varchar_pattern_ops` (incorrect — see the "Why text_pattern_ops" block
+-- above). On already-upgraded environments the old index already exists under
+-- the same name with the wrong opclass, and a plain `CREATE INDEX CONCURRENTLY
+-- IF NOT EXISTS` would no-op against that. We DROP first so the new SQL text
+-- (which `MigrationProcessImpl` keys on by hash, so it re-runs even after the
+-- old version was applied) actually replaces the existing index. On a fresh
+-- install the DROP is a no-op via `IF EXISTS`. The CREATE keeps `IF NOT EXISTS`
+-- only as a defensive against an interrupted-then-resumed migration where the
+-- DROP succeeded but the CREATE was killed before completion.
+--
 -- OPERATOR RUNBOOK — interrupted CONCURRENTLY builds.
 -- If a `CREATE INDEX CONCURRENTLY` is interrupted (deploy timeout, lock
 -- contention, OOM, connection drop), Postgres leaves an INVALID index
--- behind. With `IF NOT EXISTS` here (kept for idempotency on re-deploys
--- and force-mode reruns), a retry would silently skip the rebuild and
--- leave the table without a usable pattern index — the symptom would be
--- a service-filtered listing reverting to seq-scan latency on that one
--- table. The MigrationProcessImpl runner caches statements by SQL text
--- hash, so an embedded cleanup step cannot be made to re-run on retry —
--- this is a known pattern-level gap (also present in 1.11.0).
+-- behind. The `MigrationProcessImpl` runner caches statements by SQL text
+-- hash, so an embedded cleanup step cannot be made to re-run on retry — this
+-- is a known pattern-level gap (also present in 1.11.0).
 --
 -- Detection (run on the affected tenant):
 --   SELECT c.relname FROM pg_class c
@@ -391,49 +398,72 @@ ALTER TABLE search_index_server_stats
 -- MySQL is unaffected: every entity-table `fqnHash` column ships with
 -- `CHARACTER SET ascii COLLATE ascii_bin`, a binary collation that already
 -- permits prefix scans on the unique index. This pass is Postgres-only.
+DROP INDEX CONCURRENTLY IF EXISTS idx_chart_entity_fqnhash_pattern;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_chart_entity_fqnhash_pattern
     ON chart_entity (fqnHash text_pattern_ops);
+DROP INDEX CONCURRENTLY IF EXISTS idx_dashboard_entity_fqnhash_pattern;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_dashboard_entity_fqnhash_pattern
     ON dashboard_entity (fqnHash text_pattern_ops);
+DROP INDEX CONCURRENTLY IF EXISTS idx_dashboard_data_model_entity_fqnhash_pattern;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_dashboard_data_model_entity_fqnhash_pattern
     ON dashboard_data_model_entity (fqnHash text_pattern_ops);
+DROP INDEX CONCURRENTLY IF EXISTS idx_database_entity_fqnhash_pattern;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_database_entity_fqnhash_pattern
     ON database_entity (fqnHash text_pattern_ops);
+DROP INDEX CONCURRENTLY IF EXISTS idx_database_schema_entity_fqnhash_pattern;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_database_schema_entity_fqnhash_pattern
     ON database_schema_entity (fqnHash text_pattern_ops);
+DROP INDEX CONCURRENTLY IF EXISTS idx_glossary_term_entity_fqnhash_pattern;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_glossary_term_entity_fqnhash_pattern
     ON glossary_term_entity (fqnHash text_pattern_ops);
+DROP INDEX CONCURRENTLY IF EXISTS idx_ingestion_pipeline_entity_fqnhash_pattern;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_ingestion_pipeline_entity_fqnhash_pattern
     ON ingestion_pipeline_entity (fqnHash text_pattern_ops);
+DROP INDEX CONCURRENTLY IF EXISTS idx_metric_entity_fqnhash_pattern;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_metric_entity_fqnhash_pattern
     ON metric_entity (fqnHash text_pattern_ops);
+DROP INDEX CONCURRENTLY IF EXISTS idx_ml_model_entity_fqnhash_pattern;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_ml_model_entity_fqnhash_pattern
     ON ml_model_entity (fqnHash text_pattern_ops);
+DROP INDEX CONCURRENTLY IF EXISTS idx_policy_entity_fqnhash_pattern;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_policy_entity_fqnhash_pattern
     ON policy_entity (fqnHash text_pattern_ops);
+DROP INDEX CONCURRENTLY IF EXISTS idx_query_entity_fqnhash_pattern;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_query_entity_fqnhash_pattern
     ON query_entity (fqnHash text_pattern_ops);
+DROP INDEX CONCURRENTLY IF EXISTS idx_report_entity_fqnhash_pattern;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_report_entity_fqnhash_pattern
     ON report_entity (fqnHash text_pattern_ops);
+DROP INDEX CONCURRENTLY IF EXISTS idx_search_index_entity_fqnhash_pattern;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_search_index_entity_fqnhash_pattern
     ON search_index_entity (fqnHash text_pattern_ops);
+DROP INDEX CONCURRENTLY IF EXISTS idx_storage_container_entity_fqnhash_pattern;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_storage_container_entity_fqnhash_pattern
     ON storage_container_entity (fqnHash text_pattern_ops);
+DROP INDEX CONCURRENTLY IF EXISTS idx_table_entity_fqnhash_pattern;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_table_entity_fqnhash_pattern
     ON table_entity (fqnHash text_pattern_ops);
+DROP INDEX CONCURRENTLY IF EXISTS idx_test_case_fqnhash_pattern;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_test_case_fqnhash_pattern
     ON test_case (fqnHash text_pattern_ops);
+DROP INDEX CONCURRENTLY IF EXISTS idx_topic_entity_fqnhash_pattern;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_topic_entity_fqnhash_pattern
     ON topic_entity (fqnHash text_pattern_ops);
+DROP INDEX CONCURRENTLY IF EXISTS idx_api_collection_entity_fqnhash_pattern;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_api_collection_entity_fqnhash_pattern
     ON api_collection_entity (fqnHash text_pattern_ops);
+DROP INDEX CONCURRENTLY IF EXISTS idx_api_endpoint_entity_fqnhash_pattern;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_api_endpoint_entity_fqnhash_pattern
     ON api_endpoint_entity (fqnHash text_pattern_ops);
+DROP INDEX CONCURRENTLY IF EXISTS idx_directory_entity_fqnhash_pattern;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_directory_entity_fqnhash_pattern
     ON directory_entity (fqnHash text_pattern_ops);
+DROP INDEX CONCURRENTLY IF EXISTS idx_file_entity_fqnhash_pattern;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_file_entity_fqnhash_pattern
     ON file_entity (fqnHash text_pattern_ops);
+DROP INDEX CONCURRENTLY IF EXISTS idx_spreadsheet_entity_fqnhash_pattern;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_spreadsheet_entity_fqnhash_pattern
     ON spreadsheet_entity (fqnHash text_pattern_ops);
+DROP INDEX CONCURRENTLY IF EXISTS idx_worksheet_entity_fqnhash_pattern;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_worksheet_entity_fqnhash_pattern
     ON worksheet_entity (fqnHash text_pattern_ops);

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ContainerResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ContainerResourceIT.java
@@ -29,6 +29,7 @@ import org.openmetadata.schema.type.ContainerDataModel;
 import org.openmetadata.schema.type.ContainerFileFormat;
 import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.type.Relationship;
 import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.schema.type.api.BulkOperationResult;
 import org.openmetadata.schema.utils.ResultList;
@@ -36,6 +37,8 @@ import org.openmetadata.sdk.client.OpenMetadataClient;
 import org.openmetadata.sdk.models.ListParams;
 import org.openmetadata.sdk.models.ListResponse;
 import org.openmetadata.sdk.network.HttpMethod;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.jdbi3.CollectionDAO;
 
 /**
  * Integration tests for Container entity operations.
@@ -1306,6 +1309,501 @@ public class ContainerResourceIT extends BaseEntityIT<Container, CreateContainer
             .withType("container")
             .withFullyQualifiedName(parent.getFullyQualifiedName()));
     return createEntity(request);
+  }
+
+  /**
+   * Reproduces the production symptom on aws_s3 where leaf parquet / integration-dataset
+   * containers leaked into {@code ?root=true&service=...} listings. The leak happens when
+   * a child container exists in {@code storage_container_entity} with a multi-segment FQN
+   * but the {@code (parent, CONTAINS, child)} row is missing from
+   * {@code entity_relationship} — produced by the cascade-delete bug in
+   * {@code processDeletionBatch} that wiped relationship rows before per-entity cleanup
+   * (see {@link org.openmetadata.service.jdbi3.EntityRepository#processDeletionBatch}).
+   * We simulate that exact state here by deleting the relationship row directly and
+   * assert the root listing now excludes the orphan via the FQN-depth predicate
+   * ({@code fqnHash NOT LIKE :serviceHashChild}).
+   */
+  @Test
+  void test_rootListingExcludesOrphanedChild(TestNamespace ns) {
+    StorageService service = StorageServiceTestFactory.createS3(ns);
+
+    CreateContainer parentRequest = new CreateContainer();
+    parentRequest.setName(ns.prefix("orphan_parent"));
+    parentRequest.setService(service.getFullyQualifiedName());
+    Container parent = createEntity(parentRequest);
+
+    Container child = createChild(ns, service, parent, "orphan_child");
+
+    int rowsRemoved =
+        Entity.getCollectionDAO()
+            .relationshipDAO()
+            .delete(
+                parent.getId(),
+                "container",
+                child.getId(),
+                "container",
+                Relationship.CONTAINS.ordinal());
+    assertEquals(
+        1, rowsRemoved, "Setup: should have removed exactly one (parent, CONTAINS, child) row");
+
+    ListParams rootParams = new ListParams();
+    rootParams.addFilter("root", "true");
+    rootParams.setService(service.getFullyQualifiedName());
+    ListResponse<Container> rootContainers = listEntities(rootParams);
+
+    Set<UUID> ids =
+        rootContainers.getData().stream()
+            .map(Container::getId)
+            .collect(java.util.stream.Collectors.toSet());
+    assertTrue(ids.contains(parent.getId()), "Real root container must still appear in ?root=true listing");
+    assertFalse(
+        ids.contains(child.getId()),
+        "Orphaned child (multi-segment FQN, no parent CONTAINS row) must be excluded from "
+            + "?root=true listing — fqnHash depth predicate is the safety net.");
+  }
+
+  /**
+   * Forces the {@code batchDeleteChildren} / {@code processDeletionBatch} path:
+   * {@code deleteChildren} only takes the batch path when {@code hardDelete=true} AND
+   * {@code children.size() > 100}. Previously that path pre-deleted relationships in
+   * two batched queries before iterating {@code cleanup()} per child, and swallowed any
+   * per-child exception in the loop — so a single failed cleanup left an entity row
+   * alive with all its relationship rows already wiped (orphan with multi-segment FQN).
+   * The fix routes everything through {@code cleanup()} per entity and lets exceptions
+   * propagate. 101 is one above the 100-child threshold that gates the batch path.
+   */
+  @Test
+  void test_recursiveHardDelete_largeBatch_leavesNoOrphans(TestNamespace ns) {
+    StorageService service = StorageServiceTestFactory.createS3(ns);
+
+    CreateContainer parentRequest = new CreateContainer();
+    parentRequest.setName(ns.prefix("batch_parent"));
+    parentRequest.setService(service.getFullyQualifiedName());
+    Container parent = createEntity(parentRequest);
+
+    // Sequential creation is deliberate: each child must round-trip through the regular
+    // POST /containers path so ContainerRepository.storeRelationships writes a real
+    // (parent, CONTAINS, child) row — that's the row whose cleanup we're stress-testing.
+    int childCount = 101;
+    List<UUID> childIds = new ArrayList<>(childCount);
+    for (int i = 0; i < childCount; i++) {
+      Container child = createChild(ns, service, parent, "batch_child_" + i);
+      childIds.add(child.getId());
+    }
+
+    java.util.Map<String, String> deleteParams = new java.util.HashMap<>();
+    deleteParams.put("hardDelete", "true");
+    deleteParams.put("recursive", "true");
+    SdkClients.adminClient().containers().delete(parent.getId().toString(), deleteParams);
+
+    assertThrows(
+        Exception.class, () -> getEntity(parent.getId().toString()), "Parent must be hard-deleted");
+
+    for (UUID childId : childIds) {
+      assertThrows(
+          Exception.class,
+          () -> getEntity(childId.toString()),
+          "Child " + childId + " must be hard-deleted (no orphan entity row)");
+    }
+
+    List<String> childIdStrings = childIds.stream().map(UUID::toString).toList();
+    List<CollectionDAO.EntityRelationshipObject> orphanParentRows =
+        Entity.getCollectionDAO()
+            .relationshipDAO()
+            .findFromBatch(childIdStrings, Relationship.CONTAINS.ordinal());
+    assertTrue(
+        orphanParentRows.isEmpty(),
+        "No (parent, CONTAINS, child) entity_relationship rows must survive — "
+            + "found "
+            + orphanParentRows.size()
+            + " orphan rows after recursive hard delete of >100 children");
+  }
+
+  /**
+   * The {@code ?root=true} listing must reject anything whose FQN is two or more segments
+   * below the service — not just immediate children of containers, but grandchildren and
+   * deeper. The previous implementation (a NOT EXISTS anti-join over entity_relationship)
+   * relied on the parent CONTAINS edge being present on every non-root container; orphans
+   * and bulk-imported leaves missing that edge would surface at the service root with a
+   * deeply-nested FQN, contradicting the breadcrumb the UI shows on click. The FQN-depth
+   * predicate ({@code fqnHash NOT LIKE :serviceHashChild}) makes the FQN itself the source
+   * of truth. This test exercises the depth check at three levels (root, child, grandchild)
+   * to guard against regressions in either direction (over-filtering or under-filtering).
+   */
+  @Test
+  void test_rootListing_excludesContainersBelowFirstLevel(TestNamespace ns) {
+    StorageService service = StorageServiceTestFactory.createS3(ns);
+
+    CreateContainer rootRequest = new CreateContainer();
+    rootRequest.setName(ns.prefix("depth_root"));
+    rootRequest.setService(service.getFullyQualifiedName());
+    Container root = createEntity(rootRequest);
+
+    Container child = createChild(ns, service, root, "depth_child");
+    Container grandchild = createChild(ns, service, child, "depth_grandchild");
+
+    ListParams params = new ListParams();
+    params.addFilter("root", "true");
+    params.setService(service.getFullyQualifiedName());
+
+    ListResponse<Container> rootContainers = listEntities(params);
+    assertNotNull(rootContainers);
+    assertNotNull(rootContainers.getData());
+
+    Set<UUID> ids =
+        rootContainers.getData().stream().map(Container::getId).collect(java.util.stream.Collectors.toSet());
+    assertTrue(ids.contains(root.getId()), "root container must appear in ?root=true listing");
+    assertFalse(ids.contains(child.getId()), "child must not appear in ?root=true listing");
+    assertFalse(
+        ids.contains(grandchild.getId()),
+        "grandchild must not appear in ?root=true listing — depth check must exclude descendants below the immediate level");
+  }
+
+  /**
+   * Soft-deleted root containers must respect the {@code ?include=} flag the UI's "Deleted"
+   * toggle sends. {@code include=non-deleted} (the default) hides them; {@code include=all}
+   * surfaces them; {@code include=deleted} surfaces only deleted rows. The depth-check
+   * predicate runs alongside the include filter via {@code <sqlCondition>}; this guards
+   * against the include slot getting dropped or hardcoded to non-deleted in the listRoot
+   * SQL.
+   */
+  @Test
+  void test_rootListing_respectsIncludeFlag(TestNamespace ns) {
+    StorageService service = StorageServiceTestFactory.createS3(ns);
+
+    CreateContainer liveRequest = new CreateContainer();
+    liveRequest.setName(ns.prefix("include_live"));
+    liveRequest.setService(service.getFullyQualifiedName());
+    Container liveRoot = createEntity(liveRequest);
+
+    CreateContainer deletedRequest = new CreateContainer();
+    deletedRequest.setName(ns.prefix("include_deleted"));
+    deletedRequest.setService(service.getFullyQualifiedName());
+    Container deletedRoot = createEntity(deletedRequest);
+
+    deleteEntity(deletedRoot.getId().toString());
+
+    // Default: include=non-deleted → only live root visible.
+    ListParams ndParams = new ListParams();
+    ndParams.addFilter("root", "true");
+    ndParams.setService(service.getFullyQualifiedName());
+    Set<UUID> ndIds =
+        listEntities(ndParams).getData().stream()
+            .map(Container::getId)
+            .collect(java.util.stream.Collectors.toSet());
+    assertTrue(ndIds.contains(liveRoot.getId()), "live root must appear under include=non-deleted");
+    assertFalse(
+        ndIds.contains(deletedRoot.getId()),
+        "soft-deleted root must NOT appear under include=non-deleted (default)");
+
+    // include=all → both live and soft-deleted roots visible.
+    ListParams allParams = new ListParams();
+    allParams.addFilter("root", "true");
+    allParams.addFilter("include", "all");
+    allParams.setService(service.getFullyQualifiedName());
+    Set<UUID> allIds =
+        listEntities(allParams).getData().stream()
+            .map(Container::getId)
+            .collect(java.util.stream.Collectors.toSet());
+    assertTrue(allIds.contains(liveRoot.getId()), "live root must appear under include=all");
+    assertTrue(
+        allIds.contains(deletedRoot.getId()),
+        "soft-deleted root must appear under include=all (UI Deleted toggle ON)");
+  }
+
+  /**
+   * The {@code /containers/name/{fqn}/children} endpoint must list direct children only —
+   * grandchildren stay hidden. The previous entity_relationship implementation got this
+   * right when the parent CONTAINS edges existed. The FQN-depth implementation gets it
+   * right by construction (a grandchild has two more segments than the parent and so is
+   * excluded by {@code fqnHash NOT LIKE :parentHashChild}).
+   */
+  @Test
+  void test_listChildren_excludesGrandchildren(TestNamespace ns) throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    StorageService service = StorageServiceTestFactory.createS3(ns);
+
+    CreateContainer parentRequest = new CreateContainer();
+    parentRequest.setName(ns.prefix("kids_parent"));
+    parentRequest.setService(service.getFullyQualifiedName());
+    Container parent = createEntity(parentRequest);
+
+    Container child = createChild(ns, service, parent, "kids_child");
+    Container grandchild = createChild(ns, service, child, "kids_grandchild");
+
+    ContainerResultList page =
+        client
+            .getHttpClient()
+            .execute(
+                HttpMethod.GET,
+                "/v1/containers/name/" + parent.getFullyQualifiedName() + "/children",
+                null,
+                ContainerResultList.class);
+    assertNotNull(page);
+    assertNotNull(page.getData());
+    Set<UUID> ids =
+        page.getData().stream().map(Container::getId).collect(java.util.stream.Collectors.toSet());
+    assertTrue(ids.contains(child.getId()), "direct child must appear in /children listing");
+    assertFalse(
+        ids.contains(grandchild.getId()),
+        "grandchild must not appear in /children — depth check is exactly one level below the parent");
+    assertEquals(
+        1,
+        page.getData().stream()
+            .filter(c -> c.getId().equals(child.getId()) || c.getId().equals(grandchild.getId()))
+            .count(),
+        "page must contain exactly the direct child");
+  }
+
+  /**
+   * The {@code /children} endpoint accepts {@code ?include=all|deleted|non-deleted}
+   * to drive the soft-delete toggle on the navigation tree. The cache key for the
+   * children-page cache embeds the include value, so toggling does not return a stale
+   * page from the other side; this test exercises both the SQL filter and (when Redis
+   * is enabled) the cache key separation.
+   */
+  @Test
+  void test_listChildren_respectsIncludeFlag(TestNamespace ns) throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    StorageService service = StorageServiceTestFactory.createS3(ns);
+
+    CreateContainer parentRequest = new CreateContainer();
+    parentRequest.setName(ns.prefix("kids_include_parent"));
+    parentRequest.setService(service.getFullyQualifiedName());
+    Container parent = createEntity(parentRequest);
+
+    Container live = createChild(ns, service, parent, "kids_include_live");
+    Container deleted = createChild(ns, service, parent, "kids_include_deleted");
+    deleteEntity(deleted.getId().toString());
+
+    String basePath = "/v1/containers/name/" + parent.getFullyQualifiedName() + "/children";
+
+    ContainerResultList nonDeletedPage =
+        client
+            .getHttpClient()
+            .execute(HttpMethod.GET, basePath, null, ContainerResultList.class);
+    Set<UUID> ndIds =
+        nonDeletedPage.getData().stream()
+            .map(Container::getId)
+            .collect(java.util.stream.Collectors.toSet());
+    assertTrue(ndIds.contains(live.getId()), "live child must appear by default");
+    assertFalse(
+        ndIds.contains(deleted.getId()),
+        "soft-deleted child must NOT appear under default include=non-deleted");
+
+    ContainerResultList allPage =
+        client
+            .getHttpClient()
+            .execute(
+                HttpMethod.GET, basePath + "?include=all", null, ContainerResultList.class);
+    Set<UUID> allIds =
+        allPage.getData().stream()
+            .map(Container::getId)
+            .collect(java.util.stream.Collectors.toSet());
+    assertTrue(allIds.contains(live.getId()), "live child must appear under include=all");
+    assertTrue(
+        allIds.contains(deleted.getId()),
+        "soft-deleted child must appear under include=all (cache must not return the non-deleted page from a previous read)");
+  }
+
+  /**
+   * The FQN-depth predicate must produce direct-children-only at <em>any</em> level of
+   * the hierarchy, not just the service root. Build a 5-level chain
+   * (root → l1 → l2 → l3 → l4) and walk down, asserting at each non-leaf level that
+   * {@code /children} returns exactly the immediate next level — no deeper descendants
+   * leak through, no immediate child is missed.
+   *
+   * <p>This is the per-level dual of {@link #test_rootListing_excludesContainersBelowFirstLevel}.
+   * The depth check is mathematical (a fqnHash exactly one MD5 segment below the parent
+   * has exactly one extra '.' separator), so it should hold uniformly at every depth;
+   * a regression at level N (e.g. a planner choosing the wrong index, or someone
+   * computing parentHashChild from the wrong prefix) would only surface in this kind of
+   * iterative test.
+   */
+  @Test
+  void test_listChildren_atArbitraryDepth_returnsOnlyDirectChildren(TestNamespace ns)
+      throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    StorageService service = StorageServiceTestFactory.createS3(ns);
+
+    CreateContainer rootRequest = new CreateContainer();
+    rootRequest.setName(ns.prefix("depth_chain_root"));
+    rootRequest.setService(service.getFullyQualifiedName());
+    Container root = createEntity(rootRequest);
+
+    // Build the chain: root → l1 → l2 → l3 → l4. List<Container> chain captures each
+    // level so we can inspect the FQNs and IDs in order.
+    List<Container> chain = new ArrayList<>();
+    chain.add(root);
+    Container current = root;
+    for (int level = 1; level <= 4; level++) {
+      current = createChild(ns, service, current, "depth_chain_l" + level);
+      chain.add(current);
+    }
+
+    // For each non-leaf level i in [0, 3], /children of chain[i] must contain
+    // exactly chain[i+1] and nothing deeper from this branch.
+    for (int i = 0; i < chain.size() - 1; i++) {
+      Container parent = chain.get(i);
+      Container expectedChild = chain.get(i + 1);
+
+      ContainerResultList page =
+          client
+              .getHttpClient()
+              .execute(
+                  HttpMethod.GET,
+                  "/v1/containers/name/" + parent.getFullyQualifiedName() + "/children",
+                  null,
+                  ContainerResultList.class);
+      assertNotNull(page);
+      assertNotNull(page.getData());
+
+      Set<UUID> ids =
+          page.getData().stream()
+              .map(Container::getId)
+              .collect(java.util.stream.Collectors.toSet());
+
+      assertTrue(
+          ids.contains(expectedChild.getId()),
+          "Level " + i + ": direct child " + expectedChild.getName() + " must appear in /children");
+
+      // Every deeper level in the same chain must NOT leak through.
+      for (int j = i + 2; j < chain.size(); j++) {
+        Container deeper = chain.get(j);
+        assertFalse(
+            ids.contains(deeper.getId()),
+            "Level "
+                + i
+                + ": deeper descendant "
+                + deeper.getName()
+                + " (level "
+                + j
+                + ") must not appear in /children — FQN-depth check must hold at every level");
+      }
+    }
+  }
+
+  /**
+   * The dual of {@link #test_rootListingExcludesOrphanedChild}: when a container's parent
+   * CONTAINS row is missing, the orphan must <em>still</em> be discoverable under its
+   * FQN-implied parent's {@code /children} listing. The current FQN-based listing reads
+   * the FQN as the source of truth, so the orphan appears under its real ancestor even
+   * though the relationship row is gone — which is what the breadcrumb UI assumes.
+   *
+   * <p>This is the correctness invariant we lose if {@code /children} ever falls back to
+   * an {@code entity_relationship}-based lookup again.
+   */
+  @Test
+  void test_listChildren_orphanWithMissingRelationship_isStillDiscoverable(TestNamespace ns)
+      throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    StorageService service = StorageServiceTestFactory.createS3(ns);
+
+    CreateContainer rootRequest = new CreateContainer();
+    rootRequest.setName(ns.prefix("orphan_kids_root"));
+    rootRequest.setService(service.getFullyQualifiedName());
+    Container root = createEntity(rootRequest);
+
+    Container intermediate = createChild(ns, service, root, "orphan_kids_intermediate");
+    Container leaf = createChild(ns, service, intermediate, "orphan_kids_leaf");
+
+    // Drop the (intermediate, CONTAINS, leaf) relationship row to simulate the cascade
+    // bug's residue. The leaf's row stays in storage_container_entity, its FQN still
+    // points at intermediate, but the relationship table no longer says "intermediate
+    // contains leaf".
+    int rowsRemoved =
+        Entity.getCollectionDAO()
+            .relationshipDAO()
+            .delete(
+                intermediate.getId(),
+                "container",
+                leaf.getId(),
+                "container",
+                Relationship.CONTAINS.ordinal());
+    assertEquals(1, rowsRemoved, "Setup: should have dropped exactly one CONTAINS row");
+
+    // Despite the missing relationship, /children of intermediate must surface the leaf
+    // because the listing is FQN-driven. This is the correctness payoff of moving off
+    // entity_relationship for hierarchy listings.
+    ContainerResultList page =
+        client
+            .getHttpClient()
+            .execute(
+                HttpMethod.GET,
+                "/v1/containers/name/" + intermediate.getFullyQualifiedName() + "/children",
+                null,
+                ContainerResultList.class);
+    assertNotNull(page);
+    assertNotNull(page.getData());
+
+    Set<UUID> ids =
+        page.getData().stream().map(Container::getId).collect(java.util.stream.Collectors.toSet());
+    assertTrue(
+        ids.contains(leaf.getId()),
+        "Leaf must still appear in /children of its FQN-implied parent even though the "
+            + "(parent, CONTAINS, leaf) row was lost — FQN is the source of truth.");
+  }
+
+  /**
+   * Sibling subtrees at any depth must not bleed into one another. Build a small
+   * branching shape — root with two children A and B, each with one grandchild —
+   * and verify {@code /children} of A returns only its grandchild, never B's. Guards
+   * against a regression where {@code parentHash} computation accidentally captures
+   * sibling prefixes (e.g. by stripping fewer separators than intended) or the depth
+   * check is dropped at a non-root level.
+   */
+  @Test
+  void test_listChildren_doesNotLeakSiblingSubtree(TestNamespace ns) throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    StorageService service = StorageServiceTestFactory.createS3(ns);
+
+    CreateContainer rootRequest = new CreateContainer();
+    rootRequest.setName(ns.prefix("siblings_root"));
+    rootRequest.setService(service.getFullyQualifiedName());
+    Container root = createEntity(rootRequest);
+
+    Container branchA = createChild(ns, service, root, "siblings_branchA");
+    Container branchB = createChild(ns, service, root, "siblings_branchB");
+    Container grandchildA = createChild(ns, service, branchA, "siblings_grandchildA");
+    Container grandchildB = createChild(ns, service, branchB, "siblings_grandchildB");
+
+    // /children of branchA: only grandchildA, never grandchildB.
+    ContainerResultList branchAPage =
+        client
+            .getHttpClient()
+            .execute(
+                HttpMethod.GET,
+                "/v1/containers/name/" + branchA.getFullyQualifiedName() + "/children",
+                null,
+                ContainerResultList.class);
+    Set<UUID> aIds =
+        branchAPage.getData().stream()
+            .map(Container::getId)
+            .collect(java.util.stream.Collectors.toSet());
+    assertTrue(aIds.contains(grandchildA.getId()), "grandchildA must appear under branchA");
+    assertFalse(
+        aIds.contains(grandchildB.getId()),
+        "grandchildB must not leak into branchA's /children — sibling subtree isolation");
+    assertFalse(
+        aIds.contains(branchB.getId()), "branchB must not appear under branchA's /children");
+
+    // /children of branchB: only grandchildB, never grandchildA.
+    ContainerResultList branchBPage =
+        client
+            .getHttpClient()
+            .execute(
+                HttpMethod.GET,
+                "/v1/containers/name/" + branchB.getFullyQualifiedName() + "/children",
+                null,
+                ContainerResultList.class);
+    Set<UUID> bIds =
+        branchBPage.getData().stream()
+            .map(Container::getId)
+            .collect(java.util.stream.Collectors.toSet());
+    assertTrue(bIds.contains(grandchildB.getId()), "grandchildB must appear under branchB");
+    assertFalse(
+        bIds.contains(grandchildA.getId()),
+        "grandchildA must not leak into branchB's /children — sibling subtree isolation");
   }
 
   @Test

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ContainerResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ContainerResourceIT.java
@@ -1464,6 +1464,68 @@ public class ContainerResourceIT extends BaseEntityIT<Container, CreateContainer
   }
 
   /**
+   * {@code ?root=true} without {@code ?service=} must succeed: it returns every direct
+   * child of any service across the whole tenant. The depth predicate
+   * ({@code fqnHash NOT LIKE :serviceHashChild}) needs the bind to be present even in
+   * this case, but {@link org.openmetadata.service.jdbi3.ListFilter#getServiceCondition}
+   * only adds it when {@code ?service=} is present — the
+   * {@code ContainerDAO.rootListingParams} default ({@code '%.%.%'}) is what makes the
+   * SQL runnable here.
+   *
+   * <p>Regression guard for the "GET /containers?root=true (no service) crashes with a
+   * missing-named-parameter error" bug. Also verifies the depth check still excludes
+   * non-root descendants when no service prefix narrows the candidate set.
+   */
+  @Test
+  void test_rootListing_withoutServiceFilter_returnsRootsAcrossAllServices(TestNamespace ns) {
+    // Two distinct services. Each gets a root container and a child container so we can
+    // assert the listing covers both services and excludes children regardless of which
+    // service they belong to.
+    StorageService serviceA = StorageServiceTestFactory.createS3(ns);
+    StorageService serviceB = StorageServiceTestFactory.createS3(ns);
+
+    CreateContainer rootARequest = new CreateContainer();
+    rootARequest.setName(ns.prefix("noservice_rootA"));
+    rootARequest.setService(serviceA.getFullyQualifiedName());
+    Container rootA = createEntity(rootARequest);
+    Container childA = createChild(ns, serviceA, rootA, "noservice_childA");
+
+    CreateContainer rootBRequest = new CreateContainer();
+    rootBRequest.setName(ns.prefix("noservice_rootB"));
+    rootBRequest.setService(serviceB.getFullyQualifiedName());
+    Container rootB = createEntity(rootBRequest);
+    Container childB = createChild(ns, serviceB, rootB, "noservice_childB");
+
+    // ListParams with root=true but no service filter. Pagination: ask for a large page
+    // so both roots fit even if the tenant has unrelated rows from earlier tests.
+    ListParams params = new ListParams();
+    params.addFilter("root", "true");
+    params.setLimit(1000);
+
+    ListResponse<Container> rootContainers = listEntities(params);
+    assertNotNull(rootContainers);
+    assertNotNull(rootContainers.getData());
+
+    Set<UUID> ids =
+        rootContainers.getData().stream()
+            .map(Container::getId)
+            .collect(java.util.stream.Collectors.toSet());
+
+    assertTrue(
+        ids.contains(rootA.getId()),
+        "Root in serviceA must appear in ?root=true (no service filter) — rootListingParams default must allow cross-service listing");
+    assertTrue(
+        ids.contains(rootB.getId()),
+        "Root in serviceB must appear in ?root=true (no service filter)");
+    assertFalse(
+        ids.contains(childA.getId()),
+        "Child in serviceA must not appear — depth check must run even without service filter");
+    assertFalse(
+        ids.contains(childB.getId()),
+        "Child in serviceB must not appear — depth check must run even without service filter");
+  }
+
+  /**
    * Soft-deleted root containers must respect the {@code ?include=} flag the UI's "Deleted"
    * toggle sends. {@code include=non-deleted} (the default) hides them; {@code include=all}
    * surfaces them; {@code include=deleted} surfaces only deleted rows. The depth-check

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ContainerResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ContainerResourceIT.java
@@ -1355,7 +1355,9 @@ public class ContainerResourceIT extends BaseEntityIT<Container, CreateContainer
         rootContainers.getData().stream()
             .map(Container::getId)
             .collect(java.util.stream.Collectors.toSet());
-    assertTrue(ids.contains(parent.getId()), "Real root container must still appear in ?root=true listing");
+    assertTrue(
+        ids.contains(parent.getId()),
+        "Real root container must still appear in ?root=true listing");
     assertFalse(
         ids.contains(child.getId()),
         "Orphaned child (multi-segment FQN, no parent CONTAINS row) must be excluded from "
@@ -1451,7 +1453,9 @@ public class ContainerResourceIT extends BaseEntityIT<Container, CreateContainer
     assertNotNull(rootContainers.getData());
 
     Set<UUID> ids =
-        rootContainers.getData().stream().map(Container::getId).collect(java.util.stream.Collectors.toSet());
+        rootContainers.getData().stream()
+            .map(Container::getId)
+            .collect(java.util.stream.Collectors.toSet());
     assertTrue(ids.contains(root.getId()), "root container must appear in ?root=true listing");
     assertFalse(ids.contains(child.getId()), "child must not appear in ?root=true listing");
     assertFalse(
@@ -1579,9 +1583,7 @@ public class ContainerResourceIT extends BaseEntityIT<Container, CreateContainer
     String basePath = "/v1/containers/name/" + parent.getFullyQualifiedName() + "/children";
 
     ContainerResultList nonDeletedPage =
-        client
-            .getHttpClient()
-            .execute(HttpMethod.GET, basePath, null, ContainerResultList.class);
+        client.getHttpClient().execute(HttpMethod.GET, basePath, null, ContainerResultList.class);
     Set<UUID> ndIds =
         nonDeletedPage.getData().stream()
             .map(Container::getId)
@@ -1594,8 +1596,7 @@ public class ContainerResourceIT extends BaseEntityIT<Container, CreateContainer
     ContainerResultList allPage =
         client
             .getHttpClient()
-            .execute(
-                HttpMethod.GET, basePath + "?include=all", null, ContainerResultList.class);
+            .execute(HttpMethod.GET, basePath + "?include=all", null, ContainerResultList.class);
     Set<UUID> allIds =
         allPage.getData().stream()
             .map(Container::getId)

--- a/openmetadata-service/src/main/java/org/openmetadata/service/cache/CacheKeys.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/cache/CacheKeys.java
@@ -104,10 +104,11 @@ public final class CacheKeys {
    * parent's FQN hash + the per-parent version + page coordinates so a single version bump
    * orphans every cached page in one shot.
    *
-   * <p>{@code include} (a 1-2 char tag — "nd" / "all" / "d") is part of the key because the
-   * page result depends on whether soft-deleted children are included. Without this, toggling
-   * the UI's "Deleted" switch would return a stale page from the other side until the
-   * version stamp rotates.
+   * <p>{@code include} (a 1-2 char tag — "nd" / "a" / "d", produced by
+   * {@link org.openmetadata.service.cache.ChildrenPageCache#includeTag}) is part of the key
+   * because the page result depends on whether soft-deleted children are included. Without
+   * this, toggling the UI's "Deleted" switch would return a stale page from the other side
+   * until the version stamp rotates.
    */
   public String childrenPage(
       String type, String parentFqn, String version, int limit, int offset, String includeTag) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/cache/CacheKeys.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/cache/CacheKeys.java
@@ -103,9 +103,32 @@ public final class CacheKeys {
    * Cached page of {@code /v1/&lt;entityType&gt;/name/{parentFqn}/children}. Keyed by the
    * parent's FQN hash + the per-parent version + page coordinates so a single version bump
    * orphans every cached page in one shot.
+   *
+   * <p>{@code include} (a 1-2 char tag — "nd" / "all" / "d") is part of the key because the
+   * page result depends on whether soft-deleted children are included. Without this, toggling
+   * the UI's "Deleted" switch would return a stale page from the other side until the
+   * version stamp rotates.
    */
-  public String childrenPage(String type, String parentFqn, String version, int limit, int offset) {
+  public String childrenPage(
+      String type,
+      String parentFqn,
+      String version,
+      int limit,
+      int offset,
+      String includeTag) {
     String fqnHash = FullyQualifiedName.buildHash(parentFqn);
-    return ns + ":kids:" + type + ":" + fqnHash + ":v" + version + ":l" + limit + ":o" + offset;
+    return ns
+        + ":kids:"
+        + type
+        + ":"
+        + fqnHash
+        + ":v"
+        + version
+        + ":i"
+        + includeTag
+        + ":l"
+        + limit
+        + ":o"
+        + offset;
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/cache/CacheKeys.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/cache/CacheKeys.java
@@ -104,11 +104,11 @@ public final class CacheKeys {
    * parent's FQN hash + the per-parent version + page coordinates so a single version bump
    * orphans every cached page in one shot.
    *
-   * <p>{@code include} (a 1-2 char tag — "nd" / "a" / "d", produced by
-   * {@link org.openmetadata.service.cache.ChildrenPageCache#includeTag}) is part of the key
-   * because the page result depends on whether soft-deleted children are included. Without
-   * this, toggling the UI's "Deleted" switch would return a stale page from the other side
-   * until the version stamp rotates.
+   * <p>{@code include} (a 1-2 char tag — "nd" / "a" / "d", derived from the
+   * {@link org.openmetadata.schema.type.Include} enum value) is part of the key because the
+   * page result depends on whether soft-deleted children are included. Without this,
+   * toggling the UI's "Deleted" switch would return a stale page from the other side until
+   * the version stamp rotates.
    */
   public String childrenPage(
       String type, String parentFqn, String version, int limit, int offset, String includeTag) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/cache/CacheKeys.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/cache/CacheKeys.java
@@ -110,12 +110,7 @@ public final class CacheKeys {
    * version stamp rotates.
    */
   public String childrenPage(
-      String type,
-      String parentFqn,
-      String version,
-      int limit,
-      int offset,
-      String includeTag) {
+      String type, String parentFqn, String version, int limit, int offset, String includeTag) {
     String fqnHash = FullyQualifiedName.buildHash(parentFqn);
     return ns
         + ":kids:"

--- a/openmetadata-service/src/main/java/org/openmetadata/service/cache/ChildrenPageCache.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/cache/ChildrenPageCache.java
@@ -91,14 +91,15 @@ public class ChildrenPageCache {
   /**
    * Compact tag for the page key. Kept short to keep Redis keys readable in {@code MONITOR}
    * and {@code SCAN} output. Three values, fixed: {@code nd} (non-deleted, default),
-   * {@code all}, {@code d}.
+   * {@code a} (all), {@code d} (deleted-only). Single-letter tags also keep the cache-key
+   * "1-2 char" promise documented on {@link CacheKeys#childrenPage}.
    */
   private static String includeTag(Include include) {
     if (include == null) {
       return "nd";
     }
     return switch (include) {
-      case ALL -> "all";
+      case ALL -> "a";
       case DELETED -> "d";
       default -> "nd";
     };

--- a/openmetadata-service/src/main/java/org/openmetadata/service/cache/ChildrenPageCache.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/cache/ChildrenPageCache.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.entity.data.Container;
+import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.schema.utils.ResultList;
 
@@ -41,12 +42,14 @@ public class ChildrenPageCache {
     this.config = config;
   }
 
-  public ResultList<Container> get(String entityType, String parentFqn, int limit, int offset) {
+  public ResultList<Container> get(
+      String entityType, String parentFqn, int limit, int offset, Include include) {
     if (parentFqn == null) {
       return null;
     }
     String version = currentVersion(entityType, parentFqn);
-    String pageKey = keys.childrenPage(entityType, parentFqn, version, limit, offset);
+    String pageKey =
+        keys.childrenPage(entityType, parentFqn, version, limit, offset, includeTag(include));
     try {
       Optional<String> json = cache.get(pageKey);
       if (json.isEmpty()) {
@@ -62,7 +65,12 @@ public class ChildrenPageCache {
   }
 
   public void put(
-      String entityType, String parentFqn, int limit, int offset, ResultList<Container> page) {
+      String entityType,
+      String parentFqn,
+      int limit,
+      int offset,
+      Include include,
+      ResultList<Container> page) {
     if (parentFqn == null || page == null) {
       return;
     }
@@ -70,13 +78,30 @@ public class ChildrenPageCache {
     // the fresh stamp so the next reader at the new stamp consumes our page. The previous
     // version's slot would be unreachable and TTL out anyway.
     String version = currentVersion(entityType, parentFqn);
-    String pageKey = keys.childrenPage(entityType, parentFqn, version, limit, offset);
+    String pageKey =
+        keys.childrenPage(entityType, parentFqn, version, limit, offset, includeTag(include));
     try {
       String json = JsonUtils.pojoToJson(page);
       cache.set(pageKey, json, Duration.ofSeconds(config.entityTtlSeconds));
     } catch (Exception e) {
       LOG.warn("Failed to cache children page: {} {} v={}", entityType, parentFqn, version, e);
     }
+  }
+
+  /**
+   * Compact tag for the page key. Kept short to keep Redis keys readable in {@code MONITOR}
+   * and {@code SCAN} output. Three values, fixed: {@code nd} (non-deleted, default),
+   * {@code all}, {@code d}.
+   */
+  private static String includeTag(Include include) {
+    if (include == null) {
+      return "nd";
+    }
+    return switch (include) {
+      case ALL -> "all";
+      case DELETED -> "d";
+      default -> "nd";
+    };
   }
 
   /**

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -720,12 +720,7 @@ public interface CollectionDAO {
       // String, String)` and make every non-root list call also pick up the depth check,
       // silently filtering out child containers from generic `?service=...` listings.
       return listRootBefore(
-          getTableName(),
-          rootListingParams(filter),
-          condition,
-          limit,
-          beforeName,
-          beforeId);
+          getTableName(), rootListingParams(filter), condition, limit, beforeName, beforeId);
     }
 
     @Override
@@ -738,12 +733,7 @@ public interface CollectionDAO {
       }
 
       return listRootAfter(
-          getTableName(),
-          rootListingParams(filter),
-          condition,
-          limit,
-          afterName,
-          afterId);
+          getTableName(), rootListingParams(filter), condition, limit, afterName, afterId);
     }
 
     @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -715,15 +715,17 @@ public interface CollectionDAO {
         return EntityDAO.super.listBefore(filter, limit, beforeName, beforeId);
       }
 
-      // The root-only SQL is a NOT EXISTS anti-join — there is no outer `er` alias to refer
-      // to here, so the condition is just the regular ListFilter WHERE clause; the new
-      // SQL appends its own NOT EXISTS predicate after this. Distinct method name
-      // (listRootBefore) is required: a same-signature `listBefore` here would override
-      // EntityDAO's default `listBefore(String, Map, String, int, String, String)` and
-      // make every non-root list call also pick up the NOT EXISTS predicate, silently
-      // filtering out child containers from generic `?service=...` listings.
+      // Distinct method name (listRootBefore) is required: a same-signature `listBefore`
+      // here would override EntityDAO's default `listBefore(String, Map, String, int,
+      // String, String)` and make every non-root list call also pick up the depth check,
+      // silently filtering out child containers from generic `?service=...` listings.
       return listRootBefore(
-          getTableName(), filter.getQueryParams(), condition, limit, beforeName, beforeId);
+          getTableName(),
+          rootListingParams(filter),
+          condition,
+          limit,
+          beforeName,
+          beforeId);
     }
 
     @Override
@@ -736,7 +738,12 @@ public interface CollectionDAO {
       }
 
       return listRootAfter(
-          getTableName(), filter.getQueryParams(), condition, limit, afterName, afterId);
+          getTableName(),
+          rootListingParams(filter),
+          condition,
+          limit,
+          afterName,
+          afterId);
     }
 
     @Override
@@ -748,7 +755,25 @@ public interface CollectionDAO {
         return EntityDAO.super.listCount(filter);
       }
 
-      return listRootCount(getTableName(), getNameHashColumn(), filter.getQueryParams(), condition);
+      return listRootCount(
+          getTableName(), getNameHashColumn(), rootListingParams(filter), condition);
+    }
+
+    /**
+     * Build the bind map the listRoot SQL expects. The depth predicate
+     * ({@code fqnHash NOT LIKE :serviceHashChild}) needs the {@code serviceHashChild}
+     * bind to be set on every call, but {@link ListFilter#getServiceCondition} only
+     * adds it when {@code ?service=} is present. For the {@code ?root=true} case
+     * <em>without</em> a service filter — "all root containers across all services" —
+     * we default the bind to {@code %.%.%}, which excludes any fqnHash with two or more
+     * separators (everything strictly below the immediate level). Index usage is naturally
+     * weaker here since the prefix LIKE is also absent, but no-service root listings are
+     * rare and the result is at most one row per service.
+     */
+    private static java.util.Map<String, Object> rootListingParams(ListFilter filter) {
+      java.util.Map<String, Object> params = new java.util.HashMap<>(filter.getQueryParams());
+      params.putIfAbsent("serviceHashChild", "%.%.%");
+      return params;
     }
 
     // Root-only listing (?root=true) returns containers that are direct children of the

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -751,25 +751,36 @@ public interface CollectionDAO {
       return listRootCount(getTableName(), getNameHashColumn(), filter.getQueryParams(), condition);
     }
 
-    // Root-only listing (?root=true) returns containers that have no parent container.
-    // Earlier versions used a LEFT JOIN + IS NULL anti-join with an inlined subquery, which
-    // Postgres often plans as a hash join over the materialized child-edge set — fine for
-    // small services, painful for ones with thousands of container-to-container edges
-    // (a Tahoe-shaped 5,000-file bucket easily blows past 2s for the COUNT alone). Switching
-    // to NOT EXISTS lets the planner anti-join via the (fromEntity, toEntity, relation, toId)
-    // index instead, so each candidate row's "is this a child?" check is an index lookup.
+    // Root-only listing (?root=true) returns containers that are direct children of the
+    // service — i.e. one segment below the service in the FQN tree.
+    //
+    // Earlier implementations relied on `entity_relationship` as the source of truth ("a
+    // container is a root iff no inbound CONTAINS edge exists"). That broke under two
+    // separate failure modes:
+    //   1. Connectors (and bulk imports) that create deeply-nested containers without
+    //      writing the parent CONTAINS edge — those orphans satisfy "no inbound edge" and
+    //      surface at the service root, even though their FQN is many segments deep. The
+    //      breadcrumb UI (which reads the FQN) and the listing (which reads the relationship)
+    //      disagreed about where the container lived.
+    //   2. The NOT EXISTS anti-join needed a composite (fromEntity, toEntity, relation, toId)
+    //      index to be cheap; under pgjdbc generic plans the planner often chose the
+    //      ORDER BY index instead, falling back to a full-table scan and making the count
+    //      query 1-2s on a service with hundreds of thousands of containers.
+    //
+    // The FQN is the canonical hierarchy in OpenMetadata (it's set unconditionally at write
+    // time and is what the breadcrumb UI consumes). `fqnHash` is built by joining
+    // fixed-width MD5 segments with '.', so depth follows from the count of separators —
+    // a direct child of the service has a fqnHash matching `<serviceHash>.<32hex>` and
+    // contains no further '.'. We express "not a direct child" as `fqnHash LIKE
+    // <serviceHash>.%.%` and reject those rows. ListFilter.getFqnPrefixCondition binds
+    // both `:serviceHash` (already used by the prefix LIKE in <sqlCondition>) and
+    // `:serviceHashChild` (the `.%.%` companion) so the SQL just plugs them in.
     @SqlQuery(
         value =
             "SELECT json FROM ("
                 + "SELECT name, id, ce.json FROM <table> ce "
                 + "<sqlCondition> AND "
-                + "NOT EXISTS ("
-                + "  SELECT 1 FROM entity_relationship er "
-                + "  WHERE er.toId = ce.id "
-                + "    AND er.fromEntity = 'container' "
-                + "    AND er.toEntity = 'container' "
-                + "    AND er.relation = 0"
-                + ") AND "
+                + "ce.fqnHash NOT LIKE :serviceHashChild AND "
                 + "(name < :beforeName OR (name = :beforeName AND id < :beforeId)) "
                 + "ORDER BY name DESC, id DESC "
                 + "LIMIT :limit"
@@ -786,13 +797,7 @@ public interface CollectionDAO {
         value =
             "SELECT ce.json FROM <table> ce "
                 + "<sqlCondition> AND "
-                + "NOT EXISTS ("
-                + "  SELECT 1 FROM entity_relationship er "
-                + "  WHERE er.toId = ce.id "
-                + "    AND er.fromEntity = 'container' "
-                + "    AND er.toEntity = 'container' "
-                + "    AND er.relation = 0"
-                + ") AND "
+                + "ce.fqnHash NOT LIKE :serviceHashChild AND "
                 + "(name > :afterName OR (name = :afterName AND id > :afterId)) "
                 + "ORDER BY name, id "
                 + "LIMIT :limit")
@@ -807,26 +812,12 @@ public interface CollectionDAO {
     @ConnectionAwareSqlQuery(
         value =
             "SELECT count(<nameHashColumn>) FROM <table> ce "
-                + "<sqlCondition> AND "
-                + "NOT EXISTS ("
-                + "  SELECT 1 FROM entity_relationship er "
-                + "  WHERE er.toId = ce.id "
-                + "    AND er.fromEntity = 'container' "
-                + "    AND er.toEntity = 'container' "
-                + "    AND er.relation = 0"
-                + ")",
+                + "<sqlCondition> AND ce.fqnHash NOT LIKE :serviceHashChild",
         connectionType = MYSQL)
     @ConnectionAwareSqlQuery(
         value =
             "SELECT count(*) FROM <table> ce "
-                + "<sqlCondition> AND "
-                + "NOT EXISTS ("
-                + "  SELECT 1 FROM entity_relationship er "
-                + "  WHERE er.toId = ce.id "
-                + "    AND er.fromEntity = 'container' "
-                + "    AND er.toEntity = 'container' "
-                + "    AND er.relation = 0"
-                + ")",
+                + "<sqlCondition> AND ce.fqnHash NOT LIKE :serviceHashChild",
         connectionType = POSTGRES)
     int listRootCount(
         @Define("table") String table,
@@ -881,6 +872,71 @@ public interface CollectionDAO {
       }
       return all;
     }
+
+    // FQN-based direct-children page. The two binds (`:parentHash` = '<hash>.%' and
+    // `:parentHashChild` = '<hash>.%.%') together select containers whose FQN is exactly one
+    // segment below the parent — same shape used by the root listing in listRootAfter, just
+    // without the cursor pagination. Returns the slim projection used by the children table
+    // UI; the caller restores the service reference separately. `:includeDeleted` is a
+    // tri-state: 'NON_DELETED' (default), 'DELETED', or 'ALL'.
+    @ConnectionAwareSqlQuery(
+        value =
+            "SELECT id, "
+                + "JSON_UNQUOTE(JSON_EXTRACT(json, '$.name')) AS name, "
+                + "JSON_UNQUOTE(JSON_EXTRACT(json, '$.displayName')) AS displayName, "
+                + "JSON_UNQUOTE(JSON_EXTRACT(json, '$.fullyQualifiedName')) AS fqn, "
+                + "JSON_UNQUOTE(JSON_EXTRACT(json, '$.description')) AS description, "
+                + "deleted "
+                + "FROM storage_container_entity "
+                + "WHERE fqnHash LIKE :parentHash AND fqnHash NOT LIKE :parentHashChild "
+                + "  AND (:includeDeleted = 'ALL' "
+                + "       OR (:includeDeleted = 'DELETED' AND deleted = TRUE) "
+                + "       OR (:includeDeleted = 'NON_DELETED' AND deleted = FALSE)) "
+                + "ORDER BY name, id LIMIT :limit OFFSET :offset",
+        connectionType = MYSQL)
+    @ConnectionAwareSqlQuery(
+        value =
+            "SELECT id, "
+                + "json->>'name' AS name, "
+                + "json->>'displayName' AS displayName, "
+                + "json->>'fullyQualifiedName' AS fqn, "
+                + "json->>'description' AS description, "
+                + "deleted "
+                + "FROM storage_container_entity "
+                + "WHERE fqnHash LIKE :parentHash AND fqnHash NOT LIKE :parentHashChild "
+                + "  AND (:includeDeleted = 'ALL' "
+                + "       OR (:includeDeleted = 'DELETED' AND deleted = TRUE) "
+                + "       OR (:includeDeleted = 'NON_DELETED' AND deleted = FALSE)) "
+                + "ORDER BY name, id LIMIT :limit OFFSET :offset",
+        connectionType = POSTGRES)
+    @RegisterRowMapper(ContainerSummaryRowMapper.class)
+    List<Container> listDirectChildSummariesByParentHash(
+        @Bind("parentHash") String parentHash,
+        @Bind("parentHashChild") String parentHashChild,
+        @Bind("includeDeleted") String includeDeleted,
+        @Bind("limit") int limit,
+        @Bind("offset") int offset);
+
+    @ConnectionAwareSqlQuery(
+        value =
+            "SELECT count(fqnHash) FROM storage_container_entity "
+                + "WHERE fqnHash LIKE :parentHash AND fqnHash NOT LIKE :parentHashChild "
+                + "  AND (:includeDeleted = 'ALL' "
+                + "       OR (:includeDeleted = 'DELETED' AND deleted = TRUE) "
+                + "       OR (:includeDeleted = 'NON_DELETED' AND deleted = FALSE))",
+        connectionType = MYSQL)
+    @ConnectionAwareSqlQuery(
+        value =
+            "SELECT count(*) FROM storage_container_entity "
+                + "WHERE fqnHash LIKE :parentHash AND fqnHash NOT LIKE :parentHashChild "
+                + "  AND (:includeDeleted = 'ALL' "
+                + "       OR (:includeDeleted = 'DELETED' AND deleted = TRUE) "
+                + "       OR (:includeDeleted = 'NON_DELETED' AND deleted = FALSE))",
+        connectionType = POSTGRES)
+    int countDirectChildrenByParentHash(
+        @Bind("parentHash") String parentHash,
+        @Bind("parentHashChild") String parentHashChild,
+        @Bind("includeDeleted") String includeDeleted);
   }
 
   class ContainerSummaryRowMapper implements RowMapper<Container> {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -850,8 +850,7 @@ public interface CollectionDAO {
      */
     @ConnectionAwareSqlQuery(
         value =
-            "SELECT id, "
-                + "JSON_UNQUOTE(JSON_EXTRACT(json, '$.name')) AS name, "
+            "SELECT id, name, "
                 + "JSON_UNQUOTE(JSON_EXTRACT(json, '$.displayName')) AS displayName, "
                 + "JSON_UNQUOTE(JSON_EXTRACT(json, '$.fullyQualifiedName')) AS fqn, "
                 + "JSON_UNQUOTE(JSON_EXTRACT(json, '$.description')) AS description, "
@@ -860,8 +859,7 @@ public interface CollectionDAO {
         connectionType = MYSQL)
     @ConnectionAwareSqlQuery(
         value =
-            "SELECT id, "
-                + "json->>'name' AS name, "
+            "SELECT id, name, "
                 + "json->>'displayName' AS displayName, "
                 + "json->>'fullyQualifiedName' AS fqn, "
                 + "json->>'description' AS description, "
@@ -896,8 +894,7 @@ public interface CollectionDAO {
     // tri-state: 'NON_DELETED' (default), 'DELETED', or 'ALL'.
     @ConnectionAwareSqlQuery(
         value =
-            "SELECT id, "
-                + "JSON_UNQUOTE(JSON_EXTRACT(json, '$.name')) AS name, "
+            "SELECT id, name, "
                 + "JSON_UNQUOTE(JSON_EXTRACT(json, '$.displayName')) AS displayName, "
                 + "JSON_UNQUOTE(JSON_EXTRACT(json, '$.fullyQualifiedName')) AS fqn, "
                 + "JSON_UNQUOTE(JSON_EXTRACT(json, '$.description')) AS description, "
@@ -911,8 +908,7 @@ public interface CollectionDAO {
         connectionType = MYSQL)
     @ConnectionAwareSqlQuery(
         value =
-            "SELECT id, "
-                + "json->>'name' AS name, "
+            "SELECT id, name, "
                 + "json->>'displayName' AS displayName, "
                 + "json->>'fullyQualifiedName' AS fqn, "
                 + "json->>'description' AS description, "

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ContainerRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ContainerRepository.java
@@ -704,10 +704,13 @@ public class ContainerRepository extends EntityRepository<Container> {
 
   /**
    * Map the public {@link Include} enum to the literal value the listing SQL expects.
-   * The SQL keeps the comparison as a CASE on a literal string ('NON_DELETED' / 'ALL' /
-   * 'DELETED') rather than three separate query templates because the underlying access
-   * path is identical — the index range scan on {@code fqnHash} runs once and the per-row
-   * deleted predicate is evaluated post-index in all three modes.
+   * The SQL ({@code ContainerDAO.listDirectChildSummariesByParentHash}) gates the
+   * deleted predicate on this bind via a three-branch OR chain
+   * ({@code :includeDeleted = 'ALL' OR (:includeDeleted = 'DELETED' AND deleted = TRUE)
+   * OR (:includeDeleted = 'NON_DELETED' AND deleted = FALSE)}) rather than three
+   * separate query templates — the underlying access path is identical, the index range
+   * scan on {@code fqnHash} runs once, and the per-row deleted predicate is evaluated
+   * post-index in all three modes.
    */
   private static String includeToBindString(Include include) {
     return switch (include) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ContainerRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ContainerRepository.java
@@ -657,8 +657,9 @@ public class ContainerRepository extends EntityRepository<Container> {
     // restore) was responsible. The parent-lookup phase from the previous
     // entity_relationship-based implementation is gone — the FQN is enough.
     String parentHashRaw = FullyQualifiedName.buildHash(parentFQN);
-    String parentHash = parentHashRaw + "." + "%";
-    String parentHashChild = parentHashRaw + "." + "%" + "." + "%";
+    String parentHash = parentHashRaw + Entity.SEPARATOR + "%";
+    String parentHashChild =
+        parentHashRaw + Entity.SEPARATOR + "%" + Entity.SEPARATOR + "%";
     String includeBind = includeToBindString(safeInclude);
     CollectionDAO.ContainerDAO containerDAO = (CollectionDAO.ContainerDAO) dao;
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ContainerRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ContainerRepository.java
@@ -658,8 +658,7 @@ public class ContainerRepository extends EntityRepository<Container> {
     // entity_relationship-based implementation is gone — the FQN is enough.
     String parentHashRaw = FullyQualifiedName.buildHash(parentFQN);
     String parentHash = parentHashRaw + Entity.SEPARATOR + "%";
-    String parentHashChild =
-        parentHashRaw + Entity.SEPARATOR + "%" + Entity.SEPARATOR + "%";
+    String parentHashChild = parentHashRaw + Entity.SEPARATOR + "%" + Entity.SEPARATOR + "%";
     String includeBind = includeToBindString(safeInclude);
     CollectionDAO.ContainerDAO containerDAO = (CollectionDAO.ContainerDAO) dao;
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ContainerRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ContainerRepository.java
@@ -604,14 +604,48 @@ public class ContainerRepository extends EntityRepository<Container> {
   }
 
   public ResultList<Container> listChildren(String parentFQN, Integer limit, Integer offset) {
+    return listChildren(parentFQN, limit, offset, Include.NON_DELETED);
+  }
+
+  /**
+   * List direct children of {@code parentFQN}, paginated. Direct children are containers
+   * whose FQN is exactly one segment below {@code parentFQN} — the FQN is the canonical
+   * hierarchy in OpenMetadata, set unconditionally at write time and consumed by the
+   * breadcrumb UI.
+   *
+   * <p>Earlier implementations resolved children through {@code entity_relationship}
+   * (CONTAINS edges from the parent's UUID). That made two assumptions that don't always
+   * hold in practice:
+   * <ul>
+   *   <li>The connector or bulk-import path always writes the parent CONTAINS edge. Some
+   *       connectors only write leaf containers without their ancestors, leaving the leaf
+   *       with a deeply-nested FQN but no inbound CONTAINS edge — those leaves never appear
+   *       under any /children query for their FQN-implied parent.</li>
+   *   <li>The parent itself exists in the table. The previous code did a
+   *       {@code dao.findEntityByName(parentFQN)} preflight to resolve the parent's UUID;
+   *       a missing parent meant the call failed even though descendants existed.</li>
+   * </ul>
+   *
+   * <p>The FQN-depth approach asks the right question — "which rows have an FQN that is
+   * exactly one level below this prefix?" — and answers it with a single indexed range
+   * scan against {@code idx_storage_container_entity_fqnhash_pattern}. The parent UUID is
+   * never needed; the parent doesn't even have to exist for its descendants to be
+   * discoverable. Because each FQN segment hashes to a fixed-width MD5, "exactly one
+   * segment below" is expressible as {@code fqnHash LIKE :parentHash AND fqnHash NOT LIKE
+   * :parentHashChild}, where {@code :parentHash} is {@code <hash>.%} and
+   * {@code :parentHashChild} is {@code <hash>.%.%}.
+   */
+  public ResultList<Container> listChildren(
+      String parentFQN, Integer limit, Integer offset, Include include) {
     int safeLimit = limit != null ? limit : 0;
     int safeOffset = offset != null ? offset : 0;
+    Include safeInclude = include != null ? include : Include.NON_DELETED;
 
     ChildrenPageCache pageCache = CacheBundle.getChildrenPageCache();
     if (pageCache != null) {
       ResultList<Container> cached;
       try (var ignored = RequestLatencyContext.phase("listChildrenCacheGet")) {
-        cached = pageCache.get(CONTAINER, parentFQN, safeLimit, safeOffset);
+        cached = pageCache.get(CONTAINER, parentFQN, safeLimit, safeOffset, safeInclude);
       }
       if (cached != null) {
         return cached;
@@ -619,73 +653,37 @@ public class ContainerRepository extends EntityRepository<Container> {
     }
 
     // Phase markers feed the slow-request log so when a /children call exceeds the
-    // latency budget in prod we can tell which step (parent lookup / relationship
-    // fetch / count / slim hydration / service restore) was responsible.
-    Container parentContainer;
-    try (var ignored = RequestLatencyContext.phase("listChildrenParent")) {
-      parentContainer = dao.findEntityByName(parentFQN);
-    }
+    // latency budget in prod we can tell which step (depth query / count / service
+    // restore) was responsible. The parent-lookup phase from the previous
+    // entity_relationship-based implementation is gone — the FQN is enough.
+    String parentHashRaw = FullyQualifiedName.buildHash(parentFQN);
+    String parentHash = parentHashRaw + "." + "%";
+    String parentHashChild = parentHashRaw + "." + "%" + "." + "%";
+    String includeBind = includeToBindString(safeInclude);
+    CollectionDAO.ContainerDAO containerDAO = (CollectionDAO.ContainerDAO) dao;
 
     try {
-      List<CollectionDAO.EntityRelationshipRecord> relationshipRecords;
-      try (var ignored = RequestLatencyContext.phase("listChildrenRelationships")) {
-        relationshipRecords =
-            daoCollection
-                .relationshipDAO()
-                .findToWithOffset(
-                    parentContainer.getId(),
-                    CONTAINER,
-                    List.of(Relationship.CONTAINS.ordinal()),
-                    safeOffset,
-                    safeLimit);
+      List<Container> children;
+      try (var ignored = RequestLatencyContext.phase("listChildrenPage")) {
+        children =
+            containerDAO.listDirectChildSummariesByParentHash(
+                parentHash, parentHashChild, includeBind, safeLimit, safeOffset);
       }
 
       int total;
       try (var ignored = RequestLatencyContext.phase("listChildrenCount")) {
         total =
-            daoCollection
-                .relationshipDAO()
-                .countFindTo(
-                    parentContainer.getId(), CONTAINER, List.of(Relationship.CONTAINS.ordinal()));
+            containerDAO.countDirectChildrenByParentHash(parentHash, parentHashChild, includeBind);
       }
 
-      if (relationshipRecords.isEmpty()) {
+      if (children.isEmpty()) {
         ResultList<Container> empty = new ResultList<>(new ArrayList<>(), null, null, total);
         if (pageCache != null) {
-          pageCache.put(CONTAINER, parentFQN, safeLimit, safeOffset, empty);
+          pageCache.put(CONTAINER, parentFQN, safeLimit, safeOffset, safeInclude, empty);
         }
         return empty;
       }
 
-      // Hydrate the page with a slim projection: id, name, fqn, displayName, description.
-      // Heavy fields like dataModel, tags, owners, extension are intentionally skipped —
-      // the UI's children table only renders name and description, and parquet
-      // containers can carry multi-MB column schemas in dataModel.
-      //
-      // The IDs come straight from the relationship rows we already loaded in
-      // findToWithOffset — we deliberately do NOT call EntityUtil.getEntityReferences
-      // here because that path round-trips through Entity.getEntityReferencesByIds →
-      // EntityRepository.find → CACHE_WITH_ID, which materialises the FULL Container
-      // JSON (dataModel, tags, owners, extension) for every child just to extract its
-      // EntityReference. For 15 parquet rows that single call alone can dominate the
-      // listing latency.
-      List<UUID> ids = relationshipRecords.stream().map(r -> r.getId()).toList();
-      Map<UUID, Container> byId = new HashMap<>();
-      try (var ignored = RequestLatencyContext.phase("listChildrenHydrate")) {
-        for (Container c : ((CollectionDAO.ContainerDAO) dao).findContainerSummariesByIds(ids)) {
-          byId.put(c.getId(), c);
-        }
-      }
-      // Preserve relationship-offset ordering returned by findToWithOffset; drop
-      // any rows that no longer resolve (deleted between the relationship lookup and
-      // the bulk fetch) rather than failing the whole page.
-      List<Container> children = new ArrayList<>(ids.size());
-      for (UUID id : ids) {
-        Container container = byId.get(id);
-        if (container != null) {
-          children.add(container);
-        }
-      }
       // service is stripped from stored JSON; restore via batched relationship lookup.
       try (var ignored = RequestLatencyContext.phase("listChildrenService")) {
         fetchAndSetDefaultService(children);
@@ -693,7 +691,7 @@ public class ContainerRepository extends EntityRepository<Container> {
 
       ResultList<Container> page = new ResultList<>(children, null, null, total);
       if (pageCache != null) {
-        pageCache.put(CONTAINER, parentFQN, safeLimit, safeOffset, page);
+        pageCache.put(CONTAINER, parentFQN, safeLimit, safeOffset, safeInclude, page);
       }
       return page;
     } catch (Exception e) {
@@ -702,6 +700,21 @@ public class ContainerRepository extends EntityRepository<Container> {
               "Failed to fetch children for container [%s]: %s", parentFQN, e.getMessage()),
           e);
     }
+  }
+
+  /**
+   * Map the public {@link Include} enum to the literal value the listing SQL expects.
+   * The SQL keeps the comparison as a CASE on a literal string ('NON_DELETED' / 'ALL' /
+   * 'DELETED') rather than three separate query templates because the underlying access
+   * path is identical — the index range scan on {@code fqnHash} runs once and the per-row
+   * deleted predicate is evaluated post-index in all three modes.
+   */
+  private static String includeToBindString(Include include) {
+    return switch (include) {
+      case ALL -> "ALL";
+      case DELETED -> "DELETED";
+      default -> "NON_DELETED";
+    };
   }
 
   /**

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -4326,8 +4326,11 @@ public abstract class EntityRepository<T extends EntityInterface> {
         LOG.error(
             "Failed to delete {} '{}' during recursive batch delete: {}",
             entityType, entityId, e.getMessage(), e);
-        // Wrap with entity context so the operator can identify the row that blocked
-        // a large recursive delete. Original exception is preserved as the cause.
+        // Wrap with entity context before re-throwing so the operator can identify
+        // the row that blocked a large recursive delete. The exception still
+        // propagates — the loop still stops, the failure-semantics contract in the
+        // Javadoc still holds — we just trade an opaque stack trace for one that
+        // names the offending child.
         throw new RuntimeException(
             String.format(
                 "Failed to delete %s '%s' during recursive batch delete: %s",

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -4323,11 +4323,11 @@ public abstract class EntityRepository<T extends EntityInterface> {
         EntityInterface entity = repository.find(entityId, Include.ALL);
         repository.cleanup(entity);
       } catch (RuntimeException e) {
-        // Wrap with entity context before re-throwing so the operator can identify
-        // the row that blocked a large recursive delete. The exception still
-        // propagates — the loop still stops, the failure-semantics contract in the
-        // Javadoc still holds — we just trade an opaque stack trace for one that
-        // names the offending child.
+        LOG.error(
+            "Failed to delete {} '{}' during recursive batch delete: {}",
+            entityType, entityId, e.getMessage(), e);
+        // Wrap with entity context so the operator can identify the row that blocked
+        // a large recursive delete. Original exception is preserved as the cause.
         throw new RuntimeException(
             String.format(
                 "Failed to delete %s '%s' during recursive batch delete: %s",

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -4250,7 +4250,32 @@ public abstract class EntityRepository<T extends EntityInterface> {
   }
 
   /**
-   * Process a batch of entities for deletion
+   * Process a batch of entities for hard deletion. Entered only via
+   * {@link #batchDeleteChildren}, which only fires for {@code hardDelete=true} and
+   * {@code children.size() > 100}; the soft-delete and small-batch paths stay on the
+   * sequential {@link Entity#deleteEntity} flow.
+   *
+   * <p>Each child is removed via {@link #cleanup}, which deletes the entity row, all
+   * {@code (id, *)} and {@code (*, id)} entity_relationship rows, extensions, tag usage,
+   * threads, and caches as one atomic unit per child (cleanup opens its own JDBI
+   * transaction via {@code Entity.getJdbi().inTransaction(...)}). The previous
+   * implementation pre-deleted relationships in two batched queries before this loop and
+   * swallowed exceptions in the per-child cleanup, which is exactly what produced the
+   * orphan pattern: a failed cleanup left an entity row alive after its relationships
+   * had been wiped, surfacing in {@code /containers?root=true} and breaking
+   * {@code /children} traversal.
+   *
+   * <p><b>Failure semantics:</b> per-child atomicity, not whole-batch atomicity. If
+   * cleanup for child <em>k</em> throws, children {@code 0..k-1} have already committed
+   * via their own transactions and cannot be rolled back by the {@code @Transaction} on
+   * this method (cleanup's inner transaction is independent). The exception propagates
+   * so the loop stops; children {@code k..N-1} keep both their rows and their parent
+   * CONTAINS relationships intact. The retry path is to reissue the recursive delete on
+   * the parent — remaining children re-enter this loop. Crucially, no orphan-without-
+   * relationships row can result from an exception in this method, which is the bug
+   * this change exists to fix; achieving true all-or-nothing rollback across the batch
+   * would require sharing one JDBI handle across every cleanup call, a wider refactor
+   * deliberately scoped out of this fix.
    */
   @Transaction
   private void processDeletionBatch(
@@ -4283,36 +4308,19 @@ public abstract class EntityRepository<T extends EntityInterface> {
       deleteChildren(allGrandchildren, hardDelete, updatedBy);
     }
 
-    // Now batch delete the entities at this level (reuse stringIds from above)
-    // Only delete relationships for hard delete
-    // For soft delete, relationships must be preserved for restoration
-    if (hardDelete) {
-      // Batch delete relationships for all entities
-      daoCollection.relationshipDAO().batchDeleteFrom(stringIds, entityType);
-      daoCollection.relationshipDAO().batchDeleteTo(stringIds, entityType);
-    }
-
-    // Delete or soft-delete the entities themselves
+    // cleanup() per entity is the source of truth: it removes the row, its relationships
+    // (deleteAllFrom + deleteAllTo on (id, *) and (*, id)), extensions, tag usage, feed
+    // threads, and caches within ONE JDBI transaction owned by cleanup itself. The
+    // previous pre-batch-delete of relationships made the row-and-relationship pairing
+    // non-atomic across the loop, which is why a swallowed mid-loop exception produced
+    // the orphan-without-relationships pattern. Letting cleanup own both halves and
+    // letting exceptions propagate stops the loop early on failure; see the failure
+    // semantics note in the Javadoc above for what "stops the loop" actually guarantees.
+    @SuppressWarnings("rawtypes")
+    EntityRepository repository = Entity.getEntityRepository(entityType);
     for (UUID entityId : entityIds) {
-      try {
-        @SuppressWarnings("rawtypes")
-        EntityRepository repository = Entity.getEntityRepository(entityType);
-        if (repository.supportsSoftDelete && !hardDelete) {
-          // Soft delete
-          EntityInterface entity = repository.find(entityId, Include.ALL);
-          entity.setUpdatedBy(updatedBy);
-          entity.setUpdatedAt(System.currentTimeMillis());
-          entity.setDeleted(true);
-          repository.dao.update(entity);
-          invalidateCacheForEntity(entityType, entity.getId(), entity.getFullyQualifiedName());
-        } else {
-          // Hard delete
-          EntityInterface entity = repository.find(entityId, Include.ALL);
-          repository.cleanup(entity);
-        }
-      } catch (Exception e) {
-        LOG.error("Error deleting entity {} of type {}: {}", entityId, entityType, e.getMessage());
-      }
+      EntityInterface entity = repository.find(entityId, Include.ALL);
+      repository.cleanup(entity);
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -4319,8 +4319,21 @@ public abstract class EntityRepository<T extends EntityInterface> {
     @SuppressWarnings("rawtypes")
     EntityRepository repository = Entity.getEntityRepository(entityType);
     for (UUID entityId : entityIds) {
-      EntityInterface entity = repository.find(entityId, Include.ALL);
-      repository.cleanup(entity);
+      try {
+        EntityInterface entity = repository.find(entityId, Include.ALL);
+        repository.cleanup(entity);
+      } catch (RuntimeException e) {
+        // Wrap with entity context before re-throwing so the operator can identify
+        // the row that blocked a large recursive delete. The exception still
+        // propagates — the loop still stops, the failure-semantics contract in the
+        // Javadoc still holds — we just trade an opaque stack trace for one that
+        // names the offending child.
+        throw new RuntimeException(
+            String.format(
+                "Failed to delete %s '%s' during recursive batch delete: %s",
+                entityType, entityId, e.getMessage()),
+            e);
+      }
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -4325,7 +4325,10 @@ public abstract class EntityRepository<T extends EntityInterface> {
       } catch (RuntimeException e) {
         LOG.error(
             "Failed to delete {} '{}' during recursive batch delete: {}",
-            entityType, entityId, e.getMessage(), e);
+            entityType,
+            entityId,
+            e.getMessage(),
+            e);
         // Wrap with entity context before re-throwing so the operator can identify
         // the row that blocked a large recursive delete. The exception still
         // propagates — the loop still stops, the failure-semantics contract in the

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ListFilter.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ListFilter.java
@@ -817,9 +817,15 @@ public class ListFilter extends Filter<ListFilter> {
   }
 
   private String getFqnPrefixCondition(String tableName, String fqnPrefix, String paramName) {
-    String databaseFqnHash =
-        String.format("%s%s%%", FullyQualifiedName.buildHash(fqnPrefix), Entity.SEPARATOR);
-    queryParams.put(paramName + "Hash", databaseFqnHash);
+    String prefix = FullyQualifiedName.buildHash(fqnPrefix) + Entity.SEPARATOR;
+    queryParams.put(paramName + "Hash", prefix + "%");
+    // Companion bind for "exclude descendants below the immediate level" — used by listings
+    // that need direct children only (e.g. ContainerDAO root listings, ContainerRepository
+    // listChildren). fqnHash uses fixed-width MD5 segments joined by '.', so a fqnHash that
+    // matches `<prefix>.%.%` has at least two segments below the prefix and is therefore not
+    // a direct child. Always bound — most queries don't reference it; the cost is one map
+    // entry. Avoids threading an extra param through every listing site.
+    queryParams.put(paramName + "HashChild", prefix + "%.%");
     return tableName == null
         ? String.format("fqnHash LIKE :%s", paramName + "Hash")
         : String.format("%s.fqnHash LIKE :%s", tableName, paramName + "Hash");

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/storages/ContainerResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/storages/ContainerResource.java
@@ -757,12 +757,18 @@ public class ContainerResource extends EntityResource<Container, ContainerReposi
           @DefaultValue("0")
           @QueryParam("offset")
           @Min(value = 0, message = "must be greater than or equal to 0")
-          Integer offset) {
+          Integer offset,
+      @Parameter(
+              description = "Include all, deleted, or non-deleted children.",
+              schema = @Schema(implementation = Include.class))
+          @QueryParam("include")
+          @DefaultValue("non-deleted")
+          Include include) {
     OperationContext operationContext =
         new OperationContext(entityType, MetadataOperation.VIEW_BASIC);
     ResourceContext<Container> resourceContext = getResourceContextByName(fqn);
     authorizer.authorize(securityContext, operationContext, resourceContext);
-    return repository.listChildren(fqn, limit, offset);
+    return repository.listChildren(fqn, limit, offset, include);
   }
 
   @GET

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ListFilterTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ListFilterTest.java
@@ -201,6 +201,27 @@ class ListFilterTest {
   }
 
   /**
+   * {@code ?root=true} without {@code ?service=} must not bind {@code :serviceHash}
+   * either — confirming that the depth bind {@code :serviceHashChild} the
+   * {@code ContainerDAO.listRoot*} SQL references is not silently produced by ListFilter
+   * for a no-service call. The DAO override has to default this bind itself
+   * ({@code rootListingParams}) so the SQL stays runnable. Regression guard for the
+   * "GET /containers?root=true (no service) crashes with missing-named-parameter" bug.
+   */
+  @Test
+  void test_noServiceFilter_doesNotBindServicePatterns() {
+    ListFilter filter = new ListFilter().addQueryParam("root", "true");
+    filter.getCondition("storage_container_entity");
+
+    assertNull(
+        filter.getQueryParams().get("serviceHash"),
+        "serviceHash must not be bound when ?service= is absent");
+    assertNull(
+        filter.getQueryParams().get("serviceHashChild"),
+        "serviceHashChild must not be bound when ?service= is absent — DAO defaults it");
+  }
+
+  /**
    * Confirms the `?include=` flag still routes through the standard <sqlCondition> slot
    * regardless of which entity-specific prefix filter is in use. This is the bridge the
    * Deleted-toggle UI relies on: the user's choice translates to {@code include=} on the

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ListFilterTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ListFilterTest.java
@@ -158,10 +158,11 @@ class ListFilterTest {
     assertNotNull(hashLike, "serviceHash bind must be set when service is filtered");
     assertNotNull(hashLikeChild, "serviceHashChild bind must be set for depth-aware listings");
 
-    // Both binds share the same prefix (everything up to the first '%'). The child bind
-    // appends ".%" so it matches descendants strictly below the immediate level. fqnHash
-    // segments are MD5 (32 hex chars), so prefix + ".%" excludes direct children and
-    // prefix + ".%.%" excludes grandchildren-and-deeper.
+    // Both binds share the same hashed prefix; only the LIKE-pattern tail differs.
+    // In ContainerDAO.listRoot* the SQL uses them as:
+    //   fqnHash LIKE     :serviceHash       -- '<hash>.%'   matches all descendants
+    //   fqnHash NOT LIKE :serviceHashChild  -- '<hash>.%.%' rejects depth >= 2
+    // so the combination keeps only direct children (depth = 1).
     int prefixEnd = hashLike.indexOf('%');
     assertTrue(prefixEnd > 0, "serviceHash should be of form '<hash>.%', got: " + hashLike);
     String prefix = hashLike.substring(0, prefixEnd);

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ListFilterTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ListFilterTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.type.Include;
 
 class ListFilterTest {
   @Test
@@ -129,5 +130,98 @@ class ListFilterTest {
     assertEquals(
         "WHERE mcp_execution_entity.deleted = FALSE AND serverId = :serverId",
         filter.getCondition("mcp_execution_entity"));
+  }
+
+  /**
+   * `?service=` filtering must bind two related patterns:
+   *   - {@code :serviceHash} for "any descendant of the service" — used by every
+   *     service-filtered listing's WHERE clause via getFqnPrefixCondition.
+   *   - {@code :serviceHashChild} for "any descendant strictly below the immediate
+   *     level" — used by the root listing to negate descendants and keep only
+   *     direct children.
+   *
+   * Both binds must reflect the same MD5 prefix, only differing in the LIKE pattern's
+   * tail. This is the contract that ContainerDAO.listRoot{Before,After,Count} relies on.
+   */
+  @Test
+  void test_getServiceCondition_bindsBothPrefixAndChildDepthPatterns() {
+    ListFilter filter = new ListFilter();
+    filter.addQueryParam("service", "aws_s3");
+
+    String condition = filter.getCondition("storage_container_entity");
+    assertTrue(
+        condition.contains("storage_container_entity.fqnHash LIKE :serviceHash"),
+        "WHERE clause should reference the service prefix LIKE bind. Got: " + condition);
+
+    String hashLike = (String) filter.getQueryParams().get("serviceHash");
+    String hashLikeChild = (String) filter.getQueryParams().get("serviceHashChild");
+    assertNotNull(hashLike, "serviceHash bind must be set when service is filtered");
+    assertNotNull(hashLikeChild, "serviceHashChild bind must be set for depth-aware listings");
+
+    // Both binds share the same prefix (everything up to the first '%'). The child bind
+    // appends ".%" so it matches descendants strictly below the immediate level. fqnHash
+    // segments are MD5 (32 hex chars), so prefix + ".%" excludes direct children and
+    // prefix + ".%.%" excludes grandchildren-and-deeper.
+    int prefixEnd = hashLike.indexOf('%');
+    assertTrue(prefixEnd > 0, "serviceHash should be of form '<hash>.%', got: " + hashLike);
+    String prefix = hashLike.substring(0, prefixEnd);
+    assertEquals(prefix + "%", hashLike);
+    assertEquals(prefix + "%.%", hashLikeChild);
+  }
+
+  /**
+   * A service whose name contains a dot (e.g. {@code aws.s3}) must hash as a single
+   * quoted segment rather than splitting into {@code aws} + {@code s3}. This is the
+   * special-char handling the FQN parser provides via {@code quoteName}; the listing
+   * SQL relies on the resulting hash matching what ContainerRepository writes at create
+   * time. Regression guard: a previous quote-stripping pass produced two hashes for a
+   * single dotted name and silently broke {@code ?service=...&root=true}.
+   */
+  @Test
+  void test_getServiceCondition_dottedServiceNameUsesSingleHashedSegment() {
+    ListFilter filter = new ListFilter();
+    filter.addQueryParam("service", "aws.s3");
+    filter.getCondition("storage_container_entity");
+
+    String hashLike = (String) filter.getQueryParams().get("serviceHash");
+    String hashLikeChild = (String) filter.getQueryParams().get("serviceHashChild");
+    assertNotNull(hashLike);
+    assertNotNull(hashLikeChild);
+
+    // The MD5 of a single quoted segment is 32 hex chars; with the trailing ".%" suffix
+    // the prefix bind is exactly 34 chars. Two-segment-or-more service names would
+    // produce a longer prefix because each additional segment adds 33 chars (1 dot +
+    // 32 hex). 34 confirms quoteName collapsed the dotted name into one segment.
+    int prefixEnd = hashLike.indexOf('%');
+    assertEquals(34, prefixEnd + 1, "Dotted service name should hash to exactly one segment");
+
+    // The child bind must mirror this: same 33-char hashed prefix + ".%.%".
+    int childPrefixEnd = hashLikeChild.indexOf('%');
+    assertEquals(prefixEnd, childPrefixEnd, "Both binds must share the same prefix length");
+  }
+
+  /**
+   * Confirms the `?include=` flag still routes through the standard <sqlCondition> slot
+   * regardless of which entity-specific prefix filter is in use. This is the bridge the
+   * Deleted-toggle UI relies on: the user's choice translates to {@code include=} on the
+   * URL, which becomes a deleted clause inside the WHERE we share with the depth check.
+   */
+  @Test
+  void test_includeIsHonouredAlongsideServicePrefix() {
+    // Default (include = NON_DELETED) → AND deleted = FALSE
+    ListFilter ndFilter = new ListFilter(Include.NON_DELETED).addQueryParam("service", "aws_s3");
+    String ndCond = ndFilter.getCondition("storage_container_entity");
+    assertTrue(ndCond.contains("storage_container_entity.deleted = FALSE"), ndCond);
+
+    // ALL drops the deleted predicate altogether
+    ListFilter allFilter = new ListFilter(Include.ALL).addQueryParam("service", "aws_s3");
+    String allCond = allFilter.getCondition("storage_container_entity");
+    assertFalse(allCond.contains("storage_container_entity.deleted = FALSE"), allCond);
+    assertFalse(allCond.contains("storage_container_entity.deleted = TRUE"), allCond);
+
+    // DELETED restricts to soft-deleted rows
+    ListFilter delFilter = new ListFilter(Include.DELETED).addQueryParam("service", "aws_s3");
+    String delCond = delFilter.getCondition("storage_container_entity");
+    assertTrue(delCond.contains("storage_container_entity.deleted = TRUE"), delCond);
   }
 }


### PR DESCRIPTION
### Describe your changes:

`GET /api/v1/containers?service=...&root=true` was leaking deeply-nested orphan containers into the service-root listing (FQN says they're 5+ levels deep, breadcrumb agrees, but the listing showed them next to real buckets) and the same call was also painfully slow (~3.8s on a 580k-row table). Two fixes for the same surface plus a migration correction:

1. **Listing path is now FQN-driven, not relationship-driven.** `ListFilter.getFqnPrefixCondition` binds both the prefix `LIKE` (`<hash>.%`) and a depth-aware `NOT LIKE` companion (`<hash>.%.%`). `ContainerDAO.listRoot{Before,After,Count}` swaps the `NOT EXISTS` anti-join on `entity_relationship` for `fqnHash NOT LIKE :serviceHashChild`. `ContainerRepository.listChildren` rewritten to a single SQL roundtrip against the same FQN-depth predicate — no parent-by-name lookup, no `findToWithOffset`/`countFindTo`, no second-hop hydration. Same shape works at any tree depth (service → root, root → child, deeper). Both endpoints honour `?include=non-deleted|all|deleted`; `ChildrenPageCache` key now includes the include tag so toggling the UI Deleted switch doesn't return a stale page from the other side.

2. **Cascade-delete orphan source fixed** (`EntityRepository.processDeletionBatch`). The `>100`-children hard-delete batch path pre-deleted relationships in two batched queries before iterating per-entity `cleanup()` inside a swallow-all `try/catch` — a single failed cleanup left the entity row alive after its relationships were wiped, exactly the multi-segment-FQN orphan the listing change defends against. `cleanup()` per entity is now the single source of truth (row + relationships in one JDBI transaction); exceptions propagate so the loop stops with per-child atomicity.

3. **Migration correction.** The 23 `idx_*_fqnhash_pattern` indexes added in 1.13.0 used `varchar_pattern_ops`. The planner casts the column to text when the LIKE RHS is text-typed (every JDBC `setString` call), so `varchar_pattern_ops` doesn't match the resulting `(fqnhash)::text ~~` expression and the index is silently unused. Recreated with `text_pattern_ops`. Confirmed via `EXPLAIN ANALYZE` on a 580k-row table: same query drops from ~470ms cold (Parallel Seq Scan) to <1ms (Index Scan).

Tested with **3 new unit tests** in `ListFilterTest` (both binds present, dotted/quoted service-name special-char handling, `?include=` flowing through alongside the service prefix) and **8 new integration tests** in `ContainerResourceIT` covering: depth correctness at every level of a 5-level chain, orphan exclusion at root with the relationship row missing, orphan discoverability under its FQN-implied parent's `/children`, sibling subtree isolation, the include toggle on both endpoints, and large-batch (101-child) recursive hard delete leaving no orphan rows or relationships. Closes #27870 (its cascade fix and both new tests picked up verbatim; the listing-side `NOT EXISTS + LENGTH/REPLACE` belt-and-suspenders is replaced by the single FQN-depth predicate).

#
### Type of change:
- [x] Bug fix

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added a test that covers the exact scenario we are fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----
## Summary by Gitar

- **Refactoring:**
  - Replaced hard-coded concatenation in `ContainerRepository` with `Entity.SEPARATOR` for consistent FQN hash generation.
  - Simplified string construction for `parentHashChild` in `ContainerRepository` to use `Entity.SEPARATOR`.
- **Error handling:**
  - Improved logging in `EntityRepository` to correctly capture and log original exceptions during recursive batch deletes.
  - Restored descriptive comment blocks regarding recursive batch delete failure semantics.

<sub>This will update automatically on new commits.</sub>