### PR TITLE
Fix/mcp oauth databricks

### DIFF
--- a/bootstrap/sql/migrations/native/1.13.0/mysql/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.13.0/mysql/schemaChanges.sql
@@ -321,3 +321,9 @@ ALTER TABLE search_index_server_stats
 -- already declared `CHARACTER SET ascii COLLATE ascii_bin`, a binary
 -- collation that lets the existing unique B-tree on `fqnHash` answer LIKE
 -- prefix predicates directly. No change required on the MySQL side.
+
+-- MCP OAuth: state parameter is opaque per RFC 6749 §4.1.1 and some clients (notably the
+-- Databricks MCP Proxy) send tokens longer than 255 characters. Widen mcp_state to TEXT to
+-- avoid INSERT failures on /mcp/authorize redirects.
+ALTER TABLE mcp_pending_auth_requests
+    MODIFY COLUMN mcp_state TEXT;

--- a/bootstrap/sql/migrations/native/1.13.0/postgres/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.13.0/postgres/schemaChanges.sql
@@ -474,3 +474,9 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_spreadsheet_entity_fqnhash_pattern
 DROP INDEX CONCURRENTLY IF EXISTS idx_worksheet_entity_fqnhash_pattern;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_worksheet_entity_fqnhash_pattern
     ON worksheet_entity (fqnHash text_pattern_ops);
