### PR TITLE
fix(cli-e2e): use profileSampleConfig in profiler test builders

### DIFF
--- a/ingestion/tests/cli_e2e/base/config_builders/builders.py
+++ b/ingestion/tests/cli_e2e/base/config_builders/builders.py
@@ -58,7 +58,12 @@ class ProfilerConfigBuilder(BaseBuilder):
         self.config["source"]["sourceConfig"] = {
             "config": {
                 "type": "Profiler",
-                "profileSample": self.profilerSample,
+                "profileSampleConfig": {
+                    "sampleConfigType": "STATIC",
+                    "config": {
+                        "profileSample": self.profilerSample,
+                    },
+                },
             }
         }
 

--- a/ingestion/tests/cli_e2e/test_cli_bigquery.py
+++ b/ingestion/tests/cli_e2e/test_cli_bigquery.py
@@ -30,6 +30,11 @@ from metadata.generated.schema.entity.data.table import (
 from metadata.generated.schema.tests.basic import TestCaseResult, TestCaseStatus
 from metadata.generated.schema.tests.testCase import TestCaseParameterValue
 from metadata.generated.schema.type.basic import ProfileSampleType, Timestamp
+from metadata.generated.schema.type.samplingConfig import (
+    ProfileSampleConfig,
+    SampleConfigType,
+)
+from metadata.generated.schema.type.staticSamplingConfig import StaticSamplingConfig
 
 from .common.test_cli_db import CliCommonDB  # noqa: TID252
 from .common_e2e_sqa_mixins import SQACommonMethods  # noqa: TID252
@@ -189,8 +194,13 @@ class BigqueryCliTest(CliCommonDB.TestSuite, SQACommonMethods):
         self.openmetadata.create_or_update_table_profiler_config(
             self.get_data_quality_table(),
             TableProfilerConfig(
-                profileSampleType=ProfileSampleType.ROWS,
-                profileSample=100,
+                profileSampleConfig=ProfileSampleConfig(
+                    sampleConfigType=SampleConfigType.STATIC,
+                    config=StaticSamplingConfig(
+                        profileSample=100,
+                        profileSampleType=ProfileSampleType.ROWS,
+                    ),
+                ),
             ),
         )
 


### PR DESCRIPTION
## Summary

Fixes the scheduled `py-cli-e2e-tests` workflow, which has been failing on every run since 2026-04-17 (postgres, mysql, mssql, oracle, redshift, snowflake, redash, metabase, quicksight, tableau, bigquery_multiple_project, dbt_redshift).

[PR #27184](https://github.com/open-metadata/OpenMetadata/pull/27184) ([commit 47c88d49ce](https://github.com/open-metadata/OpenMetadata/commit/47c88d49ce), "Dynamic Sampling Config") moved `profileSample` / `profileSampleType` out of `DatabaseServiceProfilerPipeline` and `TableProfilerConfig` into a nested `profileSampleConfig` object. Both pydantic models use `extra='forbid'`, so the old format raises:

```
Error loading profiler configuration: We encountered an error parsing the configuration of your DatabaseServiceProfilerPipeline.
- Extra parameter 'profileSample'
- Invalid parameter value for 'profileSample'
```

The CLI E2E test config builders weren't updated alongside that PR — this change brings them in line with the new schema.

## Changes

- `ingestion/tests/cli_e2e/base/config_builders/builders.py` — `ProfilerConfigBuilder.build()` now emits `profileSampleConfig: { sampleConfigType: STATIC, config: { profileSample: ... } }` instead of a top-level `profileSample`.
- `ingestion/tests/cli_e2e/test_cli_bigquery.py` — `add_table_profile_config` constructs `TableProfilerConfig` with the nested `profileSampleConfig` instead of top-level `profileSample`/`profileSampleType`.

The redshift `tests/cli_e2e/database/redshift/test.yaml` is gitignored and regenerated at test runtime by the builder, so it's automatically picked up by the builder fix.

## Test plan

- [ ] `py-cli-e2e-tests` scheduled run goes green for postgres, mysql, mssql, oracle, redshift, snowflake, redash, metabase, quicksight, bigquery_multiple_project, dbt_redshift
- [ ] BigQuery data quality test (`add_table_profile_config`) successfully creates the table profiler config

🤖 Generated with [Claude Code](https://claude.com/claude-code)