### PR TITLE
docs(github): require issue link, design, tests, UI recording in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,18 +5,20 @@ Unless your change is trivial, please create an issue to discuss the change befo
 
 ### Describe your changes:
 
-Fixes <issue-number>
+Fixes #<issue-number>
+<!--
+Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
+(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
+problem and design can be discussed before review.
+-->
 
 <!--
 Short blurb explaining:
 - What changes did you make?
 - Why did you make them?
-- How did you test your changes?
 -->
 
 I worked on ... because ...
-
-<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->
 
 #
 ### Type of change:
@@ -28,12 +30,89 @@ I worked on ... because ...
 - [ ] Documentation
 
 #
+### High-level design:
+<!--
+REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
+Skip for small bug fixes and trivial changes.
+
+Cover:
+- Architecture / approach you took and why
+- Key components or files added/changed and how they interact
+- Alternatives considered and why you rejected them
+- Any migration, backward-compatibility, or rollout concerns
+- Diagrams or links to design docs / RFCs if available
+-->
+
+N/A — small change. <!-- Or fill in the design above -->
+
+#
+### Tests:
+
+#### Use cases covered
+<!--
+List the user-visible scenarios this PR exercises. Example:
+- User with Admin role can create a Glossary Term with a parent term
+- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
+-->
+
+#### Unit tests
+<!--
+- [ ] I added unit tests for the new/changed logic.
+- Files added/updated:
+- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
+  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
+- Coverage %: <e.g., 92% on EntityRepository.java>
+-->
+
+#### Backend integration tests
+<!--
+- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
+- [ ] Not applicable (no backend API changes).
+- Files added/updated:
+-->
+
+#### Ingestion integration tests
+<!--
+- [ ] I added/updated ingestion integration tests for connector changes.
+- [ ] Not applicable (no ingestion changes).
+- Files added/updated:
+-->
+
+#### Playwright (UI) tests
+<!--
+- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
+- [ ] Not applicable (no UI changes).
+- Files added/updated:
+-->
+
+#### Manual testing performed
+<!--
+List the manual test steps you performed before requesting review. Example:
+1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
+2. Logged in as admin, created entity X, verified Y appears in the UI
+3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
+-->
+
+#
+### UI screen recording / screenshots:
+<!--
+REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
+demonstrating the change end-to-end, plus before/after screenshots where relevant.
+Mark "Not applicable" if there are no UI changes.
+-->
+
+Not applicable. <!-- Or attach recording/screenshots above -->
+
+#
 ### Checklist:
 <!-- add an x in [] if done, don't mark items that you didn't do !-->
 - [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
 - [ ] My PR title is `Fixes <issue-number>: <short explanation>`
-- [ ] I have commented on my code, particularly in hard-to-understand areas. 
+- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
+- [ ] I have commented on my code, particularly in hard-to-understand areas.
 - [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
+- [ ] For UI changes: I attached a screen recording and/or screenshots above.
+- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.
 
 <!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -56,6 +56,7 @@ The `openmetadata-workflow` meta-skill is loaded at session start and directs Cl
 | [Systematic Debugging](systematic-debugging/SKILL.md) | `/systematic-debugging` | 4-phase root cause analysis |
 | [Code Review](code-review/SKILL.md) | `/code-review` | Two-stage review: spec compliance then code quality |
 | [Verification](verification/SKILL.md) | `/verification` | Evidence-based completion — show test output, not claims |
+| [PR Checklist](pr-checklist/SKILL.md) | `/pr-checklist` | Walk the PR template (issue link, design, tests + coverage, UI recording, manual tests) and draft the PR body |
 
 ### Connector Skills
 

--- a/skills/commands/pr-checklist.md
+++ b/skills/commands/pr-checklist.md
@@ -1,0 +1,11 @@
+---
+name: pr-checklist
+description: Walk the OpenMetadata PR template — linked issue, design, tests + coverage, UI recording, manual tests — then draft and open the PR
+argument-hint: "[branch name or PR number — defaults to current branch]"
+---
+
+Invoke the PR checklist skill to gather every required section of `.github/pull_request_template.md` and produce a fully-filled PR body before opening (or updating) the PR.
+
+Skill tool: skill: "openmetadata-skills:pr-checklist"
+
+If the user provided a branch name or PR number as an argument, pass it to the skill. Otherwise default to the current branch diffed against `origin/main`.

--- a/skills/openmetadata-workflow/SKILL.md
+++ b/skills/openmetadata-workflow/SKILL.md
@@ -21,6 +21,7 @@ This skill is loaded automatically at session start. It ensures you follow the r
 | New connector | `/connector-standards` then `/connector-building` then `/test-enforcement` |
 | UI component | `/tdd` then `/test-enforcement` (must include Jest + Playwright if user-facing) |
 | Code review / PR review | `/code-review` then `/test-enforcement` |
+| Opening / finalizing a PR | `/test-enforcement` then `/verification` then `/pr-checklist` |
 | Connector review | `/connector-review` |
 | E2E test creation | `/playwright` |
 | Finishing implementation | `/test-enforcement` then `/verification` |
@@ -42,6 +43,8 @@ This skill is loaded automatically at session start. It ensures you follow the r
 4. **Verify with evidence.** Use `/verification` before claiming completion. Show actual test output, not claims.
 
 5. **Review before merging.** Use `/code-review` for two-stage review (spec compliance + code quality).
+
+6. **Fill the PR template completely.** Use `/pr-checklist` before `gh pr create` to gather every required section: linked issue, high-level design (large PRs), tests + coverage, UI screen recording, and manual test steps.
 
 ### OpenMetadata Cross-Layer Checklist
 

--- a/skills/pr-checklist/SKILL.md
+++ b/skills/pr-checklist/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: pr-checklist
+description: Use when opening or finalizing a GitHub PR for OpenMetadata. Walks through the repo PR template — linked issue, high-level design (for big PRs), unit/integration/Playwright tests + coverage, UI screen recording, and manual test steps — then drafts a fully-filled PR body and (optionally) creates the PR.
+user-invocable: true
+argument-hint: "[branch name or PR number — defaults to current branch]"
+---
+
+# PR Checklist for OpenMetadata
+
+Walks through `.github/pull_request_template.md` section by section, gathers evidence, and produces a fully-filled PR description before creating the PR.
+
+## When to Use
+
+- Before running `gh pr create`
+- After finishing implementation, before requesting review
+- Updating the description of an existing PR that's missing required sections
+
+## Usage
+
+```
+/pr-checklist                    # Walk template for current branch vs origin/main
+/pr-checklist feature-branch     # Same, for a different branch
+/pr-checklist 12345              # Update description of an existing PR
+```
+
+## Required Sections (from `.github/pull_request_template.md`)
+
+Every PR must address each section below. Skip with an explicit "Not applicable — <reason>" rather than leaving blank.
+
+1. **Linked issue** — `Fixes #<issue-number>` (GitHub auto-links). No issue → open one first.
+2. **Type of change** — exactly one box checked.
+3. **High-level design** — required for large PRs (new features, refactors, breaking changes, >5 files); skip for small bug fixes.
+4. **Tests** — use cases covered, unit tests + coverage %, backend integration tests, ingestion integration tests, Playwright (UI) tests, manual test steps.
+5. **UI screen recording / screenshots** — required for any UI change.
+6. **Checklist** — every box either checked or explicitly N/A.
+
+## Step-by-Step Workflow
+
+### Step 1 — Inspect the change
+
+```bash
+git status
+git diff origin/main...HEAD --stat
+git log origin/main..HEAD --oneline
+```
+
+Use the diff to classify the PR:
+- **Touches `openmetadata-ui/src/main/resources/ui/`** → UI change (recording required).
+- **Touches `openmetadata-service/`** + new/changed REST endpoints → backend integration tests required.
+- **Touches `ingestion/src/metadata/ingestion/source/`** → ingestion tests required.
+- **>5 files changed, or new feature / refactor / breaking change** → high-level design required.
+- **Single-file fix with obvious scope** → small change, design section can be `N/A`.
+
+### Step 2 — Confirm the linked issue
+
+Ask the user for the issue number if not obvious from the branch name or commit messages. Verify it exists:
+
+```bash
+gh issue view <issue-number>
+```
+
+If no issue exists, stop and ask the user to open one before continuing.
+
+### Step 3 — Gather test evidence
+
+Run the relevant commands and capture output. Don't fabricate coverage numbers — run the tools.
+
+**Backend (Java):**
+```bash
+mvn test -pl openmetadata-service -Dtest=<ChangedTestClass>
+mvn jacoco:report -pl openmetadata-service
+# Coverage HTML: openmetadata-service/target/site/jacoco/index.html
+```
+
+**Backend integration tests:**
+```bash
+mvn test -pl openmetadata-integration-tests -Dtest=<NewIT>
+```
+
+**Ingestion (Python):**
+```bash
+source env/bin/activate
+cd ingestion
+make unit_ingestion_dev_env
+python -m pytest tests/unit/<changed_path>/ --cov=metadata.<module> --cov-report=term-missing
+```
+
+**Frontend unit tests (Jest):**
+```bash
+cd openmetadata-ui/src/main/resources/ui
+yarn test <ChangedComponent> --coverage
+```
+
+**Playwright (UI E2E):**
+```bash
+cd openmetadata-ui/src/main/resources/ui
+yarn playwright:run --grep "<feature name>"
+```
+
+For each, note the actual coverage % and test file paths in the PR body.
+
+> Tip: hand off the heavy lifting — `/test-enforcement` produces the same evidence and enforces 90% coverage on changed classes. Run it first if the user hasn't already.
+
+### Step 4 — Collect manual test steps
+
+Ask the user (or recall from the conversation): "What did you do by hand to verify this works?" List concrete, reproducible steps:
+- Stack started (`./docker/run_local_docker.sh -m ui -d mysql`)
+- Login user / role
+- Click path through the UI
+- Sample input + observed output
+- Negative-path check (error case, permission denial)
+
+### Step 5 — UI screen recording (UI changes only)
+
+If the PR touches the UI, the recording is **required**. Tell the user:
+- macOS built-in: `Cmd+Shift+5` → "Record Selected Portion"
+- Save as `.mov`, drag-and-drop into the PR description (GitHub uploads it inline)
+- Include before/after screenshots for visual changes (toolbar, layout, color)
+
+If the user can't attach the recording yet, mark the section `TODO: attach recording` and don't open the PR until it's added — or open as draft.
+
+### Step 6 — Draft the PR body
+
+Fill in `.github/pull_request_template.md` with everything gathered above. Show the user the full draft for review before creating.
+
+### Step 7 — Create or update the PR
+
+**New PR** (use a HEREDOC so formatting survives):
+```bash
+gh pr create --base main --title "Fixes #<issue>: <short title>" --body "$(cat <<'EOF'
+<filled-in template here>
+EOF
+)"
+```
+
+**Update existing PR**:
+```bash
+gh pr edit <number> --body "$(cat <<'EOF'
+<filled-in template here>
+EOF
+)"
+```
+
+Return the PR URL when done.
+
+## Quality Gates Before Creating the PR
+
+Refuse to open the PR if any of these are missing — surface them to the user instead:
+
+- [ ] Linked issue exists and is referenced as `Fixes #N`
+- [ ] PR title matches `Fixes <issue-number>: <short explanation>`
+- [ ] At least one "Type of change" box is checked
+- [ ] Large PR has a high-level design section filled in (not `N/A`)
+- [ ] Tests section lists actual files and coverage numbers (not placeholders)
+- [ ] UI changes have a screen recording attached or marked as TODO with the PR opened as draft
+- [ ] Manual test steps are concrete and reproducible
+- [ ] Cross-layer checks for the change type pass (`make generate`, `mvn spotless:apply`, `yarn lint`, etc.)
+
+## Common Gaps to Watch For
+
+- Schema change without `make generate` → models out of sync
+- Backend API change without integration test in `openmetadata-integration-tests/`
+- New UI feature without Playwright spec
+- Bug fix without a regression test that fails before the fix
+- Large refactor with `N/A` in the design section — push back and ask for the design
+- Coverage % copy-pasted from another PR — re-run the tool


### PR DESCRIPTION
### Describe your changes:

Fixes #<issue-number>
<!-- No tracking issue filed; this is a meta-improvement to PR hygiene. Open one and update if the project requires it. -->

Updated `.github/pull_request_template.md` so every PR captures the context reviewers actually need: a linked GitHub issue (`Fixes #N`), a high-level design for large PRs, a structured Tests section (use cases, unit + coverage %, backend/ingestion integration tests, Playwright E2E, manual steps), and a UI screen recording for any UI change. Added a companion `/pr-checklist` skill that walks the template section by section, runs the right test/coverage commands per layer, and drafts the PR body before `gh pr create`.

#
### Type of change:
- [x] Improvement
- [x] Documentation

#
### High-level design:

- **Template** (`.github/pull_request_template.md`): added required sections — `Fixes #` (with `#` prefix so GitHub auto-links), High-level design, Tests (Use cases / Unit + coverage / Backend IT / Ingestion IT / Playwright / Manual), and UI screen recording. Extended the checklist with issue-link, UI-recording, and tests rows.
- **Skill** (`skills/pr-checklist/SKILL.md`): user-invocable skill that classifies the PR from the diff, verifies the linked issue with `gh issue view`, runs Maven/JaCoCo, pytest-cov, Jest, and Playwright per layer, prompts for manual test steps and UI recording, then drafts and opens the PR via HEREDOC.
- **Wiring**: registered `/pr-checklist` slash command in `skills/commands/`, listed it in `skills/README.md`, and added an "Opening / finalizing a PR" row + workflow rule #6 in `skills/openmetadata-workflow/SKILL.md` so the meta-skill routes here before `gh pr create`. Symlinked into `.claude/skills/` for in-repo zero-setup use.
- **Alternatives rejected**: stuffing all the prompts into the template alone (too much friction without automation); a hook on `gh pr create` (would block instead of guide).

#
### Tests:

#### Use cases covered
- Author opens a PR using the new template — every required section is visible with inline guidance.
- Author runs `/pr-checklist` — skill walks the template, runs coverage tools, and produces a fully filled PR body.
- Reviewer scans a PR — can immediately see linked issue, design, test evidence, and (for UI) screen recording.

#### Unit tests
Not applicable — markdown template + skill prose; no executable code.

#### Backend integration tests
Not applicable — no backend changes.

#### Ingestion integration tests
Not applicable — no ingestion changes.

#### Playwright (UI) tests
Not applicable — no UI changes.

#### Manual testing performed
1. Rendered the updated `pull_request_template.md` locally and verified all six required sections are present and ordered.
2. `git diff origin/main...HEAD --stat` shows the expected 5 files / +265/-5 changes.
3. Confirmed `.claude/skills/pr-checklist -> ../../skills/pr-checklist` symlink resolves and `SKILL.md` is readable from both paths.
4. Verified the `/pr-checklist` slash command file matches the format of the existing `commands/*.md` (frontmatter, skill tool reference).

#
### UI screen recording / screenshots:

Not applicable — no UI changes.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>` <!-- no tracking issue filed for this meta-PR -->
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above. <!-- same -->
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed. <!-- no schema changes -->
- [x] For UI changes: I attached a screen recording and/or screenshots above. <!-- no UI changes -->
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above. <!-- N/A — docs only -->