### PR TITLE
fix(playwright): support selecting explore left panel asset type

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/entityPanel.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/entityPanel.ts
@@ -58,12 +58,14 @@ export const openEntitySummaryPanel = async ({
   endpoint,
   fullyQualifiedName,
   exploreTab,
+  dataAssetTypeLeftPanelTestId,
 }: {
   page: Page;
   entityName: string;
   endpoint?: string;
   fullyQualifiedName?: string;
   exploreTab?: string;
+  dataAssetTypeLeftPanelTestId?: string;
 }) => {
   if (endpoint && ENDPOINT_TO_FILTER_MAP[endpoint]) {
     await page.getByTestId('global-search-selector').waitFor({
@@ -105,6 +107,12 @@ export const openEntitySummaryPanel = async ({
     await cardByFqn.getByTestId('description-text').click();
 
     return;
+  }
+
+  if (dataAssetTypeLeftPanelTestId) {
+    const knowledgeCenterItem = page.getByTestId(dataAssetTypeLeftPanelTestId);
+    await knowledgeCenterItem.waitFor({ state: 'visible' });
+    await knowledgeCenterItem.click();
   }
 
   await page

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/explore.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/explore.ts
@@ -359,12 +359,14 @@ export const navigateToExploreAndSelectEntity = async ({
   endpoint,
   fullyQualifiedName,
   exploreTab,
+  dataAssetTypeLeftPanelTestId,
 }: {
   page: Page;
   entityName: string;
   endpoint?: string;
   fullyQualifiedName?: string;
   exploreTab?: string;
+  dataAssetTypeLeftPanelTestId?: string;
 }) => {
   await redirectToExplorePage(page);
 
@@ -378,6 +380,7 @@ export const navigateToExploreAndSelectEntity = async ({
     endpoint,
     fullyQualifiedName,
     exploreTab,
+    dataAssetTypeLeftPanelTestId,
   });
 };
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

## Description

Adds optional support in the Explore Playwright helpers to select a specific left-panel asset type before opening an entity summary panel.

This is needed for entity types such as Knowledge Center assets, which are not covered by the existing endpoint-to-filter mapping and therefore need an explicit left-panel tab selection before locating the result card.



<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

https://github.com/user-attachments/assets/8c387b71-9879-46a3-890d-3999466aa101


<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **Dependency migration:**
  - Migrated Databricks from `sqlalchemy-databricks` to `databricks-sqlalchemy`.

<sub>This will update automatically on new commits.</sub>