### PR TITLE
Fixes 21329: exclude temporal table period columns from autoClassification sampling

### DIFF
--- a/ingestion/setup.py
+++ b/ingestion/setup.py
@@ -370,6 +370,7 @@ plugins: Dict[str, Set[str]] = {  # noqa: UP006
         VERSIONS["avro"],
         VERSIONS["grpc-tools"],
         VERSIONS["sqlalchemy-bigquery"],
+        VERSIONS["spacy"],
         VERSIONS["presidio-analyzer"],
     },
     "sap-hana": {"hdbcli", "sqlalchemy-hana"},

--- a/ingestion/src/metadata/ingestion/source/database/mssql/utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/mssql/utils.py
@@ -131,6 +131,7 @@ def get_columns(self, connection, tablename, dbname, owner, schema, **kw):  # py
             Column("object_id", Integer, primary_key=True),
             Column("name", String, primary_key=True),
             Column("column_id", Integer, primary_key=True),
+            Column("generated_always_type", Integer),
             schema="sys",
         )
     )
@@ -199,6 +200,7 @@ def get_columns(self, connection, tablename, dbname, owner, schema, **kw):  # py
             identity_cols.c.seed_value,
             identity_cols.c.increment_value,
             sql.cast(extended_properties.c.value, NVARCHAR(4000)).label("comment"),
+            sys_columns.c.generated_always_type,
         )
         .where(whereclause)
         .select_from(join)
@@ -210,6 +212,9 @@ def get_columns(self, connection, tablename, dbname, owner, schema, **kw):  # py
     cols = []
     for row in cursr.mappings():
         name = row[columns.c.column_name]
+        generated_always_type = row[sys_columns.c.generated_always_type]
+        if generated_always_type in (1, 2):
+            continue
         type_ = row[columns.c.data_type]
         nullable = row[columns.c.is_nullable] == "YES"
         charlen = row[columns.c.character_maximum_length]

--- a/ingestion/src/metadata/sampler/sqlalchemy/azuresql/sampler.py
+++ b/ingestion/src/metadata/sampler/sqlalchemy/azuresql/sampler.py
@@ -18,6 +18,7 @@ from typing import List, Optional  # noqa: UP035
 from sqlalchemy import Column, Table, text
 from sqlalchemy.sql.selectable import CTE
 
