### PR TITLE
Cherry-pick #27836 to 1.12.7: batch container data-model column tag retrieval

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DataContractResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DataContractResourceIT.java
@@ -12,12 +12,15 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.openmetadata.it.factories.StorageServiceTestFactory;
 import org.openmetadata.it.util.SdkClients;
 import org.openmetadata.it.util.TestNamespace;
 import org.openmetadata.schema.api.data.ContractSLA;
+import org.openmetadata.schema.api.data.CreateContainer;
 import org.openmetadata.schema.api.data.CreateDataContract;
 import org.openmetadata.schema.api.data.CreateDatabaseSchema;
 import org.openmetadata.schema.api.data.CreateTable;
+import org.openmetadata.schema.entity.data.Container;
 import org.openmetadata.schema.entity.data.DataContract;
 import org.openmetadata.schema.entity.data.Database;
 import org.openmetadata.schema.entity.data.DatabaseSchema;
@@ -31,6 +34,7 @@ import org.openmetadata.schema.entity.datacontract.odcs.ODCSSchemaElement;
 import org.openmetadata.schema.entity.datacontract.odcs.ODCSSlaProperty;
 import org.openmetadata.schema.entity.datacontract.odcs.ODCSTeamMember;
 import org.openmetadata.schema.entity.services.DatabaseService;
+import org.openmetadata.schema.entity.services.StorageService;
 import org.openmetadata.schema.type.Column;
 import org.openmetadata.schema.type.ColumnDataType;
 import org.openmetadata.schema.type.ContractExecutionStatus;
@@ -292,6 +296,48 @@ public class DataContractResourceIT extends BaseEntityIT<DataContract, CreateDat
 
     assertNotNull(fetched);
     assertEquals(contract.getId(), fetched.getId());
+  }
+
+  @Test
+  void testGetDataContractByEntityId_containerEntity_slimEntityLoad(TestNamespace ns) {
+    // Pins the perf contract on `GET /v1/dataContracts/entity?entityType=container`.
+    //
+    // The handler used to call `Entity.getEntity(entityType, entityId, "*", ...)`
+    // which eagerly hydrates every relationship (owners, tags, followers, domains,
+    // dataProducts, extension) and deserialises the entity's full stored JSON. For
+    // a Container with a heavyweight `dataModel` — common in the Tahoe POC where
+    // a parquet-backed container carries multi-MB column-schema metadata — that
+    // single call routinely exceeded the 60-second request timeout in production
+    // and starved the connection pool, taking the API server with it.
+    //
+    // The handler now passes `"dataProducts"` (the only field the contract
+    // inheritance path actually consumes via `getEffectiveDataContract`) instead
+    // of `"*"`. This test exercises the Container path end-to-end so a future
+    // regression that puts `"*"` back in the resource layer fails here.
+    StorageService service = StorageServiceTestFactory.createS3(ns);
+    CreateContainer containerRequest =
+        new CreateContainer()
+            .withName(ns.prefix("dc_container"))
+            .withService(service.getFullyQualifiedName())
+            .withDescription("Container under data-contract perf-pinning IT");
+    Container container = SdkClients.adminClient().containers().create(containerRequest);
+
+    CreateDataContract contractRequest =
+        new CreateDataContract()
+            .withName(ns.prefix("test_get_by_container_entity"))
+            .withEntity(container.getEntityReference())
+            .withDescription("Pin slim entity load on getByEntityId");
+    DataContract created = createEntity(contractRequest);
+
+    DataContract fetched =
+        SdkClients.adminClient().dataContracts().getByEntityId(container.getId(), "container");
+
+    assertNotNull(fetched, "Container should have been resolved as a valid entity type");
+    assertEquals(
+        created.getId(),
+        fetched.getId(),
+        "getByEntityId must return the contract bound to the Container, proving the slim"
+            + " `dataProducts`-only entity load is sufficient for contract resolution");
   }
 
   @Test

--- a/openmetadata-sdk/src/main/java/org/openmetadata/sdk/fluent/Containers.java
+++ b/openmetadata-sdk/src/main/java/org/openmetadata/sdk/fluent/Containers.java
@@ -3,6 +3,7 @@ package org.openmetadata.sdk.fluent;
 import java.util.*;
 import org.openmetadata.schema.api.data.CreateContainer;
 import org.openmetadata.schema.entity.data.Container;