+
+-- MCP OAuth: state parameter is opaque per RFC 6749 §4.1.1 and some clients (notably the
+-- Databricks MCP Proxy) send tokens longer than 255 characters. Widen mcp_state to TEXT to
+-- avoid INSERT failures on /mcp/authorize redirects.
+ALTER TABLE mcp_pending_auth_requests
+    ALTER COLUMN mcp_state TYPE TEXT;

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/server/auth/handlers/RegistrationHandler.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/server/auth/handlers/RegistrationHandler.java
@@ -219,7 +219,9 @@ public class RegistrationHandler {
   }
 
   private boolean isSupportedAuthMethod(String authMethod) {
-    return "client_secret_post".equals(authMethod) || "none".equals(authMethod);
+    return "client_secret_post".equals(authMethod)
+        || "client_secret_basic".equals(authMethod)
+        || "none".equals(authMethod);
   }
 
   /**

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/server/auth/util/ClientCredentialsExtractor.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/server/auth/util/ClientCredentialsExtractor.java
@@ -14,9 +14,13 @@ import java.util.Base64;
  *   <li>{@code client_secret_post} — credentials in form body parameters.
  * </ul>
  *
- * <p>Per RFC 6749 §2.3.1, clients MUST NOT use more than one method per request. When the
- * Authorization header is present, body parameters {@code client_id}/{@code client_secret} must
- * not also be present.
+ * <p>Per RFC 6749 §2.3.1, clients MUST NOT use more than one method per request, but several
+ * widely deployed clients (notably the Databricks MCP Proxy) duplicate the same credentials in
+ * both the Authorization header and the request body. Strict rejection blocks such clients
+ * outright. This implementation therefore prefers the Basic header (treated as the authoritative
+ * channel per RFC) and tolerates duplicate body parameters only when they exactly match the
+ * header credentials. Mismatched credentials are still rejected as {@code invalid_request} since
+ * they signal either a misconfiguration or an attempted credential confusion attack.
  */
 public final class ClientCredentialsExtractor {
 
@@ -33,8 +37,8 @@ public final class ClientCredentialsExtractor {
    * @param bodyClientId value of the {@code client_id} form parameter (may be {@code null})
    * @param bodyClientSecret value of the {@code client_secret} form parameter (may be {@code null})
    * @return parsed credentials; {@code clientId} may be {@code null} when no credentials supplied
-   * @throws InvalidClientCredentialsException when the Basic header is malformed or credentials
-   *     appear in both header and body
+   * @throws InvalidClientCredentialsException when the Basic header is malformed or when body
+   *     credentials are present and do not match the header credentials
    */
   public static Credentials extract(
       HttpServletRequest request, String bodyClientId, String bodyClientSecret)
@@ -44,12 +48,22 @@ public final class ClientCredentialsExtractor {
       return new Credentials(bodyClientId, bodyClientSecret);
     }
 
-    if (bodyClientId != null || bodyClientSecret != null) {
-      throw new InvalidClientCredentialsException(
-          "Client credentials provided both in Authorization header and request body");
-    }
+    Credentials headerCreds = decodeBasic(header.substring(BASIC_PREFIX.length()).trim());
+    assertBodyMatchesHeader(headerCreds, bodyClientId, bodyClientSecret);
+    return headerCreds;
+  }
 
-    return decodeBasic(header.substring(BASIC_PREFIX.length()).trim());
+  private static void assertBodyMatchesHeader(
+      Credentials headerCreds, String bodyClientId, String bodyClientSecret)
+      throws InvalidClientCredentialsException {
+    if (bodyClientId != null && !bodyClientId.equals(headerCreds.clientId())) {
+      throw new InvalidClientCredentialsException(
+          "client_id in request body does not match Authorization header");
+    }
+    if (bodyClientSecret != null && !bodyClientSecret.equals(headerCreds.clientSecret())) {
+      throw new InvalidClientCredentialsException(
+          "client_secret in request body does not match Authorization header");
+    }
   }
 
   private static Credentials decodeBasic(String encoded) throws InvalidClientCredentialsException {

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/server/auth/util/ClientCredentialsExtractor.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/server/auth/util/ClientCredentialsExtractor.java
@@ -1,0 +1,100 @@
+package org.openmetadata.mcp.server.auth.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+/**
+ * Extracts OAuth 2.0 client credentials from a request per RFC 6749 §2.3.1.
+ *
+ * <p>Supports both transport methods:
+ * <ul>
+ *   <li>{@code client_secret_basic} — HTTP Basic auth header (preferred per RFC).
+ *   <li>{@code client_secret_post} — credentials in form body parameters.
+ * </ul>
+ *
+ * <p>Per RFC 6749 §2.3.1, clients MUST NOT use more than one method per request. When the
+ * Authorization header is present, body parameters {@code client_id}/{@code client_secret} must
+ * not also be present.
+ */
+public final class ClientCredentialsExtractor {
+
+  private static final String BASIC_PREFIX = "Basic ";
+
+  private ClientCredentialsExtractor() {}
+
+  public record Credentials(String clientId, String clientSecret) {}
+
+  /**
+   * Extract client credentials from the request.
+   *
+   * @param request the HTTP request
+   * @param bodyClientId value of the {@code client_id} form parameter (may be {@code null})
+   * @param bodyClientSecret value of the {@code client_secret} form parameter (may be {@code null})
+   * @return parsed credentials; {@code clientId} may be {@code null} when no credentials supplied
+   * @throws InvalidClientCredentialsException when the Basic header is malformed or credentials
+   *     appear in both header and body
+   */
+  public static Credentials extract(
+      HttpServletRequest request, String bodyClientId, String bodyClientSecret)
+      throws InvalidClientCredentialsException {
+    String header = request.getHeader("Authorization");
+    if (header == null || !header.regionMatches(true, 0, BASIC_PREFIX, 0, BASIC_PREFIX.length())) {
+      return new Credentials(bodyClientId, bodyClientSecret);
+    }
+
+    if (bodyClientId != null || bodyClientSecret != null) {
+      throw new InvalidClientCredentialsException(
+          "Client credentials provided both in Authorization header and request body");
+    }
+
+    return decodeBasic(header.substring(BASIC_PREFIX.length()).trim());
+  }
+
+  private static Credentials decodeBasic(String encoded) throws InvalidClientCredentialsException {
+    if (encoded.isEmpty()) {
+      throw new InvalidClientCredentialsException("Empty Basic authorization value");
+    }
+
+    byte[] decoded;
+    try {
+      decoded = Base64.getDecoder().decode(encoded);
+    } catch (IllegalArgumentException e) {
+      throw new InvalidClientCredentialsException("Malformed Base64 in Authorization header");
+    }
+
+    String credential = new String(decoded, StandardCharsets.UTF_8);
+    int colonIndex = credential.indexOf(':');
+    if (colonIndex < 0) {
+      throw new InvalidClientCredentialsException(
+          "Authorization header missing client_id:client_secret separator");
+    }
+
+    String clientId = urlDecode(credential.substring(0, colonIndex));
+    String clientSecret = urlDecode(credential.substring(colonIndex + 1));
+
+    if (clientId.isEmpty()) {
+      throw new InvalidClientCredentialsException("Empty client_id in Authorization header");
+    }
+
+    return new Credentials(clientId, clientSecret);
+  }
+
+  // RFC 6749 §2.3.1: client_id and client_secret in Basic auth are
+  // application/x-www-form-urlencoded encoded before Base64.
+  private static String urlDecode(String value) throws InvalidClientCredentialsException {
+    try {
+      return URLDecoder.decode(value, StandardCharsets.UTF_8);
+    } catch (IllegalArgumentException e) {
+      throw new InvalidClientCredentialsException(
+          "Malformed percent-encoding in Authorization header");
+    }
+  }
+
+  public static class InvalidClientCredentialsException extends Exception {
+    public InvalidClientCredentialsException(String message) {
+      super(message);
+    }
+  }
+}

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/server/transport/OAuthHttpStatelessServerTransportProvider.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/server/transport/OAuthHttpStatelessServerTransportProvider.java
@@ -901,26 +901,14 @@ public class OAuthHttpStatelessServerTransportProvider extends HttpServletStatel
                 request, params.get("client_id"), params.get("client_secret"));
       } catch (InvalidClientCredentialsException e) {
         LOG.warn("Malformed client credentials on revocation request: {}", e.getMessage());
-        setCorsHeaders(request, response);
-        response.setContentType("application/json");
-        response.setStatus(400);
-        Map<String, String> error = new HashMap<>();
-        error.put("error", "invalid_request");
-        error.put("error_description", e.getMessage());
-        getObjectMapper().writeValue(response.getOutputStream(), error);
+        sendOAuthError(request, response, 400, "invalid_request", e.getMessage());
         return;
       }
       try {
         clientAuthenticator.authenticate(credentials.clientId(), credentials.clientSecret()).join();
       } catch (Exception e) {
         LOG.warn("Client authentication failed for revocation request");
-        setCorsHeaders(request, response);
-        response.setContentType("application/json");
-        response.setStatus(401);
-        Map<String, String> error = new HashMap<>();
-        error.put("error", "invalid_client");
-        error.put("error_description", "Client authentication failed");
-        getObjectMapper().writeValue(response.getOutputStream(), error);
+        sendOAuthError(request, response, 401, "invalid_client", "Client authentication failed");
         return;
       }
 
