### PR TITLE
Fixes #27910: Add migrations to ensure PII classification is enabled in 1.12.8 and 1.13.0

### DIFF
--- a/bootstrap/sql/migrations/native/1.12.8/mysql/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.12.8/mysql/postDataMigrationSQLScript.sql
@@ -1,0 +1,19 @@
+-- Fix PII classification autoClassificationConfig (issue #27910)
+UPDATE classification
+SET json = JSON_SET(
+    json,
+    '$.autoClassificationConfig',
+    CAST('{"enabled": true, "conflictResolution": "highest_priority", "minimumConfidence": 0.6, "requireExplicitMatch": true}' AS JSON)
+)
+WHERE JSON_VALUE(json, '$.name' RETURNING CHAR) = 'PII'
+  AND JSON_EXTRACT(json, '$.autoClassificationConfig.enabled') IS NULL;
+
+-- Fix PII tags autoClassificationEnabled (issue #27910)
+UPDATE tag
+SET json = JSON_SET(json, '$.autoClassificationEnabled', CAST('true' AS JSON))
+WHERE JSON_VALUE(json, '$.classification.name' RETURNING CHAR) = 'PII'
+  AND JSON_VALUE(json, '$.name' RETURNING CHAR) IN ('NonSensitive', 'Sensitive')
+  AND (
+    JSON_EXTRACT(json, '$.autoClassificationEnabled') IS NULL
+    OR JSON_EXTRACT(json, '$.autoClassificationEnabled') = false
+  );

--- a/bootstrap/sql/migrations/native/1.12.8/postgres/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.12.8/postgres/postDataMigrationSQLScript.sql
@@ -1,0 +1,19 @@
+-- Fix PII classification autoClassificationConfig (issue #27910)
+UPDATE classification
+SET json = jsonb_set(
+    json::jsonb,
+    '{autoClassificationConfig}',
+    '{"enabled": true, "conflictResolution": "highest_priority", "minimumConfidence": 0.6, "requireExplicitMatch": true}'::jsonb
+)::json
+WHERE json->>'name' = 'PII'
+  AND json->'autoClassificationConfig'->>'enabled' IS NULL;
+
+-- Fix PII tags autoClassificationEnabled (issue #27910)
+UPDATE tag
+SET json = jsonb_set(json::jsonb, '{autoClassificationEnabled}', 'true'::jsonb)::json
+WHERE json->'classification'->>'name' = 'PII'
+  AND json->>'name' IN ('NonSensitive', 'Sensitive')
+  AND (
+    json->>'autoClassificationEnabled' IS NULL
+    OR (json->>'autoClassificationEnabled')::boolean = false
+  );

--- a/bootstrap/sql/migrations/native/1.13.0/mysql/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.13.0/mysql/postDataMigrationSQLScript.sql
@@ -103,3 +103,23 @@ SET json = JSON_ARRAY_INSERT(
 )
 WHERE JSON_UNQUOTE(JSON_EXTRACT(json, '$.name')) = 'AutoClassificationBotPolicy'
   AND JSON_EXTRACT(json, '$.rules[1].name') != 'AutoClassificationBotRule-Allow-Container';
+
+-- Fix PII classification autoClassificationConfig (issue #27910)
+UPDATE classification
+SET json = JSON_SET(
+    json,
+    '$.autoClassificationConfig',
+    CAST('{"enabled": true, "conflictResolution": "highest_priority", "minimumConfidence": 0.6, "requireExplicitMatch": true}' AS JSON)
+)
+WHERE JSON_VALUE(json, '$.name' RETURNING CHAR) = 'PII'
+  AND JSON_EXTRACT(json, '$.autoClassificationConfig.enabled') IS NULL;
+
+-- Fix PII tags autoClassificationEnabled (issue #27910)
+UPDATE tag
+SET json = JSON_SET(json, '$.autoClassificationEnabled', CAST('true' AS JSON))
+WHERE JSON_VALUE(json, '$.classification.name' RETURNING CHAR) = 'PII'
+  AND JSON_VALUE(json, '$.name' RETURNING CHAR) IN ('NonSensitive', 'Sensitive')
+  AND (
+    JSON_EXTRACT(json, '$.autoClassificationEnabled') IS NULL
+    OR JSON_EXTRACT(json, '$.autoClassificationEnabled') = false
+  );

--- a/bootstrap/sql/migrations/native/1.13.0/postgres/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.13.0/postgres/postDataMigrationSQLScript.sql
@@ -105,4 +105,24 @@ SET json = jsonb_insert(
 )
 WHERE json->>'name' = 'AutoClassificationBotPolicy'
   AND (json->'rules'->1->>'name' IS NULL OR json->'rules'->1->>'name' != 'AutoClassificationBotRule-Allow-Container');
+
+-- Fix PII classification autoClassificationConfig (issue #27910)
+UPDATE classification
+SET json = jsonb_set(
+    json::jsonb,
+    '{autoClassificationConfig}',
+    '{"enabled": true, "conflictResolution": "highest_priority", "minimumConfidence": 0.6, "requireExplicitMatch": true}'::jsonb
+)::json
+WHERE json->>'name' = 'PII'
+  AND json->'autoClassificationConfig'->>'enabled' IS NULL;
+
+-- Fix PII tags autoClassificationEnabled (issue #27910)
+UPDATE tag
+SET json = jsonb_set(json::jsonb, '{autoClassificationEnabled}', 'true'::jsonb)::json
+WHERE json->'classification'->>'name' = 'PII'
+  AND json->>'name' IN ('NonSensitive', 'Sensitive')
+  AND (
+    json->>'autoClassificationEnabled' IS NULL
+    OR (json->>'autoClassificationEnabled')::boolean = false
+  );
   


### PR DESCRIPTION
### Describe your changes:

Fixes #27910

Adds post-data migration SQL scripts for both MySQL and PostgreSQL in the 1.12.8 and 1.13.0 migration paths to ensure PII classification and tag configurations are properly enabled.

This is especially needed for instances that had already upgraded to 1.12.0 or later — those instances skipped the cherry-picked migration in 1.12.6 that was meant to enable classification parameters.

Without this fix, running auto-classification on upgraded instances would silently skip PII classification and tags (visible in debug logs as "skipped" entities), causing the classifier to produce no results.

#
### Type of change:
- [x] Bug fix

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Bug fix -->
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
- [X] I have tested upgrading from 1.11.x to 1.12.8 and 1.13.0 making sure the classification configuration exists