### PR TITLE
fix(playwright): unblock glossary bulk import after modal close

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryImportExport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryImportExport.spec.ts
@@ -264,12 +264,14 @@ test.describe('Glossary Bulk Import Export', () => {
         page.getByTestId('bulk-import-details-modal')
       ).not.toBeVisible();
 
-      await page.getByRole('dialog').getByRole('img').click();
+      await expect(page.locator('.ant-modal-mask')).toHaveCount(0);
     });
 
     await test.step('delete custom properties', async () => {
       for (const propertyName of Object.values(propertyListName)) {
         await settingClick(page, GlobalSettingOptions.GLOSSARY_TERM, true);
+
+        await page.waitForURL('**/settings/customProperties/glossaryTerm');
 
         await waitForAllLoadersToDisappear(page);
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryImportExport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryImportExport.spec.ts
@@ -262,9 +262,7 @@ test.describe('Glossary Bulk Import Export', () => {
 
       await expect(
         page.getByTestId('bulk-import-details-modal')
-      ).not.toBeVisible();
-
-      await expect(page.locator('.ant-modal-mask')).toHaveCount(0);
+      ).not.toBeAttached();
     });
 
     await test.step('delete custom properties', async () => {


### PR DESCRIPTION
Fixes `Glossary Bulk Import Export` timing out on the `delete custom properties` step: a stale post-Close click was leaving the bulk-import overlay mounted and intercepting pointer events on the next `settingClick`. Removes the bogus click, gates on `not.toBeAttached()` of the existing modal testid, and waits for the glossary-term detail URL between loop iterations.