+from metadata.generated.schema.entity.data.table import Table as TableEntity
 from metadata.generated.schema.entity.data.table import TableData, TableType
 from metadata.generated.schema.type.staticSamplingConfig import StaticSamplingConfig
 from metadata.sampler.sqlalchemy.sampler import (
@@ -36,6 +37,27 @@ class AzureSQLSampler(SQASampler):
     # an error when trying to fetch data from these columns
     # pyodbc.ProgrammingError: ('ODBC SQL type -151 is not yet supported.  column-index=x  type=-151', 'HY106')
     NOT_COMPUTE_PYODBC = {"SQASGeography", "UndeterminedType"}  # noqa: RUF012
+
+    def _get_temporal_column_names(self) -> frozenset:
+        schema_name = (
+            self.entity.databaseSchema.name
+            if isinstance(self.entity, TableEntity) and self.entity.databaseSchema
+            else "dbo"
+        )
+        query = text(
+            "SELECT c.name FROM sys.columns c"
+            " JOIN sys.tables t ON c.object_id = t.object_id"
+            " JOIN sys.schemas s ON t.schema_id = s.schema_id"
+            " WHERE t.name = :table_name"
+            " AND s.name = :schema_name"
+            " AND c.generated_always_type IN (1, 2)"
+        )
+        with self.session_factory() as session:
+            rows = session.execute(
+                query,
+                {"table_name": self.entity.name.root, "schema_name": schema_name},
+            ).fetchall()
+        return frozenset(row[0] for row in rows)
 
     def set_tablesample(self, static: StaticSamplingConfig, selectable: Table):
         """Set the TABLESAMPLE clause for MSSQL
@@ -60,7 +82,11 @@ class AzureSQLSampler(SQASampler):
     def fetch_sample_data(self, columns: Optional[List[Column]] = None) -> TableData:  # noqa: UP006, UP045
         sqa_columns = []
         if columns:
+            temporal_cols = self._get_temporal_column_names()
             for col in columns:
-                if col.type.__class__.__name__ not in self.NOT_COMPUTE_PYODBC:
-                    sqa_columns.append(col)  # noqa: PERF401
-        return super().fetch_sample_data(sqa_columns or columns)
+                if col.type.__class__.__name__ in self.NOT_COMPUTE_PYODBC:
+                    continue
+                if col.name in temporal_cols:
+                    continue
+                sqa_columns.append(col)
+        return super().fetch_sample_data(sqa_columns if columns is not None else None)

--- a/ingestion/tests/integration/auto_classification/databases/test_azuresql_temporal_table.py
+++ b/ingestion/tests/integration/auto_classification/databases/test_azuresql_temporal_table.py
@@ -1,0 +1,307 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Full integration tests for AzureSQL temporal table handling.
+
+Tests the complete workflow:
+  1. Register AzureSQL service in OpenMetadata
+  2. Create temporal table in the live DB and seed rows
+  3. Run MetadataWorkflow to ingest table structure
+  4. Run AutoClassificationWorkflow to sample and classify data
+  5. Assert sample data exists and excludes temporal period columns
+
+=============================================================================
+REQUIRED SQL PERMISSIONS
+=============================================================================
+
+The test user (AZURE_SQL_USERNAME) must have the following permissions on the
+target database. Run these statements as a db_owner or sysadmin before the
+test, substituting <user> with the value of AZURE_SQL_USERNAME:
+
+  -- Schema-level: create and drop tables
+  GRANT CREATE TABLE TO [<user>];
+  GRANT ALTER ON SCHEMA::dbo TO [<user>];
+
+  -- Table-level: read and write data
+  GRANT SELECT ON SCHEMA::dbo TO [<user>];
+  GRANT INSERT ON SCHEMA::dbo TO [<user>];
+
+  -- Required to disable system-versioning during teardown
+  -- (without this, DROP TABLE fails with 4902 / "cannot find the object")
+  GRANT CONTROL ON SCHEMA::dbo TO [<user>];
+
+  -- Required for metadata ingestion (sys catalog reads)
+  GRANT VIEW DEFINITION ON DATABASE::<dbname> TO [<user>];
+  GRANT VIEW DATABASE STATE TO [<user>];
+
+  -- If using Azure SQL, also ensure the login is allowed through the firewall
+  -- and that the user is mapped to the database:
+  --   CREATE USER [<user>] FOR LOGIN [<user>];
+  --   ALTER ROLE db_datareader ADD MEMBER [<user>];
+  --   ALTER ROLE db_datawriter ADD MEMBER [<user>];
+
+TROUBLESHOOTING
+---------------
+- Error 4902 "Cannot find the object … because it does not exist or you do not
+  have permissions": almost always a missing CONTROL or ALTER permission on
+  the schema (not a missing table). Grant CONTROL ON SCHEMA::dbo as above.
+- Error 18456 "Login failed": wrong credentials or the login is not mapped to
+  the database. Verify AZURE_SQL_USERNAME / AZURE_SQL_PASSWORD and that the
+  user exists in the database (CREATE USER … FOR LOGIN …).
+- Error 40615 / 40544 (firewall): add the client IP to the Azure SQL firewall
+  rules in the Azure portal or via:
+    EXEC sp_set_firewall_rule N'test_runner', '<ip>', '<ip>';
+
+=============================================================================
+
+Required environment variables:
+  AZURE_SQL_HOST       - AzureSQL server host (e.g. "myserver.database.windows.net,1433")
+  AZURE_SQL_DATABASE   - Database name
+  AZURE_SQL_USERNAME   - SQL authentication username
+  AZURE_SQL_PASSWORD   - SQL authentication password
+
+Optional:
+  AZURE_SQL_DRIVER     - ODBC driver name (default: "ODBC Driver 18 for SQL Server")
+  AZURE_SQL_CLEANUP    - Drop test tables after the run (default: "true"; set to "false" to keep them)
+"""
+
+import logging
+import os
+import uuid
+
+import pytest
+from sqlalchemy import create_engine, text
+
+from metadata.generated.schema.api.services.createDatabaseService import (
+    CreateDatabaseServiceRequest,
+)
+from metadata.generated.schema.entity.data.table import Table
+from metadata.generated.schema.entity.services.connections.database.azureSQLConnection import (
+    AzureSQLConnection,
+    AzureSQLScheme,
+    AzureSQLType,
+)
+from metadata.generated.schema.entity.services.databaseService import (
+    DatabaseConnection,
+    DatabaseService,
+    DatabaseServiceType,
+)
+from metadata.generated.schema.metadataIngestion.databaseServiceMetadataPipeline import (
+    DatabaseMetadataConfigType,
+)
+from metadata.generated.schema.type.filterPattern import FilterPattern
+from metadata.workflow.classification import AutoClassificationWorkflow
+from metadata.workflow.metadata import MetadataWorkflow
+
+logger = logging.getLogger(__name__)
+
+
+REQUIRED_ENV_VARS = [
+    "AZURE_SQL_HOST",
+    "AZURE_SQL_DATABASE",
+    "AZURE_SQL_USERNAME",
+    "AZURE_SQL_PASSWORD",
+]
+
+AZURE_SQL_DRIVER = os.environ.get("AZURE_SQL_DRIVER", "ODBC Driver 18 for SQL Server")
+AZURE_SQL_CLEANUP = os.environ.get("AZURE_SQL_CLEANUP", "true").lower() == "true"
+
+pytestmark = pytest.mark.skipif(
+    not all(os.environ.get(v) for v in REQUIRED_ENV_VARS),
+    reason="AzureSQL temporal table integration tests require environment variables: " + ", ".join(REQUIRED_ENV_VARS),
+)
+
+
+@pytest.fixture(scope="module")
+def table_suffix():
+    return uuid.uuid4().hex[:8]
+
+
+@pytest.fixture(scope="module")
+def create_service_request():
+    return CreateDatabaseServiceRequest(
+        name=f"azuresql_temporal_test_{uuid.uuid4().hex[:8]}",
+        serviceType=DatabaseServiceType.AzureSQL,
+        connection=DatabaseConnection(
+            config=AzureSQLConnection(
+                type=AzureSQLType.AzureSQL,
+                scheme=AzureSQLScheme.mssql_pyodbc,
+                username=os.environ["AZURE_SQL_USERNAME"],
+                password=os.environ["AZURE_SQL_PASSWORD"],
+                hostPort=os.environ["AZURE_SQL_HOST"],
+                database=os.environ["AZURE_SQL_DATABASE"],
+                driver=AZURE_SQL_DRIVER,
+            )
+        ),
+    )
+
+
+@pytest.fixture(scope="module")
+def ensure_temporal_table(db_service, table_suffix):
+    conn_config = db_service.connection.config
+    driver = (conn_config.driver or AZURE_SQL_DRIVER).replace(" ", "+")
+    password = conn_config.password.get_secret_value() if conn_config.password else os.environ["AZURE_SQL_PASSWORD"]
+    connection_url = (
+        f"mssql+pyodbc://{conn_config.username}:{password}"
+        f"@{conn_config.hostPort}/{conn_config.database}"
+        f"?driver={driver}&Encrypt=yes&TrustServerCertificate=no"
+    )
+    engine = create_engine(connection_url, echo=False)
+
+    table_name = f"om_test_temporal_{table_suffix}"
+    history_name = f"{table_name}_history"
+
+    with engine.connect() as conn:
+        conn.execute(
+            text(f"""
+            IF OBJECT_ID('dbo.[{table_name}]', 'U') IS NULL
+            BEGIN
+                CREATE TABLE dbo.[{table_name}] (
+                    id INT PRIMARY KEY,
+                    name NVARCHAR(100),
+                    email NVARCHAR(100),
+                    ValidFrom DATETIME2 GENERATED ALWAYS AS ROW START HIDDEN NOT NULL,
+                    ValidTo   DATETIME2 GENERATED ALWAYS AS ROW END   HIDDEN NOT NULL,
+                    PERIOD FOR SYSTEM_TIME (ValidFrom, ValidTo)
+                ) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = dbo.[{history_name}]))
+            END
+            """)
+        )
+        conn.commit()
+        conn.execute(
+            text(f"""
+            IF NOT EXISTS (SELECT 1 FROM dbo.[{table_name}] WHERE id IN (1, 2, 3))
+            BEGIN
+                INSERT INTO dbo.[{table_name}] (id, name, email) VALUES
+                (1, 'Alice', 'alice@example.com'),
+                (2, 'Bob',   'bob@example.com'),
+                (3, 'Carol', 'carol@example.com')
+            END
+            """)
+        )
+        conn.commit()
+
+    yield table_name
+
+    if AZURE_SQL_CLEANUP:
+        with engine.connect() as conn:
+            for stmt in [
+                f"ALTER TABLE dbo.[{table_name}] SET (SYSTEM_VERSIONING = OFF)",
+                f"DROP TABLE IF EXISTS dbo.[{table_name}]",
+                f"DROP TABLE IF EXISTS dbo.[{history_name}]",
+            ]:
+                try:
+                    conn.execute(text(stmt))
+                    conn.commit()
+                except Exception as exc:
+                    logger.error(
+                        "Cleanup failed for %r: %s. "
+                        "If the error mentions 'does not exist or you do not have permissions' (4902), "
+                        "the user lacks ALTER/CONTROL on the schema. "
+                        "Grant it with: GRANT CONTROL ON SCHEMA::dbo TO [<user>]",
+                        stmt,
+                        exc,
+                    )
+
+    engine.dispose()
+
+
+@pytest.fixture(scope="module")
+def table_name(ensure_temporal_table):
+    return ensure_temporal_table
+
+
+@pytest.fixture(scope="module")
+def ingestion_config(db_service, workflow_config, sink_config, table_name):
+    return {
+        "source": {
+            "type": db_service.connection.config.type.value.lower(),
+            "serviceName": db_service.fullyQualifiedName.root,
+            "sourceConfig": {
+                "config": {
+                    "type": DatabaseMetadataConfigType.DatabaseMetadata.value,
+                    "tableFilterPattern": FilterPattern(includes=[f"^{table_name}$"]),
+                    "schemaFilterPattern": FilterPattern(includes=["^dbo$"]),
+                }
+            },
+            "serviceConnection": db_service.connection.model_dump(),
+        },
+        "sink": sink_config,
+        "workflowConfig": workflow_config,
+    }
+
+
+@pytest.fixture(scope="module")
+def autoclassification_config(db_service, workflow_config, sink_config, table_name):
+    return {
+        "source": {
+            "type": db_service.connection.config.type.value.lower(),
+            "serviceName": db_service.fullyQualifiedName.root,
+            "sourceConfig": {
+                "config": {
+                    "type": "AutoClassification",
+                    "tableFilterPattern": FilterPattern(includes=[f"^{table_name}$"]),
+                    "schemaFilterPattern": FilterPattern(includes=["^dbo$"]),
+                    "storeSampleData": True,
+                    "enableAutoClassification": False,
+                }
+            },
+        },
+        "processor": {"type": "orm-profiler", "config": {}},
+        "sink": sink_config,
+        "workflowConfig": workflow_config,
+    }
+
+
+@pytest.fixture(scope="module")
+def load_metadata(run_workflow, ingestion_config, ensure_temporal_table, patch_passwords_for_db_services):
+    return run_workflow(MetadataWorkflow, ingestion_config)
+
+
+@pytest.fixture(scope="module")
+def run_classification(run_workflow, autoclassification_config, load_metadata, patch_passwords_for_db_services):
+    return run_workflow(AutoClassificationWorkflow, autoclassification_config)
+
+
+class TestAzureSQLTemporalTableFullWorkflow:
+    def test_temporal_columns_excluded_from_sample_data(
+        self,
+        db_service: DatabaseService,
+        metadata,
+        table_name: str,
+        run_classification,
+    ) -> None:
+        table_fqn = f"{db_service.fullyQualifiedName.root}.{db_service.connection.config.database}.dbo.{table_name}"
+        table = metadata.get_by_name(entity=Table, fqn=table_fqn)
+        assert table is not None, f"Table not found: {table_fqn}"
+
+        result = metadata.get_sample_data(table)
+        assert result is not None
+        assert result.sampleData is not None
+        assert len(result.sampleData.rows) > 0
+
+        column_names = [col.root for col in result.sampleData.columns]
+        assert "ValidFrom" not in column_names, "ValidFrom must be excluded from sample data"
+        assert "ValidTo" not in column_names, "ValidTo must be excluded from sample data"
+        assert "id" in column_names
+        assert "name" in column_names
+        assert "email" in column_names
+
+    def test_workflow_does_not_raise_on_temporal_table(
+        self,
+        db_service: DatabaseService,
+        metadata,
+        table_name: str,
+        run_classification,
+    ) -> None:
+        table_fqn = f"{db_service.fullyQualifiedName.root}.{db_service.connection.config.database}.dbo.{table_name}"
+        table = metadata.get_by_name(entity=Table, fqn=table_fqn)
+        assert table is not None, f"Table not found: {table_fqn}"

--- a/ingestion/tests/unit/observability/profiler/sqlalchemy/azuresql/test_azuresql_sampling.py
+++ b/ingestion/tests/unit/observability/profiler/sqlalchemy/azuresql/test_azuresql_sampling.py
@@ -141,6 +141,113 @@ class SampleTest(TestCase):
         )
         assert expected_query.casefold() == str(query.compile(compile_kwargs={"literal_binds": True})).casefold()
 