@@ -929,14 +917,7 @@ public class OAuthHttpStatelessServerTransportProvider extends HttpServletStatel
 
       if (token == null || token.trim().isEmpty()) {
         LOG.warn("Revocation request missing token parameter");
-        setCorsHeaders(request, response);
-        response.setContentType("application/json");
-        response.setStatus(400);
-
-        Map<String, String> error = new HashMap<>();
-        error.put("error", "invalid_request");
-        error.put("error_description", "token parameter is required");
-        getObjectMapper().writeValue(response.getOutputStream(), error);
+        sendOAuthError(request, response, 400, "invalid_request", "token parameter is required");
         return;
       }
 
@@ -958,23 +939,33 @@ public class OAuthHttpStatelessServerTransportProvider extends HttpServletStatel
       } else {
         // Actual server error
         LOG.error("Token revocation failed with server error", ex);
-        setCorsHeaders(request, response);
-        response.setContentType("application/json");
-        response.setStatus(500);
-        Map<String, String> error = new HashMap<>();
-        error.put("error", "server_error");
-        error.put("error_description", "Token revocation failed due to server error");
-        getObjectMapper().writeValue(response.getOutputStream(), error);
+        sendOAuthError(
+            request, response, 500, "server_error", "Token revocation failed due to server error");
       }
     } catch (Exception ex) {
       LOG.error("Unexpected error during token revocation", ex);
-      setCorsHeaders(request, response);
-      response.setContentType("application/json");
-      response.setStatus(500);
-      Map<String, String> error = new HashMap<>();
-      error.put("error", "server_error");
-      error.put("error_description", "Unexpected error during token revocation");
-      getObjectMapper().writeValue(response.getOutputStream(), error);
+      sendOAuthError(
+          request, response, 500, "server_error", "Unexpected error during token revocation");
     }
