### PR TITLE
Container children: search + Deleted toggle, rename tab to Containers

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ContainerResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ContainerResourceIT.java
@@ -1739,7 +1739,11 @@ public class ContainerResourceIT extends BaseEntityIT<Container, CreateContainer
    * common foot-gun than {@code %}, but both wildcards are escaped uniformly via the
    * {@link
    * org.openmetadata.service.jdbi3.ContainerRepository#buildNameLikeBind(String)}
-   * helper which prepends {@code \\} to {@code %}, {@code _}, and {@code \\} itself.
+   * helper which prepends {@code !} to {@code %}, {@code _}, and {@code !} itself, and
+   * the SQL declares {@code ESCAPE '!'} explicitly. {@code !} is preferred over
+   * backslash because JDBI's ColonPrefixSqlParser mishandles literal {@code '\'} inside
+   * single-quoted SQL strings and silently drops a downstream {@code :includeDeleted}
+   * bind.
    */
   @Test
   void test_listChildren_filterByQuery_escapesLikeWildcards(TestNamespace ns) throws Exception {

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ContainerResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ContainerResourceIT.java
@@ -1670,6 +1670,179 @@ public class ContainerResourceIT extends BaseEntityIT<Container, CreateContainer
   }
 
   /**
+   * The {@code ?q=} substring filter on {@code /children} narrows a parent's direct-child
+   * page to names containing the query (case-insensitive). Asserts both that matches are
+   * returned and that non-matching siblings under the same parent are excluded — so a UI
+   * that issues both an unfiltered and a filtered request hits two distinct result sets.
+   * Also pins the count semantics: {@code paging.total} must reflect the filtered count,
+   * not the parent's full child count, so the table footer doesn't lie about the result
+   * size when the user has typed in the search box.
+   */
+  @Test
+  void test_listChildren_filterByQuery_matchesByNameSubstring(TestNamespace ns) throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    StorageService service = StorageServiceTestFactory.createS3(ns);
+
+    CreateContainer parentRequest = new CreateContainer();
+    parentRequest.setName(ns.prefix("kids_q_parent"));
+    parentRequest.setService(service.getFullyQualifiedName());
+    Container parent = createEntity(parentRequest);
+
+    Container alpha = createChild(ns, service, parent, "kids_q_AlphaReports");
+    Container beta = createChild(ns, service, parent, "kids_q_betaReports");
+    Container gamma = createChild(ns, service, parent, "kids_q_gamma_log");
+
+    String basePath = "/v1/containers/name/" + parent.getFullyQualifiedName() + "/children";
+
+    ContainerResultList allPage =
+        client.getHttpClient().execute(HttpMethod.GET, basePath, null, ContainerResultList.class);
+    assertEquals(
+        3,
+        allPage.getPaging().getTotal().intValue(),
+        "without ?q= every direct child counts toward total");
+
+    // Substring match — the query "report" should hit both alpha and beta (different
+    // capitalisations) but never the gamma_log child whose name has no overlap.
+    ContainerResultList reportsPage =
+        client
+            .getHttpClient()
+            .execute(HttpMethod.GET, basePath + "?q=report", null, ContainerResultList.class);
+    Set<UUID> reportIds =
+        reportsPage.getData().stream()
+            .map(Container::getId)
+            .collect(java.util.stream.Collectors.toSet());
+    assertTrue(reportIds.contains(alpha.getId()), "AlphaReports must match q=report");
+    assertTrue(reportIds.contains(beta.getId()), "betaReports must match q=report");
+    assertFalse(reportIds.contains(gamma.getId()), "gamma_log must not match q=report");
+    assertEquals(
+        2,
+        reportsPage.getPaging().getTotal().intValue(),
+        "paging.total must reflect the filtered count, not the parent's full child count");
+
+    // No-result query: a substring that no sibling contains returns an empty page with a
+    // zero total, not a failure or the unfiltered list.
+    ContainerResultList emptyPage =
+        client
+            .getHttpClient()
+            .execute(HttpMethod.GET, basePath + "?q=zzznomatch", null, ContainerResultList.class);
+    assertTrue(
+        emptyPage.getData().isEmpty(),
+        "no children should be returned when the query matches nothing");
+    assertEquals(0, emptyPage.getPaging().getTotal().intValue(), "filtered total is 0");
+  }
+
+  /**
+   * Verify that {@code _} and {@code %} in the query are escaped before being sent to the
+   * SQL LIKE clause — without escaping, {@code _} would match any single character and a
+   * search for "foo_bar" would also return "fooXbar". OpenMetadata container/folder names
+   * frequently contain underscores (e.g. {@code etl_run_2024_07}) so this is the more
+   * common foot-gun than {@code %}, but both wildcards are escaped uniformly via the
+   * {@link
+   * org.openmetadata.service.jdbi3.ContainerRepository#buildNameLikeBind(String)}
+   * helper which prepends {@code \\} to {@code %}, {@code _}, and {@code \\} itself.
+   */
+  @Test
+  void test_listChildren_filterByQuery_escapesLikeWildcards(TestNamespace ns) throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    StorageService service = StorageServiceTestFactory.createS3(ns);
+
+    CreateContainer parentRequest = new CreateContainer();
+    parentRequest.setName(ns.prefix("kids_q_escape_parent"));
+    parentRequest.setService(service.getFullyQualifiedName());
+    Container parent = createEntity(parentRequest);
+
+    Container literal = createChild(ns, service, parent, "kids_q_foo_bar");
+    Container wildcardImpostor = createChild(ns, service, parent, "kids_q_fooXbar");
+
+    String basePath = "/v1/containers/name/" + parent.getFullyQualifiedName() + "/children";
+
+    ContainerResultList page =
+        client
+            .getHttpClient()
+            .execute(HttpMethod.GET, basePath + "?q=foo_bar", null, ContainerResultList.class);
+    Set<UUID> ids =
+        page.getData().stream().map(Container::getId).collect(java.util.stream.Collectors.toSet());
+    assertTrue(
+        ids.contains(literal.getId()),
+        "literal underscore in the query must match the literal-underscore name");
+    assertFalse(
+        ids.contains(wildcardImpostor.getId()),
+        "underscore in the query must not behave as a single-char LIKE wildcard");
+  }
+
+  /**
+   * Pins the rule that {@code ?include=deleted} is scoped per-level — at level X, the
+   * toggle returns only direct children of X whose own {@code deleted=true}. A
+   * soft-deleted descendant deeper than one level below X must NOT appear at X's
+   * {@code /children} listing, regardless of the include toggle. Each parent shows
+   * only its own direct children; the toggle filters that direct-children set by
+   * deleted flag, never recurses.
+   *
+   * <p>Both the direct-children-only depth predicate
+   * ({@code fqnHash NOT LIKE :parentHashChild}) and the include filter contribute to
+   * this guarantee; a regression that drops the depth check while keeping the include
+   * check would silently start surfacing deleted descendants from deeper levels at
+   * ancestor /children listings.
+   *
+   * <p>Builds chain root → l1 → l2 → l3 (l3 soft-deleted), then asserts /children at
+   * each level under all three include modes. l3 must only appear under l2 with
+   * include=deleted or include=all; never under root or l1.
+   */
+  @Test
+  void test_listChildren_includeDeleted_scopedToDirectChildrenAtEachLevel(TestNamespace ns)
+      throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    StorageService service = StorageServiceTestFactory.createS3(ns);
+
+    CreateContainer rootRequest = new CreateContainer();
+    rootRequest.setName(ns.prefix("delete_scoping_root"));
+    rootRequest.setService(service.getFullyQualifiedName());
+    Container root = createEntity(rootRequest);
+
+    Container l1 = createChild(ns, service, root, "delete_scoping_l1");
+    Container l2 = createChild(ns, service, l1, "delete_scoping_l2");
+    Container l3 = createChild(ns, service, l2, "delete_scoping_l3");
+    deleteEntity(l3.getId().toString());
+
+    assertChildren(client, root, "include=non-deleted (default)", "", Set.of(l1.getId()));
+    assertChildren(
+        client, root, "include=deleted at root", "?include=deleted", Set.of() /* none */);
+    assertChildren(client, root, "include=all at root", "?include=all", Set.of(l1.getId()));
+
+    assertChildren(client, l1, "include=non-deleted (default)", "", Set.of(l2.getId()));
+    assertChildren(client, l1, "include=deleted at l1", "?include=deleted", Set.of() /* none */);
+    assertChildren(client, l1, "include=all at l1", "?include=all", Set.of(l2.getId()));
+
+    assertChildren(client, l2, "include=non-deleted (default)", "", Set.of() /* none */);
+    assertChildren(client, l2, "include=deleted at l2", "?include=deleted", Set.of(l3.getId()));
+    assertChildren(client, l2, "include=all at l2", "?include=all", Set.of(l3.getId()));
+  }
+
+  private void assertChildren(
+      OpenMetadataClient client, Container parent, String label, String query, Set<UUID> expected)
+      throws Exception {
+    String basePath = "/v1/containers/name/" + parent.getFullyQualifiedName() + "/children" + query;
+    ContainerResultList page =
+        client.getHttpClient().execute(HttpMethod.GET, basePath, null, ContainerResultList.class);
+    Set<UUID> actual =
+        page.getData().stream().map(Container::getId).collect(java.util.stream.Collectors.toSet());
+    assertEquals(
+        expected,
+        actual,
+        () ->
+            String.format(
+                "/children of %s with %s — expected %s, got %s",
+                parent.getName(), label, expected, actual));
+    assertEquals(
+        expected.size(),
+        page.getPaging().getTotal().intValue(),
+        () ->
+            String.format(
+                "paging.total at %s with %s must reflect filtered direct-children count",
+                parent.getName(), label));
+  }
+
+  /**
    * The FQN-depth predicate must produce direct-children-only at <em>any</em> level of
    * the hierarchy, not just the service root. Build a 5-level chain
    * (root → l1 → l2 → l3 → l4) and walk down, asserting at each non-leaf level that

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -891,7 +891,15 @@ public interface CollectionDAO {
     // segment below the parent — same shape used by the root listing in listRootAfter, just
     // without the cursor pagination. Returns the slim projection used by the children table
     // UI; the caller restores the service reference separately. `:includeDeleted` is a
-    // tri-state: 'NON_DELETED' (default), 'DELETED', or 'ALL'.
+    // tri-state: 'NON_DELETED' (default), 'DELETED', or 'ALL'. `:nameLike` is a LIKE pattern
+    // applied to LOWER(name); callers pass '%' for "no filter" or '%<lowercased-escaped>%'
+    // for a substring search. ESCAPE '!' is set explicitly so the same pattern semantics
+    // hold on MySQL (default escape is '\') and PostgreSQL (default has no escape char).
+    // '!' is preferred over '\' because the JDBI ColonPrefixSqlParser scans string literals
+    // to skip ':' bind markers inside them, and a literal {@code '\'} confuses the scanner
+    // (it treats the trailing backslash as an escape and consumes the closing quote),
+    // leaving a downstream {@code :includeDeleted} bind un-substituted and the prepared
+    // statement malformed.
     @ConnectionAwareSqlQuery(
         value =
             "SELECT id, name, "
@@ -901,6 +909,7 @@ public interface CollectionDAO {
                 + "deleted "
                 + "FROM storage_container_entity "
                 + "WHERE fqnHash LIKE :parentHash AND fqnHash NOT LIKE :parentHashChild "
+                + "  AND LOWER(name) LIKE :nameLike ESCAPE '!' "
                 + "  AND (:includeDeleted = 'ALL' "
                 + "       OR (:includeDeleted = 'DELETED' AND deleted = TRUE) "
                 + "       OR (:includeDeleted = 'NON_DELETED' AND deleted = FALSE)) "
@@ -915,6 +924,7 @@ public interface CollectionDAO {
                 + "deleted "
                 + "FROM storage_container_entity "
                 + "WHERE fqnHash LIKE :parentHash AND fqnHash NOT LIKE :parentHashChild "
+                + "  AND LOWER(name) LIKE :nameLike ESCAPE '!' "
                 + "  AND (:includeDeleted = 'ALL' "
                 + "       OR (:includeDeleted = 'DELETED' AND deleted = TRUE) "
                 + "       OR (:includeDeleted = 'NON_DELETED' AND deleted = FALSE)) "
@@ -924,6 +934,7 @@ public interface CollectionDAO {
     List<Container> listDirectChildSummariesByParentHash(
         @Bind("parentHash") String parentHash,
         @Bind("parentHashChild") String parentHashChild,
+        @Bind("nameLike") String nameLike,
         @Bind("includeDeleted") String includeDeleted,
         @Bind("limit") int limit,
         @Bind("offset") int offset);
@@ -932,6 +943,7 @@ public interface CollectionDAO {
         value =
             "SELECT count(fqnHash) FROM storage_container_entity "
                 + "WHERE fqnHash LIKE :parentHash AND fqnHash NOT LIKE :parentHashChild "
+                + "  AND LOWER(name) LIKE :nameLike ESCAPE '!' "
                 + "  AND (:includeDeleted = 'ALL' "
                 + "       OR (:includeDeleted = 'DELETED' AND deleted = TRUE) "
                 + "       OR (:includeDeleted = 'NON_DELETED' AND deleted = FALSE))",
@@ -940,6 +952,7 @@ public interface CollectionDAO {
         value =
             "SELECT count(*) FROM storage_container_entity "
                 + "WHERE fqnHash LIKE :parentHash AND fqnHash NOT LIKE :parentHashChild "
+                + "  AND LOWER(name) LIKE :nameLike ESCAPE '!' "
                 + "  AND (:includeDeleted = 'ALL' "
                 + "       OR (:includeDeleted = 'DELETED' AND deleted = TRUE) "
                 + "       OR (:includeDeleted = 'NON_DELETED' AND deleted = FALSE))",
@@ -947,6 +960,7 @@ public interface CollectionDAO {
     int countDirectChildrenByParentHash(
         @Bind("parentHash") String parentHash,
         @Bind("parentHashChild") String parentHashChild,
+        @Bind("nameLike") String nameLike,
         @Bind("includeDeleted") String includeDeleted);
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ContainerRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ContainerRepository.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -604,7 +605,12 @@ public class ContainerRepository extends EntityRepository<Container> {
   }
 
   public ResultList<Container> listChildren(String parentFQN, Integer limit, Integer offset) {
-    return listChildren(parentFQN, limit, offset, Include.NON_DELETED);
+    return listChildren(parentFQN, limit, offset, Include.NON_DELETED, null);
+  }
+
+  public ResultList<Container> listChildren(
+      String parentFQN, Integer limit, Integer offset, Include include) {
+    return listChildren(parentFQN, limit, offset, include, null);
   }
 
   /**
@@ -634,14 +640,24 @@ public class ContainerRepository extends EntityRepository<Container> {
    * segment below" is expressible as {@code fqnHash LIKE :parentHash AND fqnHash NOT LIKE
    * :parentHashChild}, where {@code :parentHash} is {@code <hash>.%} and
    * {@code :parentHashChild} is {@code <hash>.%.%}.
+   *
+   * <p>{@code search} narrows the page to children whose name contains the given substring
+   * (case-insensitive). Empty / null disables the filter — the caller passes the raw text
+   * the user typed; LIKE wildcards in the query are escaped here so {@code _} and
+   * {@code %} match literally. Searches bypass {@link ChildrenPageCache} since the same
+   * parent will typically be queried with many different substrings (cache hit rate ≈ 0)
+   * and caching every variant inflates the working set; the depth-only listing remains
+   * cached as before.
    */
   public ResultList<Container> listChildren(
-      String parentFQN, Integer limit, Integer offset, Include include) {
+      String parentFQN, Integer limit, Integer offset, Include include, String search) {
     int safeLimit = limit != null ? limit : 0;
     int safeOffset = offset != null ? offset : 0;
     Include safeInclude = include != null ? include : Include.NON_DELETED;
+    String nameLike = buildNameLikeBind(search);
+    boolean hasSearch = !"%".equals(nameLike);
 
-    ChildrenPageCache pageCache = CacheBundle.getChildrenPageCache();
+    ChildrenPageCache pageCache = hasSearch ? null : CacheBundle.getChildrenPageCache();
     if (pageCache != null) {
       ResultList<Container> cached;
       try (var ignored = RequestLatencyContext.phase("listChildrenCacheGet")) {
@@ -667,13 +683,14 @@ public class ContainerRepository extends EntityRepository<Container> {
       try (var ignored = RequestLatencyContext.phase("listChildrenPage")) {
         children =
             containerDAO.listDirectChildSummariesByParentHash(
-                parentHash, parentHashChild, includeBind, safeLimit, safeOffset);
+                parentHash, parentHashChild, nameLike, includeBind, safeLimit, safeOffset);
       }
 
       int total;
       try (var ignored = RequestLatencyContext.phase("listChildrenCount")) {
         total =
-            containerDAO.countDirectChildrenByParentHash(parentHash, parentHashChild, includeBind);
+            containerDAO.countDirectChildrenByParentHash(
+                parentHash, parentHashChild, nameLike, includeBind);
       }
 
       if (children.isEmpty()) {
@@ -700,6 +717,32 @@ public class ContainerRepository extends EntityRepository<Container> {
               "Failed to fetch children for container [%s]: %s", parentFQN, e.getMessage()),
           e);
     }
+  }
+
+  /**
+   * Build the LIKE bind for the optional name filter. Returns {@code "%"} (which always
+   * matches) when no search is supplied so the SQL stays branch-free. When a search is
+   * supplied the pattern is lowercased to match the {@code LOWER(name)} expression in the
+   * SQL and the LIKE wildcards {@code %} and {@code _} (plus the escape character
+   * {@code !}) are escaped so a name containing them matches literally rather than
+   * acting as a wildcard. The SQL declares {@code ESCAPE '!'} explicitly because the
+   * MySQL/PostgreSQL defaults differ; {@code !} is preferred over {@code \} because
+   * a literal backslash inside a single-quoted SQL string confuses JDBI's
+   * ColonPrefixSqlParser when it scans for {@code :name} bind markers, leaving a
+   * downstream bind un-substituted (see ContainerDAO comment block).
+   */
+  private static String buildNameLikeBind(String search) {
+    if (search == null || search.isBlank()) {
+      return "%";
+    }
+    String escaped =
+        search
+            .trim()
+            .toLowerCase(Locale.ROOT)
+            .replace("!", "!!")
+            .replace("%", "!%")
+            .replace("_", "!_");
+    return "%" + escaped + "%";
   }
 
   /**

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/storages/ContainerResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/storages/ContainerResource.java
@@ -763,12 +763,17 @@ public class ContainerResource extends EntityResource<Container, ContainerReposi
               schema = @Schema(implementation = Include.class))
           @QueryParam("include")
           @DefaultValue("non-deleted")
-          Include include) {
+          Include include,
+      @Parameter(
+              description =
+                  "Optional case-insensitive substring filter on the child container name.")
+          @QueryParam("q")
+          String q) {
     OperationContext operationContext =
         new OperationContext(entityType, MetadataOperation.VIEW_BASIC);
     ResourceContext<Container> resourceContext = getResourceContextByName(fqn);
     authorizer.authorize(securityContext, operationContext, resourceContext);
-    return repository.listChildren(fqn, limit, offset, include);
+    return repository.listChildren(fqn, limit, offset, include, q);
   }
 
   @GET

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Container.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Container.spec.ts
@@ -92,7 +92,9 @@ test.describe('Container entity specific tests ', () => {
   }) => {
     await container.visitEntityPage(page);
 
-    await page.getByText('Children').click();
+    // Tab is identified by EntityTabs.CHILDREN ('children'); the displayed text
+    // is now 'Containers' (label.container-plural) so target the testid, not text.
+    await page.getByTestId('children').click();
 
     await expect(page.getByTestId('pagination')).toBeVisible();
     await expect(page.getByTestId('previous')).toBeDisabled();
@@ -443,5 +445,462 @@ test.describe('Deeply nested container navigation', () => {
       await expect(breadcrumb).not.toContainText(deepContainer3Name);
       await expect(breadcrumb).not.toContainText(deepContainer4Name);
     });
+  });
+});
+
+// Children tab search + Deleted toggle.
+//
+// The /children listing on the Container detail page (renamed from "Children"
+// to "Containers" — same EntityTabs.CHILDREN tab key) now supports:
+//   - case-insensitive substring search via ?q=...
+//   - the same Deleted / non-deleted Switch the service-level Containers tab
+//     already had.
+//
+// These tests pin three behaviours that are easy to regress at the wiring
+// layer (the SQL is covered by ContainerResourceIT):
+//   1. Search filters the parent's direct children only — siblings of the
+//      parent and their descendants must never leak into the result. This is
+//      the per-parent dual of the FQN-depth predicate already enforced by
+//      listDirectChildSummariesByParentHash; if a future change forwards the
+//      query to a service-wide search index instead of the FQN-scoped DAO
+//      method, that scoping would silently break.
+//   2. The Deleted Switch flips include between non-deleted (default) and
+//      deleted, hiding/showing soft-deleted children.
+//   3. Search and the Deleted Switch compose — a deleted child is reachable
+//      via search only when the toggle is on.
+test.describe('Children tab search + Deleted toggle', () => {
+  test.slow(true);
+
+  const serviceName = `pw-storage-service-search-${uuid()}`;
+  const parentName = `pw-search-parent-${uuid()}`;
+  const siblingParentName = `pw-search-other-parent-${uuid()}`;
+
+  // Suffixes are stable so search assertions don't have to thread uuids; full
+  // names get a uuid baked in so the entities don't collide with prior runs.
+  const aliceChildName = `pw-search-alice-${uuid()}`;
+  const aliceClonedSiblingName = `pw-search-alice-clone-${uuid()}`;
+  const bobChildName = `pw-search-bob-${uuid()}`;
+  const carolChildName = `pw-search-carol-${uuid()}`;
+  const deletedChildName = `pw-search-deleted-${uuid()}`;
+  const SEARCH_TERM_ALICE = 'alice';
+  const SEARCH_TERM_DELETED = 'deleted';
+  const SEARCH_TERM_NO_MATCH = 'zzzdoesnotmatch';
+
+  let parentFqn = '';
+
+  test.beforeAll('Setup search/deleted fixtures', async ({ browser }) => {
+    const { afterAction, apiContext } = await performAdminLogin(browser);
+
+    await apiContext.post('/api/v1/services/storageServices', {
+      data: {
+        name: serviceName,
+        ...S3_SERVICE_CONFIG,
+      },
+    });
+
+    // Two parents under the same service so we can verify search results
+    // don't leak across parents. The "alice clone" sibling forces this:
+    // it shares the SEARCH_TERM_ALICE substring but lives under a different
+    // parent; it must NOT appear when searching from the search-parent's
+    // children tab.
+    const parentRes = await apiContext.post('/api/v1/containers', {
+      data: { name: parentName, service: serviceName },
+    });
+    const parent = await parentRes.json();
+    parentFqn = parent.fullyQualifiedName;
+
+    const siblingParentRes = await apiContext.post('/api/v1/containers', {
+      data: { name: siblingParentName, service: serviceName },
+    });
+    const siblingParent = await siblingParentRes.json();
+
+    for (const childName of [
+      aliceChildName,
+      bobChildName,
+      carolChildName,
+      deletedChildName,
+    ]) {
+      await apiContext.post('/api/v1/containers', {
+        data: {
+          name: childName,
+          service: serviceName,
+          parent: { id: parent.id, type: 'container' },
+        },
+      });
+    }
+
+    await apiContext.post('/api/v1/containers', {
+      data: {
+        name: aliceClonedSiblingName,
+        service: serviceName,
+        parent: { id: siblingParent.id, type: 'container' },
+      },
+    });
+
+    // Soft-delete one of the parent's children so the Deleted toggle has
+    // something to reveal. Direct API soft-delete is faster + more reliable
+    // than driving the manage-button flow for each setup run.
+    const deletedChildRes = await apiContext.get(
+      `/api/v1/containers/name/${encodeURIComponent(
+        `${serviceName}.${parentName}.${deletedChildName}`
+      )}`
+    );
+    const deletedChild = await deletedChildRes.json();
+    await apiContext.delete(
+      `/api/v1/containers/${deletedChild.id}?hardDelete=false&recursive=true`
+    );
+
+    await afterAction();
+  });
+
+  test.afterAll('Tear down search/deleted fixtures', async ({ browser }) => {
+    const { afterAction, apiContext } = await performAdminLogin(browser);
+
+    await apiContext.delete(
+      `/api/v1/services/storageServices/name/${encodeURIComponent(
+        serviceName
+      )}?recursive=true&hardDelete=true`
+    );
+
+    await afterAction();
+  });
+
+  test.beforeEach('Visit parent container Containers tab', async ({ page }) => {
+    // Match the proven nav pattern used by the existing "Deeply nested
+    // container navigation" describe in this file: register the response
+    // listener BEFORE goto, then await it. The container's only tab when
+    // dataModel is empty (our fixture parents) is CHILDREN, so the page
+    // fires /children automatically on mount — no separate tab click needed.
+    const initialChildrenResponse = page.waitForResponse(
+      (res) =>
+        res.url().includes(`/api/v1/containers/name/`) &&
+        res.url().includes('/children?') &&
+        res.status() === 200
+    );
+    await page.goto(`/container/${parentFqn}`);
+    await initialChildrenResponse;
+    await waitForAllLoadersToDisappear(page);
+  });
+
+  test('search filters direct children only — sibling subtree never leaks', async ({
+    page,
+  }) => {
+    // Baseline — all four live children of the parent are visible, the
+    // soft-deleted one is hidden by default, and the alice-clone under the
+    // sibling parent does not appear (it lives under a different FQN prefix).
+    const childTable = page.getByTestId('container-list-table');
+    await expect(childTable.getByText(aliceChildName)).toBeVisible();
+    await expect(childTable.getByText(bobChildName)).toBeVisible();
+    await expect(childTable.getByText(carolChildName)).toBeVisible();
+    await expect(childTable.getByText(deletedChildName)).toHaveCount(0);
+    await expect(childTable.getByText(aliceClonedSiblingName)).toHaveCount(0);
+
+    // The search request must include the parent's FQN AND the q= bind. If
+    // someone wires this through the global search index, the URL would no
+    // longer match this matcher and the test fails fast — exactly the scoping
+    // regression we want to catch.
+    const searchResponse = page.waitForResponse(
+      (res) =>
+        res.url().includes(`/api/v1/containers/name/`) &&
+        res.url().includes(encodeURIComponent(parentFqn)) &&
+        res.url().includes('/children?') &&
+        res.url().includes(`q=${SEARCH_TERM_ALICE}`) &&
+        res.status() === 200
+    );
+    await page.getByTestId('searchbar').fill(SEARCH_TERM_ALICE);
+    await searchResponse;
+    await waitForAllLoadersToDisappear(page);
+
+    // Filtered view: only the alice child of the search-parent. The sibling
+    // parent's alice-clone shares the substring but must not appear because
+    // the q= filter is applied AFTER the FQN-depth gate, not in place of it.
+    await expect(childTable.getByText(aliceChildName)).toBeVisible();
+    await expect(childTable.getByText(aliceClonedSiblingName)).toHaveCount(0);
+    await expect(childTable.getByText(bobChildName)).toHaveCount(0);
+    await expect(childTable.getByText(carolChildName)).toHaveCount(0);
+
+    // Empty state — a substring no child contains returns zero rows. Empty
+    // here means the API returned an empty page, not that the filter was
+    // ignored and the previous full result is still on screen.
+    const emptyResponse = page.waitForResponse(
+      (res) =>
+        res.url().includes('/children?') &&
+        res.url().includes(`q=${SEARCH_TERM_NO_MATCH}`) &&
+        res.status() === 200
+    );
+    await page.getByTestId('searchbar').fill(SEARCH_TERM_NO_MATCH);
+    await emptyResponse;
+    await waitForAllLoadersToDisappear(page);
+
+    await expect(childTable.getByText(aliceChildName)).toHaveCount(0);
+    await expect(childTable.getByText(bobChildName)).toHaveCount(0);
+    await expect(childTable.getByText(carolChildName)).toHaveCount(0);
+
+    // Clearing the search restores the unfiltered listing — same baseline
+    // as the start of the test.
+    const clearResponse = page.waitForResponse(
+      (res) =>
+        res.url().includes('/children?') &&
+        !res.url().includes('q=') &&
+        res.status() === 200
+    );
+    await page.getByTestId('searchbar').fill('');
+    await clearResponse;
+    await waitForAllLoadersToDisappear(page);
+
+    await expect(childTable.getByText(aliceChildName)).toBeVisible();
+    await expect(childTable.getByText(bobChildName)).toBeVisible();
+    await expect(childTable.getByText(carolChildName)).toBeVisible();
+  });
+
+  test('Deleted toggle reveals and hides soft-deleted children', async ({
+    page,
+  }) => {
+    const childTable = page.getByTestId('container-list-table');
+
+    // Default state — non-deleted only. The soft-deleted child fixture is
+    // hidden, the three live children are visible.
+    await expect(childTable.getByText(deletedChildName)).toHaveCount(0);
+    await expect(childTable.getByText(aliceChildName)).toBeVisible();
+
+    // Toggle on — include flips to 'deleted'. The deleted child appears,
+    // the live children disappear (deleted-only mode, not "all").
+    const deletedOnResponse = page.waitForResponse(
+      (res) =>
+        res.url().includes('/children?') &&
+        res.url().includes('include=deleted') &&
+        res.status() === 200
+    );
+    await page.getByTestId('show-deleted').click();
+    await deletedOnResponse;
+    await waitForAllLoadersToDisappear(page);
+
+    await expect(childTable.getByText(deletedChildName)).toBeVisible();
+    await expect(childTable.getByText(aliceChildName)).toHaveCount(0);
+    await expect(childTable.getByText(bobChildName)).toHaveCount(0);
+
+    // Toggle off — back to non-deleted. Re-fetches must hit the API and the
+    // deleted child must drop out again. Pinning include=non-deleted in the
+    // URL guards against the cache returning a stale page from the toggled
+    // request (ChildrenPageCache key includes the include tag for this
+    // reason).
+    const deletedOffResponse = page.waitForResponse(
+      (res) =>
+        res.url().includes('/children?') &&
+        res.url().includes('include=non-deleted') &&
+        res.status() === 200
+    );
+    await page.getByTestId('show-deleted').click();
+    await deletedOffResponse;
+    await waitForAllLoadersToDisappear(page);
+
+    await expect(childTable.getByText(deletedChildName)).toHaveCount(0);
+    await expect(childTable.getByText(aliceChildName)).toBeVisible();
+  });
+
+  test('search + Deleted toggle compose to find soft-deleted children by name', async ({
+    page,
+  }) => {
+    const childTable = page.getByTestId('container-list-table');
+
+    // Start in default mode and search for the deleted child's substring —
+    // it must NOT appear because include defaults to non-deleted, regardless
+    // of whether the substring matches.
+    const initialSearchResponse = page.waitForResponse(
+      (res) =>
+        res.url().includes('/children?') &&
+        res.url().includes(`q=${SEARCH_TERM_DELETED}`) &&
+        res.url().includes('include=non-deleted') &&
+        res.status() === 200
+    );
+    await page.getByTestId('searchbar').fill(SEARCH_TERM_DELETED);
+    await initialSearchResponse;
+    await waitForAllLoadersToDisappear(page);
+
+    await expect(childTable.getByText(deletedChildName)).toHaveCount(0);
+
+    // Flip Deleted on while the search is active — the request must carry
+    // BOTH q= and include=deleted, and the deleted child becomes visible.
+    // Asserting on the URL params (not just the result) catches the case
+    // where the toggle handler resets the search state — a likely bug if
+    // the page-reset on toggle change ever drops the search value too.
+    const combinedResponse = page.waitForResponse(
+      (res) =>
+        res.url().includes('/children?') &&
+        res.url().includes(`q=${SEARCH_TERM_DELETED}`) &&
+        res.url().includes('include=deleted') &&
+        res.status() === 200
+    );
+    await page.getByTestId('show-deleted').click();
+    await combinedResponse;
+    await waitForAllLoadersToDisappear(page);
+
+    await expect(childTable.getByText(deletedChildName)).toBeVisible();
+    await expect(childTable.getByText(aliceChildName)).toHaveCount(0);
+  });
+});
+
+// Multi-level scoping for the Deleted toggle.
+//
+// At every level of a container hierarchy, ?include=deleted shows ONLY direct
+// children of that level whose own deleted=true — never grandchildren or deeper
+// descendants. This pins the FQN-depth predicate (fqnHash NOT LIKE :parentHashChild)
+// at the UI layer; the API-side equivalent lives in
+// ContainerResourceIT#test_listChildren_includeDeleted_scopedToDirectChildrenAtEachLevel.
+//
+// The screenshot scenario this guards against: user soft-deletes a grandchild,
+// navigates back up to the grandparent, toggles "Deleted" ON, and is surprised
+// the grandchild doesn't appear. The behavior is correct (the toggle is a literal
+// per-level filter, not a recursive search), but it's the kind of cross-level
+// expectation that's easy to break with one accidental change to the SQL — e.g.
+// dropping the depth predicate while keeping the deleted filter would silently
+// start surfacing deleted descendants from any depth.
+test.describe('Children tab Deleted toggle is scoped per-level', () => {
+  test.slow(true);
+
+  const serviceName = `pw-storage-service-scope-${uuid()}`;
+  const grandparentName = `pw-scope-grandparent-${uuid()}`;
+  const parentName = `pw-scope-parent-${uuid()}`;
+  const deletedChildName = `pw-scope-deleted-grandchild-${uuid()}`;
+
+  let grandparentFqn = '';
+  let parentFqn = '';
+
+  test.beforeAll(
+    'Setup three-level chain with deleted leaf',
+    async ({ browser }) => {
+      const { afterAction, apiContext } = await performAdminLogin(browser);
+
+      await apiContext.post('/api/v1/services/storageServices', {
+        data: {
+          name: serviceName,
+          ...S3_SERVICE_CONFIG,
+        },
+      });
+
+      const grandparentRes = await apiContext.post('/api/v1/containers', {
+        data: { name: grandparentName, service: serviceName },
+      });
+      const grandparent = await grandparentRes.json();
+      grandparentFqn = grandparent.fullyQualifiedName;
+
+      const parentRes = await apiContext.post('/api/v1/containers', {
+        data: {
+          name: parentName,
+          service: serviceName,
+          parent: { id: grandparent.id, type: 'container' },
+        },
+      });
+      const parent = await parentRes.json();
+      parentFqn = parent.fullyQualifiedName;
+
+      const deletedChildRes = await apiContext.post('/api/v1/containers', {
+        data: {
+          name: deletedChildName,
+          service: serviceName,
+          parent: { id: parent.id, type: 'container' },
+        },
+      });
+      const deletedChild = await deletedChildRes.json();
+
+      // Soft-delete the leaf via API (faster + more reliable than the manage-button
+      // flow). hardDelete=false keeps the row but flips deleted=true.
+      await apiContext.delete(
+        `/api/v1/containers/${deletedChild.id}?hardDelete=false&recursive=true`
+      );
+
+      await afterAction();
+    }
+  );
+
+  test.afterAll('Tear down three-level chain', async ({ browser }) => {
+    const { afterAction, apiContext } = await performAdminLogin(browser);
+
+    await apiContext.delete(
+      `/api/v1/services/storageServices/name/${encodeURIComponent(
+        serviceName
+      )}?recursive=true&hardDelete=true`
+    );
+
+    await afterAction();
+  });
+
+  test('grandparent Deleted toggle returns empty — deleted grandchild does not bubble up', async ({
+    page,
+  }) => {
+    const initialChildrenResponse = page.waitForResponse(
+      (res) =>
+        res.url().includes('/api/v1/containers/name/') &&
+        res.url().includes(encodeURIComponent(grandparentFqn)) &&
+        res.url().includes('/children?') &&
+        res.status() === 200
+    );
+    await page.goto(`/container/${grandparentFqn}`);
+    await initialChildrenResponse;
+    await waitForAllLoadersToDisappear(page);
+
+    const childTable = page.getByTestId('container-list-table');
+
+    // Default mode: the alive direct child (the parent in the chain) is visible.
+    // The deleted leaf is NOT — it's a grandchild, not a direct child.
+    await expect(childTable.getByText(parentName)).toBeVisible();
+    await expect(childTable.getByText(deletedChildName)).toHaveCount(0);
+
+    // Toggle ON at the grandparent level. The request must carry include=deleted
+    // and the URL must still target the grandparent FQN — pinning that the toggle
+    // is applied locally and not somehow widened to a service-wide search.
+    const deletedResponse = page.waitForResponse(
+      (res) =>
+        res.url().includes(encodeURIComponent(grandparentFqn)) &&
+        res.url().includes('/children?') &&
+        res.url().includes('include=deleted') &&
+        res.status() === 200
+    );
+    await page.getByTestId('show-deleted').click();
+    await deletedResponse;
+    await waitForAllLoadersToDisappear(page);
+
+    // Empty: the grandparent has zero deleted DIRECT children — the deleted leaf
+    // is one level deeper. Both the alive parent and the deleted grandchild are
+    // absent (parent because it's not deleted, grandchild because it's not direct).
+    await expect(childTable.getByText(parentName)).toHaveCount(0);
+    await expect(childTable.getByText(deletedChildName)).toHaveCount(0);
+  });
+
+  test('parent Deleted toggle reveals the deleted grandchild — its actual direct parent', async ({
+    page,
+  }) => {
+    const initialChildrenResponse = page.waitForResponse(
+      (res) =>
+        res.url().includes('/api/v1/containers/name/') &&
+        res.url().includes(encodeURIComponent(parentFqn)) &&
+        res.url().includes('/children?') &&
+        res.status() === 200
+    );
+    await page.goto(`/container/${parentFqn}`);
+    await initialChildrenResponse;
+    await waitForAllLoadersToDisappear(page);
+
+    const childTable = page.getByTestId('container-list-table');
+
+    // Default mode at the direct parent of the deleted leaf — the deleted leaf
+    // is hidden because include defaults to non-deleted.
+    await expect(childTable.getByText(deletedChildName)).toHaveCount(0);
+
+    const deletedResponse = page.waitForResponse(
+      (res) =>
+        res.url().includes(encodeURIComponent(parentFqn)) &&
+        res.url().includes('/children?') &&
+        res.url().includes('include=deleted') &&
+        res.status() === 200
+    );
+    await page.getByTestId('show-deleted').click();
+    await deletedResponse;
+    await waitForAllLoadersToDisappear(page);
+
+    // Toggle ON at the actual direct parent — the deleted leaf appears here and
+    // only here. Asserting it appears at this level (and not at the grandparent
+    // in the previous test) is the dual that pins the per-level scoping.
+    await expect(childTable.getByText(deletedChildName)).toBeVisible();
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/Container/ContainerChildren/ContainerChildren.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Container/ContainerChildren/ContainerChildren.test.tsx
@@ -10,8 +10,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+import { Include } from '../../../generated/type/include';
 import { usePaging } from '../../../hooks/paging/usePaging';
 import { getContainerChildrenByName } from '../../../rest/storageAPI';
 import { descriptionTableObject } from '../../../utils/TableColumn.util';
@@ -54,22 +55,54 @@ jest.mock('../../Customization/GenericTab/GenericTab', () => ({
 }));
 
 jest.mock('../../../rest/storageAPI');
-jest.mock('../../../hooks/paging/usePaging', () => ({
-  usePaging: jest.fn().mockImplementation(() => ({
-    pageSize: 15,
-    paging: {
-      total: 2,
-    },
-  })),
-}));
+jest.mock('../../../hooks/paging/usePaging', () => {
+  const handlers = {
+    handlePageChange: jest.fn(),
+    handlePageSizeChange: jest.fn(),
+    handlePagingChange: jest.fn(),
+  };
+
+  return {
+    usePaging: jest.fn().mockImplementation(() => ({
+      pageSize: 15,
+      paging: {
+        total: 2,
+      },
+      ...handlers,
+    })),
+  };
+});
 
 describe('ContainerChildren', () => {
-  it('Should call fetch container function on load', () => {
+  beforeEach(() => {
+    (getContainerChildrenByName as jest.Mock).mockReset();
+    (getContainerChildrenByName as jest.Mock).mockResolvedValue({
+      data: [],
+      paging: { total: 0 },
+    });
+  });
+
+  it('Should call fetch container function on load with non-deleted include', () => {
     render(<ContainerChildren />, { wrapper: MemoryRouter });
 
     expect(getContainerChildrenByName).toHaveBeenCalledWith('', {
       limit: 15,
       offset: 0,
+      include: Include.NonDeleted,
+    });
+  });
+
+  it('Should switch include to deleted when the toggle is enabled', async () => {
+    render(<ContainerChildren />, { wrapper: MemoryRouter });
+
+    fireEvent.click(screen.getByTestId('show-deleted'));
+
+    await waitFor(() => {
+      expect(getContainerChildrenByName).toHaveBeenLastCalledWith('', {
+        limit: 15,
+        offset: 0,
+        include: Include.Deleted,
+      });
     });
   });
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Container/ContainerChildren/ContainerChildren.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Container/ContainerChildren/ContainerChildren.tsx
@@ -97,15 +97,20 @@ const ContainerChildren: FC<ContainerChildrenProps> = ({ isReadOnly }) => {
     [t]
   );
 
-  // Track the FQN of the latest in-flight fetch so a slow earlier response for a
-  // previous container does not overwrite the newer container's data when the
-  // user navigates between containers.
-  const latestFetchFqn = useRef<string>('');
+  // Stale-response guard: every fetch issued from this component bumps a
+  // monotonically-increasing token, and only the response whose token still
+  // matches the latest one allowed to write to state. Keying on the parent FQN
+  // alone (the previous approach) caught navigation-between-containers but not
+  // overlapping fetches against the SAME container — which happen routinely
+  // when the user types into the search box (debounced 500ms) or flips the
+  // Deleted toggle while a slower request is still in-flight. Without this,
+  // an older response can overwrite a newer one's filtered result set.
+  const fetchTokenRef = useRef(0);
 
   const fetchContainerChildren = useCallback(
     async (pagingOffset?: number) => {
       const fetchFqn = decodedContainerName;
-      latestFetchFqn.current = fetchFqn;
+      const token = ++fetchTokenRef.current;
       setIsChildrenLoading(true);
       try {
         const trimmedQuery = searchValue.trim();
@@ -115,18 +120,18 @@ const ContainerChildren: FC<ContainerChildrenProps> = ({ isReadOnly }) => {
           include: showDeleted ? Include.Deleted : Include.NonDeleted,
           ...(trimmedQuery ? { q: trimmedQuery } : {}),
         });
-        if (latestFetchFqn.current !== fetchFqn) {
+        if (fetchTokenRef.current !== token) {
           return;
         }
         setContainerChildrenData(data ?? []);
         handlePagingChange(paging);
         onChildrenCountChange?.(paging.total);
       } catch (error) {
-        if (latestFetchFqn.current === fetchFqn) {
+        if (fetchTokenRef.current === token) {
           showErrorToast(error as AxiosError);
         }
       } finally {
-        if (latestFetchFqn.current === fetchFqn) {
+        if (fetchTokenRef.current === token) {
           setIsChildrenLoading(false);
         }
       }
@@ -161,6 +166,17 @@ const ContainerChildren: FC<ContainerChildrenProps> = ({ isReadOnly }) => {
     },
     [handlePageChange]
   );
+
+  // Clear filters when navigating between containers. Without this, filters
+  // set on the previous container (a search query, a Deleted toggle that was
+  // ON) silently carry over to the next container's listing — making the new
+  // page look empty even though it has children, and there's no URL state to
+  // reflect that a filter is active. Reset before the fetch so the next
+  // useEffect sees the cleared values and queries the unfiltered page.
+  useEffect(() => {
+    setSearchValue('');
+    setShowDeleted(false);
+  }, [decodedContainerName]);
 
   useEffect(() => {
     if (isReadOnly) {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Container/ContainerChildren/ContainerChildren.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Container/ContainerChildren/ContainerChildren.tsx
@@ -10,13 +10,16 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+import { Switch, Typography } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
 import { AxiosError } from 'axios';
 import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
+import { INITIAL_PAGING_VALUE } from '../../../constants/constants';
 import { EntityType } from '../../../enums/entity.enum';
 import { Container } from '../../../generated/entity/data/container';
+import { Include } from '../../../generated/type/include';
 import { usePaging } from '../../../hooks/paging/usePaging';
 import { useFqn } from '../../../hooks/useFqn';
 import { getContainerChildrenByName } from '../../../rest/storageAPI';
@@ -64,6 +67,8 @@ const ContainerChildren: FC<ContainerChildrenProps> = ({ isReadOnly }) => {
   const [containerChildrenData, setContainerChildrenData] = useState<
     ContainerChildRow[]
   >([]);
+  const [showDeleted, setShowDeleted] = useState(false);
+  const [searchValue, setSearchValue] = useState('');
 
   const columns: ColumnsType<ContainerChildRow> = useMemo(
     () => [
@@ -103,9 +108,12 @@ const ContainerChildren: FC<ContainerChildrenProps> = ({ isReadOnly }) => {
       latestFetchFqn.current = fetchFqn;
       setIsChildrenLoading(true);
       try {
+        const trimmedQuery = searchValue.trim();
         const { data, paging } = await getContainerChildrenByName(fetchFqn, {
           limit: pageSize,
           offset: pagingOffset ?? 0,
+          include: showDeleted ? Include.Deleted : Include.NonDeleted,
+          ...(trimmedQuery ? { q: trimmedQuery } : {}),
         });
         if (latestFetchFqn.current !== fetchFqn) {
           return;
@@ -123,13 +131,36 @@ const ContainerChildren: FC<ContainerChildrenProps> = ({ isReadOnly }) => {
         }
       }
     },
-    [decodedContainerName, pageSize, handlePagingChange, onChildrenCountChange]
+    [
+      decodedContainerName,
+      pageSize,
+      handlePagingChange,
+      onChildrenCountChange,
+      showDeleted,
+      searchValue,
+    ]
   );
 
   const handleChildrenPageChange = (data: PagingHandlerParams) => {
     handlePageChange(data.currentPage);
     fetchContainerChildren((data.currentPage - 1) * pageSize);
   };
+
+  const handleSearchChange = useCallback(
+    (value: string) => {
+      setSearchValue(value);
+      handlePageChange(INITIAL_PAGING_VALUE);
+    },
+    [handlePageChange]
+  );
+
+  const handleShowDeletedChange = useCallback(
+    (checked: boolean) => {
+      setShowDeleted(checked);
+      handlePageChange(INITIAL_PAGING_VALUE);
+    },
+    [handlePageChange]
+  );
 
   useEffect(() => {
     if (isReadOnly) {
@@ -151,6 +182,18 @@ const ContainerChildren: FC<ContainerChildrenProps> = ({ isReadOnly }) => {
     onChildrenCountChange?.(children.length);
   }, [isReadOnly, container?.children, onChildrenCountChange]);
 
+  const searchProps = useMemo(
+    () => ({
+      placeholder: t('label.search-for-type', {
+        type: t('label.container-plural'),
+      }),
+      typingInterval: 500,
+      searchValue,
+      onSearch: handleSearchChange,
+    }),
+    [handleSearchChange, searchValue, t]
+  );
+
   return (
     <Table
       columns={columns}
@@ -166,12 +209,27 @@ const ContainerChildren: FC<ContainerChildrenProps> = ({ isReadOnly }) => {
       }}
       data-testid="container-list-table"
       dataSource={containerChildrenData}
+      extraTableFilters={
+        !isReadOnly && (
+          <span>
+            <Switch
+              checked={showDeleted}
+              data-testid="show-deleted"
+              onClick={handleShowDeletedChange}
+            />
+            <Typography.Text className="m-l-xs">
+              {t('label.deleted')}
+            </Typography.Text>
+          </span>
+        )
+      }
       loading={isChildrenLoading}
       locale={{
         emptyText: <ErrorPlaceHolder className="p-y-md" />,
       }}
       pagination={false}
       rowKey="id"
+      searchProps={isReadOnly ? undefined : searchProps}
       size="small"
     />
   );

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ContainerPage/ContainerPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ContainerPage/ContainerPage.test.tsx
@@ -470,7 +470,7 @@ describe('Container Page Component', () => {
     expect(screen.getByText('Loader')).toBeVisible();
 
     const childrenTab = await screen.findByRole('tab', {
-      name: 'label.children',
+      name: 'label.container-plural',
     });
 
     userEvent.click(childrenTab);
@@ -499,7 +499,7 @@ describe('Container Page Component', () => {
     expect(screen.getByText('Loader')).toBeVisible();
 
     const childrenTab = await screen.findByRole('tab', {
-      name: 'label.children',
+      name: 'label.container-plural',
     });
 
     expect(childrenTab).toHaveAttribute('aria-selected', 'true');

--- a/openmetadata-ui/src/main/resources/ui/src/rest/storageAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/storageAPI.ts
@@ -65,12 +65,14 @@ export const getContainerByName = async (name: string, params?: ListParams) => {
 
 export const getContainerChildrenByName = async (
   fqn: string,
-  params?: ListParamsWithOffset
+  params?: ListParamsWithOffset & { q?: string }
 ) => {
   // The /children endpoint returns slim Container summaries
   // (id, name, displayName, fullyQualifiedName, description, service) — not
   // EntityReferences. dataModel/tags/owners/extension are intentionally not
   // populated. Re-fetch via getContainerByName when full details are needed.
+  // `include` toggles between non-deleted (default), deleted-only, and all.
+  // `q` is a case-insensitive substring filter on the child container name.
   const response = await APIClient.get<PagingResponse<Container[]>>(
     `${BASE_URL}/name/${getEncodedFqn(fqn)}/children`,
     {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ContainerDetailUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ContainerDetailUtils.tsx
@@ -155,7 +155,9 @@ export const getContainerDetailPageTabs = ({
               <TabsLabel
                 count={childrenCount}
                 id={EntityTabs.CHILDREN}
-                name={labelMap?.[EntityTabs.CHILDREN] ?? t('label.children')}
+                name={
+                  labelMap?.[EntityTabs.CHILDREN] ?? t('label.container-plural')
+                }
               />
             ),
             key: EntityTabs.CHILDREN,
@@ -179,7 +181,7 @@ export const getContainerDetailPageTabs = ({
               <TabsLabel
                 count={childrenCount}
                 id={EntityTabs.CHILDREN}
-                name={t('label.children')}
+                name={t('label.container-plural')}
               />
             ),
             key: EntityTabs.CHILDREN,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ContainerDetailUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ContainerDetailUtils.tsx
@@ -181,7 +181,9 @@ export const getContainerDetailPageTabs = ({
               <TabsLabel
                 count={childrenCount}
                 id={EntityTabs.CHILDREN}
-                name={t('label.container-plural')}
+                name={
+                  labelMap?.[EntityTabs.CHILDREN] ?? t('label.container-plural')
+                }
               />
             ),
             key: EntityTabs.CHILDREN,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ContainerDetailsClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ContainerDetailsClassBase.ts
@@ -96,7 +96,14 @@ class ContainerDetailsClassBase {
     ].map((tab: EntityTabs) => ({
       id: tab,
       name: tab,
-      displayName: getTabLabelFromId(tab),
+      // Container-specific override: TAB_LABEL_MAP renders EntityTabs.CHILDREN as
+      // "Children" globally (used by other entity types like Directory), but for
+      // Container detail pages the tab is displayed as "Containers" — keep the
+      // customize-page editor in sync with what the live page shows.
+      displayName:
+        tab === EntityTabs.CHILDREN
+          ? i18n.t('label.container-plural')
+          : getTabLabelFromId(tab),
       layout: this.getDefaultLayout(tab),
       editable: tab === EntityTabs.CHILDREN || tab === EntityTabs.SCHEMA,
     }));

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ContainerDetailsClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ContainerDetailsClassBase.ts
@@ -201,7 +201,7 @@ class ContainerDetailsClassBase {
       },
       {
         fullyQualifiedName: DetailPageWidgetKeys.CONTAINER_CHILDREN,
-        name: i18n.t('label.children'),
+        name: i18n.t('label.container-plural'),
         data: {
           gridSizes: ['large'] as GridSizes[],
         },


### PR DESCRIPTION
### Describe your changes:

Adds case-insensitive substring search (`?q=`) and a Deleted include toggle to `/v1/containers/.../children`, mirroring the controls already on the service-level Containers tab, and renames the Container detail page's "Children" tab to "Containers" for consistency with the file-system-style nested navigation (URL slug unchanged). Backend search uses `LOWER(name) LIKE :nameLike ESCAPE '!'` (`!` chosen over `\` because JDBI's ColonPrefixSqlParser mishandles literal backslashes in single-quoted SQL and silently strips a downstream bind), and bypasses the children-page cache when `q` is non-empty since per-substring hit rate is ≈0. Coverage: 3 new backend IT tests (substring match, LIKE-wildcard escaping, per-level scoping of `include=deleted`) and 5 new Playwright tests (search scoping, Deleted toggle reveal/hide, search + toggle composition, plus multi-level scoping pinning that a soft-deleted descendant must NOT bubble up to ancestor `/children` listings).


<img width="1478" height="697" alt="image" src="https://github.com/user-attachments/assets/1c4002f1-e952-4ebd-8e1e-711b2dc3d460" />

<img width="1486" height="768" alt="image" src="https://github.com/user-attachments/assets/b75c6d1b-10c3-4c9c-a2c4-d41018236850" />


#
### Type of change:
- [x] Improvement

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests around the new logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----
## Summary by Gitar

- **Improved UI state handling:**
  - Replaced FQN-based fetch tracking with a monotonic `fetchTokenRef` to prevent race conditions during rapid search/toggle changes.
  - Added `useEffect` to reset `searchValue` and `showDeleted` filters when navigating between different containers.
- **Refined UI display:**
  - Overrode `EntityTabs.CHILDREN` display name to "Containers" via `ContainerDetailsClassBase` for better UX consistency.
  - Updated `TabsLabel` in `ContainerDetailUtils` to use the dynamic `labelMap` for the children tab.
- **Backend testing/documentation:**
  - Clarified in `ContainerResourceIT` that `!` is used as an escape character instead of `\` to avoid JDBI parser issues with SQL bind parameters.

<sub>This will update automatically on new commits.</sub>