+    def test_temporal_columns_excluded_from_fetch_sample_data(self, sampler_mock):
+        """
+        Temporal table period columns (GENERATED ALWAYS AS ROW START/END) must be
+        excluded from the sample query so that TABLESAMPLE does not fail on temporal
+        tables (SQL Server error 13541) and pyodbc does not error on period column types.
+        """
+        from unittest.mock import MagicMock, patch
+
+        from sqlalchemy.types import DateTime
+
+        sampler = AzureSQLSampler(
+            service_connection_config=self.azuresql_conn,
+            ometa_client=None,
+            entity=self.table_entity,
+            sample_config=SampleConfig(),
+        )
+
+        valid_from_col = MagicMock()
+        valid_from_col.name = "ValidFrom"
+        valid_from_col.type = DateTime()
+
+        valid_to_col = MagicMock()
+        valid_to_col.name = "ValidTo"
+        valid_to_col.type = DateTime()
+
+        id_col = MagicMock()
+        id_col.name = "id"
+        id_col.type.__class__.__name__ = "Integer"
+
+        columns_passed_to_super = []
+
+        def capture_fetch(*args, **kwargs):
+            cols = args[0] if args else kwargs.get("columns")
+            if cols:
+                columns_passed_to_super.extend(cols)
+            from metadata.generated.schema.entity.data.table import TableData
+
+            return TableData(columns=[], rows=[])
+
+        with (
+            patch.object(
+                sampler,
+                "_get_temporal_column_names",
+                return_value=frozenset({"ValidFrom", "ValidTo"}),
+            ),
+            patch.object(
+                SQASampler,
+                "fetch_sample_data",
+                side_effect=capture_fetch,
+            ),
+        ):
+            sampler.fetch_sample_data(columns=[id_col, valid_from_col, valid_to_col])
+
+        passed_names = {col.name for col in columns_passed_to_super}
+        assert "ValidFrom" not in passed_names
+        assert "ValidTo" not in passed_names
+        assert "id" in passed_names
+
+    def test_all_columns_filtered_passes_empty_list_not_original(self, sampler_mock):
+        """
+        When every column is a temporal period column, sqa_columns is [].
+        The empty list must be passed to super(), not the original column list —
+        otherwise the filter is bypassed entirely (falsy empty list bug).
+        """
+        from unittest.mock import MagicMock, patch
+
+        from sqlalchemy.types import DateTime
+
+        sampler = AzureSQLSampler(
+            service_connection_config=self.azuresql_conn,
+            ometa_client=None,
+            entity=self.table_entity,
+            sample_config=SampleConfig(),
+        )
+
+        valid_from_col = MagicMock()
+        valid_from_col.name = "ValidFrom"
+        valid_from_col.type = DateTime()
+
+        valid_to_col = MagicMock()
+        valid_to_col.name = "ValidTo"
+        valid_to_col.type = DateTime()
+
+        received = {}
+
+        def capture_fetch(cols=None):
+            received["columns"] = cols
+            from metadata.generated.schema.entity.data.table import TableData
+
+            return TableData(columns=[], rows=[])
+
+        with (
+            patch.object(
+                sampler,
+                "_get_temporal_column_names",
+                return_value=frozenset({"ValidFrom", "ValidTo"}),
+            ),
+            patch.object(
+                SQASampler,
+                "fetch_sample_data",
+                side_effect=capture_fetch,
+            ),
+        ):
+            sampler.fetch_sample_data(columns=[valid_from_col, valid_to_col])
+
+        assert received["columns"] == [], "Expected empty list when all columns are filtered, not the original list"
+
     def test_sampling_with_partition(self, sampler_mock):
         """
         use specified partition columns.

--- a/ingestion/tests/unit/pii/test_cases/azuresql_temporal_table.py
+++ b/ingestion/tests/unit/pii/test_cases/azuresql_temporal_table.py
@@ -1,0 +1,123 @@
+import uuid
+
+from metadata.generated.schema.entity.data.table import (
+    Column,
+    ColumnName,
+    DataType,
+    Table,
+    TableData,
+)
+from metadata.generated.schema.type.basic import (
+    EntityName,
+    FullyQualifiedEntityName,
+    Uuid,
+)
+from metadata.generated.schema.type.tagLabel import (
+    LabelType,
+    State,
+    TagFQN,
+    TagLabel,
+    TagSource,
+)
+from metadata.ingestion.models.table_metadata import ColumnTag
+from metadata.sampler.models import SampleData
+
+table = Table(
+    id=Uuid(root=uuid.uuid4()),
+    name=EntityName(root="customers_temporal"),
+    fullyQualifiedName=FullyQualifiedEntityName(root="Service.database.schema.customers_temporal"),
+    columns=[
+        Column(
+            name=ColumnName(root="id"),
+            displayName=None,
+            dataType=DataType.INT,
+            arrayDataType=None,
+            dataLength=1,
+            precision=1,
+            scale=None,
+            dataTypeDisplay="int",
+            fullyQualifiedName=FullyQualifiedEntityName(root="Service.database.schema.customers_temporal.id"),
+        ),
+        Column(
+            name=ColumnName(root="name"),
+            displayName=None,
+            dataType=DataType.STRING,
+            arrayDataType=None,
+            dataLength=1,
+            precision=1,
+            scale=None,
+            dataTypeDisplay="string",
+            fullyQualifiedName=FullyQualifiedEntityName(root="Service.database.schema.customers_temporal.name"),
+        ),
+        Column(
+            name=ColumnName(root="email"),
+            displayName=None,
+            dataType=DataType.STRING,
+            arrayDataType=None,
+            dataLength=1,
+            precision=1,
+            scale=None,
+            dataTypeDisplay="string",
+            fullyQualifiedName=FullyQualifiedEntityName(root="Service.database.schema.customers_temporal.email"),
+        ),
+        Column(
+            name=ColumnName(root="ValidFrom"),
+            displayName=None,
+            dataType=DataType.DATETIME,
+            arrayDataType=None,
+            dataLength=1,
+            precision=1,
+            scale=None,
+            dataTypeDisplay="datetime",
+            fullyQualifiedName=FullyQualifiedEntityName(root="Service.database.schema.customers_temporal.ValidFrom"),
+        ),
+        Column(
+            name=ColumnName(root="ValidTo"),
+            displayName=None,
+            dataType=DataType.DATETIME,
+            arrayDataType=None,
+            dataLength=1,
+            precision=1,
+            scale=None,
+            dataTypeDisplay="datetime",
+            fullyQualifiedName=FullyQualifiedEntityName(root="Service.database.schema.customers_temporal.ValidTo"),
+        ),
+    ],
+)
+
+sample_data = SampleData(
+    data=TableData(
+        columns=[
+            ColumnName(root="id"),
+            ColumnName(root="name"),
+            ColumnName(root="email"),
+        ],
+        rows=[
+            [1, "Alice", "alice@example.com"],
+            [2, "Bob", "bob@example.com"],
+            [3, "Charlie", "charlie@example.com"],
+            [4, "Diana", "diana@example.com"],
+            [5, "Eve", "eve@example.com"],
+            [6, "Frank", "frank@example.com"],
+            [7, "Grace", "grace@example.com"],
+            [8, "Henry", "henry@example.com"],
+            [9, "Iris", "iris@example.com"],
+            [10, "Jack", "jack@example.com"],
+        ],
+    )
+)
+
+expected_column_tags = [
+    ColumnTag(
+        column_fqn="Service.database.schema.customers_temporal.email",
+        tag_label=TagLabel(
+            source=TagSource.Classification,
+            labelType=LabelType.Generated,
+            state=State.Suggested,
+            name="Sensitive",
+            tagFQN=TagFQN(
+                root="PII.Sensitive",
+            ),
+        ),
+    ),
+]


### PR DESCRIPTION
## Summary

- Fixes `list index out of range` error in autoClassification ingestion for AzureSQL tables with **Temporal Tables** enabled (issue #21329)
- SQL Server temporal tables add `GENERATED ALWAYS AS ROW START/END` period columns (`ValidFrom`/`ValidTo`) that break the autoClassification sampler in two ways: `TABLESAMPLE` is not supported on temporal tables (SQL Server error 13541), and pyodbc cannot reliably handle period column types
- **Fix 1** (`mssql/utils.py`): filters `generated_always_type IN (1, 2)` in `get_columns` so temporal period columns are never stored in entity metadata
- **Fix 2** (`azuresql/sampler.py`): adds `_get_temporal_column_names()` querying `sys.columns` to detect and exclude temporal period columns in `fetch_sample_data`, as a defense-in-depth guard

## Test plan

- [ ] Unit test added to `test_azuresql_sampling.py`: verifies `fetch_sample_data` filters out columns returned by `_get_temporal_column_names` (mocked)
- [ ] PII processor test case added (`test_cases/azuresql_temporal_table.py`): table entity has 5 columns including `ValidFrom`/`ValidTo`, sample data has only the 3 regular columns — verifies the processor handles this correctly and detects PII on `email`
- [ ] Integration test added (`test_azuresql_temporal_table.py`): skipped unless `AZURE_SQL_HOST`, `AZURE_SQL_DATABASE`, `AZURE_SQL_USERNAME`, `AZURE_SQL_PASSWORD` env vars are set; creates a real temporal table and asserts temporal columns are absent from sample data

Closes #21329

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----
## Summary by Gitar

- **Dependency management:**
  - Added `spacy` to `ingestion/setup.py` to ensure compatibility and resolve issues with `spacy<3.8`.
- **Database ingestion/sampling fixes:**
  - Updated `mssql/utils.py` to filter out temporal period columns using `generated_always_type` during metadata extraction.
  - Added `_get_temporal_column_names` to `AzureSQLSampler` to detect and exclude temporal columns during `fetch_sample_data`.
- **Testing:**
  - Added integration tests for AzureSQL temporal tables covering metadata and auto-classification workflows.
  - Added unit tests to verify proper column exclusion and handling of empty column sets in `AzureSQLSampler`.
  - Added PII processor test cases including `azuresql_temporal_table.py` and updates to `customers_sensitive.py`.

<sub>This will update automatically on new commits.</sub>