### PR TITLE
Chore(UI): test.slow() for CSVImportWithQuotesAndCommas to cover 1.13 AUT timing

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CSVImportWithQuotesAndCommas.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CSVImportWithQuotesAndCommas.spec.ts
@@ -51,6 +51,8 @@ test.describe('CSV Import with Commas and Quotes - All Entity Types', () => {
   test('Create glossary with CSV, export it, create new glossary and import exported data', async ({
     page,
   }) => {
+    test.slow();
+
     const { apiContext } = await getApiContext(page);
     const sourceGlossary = new Glossary(`QuotesCommas-${uuid()}`);
     const targetGlossary = new Glossary(`QuotesCommas-Target-${uuid()}`);


### PR DESCRIPTION
## Summary

- Adds `test.slow()` to `CSVImportWithQuotesAndCommas.spec.ts` so the single test in this spec gets a 180s timeout instead of the default 60s.
- Matches the precedent in #27782 (`b053fecfea`), which did the same for `customProperties`.

## Why

On 1.13 AUT, the CSV-import end-to-end flow consistently lands at ~48–52s — right at the 60s test-timeout boundary — and times out under any extra cluster jitter. Walking the recent run history:

| Image | First attempt | Retry #1 |
| --- | --- | --- |
| n55 (Apr 28) | ✘ 30.9s | ✘ 28.1s |
| n56 (Apr 29) | ✘ 48.9s | ✘ 51.3s |
| n67 (May 3) | ✘ 1.0m | ✓ 52.4s |
| n70 (May 4) | ✘ 1.0m | ✘ 1.0m |

Same test on regular (non-AUT) 1.13 Playwright passes in ~24s, and the same test on main AUT (run `25235690014`, May 1) passes in 37.4s. The slow path is specific to 1.13 AUT (legacy task/feed system + bounded-executor backpressure under upgrade-loaded sample data).

`test.slow()` is the unblocker; the underlying backend latency is a separate investigation.

## Test plan

- [ ] Re-run the AUT MySQL 1.9.1 ➡ 1.13 workflow and confirm `CSV Import with Commas and Quotes - All Entity Types › Create glossary with CSV, export it, create new glossary and import exported data` passes within the new 180s budget.
- [ ] Verify regular 1.13 Playwright runs still pass (no behavior change for the fast path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)