### PR TITLE
fix(dataInsights): resolve id -> id.keyword for Summary Card Quick Function COUNT

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/dataInsightAggregators/DataInsightAggregatorFieldResolver.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/dataInsightAggregators/DataInsightAggregatorFieldResolver.java
@@ -1,0 +1,23 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ *  except in compliance with the License. You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License
+ *  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+package org.openmetadata.service.search.dataInsightAggregators;
+
+public final class DataInsightAggregatorFieldResolver {
+
+  private DataInsightAggregatorFieldResolver() {}
+
+  // The DI index maps `id` as text+keyword. value_count and cardinality require keyword/doc_values,
+  // so target the .keyword sub-field — matching the formula path default in
+  // getDateHistogramByFormula.
+  public static String resolveCountField(String field) {
+    return "id".equals(field) ? "id.keyword" : field;
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/dataInsightAggregators/ElasticSearchDynamicChartAggregatorInterface.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/dataInsightAggregators/ElasticSearchDynamicChartAggregatorInterface.java
@@ -30,6 +30,7 @@ import org.openmetadata.schema.dataInsight.custom.DataInsightCustomChartResultLi
 import org.openmetadata.schema.dataInsight.custom.FormulaHolder;
 import org.openmetadata.schema.dataInsight.custom.Function;
 import org.openmetadata.service.jdbi3.DataInsightSystemChartRepository;
+import org.openmetadata.service.search.dataInsightAggregators.DataInsightAggregatorFieldResolver;
 import org.openmetadata.service.security.policyevaluator.CompiledRule;
 import org.springframework.expression.Expression;
 
@@ -41,12 +42,18 @@ public interface ElasticSearchDynamicChartAggregatorInterface {
   private static Aggregation getSubAggregationsByFunction(
       Function function, String field, int index) {
     return switch (function) {
-      case COUNT -> Aggregation.of(a -> a.valueCount(v -> v.field(field)));
+      case COUNT -> Aggregation.of(
+          a ->
+              a.valueCount(
+                  v -> v.field(DataInsightAggregatorFieldResolver.resolveCountField(field))));
       case SUM -> Aggregation.of(a -> a.sum(s -> s.field(field)));
       case AVG -> Aggregation.of(a -> a.avg(avg -> avg.field(field)));
       case MIN -> Aggregation.of(a -> a.min(m -> m.field(field)));
       case MAX -> Aggregation.of(a -> a.max(m -> m.field(field)));
-      case UNIQUE -> Aggregation.of(a -> a.cardinality(c -> c.field(field)));
+      case UNIQUE -> Aggregation.of(
+          a ->
+              a.cardinality(
+                  c -> c.field(DataInsightAggregatorFieldResolver.resolveCountField(field))));
     };
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/dataInsightAggregator/OpenSearchDynamicChartAggregatorInterface.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/dataInsightAggregator/OpenSearchDynamicChartAggregatorInterface.java
@@ -18,6 +18,7 @@ import org.openmetadata.schema.dataInsight.custom.DataInsightCustomChartResultLi
 import org.openmetadata.schema.dataInsight.custom.FormulaHolder;
 import org.openmetadata.schema.dataInsight.custom.Function;
 import org.openmetadata.service.jdbi3.DataInsightSystemChartRepository;
+import org.openmetadata.service.search.dataInsightAggregators.DataInsightAggregatorFieldResolver;
 import org.openmetadata.service.security.policyevaluator.CompiledRule;
 import org.springframework.expression.Expression;
 import os.org.opensearch.client.json.JsonData;
@@ -37,12 +38,18 @@ public interface OpenSearchDynamicChartAggregatorInterface {
   private static Aggregation getSubAggregationsByFunction(
       Function function, String field, int index) {
     return switch (function) {
-      case COUNT -> Aggregation.of(a -> a.valueCount(v -> v.field(field)));
+      case COUNT -> Aggregation.of(
+          a ->
+              a.valueCount(
+                  v -> v.field(DataInsightAggregatorFieldResolver.resolveCountField(field))));
       case SUM -> Aggregation.of(a -> a.sum(s -> s.field(field)));
       case AVG -> Aggregation.of(a -> a.avg(avg -> avg.field(field)));
       case MIN -> Aggregation.of(a -> a.min(m -> m.field(field)));
       case MAX -> Aggregation.of(a -> a.max(m -> m.field(field)));
-      case UNIQUE -> Aggregation.of(a -> a.cardinality(c -> c.field(field)));
+      case UNIQUE -> Aggregation.of(
+          a ->
+              a.cardinality(
+                  c -> c.field(DataInsightAggregatorFieldResolver.resolveCountField(field))));
     };
   }
 


### PR DESCRIPTION
Fixes open-metadata/openmetadata-collate#3989

## Summary

Data Insights custom Summary Card charts created via the Quick Function tab with `Function = count, Field = Id` returned a meaningless count (`0` on ES 9, `1` on older ES) regardless of how many entities matched the filter. Reported by a customer whose KPIs (% sensitive, % classified, % with owner, etc.) all showed `1`.

The aggregator interface has two parallel COUNT code paths that disagreed on the field used for `value_count`:

- **Formula** path (`getDateHistogramByFormula`, line 89) defaults to `id.keyword` — works.
- **Quick Function** path (`getSubAggregationsByFunction`, line 44) passes the raw user field through. The UI sends `"id"`. The DI mapping defines `id` as `text` with a `.keyword` sub-field, and `value_count` on a text field requires fielddata (disabled by default), so ES rejects the aggregation on every shard. The error is silently swallowed and the chart returns garbage.

Every system-seeded SummaryCard already uses the formula path with `id.keyword` (verified for `total_data_assets_summary_card`, `data_assets_with_description_summary_card`, etc.), so this defect only surfaces on user-built custom charts.

## Change

Extracted a small `DataInsightAggregatorFieldResolver` helper that rewrites `"id"` to `"id.keyword"` for COUNT and UNIQUE aggregations. Both `ElasticSearchDynamicChartAggregatorInterface` and `OpenSearchDynamicChartAggregatorInterface` route through it. Other functions (SUM/AVG/MIN/MAX) and other fields are untouched.

This brings the Quick Function path into alignment with the convention every system-seeded chart already follows.

### Why not change the index mapping instead?

Considered and rejected. Changing `id` from `text+keyword` to plain `keyword` would actively contradict this fix — `id.keyword` would no longer resolve, and during a rolling deployment we'd have the worst of both worlds (broken on legacy and new indices). The wasted analyzer work on a 36-char UUID is negligible and `text+keyword` is standard across the rest of the OpenMetadata indices. If schema cleanup is ever desired, that's a standalone effort that would flip the rewrite the other direction at the same time.

### Why not collapse the code at `ElasticSearchSummaryCardAggregator.java:109-115` while we're here?

Considered. The reverse-iteration that returns only the latest non-null bucket is **correct** given the per-entity-per-day snapshot model used by `DataAssetsWorkflow`. Each day is a complete state snapshot — summing across days would yield meaningless "entity-days". Leave as-is.

## Test plan

- [x] `mvn -pl openmetadata-service compile` — BUILD SUCCESS
- [x] `mvn spotless:apply` applied
- [x] Manually reproduced against a local Collate stack (Docker Compose, ES 9.3.0): pre-fix chart returns `count=0`, post-fix returns the correct count of matching entities
- [ ] End-to-end IT in `collate-integration-tests` (`DataInsightCustomChartCountIT`) — creates 5 tagged tables, builds the exact customer-facing chart with `field=id` and a tag filter, asserts `results[0].count == 5` against `live=true`. Will land in a follow-up PR on the closed Collate repo since the create endpoint (`/v1/analytics/dataInsights/custom/charts`) is Collate-only.