### PR TITLE
fix(search): support embedding and parentId on column search index

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ColumnSearchIndexIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ColumnSearchIndexIT.java
@@ -231,6 +231,47 @@ public class ColumnSearchIndexIT {
     }
 
     @Test
+    @DisplayName("Column parentId equals parent table id when embeddings are enabled")
+    void testColumnParentIdMatchesParentTable(TestNamespace ns) throws Exception {
+      OpenMetadataClient client = SdkClients.adminClient();
+
+      Table table = createTableWithColumns(ns, "col_parent_id");
+
+      TimeUnit.SECONDS.sleep(2);
+
+      String columnName = ns.prefix("user_email");
+      String response =
+          client
+              .search()
+              .query(columnName)
+              .index("column_search_index")
+              .size(10)
+              .deleted(false)
+              .execute();
+
+      JsonNode root = OBJECT_MAPPER.readTree(response);
+      JsonNode hits = root.path("hits").path("hits");
+
+      // parentId is only written when vector embeddings are enabled in the test environment.
+      // When present, it must be the parent table id so hybrid-search collapse groups column
+      // chunks with their table doc.
+      for (JsonNode hit : hits) {
+        JsonNode source = hit.path("_source");
+        String fqn = source.path("fullyQualifiedName").asText("");
+        if (fqn.contains(ns.prefix(""))) {
+          JsonNode parentIdNode = source.path("parentId");
+          if (!parentIdNode.isMissingNode() && !parentIdNode.asText().isEmpty()) {
+            assertEquals(
+                table.getId().toString(),
+                parentIdNode.asText(),
+                "Column parentId must match parent table id (hybrid-search collapse target)");
+          }
+          break;
+        }
+      }
+    }
+
+    @Test
     @DisplayName("Should return columns with databaseSchema reference for breadcrumb")
     void testColumnHasSchemaReference(TestNamespace ns) throws Exception {
       OpenMetadataClient client = SdkClients.adminClient();

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/VectorEmbeddingIntegrationIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/VectorEmbeddingIntegrationIT.java
@@ -26,6 +26,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.openmetadata.schema.entity.data.Table;
+import org.openmetadata.schema.type.Column;
+import org.openmetadata.schema.type.ColumnDataType;
 import org.openmetadata.service.search.opensearch.OsUtils;
 import org.openmetadata.service.search.vector.OpenSearchVectorService;
 import org.openmetadata.service.search.vector.VectorDocBuilder;
@@ -331,6 +333,59 @@ class VectorEmbeddingIntegrationIT {
   }
 
   @Test
+  void testGenerateColumnEmbeddingFields() {
+    Column column = createTestColumn("user_email", "Customer email address", testTable);
+
+    Map<String, Object> fields = vectorService.generateColumnEmbeddingFields(column, testTable);
+
+    assertNotNull(fields);
+    assertNotNull(fields.get("embedding"));
+    assertNotNull(fields.get("textToLLMContext"));
+    assertNotNull(fields.get("textToEmbed"));
+    assertNotNull(fields.get("fingerprint"));
+    assertEquals(0, fields.get("chunkIndex"));
+    assertTrue((int) fields.get("chunkCount") >= 1);
+
+    assertEquals(
+        testTable.getId().toString(),
+        fields.get("parentId"),
+        "Column parentId must point at the parent table id (Option B) so column hits collapse with their table in hybrid search");
+
+    float[] embedding = (float[]) fields.get("embedding");
+    assertEquals(
+        embeddingClient.getDimension(),
+        embedding.length,
+        "Column embedding dimension should match client dimension");
+
+    String textToEmbed = (String) fields.get("textToEmbed");
+    assertTrue(
+        textToEmbed.contains("user_email"), "textToEmbed should contain the column name");
+    assertTrue(
+        textToEmbed.contains(testTable.getName()), "textToEmbed should anchor in parent table");
+    assertTrue(
+        textToEmbed.contains("Customer email address"),
+        "textToEmbed should include the column description");
+  }
+
+  @Test
+  void testColumnFingerprintIsStableAndContentSensitive() {
+    Column column = createTestColumn("amount", "Order amount in USD", testTable);
+
+    Map<String, Object> first = vectorService.generateColumnEmbeddingFields(column, testTable);
+    Map<String, Object> second = vectorService.generateColumnEmbeddingFields(column, testTable);
+    assertEquals(
+        first.get("fingerprint"),
+        second.get("fingerprint"),
+        "Column fingerprint should be stable for unchanged content");
+
+    column.setDescription("Order amount in EUR");
+    Map<String, Object> updated = vectorService.generateColumnEmbeddingFields(column, testTable);
+    assertFalse(
+        first.get("fingerprint").equals(updated.get("fingerprint")),
+        "Column fingerprint should change when description changes");
+  }
+
+  @Test
   void testPatchTableDescriptionUpdatesEmbeddingForSemanticSearch() throws Exception {
     UUID decoyId = UUID.randomUUID();
     Table decoyTable =
@@ -579,5 +634,14 @@ class VectorEmbeddingIntegrationIT {
         .withVersion(1.0)
         .withUpdatedAt(System.currentTimeMillis())
         .withUpdatedBy("test-user");
+  }
+
+  private Column createTestColumn(String name, String description, Table parentTable) {
+    return new Column()
+        .withName(name)
+        .withDescription(description)
+        .withDataType(ColumnDataType.VARCHAR)
+        .withDataTypeDisplay("varchar(255)")
+        .withFullyQualifiedName(parentTable.getFullyQualifiedName() + "." + name);
   }
 }

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/VectorEmbeddingIntegrationIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/VectorEmbeddingIntegrationIT.java
@@ -358,8 +358,7 @@ class VectorEmbeddingIntegrationIT {
         "Column embedding dimension should match client dimension");
 
     String textToEmbed = (String) fields.get("textToEmbed");
-    assertTrue(
-        textToEmbed.contains("user_email"), "textToEmbed should contain the column name");
+    assertTrue(textToEmbed.contains("user_email"), "textToEmbed should contain the column name");
     assertTrue(
         textToEmbed.contains(testTable.getName()), "textToEmbed should anchor in parent table");
     assertTrue(
@@ -383,6 +382,84 @@ class VectorEmbeddingIntegrationIT {
     assertFalse(
         first.get("fingerprint").equals(updated.get("fingerprint")),
         "Column fingerprint should change when description changes");
+  }
+
+  @Test
+  void testRefreshTableColumnEmbeddingsWritesAllColumns() throws Exception {
+    String columnIndex = "column_search_index";
+    createColumnIndex(columnIndex);
+
+    Column userId = createTestColumn("user_id", "User identifier", testTable);
+    Column userEmail = createTestColumn("user_email", "Customer email", testTable);
+    testTable.setColumns(List.of(userId, userEmail));
+
+    indexEmptyColumnDoc(columnIndex, userId);
+    indexEmptyColumnDoc(columnIndex, userEmail);
+
+    vectorService.refreshTableColumnEmbeddings(testTable, columnIndex);
+    Thread.sleep(1000);
+
+    Map<String, Object> userIdDoc =
+        getColumnDocument(
+            columnIndex,
+            org.openmetadata.service.search.indexes.ColumnSearchIndex.generateColumnId(
+                userId.getFullyQualifiedName()));
+    Map<String, Object> userEmailDoc =
+        getColumnDocument(
+            columnIndex,
+            org.openmetadata.service.search.indexes.ColumnSearchIndex.generateColumnId(
+                userEmail.getFullyQualifiedName()));
+
+    assertNotNull(userIdDoc, "user_id column doc should exist");
+    assertNotNull(userIdDoc.get("embedding"), "user_id should have an embedding");
+    assertNotNull(userIdDoc.get("fingerprint"));
+    assertEquals(
+        testTable.getId().toString(),
+        userIdDoc.get("parentId"),
+        "Column parentId should be the parent table id");
+
+    assertNotNull(userEmailDoc, "user_email column doc should exist");
+    assertNotNull(userEmailDoc.get("embedding"));
+    assertEquals(testTable.getId().toString(), userEmailDoc.get("parentId"));
+
+    openSearchClient.indices().delete(d -> d.index(columnIndex));
+  }
+
+  @Test
+  void testColumnFingerprintOptimization() throws Exception {
+    String columnIndex = "column_search_index_fp";
+    createColumnIndex(columnIndex);
+
+    Column column = createTestColumn("amount", "Order amount in USD", testTable);
+    indexEmptyColumnDoc(columnIndex, column);
+
+    vectorService.updateColumnEmbedding(column, testTable, columnIndex);
+    Thread.sleep(1000);
+
+    String columnDocId =
+        org.openmetadata.service.search.indexes.ColumnSearchIndex.generateColumnId(
+            column.getFullyQualifiedName());
+    Map<String, Object> initial = getColumnDocument(columnIndex, columnDocId);
+    String initialFingerprint = (String) initial.get("fingerprint");
+    assertNotNull(initialFingerprint);
+
+    vectorService.updateColumnEmbedding(column, testTable, columnIndex);
+    Thread.sleep(1000);
+    Map<String, Object> unchanged = getColumnDocument(columnIndex, columnDocId);
+    assertEquals(
+        initialFingerprint,
+        unchanged.get("fingerprint"),
+        "Column fingerprint should not change when content is unchanged");
+
+    column.setDescription("Order amount in EUR");
+    vectorService.updateColumnEmbedding(column, testTable, columnIndex);
+    Thread.sleep(1000);
+    Map<String, Object> after = getColumnDocument(columnIndex, columnDocId);
+    assertFalse(
+        initialFingerprint.equals(after.get("fingerprint")),
+        "Column fingerprint should change after description update");
+
+    openSearchClient.indices().delete(d -> d.index(columnIndex));
   }
 
   @Test
@@ -643,5 +720,134 @@ class VectorEmbeddingIntegrationIT {
         .withDataType(ColumnDataType.VARCHAR)
         .withDataTypeDisplay("varchar(255)")
         .withFullyQualifiedName(parentTable.getFullyQualifiedName() + "." + name);
+  }
+
+  private void createColumnIndex(String columnIndex) throws Exception {
+    InputStream indexStream =
+        getClass().getResourceAsStream("/elasticsearch/en/column_index_mapping.json");
+    String rawMapping = new String(indexStream.readAllBytes(), StandardCharsets.UTF_8);
+
+    String enrichedMapping = OsUtils.enrichIndexMappingForOpenSearch(rawMapping);
+    JsonNode indexConfig = mapper.readTree(enrichedMapping);
+    int actualDimension = embeddingClient.getDimension();
+
+    ObjectNode properties = (ObjectNode) indexConfig.get("mappings").get("properties");
+    if (!properties.has("embedding")) {
+      ObjectNode embeddingNode = mapper.createObjectNode();
+      embeddingNode.put("type", "knn_vector");
+      embeddingNode.put("dimension", actualDimension);
+      ObjectNode methodNode = mapper.createObjectNode();
+      methodNode.put("name", "hnsw");
+      methodNode.put("engine", "lucene");
+      methodNode.put("space_type", "cosinesimil");
+      ObjectNode paramsNode = mapper.createObjectNode();
+      paramsNode.put("m", 48);
+      paramsNode.put("ef_construction", 256);
+      methodNode.set("parameters", paramsNode);
+      embeddingNode.set("method", methodNode);
+      properties.set("embedding", embeddingNode);
+
+      JsonNode settingsNode = indexConfig.path("settings").path("index");
+      if (settingsNode.isObject()) {
+        ((ObjectNode) settingsNode).put("knn", true);
+      } else {
+        ObjectNode settings = (ObjectNode) indexConfig.path("settings");
+        ObjectNode indexSettings = mapper.createObjectNode();
+        indexSettings.put("knn", true);
+        if (settings.isMissingNode()) {
+          settings = mapper.createObjectNode();
+          ((ObjectNode) indexConfig).set("settings", settings);
+        }
+        settings.set("index", indexSettings);
+      }
+    } else {
+      ((ObjectNode) properties.get("embedding")).put("dimension", actualDimension);
+    }
+
+    String indexMapping = mapper.writeValueAsString(indexConfig);
+
+    var genericClient = openSearchClient.generic();
+    try (var response =
+        genericClient.execute(
+            os.org.opensearch.client.opensearch.generic.Requests.builder()
+                .method("PUT")
+                .endpoint("/" + columnIndex)
+                .json(indexMapping)
+                .build())) {
+      if (response.getStatus() >= 400) {
+        String errorBody = response.getBody().map(b -> b.bodyAsString()).orElse("no body");
+        throw new IOException(
+            "Failed to create index "
+                + columnIndex
+                + " (status "
+                + response.getStatus()
+                + "): "
+                + errorBody);
+      }
+    }
+  }
+
+  private void indexEmptyColumnDoc(String columnIndex, Column column) throws Exception {
+    String docId =
+        org.openmetadata.service.search.indexes.ColumnSearchIndex.generateColumnId(
+            column.getFullyQualifiedName());
+    String docJson =
+        mapper.writeValueAsString(
+            Map.of(
+                "name",
+                column.getName(),
+                "fullyQualifiedName",
+                column.getFullyQualifiedName(),
+                "deleted",
+                false,
+                "entityType",
+                "tableColumn"));
+
+    var genericClient = openSearchClient.generic();
+    try (var response =
+        genericClient.execute(
+            os.org.opensearch.client.opensearch.generic.Requests.builder()
+                .method("PUT")
+                .endpoint("/" + columnIndex + "/_doc/" + docId + "?refresh=true")
+                .json(docJson)
+                .build())) {
+      if (response.getStatus() >= 400) {
+        String errorBody = response.getBody().map(b -> b.bodyAsString()).orElse("no body");
+        throw new IOException("Failed to index column doc: " + errorBody);
+      }
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, Object> getColumnDocument(String columnIndex, String docId) throws Exception {
+    openSearchClient.indices().refresh(r -> r.index(columnIndex));
+    var genericClient = openSearchClient.generic();
+    try (var response =
+        genericClient.execute(
+            os.org.opensearch.client.opensearch.generic.Requests.builder()
+                .method("GET")
+                .endpoint("/" + columnIndex + "/_doc/" + docId)
+                .build())) {
+      if (response.getStatus() == 404) {
+        return null;
+      }
+      String body =
+          response
+              .getBody()
+              .map(
+                  b -> {
+                    try {
+                      return new String(b.bodyAsBytes(), StandardCharsets.UTF_8);
+                    } catch (Exception e) {
+                      return "{}";
+                    }
+                  })
+              .orElse("{}");
+      JsonNode root = mapper.readTree(body);
+      if (root.has("_source")) {
+        return mapper.convertValue(root.get("_source"), Map.class);
+      }
+      return null;
+    }
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/OpenSearchBulkSink.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/OpenSearchBulkSink.java
@@ -593,12 +593,25 @@ public class OpenSearchBulkSink implements BulkSink {
     }
 
     List<Column> flattenedColumns = ColumnSearchIndex.flattenColumns(table.getColumns());
+
+    boolean columnEmbeddingsEnabled = isColumnVectorEmbeddingEnabled();
+    Map<String, String> existingFingerprints =
+        (columnEmbeddingsEnabled && !recreateIndex)
+            ? fetchExistingColumnFingerprints(flattenedColumns, columnIndexName)
+            : Collections.emptyMap();
+
     for (Column column : flattenedColumns) {
       try {
         ColumnSearchIndex columnIndex = new ColumnSearchIndex(column, table);
         Map<String, Object> searchIndexDoc = columnIndex.buildSearchIndexDoc();
-        String json = JsonUtils.pojoToJson(searchIndexDoc);
         String docId = searchIndexDoc.get("id").toString();
+
+        if (columnEmbeddingsEnabled) {
+          enrichColumnDocWithEmbedding(
+              column, table, searchIndexDoc, docId, recreateIndex, existingFingerprints);
+        }
+
+        String json = JsonUtils.pojoToJson(searchIndexDoc);
 
         BulkOperation operation;
         if (recreateIndex) {
@@ -632,6 +645,69 @@ public class OpenSearchBulkSink implements BulkSink {
             table.getFullyQualifiedName(),
             e);
       }
+    }
+  }
+
+  private boolean isColumnVectorEmbeddingEnabled() {
+    return searchRepository.isVectorEmbeddingEnabled()
+        && OpenSearchVectorService.getInstance() != null
+        && searchRepository.getIndexMapping(Entity.TABLE_COLUMN) != null;
+  }
+
+  private void enrichColumnDocWithEmbedding(
+      Column column,
+      Table table,
+      Map<String, Object> searchIndexDoc,
+      String docId,
+      boolean recreateIndex,
+      Map<String, String> existingFingerprints) {
+    OpenSearchVectorService vectorService = OpenSearchVectorService.getInstance();
+    if (vectorService == null) {
+      return;
+    }
+    try {
+      if (!recreateIndex) {
+        String currentFp = VectorDocBuilder.computeFingerprintForColumn(column, table);
+        String existingFp = existingFingerprints.get(docId);
+        if (existingFp != null && existingFp.equals(currentFp)) {
+          searchIndexDoc.put("fingerprint", currentFp);
+          searchIndexDoc.put("parentId", table.getId().toString());
+          vectorSuccess.incrementAndGet();
+          return;
+        }
+      }
+      Map<String, Object> embeddingFields =
+          vectorService.generateColumnEmbeddingFields(column, table);
+      searchIndexDoc.putAll(embeddingFields);
+      vectorSuccess.incrementAndGet();
+    } catch (Exception e) {
+      LOG.warn(
+          "Failed to generate embeddings for column {}: {}",
+          column.getFullyQualifiedName(),
+          e.getMessage(),
+          e);
+      vectorFailed.incrementAndGet();
+    }
+  }
+
+  private Map<String, String> fetchExistingColumnFingerprints(
+      List<Column> columns, String columnIndexName) {
+    if (columns.isEmpty()) {
+      return Collections.emptyMap();
+    }
+    OpenSearchVectorService vectorService = OpenSearchVectorService.getInstance();
+    if (vectorService == null) {
+      return Collections.emptyMap();
+    }
+    try {
+      List<String> docIds = new ArrayList<>(columns.size());
+      for (Column column : columns) {
+        docIds.add(ColumnSearchIndex.generateColumnId(column.getFullyQualifiedName()));
+      }
+      return vectorService.getExistingFingerprintsBatch(columnIndexName, docIds);
+    } catch (Exception e) {
+      LOG.warn("Failed to fetch existing column fingerprints: {}", e.getMessage());
+      return Collections.emptyMap();
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
@@ -182,6 +182,50 @@ public class OpenSearchVectorService implements VectorIndexService {
   }
 
   @Override
+  public void updateColumnEmbedding(Column column, Table parentTable, String columnIndexName) {
+    try {
+      String columnId =
+          org.openmetadata.service.search.indexes.ColumnSearchIndex.generateColumnId(
+              column.getFullyQualifiedName());
+      String existingFingerprint = getExistingFingerprint(columnIndexName, columnId);
+      String currentFingerprint = VectorDocBuilder.computeFingerprintForColumn(column, parentTable);
+
+      if (currentFingerprint.equals(existingFingerprint)) {
+        LOG.debug("Skipping column {} - fingerprint unchanged", columnId);
+        return;
+      }
+
+      Map<String, Object> embeddingFields = generateColumnEmbeddingFields(column, parentTable);
+      partialUpdateEntity(columnIndexName, columnId, embeddingFields);
+    } catch (Exception e) {
+      LOG.error(
+          "Failed to update embedding for column {}: {}",
+          column.getFullyQualifiedName(),
+          e.getMessage(),
+          e);
+    }
+  }
+
+  /**
+   * Fan out embedding refresh to every column on a table. Columns are not entities — they have no
+   * lifecycle event of their own, so their embeddings would otherwise drift whenever a user
+   * patches the parent table's description, columns, or tags. Called from the table lifecycle
+   * handler and the reembed CLI's table consumer.
+   */
+  @Override
+  public void refreshTableColumnEmbeddings(Table table, String columnIndexName) {
+    if (table == null || table.getColumns() == null || table.getColumns().isEmpty()) {
+      return;
+    }
+    List<Column> flattened =
+        org.openmetadata.service.search.indexes.ColumnSearchIndex.flattenColumns(
+            table.getColumns());
+    for (Column column : flattened) {
+      updateColumnEmbedding(column, table, columnIndexName);
+    }
+  }
+
+  @Override
   @SuppressWarnings("unchecked")
   public VectorSearchResponse search(
       String query,

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
@@ -14,6 +14,8 @@ import java.util.Optional;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.EntityInterface;
+import org.openmetadata.schema.entity.data.Table;
+import org.openmetadata.schema.type.Column;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.events.lifecycle.EntityLifecycleEventDispatcher;
 import org.openmetadata.service.search.vector.client.EmbeddingClient;
@@ -153,6 +155,11 @@ public class OpenSearchVectorService implements VectorIndexService {
   @Override
   public Map<String, Object> generateEmbeddingFields(EntityInterface entity) {
     return VectorDocBuilder.buildEmbeddingFields(entity, embeddingClient);
+  }
+
+  @Override
+  public Map<String, Object> generateColumnEmbeddingFields(Column column, Table parentTable) {
+    return VectorDocBuilder.buildColumnEmbeddingFields(column, parentTable, embeddingClient);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorDocBuilder.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorDocBuilder.java
@@ -187,6 +187,143 @@ public class VectorDocBuilder {
     return TextChunkManager.computeFingerprint(metaLight + "|" + body);
   }
 
+  /**
+   * Generate embedding fields for a {@link Column} doc indexed under the parent {@link Table}.
+   * Mirrors {@link #buildEmbeddingFields(EntityInterface, EmbeddingClient)} but works on a column
+   * (which is not an EntityInterface). {@code parentId} is set to the parent table id so the
+   * hybrid-search collapse groups column hits with their table — matching how chunks of the same
+   * doc are deduplicated.
+   */
+  public static Map<String, Object> buildColumnEmbeddingFields(
+      Column column, Table parentTable, EmbeddingClient embeddingClient) {
+    String parentId = parentTable.getId().toString();
+
+    String metaLight = buildColumnMetaLightText(column, parentTable);
+    String body = buildColumnBodyText(column);
+    String semanticMetaLight = buildColumnSemanticMetaLightText(column, parentTable);
+    String semanticBody = buildColumnSemanticBodyText(column);
+    String fingerprint = computeFingerprintForColumn(column, parentTable);
+
+    List<String> chunks = TextChunkManager.chunk(body);
+    int chunkCount = chunks.size();
+    List<String> semanticChunks = TextChunkManager.chunk(semanticBody);
+
+    String textToLLMContext =
+        String.format("%s%s | chunk %d/%d", metaLight, chunks.get(0), 1, chunkCount);
+    String semanticBodyChunk = semanticChunks.get(0);
+    String textToEmbed = joinSemanticParts(semanticMetaLight, semanticBodyChunk);
+
+    float[] embedding = embeddingClient.embed(textToEmbed);
+
+    Map<String, Object> fields = new HashMap<>();
+    fields.put("embedding", embedding);
+    fields.put("textToLLMContext", textToLLMContext);
+    fields.put("textToEmbed", textToEmbed);
+    fields.put("chunkIndex", 0);
+    fields.put("chunkCount", chunkCount);
+    fields.put("parentId", parentId);
+    fields.put("fingerprint", fingerprint);
+
+    return fields;
+  }
+
+  public static String computeFingerprintForColumn(Column column, Table parentTable) {
+    String metaLight = buildColumnMetaLightText(column, parentTable);
+    String body = buildColumnBodyText(column);
+    return TextChunkManager.computeFingerprint(metaLight + "|" + body);
+  }
+
+  static String buildColumnMetaLightText(Column column, Table parentTable) {
+    List<TagLabel> tagsPojo = column.getTags() != null ? column.getTags() : Collections.emptyList();
+    List<String> classificationTagFqns =
+        tagsPojo.stream()
+            .filter(tag -> tag.getSource() == null || !"Glossary".equals(tag.getSource().value()))
+            .filter(tag -> !tag.getTagFQN().startsWith("Tier."))
+            .map(TagLabel::getTagFQN)
+            .collect(Collectors.toList());
+    List<String> glossaryTermFqns =
+        tagsPojo.stream()
+            .filter(tag -> tag.getSource() != null && "Glossary".equals(tag.getSource().value()))
+            .map(TagLabel::getTagFQN)
+            .collect(Collectors.toList());
+
+    List<String> parts = new ArrayList<>();
+    parts.add("name: " + orEmpty(column.getName()));
+    parts.add("displayName: " + orEmpty(column.getDisplayName()));
+    parts.add("entityType: " + Entity.TABLE_COLUMN);
+    parts.add("fullyQualifiedName: " + orEmpty(column.getFullyQualifiedName()));
+    parts.add(
+        "dataType: " + (column.getDataType() != null ? column.getDataType().toString() : "[]"));
+    parts.add("dataTypeDisplay: " + orEmpty(column.getDataTypeDisplay()));
+    parts.add("table: " + orEmpty(parentTable.getFullyQualifiedName()));
+    parts.add("serviceType: " + orEmpty(extractServiceType(parentTable)));
+    parts.add("tags: " + joinOrEmpty(classificationTagFqns));
+    parts.add("Associated glossary terms: " + joinOrEmpty(glossaryTermFqns));
+    return String.join("; ", parts) + " | ";
+  }
+
+  static String buildColumnBodyText(Column column) {
+    return "description: " + removeHtml(orEmpty(column.getDescription()));
+  }
+
+  static String buildColumnSemanticMetaLightText(Column column, Table parentTable) {
+    List<String> phrases = new ArrayList<>();
+    String columnLabel = humanizeEntityType(Entity.TABLE_COLUMN);
+    String name = column.getName();
+    String displayName = column.getDisplayName();
+    String subject = null;
+    if (displayName != null && !displayName.isBlank() && !displayName.equals(name)) {
+      subject = (name == null || name.isBlank()) ? displayName : displayName + " (" + name + ")";
+    } else if (name != null && !name.isBlank()) {
+      subject = name;
+    }
+    if (subject != null) {
+      phrases.add(columnLabel + " " + subject);
+    } else {
+      phrases.add(columnLabel);
+    }
+
+    String tableName =
+        parentTable.getDisplayName() != null && !parentTable.getDisplayName().isBlank()
+            ? parentTable.getDisplayName()
+            : parentTable.getName();
+    if (tableName != null && !tableName.isBlank()) {
+      phrases.add("In table " + tableName);
+    }
+
+    if (column.getDataTypeDisplay() != null && !column.getDataTypeDisplay().isBlank()) {
+      phrases.add("Type " + column.getDataTypeDisplay());
+    } else if (column.getDataType() != null) {
+      phrases.add("Type " + column.getDataType());
+    }
+
+    List<TagLabel> tagsPojo = column.getTags() != null ? column.getTags() : Collections.emptyList();
+    List<String> classificationTagNames =
+        tagsPojo.stream()
+            .filter(tag -> tag.getSource() == null || !"Glossary".equals(tag.getSource().value()))
+            .filter(tag -> !tag.getTagFQN().startsWith("Tier."))
+            .map(tag -> tag.getTagFQN().replace('.', ' '))
+            .collect(Collectors.toList());
+    if (!classificationTagNames.isEmpty()) {
+      phrases.add("Tagged as " + String.join(", ", classificationTagNames));
+    }
+    List<String> glossaryTermNames =
+        tagsPojo.stream()
+            .filter(tag -> tag.getSource() != null && "Glossary".equals(tag.getSource().value()))
+            .map(tag -> tag.getName() != null ? tag.getName() : tag.getTagFQN())
+            .collect(Collectors.toList());
+    if (!glossaryTermNames.isEmpty()) {
+      phrases.add("Related glossary terms " + String.join(", ", glossaryTermNames));
+    }
+
+    return String.join(". ", phrases);
+  }
+
+  static String buildColumnSemanticBodyText(Column column) {
+    String description = removeHtml(column.getDescription() == null ? "" : column.getDescription());
+    return description.isEmpty() ? "" : description;
+  }
+
   static String buildMetaLightText(EntityInterface entity, String entityType) {
     boolean isGlossary = entity instanceof Glossary;
     boolean isGlossaryTerm = entity instanceof GlossaryTerm;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorEmbeddingHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorEmbeddingHandler.java
@@ -3,6 +3,7 @@ package org.openmetadata.service.search.vector;
 import java.util.Locale;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.EntityInterface;
+import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.schema.type.ChangeDescription;
 import org.openmetadata.search.IndexMapping;
 import org.openmetadata.service.Entity;
@@ -73,9 +74,24 @@ public class VectorEmbeddingHandler implements EntityLifecycleEventHandler {
         return;
       }
       vectorService.updateEntityEmbedding(entity, entityIndexName);
+      // Columns are not entities and have no lifecycle events of their own. Their embeddings
+      // would otherwise drift on every table patch (description, columns, tags). Fan out from
+      // the parent table's lifecycle event so the column index stays in sync with the table.
+      if (entity instanceof Table table) {
+        refreshColumnEmbeddings(table);
+      }
     } catch (Exception e) {
       LOG.error("Failed to update embedding for entity {}: {}", entity.getId(), e.getMessage(), e);
     }
+  }
+
+  private void refreshColumnEmbeddings(Table table) {
+    String columnIndexName = resolveEntityIndexName(Entity.TABLE_COLUMN);
+    if (columnIndexName == null) {
+      LOG.debug("No index mapping for {} - skipping column embedding refresh", Entity.TABLE_COLUMN);
+      return;
+    }
+    vectorService.refreshTableColumnEmbeddings(table, columnIndexName);
   }
 
   private String resolveEntityIndexName(String entityType) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorIndexService.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorIndexService.java
@@ -3,6 +3,8 @@ package org.openmetadata.service.search.vector;
 import java.util.List;
 import java.util.Map;
 import org.openmetadata.schema.EntityInterface;
+import org.openmetadata.schema.entity.data.Table;
+import org.openmetadata.schema.type.Column;
 import org.openmetadata.service.search.vector.utils.DTOs.VectorSearchResponse;
 
 public interface VectorIndexService {
@@ -10,6 +12,8 @@ public interface VectorIndexService {
   String VECTOR_EMBEDDING_ALIAS = "dataAssetEmbeddings";
 
   Map<String, Object> generateEmbeddingFields(EntityInterface entity);
+
+  Map<String, Object> generateColumnEmbeddingFields(Column column, Table parentTable);
 
   void updateEntityEmbedding(EntityInterface entity, String entityIndexName);
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorIndexService.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorIndexService.java
@@ -17,6 +17,10 @@ public interface VectorIndexService {
 
   void updateEntityEmbedding(EntityInterface entity, String entityIndexName);
 
+  void updateColumnEmbedding(Column column, Table parentTable, String columnIndexName);
+
+  void refreshTableColumnEmbeddings(Table table, String columnIndexName);
+
   VectorSearchResponse search(
       String query, Map<String, List<String>> filters, int size, int from, int k, double threshold);
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
@@ -1644,9 +1644,18 @@ public class OpenMetadataOperations implements Callable<Integer> {
           LOG.warn("No index mapping found for entity type: {}, skipping batch", entityType);
           continue;
         }
+        boolean isTable = Entity.TABLE.equals(entityType);
+        String columnIndexName = isTable ? resolveEntityIndexName(Entity.TABLE_COLUMN) : null;
         for (EntityInterface entity : task.batch().getData()) {
           try {
             vecService.updateEntityEmbedding(entity, entityIndexName);
+            // Columns aren't iterated as a top-level entity type — fan out from the parent
+            // table here so reembed refreshes both indexes in one pass.
+            if (isTable
+                && columnIndexName != null
+                && entity instanceof org.openmetadata.schema.entity.data.Table table) {
+              vecService.refreshTableColumnEmbeddings(table, columnIndexName);
+            }
             processedCounts
                 .computeIfAbsent(
                     entityType, key -> new java.util.concurrent.atomic.AtomicInteger(0))

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/VectorDocBuilderTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/VectorDocBuilderTest.java
@@ -557,4 +557,191 @@ class VectorDocBuilderTest {
     table.setDeleted(false);
     return table;
   }
+
+  @Test
+  void testBuildColumnEmbeddingFieldsBasic() {
+    Table table = createTestTable("orders", "Orders", "Customer orders");
+    Column column = createTestColumn("user_email", "User Email", "Customer email", table);
+
+    Map<String, Object> fields =
+        VectorDocBuilder.buildColumnEmbeddingFields(column, table, MOCK_CLIENT);
+
+    assertNotNull(fields);
+    assertNotNull(fields.get("embedding"));
+    assertNotNull(fields.get("textToLLMContext"));
+    assertNotNull(fields.get("textToEmbed"));
+    assertNotNull(fields.get("fingerprint"));
+    assertEquals(0, fields.get("chunkIndex"));
+    assertTrue((int) fields.get("chunkCount") >= 1);
+  }
+
+  @Test
+  void testBuildColumnEmbeddingFieldsParentIdIsParentTableId() {
+    Table table = createTestTable("orders", null, "desc");
+    Column column = createTestColumn("amount", null, "Order amount", table);
+
+    Map<String, Object> fields =
+        VectorDocBuilder.buildColumnEmbeddingFields(column, table, MOCK_CLIENT);
+
+    assertEquals(
+        table.getId().toString(),
+        fields.get("parentId"),
+        "parentId must be the parent table id so columns collapse with their table on hybrid search");
+  }
+
+  @Test
+  void testBuildColumnEmbeddingFieldsContainsEmbeddingVector() {
+    Table table = createTestTable("vec_table", null, "table desc");
+    Column column = createTestColumn("vec_col", null, "column desc", table);
+
+    Map<String, Object> fields =
+        VectorDocBuilder.buildColumnEmbeddingFields(column, table, MOCK_CLIENT);
+
+    Object embedding = fields.get("embedding");
+    assertInstanceOf(float[].class, embedding);
+    assertEquals(384, ((float[]) embedding).length);
+  }
+
+  @Test
+  void testColumnFingerprintConsistency() {
+    Table table = createTestTable("fp_table", null, "table");
+    Column column = createTestColumn("fp_col", null, "Same description", table);
+
+    String fp1 = VectorDocBuilder.computeFingerprintForColumn(column, table);
+    String fp2 = VectorDocBuilder.computeFingerprintForColumn(column, table);
+
+    assertEquals(fp1, fp2);
+  }
+
+  @Test
+  void testColumnFingerprintChangesWithContent() {
+    Table table = createTestTable("fp_table", null, "table");
+    Column column = createTestColumn("fp_col", null, "Original description", table);
+    String fp1 = VectorDocBuilder.computeFingerprintForColumn(column, table);
+
+    column.setDescription("Modified description");
+    String fp2 = VectorDocBuilder.computeFingerprintForColumn(column, table);
+
+    assertNotEquals(fp1, fp2);
+  }
+
+  @Test
+  void testColumnFingerprintChangesWithDataType() {
+    Table table = createTestTable("fp_table", null, "table");
+    Column column = createTestColumn("fp_col", null, "desc", table);
+    column.setDataType(ColumnDataType.VARCHAR);
+    String fp1 = VectorDocBuilder.computeFingerprintForColumn(column, table);
+
+    column.setDataType(ColumnDataType.INT);
+    String fp2 = VectorDocBuilder.computeFingerprintForColumn(column, table);
+
+    assertNotEquals(fp1, fp2);
+  }
+
+  @Test
+  void testColumnSemanticTextIncludesParentTableContext() {
+    Table table = createTestTable("orders", "Orders", "desc");
+    Column column = createTestColumn("user_id", "User Id", "Foreign key to users", table);
+
+    String semantic = VectorDocBuilder.buildColumnSemanticMetaLightText(column, table);
+
+    assertTrue(semantic.contains("User Id"), "should include column display name");
+    assertTrue(semantic.contains("In table Orders"), "should include parent table context");
+  }
+
+  @Test
+  void testColumnSemanticTextDropsStructuralScaffolding() {
+    Table table = createTestTable("orders", null, "desc");
+    Column column = createTestColumn("amount", null, "Order amount in USD", table);
+
+    String semantic = VectorDocBuilder.buildColumnSemanticMetaLightText(column, table);
+
+    assertFalse(semantic.contains("name:"));
+    assertFalse(semantic.contains("dataType:"));
+    assertFalse(semantic.contains("entityType:"));
+    assertFalse(semantic.contains("[]"));
+    assertFalse(semantic.contains(" | "));
+  }
+
+  @Test
+  void testColumnSemanticTextIncludesTagsAsPhrases() {
+    Table table = createTestTable("orders", null, "desc");
+    Column column = createTestColumn("ssn", null, "Social security", table);
+    TagLabel tag = new TagLabel();
+    tag.setTagFQN("PII.Sensitive");
+    tag.setName("Sensitive");
+    column.setTags(List.of(tag));
+
+    String semantic = VectorDocBuilder.buildColumnSemanticMetaLightText(column, table);
+
+    assertTrue(semantic.contains("Tagged as PII Sensitive"));
+  }
+
+  @Test
+  void testColumnMetaLightContainsColumnInfo() {
+    Table table = createTestTable("meta_table", null, "desc");
+    table.setFullyQualifiedName("svc.db.schema.meta_table");
+    Column column = createTestColumn("user_email", "User Email", "email", table);
+    column.setDataType(ColumnDataType.VARCHAR);
+    column.setDataTypeDisplay("varchar(255)");
+
+    String metaLight = VectorDocBuilder.buildColumnMetaLightText(column, table);
+
+    assertTrue(metaLight.contains("name: user_email"));
+    assertTrue(metaLight.contains("displayName: User Email"));
+    assertTrue(metaLight.contains("entityType: tableColumn"));
+    assertTrue(metaLight.contains("dataType: VARCHAR"));
+    assertTrue(metaLight.contains("dataTypeDisplay: varchar(255)"));
+    assertTrue(metaLight.contains("table: svc.db.schema.meta_table"));
+    assertTrue(metaLight.endsWith(" | "));
+  }
+
+  @Test
+  void testColumnBodyTextContainsDescription() {
+    Table table = createTestTable("body_table", null, "table desc");
+    Column column = createTestColumn("body_col", null, "This is the column body", table);
+
+    String body = VectorDocBuilder.buildColumnBodyText(column);
+
+    assertTrue(body.contains("This is the column body"));
+  }
+
+  @Test
+  void testColumnTextToEmbedJoinsMetaAndBodyWithPeriod() {
+    Table table = createTestTable("orders", "Orders", "desc");
+    Column column = createTestColumn("amount", "Amount", "Order amount", table);
+
+    Map<String, Object> fields =
+        VectorDocBuilder.buildColumnEmbeddingFields(column, table, MOCK_CLIENT);
+    String semantic = (String) fields.get("textToEmbed");
+
+    assertTrue(semantic.startsWith("table Column Amount (amount)"));
+    assertTrue(semantic.contains("In table Orders"));
+    assertTrue(semantic.contains(". Order amount"));
+  }
+
+  @Test
+  void testColumnTextToLLMContextRetainsLegacyFormat() {
+    Table table = createTestTable("orders", null, "desc");
+    Column column = createTestColumn("amount", null, "Order amount", table);
+
+    Map<String, Object> fields =
+        VectorDocBuilder.buildColumnEmbeddingFields(column, table, MOCK_CLIENT);
+    String legacy = (String) fields.get("textToLLMContext");
+
+    assertTrue(legacy.contains("name: amount"));
+    assertTrue(legacy.contains("displayName: []"), "legacy keeps empty placeholders");
+    assertTrue(legacy.contains(" | chunk 1/"));
+  }
+
+  private Column createTestColumn(
+      String name, String displayName, String description, Table parentTable) {
+    Column column = new Column();
+    column.setName(name);
+    column.setDisplayName(displayName);
+    column.setDescription(description);
+    column.setFullyQualifiedName(parentTable.getFullyQualifiedName() + "." + name);
+    column.setDataType(ColumnDataType.VARCHAR);
+    return column;
+  }
 }

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/column_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/column_index_mapping.json
@@ -614,6 +614,24 @@
       },
       "descriptionStatus": {
         "type": "keyword"
+      },
+      "fingerprint": {
+        "type": "keyword"
+      },
+      "textToLLMContext": {
+        "type": "text"
+      },
+      "textToEmbed": {
+        "type": "text"
+      },
+      "chunkIndex": {
+        "type": "integer"
+      },
+      "chunkCount": {
+        "type": "integer"
+      },
+      "parentId": {
+        "type": "keyword"
       }
     }
   }

--- a/openmetadata-spec/src/main/resources/elasticsearch/indexMapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/indexMapping.json
@@ -23,7 +23,7 @@
     "indexName": "column_search_index",
     "indexMappingFile": "/elasticsearch/%s/column_index_mapping.json",
     "alias": "tableColumn",
-    "parentAliases": ["all", "table", "dataAsset"],
+    "parentAliases": ["all", "table", "dataAsset", "dataAssetEmbeddings"],
     "childAliases": []
   },
   "storedProcedure": {

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/column_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/column_index_mapping.json
@@ -619,6 +619,24 @@
       },
       "descriptionStatus": {
         "type": "keyword"
+      },
+      "fingerprint": {
+        "type": "keyword"
+      },
+      "textToLLMContext": {
+        "type": "text"
+      },
+      "textToEmbed": {
+        "type": "text"
+      },
+      "chunkIndex": {
+        "type": "integer"
+      },
+      "chunkCount": {
+        "type": "integer"
+      },
+      "parentId": {
+        "type": "keyword"
       }
     }
   }

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/column_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/column_index_mapping.json
@@ -633,6 +633,24 @@
       },
       "descriptionStatus": {
         "type": "keyword"
+      },
+      "fingerprint": {
+        "type": "keyword"
+      },
+      "textToLLMContext": {
+        "type": "text"
+      },
+      "textToEmbed": {
+        "type": "text"
+      },
+      "chunkIndex": {
+        "type": "integer"
+      },
+      "chunkCount": {
+        "type": "integer"
+      },
+      "parentId": {
+        "type": "keyword"
       }
     }
   }

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/column_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/column_index_mapping.json
@@ -611,6 +611,24 @@
       },
       "descriptionStatus": {
         "type": "keyword"
+      },
+      "fingerprint": {
+        "type": "keyword"
+      },
+      "textToLLMContext": {
+        "type": "text"
+      },
+      "textToEmbed": {
+        "type": "text"
+      },
+      "chunkIndex": {
+        "type": "integer"
+      },
+      "chunkCount": {
+        "type": "integer"
+      },
+      "parentId": {
+        "type": "keyword"
       }
     }
   }


### PR DESCRIPTION
## Summary

The `column_search_index` was created without the `embedding` (knn_vector) field and without `parentId`, which:
- breaks semantic search over columns in AskCollate (vector pipeline can't run against the index)
- breaks hybrid-search deduplication, which collapses chunks belonging to the same doc on `parentId`

This change adds embedding generation for columns through the existing vector pipeline, with `parentId` set to the parent table id so column \"chunks\" collapse under their table in hybrid search results.

## What changed

**Index mappings (`column_index_mapping.json` × en/jp/ru/zh)**
Added `fingerprint`, `parentId`, `textToLLMContext`, `textToEmbed`, `chunkIndex`, `chunkCount`. The `embedding` knn_vector field is auto-injected at runtime by `OsUtils.addKnnVectorSettings` because `fingerprint` is now present in the mapping (same convention every other vector-enabled index follows).

**`VectorDocBuilder`**
- New `buildColumnEmbeddingFields(Column, Table, EmbeddingClient)` — column-aware version of `buildEmbeddingFields`. Builds metaLight from column name/displayName/dataType/tags/parent-table FQN, body from the column description, semantic variants, computes fingerprint, runs the embedding client.
- New `computeFingerprintForColumn(Column, Table)` for skip-if-unchanged dedup.
- `parentId` is set to the **parent table id** (Option B), so a query that matches both the table doc and several of its column chunks returns one collapsed result per table — the highest-scoring chunk surfaces.

**`VectorIndexService` / `OpenSearchVectorService`**
Added `generateColumnEmbeddingFields(Column, Table)` to the interface and OS implementation.

**`OpenSearchBulkSink.indexTableColumns`**
- Pre-fetches existing column fingerprints in a single batched `_search` against the column index when embeddings are enabled.
- For each column, computes the fingerprint and either skips (unchanged → write doc with `fingerprint`/`parentId` only) or merges fresh embedding fields into the doc map before bulk-indexing.
- Reuses the existing `vectorSuccess` / `vectorFailed` counters so column embedding stats roll up with table embedding stats in the reindex UI.
- ES path is untouched — vector search is OpenSearch-only in this codebase (`OsUtils.addKnnVectorSettings` is OS-specific).

## Why \`parentId = parent_table.id\`

The OpenSearch search query uses `collapse: { field: parentId }`, which keeps only the top-scoring hit per `parentId`. Setting columns' `parentId` to the parent table id matches the issue author's framing (\"chunks that belong to the same doc\") — a query for \"user transactions\" that hits the table description and three of its columns surfaces one result per table, with the most relevant chunk at the top, rather than four near-duplicate hits about the same table.

## Test plan

- [ ] Reindex with embeddings enabled and confirm `column_search_index` has `embedding` (knn_vector) injected at index-creation time
- [ ] Verify each column doc has `parentId == parent table id`, `fingerprint`, `textToEmbed`, `embedding[]` populated
- [ ] AskCollate semantic search returns column results
- [ ] Hybrid-search dedup: a query that matches both a table and its columns returns one collapsed result per table, not duplicates
- [ ] Re-running indexing without source changes skips embedding generation (fingerprint dedup hit)
- [ ] Languages other than `en` (`jp`/`ru`/`zh`) build and pick up the new fields

Refs: open-metadata/openmetadata-collate#3801

🤖 Generated with [Claude Code](https://claude.com/claude-code)