+  }
+
+  /**
+   * Sends a uniform OAuth error response per RFC 6749 §5.2 / RFC 7009 §2.2.1: JSON body with
+   * {@code error} and {@code error_description}, plus standard CORS + content-type headers.
+   */
+  private void sendOAuthError(
+      HttpServletRequest request,
+      HttpServletResponse response,
+      int status,
+      String error,
+      String description)
+      throws IOException {
+    setCorsHeaders(request, response);
+    response.setContentType("application/json");
+    response.setStatus(status);
+    Map<String, String> body = new HashMap<>();
+    body.put("error", error);
+    body.put("error_description", description);
+    getObjectMapper().writeValue(response.getOutputStream(), body);
   }
 }

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/server/transport/OAuthHttpStatelessServerTransportProvider.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/server/transport/OAuthHttpStatelessServerTransportProvider.java
@@ -32,6 +32,8 @@ import org.openmetadata.mcp.server.auth.handlers.RevocationHandler;
 import org.openmetadata.mcp.server.auth.middleware.ClientAuthenticator;
 import org.openmetadata.mcp.server.auth.repository.OAuthClientRepository;
 import org.openmetadata.mcp.server.auth.repository.OAuthTokenRepository;
+import org.openmetadata.mcp.server.auth.util.ClientCredentialsExtractor;
+import org.openmetadata.mcp.server.auth.util.ClientCredentialsExtractor.InvalidClientCredentialsException;
 import org.openmetadata.schema.services.connections.metadata.AuthProvider;
 import org.openmetadata.service.security.JwtFilter;
 import org.openmetadata.service.security.auth.SecurityConfigurationManager;
@@ -125,10 +127,12 @@ public class OAuthHttpStatelessServerTransportProvider extends HttpServletStatel
     metadata.setScopesSupported(supportedScopes);
     metadata.setResponseTypesSupported(List.of("code"));
     metadata.setGrantTypesSupported(List.of("authorization_code", "refresh_token"));
-    metadata.setTokenEndpointAuthMethodsSupported(List.of("client_secret_post"));
+    metadata.setTokenEndpointAuthMethodsSupported(
+        List.of("client_secret_basic", "client_secret_post", "none"));
     metadata.setCodeChallengeMethodsSupported(List.of("S256"));
     metadata.setRevocationEndpoint(URI.create(baseUrl + mcpEndpoint + "/revoke"));
-    metadata.setRevocationEndpointAuthMethodsSupported(List.of("client_secret_post"));
+    metadata.setRevocationEndpointAuthMethodsSupported(
+        List.of("client_secret_basic", "client_secret_post"));
 
     // Create Protected Resource metadata (RFC 9728) - MCP requirement
     this.resourceMetadataUrl =
@@ -196,10 +200,12 @@ public class OAuthHttpStatelessServerTransportProvider extends HttpServletStatel
     newMetadata.setScopesSupported(supportedScopes);
     newMetadata.setResponseTypesSupported(List.of("code"));
     newMetadata.setGrantTypesSupported(List.of("authorization_code", "refresh_token"));
-    newMetadata.setTokenEndpointAuthMethodsSupported(List.of("client_secret_post"));
+    newMetadata.setTokenEndpointAuthMethodsSupported(
+        List.of("client_secret_basic", "client_secret_post", "none"));
     newMetadata.setCodeChallengeMethodsSupported(List.of("S256"));
     newMetadata.setRevocationEndpoint(URI.create(baseUrl + mcpEndpoint + "/revoke"));
