### PR TITLE
test(playwright): extend verifyDataProductsCount poll timeout to 2m

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts
@@ -1896,6 +1896,8 @@ test.describe('Domain Rename Comprehensive Tests', () => {
   test('Rename domain with data products attached at domain and subdomain levels', async ({
     page,
   }) => {
+    test.setTimeout(240_000);
+
     const { afterAction, apiContext } = await getApiContext(page);
     const domain = new Domain();
     const domainDataProduct = new DataProduct([domain]);

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/domain.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/domain.ts
@@ -1402,7 +1402,7 @@ export const verifyDataProductsCount = async (
         },
         {
           message: `Wait for data product search index to show ${expectedCount} results for domain "${domainFqn}"`,
-          timeout: 30_000,
+          timeout: 120_000,
           intervals: [2_000, 3_000, 5_000],
         }
       )


### PR DESCRIPTION
## Summary
- Bump the search-index poll timeout in `verifyDataProductsCount` from 30s to 120s so domain-rename tests don't fail when the data product index lags after a domain rename on slow CI.
- Add `test.setTimeout(240_000)` to the only caller that exercises the poll path (`Rename domain with data products attached at domain and subdomain levels`) so the longer poll fits comfortably within the test budget. The describe-level `test.slow(true)` only gives 180s, which leaves ~35s of headroom against a worst-case 120s poll plus pre/post-poll work; 240s gives a safe buffer.
- The other test that calls `verifyDataProductsCount` (`Verify domain data products count includes subdomain data products`) does not pass `options`, so the poll path never runs there and no timeout adjustment is needed.

## Test plan
- [ ] `yarn playwright:run --grep "Rename domain with data products attached"` passes locally.
- [ ] `yarn playwright:run --grep "Verify domain data products count"` still passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)