+import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.sdk.client.OpenMetadataClient;
 
 /**
@@ -39,6 +40,13 @@ import org.openmetadata.sdk.client.OpenMetadataClient;
  * list()
  *     .limit(50)
  *     .forEach(container -> process(container));
+ *
+ * // Page through immediate children of a container (slim projection — no
+ * // dataModel/tags/owners) via the dedicated endpoint
+ * List&lt;Container&gt; kids = listChildren(parentFqn).limit(50).offset(0).fetch();
+ *
+ * // Walk the ancestor chain (root → immediate parent) in one call
+ * List&lt;EntityReference&gt; chain = listAncestors(parentFqn);
  * </pre>
  */
 public final class Containers {
@@ -86,6 +94,28 @@ public final class Containers {
 
   public static ContainerLister list() {
     return new ContainerLister(getClient());
+  }
+
+  // ==================== Children / Ancestors ====================
+
+  /**
+   * Page through the immediate children of a container via the dedicated
+   * {@code /v1/containers/name/{fqn}/children} endpoint. Use this instead of fetching the
+   * parent with {@code fields=children} — that field is no longer served because the inline
+   * payload is unbounded for buckets with many objects.
+   */
+  public static ContainerChildrenLister listChildren(String parentFqn) {
+    return new ContainerChildrenLister(getClient(), parentFqn);
+  }
+
+  /**
+   * Resolve the full ancestor chain for a container in a single call. Returns
+   * {@link EntityReference}s ordered from the root container (immediate child of the storage
+   * service) down to the immediate parent of {@code fqn}. Empty list when the container is at
+   * the top level.
+   */
+  public static List<EntityReference> listAncestors(String fqn) {
+    return getClient().containers().listAncestors(fqn);
   }
 
   // ==================== Creator ====================
@@ -252,6 +282,41 @@ public final class Containers {
     }
   }
 
+  // ==================== Children / Ancestors Lister ====================
+
+  public static class ContainerChildrenLister {
+    private final OpenMetadataClient client;
+    private final String parentFqn;
+    private Integer limit;
+    private Integer offset;
+
+    ContainerChildrenLister(OpenMetadataClient client, String parentFqn) {
+      this.client = client;
+      this.parentFqn = parentFqn;
+    }
+
+    public ContainerChildrenLister limit(int limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    public ContainerChildrenLister offset(int offset) {
+      this.offset = offset;
+      return this;
+    }
+
+    public List<Container> fetch() {
+      var params = new org.openmetadata.sdk.models.ListParams();
+      if (limit != null) params.setLimit(limit);
+      if (offset != null) params.setOffset(offset);
+      return client.containers().listChildren(parentFqn, params).getData();
+    }
+
+    public void forEach(java.util.function.Consumer<Container> action) {
+      fetch().forEach(action);
+    }
+  }
+
   // ==================== Fluent Entity ====================
 
   public static class FluentContainer {
@@ -287,6 +352,20 @@ public final class Containers {
         modified = false;
       }
       return this;
+    }
+
+    /**
+     * Page this container's immediate children via the dedicated paginated endpoint, using
+     * the parent's FQN. Returned containers are slim projections; re-fetch via
+     * {@link Containers#findByName(String)} for full details.
+     */
+    public ContainerChildrenLister children() {
+      return new ContainerChildrenLister(client, container.getFullyQualifiedName());
+    }
+
+    /** Walk this container's ancestor chain (root → immediate parent) in one server call. */
+    public List<EntityReference> ancestors() {
+      return client.containers().listAncestors(container.getFullyQualifiedName());
     }
 
     public ContainerDeleter delete() {

--- a/openmetadata-sdk/src/main/java/org/openmetadata/sdk/services/EntityServiceBase.java
+++ b/openmetadata-sdk/src/main/java/org/openmetadata/sdk/services/EntityServiceBase.java
@@ -157,7 +157,7 @@ public abstract class EntityServiceBase<T> {
    * @param name The entity name or FQN, which may contain quotes and special characters
    * @return The properly encoded path string
    */
-  private String buildPathWithEncodedName(String name) {
+  protected String buildPathWithEncodedName(String name) {
     // Use HttpUrl.Builder to properly encode the name as a path segment
     // This handles special characters, quotes, and Unicode properly
     HttpUrl baseUrl = HttpUrl.parse("http://localhost" + basePath + "/name");

--- a/openmetadata-sdk/src/main/java/org/openmetadata/sdk/services/storages/ContainerService.java
+++ b/openmetadata-sdk/src/main/java/org/openmetadata/sdk/services/storages/ContainerService.java
@@ -1,10 +1,17 @@
 package org.openmetadata.sdk.services.storages;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.Collections;
+import java.util.List;
 import org.openmetadata.schema.api.data.CreateContainer;
 import org.openmetadata.schema.entity.data.Container;
+import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.sdk.exceptions.OpenMetadataException;
+import org.openmetadata.sdk.models.ListParams;
+import org.openmetadata.sdk.models.ListResponse;
 import org.openmetadata.sdk.network.HttpClient;
 import org.openmetadata.sdk.network.HttpMethod;
+import org.openmetadata.sdk.network.RequestOptions;
 import org.openmetadata.sdk.services.EntityServiceBase;
 
 public class ContainerService extends EntityServiceBase<Container> {
@@ -20,5 +27,48 @@ public class ContainerService extends EntityServiceBase<Container> {
   // Create container using CreateContainer request
   public Container create(CreateContainer request) throws OpenMetadataException {
     return httpClient.execute(HttpMethod.POST, basePath, request, Container.class);
+  }
+
+  /**
+   * Page through the immediate children of a Container via the dedicated
+   * {@code /v1/containers/name/{fqn}/children} endpoint. Use this instead of fetching the
+   * parent with {@code fields=children} — that field is no longer served because the inline
+   * payload is unbounded for buckets with many objects.
+   *
+   * <p>Each row is a slim {@link Container} projection (id, name, displayName, fqn,
+   * description, service); {@code dataModel}, {@code tags}, {@code owners}, {@code extension}
+   * are not populated. Re-fetch the specific child via {@link #getByName(String)} when full
+   * details are needed.
+   */
+  public ListResponse<Container> listChildren(String fqn, ListParams params)
+      throws OpenMetadataException {
+    String path = buildPathWithEncodedName(fqn) + "/children";
+    RequestOptions options =
+        RequestOptions.builder()
+            .queryParams(params != null ? params.toQueryParams() : Collections.emptyMap())
+            .build();
+    String responseStr = httpClient.executeForString(HttpMethod.GET, path, null, options);
+    return deserializeListResponse(responseStr);
+  }
+
+  public ListResponse<Container> listChildren(String fqn) throws OpenMetadataException {
+    return listChildren(fqn, new ListParams());
+  }
+
+  /**
+   * Resolve the full ancestor chain for a container in a single call. Returns
+   * {@link EntityReference}s ordered from the root container (immediate child of the storage
+   * service) down to the immediate parent of {@code fqn}. Empty when the container is at the
+   * top level.
+   */
+  public List<EntityReference> listAncestors(String fqn) throws OpenMetadataException {
+    String path = buildPathWithEncodedName(fqn) + "/ancestors";
+    String responseStr = httpClient.executeForString(HttpMethod.GET, path, null, null);
+    try {
+      return objectMapper.readValue(responseStr, new TypeReference<List<EntityReference>>() {});
+    } catch (Exception e) {
+      throw new OpenMetadataException(
+          "Failed to deserialize ancestors response: " + e.getMessage(), e);
+    }
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/OpenMetadataApplication.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/OpenMetadataApplication.java
@@ -613,6 +613,8 @@ public class OpenMetadataApplication extends Application<OpenMetadataApplication
   }
 
   private void registerHealthCheck(Environment environment) {
+    // Liveness probe target — pure process-aliveness, intentionally NOT coupled to
+    // any downstream system. See OpenMetadataServerHealthCheck for the design rationale.
     environment
         .healthChecks()
         .register("OpenMetadataServerHealthCheck", new OpenMetadataServerHealthCheck());

--- a/openmetadata-service/src/main/java/org/openmetadata/service/OpenMetadataServerHealthCheck.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/OpenMetadataServerHealthCheck.java
@@ -16,6 +16,34 @@ package org.openmetadata.service;
 import com.codahale.metrics.health.HealthCheck;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * Liveness probe target for Dropwizard's admin connector ({@code /healthcheck}).
+ *
+ * <p><b>This is a pure process-aliveness check by design.</b> If the JVM can run this method
+ * and return a value, the pod is alive — that is all kubelet liveness needs to know. We
+ * intentionally do <b>not</b> probe the database, the search backend, the cache provider,
+ * or any other downstream system from here. Coupling the liveness probe to downstream
+ * latency causes counterproductive restart loops: a slow but otherwise functional database
+ * makes liveness fail, kubelet kills the pod, the new pod cold-starts (cold cache, fresh
+ * connection storms, JIT warmup), the restart pressure pushes the database even harder,
+ * and the cycle accelerates. Killing the process never speeds up the database.
+ *
+ * <p>Operators that want database/cache health visibility should:
+ * <ul>
+ *   <li>Use a separate <b>readiness</b> probe (or the application-layer endpoints) that can
+ *       fail without triggering a pod kill — readiness only stops sending traffic.
+ *   <li>Scrape the {@code /prometheus} (or admin metrics) endpoint for HikariCP pool
+ *       statistics ({@code hikaricp_active_connections},
+ *       {@code hikaricp_pending_threads}, etc.) and alert on those.
+ *   <li>Run the existing {@code DatabaseAndSearchServiceStatusJob} background reporter,
+ *       which surfaces DB/search status without affecting liveness.
+ * </ul>
+ *
+ * <p>For production deployments, prefer this admin-port {@code /healthcheck} over the
+ * application-port {@code /api/v1/system/health} probe target — the admin connector has
+ * its own request thread pool, so a saturated API tier (slow listing queries, hot tag
+ * aggregations) cannot starve the probe even before any timeout fires.
+ */
 @Slf4j
 public class OpenMetadataServerHealthCheck extends HealthCheck {
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -794,6 +794,67 @@ public interface CollectionDAO {
         @Define("nameHashColumn") String nameHashColumn,
         @BindMap Map<String, ?> params,
         @Define("sqlCondition") String mysqlCond);
+
+    /**
+     * Lightweight projection used by paginated children listings. Pulls only the columns the
+     * UI's children table needs (id, name, displayName, fqn, description) plus the soft-delete
+     * flag. Skips JSON deserialization of heavy fields like {@code dataModel}, {@code tags},
+     * and {@code owners} which can each carry MBs of column-schema metadata for parquet
+     * containers. The service reference is restored separately by
+     * {@link ContainerRepository#fetchAndSetDefaultService(java.util.List)}.
+     */
+    @ConnectionAwareSqlQuery(
+        value =
+            "SELECT id, "
+                + "JSON_UNQUOTE(JSON_EXTRACT(json, '$.name')) AS name, "
+                + "JSON_UNQUOTE(JSON_EXTRACT(json, '$.displayName')) AS displayName, "
+                + "JSON_UNQUOTE(JSON_EXTRACT(json, '$.fullyQualifiedName')) AS fqn, "
+                + "JSON_UNQUOTE(JSON_EXTRACT(json, '$.description')) AS description, "
+                + "deleted "
+                + "FROM storage_container_entity WHERE id IN (<ids>)",
+        connectionType = MYSQL)
+    @ConnectionAwareSqlQuery(
+        value =
+            "SELECT id, "
+                + "json->>'name' AS name, "
+                + "json->>'displayName' AS displayName, "
+                + "json->>'fullyQualifiedName' AS fqn, "
+                + "json->>'description' AS description, "
+                + "deleted "
+                + "FROM storage_container_entity WHERE id IN (<ids>)",
+        connectionType = POSTGRES)
+    @RegisterRowMapper(ContainerSummaryRowMapper.class)
+    List<Container> findContainerSummaryRows(@BindList("ids") List<String> ids);
+
+    default List<Container> findContainerSummariesByIds(List<UUID> ids) {
+      if (ids == null || ids.isEmpty()) {
+        return List.of();
+      }
+      List<String> idStrings = ids.stream().map(UUID::toString).distinct().toList();
+      int maxChunkSize = 30000;
+      if (idStrings.size() <= maxChunkSize) {
+        return findContainerSummaryRows(idStrings);
+      }
+      List<Container> all = new ArrayList<>(idStrings.size());
+      for (int i = 0; i < idStrings.size(); i += maxChunkSize) {
+        List<String> chunk = idStrings.subList(i, Math.min(i + maxChunkSize, idStrings.size()));
+        all.addAll(findContainerSummaryRows(chunk));
+      }
+      return all;
+    }
+  }
+
+  class ContainerSummaryRowMapper implements RowMapper<Container> {
+    @Override
+    public Container map(ResultSet rs, StatementContext ctx) throws SQLException {
+      return new Container()
+          .withId(UUID.fromString(rs.getString("id")))
+          .withName(rs.getString("name"))
+          .withDisplayName(rs.getString("displayName"))
+          .withFullyQualifiedName(rs.getString("fqn"))
+          .withDescription(rs.getString("description"))
+          .withDeleted(rs.getBoolean("deleted"));
+    }
   }
 
   interface SearchServiceDAO extends EntityDAO<SearchService> {
@@ -5033,6 +5094,37 @@ public interface CollectionDAO {
                 value = "targetFQNHash",
                 parts = {":targetFQNHashPrefix", ":postfix"})
             String... targetFQNHash);
+
+    @SqlQuery(
+        "SELECT tu.source, tu.tagFQN, tu.labelType, tu.targetFQNHash, tu.state, tu.reason, tu.appliedAt, tu.appliedBy, tu.metadata, "
+            + "CASE "
+            + "  WHEN tu.source = 1 THEN gterm.json "
+            + "  WHEN tu.source = 0 THEN ta.json "
+            + "END as json "
+            + "FROM tag_usage tu "
+            + "LEFT JOIN glossary_term_entity gterm ON tu.source = 1 AND gterm.fqnHash = tu.tagFQNHash "
+            + "LEFT JOIN tag ta ON tu.source = 0 AND ta.fqnHash = tu.tagFQNHash "
+            + "WHERE tu.targetFQNHash IN (<targetFQNHashes>)")
+    @RegisterRowMapper(TagLabelRowMapperWithTargetFqnHash.class)
+    List<Pair<String, TagLabel>> getTagsInternalByTargetHashes(
+        @BindList("targetFQNHashes") List<String> targetFQNHashes);
+
+    int TAG_BATCH_CHUNK_SIZE = 1000;
+
+    default Map<String, List<TagLabel>> getTagsByTargetFQNHashes(List<String> targetFQNHashes) {
+      Map<String, List<TagLabel>> resultSet = new LinkedHashMap<>();
+      if (targetFQNHashes == null || targetFQNHashes.isEmpty()) {
+        return resultSet;
+      }
+      for (int i = 0; i < targetFQNHashes.size(); i += TAG_BATCH_CHUNK_SIZE) {
+        List<String> chunk =
+            targetFQNHashes.subList(i, Math.min(i + TAG_BATCH_CHUNK_SIZE, targetFQNHashes.size()));
+        for (Pair<String, TagLabel> pair : getTagsInternalByTargetHashes(chunk)) {
+          resultSet.computeIfAbsent(pair.getLeft(), k -> new ArrayList<>()).add(pair.getRight());
+        }
+      }
+      return resultSet;
+    }
 
     @SqlQuery("SELECT * FROM tag_usage")
     @Deprecated(since = "Release 1.1")

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ContainerRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/ContainerRepository.java
@@ -9,19 +9,23 @@ import static org.openmetadata.service.Entity.FIELD_PARENT;
 import static org.openmetadata.service.Entity.FIELD_TAGS;
 import static org.openmetadata.service.Entity.STORAGE_SERVICE;
 import static org.openmetadata.service.Entity.getEntityReferenceById;
-import static org.openmetadata.service.Entity.populateEntityFieldTags;
 import static org.openmetadata.service.resources.tags.TagLabelUtil.addDerivedTagsGracefully;
-import static org.openmetadata.service.util.EntityUtil.getEntityReferences;
+import static org.openmetadata.service.resources.tags.TagLabelUtil.addDerivedTagsWithPreFetched;
+import static org.openmetadata.service.resources.tags.TagLabelUtil.batchFetchDerivedTags;
+import static org.openmetadata.service.util.EntityUtil.getFlattenedEntityField;
 
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.jdbi.v3.sqlobject.transaction.Transaction;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.api.feed.ResolveTask;
@@ -46,8 +50,11 @@ import org.openmetadata.service.resources.storages.ContainerResource;
 import org.openmetadata.service.util.EntityUtil;
 import org.openmetadata.service.util.EntityUtil.RelationIncludes;
 import org.openmetadata.service.util.FullyQualifiedName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ContainerRepository extends EntityRepository<Container> {
+  private static final Logger LOG = LoggerFactory.getLogger(ContainerRepository.class);
   private static final String CONTAINER_UPDATE_FIELDS = "dataModel";
   private static final String CONTAINER_PATCH_FIELDS = "dataModel";
   private static final Set<String> CHANGE_SUMMARY_FIELDS = Set.of("dataModel.columns.description");
@@ -63,10 +70,11 @@ public class ContainerRepository extends EntityRepository<Container> {
         CHANGE_SUMMARY_FIELDS);
     supportsSearch = true;
 
+    allowedFields.remove("children");
+
     // Register bulk field fetchers for efficient database operations
     fieldFetchers.put(FIELD_PARENT, this::fetchAndSetParents);
     fieldFetchers.put(FIELD_TAGS, this::fetchAndSetDataModelColumnTags);
-    fieldFetchers.put("children", this::fetchAndSetChildren);
   }
 
   @Override
@@ -75,13 +83,9 @@ public class ContainerRepository extends EntityRepository<Container> {
     setDefaultFields(container);
     container.setParent(
         fields.contains(FIELD_PARENT) ? getContainerParent(container) : container.getParent());
-    container.setChildren(
-        fields.contains("children") ? getChildren(container) : container.getChildren());
     if (container.getDataModel() != null) {
       populateDataModelColumnTags(
-          fields.contains(FIELD_TAGS),
-          container.getFullyQualifiedName(),
-          container.getDataModel().getColumns());
+          fields.contains(FIELD_TAGS), container.getDataModel().getColumns());
     }
   }
 
@@ -111,22 +115,30 @@ public class ContainerRepository extends EntityRepository<Container> {
       return;
     }
 
-    // First, fetch container-level tags (important for search indexing)
+    // Container-level tags. Important for search indexing where we may process 100k+
+    // containers in a single bulk batch — we must not issue a derived-tag DB query per
+    // container, so collect all tags up front and batch derived tags once.
     List<String> entityFQNs = containers.stream().map(Container::getFullyQualifiedName).toList();
     Map<String, List<TagLabel>> tagsMap = batchFetchTags(entityFQNs);
+
+    Map<String, List<TagLabel>> derivedTagsMap =
+        tryBatchFetchDerivedTags(tagsMap, containers.size() + " containers");
+
     for (Container container : containers) {
-      container.setTags(
-          addDerivedTagsGracefully(
-              tagsMap.getOrDefault(container.getFullyQualifiedName(), Collections.emptyList())));
+      List<TagLabel> containerTags =
+          tagsMap.getOrDefault(container.getFullyQualifiedName(), Collections.emptyList());
+      if (derivedTagsMap != null) {
+        container.setTags(addDerivedTagsWithPreFetched(containerTags, derivedTagsMap));
+      } else {
+        container.setTags(addDerivedTagsGracefully(containerTags));
+      }
     }
 
     // Then, if dataModel field is requested, also fetch data model column tags
     if (fields.contains("dataModel")) {
       // Filter containers that have data models and use bulk tag fetching
       List<Container> containersWithDataModels =
-          containers.stream()
-              .filter(c -> c.getDataModel() != null)
-              .collect(java.util.stream.Collectors.toList());
+          containers.stream().filter(c -> c.getDataModel() != null).collect(Collectors.toList());
 
       if (!containersWithDataModels.isEmpty()) {
         bulkPopulateEntityFieldTags(containersWithDataModels, c -> c.getDataModel().getColumns());
@@ -222,14 +234,22 @@ public class ContainerRepository extends EntityRepository<Container> {
             .relationshipDAO()
             .findFromBatch(entityListToStrings(containers), Relationship.CONTAINS.ordinal());
 
+    // De-dupe service IDs before resolving them to references. In any practical paged
+    // listing the children are all under the same storage service, so the naive loop
+    // below would call getEntityReferenceById N times for the same service id —
+    // each call hits CACHE_WITH_ID (or DB) for the full StorageService JSON. Cache one
+    // ref per unique service id and fan it back out to every child.
+    Map<UUID, EntityReference> serviceRefById = new HashMap<>();
     for (CollectionDAO.EntityRelationshipObject record : records) {
-      UUID containerId = UUID.fromString(record.getToId());
-      if (STORAGE_SERVICE.equals(record.getFromEntity())) {
-        EntityReference serviceRef =
-            getEntityReferenceById(
-                STORAGE_SERVICE, UUID.fromString(record.getFromId()), NON_DELETED);
-        serviceMap.put(containerId, serviceRef);
+      if (!STORAGE_SERVICE.equals(record.getFromEntity())) {
+        continue;
       }
+      UUID containerId = UUID.fromString(record.getToId());
+      UUID serviceId = UUID.fromString(record.getFromId());
+      EntityReference serviceRef =
+          serviceRefById.computeIfAbsent(
+              serviceId, id -> getEntityReferenceById(STORAGE_SERVICE, id, NON_DELETED));
+      serviceMap.put(containerId, serviceRef);
     }
 
     return serviceMap;
@@ -241,9 +261,69 @@ public class ContainerRepository extends EntityRepository<Container> {
     container.withDataModel(fields.contains("dataModel") ? container.getDataModel() : null);
   }
 
-  private void populateDataModelColumnTags(
-      boolean setTags, String fqnPrefix, List<Column> columns) {
-    populateEntityFieldTags(entityType, columns, fqnPrefix, setTags);
+  private void populateDataModelColumnTags(boolean setTags, List<Column> columns) {
+    if (!setTags) {
+      // Caller didn't ask for tags — leave the column tree untouched. The original
+      // code looped here calling c.setTags(c.getTags()) (a no-op carried over from
+      // Entity.populateEntityFieldTags); skip that pointless walk.
+      return;
+    }
+    List<Column> flattenedColumns = getFlattenedEntityField(columns);
+    if (flattenedColumns.isEmpty()) {
+      return;
+    }
+    Map<String, Column> hashToColumn =
+        flattenedColumns.stream()
+            .collect(
+                Collectors.toMap(
+                    c -> FullyQualifiedName.buildHash(c.getFullyQualifiedName()),
+                    c -> c,
+                    (a, b) -> a,
+                    LinkedHashMap::new));
+    Map<String, List<TagLabel>> tagsByHash =
+        daoCollection
+            .tagUsageDAO()
+            .getTagsByTargetFQNHashes(new ArrayList<>(hashToColumn.keySet()));
+
+    // Batch-fetch derived tags for every glossary tag across all columns in a single query.
+    // Falls back to per-column gracefully on failure to avoid changing existing semantics.
+    Map<String, List<TagLabel>> derivedTagsMap =
+        tryBatchFetchDerivedTags(tagsByHash, "container columns");
+
+    for (Map.Entry<String, Column> entry : hashToColumn.entrySet()) {
+      List<TagLabel> columnTags = tagsByHash.get(entry.getKey());
+      if (columnTags == null) {
+        entry.getValue().setTags(new ArrayList<>());
+      } else if (derivedTagsMap != null) {
+        entry.getValue().setTags(addDerivedTagsWithPreFetched(columnTags, derivedTagsMap));
+      } else {
+        entry.getValue().setTags(addDerivedTagsGracefully(columnTags));
+      }
+    }
+  }
+
+  /**
+   * Run a single batched derived-tag lookup across every TagLabel value in {@code tagsByKey},
+   * returning {@code null} on failure so callers can fall back to per-row
+   * {@link #addDerivedTagsGracefully(List)}. Used by both the bulk container path and the
+   * single-container column path so the warn-and-fall-back behavior stays in lockstep.
+   */
+  private Map<String, List<TagLabel>> tryBatchFetchDerivedTags(
+      Map<String, List<TagLabel>> tagsByKey, String contextDescription) {
+    try {
+      List<TagLabel> allTags =
+          tagsByKey.values().stream()
+              .filter(Objects::nonNull)
+              .flatMap(List::stream)
+              .collect(Collectors.toList());
+      return batchFetchDerivedTags(allTags);
+    } catch (Exception ex) {
+      LOG.warn(
+          "Failed to batch fetch derived tags for {}. Falling back to per-row.",
+          contextDescription,
+          ex);
+      return null;
+    }
   }
 
   private void setDefaultFields(Container container) {
@@ -469,14 +549,35 @@ public class ContainerRepository extends EntityRepository<Container> {
         return new ResultList<>(new ArrayList<>(), null, null, total);
       }
 
-      List<EntityReference> refs = getEntityReferences(relationshipRecords);
-      List<Container> children = new ArrayList<>();
-
-      for (EntityReference ref : refs) {
-        Container container =
-            Entity.getEntity(ref, EntityUtil.Fields.EMPTY_FIELDS.toString(), Include.ALL);
-        children.add(container);
+      // Hydrate the page with a slim projection: id, name, fqn, displayName, description.
+      // Heavy fields like dataModel, tags, owners, extension are intentionally skipped —
+      // the UI's children table only renders name and description, and parquet
+      // containers can carry multi-MB column schemas in dataModel.
+      //
+      // The IDs come straight from the relationship rows we already loaded in
+      // findToWithOffset — we deliberately do NOT call EntityUtil.getEntityReferences
+      // here because that path round-trips through Entity.getEntityReferencesByIds →
+      // EntityRepository.find → CACHE_WITH_ID, which materialises the FULL Container
+      // JSON (dataModel, tags, owners, extension) for every child just to extract its
+      // EntityReference. For 15 parquet rows that single call alone can dominate the
+      // listing latency.
+      List<UUID> ids = relationshipRecords.stream().map(r -> r.getId()).toList();
+      Map<UUID, Container> byId = new HashMap<>();
+      for (Container c : ((CollectionDAO.ContainerDAO) dao).findContainerSummariesByIds(ids)) {
+        byId.put(c.getId(), c);
       }
+      // Preserve relationship-offset ordering returned by findToWithOffset; drop
+      // any rows that no longer resolve (deleted between the relationship lookup and
+      // the bulk fetch) rather than failing the whole page.
+      List<Container> children = new ArrayList<>(ids.size());
+      for (UUID id : ids) {
+        Container container = byId.get(id);
+        if (container != null) {
+          children.add(container);
+        }
+      }
+      // service is stripped from stored JSON; restore via batched relationship lookup.
+      fetchAndSetDefaultService(children);
 
       return new ResultList<>(children, null, null, total);
     } catch (Exception e) {
@@ -485,6 +586,56 @@ public class ContainerRepository extends EntityRepository<Container> {
               "Failed to fetch children for container [%s]: %s", parentFQN, e.getMessage()),
           e);
     }
+  }
+
+  /**
+   * Return the parent chain for the given container, ordered from root container (immediate
+   * child of the storage service) down to the immediate parent. Empty when the container is at
+   * the top level. Resolves the entire chain in a single batched DB lookup so the UI does not
+   * need to issue one parent fetch per breadcrumb level.
+   */
+  public List<EntityReference> getAncestors(String fqn) {
+    String[] parts = FullyQualifiedName.split(fqn);
+    // parts[0] is the storage service; parts[parts.length - 1] is the container itself.
+    // Ancestors live at indices 1 .. parts.length - 2.
+    if (parts.length < 3) {
+      return Collections.emptyList();
+    }
+
+    // FullyQualifiedName.split preserves each segment as it appears in the source
+    // FQN (quoted segments stay quoted, unquoted stay unquoted). We still round-trip
+    // every segment through FullyQualifiedName.add — its quoteName step is idempotent,
+    // and it reapplies quotes to any unquoted segment that needs them so the
+    // reconstructed prefix matches the canonical FQN stored in the DB. Naively
+    // concatenating raw parts with '.' would skip that re-quoting step and break the
+    // IN-by-fqnHash lookup for any container whose name (or ancestor's name) contains
+    // an FQN-separator character.
+    List<String> ancestorFqns = new ArrayList<>(parts.length - 2);
+    String current = FullyQualifiedName.quoteName(parts[0]);
+    for (int i = 1; i < parts.length - 1; i++) {
+      current = FullyQualifiedName.add(current, parts[i]);
+      ancestorFqns.add(current);
+    }
+
+    // Projection-only batched IN query: pulls just the columns needed to build
+    // an EntityReference (id, name, displayName, fqn, deleted) instead of the
+    // full Container JSON. For a 10-level chain this avoids deserializing
+    // ~10 × 5–50 KB of unused container payload per breadcrumb request.
+    List<EntityReference> ancestors = dao.findReferencesByFqns(ancestorFqns, NON_DELETED);
+
+    // Preserve the root → immediate-parent ordering even if the DAO returns rows out of order.
+    Map<String, EntityReference> byFqn = new HashMap<>();
+    for (EntityReference ancestor : ancestors) {
+      byFqn.put(ancestor.getFullyQualifiedName(), ancestor);
+    }
+    List<EntityReference> ordered = new ArrayList<>(ancestorFqns.size());
+    for (String ancestorFqn : ancestorFqns) {
+      EntityReference ancestor = byFqn.get(ancestorFqn);
+      if (ancestor != null) {
+        ordered.add(ancestor);
+      }
+    }
+    return Collections.unmodifiableList(ordered);
   }
 
   static class DataModelDescriptionTaskWorkflow extends DescriptionTaskWorkflow {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityDAO.java
@@ -39,6 +39,7 @@ import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.sqlobject.transaction.Transaction;
 import org.openmetadata.schema.EntityInterface;
+import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
@@ -151,6 +152,173 @@ public interface EntityDAO<T extends EntityInterface> {
       @Bind("id") String id,
       @Bind("json") String json,
       @Bind("version") String version);
+
+  /**
+   * List (id, fullyQualifiedName) pairs for all rows whose FQN hash begins with {@code
+   * oldPrefixHash}. Used by rename cascade flows to enumerate which children need cache
+   * invalidation before an {@link #updateFqn} bulk rewrite.
+   */
+  @ConnectionAwareSqlQuery(
+      value =
+          "SELECT id, JSON_UNQUOTE(JSON_EXTRACT(json, '$.fullyQualifiedName')) AS fqn FROM <table> "
+              + "WHERE <nameHashColumn> LIKE :prefix",
+      connectionType = MYSQL)
+  @ConnectionAwareSqlQuery(
+      value =
+          "SELECT id, json->>'fullyQualifiedName' AS fqn FROM <table> "
+              + "WHERE <nameHashColumn> LIKE :prefix",
+      connectionType = POSTGRES)
+  @RegisterRowMapper(EntityIdFqnPairMapper.class)
+  List<EntityIdFqnPair> listIdFqnByPrefixHash(
+      @Define("table") String table,
+      @Define("nameHashColumn") String nameHashColumn,
+      @Bind("prefix") String prefix);
+
+  default List<EntityIdFqnPair> listDescendantIdFqnByPrefix(String oldPrefix) {
+    if (!getNameHashColumn().equals("fqnHash")) {
+      return java.util.Collections.emptyList();
+    }
+    String prefixPattern = FullyQualifiedName.buildHash(oldPrefix) + ".%";
+    return listIdFqnByPrefixHash(getTableName(), getNameHashColumn(), prefixPattern);
+  }
+
+  final class EntityIdFqnPair {
+    public final UUID id;
+    public final String fqn;
+
+    public EntityIdFqnPair(UUID id, String fqn) {
+      this.id = id;
+      this.fqn = fqn;
+    }
+  }
+
+  class EntityIdFqnPairMapper implements RowMapper<EntityIdFqnPair> {
+    @Override
+    public EntityIdFqnPair map(ResultSet rs, StatementContext ctx) throws SQLException {
+      return new EntityIdFqnPair(UUID.fromString(rs.getString("id")), rs.getString("fqn"));
+    }
+  }
+
+  /**
+   * Lightweight projection of just the fields {@link EntityReference} needs (id, name,
+   * displayName, fullyQualifiedName, deleted). Used by paths that only need to render a
+   * reference — e.g. breadcrumbs — and want to avoid deserializing the full entity JSON for
+   * every row.
+   */
+  @ConnectionAwareSqlQuery(
+      value =
+          "SELECT id, "
+              + "JSON_UNQUOTE(JSON_EXTRACT(json, '$.name')) AS name, "
+              + "JSON_UNQUOTE(JSON_EXTRACT(json, '$.displayName')) AS displayName, "
+              + "JSON_UNQUOTE(JSON_EXTRACT(json, '$.fullyQualifiedName')) AS fqn, "
+              + "deleted "
+              + "FROM <table> WHERE <nameHashColumn> IN (<names>) <cond>",
+      connectionType = MYSQL)
+  @ConnectionAwareSqlQuery(
+      value =
+          "SELECT id, "
+              + "json->>'name' AS name, "
+              + "json->>'displayName' AS displayName, "
+              + "json->>'fullyQualifiedName' AS fqn, "
+              + "deleted "
+              + "FROM <table> WHERE <nameHashColumn> IN (<names>) <cond>",
+      connectionType = POSTGRES)
+  @RegisterRowMapper(EntityReferenceRowMapper.class)
+  List<EntityReferenceRow> findReferencesByNameHashes(
+      @Define("table") String table,
+      @Define("nameHashColumn") String nameHashColumn,
+      @BindList("names") List<String> nameHashes,
+      @Define("cond") String cond);
+
+  /**
+   * Variant of {@link #findReferencesByNameHashes} for tables that don't carry a
+   * {@code deleted} column (entities that override {@link #supportsSoftDelete()} to return
+   * {@code false}). Selecting {@code deleted} on those tables would throw
+   * {@code SQLSyntaxErrorException}; the row mapper substitutes {@code FALSE} for the absent
+   * column so the call site can treat both cases uniformly.
+   */
+  @ConnectionAwareSqlQuery(
+      value =
+          "SELECT id, "
+              + "JSON_UNQUOTE(JSON_EXTRACT(json, '$.name')) AS name, "
+              + "JSON_UNQUOTE(JSON_EXTRACT(json, '$.displayName')) AS displayName, "
+              + "JSON_UNQUOTE(JSON_EXTRACT(json, '$.fullyQualifiedName')) AS fqn, "
+              + "FALSE AS deleted "
+              + "FROM <table> WHERE <nameHashColumn> IN (<names>)",
+      connectionType = MYSQL)
+  @ConnectionAwareSqlQuery(
+      value =
+          "SELECT id, "
+              + "json->>'name' AS name, "
+              + "json->>'displayName' AS displayName, "
+              + "json->>'fullyQualifiedName' AS fqn, "
+              + "FALSE AS deleted "
+              + "FROM <table> WHERE <nameHashColumn> IN (<names>)",
+      connectionType = POSTGRES)
+  @RegisterRowMapper(EntityReferenceRowMapper.class)
+  List<EntityReferenceRow> findReferencesByNameHashesNoDeleted(
+      @Define("table") String table,
+      @Define("nameHashColumn") String nameHashColumn,
+      @BindList("names") List<String> nameHashes);
+
+  /**
+   * Resolve a list of FQNs to {@link EntityReference}s in a single batched query without
+   * deserializing the full entity JSON. Returns refs in arbitrary order — callers that need
+   * ordering should reorder by FQN.
+   */
+  default List<EntityReference> findReferencesByFqns(List<String> entityFQNs, Include include) {
+    if (CollectionUtils.isEmpty(entityFQNs)) {
+      return List.of();
+    }
+    List<String> nameHashes =
+        entityFQNs.stream().distinct().map(FullyQualifiedName::buildHash).toList();
+    int maxChunkSize = 30000;
+    if (nameHashes.size() <= maxChunkSize) {
+      return findReferenceRows(nameHashes, include).stream()
+          .map(row -> row.toEntityReference(Entity.getEntityTypeFromClass(getEntityClass())))
+          .toList();
+    }
+    List<EntityReference> all = new ArrayList<>(nameHashes.size());
+    for (int i = 0; i < nameHashes.size(); i += maxChunkSize) {
+      List<String> chunk = nameHashes.subList(i, Math.min(i + maxChunkSize, nameHashes.size()));
+      findReferenceRows(chunk, include).stream()
+          .map(row -> row.toEntityReference(Entity.getEntityTypeFromClass(getEntityClass())))
+          .forEach(all::add);
+    }
+    return all;
+  }
+
+  private List<EntityReferenceRow> findReferenceRows(List<String> nameHashes, Include include) {
+    if (!supportsSoftDelete()) {
+      return findReferencesByNameHashesNoDeleted(getTableName(), getNameHashColumn(), nameHashes);
+    }
+    return findReferencesByNameHashes(
+        getTableName(), getNameHashColumn(), nameHashes, getCondition(include));
+  }
+
+  record EntityReferenceRow(UUID id, String name, String displayName, String fqn, boolean deleted) {
+    public EntityReference toEntityReference(String entityType) {
+      return new EntityReference()
+          .withId(id)
+          .withType(entityType)
+          .withName(name)
+          .withDisplayName(displayName)
+          .withFullyQualifiedName(fqn)
+          .withDeleted(deleted);
+    }
+  }
+
+  class EntityReferenceRowMapper implements RowMapper<EntityReferenceRow> {
+    @Override
+    public EntityReferenceRow map(ResultSet rs, StatementContext ctx) throws SQLException {
+      return new EntityReferenceRow(
+          UUID.fromString(rs.getString("id")),
+          rs.getString("name"),
+          rs.getString("displayName"),
+          rs.getString("fqn"),
+          rs.getBoolean("deleted"));
+    }
+  }
 
   default void updateFqn(String oldPrefix, String newPrefix) {
     LOG.info("Updating FQN for {} from {} to {}", getTableName(), oldPrefix, newPrefix);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/HikariCPDataSourceFactory.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/HikariCPDataSourceFactory.java
@@ -160,14 +160,19 @@ public class HikariCPDataSourceFactory extends DataSourceFactory {
     }
     config.setValidationTimeout(validTimeout != null ? validTimeout : 5000L);
 
-    // Leak detection threshold - default 0 (disabled)
     Long leakThreshold = leakDetectionThreshold;
     if (leakThreshold == null
         && properties != null
         && properties.containsKey("leakDetectionThreshold")) {
       leakThreshold = Long.parseLong(properties.get("leakDetectionThreshold"));
     }
-    config.setLeakDetectionThreshold(leakThreshold != null ? leakThreshold : 0L);
+    // Default leakDetectionThreshold to 60s (HikariCP's own default is 0 = disabled).
+    // On a busy server a leaked connection silently drains the pool until requests
+    // start queuing and k8s liveness probes fail; with this on, HikariCP logs a stack
+    // trace for any borrow that exceeds the threshold so the offending caller is
+    // identifiable. Operators that need a different threshold can override via
+    // `leakDetectionThreshold` in openmetadata.yaml.
+    config.setLeakDetectionThreshold(leakThreshold != null ? leakThreshold : 60000L);
 
     config.setAutoCommit(autoCommit);
     config.setReadOnly(readOnly);
@@ -262,7 +267,12 @@ public class HikariCPDataSourceFactory extends DataSourceFactory {
     props.putIfAbsent("defaultRowFetchSize", "100");
     props.putIfAbsent("loginTimeout", "30");
     props.putIfAbsent("connectTimeout", "30");
-    props.putIfAbsent("socketTimeout", "0");
+    // Default socketTimeout from "0" (infinite — a stuck DB read held the
+    // connection forever, exhausted the pool, and stalled k8s liveness probes)
+    // to 5 minutes. Real OpenMetadata queries should never run that long; jobs
+    // that legitimately need a longer cap (bulk imports, reindex) should run
+    // with their own pool config.
+    props.putIfAbsent("socketTimeout", "300");
     props.putIfAbsent("tcpKeepAlive", "true");
     props.putIfAbsent("ApplicationName", "OpenMetadata");
 
@@ -318,7 +328,9 @@ public class HikariCPDataSourceFactory extends DataSourceFactory {
     props.putIfAbsent("connectionCollation", "utf8mb4_unicode_ci");
     // MySQL connectTimeout is in milliseconds
     props.putIfAbsent("connectTimeout", "30000");
-    props.putIfAbsent("socketTimeout", "0");
+    // Default socketTimeout from "0" (infinite — see PostgreSQL note above) to
+    // 5 minutes (in milliseconds for MySQL).
+    props.putIfAbsent("socketTimeout", "300000");
 
     Map<String, String> properties = getProperties();
     if (properties != null) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/data/DataContractResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/data/DataContractResource.java
@@ -317,7 +317,15 @@ public class DataContractResource extends EntityResource<DataContract, DataContr
         new OperationContext(entityType, MetadataOperation.VIEW_ALL),
         getResourceContextById(entityId));
 
-    EntityInterface entity = Entity.getEntity(entityType, entityId, "*", Include.NON_DELETED);
+    // Only `dataProducts` is consulted by getEffectiveDataContract for inheritance;
+    // the rest of the resolution path uses entity.getEntityReference() (id, name,
+    // type, fqn). Loading the full entity with "*" was pulling every relationship
+    // (owners, tags, followers, domains, extension) and the heavy stored JSON for
+    // the entity (e.g. a parquet container's dataModel can be MBs of column-schema
+    // metadata). For containers this single line drove the endpoint past the
+    // 1-minute timeout in production. Limit the fetch to the only field we need.
+    EntityInterface entity =
+        Entity.getEntity(entityType, entityId, "dataProducts", Include.NON_DELETED);
     DataContract dataContract = repository.getEffectiveDataContract(entity);
 
     if (dataContract == null) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/storages/ContainerResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/storages/ContainerResource.java
@@ -37,6 +37,7 @@ import org.openmetadata.schema.api.data.RestoreEntity;
 import org.openmetadata.schema.entity.data.Container;
 import org.openmetadata.schema.type.ChangeEvent;
 import org.openmetadata.schema.type.EntityHistory;
+import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.schema.utils.ResultList;
@@ -47,6 +48,8 @@ import org.openmetadata.service.limits.Limits;
 import org.openmetadata.service.resources.Collection;
 import org.openmetadata.service.resources.EntityResource;
 import org.openmetadata.service.security.Authorizer;
+import org.openmetadata.service.security.policyevaluator.OperationContext;
+import org.openmetadata.service.security.policyevaluator.ResourceContext;
 
 @Path("/v1/containers")
 @Tag(
@@ -663,6 +666,38 @@ public class ContainerResource extends EntityResource<Container, ContainerReposi
           @QueryParam("offset")
           @Min(value = 0, message = "must be greater than or equal to 0")
           Integer offset) {
+    OperationContext operationContext =
+        new OperationContext(entityType, MetadataOperation.VIEW_BASIC);
+    ResourceContext<Container> resourceContext = getResourceContextByName(fqn);
+    authorizer.authorize(securityContext, operationContext, resourceContext);
     return repository.listChildren(fqn, limit, offset);
+  }
+
+  @GET
+  @Path("/name/{fqn}/ancestors")
+  @Operation(
+      operationId = "listContainerAncestors",
+      summary = "List ancestor containers (parent chain)",
+      description =
+          "Return the ordered chain of ancestor containers from root (immediate child of the storage service) down to the immediate parent of the given container. Resolved via a single batched fetch — useful for rendering breadcrumbs without N sequential parent lookups.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Ordered list of ancestor container references",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(type = "array", implementation = EntityReference.class)))
+      })
+  public List<EntityReference> listAncestors(
+      @Context UriInfo uriInfo,
+      @Context SecurityContext securityContext,
+      @Parameter(description = "Fully qualified name of the container") @PathParam("fqn")
+          String fqn) {
+    OperationContext operationContext =
+        new OperationContext(entityType, MetadataOperation.VIEW_BASIC);
+    ResourceContext<Container> resourceContext = getResourceContextByName(fqn);
+    authorizer.authorize(securityContext, operationContext, resourceContext);
+    return repository.getAncestors(fqn);
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/system/SystemResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/system/SystemResource.java
@@ -570,7 +570,19 @@ public class SystemResource {
   @Operation(
       operationId = "healthCheck",
       summary = "Health check endpoint",
-      description = "Simple health check endpoint that returns 200 OK",
+      description =
+          "Pure process-aliveness probe — returns 200 OK as long as the JVM can run this"
+              + " handler and Jetty can serve a response. Intentionally does NOT probe the"
+              + " database, search backend, cache, or any other downstream system. Coupling"
+              + " the liveness probe to downstream latency creates restart loops: a slow"
+              + " (but otherwise healthy) database trips the probe, kubelet kills the pod,"
+              + " the new pod cold-starts and re-storms the database, and the cycle"
+              + " accelerates. Killing the process never speeds up the database.\n\n"
+              + "If you need DB/cache health visibility for routing decisions, use a"
+              + " separate readiness probe (which doesn't trigger a pod kill) or scrape"
+              + " HikariCP pool stats from the metrics endpoint.\n\n"
+              + "For production, prefer the admin-port `/healthcheck` over this endpoint —"
+              + " admin runs on its own thread pool insulated from API saturation.",
       responses = {@ApiResponse(responseCode = "200", description = "Service is healthy")})
   public Response healthCheck() {
     return Response.ok("OK").build();

--- a/openmetadata-service/src/test/java/org/openmetadata/service/OpenMetadataServerHealthCheckTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/OpenMetadataServerHealthCheckTest.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.codahale.metrics.health.HealthCheck.Result;
+import org.junit.jupiter.api.Test;
+
+class OpenMetadataServerHealthCheckTest {
+
+  @Test
+  void check_returnsHealthy() {
+    OpenMetadataServerHealthCheck check = new OpenMetadataServerHealthCheck();
+    Result result = check.check();
+    assertTrue(result.isHealthy(), "process-aliveness probe must always be healthy");
+  }
+}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Container/ContainerChildren/ContainerChildren.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Container/ContainerChildren/ContainerChildren.tsx
@@ -12,12 +12,11 @@
  */
 import { ColumnsType } from 'antd/lib/table';
 import { AxiosError } from 'axios';
-import { FC, useEffect, useMemo, useState } from 'react';
+import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { EntityType } from '../../../enums/entity.enum';
 import { Container } from '../../../generated/entity/data/container';
-import { EntityReference } from '../../../generated/type/entityReference';
 import { usePaging } from '../../../hooks/paging/usePaging';
 import { useFqn } from '../../../hooks/useFqn';
 import { getContainerChildrenByName } from '../../../rest/storageAPI';
@@ -30,8 +29,25 @@ import { PagingHandlerParams } from '../../common/NextPrevious/NextPrevious.inte
 import Table from '../../common/Table/Table';
 import { useGenericContext } from '../../Customization/GenericProvider/GenericProvider';
 import { ContainerChildrenProps } from './ContainerChildren.interface';
+import { useContainerChildrenCountSetter } from './ContainerChildrenCountContext';
+
+// Row shape rendered by the children table: every field used by the columns
+// (id, name, displayName, fullyQualifiedName, description) is structurally
+// satisfied by both the slim Container summaries returned by the /children
+// endpoint and the EntityReference[] the customize-page widget preview feeds
+// in via the parent Container's `children`. Picking this minimum keeps both
+// inputs strongly typed without an unchecked cast and without forcing the
+// preview path to mint synthetic Containers (which would need `service`, etc).
+type ContainerChildRow = {
+  id: string;
+  name?: string;
+  displayName?: string;
+  fullyQualifiedName?: string;
+  description?: string;
+};
 
 const ContainerChildren: FC<ContainerChildrenProps> = ({ isReadOnly }) => {
+  const onChildrenCountChange = useContainerChildrenCountSetter();
   const { t } = useTranslation();
   const {
     paging,
@@ -46,17 +62,17 @@ const ContainerChildren: FC<ContainerChildrenProps> = ({ isReadOnly }) => {
   const { fqn: decodedContainerName } = useFqn();
   const [isChildrenLoading, setIsChildrenLoading] = useState(false);
   const [containerChildrenData, setContainerChildrenData] = useState<
-    EntityReference[]
+    ContainerChildRow[]
   >([]);
 
-  const columns: ColumnsType<EntityReference> = useMemo(
+  const columns: ColumnsType<ContainerChildRow> = useMemo(
     () => [
       {
         title: t('label.name'),
         dataIndex: 'name',
         width: 400,
         key: 'name',
-        sorter: getColumnSorter<EntityReference, 'name'>('name'),
+        sorter: getColumnSorter<ContainerChildRow, 'name'>('name'),
         render: (_, record) => (
           <div className="d-inline-flex w-max-90">
             <Link
@@ -65,35 +81,51 @@ const ContainerChildren: FC<ContainerChildrenProps> = ({ isReadOnly }) => {
               to={getEntityDetailsPath(
                 EntityType.CONTAINER,
                 record.fullyQualifiedName ?? ''
-              )}>
+              )}
+            >
               {getEntityName(record)}
             </Link>
           </div>
         ),
       },
-      ...descriptionTableObject<EntityReference>(),
+      ...descriptionTableObject<ContainerChildRow>(),
     ],
-    []
+    [t]
   );
 
-  const fetchContainerChildren = async (pagingOffset?: number) => {
-    setIsChildrenLoading(true);
-    try {
-      const { data, paging } = await getContainerChildrenByName(
-        decodedContainerName,
-        {
+  // Track the FQN of the latest in-flight fetch so a slow earlier response for a
+  // previous container does not overwrite the newer container's data when the
+  // user navigates between containers.
+  const latestFetchFqn = useRef<string>('');
+
+  const fetchContainerChildren = useCallback(
+    async (pagingOffset?: number) => {
+      const fetchFqn = decodedContainerName;
+      latestFetchFqn.current = fetchFqn;
+      setIsChildrenLoading(true);
+      try {
+        const { data, paging } = await getContainerChildrenByName(fetchFqn, {
           limit: pageSize,
           offset: pagingOffset ?? 0,
+        });
+        if (latestFetchFqn.current !== fetchFqn) {
+          return;
         }
-      );
-      setContainerChildrenData(data ?? []);
-      handlePagingChange(paging);
-    } catch (error) {
-      showErrorToast(error as AxiosError);
-    } finally {
-      setIsChildrenLoading(false);
-    }
-  };
+        setContainerChildrenData(data ?? []);
+        handlePagingChange(paging);
+        onChildrenCountChange?.(paging.total);
+      } catch (error) {
+        if (latestFetchFqn.current === fetchFqn) {
+          showErrorToast(error as AxiosError);
+        }
+      } finally {
+        if (latestFetchFqn.current === fetchFqn) {
+          setIsChildrenLoading(false);
+        }
+      }
+    },
+    [decodedContainerName, pageSize, handlePagingChange, onChildrenCountChange]
+  );
 
   const handleChildrenPageChange = (data: PagingHandlerParams) => {
     handlePageChange(data.currentPage);
@@ -101,12 +133,24 @@ const ContainerChildren: FC<ContainerChildrenProps> = ({ isReadOnly }) => {
   };
 
   useEffect(() => {
-    if (!isReadOnly) {
-      fetchContainerChildren();
-    } else {
-      setContainerChildrenData(container?.children ?? []);
+    if (isReadOnly) {
+      return;
     }
-  }, [pageSize, isReadOnly]);
+    fetchContainerChildren();
+  }, [pageSize, isReadOnly, decodedContainerName, fetchContainerChildren]);
+
+  useEffect(() => {
+    if (!isReadOnly) {
+      return;
+    }
+    // Read-only mode is used by the customize-page widget preview, which feeds
+    // synthetic data via the parent Container's `children` (an EntityReference[]).
+    // Both Container and EntityReference are structurally assignable to
+    // ContainerChildRow, so no cast is needed.
+    const children = container?.children ?? [];
+    setContainerChildrenData(children);
+    onChildrenCountChange?.(children.length);
+  }, [isReadOnly, container?.children, onChildrenCountChange]);
 
   return (
     <Table

--- a/openmetadata-ui/src/main/resources/ui/src/components/Container/ContainerChildren/ContainerChildrenCountContext.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Container/ContainerChildren/ContainerChildrenCountContext.ts
@@ -1,0 +1,23 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { createContext, useContext } from 'react';
+
+// Lets the parent ContainerPage receive the children-count back from a deeply
+// nested ContainerChildren that may be rendered through the customizable widget
+// system (where prop drilling is not available).
+export const ContainerChildrenCountContext = createContext<
+  ((count: number) => void) | null
+>(null);
+
+export const useContainerChildrenCountSetter = () =>
+  useContext(ContainerChildrenCountContext);

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetsHeader/DataAssetsHeader.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetsHeader/DataAssetsHeader.component.tsx
@@ -43,14 +43,9 @@ import {
 } from '../../../constants/Services.constant';
 import { TAG_START_WITH } from '../../../constants/Tag.constants';
 import { useTourProvider } from '../../../context/TourProvider/TourProvider';
-import {
-  EntityTabs,
-  EntityType,
-  TabSpecificField,
-} from '../../../enums/entity.enum';
+import { EntityTabs, EntityType } from '../../../enums/entity.enum';
 import { ServiceCategory } from '../../../enums/service.enum';
 import { LineageLayer } from '../../../generated/configuration/lineageSettings';
-import { Container } from '../../../generated/entity/data/container';
 import {
   ContractExecutionStatus,
   DataContract,
@@ -58,6 +53,7 @@ import {
 import { EntityStatus } from '../../../generated/entity/data/glossaryTerm';
 import { Table } from '../../../generated/entity/data/table';
 import { Thread } from '../../../generated/entity/feed/thread';
+import { EntityReference } from '../../../generated/type/entityReference';
 import { useApplicationStore } from '../../../hooks/useApplicationStore';
 import { useCustomPages } from '../../../hooks/useCustomPages';
 import { useEntityRules } from '../../../hooks/useEntityRules';
@@ -65,7 +61,7 @@ import { triggerOnDemandApp } from '../../../rest/applicationAPI';
 import { getContractByEntityId } from '../../../rest/contractAPI';
 import { getActiveAnnouncement } from '../../../rest/feedsAPI';
 import { getDataQualityLineage } from '../../../rest/lineageAPI';
-import { getContainerByName } from '../../../rest/storageAPI';
+import { getContainerAncestors } from '../../../rest/storageAPI';
 import {
   getDataAssetsHeaderInfo,
   isDataAssetsWithServiceField,
@@ -151,7 +147,9 @@ export const DataAssetsHeader = ({
   const { customizedPage } = useCustomPages(
     ENTITY_PAGE_TYPE_MAP[entityType as CustomizeEntityType]
   );
-  const [parentContainers, setParentContainers] = useState<Container[]>([]);
+  const [parentContainers, setParentContainers] = useState<EntityReference[]>(
+    []
+  );
   const [isBreadcrumbLoading, setIsBreadcrumbLoading] = useState(false);
   const [dqFailureCount, setDqFailureCount] = useState(0);
   const [isFollowingLoading, setIsFollowingLoading] = useState(false);
@@ -333,27 +331,21 @@ export const DataAssetsHeader = ({
     }
   };
 
-  const fetchContainerParent = async (
-    parentName: string,
-    parents = [] as Container[]
-  ) => {
-    if (isEmpty(parentName)) {
+  const fetchContainerAncestors = async (containerFqn: string) => {
+    // Always reset state at the top so a navigation to a container without an FQN
+    // (or to one whose ancestor fetch fails) doesn't keep painting the previous
+    // container's breadcrumbs. Without this reset, switching between containers
+    // could leave stale ancestors visible after either an early return or an error.
+    setParentContainers([]);
+    if (isEmpty(containerFqn)) {
       return;
     }
     setIsBreadcrumbLoading(true);
     try {
-      const response = await getContainerByName(parentName, {
-        fields: TabSpecificField.PARENT,
-      });
-      const updatedParent = [response, ...parents];
-      if (response?.parent?.fullyQualifiedName) {
-        await fetchContainerParent(
-          response.parent.fullyQualifiedName,
-          updatedParent
-        );
-      } else {
-        setParentContainers(updatedParent);
-      }
+      // Single batched server call replaces what used to be one
+      // getContainerByName per ancestor level.
+      const ancestors = await getContainerAncestors(containerFqn);
+      setParentContainers(ancestors ?? []);
     } catch (error) {
       showErrorToast(error as AxiosError, t('server.unexpected-response'));
     } finally {
@@ -367,10 +359,9 @@ export const DataAssetsHeader = ({
       fetchDQFailureCount();
     }
     if (entityType === EntityType.CONTAINER && !isCustomizedView) {
-      const asset = dataAsset;
-      fetchContainerParent(asset.parent?.fullyQualifiedName ?? '');
+      fetchContainerAncestors(dataAsset.fullyQualifiedName ?? '');
     }
-  }, [dataAsset.fullyQualifiedName, isTourPage, isCustomizedView]);
+  }, [dataAsset.fullyQualifiedName, entityType, isTourPage, isCustomizedView]);
 
   const { extraInfo, breadcrumbs }: DataAssetHeaderInfo = useMemo(
     () =>

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetsHeader/DataAssetsHeader.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetsHeader/DataAssetsHeader.test.tsx
@@ -28,7 +28,7 @@ import { MOCK_TIER_DATA } from '../../../mocks/TableData.mock';
 import { triggerOnDemandApp } from '../../../rest/applicationAPI';
 import { getContractByEntityId } from '../../../rest/contractAPI';
 import { getDataQualityLineage } from '../../../rest/lineageAPI';
-import { getContainerByName } from '../../../rest/storageAPI';
+import { getContainerAncestors } from '../../../rest/storageAPI';
 import { ExtraInfoLink } from '../../../utils/DataAssetsHeader.utils';
 import { getDataContractStatusIcon } from '../../../utils/DataContract/DataContractUtils';
 import { DEFAULT_ENTITY_PERMISSION } from '../../../utils/PermissionsUtils';
@@ -175,9 +175,9 @@ jest.mock('../../Tag/TagsV1/TagsV1.component', () =>
 );
 
 jest.mock('../../../rest/storageAPI', () => ({
-  getContainerByName: jest
+  getContainerAncestors: jest
     .fn()
-    .mockImplementation(() => Promise.resolve({ name: 'test' })),
+    .mockImplementation(() => Promise.resolve([])),
 }));
 
 let mockIsAlertSupported = false;
@@ -255,26 +255,77 @@ describe('ExtraInfoLink component', () => {
 });
 
 describe('DataAssetsHeader component', () => {
-  it('should call getContainerByName API on Page load for container assets', () => {
-    const mockGetContainerByName = getContainerByName as jest.Mock;
+  it('should call getContainerAncestors API on Page load for container assets', () => {
+    const mockGetContainerAncestors = getContainerAncestors as jest.Mock;
     render(<DataAssetsHeader {...mockProps} />);
 
-    expect(mockGetContainerByName).toHaveBeenCalledWith('fullyQualifiedName', {
-      fields: 'parent',
-    });
+    // The breadcrumb resolution is now a single batched server call against
+    // the container's own FQN. The server returns the full ancestor chain.
+    expect(mockGetContainerAncestors).toHaveBeenCalledWith(
+      mockProps.dataAsset.fullyQualifiedName
+    );
     expect(getDataQualityLineage).not.toHaveBeenCalled();
   });
 
-  it('should not call getContainerByName API if parent is undefined', () => {
-    const mockGetContainerByName = getContainerByName as jest.Mock;
+  it('should not call getContainerAncestors API when the container FQN is missing', () => {
+    const mockGetContainerAncestors = getContainerAncestors as jest.Mock;
+    mockGetContainerAncestors.mockClear();
     render(
       <DataAssetsHeader
         {...mockProps}
-        dataAsset={{ ...mockProps.dataAsset, parent: undefined }}
+        dataAsset={{ ...mockProps.dataAsset, fullyQualifiedName: '' }}
       />
     );
 
-    expect(mockGetContainerByName).not.toHaveBeenCalled();
+    expect(mockGetContainerAncestors).not.toHaveBeenCalled();
+  });
+
+  it('should resolve the full ancestor chain in a single API call', async () => {
+    // Replaces the old recursive behaviour where each ancestor required its
+    // own getContainerByName request. We assert the breadcrumb resolution
+    // makes exactly one network call regardless of nesting depth.
+    const mockGetContainerAncestors = getContainerAncestors as jest.Mock;
+    mockGetContainerAncestors.mockClear();
+    mockGetContainerAncestors.mockResolvedValue([
+      {
+        id: 'root-id',
+        type: 'container',
+        name: 'root',
+        displayName: 'Root',
+        fullyQualifiedName: 's3.root',
+      },
+      {
+        id: 'mid-id',
+        type: 'container',
+        name: 'mid',
+        displayName: 'Mid',
+        fullyQualifiedName: 's3.root.mid',
+      },
+      {
+        id: 'leaf-parent-id',
+        type: 'container',
+        name: 'leaf_parent',
+        displayName: 'Leaf Parent',
+        fullyQualifiedName: 's3.root.mid.leaf_parent',
+      },
+    ]);
+
+    await act(async () => {
+      render(
+        <DataAssetsHeader
+          {...mockProps}
+          dataAsset={{
+            ...mockProps.dataAsset,
+            fullyQualifiedName: 's3.root.mid.leaf_parent.leaf',
+          }}
+        />
+      );
+    });
+
+    expect(mockGetContainerAncestors).toHaveBeenCalledTimes(1);
+    expect(mockGetContainerAncestors).toHaveBeenCalledWith(
+      's3.root.mid.leaf_parent.leaf'
+    );
   });
 
   it('should render the Tier data if present', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ContainerPage/ContainerPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ContainerPage/ContainerPage.test.tsx
@@ -21,6 +21,7 @@ import { Include } from '../../generated/type/include';
 import {
   addContainerFollower,
   getContainerByName,
+  getContainerChildrenByName,
 } from '../../rest/storageAPI';
 import ContainerPage from './ContainerPage';
 import {
@@ -293,6 +294,10 @@ describe('Container Page Component', () => {
       jest.requireMock('../../utils/PermissionsUtils');
     getPrioritizedEditPermission.mockReturnValue(true);
     getPrioritizedViewPermission.mockReturnValue(true);
+    (getContainerChildrenByName as jest.Mock).mockResolvedValue({
+      data: [],
+      paging: { total: 0 },
+    });
   });
 
   it('should show error-placeholder, if not have view permission', async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ContainerPage/ContainerPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ContainerPage/ContainerPage.tsx
@@ -21,6 +21,7 @@ import { withActivityFeed } from '../../components/AppRouter/withActivityFeed';
 import ErrorPlaceHolder from '../../components/common/ErrorWithPlaceholder/ErrorPlaceHolder';
 import { AlignRightIconButton } from '../../components/common/IconButtons/EditIconButton';
 import Loader from '../../components/common/Loader/Loader';
+import { ContainerChildrenCountContext } from '../../components/Container/ContainerChildren/ContainerChildrenCountContext';
 import { GenericProvider } from '../../components/Customization/GenericProvider/GenericProvider';
 import { DataAssetsHeader } from '../../components/DataAssets/DataAssetsHeader/DataAssetsHeader.component';
 import { DataAssetWithDomains } from '../../components/DataAssets/DataAssetsHeader/DataAssetsHeader.interface';
@@ -221,22 +222,6 @@ const ContainerPage = () => {
       setIsLoading(false);
     }
   };
-
-  // Fetch children count to show it in Tab label
-  const fetchContainerChildren = useCallback(async () => {
-    // Use resolvedEntityFqn for children
-    if (!resolvedEntityFqn) {
-      return;
-    }
-    try {
-      const { paging } = await getContainerChildrenByName(resolvedEntityFqn, {
-        limit: 0,
-      });
-      setChildrenCount(paging.total);
-    } catch (error) {
-      showErrorToast(error as AxiosError);
-    }
-  }, [resolvedEntityFqn]);
 
   const { deleted, version, isUserFollowing } = useMemo(() => {
     return {
@@ -623,10 +608,35 @@ const ContainerPage = () => {
   }, [decodedEntityFqn, resolvedEntityFqn, containerData, activeColumnFqn]);
 
   useEffect(() => {
-    if (resolvedEntityFqn) {
-      fetchContainerChildren();
-      getEntityFeedCount();
+    if (!resolvedEntityFqn) {
+      return;
     }
+    // Reset so a stale value from the previous container isn't shown.
+    setChildrenCount(0);
+    getEntityFeedCount();
+
+    // Eager-fetch the children total so the tab badge is correct even before
+    // the user opens the Children tab. ContainerChildren is lazily mounted, so
+    // its onChildrenCountChange callback only fires once the tab is clicked —
+    // for containers that default to a different tab (e.g. dataModel-bearing
+    // ones that open the Schema tab), the badge would otherwise stay at 0
+    // until the user navigates. limit=0 returns just paging.total without any
+    // row payload.
+    let cancelled = false;
+    getContainerChildrenByName(resolvedEntityFqn, { limit: 0 })
+      .then((resp) => {
+        if (!cancelled) {
+          setChildrenCount(resp?.paging?.total ?? 0);
+        }
+      })
+      .catch(() => {
+        // Non-critical; the count will populate when the user opens the tab
+        // and ContainerChildren reports it via the context setter.
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [resolvedEntityFqn]);
 
   const toggleTabExpanded = () => {
@@ -715,27 +725,30 @@ const ContainerPage = () => {
           isTabExpanded={isTabExpanded}
           permissions={containerPermissions}
           type={EntityType.CONTAINER as CustomizeEntityType}
-          onUpdate={handleContainerUpdate}>
-          <Col className="entity-details-page-tabs" span={24}>
-            <Tabs
-              activeKey={tab}
-              className="tabs-new"
-              data-testid="tabs"
-              items={tabs}
-              tabBarExtraContent={
-                isExpandViewSupported && (
-                  <AlignRightIconButton
-                    className={isTabExpanded ? 'rotate-180' : ''}
-                    title={
-                      isTabExpanded ? t('label.collapse') : t('label.expand')
-                    }
-                    onClick={toggleTabExpanded}
-                  />
-                )
-              }
-              onChange={handleTabChange}
-            />
-          </Col>
+          onUpdate={handleContainerUpdate}
+        >
+          <ContainerChildrenCountContext.Provider value={setChildrenCount}>
+            <Col className="entity-details-page-tabs" span={24}>
+              <Tabs
+                activeKey={tab}
+                className="tabs-new"
+                data-testid="tabs"
+                items={tabs}
+                tabBarExtraContent={
+                  isExpandViewSupported && (
+                    <AlignRightIconButton
+                      className={isTabExpanded ? 'rotate-180' : ''}
+                      title={
+                        isTabExpanded ? t('label.collapse') : t('label.expand')
+                      }
+                      onClick={toggleTabExpanded}
+                    />
+                  )
+                }
+                onChange={handleTabChange}
+              />
+            </Col>
+          </ContainerChildrenCountContext.Provider>
         </GenericProvider>
 
         <LimitWrapper resource="container">

--- a/openmetadata-ui/src/main/resources/ui/src/rest/contractAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/contractAPI.ts
@@ -85,10 +85,17 @@ export const getContractByEntityId = async (
   entityType: EntityType = EntityType.TABLE,
   fields: string[] = []
 ) => {
+  // Build the query string conditionally: previously we always appended
+  // `&fields=${fields.join(',')}`, which produced `?fields=` (empty string)
+  // when callers omitted the fields argument. The backend treated that as
+  // a request to evaluate every field and the call could time out at 1
+  // minute on heavyweight contracts. Drop the param entirely when empty.
+  const params = new URLSearchParams({ entityId, entityType });
+  if (fields.length > 0) {
+    params.set('fields', fields.join(','));
+  }
   const response = await APIClient.get<DataContract>(
-    `/dataContracts/entity?entityId=${entityId}&entityType=${entityType}&fields=${fields.join(
-      ','
-    )}`
+    `/dataContracts/entity?${params.toString()}`
   );
 
   return response.data;

--- a/openmetadata-ui/src/main/resources/ui/src/rest/storageAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/storageAPI.ts
@@ -64,14 +64,32 @@ export const getContainerByName = async (name: string, params?: ListParams) => {
 };
 
 export const getContainerChildrenByName = async (
-  name: string,
+  fqn: string,
   params?: ListParamsWithOffset
 ) => {
-  const response = await APIClient.get<PagingResponse<Container['children']>>(
-    `${BASE_URL}/name/${getEncodedFqn(name)}/children`,
+  // The /children endpoint returns slim Container summaries
+  // (id, name, displayName, fullyQualifiedName, description, service) — not
+  // EntityReferences. dataModel/tags/owners/extension are intentionally not
+  // populated. Re-fetch via getContainerByName when full details are needed.
+  const response = await APIClient.get<PagingResponse<Container[]>>(
+    `${BASE_URL}/name/${getEncodedFqn(fqn)}/children`,
     {
       params,
     }
+  );
+
+  return response.data;
+};
+
+/**
+ * Resolve the full ancestor chain for a container in a single call.
+ * Returns references ordered from root container (immediate child of the
+ * storage service) down to the immediate parent of `fqn`. Empty when the
+ * container is at the top level.
+ */
+export const getContainerAncestors = async (fqn: string) => {
+  const response = await APIClient.get<EntityReference[]>(
+    `${BASE_URL}/name/${getEncodedFqn(fqn)}/ancestors`
   );
 
   return response.data;

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataAssetsHeader.utils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataAssetsHeader.utils.tsx
@@ -63,6 +63,7 @@ import { PipelineService } from '../generated/entity/services/pipelineService';
 import { SearchService } from '../generated/entity/services/searchService';
 import { SecurityService } from '../generated/entity/services/securityService';
 import { StorageService } from '../generated/entity/services/storageService';
+import { EntityReference } from '../generated/type/entityReference';
 import { formatDateTime } from './date-time/DateTimeUtils';
 import {
   getBreadcrumbForEntitiesWithServiceOnly,
@@ -91,7 +92,8 @@ export const ExtraInfoLabel = ({
         <Divider className="self-center" type="vertical" />
         <Typography.Text
           className="self-center text-xs whitespace-nowrap"
-          data-testid={dataTestId}>
+          data-testid={dataTestId}
+        >
           {!isEmpty(label) && (
             <span className="text-grey-muted">{`${label}: `}</span>
           )}
@@ -105,7 +107,8 @@ export const ExtraInfoLabel = ({
     <div className="d-flex align-start extra-info-container">
       <Typography.Text
         className="whitespace-nowrap text-sm d-flex flex-col gap-2 w-full"
-        data-testid={dataTestId}>
+        data-testid={dataTestId}
+      >
         {!isEmpty(label) && (
           <span className="extra-info-label-heading">{label}</span>
         )}
@@ -114,7 +117,8 @@ export const ExtraInfoLabel = ({
           className={classNames('font-medium extra-info-value')}
           ellipsis={{
             tooltip: true,
-          }}>
+          }}
+        >
           {value ?? NO_DATA_PLACEHOLDER}
         </Typography.Text>
       </Typography.Text>
@@ -138,7 +142,8 @@ export const ExtraInfoLink = ({
   <div
     className={classNames('d-flex  text-sm  flex-col gap-2', {
       'w-48': ellipsis,
-    })}>
+    })}
+  >
     {!isEmpty(label) && (
       <span className="extra-info-label-heading  m-r-xss">{label}</span>
     )}
@@ -149,7 +154,8 @@ export const ExtraInfoLink = ({
           className="extra-info-link"
           href={href}
           rel={newTab ? 'noopener noreferrer' : undefined}
-          target={newTab ? '_blank' : undefined}>
+          target={newTab ? '_blank' : undefined}
+        >
           {value}
         </Typography.Link>
       </Tooltip>
@@ -166,7 +172,7 @@ export const getDataAssetsHeaderInfo = (
   entityType: DataAssetsHeaderProps['entityType'],
   dataAsset: DataAssetsHeaderProps['dataAsset'],
   entityName: string,
-  parentContainers: Container[]
+  parentContainers: EntityReference[]
 ) => {
   const returnData: DataAssetHeaderInfo = {
     extraInfo: <></>,


### PR DESCRIPTION
## Summary

Cherry-pick of [#27836](https://github.com/open-metadata/OpenMetadata/pull/27836) onto `1.12.7`.

Container retrieval was running an unbounded `LIKE 'hashPrefix.%'` against `tag_usage` to fetch tags for a container's data-model columns. For buckets with hundreds of thousands of nested objects this returned the entire descendant subtree per request, then filtered in memory. Replaces the prefix `LIKE` with a batched exact-match `IN` over the columns' hashes.

The original PR is large (33 files, multiple unrelated concerns piled in). The merge commit didn't apply cleanly. Conflicts were resolved by keeping **only the PR-introduced changes that fix the perf issue**, and reverting non-PR drift to `1.12.7`'s `HEAD`.

## Kept (the perf fix)

- **`CollectionDAO.TagUsageDAO`** — new `getTagsInternalByTargetHashes` (IN-by-hash) + `getTagsByTargetFQNHashes` chunked helper
- **`ContainerRepository`** — `populateDataModelColumnTags` rewrite, batched derived-tag fetch in single + bulk paths, `tryBatchFetchDerivedTags` helper
- **`ContainerRepository.listChildren`** — slim projection via `findContainerSummariesByIds`
- **`ContainerRepository.getAncestors`** + **`EntityDAO.findReferencesByFqns`** batched lookup; `/ancestors` REST endpoint
- UI: breadcrumb ancestors call, paginated children listing

## Dropped (not part of the perf fix, or depends on schema/code not on 1.12.7)

| Dropped | Why |
|---|---|
| `addSampleData` / `getSampleData` / `deleteSampleData` on `ContainerRepository` | 1.12.7's `Container` schema has no `sampleData` field — would not compile |
| `RequestLatencyContext.phase()` instrumentation in `listChildren` | Slow-request rewrite; method not on 1.12.7 |
| `RuleEnforcementProvider` `useRef` dedupe rewrite | Unrelated refactor |
| `ContainerResourceIT` PATCH-nested-columns + PII test additions | Depends on PR features not all backported |
| `ingestion/.../container_mixin.py`, `test_container_classification.py`, SDK `list_children` / `list_ancestors` helpers | Depend on `list_container_children` client method not on 1.12.7 |
| `slowrequest` / `OMSqlLogger` logback config | Logging-config drift from main, unrelated |

## Compile check

`mvn compile -pl openmetadata-service` passes for everything touched here. There is one unrelated pre-existing error on `1.12.7` (`EmbeddingClient.java:58 getMaxConcurrentEmbeddingRequests`) that is **not** introduced by this PR — verified by stashing this branch and recompiling clean `1.12.7`.

## Test plan

- [ ] CI green (Java + UI build, unit tests, IT smoke)
- [ ] Manual: GET on a container with deep nested children no longer fans out to the whole subtree (verify against tag_usage query plan / row counts)
- [ ] Manual: `/v1/containers/name/{fqn}/ancestors` returns root → immediate-parent ordered chain
- [ ] Manual: container detail page breadcrumb still renders
- [ ] No regression on `/v1/containers/name/{fqn}/children` (paginated children listing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)