-    newMetadata.setRevocationEndpointAuthMethodsSupported(List.of("client_secret_post"));
+    newMetadata.setRevocationEndpointAuthMethodsSupported(
+        List.of("client_secret_basic", "client_secret_post"));
     this.oauthMetadata = newMetadata;
 
     ProtectedResourceMetadata newResourceMetadata = new ProtectedResourceMetadata();
@@ -570,8 +576,16 @@ public class OAuthHttpStatelessServerTransportProvider extends HttpServletStatel
 
     try {
       String grantType = params.get("grant_type");
-      String clientId = params.get("client_id");
-      String clientSecret = params.get("client_secret");
+      ClientCredentialsExtractor.Credentials credentials;
+      try {
+        credentials =
+            ClientCredentialsExtractor.extract(
+                request, params.get("client_id"), params.get("client_secret"));
+      } catch (InvalidClientCredentialsException e) {
+        throw new TokenException("invalid_request", e.getMessage());
+      }
+      String clientId = credentials.clientId();
+      String clientSecret = credentials.clientSecret();
       OAuthToken token = null;
 
       // Authenticate the client before processing any grant type
@@ -880,10 +894,24 @@ public class OAuthHttpStatelessServerTransportProvider extends HttpServletStatel
               });
 
       // Authenticate client before revocation (RFC 7009 Section 2.1)
