### PR TITLE
Fixes 27911: recognizer inclusion based on language

### DIFF
--- a/ingestion/src/metadata/pii/tag_analyzer.py
+++ b/ingestion/src/metadata/pii/tag_analyzer.py
@@ -79,6 +79,12 @@ class TagAnalyzer:
             get_entity_link(Table, FQN_SEPARATOR.join(table_fqn_parts), column_name=column_name) in blacklisted_entities
         )
 
+    def _supports_language(self, created: EntityRecognizer) -> bool:
+        return self._language is ClassificationLanguage.any or created.supported_language in {
+            ClassificationLanguage.any.value,
+            self._language.value,
+        }
+
     def get_recognizers_by(self, target: recognizer.Target) -> list[EntityRecognizer]:
         if self.tag.autoClassificationEnabled is False:
             return []
@@ -94,12 +100,7 @@ class TagAnalyzer:
                 continue
 
             created = PresidioRecognizerFactory.create_recognizer(recognizer)
-            if created is not None:
-                if (
-                    self._language is not ClassificationLanguage.any
-                    and created.supported_language != self._language.value
-                ):
-                    continue
+            if created is not None and self._supports_language(created):
                 recognizers.append(created)
 
         return recognizers

--- a/ingestion/tests/unit/metadata/pii/test_language_filtering.py
+++ b/ingestion/tests/unit/metadata/pii/test_language_filtering.py
@@ -285,3 +285,94 @@ class TestLanguageModelMapping:
 
         model = get_model_for_language(ClassificationLanguage.en)
         assert model == "en_core_web_md"
+
+
+class TestAnyLanguageRecognizerPassthrough:
+    """Regression tests: recognizers with supportedLanguage=any must not be skipped."""
+
+    @pytest.fixture
+    def any_language_tag(self):
+        return Tag(
+            id=uuid.uuid4(),
+            name="AnyLang",
+            fullyQualifiedName="PII.AnyLang",
+            description="Tag with any-language recognizer",
+            autoClassificationEnabled=True,
+            recognizers=[
+                Recognizer(
+                    name="AnyLang_Recognizer",
+                    enabled=True,
+                    target=Target.content,
+                    recognizerConfig=RecognizerConfig(
+                        root=PredefinedRecognizer(
+                            type="predefined",
+                            name=PredefinedName.EsNifRecognizer,
+                            supportedLanguage=ClassificationLanguage.any,
+                        )
+                    ),
+                )
+            ],
+        )
+
+    @pytest.fixture
+    def fr_language_tag(self):
+        return Tag(
+            id=uuid.uuid4(),
+            name="FrLang",
+            fullyQualifiedName="PII.FrLang",
+            description="Tag with French-language recognizer",
+            autoClassificationEnabled=True,
+            recognizers=[
+                Recognizer(
+                    name="Fr_Recognizer",
+                    enabled=True,
+                    target=Target.content,
+                    recognizerConfig=RecognizerConfig(
+                        root=PredefinedRecognizer(
+                            type="predefined",
+                            name=PredefinedName.EsNifRecognizer,
+                            supportedLanguage=ClassificationLanguage.fr,
+                        )
+                    ),
+                )
+            ],
+        )
+
+    def test_any_language_recognizer_included_when_agent_is_en(self, any_language_tag, sample_column, mock_nlp_engine):
+        analyzer = TagAnalyzer(
+            tag=any_language_tag,
+            column=sample_column,
+            nlp_engine=mock_nlp_engine,
+            language=ClassificationLanguage.en,
+        )
+
+        recognizers = analyzer.get_recognizers_by(Target.content)
+
+        assert len(recognizers) == 1
+        assert recognizers[0].supported_language == ClassificationLanguage.any.value
+
+    def test_any_language_recognizer_included_when_agent_is_any(self, any_language_tag, sample_column, mock_nlp_engine):
+        analyzer = TagAnalyzer(
+            tag=any_language_tag,
+            column=sample_column,
+            nlp_engine=mock_nlp_engine,
+            language=ClassificationLanguage.any,
+        )
+
+        recognizers = analyzer.get_recognizers_by(Target.content)
+
+        assert len(recognizers) == 1
+
+    def test_specific_language_recognizer_excluded_when_agent_language_differs(
+        self, fr_language_tag, sample_column, mock_nlp_engine
+    ):
+        analyzer = TagAnalyzer(
+            tag=fr_language_tag,
+            column=sample_column,
+            nlp_engine=mock_nlp_engine,
+            language=ClassificationLanguage.en,
+        )
+
+        recognizers = analyzer.get_recognizers_by(Target.content)
+
+        assert len(recognizers) == 0


### PR DESCRIPTION
## Summary

Fixes #27911

`TagAnalyzer.get_recognizers_by()` was silently dropping recognizers configured with `supportedLanguage = any` (language-agnostic) whenever the auto-classification agent ran with a specific language (e.g. `en`).

The old two-clause filter:

```python
if (
    self._language is not ClassificationLanguage.any
    and created.supported_language != self._language.value
):
    continue
```

evaluated `"any" != "en"` → `True` for any-language recognizers, causing them to be skipped regardless of intent. The `any` sentinel is supposed to mean "this recognizer works for all languages".

## Changes

- **`ingestion/src/metadata/pii/tag_analyzer.py`**: extracted the language-filter condition into a `_supports_language(created)` method with correct positive logic — a recognizer is included if the agent is in `any`-mode, OR the recognizer itself is `any`-language, OR the languages match exactly.
- **`ingestion/tests/unit/metadata/pii/test_language_filtering.py`**: added `TestAnyLanguageRecognizerPassthrough` with three regression tests covering the fixed case (`any`-recognizer + specific-language agent), the already-passing case (`any`-recognizer + `any`-agent), and the existing exclusion behavior (mismatched specific languages).

## Test plan

- [x] `pytest ingestion/tests/unit/metadata/pii/test_language_filtering.py::TestAnyLanguageRecognizerPassthrough -v` — 3 new tests pass
- [x] `pytest ingestion/tests/unit/metadata/pii/ -v` — full PII unit suite passes (no regressions)