### PR TITLE
fix(reindex): Stop button + O(N²) cursor init in distributed mode

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/DistributedSearchIndexCoordinator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/DistributedSearchIndexCoordinator.java
@@ -310,7 +310,7 @@ public class DistributedSearchIndexCoordinator {
         // future caller passes overlapping or out-of-order targets we still emit a
         // boundary instead of silently dropping the partition.
         if (!afterName.isEmpty()) {
-          result.put(nextTarget, encodeBoundaryCursor(repo, afterName, afterId));
+          result.put(nextTarget, encodeBoundaryCursor(afterName, afterId));
         }
         targetIdx++;
         nextTarget = (targetIdx < sortedTargets.size()) ? sortedTargets.get(targetIdx) : -1;
@@ -343,11 +343,10 @@ public class DistributedSearchIndexCoordinator {
     return JsonUtils.readValue(batch.get(batch.size() - 1), repo.getEntityClass());
   }
 
-  private <T extends org.openmetadata.schema.EntityInterface> String encodeBoundaryCursor(
-      EntityRepository<T> repo, String name, String id) {
-    // Reconstruct a minimal entity with the same cursor identity. We don't have the full
-    // entity here (we already advanced past it), so synthesize one of the right type via
-    // the repository. Used only on the unreachable defensive branch above.
+  private static String encodeBoundaryCursor(String name, String id) {
+    // Used only on the unreachable defensive branch in walkAndRecord — we've already
+    // advanced past the entity so we don't have the live object to call
+    // repo.getCursorValue() on. Build the {name,id} cursor map manually instead.
     Map<String, String> cursorMap = new HashMap<>();
     cursorMap.put("name", name);
     cursorMap.put("id", id);
@@ -685,24 +684,33 @@ public class DistributedSearchIndexCoordinator {
 
     long now = System.currentTimeMillis();
 
-    // Check if we should retry
+    // Status-guarded write — if requestStop already moved this row to CANCELLED,
+    // updateIfProcessing returns 0 and we leave the cancellation authoritative
+    // instead of resurrecting the row to PENDING (retry) or FAILED (terminal).
     if (record.retryCount() < MAX_PARTITION_RETRIES) {
-      // Reset to pending for retry
-      partitionDAO.update(
-          partitionId.toString(),
-          PartitionStatus.PENDING.name(),
-          record.cursor(),
-          record.processedCount(),
-          record.successCount(),
-          record.failedCount(),
-          null,
-          null,
-          null,
-          null,
-          now,
-          errorMessage,
-          record.retryCount() + 1);
-
+      int updated =
+          partitionDAO.updateIfProcessing(
+              partitionId.toString(),
+              PartitionStatus.PENDING.name(),
+              record.cursor(),
+              record.processedCount(),
+              record.successCount(),
+              record.failedCount(),
+              null,
+              null,
+              null,
+              null,
+              now,
+              errorMessage,
+              record.retryCount() + 1);
+      if (updated == 0) {
+        LOG.info(
+            "Skipped retry-requeue of partition {} (entity {}) — row no longer PROCESSING "
+                + "(likely cancelled by Stop); leaving authoritative state intact.",
+            partitionId,
+            record.entityType());
+        return;
+      }
       LOG.warn(
           "Partition {} failed, queued for retry ({}/{}): {}",
           partitionId,
@@ -710,21 +718,29 @@ public class DistributedSearchIndexCoordinator {
           MAX_PARTITION_RETRIES,
           errorMessage);
     } else {
-      // Mark as permanently failed
-      partitionDAO.update(
-          partitionId.toString(),
-          PartitionStatus.FAILED.name(),
-          record.cursor(),
-          record.processedCount(),
-          record.successCount(),
-          record.failedCount(),
-          record.assignedServer(),
-          record.claimedAt(),
-          record.startedAt(),
-          now,
-          now,
-          errorMessage,
-          record.retryCount());
+      int updated =
+          partitionDAO.updateIfProcessing(
+              partitionId.toString(),
+              PartitionStatus.FAILED.name(),
+              record.cursor(),
+              record.processedCount(),
+              record.successCount(),
+              record.failedCount(),
+              record.assignedServer(),
+              record.claimedAt(),
+              record.startedAt(),
+              now,
+              now,
+              errorMessage,
+              record.retryCount());
+      if (updated == 0) {
+        LOG.info(
+            "Skipped terminal-failure of partition {} (entity {}) — row no longer PROCESSING "
+                + "(likely cancelled by Stop); leaving authoritative state intact.",
+            partitionId,
+            record.entityType());
+        return;
+      }
 
       LOG.error(
           "Partition {} permanently failed after {} retries: {}",
@@ -1007,6 +1023,11 @@ public class DistributedSearchIndexCoordinator {
 
       updateJob(jobDAO, completed);
 
+      // Drop the precomputed cursor cache for this job — once terminal it can never be
+      // re-claimed, and long-running servers would otherwise leak ~one entry per reindex
+      // run for the lifetime of the process.
+      partitionStartCursors.remove(jobId);
+
       LOG.info(
           "Job {} completed with status {} (success: {}, failed: {})",
           jobId,
@@ -1236,6 +1257,10 @@ public class DistributedSearchIndexCoordinator {
 
     // Partitions are deleted via CASCADE
     jobDAO.delete(jobId.toString());
+    // Defensive: checkAndUpdateJobCompletion already evicts on terminal transition,
+    // but a job can be inserted, terminate, and then be deleted across server restarts —
+    // remove here too so this path is self-sufficient.
+    partitionStartCursors.remove(jobId);
 
     LOG.info("Deleted job {} and its partitions", jobId);
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/DistributedSearchIndexCoordinator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/DistributedSearchIndexCoordinator.java
@@ -13,18 +13,22 @@
 
 package org.openmetadata.service.apps.bundles.searchIndex.distributed;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.system.EventPublisherJob;
+import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.apps.bundles.searchIndex.ReindexingConfiguration;
 import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.CollectionDAO.SearchIndexJobDAO;
@@ -35,6 +39,9 @@ import org.openmetadata.service.jdbi3.CollectionDAO.SearchIndexPartitionDAO.Enti
 import org.openmetadata.service.jdbi3.CollectionDAO.SearchIndexPartitionDAO.SearchIndexPartitionRecord;
 import org.openmetadata.service.jdbi3.CollectionDAO.SearchIndexPartitionDAO.ServerStatsRecord;
 import org.openmetadata.service.jdbi3.CollectionDAO.SearchReindexLockDAO;
+import org.openmetadata.service.jdbi3.EntityRepository;
+import org.openmetadata.service.jdbi3.ListFilter;
+import org.openmetadata.service.util.RestUtil;
 
 /**
  * Coordinates distributed search index jobs across multiple OpenMetadata server instances.
@@ -93,6 +100,22 @@ public class DistributedSearchIndexCoordinator {
 
   /** Monotonic counter to guarantee unique claimedAt values across concurrent worker threads. */
   private final AtomicLong claimCounter = new AtomicLong(0);
+
+  /**
+   * Per-entity precomputed partition-boundary cursors. Replaces the per-PartitionWorker
+   * call to {@code EntityRepository.getCursorAtOffset(filter, partitionStart)} which
+   * underneath uses SQL {@code OFFSET partitionStart} — O(partitionStart) per worker, total
+   * O(N²) across all partitions. Now we walk each entity table once via keyset
+   * pagination at job start, recording the cursor at every partition boundary. Workers
+   * read in O(1) from this map.
+   *
+   * <p>Key: entityType. Value: map from partition rangeStart → encoded keyset cursor.
+   * A null value (or missing key) means "no cursor available, fall back to the slow
+   * path" — used when this coordinator did not initialize the partitions itself
+   * (recovery on a different server).
+   */
+  private final ConcurrentHashMap<String, Map<Long, String>> partitionStartCursors =
+      new ConcurrentHashMap<>();
 
   public DistributedSearchIndexCoordinator(CollectionDAO collectionDAO) {
     this.collectionDAO = collectionDAO;
@@ -194,6 +217,128 @@ public class DistributedSearchIndexCoordinator {
   }
 
   /**
+   * Look up the precomputed keyset cursor at a partition's start. Returns null when the
+   * cache has not been populated for this entity type (e.g., this server picked up a
+   * partition created by another server) — callers fall back to the slower OFFSET-based
+   * EntityRepository.getCursorAtOffset path.
+   *
+   * <p>Hits cache in O(1) for the normal case where this coordinator initialized the
+   * partitions and a worker on the same server is processing them.
+   */
+  public String getPartitionStartCursor(String entityType, long rangeStart) {
+    if (rangeStart <= 0) {
+      return null;
+    }
+    Map<Long, String> entityCursors = partitionStartCursors.get(entityType);
+    if (entityCursors == null) {
+      return null;
+    }
+    return entityCursors.get(rangeStart);
+  }
+
+  /**
+   * Walk each entity type's table once via keyset pagination, recording the cursor at
+   * every partition's rangeStart. Only called from initializePartitions. Time-series
+   * entities are skipped — their PartitionWorker uses a synthetic offset cursor that
+   * doesn't require a real keyset lookup.
+   */
+  private void precomputePartitionStartCursors(List<SearchIndexPartition> partitions) {
+    Map<String, List<SearchIndexPartition>> byEntity =
+        partitions.stream()
+            .filter(p -> p.getEntityType() != null)
+            .filter(p -> !PartitionWorker.TIME_SERIES_ENTITIES.contains(p.getEntityType()))
+            .collect(Collectors.groupingBy(SearchIndexPartition::getEntityType));
+
+    for (Map.Entry<String, List<SearchIndexPartition>> e : byEntity.entrySet()) {
+      String entityType = e.getKey();
+      try {
+        Map<Long, String> cursorByRangeStart = walkBoundaries(entityType, e.getValue());
+        partitionStartCursors.put(entityType, cursorByRangeStart);
+      } catch (Exception ex) {
+        // If precomputation fails (entity type not registered, transport error, etc.) the
+        // workers fall back to the existing OFFSET path. Don't block job initialization.
+        LOG.warn(
+            "Failed to precompute partition start cursors for entity {}; workers will fall back to OFFSET path",
+            entityType,
+            ex);
+      }
+    }
+  }
+
+  private Map<Long, String> walkBoundaries(
+      String entityType, List<SearchIndexPartition> entityPartitions) {
+    List<Long> sortedTargets =
+        entityPartitions.stream()
+            .map(SearchIndexPartition::getRangeStart)
+            .filter(r -> r > 0)
+            .sorted()
+            .distinct()
+            .collect(Collectors.toList());
+    Map<Long, String> result = new HashMap<>();
+    if (sortedTargets.isEmpty()) {
+      return result;
+    }
+
+    EntityRepository<?> repo = Entity.getEntityRepository(entityType);
+    ListFilter filter = new ListFilter(Include.ALL);
+
+    String afterName = null;
+    String afterId = null;
+    long currentOffset = 0;
+    int targetIdx = 0;
+    long nextTarget = sortedTargets.get(targetIdx);
+    final int batchSize = 10_000;
+
+    while (targetIdx < sortedTargets.size()) {
+      long need = nextTarget - currentOffset;
+      if (need <= 0) {
+        // Walked past this target via a larger batch; record the most recent boundary.
+        // Shouldn't happen in practice because we batch in fixed sizes, but be defensive.
+        targetIdx++;
+        if (targetIdx < sortedTargets.size()) {
+          nextTarget = sortedTargets.get(targetIdx);
+        }
+        continue;
+      }
+      int fetch = (int) Math.min(need, batchSize);
+      List<String> batch = repo.getDao().listAfter(filter, fetch, afterName, afterId);
+      if (batch.isEmpty()) {
+        break;
+      }
+      currentOffset += batch.size();
+      String lastJson = batch.get(batch.size() - 1);
+      Map<String, Object> lastEntity =
+          JsonUtils.readValue(lastJson, new TypeReference<Map<String, Object>>() {});
+      String lastName = (String) lastEntity.get("name");
+      Object lastIdObj = lastEntity.get("id");
+      String lastId = lastIdObj == null ? null : lastIdObj.toString();
+      afterName = lastName;
+      afterId = lastId;
+
+      if (currentOffset >= nextTarget) {
+        // The cursor for an offset N is the cursor of row N-1 (0-indexed boundary).
+        Map<String, String> cursorMap = new HashMap<>();
+        cursorMap.put("name", lastName);
+        cursorMap.put("id", lastId);
+        result.put(nextTarget, RestUtil.encodeCursor(JsonUtils.pojoToJson(cursorMap)));
+        targetIdx++;
+        if (targetIdx < sortedTargets.size()) {
+          nextTarget = sortedTargets.get(targetIdx);
+        }
+      }
+      if (batch.size() < fetch) {
+        break; // entity exhausted
+      }
+    }
+    LOG.debug(
+        "Precomputed {} boundary cursors for entity {} (currentOffset={})",
+        result.size(),
+        entityType,
+        currentOffset);
+    return result;
+  }
+
+  /**
    * Initialize partitions for a job.
    *
    * @param jobId The job ID
@@ -232,6 +377,11 @@ public class DistributedSearchIndexCoordinator {
           partitions.size(),
           jobId,
           entityTypes.size());
+
+      // Precompute keyset cursors at every partition boundary in a single keyset walk per
+      // entity type. Replaces per-worker EntityRepository.getCursorAtOffset(SQL OFFSET) calls
+      // — O(N²) total scan cost across all partitions — with one O(N) keyset traversal here.
+      precomputePartitionStartCursors(partitions);
     }
 
     // Calculate staggered claimableAt timestamps for partitions
@@ -613,19 +763,24 @@ public class DistributedSearchIndexCoordinator {
       return;
     }
 
+    long now = System.currentTimeMillis();
     SearchIndexJob stopping =
-        job.toBuilder()
-            .status(IndexJobStatus.STOPPING)
-            .updatedAt(System.currentTimeMillis())
-            .build();
+        job.toBuilder().status(IndexJobStatus.STOPPING).updatedAt(now).build();
 
     updateJob(jobDAO, stopping);
 
-    // Cancel all pending partitions
+    // Cancel both PENDING and PROCESSING partitions. The previous cancelPendingPartitions
+    // left PROCESSING rows orphaned: workerExecutor.shutdownNow() killed the worker threads
+    // but did not update partition status, so checkAndUpdateJobCompletion (which requires
+    // processing.isEmpty()) never flipped STOPPING → STOPPED. The strategy's monitor loop
+    // kept polling forever and the UI showed "Running" with a ticking timer.
     SearchIndexPartitionDAO partitionDAO = collectionDAO.searchIndexPartitionDAO();
-    partitionDAO.cancelPendingPartitions(jobId.toString());
+    int cancelled = partitionDAO.cancelInFlightPartitions(jobId.toString(), now);
+    LOG.info("Requested stop for job {} ({} in-flight partitions cancelled)", jobId, cancelled);
 
-    LOG.info("Requested stop for job {}", jobId);
+    // Drive STOPPING → STOPPED immediately so monitorDistributedJob exits without
+    // waiting for the next poll tick.
+    checkAndUpdateJobCompletion(jobId);
   }
 
   /**

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/DistributedSearchIndexCoordinator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/DistributedSearchIndexCoordinator.java
@@ -13,7 +13,6 @@
 
 package org.openmetadata.service.apps.bundles.searchIndex.distributed;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -102,19 +101,19 @@ public class DistributedSearchIndexCoordinator {
   private final AtomicLong claimCounter = new AtomicLong(0);
 
   /**
-   * Per-entity precomputed partition-boundary cursors. Replaces the per-PartitionWorker
-   * call to {@code EntityRepository.getCursorAtOffset(filter, partitionStart)} which
-   * underneath uses SQL {@code OFFSET partitionStart} — O(partitionStart) per worker, total
-   * O(N²) across all partitions. Now we walk each entity table once via keyset
-   * pagination at job start, recording the cursor at every partition boundary. Workers
-   * read in O(1) from this map.
+   * Per-job, per-entity precomputed partition-boundary cursors. Replaces the per-
+   * PartitionWorker call to {@code EntityRepository.getCursorAtOffset(filter,
+   * partitionStart)} which underneath uses SQL {@code OFFSET partitionStart} —
+   * O(partitionStart) per worker, total O(N²) across all partitions. We now walk each
+   * entity table once via keyset pagination at job start, recording the cursor at every
+   * partition boundary. Workers read in O(1) from this map.
    *
-   * <p>Key: entityType. Value: map from partition rangeStart → encoded keyset cursor.
-   * A null value (or missing key) means "no cursor available, fall back to the slow
-   * path" — used when this coordinator did not initialize the partitions itself
-   * (recovery on a different server).
+   * <p>Key: jobId. Value: map of entityType → (rangeStart → encoded keyset cursor).
+   * Scoped by jobId so cursors precomputed for an earlier job on this server cannot
+   * falsely match a later job that was initialized on another server (which would skip
+   * or duplicate rows).
    */
-  private final ConcurrentHashMap<String, Map<Long, String>> partitionStartCursors =
+  private final ConcurrentHashMap<UUID, Map<String, Map<Long, String>>> partitionStartCursors =
       new ConcurrentHashMap<>();
 
   public DistributedSearchIndexCoordinator(CollectionDAO collectionDAO) {
@@ -218,18 +217,19 @@ public class DistributedSearchIndexCoordinator {
 
   /**
    * Look up the precomputed keyset cursor at a partition's start. Returns null when the
-   * cache has not been populated for this entity type (e.g., this server picked up a
-   * partition created by another server) — callers fall back to the slower OFFSET-based
-   * EntityRepository.getCursorAtOffset path.
-   *
-   * <p>Hits cache in O(1) for the normal case where this coordinator initialized the
-   * partitions and a worker on the same server is processing them.
+   * cache has not been populated for this jobId+entityType (e.g., this server picked up
+   * a partition created by another server, or precomputation failed) — callers fall back
+   * to the slower OFFSET-based EntityRepository.getCursorAtOffset path.
    */
-  public String getPartitionStartCursor(String entityType, long rangeStart) {
-    if (rangeStart <= 0) {
+  public String getPartitionStartCursor(UUID jobId, String entityType, long rangeStart) {
+    if (rangeStart <= 0 || jobId == null) {
       return null;
     }
-    Map<Long, String> entityCursors = partitionStartCursors.get(entityType);
+    Map<String, Map<Long, String>> jobCache = partitionStartCursors.get(jobId);
+    if (jobCache == null) {
+      return null;
+    }
+    Map<Long, String> entityCursors = jobCache.get(entityType);
     if (entityCursors == null) {
       return null;
     }
@@ -238,52 +238,65 @@ public class DistributedSearchIndexCoordinator {
 
   /**
    * Walk each entity type's table once via keyset pagination, recording the cursor at
-   * every partition's rangeStart. Only called from initializePartitions. Time-series
-   * entities are skipped — their PartitionWorker uses a synthetic offset cursor that
-   * doesn't require a real keyset lookup.
+   * every partition's rangeStart. Time-series entities are skipped — their PartitionWorker
+   * uses a synthetic offset cursor that doesn't require a real keyset lookup.
    */
-  private void precomputePartitionStartCursors(List<SearchIndexPartition> partitions) {
+  private void precomputePartitionStartCursors(UUID jobId, List<SearchIndexPartition> partitions) {
     Map<String, List<SearchIndexPartition>> byEntity =
         partitions.stream()
             .filter(p -> p.getEntityType() != null)
             .filter(p -> !PartitionWorker.TIME_SERIES_ENTITIES.contains(p.getEntityType()))
             .collect(Collectors.groupingBy(SearchIndexPartition::getEntityType));
 
+    Map<String, Map<Long, String>> jobCache = new HashMap<>();
     for (Map.Entry<String, List<SearchIndexPartition>> e : byEntity.entrySet()) {
-      String entityType = e.getKey();
       try {
-        Map<Long, String> cursorByRangeStart = walkBoundaries(entityType, e.getValue());
-        partitionStartCursors.put(entityType, cursorByRangeStart);
+        jobCache.put(e.getKey(), walkBoundaries(e.getKey(), e.getValue()));
       } catch (Exception ex) {
-        // If precomputation fails (entity type not registered, transport error, etc.) the
-        // workers fall back to the existing OFFSET path. Don't block job initialization.
+        // Workers fall back to OFFSET path; don't block job initialization.
         LOG.warn(
             "Failed to precompute partition start cursors for entity {}; workers will fall back to OFFSET path",
-            entityType,
+            e.getKey(),
             ex);
       }
     }
+    partitionStartCursors.put(jobId, jobCache);
   }
 
   private Map<Long, String> walkBoundaries(
       String entityType, List<SearchIndexPartition> entityPartitions) {
-    List<Long> sortedTargets =
-        entityPartitions.stream()
-            .map(SearchIndexPartition::getRangeStart)
-            .filter(r -> r > 0)
-            .sorted()
-            .distinct()
-            .collect(Collectors.toList());
+    List<Long> sortedTargets = sortedDistinctTargets(entityPartitions);
     Map<Long, String> result = new HashMap<>();
     if (sortedTargets.isEmpty()) {
       return result;
     }
-
     EntityRepository<?> repo = Entity.getEntityRepository(entityType);
-    ListFilter filter = new ListFilter(Include.ALL);
+    walkAndRecord(repo, sortedTargets, result);
+    LOG.debug("Precomputed {} boundary cursors for entity {}", result.size(), entityType);
+    return result;
+  }
 
-    String afterName = null;
-    String afterId = null;
+  private static List<Long> sortedDistinctTargets(List<SearchIndexPartition> partitions) {
+    return partitions.stream()
+        .map(SearchIndexPartition::getRangeStart)
+        .filter(r -> r > 0)
+        .sorted()
+        .distinct()
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Walk forward via keyset pagination (NOT SQL OFFSET), advancing through batches and
+   * recording the encoded cursor at each {@code sortedTargets} offset. First call uses
+   * empty-string cursors to match {@code parseCursorMap("")} semantics — using NULL would
+   * make the {@code name > :afterName} predicate evaluate to NULL/false and return zero
+   * rows.
+   */
+  private <T extends org.openmetadata.schema.EntityInterface> void walkAndRecord(
+      EntityRepository<T> repo, List<Long> sortedTargets, Map<Long, String> result) {
+    ListFilter filter = new ListFilter(Include.ALL);
+    String afterName = "";
+    String afterId = "";
     long currentOffset = 0;
     int targetIdx = 0;
     long nextTarget = sortedTargets.get(targetIdx);
@@ -292,12 +305,15 @@ public class DistributedSearchIndexCoordinator {
     while (targetIdx < sortedTargets.size()) {
       long need = nextTarget - currentOffset;
       if (need <= 0) {
-        // Walked past this target via a larger batch; record the most recent boundary.
-        // Shouldn't happen in practice because we batch in fixed sizes, but be defensive.
-        targetIdx++;
-        if (targetIdx < sortedTargets.size()) {
-          nextTarget = sortedTargets.get(targetIdx);
+        // Walked past this target — record the most recent cursor as best-effort.
+        // Unreachable with uniform partition sizes (fetch <= need), but defensive: if a
+        // future caller passes overlapping or out-of-order targets we still emit a
+        // boundary instead of silently dropping the partition.
+        if (!afterName.isEmpty()) {
+          result.put(nextTarget, encodeBoundaryCursor(repo, afterName, afterId));
         }
+        targetIdx++;
+        nextTarget = (targetIdx < sortedTargets.size()) ? sortedTargets.get(targetIdx) : -1;
         continue;
       }
       int fetch = (int) Math.min(need, batchSize);
@@ -305,37 +321,37 @@ public class DistributedSearchIndexCoordinator {
       if (batch.isEmpty()) {
         break;
       }
+      T lastEntity = repo.getEntityClass().cast(deserializeLast(repo, batch));
       currentOffset += batch.size();
-      String lastJson = batch.get(batch.size() - 1);
-      Map<String, Object> lastEntity =
-          JsonUtils.readValue(lastJson, new TypeReference<Map<String, Object>>() {});
-      String lastName = (String) lastEntity.get("name");
-      Object lastIdObj = lastEntity.get("id");
-      String lastId = lastIdObj == null ? null : lastIdObj.toString();
-      afterName = lastName;
-      afterId = lastId;
+      afterName =
+          org.openmetadata.service.util.FullyQualifiedName.unquoteName(lastEntity.getName());
+      afterId = lastEntity.getId() == null ? "" : lastEntity.getId().toString();
 
       if (currentOffset >= nextTarget) {
-        // The cursor for an offset N is the cursor of row N-1 (0-indexed boundary).
-        Map<String, String> cursorMap = new HashMap<>();
-        cursorMap.put("name", lastName);
-        cursorMap.put("id", lastId);
-        result.put(nextTarget, RestUtil.encodeCursor(JsonUtils.pojoToJson(cursorMap)));
+        result.put(nextTarget, RestUtil.encodeCursor(repo.getCursorValue(lastEntity)));
         targetIdx++;
-        if (targetIdx < sortedTargets.size()) {
-          nextTarget = sortedTargets.get(targetIdx);
-        }
+        nextTarget = (targetIdx < sortedTargets.size()) ? sortedTargets.get(targetIdx) : -1;
       }
       if (batch.size() < fetch) {
         break; // entity exhausted
       }
     }
-    LOG.debug(
-        "Precomputed {} boundary cursors for entity {} (currentOffset={})",
-        result.size(),
-        entityType,
-        currentOffset);
-    return result;
+  }
+
+  private <T extends org.openmetadata.schema.EntityInterface> Object deserializeLast(
+      EntityRepository<T> repo, List<String> batch) {
+    return JsonUtils.readValue(batch.get(batch.size() - 1), repo.getEntityClass());
+  }
+
+  private <T extends org.openmetadata.schema.EntityInterface> String encodeBoundaryCursor(
+      EntityRepository<T> repo, String name, String id) {
+    // Reconstruct a minimal entity with the same cursor identity. We don't have the full
+    // entity here (we already advanced past it), so synthesize one of the right type via
+    // the repository. Used only on the unreachable defensive branch above.
+    Map<String, String> cursorMap = new HashMap<>();
+    cursorMap.put("name", name);
+    cursorMap.put("id", id);
+    return RestUtil.encodeCursor(JsonUtils.pojoToJson(cursorMap));
   }
 
   /**
@@ -381,7 +397,7 @@ public class DistributedSearchIndexCoordinator {
       // Precompute keyset cursors at every partition boundary in a single keyset walk per
       // entity type. Replaces per-worker EntityRepository.getCursorAtOffset(SQL OFFSET) calls
       // — O(N²) total scan cost across all partitions — with one O(N) keyset traversal here.
-      precomputePartitionStartCursors(partitions);
+      precomputePartitionStartCursors(jobId, partitions);
     }
 
     // Calculate staggered claimableAt timestamps for partitions
@@ -583,20 +599,34 @@ public class DistributedSearchIndexCoordinator {
     }
 
     long now = System.currentTimeMillis();
-    partitionDAO.update(
-        partitionId.toString(),
-        PartitionStatus.COMPLETED.name(),
-        record.rangeEnd(),
-        successCount + failedCount,
-        successCount,
-        failedCount,
-        record.assignedServer(),
-        record.claimedAt(),
-        record.startedAt(),
-        now,
-        now,
-        record.lastError(),
-        record.retryCount());
+    // Status-guarded write: a worker on another server might be the one calling this
+    // moments after requestStop already wrote CANCELLED via cancelInFlightPartitions.
+    // updateIfProcessing returns 0 when the row is no longer PROCESSING, leaving the
+    // CANCELLED state authoritative.
+    int updated =
+        partitionDAO.updateIfProcessing(
+            partitionId.toString(),
+            PartitionStatus.COMPLETED.name(),
+            record.rangeEnd(),
+            successCount + failedCount,
+            successCount,
+            failedCount,
+            record.assignedServer(),
+            record.claimedAt(),
+            record.startedAt(),
+            now,
+            now,
+            record.lastError(),
+            record.retryCount());
+
+    if (updated == 0) {
+      LOG.info(
+          "Skipped completion of partition {} (entity {}) — row no longer PROCESSING (likely "
+              + "cancelled by Stop); leaving authoritative state intact.",
+          partitionId,
+          record.entityType());
+      return;
+    }
 
     LOG.info(
         "Completed partition {} for entity type {} (success: {}, failed: {})",

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/PartitionWorker.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/PartitionWorker.java
@@ -203,7 +203,7 @@ public class PartitionWorker {
 
       // Initialize keyset cursor for efficient pagination (avoids OFFSET degradation)
       long cursorInitStart = System.currentTimeMillis();
-      String keysetCursor = initializeKeysetCursor(entityType, rangeStart);
+      String keysetCursor = initializeKeysetCursor(partition, rangeStart);
       LOG.debug(
           "initializeKeysetCursor for {} offset={} took {}ms",
           entityType,
@@ -244,7 +244,7 @@ public class PartitionWorker {
 
           // If keyset cursor exhausted, recompute or stop
           if (keysetCursor == null && currentOffset < rangeEnd) {
-            keysetCursor = initializeKeysetCursor(entityType, currentOffset);
+            keysetCursor = initializeKeysetCursor(partition, currentOffset);
             if (keysetCursor == null) {
               LOG.debug(
                   "{} partition {} data exhausted at offset {} (rangeEnd: {}), "
@@ -301,7 +301,7 @@ public class PartitionWorker {
 
           // Recompute keyset cursor after failure
           if (currentOffset < rangeEnd) {
-            keysetCursor = initializeKeysetCursor(entityType, currentOffset);
+            keysetCursor = initializeKeysetCursor(partition, currentOffset);
             if (keysetCursor == null) {
               break;
             }
@@ -639,10 +639,11 @@ public class PartitionWorker {
     }
   }
 
-  private String initializeKeysetCursor(String entityType, long offset) {
+  private String initializeKeysetCursor(SearchIndexPartition partition, long offset) {
     if (offset <= 0) {
       return null;
     }
+    String entityType = partition.getEntityType();
     if (TIME_SERIES_ENTITIES.contains(entityType)) {
       return RestUtil.encodeCursor(String.valueOf(offset));
     }
@@ -650,8 +651,10 @@ public class PartitionWorker {
     // rangeStart at job initialization (single keyset walk per entity type, O(N) total).
     // Only the partition's first call lands on a known rangeStart value; mid-partition
     // recomputes (after batch failure) won't hit this path and fall through to the
-    // OFFSET-based fallback below.
-    String precomputed = coordinator.getPartitionStartCursor(entityType, offset);
+    // OFFSET-based fallback below. Cache lookup is scoped by jobId to avoid stale hits
+    // from a previous job that ran on the same server.
+    String precomputed =
+        coordinator.getPartitionStartCursor(partition.getJobId(), entityType, offset);
     if (precomputed != null) {
       return precomputed;
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/PartitionWorker.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/PartitionWorker.java
@@ -57,7 +57,7 @@ public class PartitionWorker {
   private static final long MAX_CURSOR_INITIALIZATION_OFFSET = (long) Integer.MAX_VALUE + 1L;
 
   /** Time series entity types that need special handling */
-  private static final Set<String> TIME_SERIES_ENTITIES =
+  static final Set<String> TIME_SERIES_ENTITIES =
       Set.of(
           ReportData.ReportDataType.ENTITY_REPORT_DATA.value(),
           ReportData.ReportDataType.RAW_COST_ANALYSIS_REPORT_DATA.value(),
@@ -643,22 +643,29 @@ public class PartitionWorker {
     if (offset <= 0) {
       return null;
     }
-    if (!TIME_SERIES_ENTITIES.contains(entityType)) {
-      int cursorOffset = toCursorOffset(entityType, offset);
-      ListFilter filter = new ListFilter(Include.ALL);
-      String cursor =
-          Entity.getEntityRepository(entityType).getCursorAtOffset(filter, cursorOffset);
-      if (cursor == null) {
-        LOG.debug(
-            "getCursorAtOffset returned null for {} at offset {} (cursorOffset={})",
-            entityType,
-            offset,
-            cursorOffset);
-      }
-      return cursor;
-    } else {
+    if (TIME_SERIES_ENTITIES.contains(entityType)) {
       return RestUtil.encodeCursor(String.valueOf(offset));
     }
+    // Fast path: coordinator precomputed boundary cursors for every partition's
+    // rangeStart at job initialization (single keyset walk per entity type, O(N) total).
+    // Only the partition's first call lands on a known rangeStart value; mid-partition
+    // recomputes (after batch failure) won't hit this path and fall through to the
+    // OFFSET-based fallback below.
+    String precomputed = coordinator.getPartitionStartCursor(entityType, offset);
+    if (precomputed != null) {
+      return precomputed;
+    }
+    int cursorOffset = toCursorOffset(entityType, offset);
+    ListFilter filter = new ListFilter(Include.ALL);
+    String cursor = Entity.getEntityRepository(entityType).getCursorAtOffset(filter, cursorOffset);
+    if (cursor == null) {
+      LOG.debug(
+          "getCursorAtOffset returned null for {} at offset {} (cursorOffset={})",
+          entityType,
+          offset,
+          cursorOffset);
+    }
+    return cursor;
   }
 
   private int toCursorOffset(String entityType, long offset) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -11833,6 +11833,12 @@ public interface CollectionDAO {
         "UPDATE search_index_partition SET status = 'CANCELLED' WHERE jobId = :jobId AND status = 'PENDING'")
     int cancelPendingPartitions(@Bind("jobId") String jobId);
 
+    @SqlUpdate(
+        "UPDATE search_index_partition SET status = 'CANCELLED', "
+            + "lastError = 'Stopped by user', completedAt = :now, lastUpdateAt = :now "
+            + "WHERE jobId = :jobId AND status IN ('PENDING','PROCESSING')")
+    int cancelInFlightPartitions(@Bind("jobId") String jobId, @Bind("now") long now);
+
     @SqlQuery(
         "SELECT * FROM search_index_partition WHERE jobId = :jobId AND status = 'PROCESSING' "
             + "AND lastUpdateAt < :staleThreshold")

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -11839,6 +11839,34 @@ public interface CollectionDAO {
             + "WHERE jobId = :jobId AND status IN ('PENDING','PROCESSING')")
     int cancelInFlightPartitions(@Bind("jobId") String jobId, @Bind("now") long now);
 
+    /**
+     * Status-guarded update: only mutates the row when it is still PROCESSING. Used by
+     * completion / failure paths so a late-arriving worker write cannot revert a CANCELLED
+     * row (set by requestStop) back to COMPLETED/FAILED. Returns the number of rows
+     * updated — 0 means another writer (typically requestStop) already moved the row to
+     * a terminal state and the caller should treat its update as a no-op.
+     */
+    @SqlUpdate(
+        "UPDATE search_index_partition SET status = :status, processingCursor = :cursor, "
+            + "processedCount = :processedCount, successCount = :successCount, failedCount = :failedCount, "
+            + "assignedServer = :assignedServer, claimedAt = :claimedAt, startedAt = :startedAt, "
+            + "completedAt = :completedAt, lastUpdateAt = :lastUpdateAt, lastError = :lastError, "
+            + "retryCount = :retryCount WHERE id = :id AND status = 'PROCESSING'")
+    int updateIfProcessing(
+        @Bind("id") String id,
+        @Bind("status") String status,
+        @Bind("cursor") long cursor,
+        @Bind("processedCount") long processedCount,
+        @Bind("successCount") long successCount,
+        @Bind("failedCount") long failedCount,
+        @Bind("assignedServer") String assignedServer,
+        @Bind("claimedAt") Long claimedAt,
+        @Bind("startedAt") Long startedAt,
+        @Bind("completedAt") Long completedAt,
+        @Bind("lastUpdateAt") Long lastUpdateAt,
+        @Bind("lastError") String lastError,
+        @Bind("retryCount") int retryCount);
+
     @SqlQuery(
         "SELECT * FROM search_index_partition WHERE jobId = :jobId AND status = 'PROCESSING' "
             + "AND lastUpdateAt < :staleThreshold")

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/DistributedSearchIndexCoordinatorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/DistributedSearchIndexCoordinatorTest.java
@@ -16,6 +16,7 @@ package org.openmetadata.service.apps.bundles.searchIndex.distributed;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -34,6 +35,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -744,15 +746,31 @@ class DistributedSearchIndexCoordinatorTest {
             0L); // claimableAt
 
     when(partitionDAO.findById(partitionId.toString())).thenReturn(record);
+    when(partitionDAO.updateIfProcessing(
+            anyString(),
+            anyString(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            any(),
+            any(),
+            any(),
+            any(),
+            anyLong(),
+            anyString(),
+            anyInt()))
+        .thenReturn(1);
 
     coordinator.failPartition(partitionId, "Connection timeout");
 
-    // Verify partition was reset to PENDING for retry
+    // Verify partition was reset to PENDING for retry via the status-guarded SQL,
+    // and the unguarded update() is never called (Stop must remain authoritative).
     ArgumentCaptor<String> statusCaptor = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<Integer> retryCaptor = ArgumentCaptor.forClass(Integer.class);
 
     verify(partitionDAO)
-        .update(
+        .updateIfProcessing(
             eq(partitionId.toString()),
             statusCaptor.capture(),
             anyLong(),
@@ -766,9 +784,106 @@ class DistributedSearchIndexCoordinatorTest {
             anyLong(),
             eq("Connection timeout"),
             retryCaptor.capture());
+    verify(partitionDAO, never())
+        .update(
+            anyString(),
+            anyString(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            any(),
+            any(),
+            any(),
+            any(),
+            anyLong(),
+            anyString(),
+            anyInt());
 
     assertEquals(PartitionStatus.PENDING.name(), statusCaptor.getValue());
     assertEquals(1, retryCaptor.getValue()); // retryCount incremented
+  }
+
+  @Test
+  void testFailPartition_NoOpWhenAlreadyCancelled() {
+    UUID jobId = UUID.randomUUID();
+    UUID partitionId = UUID.randomUUID();
+
+    SearchIndexPartitionRecord record =
+        new SearchIndexPartitionRecord(
+            partitionId.toString(),
+            jobId.toString(),
+            "table",
+            0,
+            0,
+            5000,
+            5000,
+            7500,
+            50,
+            PartitionStatus.PROCESSING.name(),
+            2500,
+            2500,
+            2400,
+            100,
+            TEST_SERVER_ID,
+            System.currentTimeMillis() - 10000,
+            System.currentTimeMillis() - 10000,
+            null,
+            System.currentTimeMillis() - 1000,
+            null,
+            0,
+            0L);
+
+    when(partitionDAO.findById(partitionId.toString())).thenReturn(record);
+    // Simulate the row already being CANCELLED by requestStop on another server —
+    // the guarded SQL matches zero rows.
+    when(partitionDAO.updateIfProcessing(
+            anyString(),
+            anyString(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            any(),
+            any(),
+            any(),
+            any(),
+            anyLong(),
+            anyString(),
+            anyInt()))
+        .thenReturn(0);
+
+    coordinator.failPartition(partitionId, "Connection timeout");
+
+    // The unguarded update() must not be called — that's what would resurrect a CANCELLED row.
+    verify(partitionDAO, never())
+        .update(
+            anyString(),
+            anyString(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            any(),
+            any(),
+            any(),
+            any(),
+            anyLong(),
+            anyString(),
+            anyInt());
+    // No job-completion check should run — the cancellation already drove that path.
+    verify(jobDAO, never())
+        .update(
+            anyString(),
+            anyString(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            anyString(),
+            any(),
+            any(),
+            anyLong(),
+            any());
   }
 
   @Test
@@ -836,12 +951,28 @@ class DistributedSearchIndexCoordinatorTest {
     AggregatedStatsRecord aggregatedStats =
         new AggregatedStatsRecord(5000, 2500, 2400, 100, 1, 0, 1, 0, 0);
     when(partitionDAO.getAggregatedStats(jobId.toString())).thenReturn(aggregatedStats);
+    when(partitionDAO.updateIfProcessing(
+            anyString(),
+            anyString(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            anyString(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            anyString(),
+            anyInt()))
+        .thenReturn(1);
 
     coordinator.failPartition(partitionId, "Connection timeout");
 
-    // Verify partition was marked as FAILED (not retried)
+    // Verify partition was marked as FAILED via the status-guarded SQL,
+    // and the unguarded update() is never called.
     verify(partitionDAO)
-        .update(
+        .updateIfProcessing(
             eq(partitionId.toString()),
             eq(PartitionStatus.FAILED.name()),
             anyLong(),
@@ -855,6 +986,21 @@ class DistributedSearchIndexCoordinatorTest {
             anyLong(),
             eq("Connection timeout"),
             eq(3));
+    verify(partitionDAO, never())
+        .update(
+            anyString(),
+            anyString(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            any(),
+            any(),
+            any(),
+            any(),
+            anyLong(),
+            anyString(),
+            anyInt());
   }
 
   @Test
@@ -1088,6 +1234,64 @@ class DistributedSearchIndexCoordinatorTest {
             any(),
             anyLong(),
             any());
+  }
+
+  @Test
+  void testCheckAndUpdateJobCompletion_EvictsPartitionStartCursorsCache() throws Exception {
+    UUID jobId = UUID.randomUUID();
+
+    // Seed the per-jobId cursor cache directly. Going through precomputePartitionStartCursors
+    // would require real EntityRepository wiring — testing the eviction contract is the
+    // point here, not the population path.
+    java.lang.reflect.Field cacheField =
+        DistributedSearchIndexCoordinator.class.getDeclaredField("partitionStartCursors");
+    cacheField.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    Map<UUID, Map<String, Map<Long, String>>> cache =
+        (Map<UUID, Map<String, Map<Long, String>>>) cacheField.get(coordinator);
+    Map<String, Map<Long, String>> entityCursors = new HashMap<>();
+    entityCursors.put("table", Map.of(10000L, "encoded-cursor-blob"));
+    cache.put(jobId, entityCursors);
+
+    assertNotNull(
+        coordinator.getPartitionStartCursor(jobId, "table", 10000L),
+        "Cache should hold the seeded cursor before terminal transition");
+
+    // RUNNING job with no remaining partitions — checkAndUpdateJobCompletion should
+    // promote it to COMPLETED and evict the cache entry.
+    EventPublisherJob jobConfig = new EventPublisherJob().withEntities(Set.of("table"));
+    SearchIndexJobRecord runningJob =
+        new SearchIndexJobRecord(
+            jobId.toString(),
+            IndexJobStatus.RUNNING.name(),
+            JsonUtils.pojoToJson(jobConfig),
+            "staged_",
+            null,
+            100,
+            100,
+            100,
+            0,
+            "{}",
+            "admin",
+            System.currentTimeMillis() - 60000,
+            System.currentTimeMillis() - 50000,
+            null,
+            System.currentTimeMillis(),
+            null,
+            System.currentTimeMillis() - 55000,
+            1);
+    when(jobDAO.findById(jobId.toString())).thenReturn(runningJob);
+    when(partitionDAO.findByJobIdAndStatus(eq(jobId.toString()), anyString()))
+        .thenReturn(List.of());
+    when(partitionDAO.getAggregatedStats(jobId.toString()))
+        .thenReturn(new AggregatedStatsRecord(100, 100, 100, 0, 1, 1, 0, 0, 0));
+
+    coordinator.checkAndUpdateJobCompletion(jobId);
+
+    assertNull(
+        coordinator.getPartitionStartCursor(jobId, "table", 10000L),
+        "Cache should be evicted once the job reaches a terminal state — long-running"
+            + " servers must not retain cursor blobs across many reindex runs.");
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/DistributedSearchIndexCoordinatorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/DistributedSearchIndexCoordinatorTest.java
@@ -871,8 +871,118 @@ class DistributedSearchIndexCoordinatorTest {
             anyLong(),
             any());
 
-    // Verify pending partitions were cancelled
-    verify(partitionDAO).cancelPendingPartitions(jobId.toString());
+    // Both PENDING and PROCESSING partitions must be cancelled — leaving PROCESSING orphaned
+    // means workerExecutor.shutdownNow() kills the threads but the rows stay PROCESSING in
+    // the DB, so checkAndUpdateJobCompletion (which requires processing.isEmpty()) never
+    // flips STOPPING → STOPPED and the strategy's monitor loop polls forever.
+    verify(partitionDAO).cancelInFlightPartitions(eq(jobId.toString()), anyLong());
+    verify(partitionDAO, never()).cancelPendingPartitions(jobId.toString());
+  }
+
+  /**
+   * Regression test for the user-visible "stop button does nothing" bug. Reproduces the exact
+   * production scenario: distributed reindex running with PROCESSING partitions, user clicks
+   * Stop. Without this fix the job would stay in STOPPING forever because
+   * checkAndUpdateJobCompletion requires processing.isEmpty() and PROCESSING rows were never
+   * cancelled. With the fix, requestStop cancels in-flight partitions AND drives the state
+   * machine forward in the same call, so the job transitions to STOPPED before requestStop
+   * returns.
+   */
+  @Test
+  void testRequestStop_ProcessingPartitionsTransitionToStopped() {
+    UUID jobId = UUID.randomUUID();
+    EventPublisherJob jobConfig = new EventPublisherJob().withEntities(Set.of("table"));
+
+    SearchIndexJobRecord runningJob =
+        new SearchIndexJobRecord(
+            jobId.toString(),
+            IndexJobStatus.RUNNING.name(),
+            JsonUtils.pojoToJson(jobConfig),
+            "staged_123_",
+            null,
+            10000,
+            5000,
+            4900,
+            100,
+            "{}",
+            "admin",
+            System.currentTimeMillis() - 60000,
+            System.currentTimeMillis() - 50000,
+            null,
+            System.currentTimeMillis(),
+            null,
+            System.currentTimeMillis() - 55000,
+            2);
+
+    SearchIndexJobRecord stoppingJob =
+        new SearchIndexJobRecord(
+            runningJob.id(),
+            IndexJobStatus.STOPPING.name(),
+            runningJob.jobConfiguration(),
+            runningJob.targetIndexPrefix(),
+            runningJob.stagedIndexMapping(),
+            runningJob.totalRecords(),
+            runningJob.processedRecords(),
+            runningJob.successRecords(),
+            runningJob.failedRecords(),
+            runningJob.stats(),
+            runningJob.createdBy(),
+            runningJob.createdAt(),
+            runningJob.startedAt(),
+            runningJob.completedAt(),
+            System.currentTimeMillis(),
+            runningJob.errorMessage(),
+            runningJob.registrationDeadline(),
+            runningJob.registeredServerCount());
+
+    // First findById returns RUNNING (entry into requestStop). After the STOPPING write,
+    // checkAndUpdateJobCompletion's findById should see STOPPING.
+    when(jobDAO.findById(jobId.toString())).thenReturn(runningJob, stoppingJob);
+
+    // Critical: cancelInFlightPartitions empties both PENDING and PROCESSING. The
+    // post-cancel partition lists are all empty, so checkAndUpdateJobCompletion's
+    // pending.isEmpty() && processing.isEmpty() check passes and STOPPING → STOPPED fires.
+    when(partitionDAO.cancelInFlightPartitions(eq(jobId.toString()), anyLong())).thenReturn(3);
+    when(partitionDAO.findByJobIdAndStatus(jobId.toString(), PartitionStatus.PENDING.name()))
+        .thenReturn(List.of());
+    when(partitionDAO.findByJobIdAndStatus(jobId.toString(), PartitionStatus.PROCESSING.name()))
+        .thenReturn(List.of());
+    when(partitionDAO.findByJobIdAndStatus(jobId.toString(), PartitionStatus.FAILED.name()))
+        .thenReturn(List.of());
+    when(partitionDAO.findByJobIdAndStatus(jobId.toString(), PartitionStatus.CANCELLED.name()))
+        .thenReturn(List.of());
+
+    coordinator.requestStop(jobId);
+
+    // STOPPING write happens first.
+    verify(jobDAO)
+        .update(
+            eq(jobId.toString()),
+            eq(IndexJobStatus.STOPPING.name()),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            anyString(),
+            any(),
+            any(),
+            anyLong(),
+            any());
+
+    // STOPPED write happens before requestStop returns — driven by the in-call
+    // checkAndUpdateJobCompletion. Without the fix this never fires because PROCESSING
+    // rows were never cleaned up and the state machine couldn't advance.
+    verify(jobDAO)
+        .update(
+            eq(jobId.toString()),
+            eq(IndexJobStatus.STOPPED.name()),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            anyString(),
+            any(),
+            any(),
+            anyLong(),
+            any());
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/DistributedSearchIndexCoordinatorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/DistributedSearchIndexCoordinatorTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -534,6 +535,21 @@ class DistributedSearchIndexCoordinatorTest {
             0L); // claimableAt
 
     when(partitionDAO.findById(partitionId.toString())).thenReturn(record);
+    when(partitionDAO.updateIfProcessing(
+            eq(partitionId.toString()),
+            anyString(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            anyString(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            any(),
+            anyInt()))
+        .thenReturn(1);
 
     // Mock that there are still pending partitions
     when(partitionDAO.findByJobIdAndStatus(jobId.toString(), PartitionStatus.PENDING.name()))
@@ -541,9 +557,11 @@ class DistributedSearchIndexCoordinatorTest {
 
     coordinator.completePartition(partitionId, 4900, 100);
 
-    // Verify partition was updated to COMPLETED
+    // Verify partition was updated to COMPLETED via the status-guarded SQL — the unguarded
+    // update() must NOT be called, so a late completion write can no longer overwrite a
+    // CANCELLED row written by requestStop on another server.
     verify(partitionDAO)
-        .update(
+        .updateIfProcessing(
             eq(partitionId.toString()),
             eq(PartitionStatus.COMPLETED.name()),
             eq(5000L), // cursor = rangeEnd
@@ -557,6 +575,78 @@ class DistributedSearchIndexCoordinatorTest {
             anyLong(),
             any(),
             anyInt());
+    verify(partitionDAO, never())
+        .update(
+            anyString(),
+            anyString(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            anyString(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            any(),
+            anyInt());
+  }
+
+  @Test
+  void testCompletePartition_NoOpWhenAlreadyCancelled() {
+    UUID jobId = UUID.randomUUID();
+    UUID partitionId = UUID.randomUUID();
+    EntityCompletionTracker tracker = mock(EntityCompletionTracker.class);
+    coordinator.setEntityCompletionTracker(tracker);
+
+    SearchIndexPartitionRecord record =
+        new SearchIndexPartitionRecord(
+            partitionId.toString(),
+            jobId.toString(),
+            "table",
+            0,
+            0,
+            5000,
+            5000,
+            7500,
+            50,
+            PartitionStatus.PROCESSING.name(),
+            2500,
+            2500,
+            2400,
+            100,
+            TEST_SERVER_ID,
+            System.currentTimeMillis() - 10000,
+            System.currentTimeMillis() - 10000,
+            null,
+            System.currentTimeMillis() - 1000,
+            null,
+            0,
+            0L);
+
+    when(partitionDAO.findById(partitionId.toString())).thenReturn(record);
+    // updateIfProcessing returns 0 — row is no longer PROCESSING (already CANCELLED by
+    // requestStop). The completion writer must not advance the tracker and must not
+    // touch job state, leaving STOPPED as the authoritative outcome.
+    when(partitionDAO.updateIfProcessing(
+            eq(partitionId.toString()),
+            anyString(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            anyString(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            any(),
+            anyInt()))
+        .thenReturn(0);
+
+    coordinator.completePartition(partitionId, 4900, 100);
+
+    verify(tracker, never()).recordPartitionComplete(anyString(), anyBoolean());
   }
 
   @Test
@@ -592,6 +682,21 @@ class DistributedSearchIndexCoordinatorTest {
             0L);
 
     when(partitionDAO.findById(partitionId.toString())).thenReturn(record);
+    when(partitionDAO.updateIfProcessing(
+            eq(partitionId.toString()),
+            anyString(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            anyString(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            any(),
+            anyInt()))
+        .thenReturn(1);
     when(jobDAO.findById(jobId.toString()))
         .thenReturn(createJobRecord(jobId, IndexJobStatus.RUNNING, null, "{}"));
     when(partitionDAO.findByJobIdAndStatus(jobId.toString(), PartitionStatus.PENDING.name()))

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/JobRecoveryOrphanDetectionTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/JobRecoveryOrphanDetectionTest.java
@@ -242,6 +242,21 @@ class JobRecoveryOrphanDetectionTest {
       when(record.lastError()).thenReturn(null);
       when(record.retryCount()).thenReturn(0);
       when(partitionDAO.findById(partitionId.toString())).thenReturn(record);
+      when(partitionDAO.updateIfProcessing(
+              anyString(),
+              anyString(),
+              anyLong(),
+              anyLong(),
+              anyLong(),
+              anyLong(),
+              anyString(),
+              anyLong(),
+              anyLong(),
+              anyLong(),
+              anyLong(),
+              any(),
+              anyInt()))
+          .thenReturn(1);
 
       // Mock job completion check — job still has pending partitions
       when(partitionDAO.findByJobIdAndStatus(JOB_ID.toString(), "PENDING"))
@@ -273,6 +288,21 @@ class JobRecoveryOrphanDetectionTest {
       when(record.lastError()).thenReturn(null);
       when(record.retryCount()).thenReturn(0);
       when(partitionDAO.findById(partitionId.toString())).thenReturn(record);
+      when(partitionDAO.updateIfProcessing(
+              anyString(),
+              anyString(),
+              anyLong(),
+              anyLong(),
+              anyLong(),
+              anyLong(),
+              anyString(),
+              anyLong(),
+              anyLong(),
+              anyLong(),
+              anyLong(),
+              any(),
+              anyInt()))
+          .thenReturn(1);
 
       when(partitionDAO.findByJobIdAndStatus(JOB_ID.toString(), "PENDING"))
           .thenReturn(List.of(record));

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/PartitionWorkerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/PartitionWorkerTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
@@ -287,6 +288,7 @@ class PartitionWorkerTest {
 
     try (MockedStatic<Entity> entityMock = mockStatic(Entity.class)) {
       entityMock.when(() -> Entity.getEntityRepository("table")).thenReturn(repository);
+      when(coordinator.getPartitionStartCursor("table", 5L)).thenReturn(null);
       when(repository.getCursorAtOffset(any(ListFilter.class), eq(4))).thenReturn("cursor-4");
 
       assertNull(
@@ -314,6 +316,35 @@ class PartitionWorkerTest {
             new Class<?>[] {String.class, long.class},
             Entity.QUERY_COST_RECORD,
             5L));
+  }
+
+  /**
+   * Bug 2 regression: precomputed cursor on the coordinator must short-circuit the
+   * OFFSET-based fallback. Without this, every PartitionWorker pays SQL OFFSET cost at the
+   * partition start (O(rangeStart) per partition, O(N²) across all partitions for a job).
+   * With it, workers hit the cache in O(1) and the slow path is never invoked.
+   */
+  @Test
+  void initializeKeysetCursorHitsPrecomputedCacheAndSkipsOffsetFallback() throws Exception {
+    @SuppressWarnings("unchecked")
+    EntityRepository<EntityInterface> repository = mock(EntityRepository.class);
+
+    try (MockedStatic<Entity> entityMock = mockStatic(Entity.class)) {
+      entityMock.when(() -> Entity.getEntityRepository("table")).thenReturn(repository);
+      when(coordinator.getPartitionStartCursor("table", 10000L)).thenReturn("precomputed-10k");
+
+      Object cursor =
+          invokePrivate(
+              worker,
+              "initializeKeysetCursor",
+              new Class<?>[] {String.class, long.class},
+              "table",
+              10000L);
+
+      assertEquals("precomputed-10k", cursor);
+      verify(coordinator).getPartitionStartCursor("table", 10000L);
+      verify(repository, never()).getCursorAtOffset(any(ListFilter.class), anyInt());
+    }
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/PartitionWorkerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/PartitionWorkerTest.java
@@ -286,25 +286,55 @@ class PartitionWorkerTest {
     @SuppressWarnings("unchecked")
     EntityRepository<EntityInterface> repository = mock(EntityRepository.class);
 
+    UUID jobId = UUID.randomUUID();
+    SearchIndexPartition tablePartition =
+        SearchIndexPartition.builder()
+            .id(UUID.randomUUID())
+            .jobId(jobId)
+            .entityType("table")
+            .partitionIndex(0)
+            .rangeStart(5)
+            .rangeEnd(10)
+            .estimatedCount(5)
+            .workUnits(5)
+            .priority(50)
+            .status(PartitionStatus.PENDING)
+            .cursor(0)
+            .build();
+    SearchIndexPartition timeSeriesPartition =
+        SearchIndexPartition.builder()
+            .id(UUID.randomUUID())
+            .jobId(jobId)
+            .entityType(Entity.QUERY_COST_RECORD)
+            .partitionIndex(0)
+            .rangeStart(5)
+            .rangeEnd(10)
+            .estimatedCount(5)
+            .workUnits(5)
+            .priority(50)
+            .status(PartitionStatus.PENDING)
+            .cursor(0)
+            .build();
+
     try (MockedStatic<Entity> entityMock = mockStatic(Entity.class)) {
       entityMock.when(() -> Entity.getEntityRepository("table")).thenReturn(repository);
-      when(coordinator.getPartitionStartCursor("table", 5L)).thenReturn(null);
+      when(coordinator.getPartitionStartCursor(jobId, "table", 5L)).thenReturn(null);
       when(repository.getCursorAtOffset(any(ListFilter.class), eq(4))).thenReturn("cursor-4");
 
       assertNull(
           invokePrivate(
               worker,
               "initializeKeysetCursor",
-              new Class<?>[] {String.class, long.class},
-              "table",
+              new Class<?>[] {SearchIndexPartition.class, long.class},
+              tablePartition,
               0L));
       assertEquals(
           "cursor-4",
           invokePrivate(
               worker,
               "initializeKeysetCursor",
-              new Class<?>[] {String.class, long.class},
-              "table",
+              new Class<?>[] {SearchIndexPartition.class, long.class},
+              tablePartition,
               5L));
     }
 
@@ -313,8 +343,8 @@ class PartitionWorkerTest {
         invokePrivate(
             worker,
             "initializeKeysetCursor",
-            new Class<?>[] {String.class, long.class},
-            Entity.QUERY_COST_RECORD,
+            new Class<?>[] {SearchIndexPartition.class, long.class},
+            timeSeriesPartition,
             5L));
   }
 
@@ -322,27 +352,46 @@ class PartitionWorkerTest {
    * Bug 2 regression: precomputed cursor on the coordinator must short-circuit the
    * OFFSET-based fallback. Without this, every PartitionWorker pays SQL OFFSET cost at the
    * partition start (O(rangeStart) per partition, O(N²) across all partitions for a job).
-   * With it, workers hit the cache in O(1) and the slow path is never invoked.
+   * With it, workers hit the cache in O(1) and the slow path is never invoked. Cache key
+   * includes jobId so cursors precomputed for an earlier job on this server cannot
+   * falsely match a later job initialized elsewhere.
    */
   @Test
   void initializeKeysetCursorHitsPrecomputedCacheAndSkipsOffsetFallback() throws Exception {
     @SuppressWarnings("unchecked")
     EntityRepository<EntityInterface> repository = mock(EntityRepository.class);
 
+    UUID jobId = UUID.randomUUID();
+    SearchIndexPartition partition =
+        SearchIndexPartition.builder()
+            .id(UUID.randomUUID())
+            .jobId(jobId)
+            .entityType("table")
+            .partitionIndex(1)
+            .rangeStart(10000)
+            .rangeEnd(20000)
+            .estimatedCount(10000)
+            .workUnits(10000)
+            .priority(50)
+            .status(PartitionStatus.PENDING)
+            .cursor(10000)
+            .build();
+
     try (MockedStatic<Entity> entityMock = mockStatic(Entity.class)) {
       entityMock.when(() -> Entity.getEntityRepository("table")).thenReturn(repository);
-      when(coordinator.getPartitionStartCursor("table", 10000L)).thenReturn("precomputed-10k");
+      when(coordinator.getPartitionStartCursor(jobId, "table", 10000L))
+          .thenReturn("precomputed-10k");
 
       Object cursor =
           invokePrivate(
               worker,
               "initializeKeysetCursor",
-              new Class<?>[] {String.class, long.class},
-              "table",
+              new Class<?>[] {SearchIndexPartition.class, long.class},
+              partition,
               10000L);
 
       assertEquals("precomputed-10k", cursor);
-      verify(coordinator).getPartitionStartCursor("table", 10000L);
+      verify(coordinator).getPartitionStartCursor(jobId, "table", 10000L);
       verify(repository, never()).getCursorAtOffset(any(ListFilter.class), anyInt());
     }
   }
@@ -920,6 +969,21 @@ class PartitionWorkerTest {
     @SuppressWarnings("unchecked")
     EntityRepository<EntityInterface> repository = mock(EntityRepository.class);
 
+    SearchIndexPartition partition =
+        SearchIndexPartition.builder()
+            .id(UUID.randomUUID())
+            .jobId(UUID.randomUUID())
+            .entityType("table")
+            .partitionIndex(0)
+            .rangeStart(5)
+            .rangeEnd(10)
+            .estimatedCount(5)
+            .workUnits(5)
+            .priority(50)
+            .status(PartitionStatus.PENDING)
+            .cursor(0)
+            .build();
+
     try (MockedStatic<Entity> entityMock = mockStatic(Entity.class)) {
       entityMock.when(() -> Entity.getEntityRepository("table")).thenReturn(repository);
       when(repository.getCursorAtOffset(any(ListFilter.class), eq(4))).thenReturn(null);
@@ -928,14 +992,29 @@ class PartitionWorkerTest {
           invokePrivate(
               worker,
               "initializeKeysetCursor",
-              new Class<?>[] {String.class, long.class},
-              "table",
+              new Class<?>[] {SearchIndexPartition.class, long.class},
+              partition,
               5L));
     }
   }
 
   @Test
   void initializeKeysetCursorRejectsOffsetsBeyondSupportedRange() {
+    SearchIndexPartition partition =
+        SearchIndexPartition.builder()
+            .id(UUID.randomUUID())
+            .jobId(UUID.randomUUID())
+            .entityType("table")
+            .partitionIndex(0)
+            .rangeStart(0)
+            .rangeEnd(Integer.MAX_VALUE)
+            .estimatedCount(0)
+            .workUnits(0)
+            .priority(50)
+            .status(PartitionStatus.PENDING)
+            .cursor(0)
+            .build();
+
     IllegalArgumentException exception =
         assertThrows(
             IllegalArgumentException.class,
@@ -943,8 +1022,8 @@ class PartitionWorkerTest {
                 invokePrivate(
                     worker,
                     "initializeKeysetCursor",
-                    new Class<?>[] {String.class, long.class},
-                    "table",
+                    new Class<?>[] {SearchIndexPartition.class, long.class},
+                    partition,
                     (long) Integer.MAX_VALUE + 2L));
 
     assertTrue(exception.getMessage().contains("does not support offsets above"));


### PR DESCRIPTION
## Summary

Two independent bugs in the distributed search-index pipeline that surface together in production as "stop does nothing, distributed mode hangs even on a single server."

### Bug 1 — Stop button never finalizes the run

`DistributedSearchIndexCoordinator.requestStop()` cancels only `PENDING` partitions:

```java
partitionDAO.cancelPendingPartitions(jobId);   // WHERE status = 'PENDING'
```

`workerExecutor.shutdownNow()` (added in #27876) interrupts the worker threads, but the partition rows they were holding stay `PROCESSING` in the DB. `checkAndUpdateJobCompletion` requires `pending.isEmpty() && processing.isEmpty()` to flip `STOPPING → STOPPED`; `PROCESSING` never empties because nothing updates the rows.

Result: strategy's `monitorDistributedJob` loops forever, the `AppRunRecord` never finalizes, the UI shows "Running" with a ticking `now() - startTime` timer.

**Fix:** new `cancelInFlightPartitions` SQL covering both states + immediate `checkAndUpdateJobCompletion` call from `requestStop` so the state machine advances in-call.

### Bug 2 — Distributed reader is O(N²) due to `getCursorAtOffset`

`PartitionWorker.initializeKeysetCursor` calls `EntityRepository.getCursorAtOffset(filter, partitionStart)` per partition. That's `dao.listAfter(filter, 1, partitionStart)` — SQL `LIMIT 1 OFFSET partitionStart`, O(partitionStart) per call.

For a 581k-record table with `partitionSize=10000`, partitions start at offsets `0, 10k, 20k, …, 570k`. Total cursor-init scan cost: `0 + 10k + 20k + … + 570k ≈ 16.5M rows`. Single-server (`KeysetBatchReader`) does ~581k. **28× more DB work** + parallel worker contention amplifies to **140× wall-clock slowdown** (1.4k r/s single-server vs 10 r/s distributed on identical data).

**Fix:** `DistributedSearchIndexCoordinator.precomputePartitionStartCursors` does one keyset walk per entity type at job init, batching in 10k chunks, recording the cursor at every partition's `rangeStart`. `O(N)` total per entity. Workers consult the cache (`getPartitionStartCursor`) in O(1); fall back to the OFFSET path on a miss (recovery scenarios).

## Test plan

- [x] `mvn test -pl openmetadata-service -Dtest='DistributedSearchIndexCoordinatorTest,PartitionWorkerTest'` → 78 tests pass
- [x] **Bug 1 regression test** `testRequestStop_ProcessingPartitionsTransitionToStopped` — reproduces the production scenario (RUNNING job + PROCESSING partitions, user clicks Stop), asserts STOPPED is written before `requestStop` returns. Verified to fail with the old `cancelPendingPartitions` SQL.
- [x] **Bug 2 regression test** `initializeKeysetCursorHitsPrecomputedCacheAndSkipsOffsetFallback` — verifies the cache hit short-circuits the OFFSET fallback (`verify(repository, never()).getCursorAtOffset(...)`).
- [x] Existing `testRequestStop_Success` tightened: now asserts `cancelInFlightPartitions` is used and `cancelPendingPartitions` is **not** — pins the new contract.
- [ ] Manual: trigger a distributed reindex on a populated dataset, click Stop, verify the run finalizes within seconds and the UI updates.
- [ ] Manual: trigger a distributed reindex on the same dataset that single-server completes in N minutes; expect comparable wall-clock (within ~2×) instead of the 140× regression.

## Cherry-pick

Both fixes are surgical (5 files, +333/-24). Should cherry-pick cleanly to `1.13`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)