-      String clientId = params.get("client_id");
-      String clientSecret = params.get("client_secret");
+      ClientCredentialsExtractor.Credentials credentials;
       try {
-        clientAuthenticator.authenticate(clientId, clientSecret).join();
+        credentials =
+            ClientCredentialsExtractor.extract(
+                request, params.get("client_id"), params.get("client_secret"));
+      } catch (InvalidClientCredentialsException e) {
+        LOG.warn("Malformed client credentials on revocation request: {}", e.getMessage());
+        setCorsHeaders(request, response);
+        response.setContentType("application/json");
+        response.setStatus(400);
+        Map<String, String> error = new HashMap<>();
+        error.put("error", "invalid_request");
+        error.put("error_description", e.getMessage());
+        getObjectMapper().writeValue(response.getOutputStream(), error);
+        return;
+      }
+      try {
+        clientAuthenticator.authenticate(credentials.clientId(), credentials.clientSecret()).join();
       } catch (Exception e) {
         LOG.warn("Client authentication failed for revocation request");
         setCorsHeaders(request, response);

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/server/auth/handlers/RegistrationHandlerTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/server/auth/handlers/RegistrationHandlerTest.java
@@ -224,6 +224,51 @@ class RegistrationHandlerTest {
   }
 
   @Test
+  void testClientSecretBasic_accepted() {
+    OAuthClientMetadata metadata = validMetadata();
+    metadata.setTokenEndpointAuthMethod("client_secret_basic");
+
+    OAuthClientInformation result = handler.handle(metadata).join();
+
+    assertThat(result.getTokenEndpointAuthMethod()).isEqualTo("client_secret_basic");
+    verify(clientRepository).register(any());
+  }
+
+  @Test
+  void testClientSecretPost_accepted() {
+    OAuthClientMetadata metadata = validMetadata();
+    metadata.setTokenEndpointAuthMethod("client_secret_post");
+
+    OAuthClientInformation result = handler.handle(metadata).join();
+
+    assertThat(result.getTokenEndpointAuthMethod()).isEqualTo("client_secret_post");
+    verify(clientRepository).register(any());
+  }
+
+  @Test
+  void testNoneAuthMethod_accepted() {
+    OAuthClientMetadata metadata = validMetadata();
+    metadata.setTokenEndpointAuthMethod("none");
+
+    OAuthClientInformation result = handler.handle(metadata).join();
+
+    assertThat(result.getTokenEndpointAuthMethod()).isEqualTo("none");
+    verify(clientRepository).register(any());
+  }
+
+  @Test
+  void testUnsupportedAuthMethod_throwsRegistrationException() {
+    OAuthClientMetadata metadata = validMetadata();
+    metadata.setTokenEndpointAuthMethod("private_key_jwt");
+
+    assertThatThrownBy(() -> handler.handle(metadata).join())
+        .isInstanceOf(CompletionException.class)
+        .hasRootCauseInstanceOf(RegistrationException.class);
+
+    verify(clientRepository, never()).register(any());
+  }
+
+  @Test
   void testFieldLengthExceeded_throwsRegistrationException() {
     OAuthClientMetadata metadata = validMetadata();
     metadata.setClientName("x".repeat(256));

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/server/auth/util/ClientCredentialsExtractorTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/server/auth/util/ClientCredentialsExtractorTest.java
@@ -83,20 +83,44 @@ class ClientCredentialsExtractorTest {
   }
 
   @Test
-  void testHeaderAndBody_throws() {
+  void testHeaderAndBody_mismatchedClientId_throws() {
     HttpServletRequest request = requestWithAuthHeader(basicHeader("hdr-client", "hdr-secret"));
 
     assertThatThrownBy(
-            () -> ClientCredentialsExtractor.extract(request, "body-client", "body-secret"))
-        .isInstanceOf(InvalidClientCredentialsException.class);
+            () -> ClientCredentialsExtractor.extract(request, "body-client", "hdr-secret"))
+        .isInstanceOf(InvalidClientCredentialsException.class)
+        .hasMessageContaining("client_id");
   }
 
   @Test
-  void testHeaderAndBodyClientIdOnly_throws() {
+  void testHeaderAndBody_mismatchedClientSecret_throws() {
     HttpServletRequest request = requestWithAuthHeader(basicHeader("hdr-client", "hdr-secret"));
 
-    assertThatThrownBy(() -> ClientCredentialsExtractor.extract(request, "body-client", null))
-        .isInstanceOf(InvalidClientCredentialsException.class);
+    assertThatThrownBy(
+            () -> ClientCredentialsExtractor.extract(request, "hdr-client", "body-secret"))
+        .isInstanceOf(InvalidClientCredentialsException.class)
+        .hasMessageContaining("client_secret");
+  }
+
+  @Test
+  void testHeaderAndBody_matchingDuplicates_returnsHeaderCredentials() throws Exception {
+    HttpServletRequest request = requestWithAuthHeader(basicHeader("hdr-client", "hdr-secret"));
+
+    Credentials credentials =
+        ClientCredentialsExtractor.extract(request, "hdr-client", "hdr-secret");
+
+    assertThat(credentials.clientId()).isEqualTo("hdr-client");
+    assertThat(credentials.clientSecret()).isEqualTo("hdr-secret");
+  }
+
+  @Test
+  void testHeaderAndBody_clientIdOnlyAndMatching_returnsHeaderCredentials() throws Exception {
+    HttpServletRequest request = requestWithAuthHeader(basicHeader("hdr-client", "hdr-secret"));
+
+    Credentials credentials = ClientCredentialsExtractor.extract(request, "hdr-client", null);
+
+    assertThat(credentials.clientId()).isEqualTo("hdr-client");
+    assertThat(credentials.clientSecret()).isEqualTo("hdr-secret");
   }
 
   @Test

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/server/auth/util/ClientCredentialsExtractorTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/server/auth/util/ClientCredentialsExtractorTest.java
@@ -124,6 +124,16 @@ class ClientCredentialsExtractorTest {
   }
 
   @Test
+  void testHeaderAndBody_clientSecretOnlyAndMatching_returnsHeaderCredentials() throws Exception {
+    HttpServletRequest request = requestWithAuthHeader(basicHeader("hdr-client", "hdr-secret"));
+
+    Credentials credentials = ClientCredentialsExtractor.extract(request, null, "hdr-secret");
+
+    assertThat(credentials.clientId()).isEqualTo("hdr-client");
+    assertThat(credentials.clientSecret()).isEqualTo("hdr-secret");
+  }
+
+  @Test
   void testBasicHeader_missingColon_throws() {
     String header =
         "Basic " + Base64.getEncoder().encodeToString("nocolon".getBytes(StandardCharsets.UTF_8));

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/server/auth/util/ClientCredentialsExtractorTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/server/auth/util/ClientCredentialsExtractorTest.java
@@ -1,0 +1,161 @@
+package org.openmetadata.mcp.server.auth.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.mcp.server.auth.util.ClientCredentialsExtractor.Credentials;
+import org.openmetadata.mcp.server.auth.util.ClientCredentialsExtractor.InvalidClientCredentialsException;
+
+class ClientCredentialsExtractorTest {
+
+  private HttpServletRequest requestWithAuthHeader(String headerValue) {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getHeader("Authorization")).thenReturn(headerValue);
+    return request;
+  }
+
+  private static String basicHeader(String clientId, String clientSecret) {
+    String raw = clientId + ":" + clientSecret;
+    return "Basic " + Base64.getEncoder().encodeToString(raw.getBytes(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void testBasicHeader_parsesCredentials() throws Exception {
+    HttpServletRequest request = requestWithAuthHeader(basicHeader("my-client", "s3cret"));
+
+    Credentials credentials = ClientCredentialsExtractor.extract(request, null, null);
+
+    assertThat(credentials.clientId()).isEqualTo("my-client");
+    assertThat(credentials.clientSecret()).isEqualTo("s3cret");
+  }
+
+  @Test
+  void testBasicHeader_lowercaseScheme_accepted() throws Exception {
+    String encoded = Base64.getEncoder().encodeToString("a:b".getBytes(StandardCharsets.UTF_8));
+    HttpServletRequest request = requestWithAuthHeader("basic " + encoded);
+
+    Credentials credentials = ClientCredentialsExtractor.extract(request, null, null);
+
+    assertThat(credentials.clientId()).isEqualTo("a");
+    assertThat(credentials.clientSecret()).isEqualTo("b");
+  }
+
+  @Test
+  void testBasicHeader_urlEncodedCredentials_decoded() throws Exception {
+    // RFC 6749 §2.3.1: client_id / client_secret are application/x-www-form-urlencoded
+    // before Base64. Secret containing ':' is encoded as %3A.
+    String encodedRaw = "client%2Fid:secret%3Awith%3Acolons";
+    String header =
+        "Basic " + Base64.getEncoder().encodeToString(encodedRaw.getBytes(StandardCharsets.UTF_8));
+    HttpServletRequest request = requestWithAuthHeader(header);
+
+    Credentials credentials = ClientCredentialsExtractor.extract(request, null, null);
+
+    assertThat(credentials.clientId()).isEqualTo("client/id");
+    assertThat(credentials.clientSecret()).isEqualTo("secret:with:colons");
+  }
+
+  @Test
+  void testNoHeaderNoBody_returnsNullCredentials() throws Exception {
+    HttpServletRequest request = requestWithAuthHeader(null);
+
+    Credentials credentials = ClientCredentialsExtractor.extract(request, null, null);
+
+    assertThat(credentials.clientId()).isNull();
+    assertThat(credentials.clientSecret()).isNull();
+  }
+
+  @Test
+  void testBodyOnly_returnsBodyValues() throws Exception {
+    HttpServletRequest request = requestWithAuthHeader(null);
+
+    Credentials credentials =
+        ClientCredentialsExtractor.extract(request, "body-client", "body-secret");
+
+    assertThat(credentials.clientId()).isEqualTo("body-client");
+    assertThat(credentials.clientSecret()).isEqualTo("body-secret");
+  }
+
+  @Test
+  void testHeaderAndBody_throws() {
+    HttpServletRequest request = requestWithAuthHeader(basicHeader("hdr-client", "hdr-secret"));
+
+    assertThatThrownBy(
+            () -> ClientCredentialsExtractor.extract(request, "body-client", "body-secret"))
+        .isInstanceOf(InvalidClientCredentialsException.class);
+  }
+
+  @Test
+  void testHeaderAndBodyClientIdOnly_throws() {
+    HttpServletRequest request = requestWithAuthHeader(basicHeader("hdr-client", "hdr-secret"));
+
+    assertThatThrownBy(() -> ClientCredentialsExtractor.extract(request, "body-client", null))
+        .isInstanceOf(InvalidClientCredentialsException.class);
+  }
+
+  @Test
+  void testBasicHeader_missingColon_throws() {
+    String header =
+        "Basic " + Base64.getEncoder().encodeToString("nocolon".getBytes(StandardCharsets.UTF_8));
+    HttpServletRequest request = requestWithAuthHeader(header);
+
+    assertThatThrownBy(() -> ClientCredentialsExtractor.extract(request, null, null))
+        .isInstanceOf(InvalidClientCredentialsException.class);
+  }
+
+  @Test
+  void testBasicHeader_invalidBase64_throws() {
+    HttpServletRequest request = requestWithAuthHeader("Basic !!!not-base64!!!");
+
+    assertThatThrownBy(() -> ClientCredentialsExtractor.extract(request, null, null))
+        .isInstanceOf(InvalidClientCredentialsException.class);
+  }
+
+  @Test
+  void testBasicHeader_emptyValue_throws() {
+    HttpServletRequest request = requestWithAuthHeader("Basic ");
+
+    assertThatThrownBy(() -> ClientCredentialsExtractor.extract(request, null, null))
+        .isInstanceOf(InvalidClientCredentialsException.class);
+  }
+
+  @Test
+  void testBasicHeader_emptyClientId_throws() {
+    String header =
+        "Basic " + Base64.getEncoder().encodeToString(":secret".getBytes(StandardCharsets.UTF_8));
+    HttpServletRequest request = requestWithAuthHeader(header);
+
+    assertThatThrownBy(() -> ClientCredentialsExtractor.extract(request, null, null))
+        .isInstanceOf(InvalidClientCredentialsException.class);
+  }
+
+  @Test
+  void testBasicHeader_emptyClientSecret_allowed() throws Exception {
+    String header =
+        "Basic "
+            + Base64.getEncoder().encodeToString("public-client:".getBytes(StandardCharsets.UTF_8));
+    HttpServletRequest request = requestWithAuthHeader(header);
+
+    Credentials credentials = ClientCredentialsExtractor.extract(request, null, null);
+
+    assertThat(credentials.clientId()).isEqualTo("public-client");
+    assertThat(credentials.clientSecret()).isEmpty();
+  }
+
+  @Test
+  void testNonBasicScheme_fallsBackToBody() throws Exception {
+    HttpServletRequest request = requestWithAuthHeader("Bearer abc.def.ghi");
+
+    Credentials credentials =
+        ClientCredentialsExtractor.extract(request, "body-client", "body-secret");
+
+    assertThat(credentials.clientId()).isEqualTo("body-client");
+    assertThat(credentials.clientSecret()).isEqualTo("body-secret");
+  }
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes https://github.com/open-metadata/OpenMetadata/issues/27924

MCP Databricks OAuth login fix: Two issues blocked Databricks Supervisor login. 

1. mcp_state column was VARCHAR(255) but Databricks sends ~380-char state tokens → INSERT failed
2. OAuth extractor strictly rejected duplicate client creds in both Authorization header and body, but Databricks (along with several real-world clients) sends both.   

 **Fix**: widen mcp_state to TEXT in 1.13.0 migration; extractor now prefers Basic header and tolerates matching body duplicates, still rejects mismatches.

<!-- For frontend related change, please add screenshots and/or videos of your changes preview! -->

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] I have commented on my code, particularly in hard-to-understand areas. 
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **Refactored error handling:**
  - Centralized OAuth error responses by introducing `sendOAuthError` helper in `OAuthHttpStatelessServerTransportProvider`.
  - Removed redundant boilerplate code for JSON error serialization across `handleRevocationRequest`.

<sub>This will update automatically on new commits.</sub>