### PR TITLE
fix(mcp): emit SSE response when client negotiates text/event-stream

### DIFF
--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/server/transport/HttpServletStatelessServerTransport.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/server/transport/HttpServletStatelessServerTransport.java
@@ -49,6 +49,24 @@ public class HttpServletStatelessServerTransport extends HttpServlet
 
   public static final String FAILED_TO_SEND_ERROR_RESPONSE = "Failed to send error response: {}";
 
+  static final String HEADER_CACHE_CONTROL = "Cache-Control";
+
+  static final String HEADER_CONNECTION = "Connection";
+
+  static final String HEADER_X_ACCEL_BUFFERING = "X-Accel-Buffering";
+
+  static final String CACHE_CONTROL_NO_CACHE = "no-cache";
+
+  static final String CONNECTION_KEEP_ALIVE = "keep-alive";
+
+  static final String X_ACCEL_BUFFERING_NO = "no";
+
+  static final String SSE_DATA_PREFIX = "data: ";
+
+  static final String SSE_LINE_TERMINATOR = "\n";
+
+  static final String SSE_EVENT_TERMINATOR = "\n\n";
+
   private final ObjectMapper objectMapper;
 
   private final McpJsonMapper jsonMapper;
@@ -255,19 +273,27 @@ public class HttpServletStatelessServerTransport extends HttpServlet
    * Streamable HTTP clients (e.g. Databricks Supervisor Agent's "databricks" v1.0.0 client) that
    * negotiate {@code text/event-stream} via the {@code Accept} header and refuse to parse plain
    * {@code application/json} responses.
+   *
+   * <p>Per the W3C SSE spec, payloads containing line breaks must prefix every line with
+   * {@code data: }. The default {@code McpJsonMapper} produces compact JSON, but this method
+   * splits defensively so that any embedded newline (e.g., a literal {@code \n} inside an error
+   * message) cannot truncate the event for the client.
    */
   static void writeSseResponse(HttpServletResponse response, String jsonResponseText)
       throws IOException {
     response.setContentType(TEXT_EVENT_STREAM);
     response.setCharacterEncoding(UTF_8);
-    response.setHeader("Cache-Control", "no-cache");
-    response.setHeader("Connection", "keep-alive");
-    response.setHeader("X-Accel-Buffering", "no");
+    response.setHeader(HEADER_CACHE_CONTROL, CACHE_CONTROL_NO_CACHE);
+    response.setHeader(HEADER_CONNECTION, CONNECTION_KEEP_ALIVE);
+    response.setHeader(HEADER_X_ACCEL_BUFFERING, X_ACCEL_BUFFERING_NO);
     response.setStatus(HttpServletResponse.SC_OK);
     PrintWriter writer = response.getWriter();
-    writer.write("data: ");
-    writer.write(jsonResponseText);
-    writer.write("\n\n");
+    for (String line : jsonResponseText.split("\\R", -1)) {
+      writer.write(SSE_DATA_PREFIX);
+      writer.write(line);
+      writer.write(SSE_LINE_TERMINATOR);
+    }
+    writer.write(SSE_LINE_TERMINATOR);
     writer.flush();
   }
 

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/server/transport/HttpServletStatelessServerTransport.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/server/transport/HttpServletStatelessServerTransport.java
@@ -133,12 +133,14 @@ public class HttpServletStatelessServerTransport extends HttpServlet
     McpTransportContext transportContext = this.contextExtractor.extract(request);
 
     String accept = request.getHeader(ACCEPT);
-    if (accept == null || !accept.contains(APPLICATION_JSON)) {
+    boolean acceptsJson = accept != null && accept.contains(APPLICATION_JSON);
+    boolean acceptsSse = accept != null && accept.contains(TEXT_EVENT_STREAM);
+    if (!acceptsJson && !acceptsSse) {
       this.responseError(
           response,
           HttpServletResponse.SC_BAD_REQUEST,
           McpError.builder(McpSchema.ErrorCodes.INVALID_REQUEST)
-              .message("application/json required in Accept header")
+              .message("Accept header must include application/json or text/event-stream")
               .build());
       return;
     }
@@ -162,14 +164,12 @@ public class HttpServletStatelessServerTransport extends HttpServlet
                   .contextWrite(ctx -> ctx.put(McpTransportContext.KEY, transportContext))
                   .block();
 
-          response.setContentType(APPLICATION_JSON);
-          response.setCharacterEncoding(UTF_8);
-          response.setStatus(HttpServletResponse.SC_OK);
-
           String jsonResponseText = jsonMapper.writeValueAsString(jsonrpcResponse);
-          PrintWriter writer = response.getWriter();
-          writer.write(jsonResponseText);
-          writer.flush();
+          if (acceptsSse) {
+            writeSseResponse(response, jsonResponseText);
+          } else {
+            writeJsonResponse(response, jsonResponseText);
+          }
         } catch (Exception e) {
           logger.error("Failed to handle request: {}", e.getMessage());
           this.responseError(
@@ -237,6 +237,37 @@ public class HttpServletStatelessServerTransport extends HttpServlet
     String jsonError = jsonMapper.writeValueAsString(mcpError);
     PrintWriter writer = response.getWriter();
     writer.write(jsonError);
+    writer.flush();
+  }
+
+  static void writeJsonResponse(HttpServletResponse response, String jsonResponseText)
+      throws IOException {
+    response.setContentType(APPLICATION_JSON);
+    response.setCharacterEncoding(UTF_8);
+    response.setStatus(HttpServletResponse.SC_OK);
+    PrintWriter writer = response.getWriter();
+    writer.write(jsonResponseText);
+    writer.flush();
+  }
+
+  /**
+   * Writes a JSON-RPC response as a one-shot Server-Sent Events stream. Required for MCP
+   * Streamable HTTP clients (e.g. Databricks Supervisor Agent's "databricks" v1.0.0 client) that
+   * negotiate {@code text/event-stream} via the {@code Accept} header and refuse to parse plain
+   * {@code application/json} responses.
+   */
+  static void writeSseResponse(HttpServletResponse response, String jsonResponseText)
+      throws IOException {
+    response.setContentType(TEXT_EVENT_STREAM);
+    response.setCharacterEncoding(UTF_8);
+    response.setHeader("Cache-Control", "no-cache");
+    response.setHeader("Connection", "keep-alive");
+    response.setHeader("X-Accel-Buffering", "no");
+    response.setStatus(HttpServletResponse.SC_OK);
+    PrintWriter writer = response.getWriter();
+    writer.write("data: ");
+    writer.write(jsonResponseText);
+    writer.write("\n\n");
     writer.flush();
   }
 

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/server/transport/HttpServletStatelessServerTransportTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/server/transport/HttpServletStatelessServerTransportTest.java
@@ -1,0 +1,100 @@
+/*
+ *  Copyright 2025 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.mcp.server.transport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class HttpServletStatelessServerTransportTest {
+
+  private static final String JSON_RESPONSE = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}";
+
+  private HttpServletResponse response;
+  private StringWriter body;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    response = mock(HttpServletResponse.class);
+    body = new StringWriter();
+    when(response.getWriter()).thenReturn(new PrintWriter(body));
+  }
+
+  @Test
+  void writeJsonResponse_setsContentTypeAndStatus() throws Exception {
+    HttpServletStatelessServerTransport.writeJsonResponse(response, JSON_RESPONSE);
+
+    verify(response).setContentType(HttpServletStatelessServerTransport.APPLICATION_JSON);
+    verify(response).setCharacterEncoding(HttpServletStatelessServerTransport.UTF_8);
+    verify(response).setStatus(HttpServletResponse.SC_OK);
+    assertThat(body.toString()).isEqualTo(JSON_RESPONSE);
+  }
+
+  @Test
+  void writeSseResponse_emitsSingleSseEvent() throws Exception {
+    HttpServletStatelessServerTransport.writeSseResponse(response, JSON_RESPONSE);
+
+    verify(response).setContentType(HttpServletStatelessServerTransport.TEXT_EVENT_STREAM);
+    verify(response).setCharacterEncoding(HttpServletStatelessServerTransport.UTF_8);
+    verify(response).setStatus(HttpServletResponse.SC_OK);
+    assertThat(body.toString()).isEqualTo("data: " + JSON_RESPONSE + "\n\n");
+  }
+
+  @Test
+  void writeSseResponse_setsStreamingHeaders() throws Exception {
+    HttpServletStatelessServerTransport.writeSseResponse(response, JSON_RESPONSE);
+
+    verify(response).setHeader("Cache-Control", "no-cache");
+    verify(response).setHeader("Connection", "keep-alive");
+    verify(response).setHeader("X-Accel-Buffering", "no");
+  }
+
+  @Test
+  void writeJsonResponse_doesNotSetStreamingHeaders() throws Exception {
+    HttpServletStatelessServerTransport.writeJsonResponse(response, JSON_RESPONSE);
+
+    verify(response, org.mockito.Mockito.never()).setHeader(anyString(), anyString());
+  }
+
+  @Test
+  void writeSseResponse_doesNotCallSendError() throws Exception {
+    HttpServletStatelessServerTransport.writeSseResponse(response, JSON_RESPONSE);
+
+    verify(response, org.mockito.Mockito.never()).sendError(anyInt());
+    verify(response, org.mockito.Mockito.never()).sendError(anyInt(), anyString());
+  }
+
+  @Test
+  void writeSseResponse_payloadStartsWithDataPrefix_perSseSpec() throws Exception {
+    HttpServletStatelessServerTransport.writeSseResponse(response, JSON_RESPONSE);
+
+    String written = body.toString();
+    assertThat(written).startsWith("data: ");
+    assertThat(written).endsWith("\n\n");
+  }
+
+  @Test
+  void responseFlush_writerOnly() {
+    verifyNoInteractions(response);
+  }
+}

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/server/transport/HttpServletStatelessServerTransportTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/server/transport/HttpServletStatelessServerTransportTest.java
@@ -64,9 +64,36 @@ class HttpServletStatelessServerTransportTest {
   void writeSseResponse_setsStreamingHeaders() throws Exception {
     HttpServletStatelessServerTransport.writeSseResponse(response, JSON_RESPONSE);
 
-    verify(response).setHeader("Cache-Control", "no-cache");
-    verify(response).setHeader("Connection", "keep-alive");
-    verify(response).setHeader("X-Accel-Buffering", "no");
+    verify(response)
+        .setHeader(
+            HttpServletStatelessServerTransport.HEADER_CACHE_CONTROL,
+            HttpServletStatelessServerTransport.CACHE_CONTROL_NO_CACHE);
+    verify(response)
+        .setHeader(
+            HttpServletStatelessServerTransport.HEADER_CONNECTION,
+            HttpServletStatelessServerTransport.CONNECTION_KEEP_ALIVE);
+    verify(response)
+        .setHeader(
+            HttpServletStatelessServerTransport.HEADER_X_ACCEL_BUFFERING,
+            HttpServletStatelessServerTransport.X_ACCEL_BUFFERING_NO);
+  }
+
+  @Test
+  void writeSseResponse_payloadWithNewlines_prefixesEachLine() throws Exception {
+    String multiLineJson = "{\n  \"jsonrpc\": \"2.0\"\n}";
+
+    HttpServletStatelessServerTransport.writeSseResponse(response, multiLineJson);
+
+    assertThat(body.toString()).isEqualTo("data: {\ndata:   \"jsonrpc\": \"2.0\"\ndata: }\n\n");
+  }
+
+  @Test
+  void writeSseResponse_payloadWithCarriageReturnLineFeed_prefixesEachLine() throws Exception {
+    String windowsJson = "{\r\n  \"x\": 1\r\n}";
+
+    HttpServletStatelessServerTransport.writeSseResponse(response, windowsJson);
+
+    assertThat(body.toString()).isEqualTo("data: {\ndata:   \"x\": 1\ndata: }\n\n");
   }
 
   @Test


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes https://github.com/open-metadata/ai-platform/issues/635

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
- How did you test your changes?
-->

**Issue**: MCP Supervisor Agent fix: Databricks Supervisor sends Accept: text/event-stream and only parses SSE responses. Our MCP server was always returning plain JSON, so the supervisor silently dropped the response and hung on "Generating response…".  
                                                                                                              
**Fixed**: server now emits SSE format when the client asks for it. Existing clients (Playground, langchain) unaffected.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **Refactored SSE implementation:**
  - Extracted SSE header and format constants into `HttpServletStatelessServerTransport` for maintainability.
- **Improved SSE protocol compliance:**
  - Updated `writeSseResponse` to split multi-line JSON payloads and prefix each line with `data: ` to prevent truncation.
- **Enhanced test coverage:**
  - Added unit tests in `HttpServletStatelessServerTransportTest` to verify correct handling of newline characters and carriage returns in SSE payloads.

<sub>This will update automatically on new commits.</sub>