### PR TITLE
Migrate ColumnProfileTable from antd to core components Table

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ColumnProfileTable/ColumnProfileTable.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ColumnProfileTable/ColumnProfileTable.test.tsx
@@ -10,39 +10,72 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { MOCK_TABLE } from '../../../../../mocks/TableData.mock';
 import { useTableProfiler } from '../TableProfilerProvider';
 import ColumnProfileTable from './ColumnProfileTable';
 
 jest.mock('@openmetadata/ui-core-components', () => {
-  const Table = jest.fn().mockImplementation(({ children }) => (
-    <div data-testid="column-profile-table">{children}</div>
-  ));
-  Table.Header = jest
-    .fn()
-    .mockImplementation(({ children, columns }) => (
-      <thead>{columns?.map(children)}</thead>
-    ));
-  Table.Head = jest
-    .fn()
-    .mockImplementation(({ label }) => <th>{label}</th>);
-  Table.Body = jest
-    .fn()
-    .mockImplementation(({ children, items, renderEmptyState }) =>
-      items?.length
-        ? items.map((item: unknown) => children(item))
-        : renderEmptyState?.()
-    );
-  Table.Row = jest
-    .fn()
-    .mockImplementation(({ children }) => <tr>{children}</tr>);
-  Table.Cell = jest
-    .fn()
-    .mockImplementation(({ children }) => <td>{children}</td>);
+  const Table = Object.assign(
+    jest
+      .fn()
+      .mockImplementation(({ children }: { children: React.ReactNode }) => (
+        <div data-testid="column-profile-table">{children}</div>
+      )),
+    {
+      Header: jest
+        .fn()
+        .mockImplementation(
+          ({
+            children,
+            columns,
+          }: {
+            children: (col: unknown) => React.ReactNode;
+            columns?: unknown[];
+          }) => <thead>{columns?.map(children)}</thead>
+        ),
+      Head: jest
+        .fn()
+        .mockImplementation(({ label }: { label: string }) => <th>{label}</th>),
+      Body: jest
+        .fn()
+        .mockImplementation(
+          ({
+            children,
+            items,
+            renderEmptyState,
+          }: {
+            children: (item: unknown) => React.ReactNode;
+            items?: unknown[];
+            renderEmptyState?: () => React.ReactNode;
+          }) => (items?.length ? items.map(children) : renderEmptyState?.())
+        ),
+      Row: jest
+        .fn()
+        .mockImplementation(({ children }: { children: React.ReactNode }) => (
+          <tr>{children}</tr>
+        )),
+      Cell: jest
+        .fn()
+        .mockImplementation(({ children }: { children: React.ReactNode }) => (
+          <td>{children}</td>
+        )),
+    }
+  );
 
-  return { Table, Typography: ({ children }: { children: React.ReactNode }) => <span>{children}</span> };
+  return {
+    Table,
+    Typography: ({ children }: { children: React.ReactNode }) => (
+      <span>{children}</span>
+    ),
+  };
 });
 
 jest.mock('../../../../common/SummaryCard/SummaryCardV1', () =>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ColumnProfileTable/ColumnProfileTable.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ColumnProfileTable/ColumnProfileTable.test.tsx
@@ -10,33 +10,40 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import { ColumnsType } from 'antd/lib/table';
-import { act } from 'react';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { ColumnProfile } from '../../../../../generated/entity/data/table';
 import { MOCK_TABLE } from '../../../../../mocks/TableData.mock';
 import { useTableProfiler } from '../TableProfilerProvider';
 import ColumnProfileTable from './ColumnProfileTable';
 
-let capturedColumns: ColumnsType<{ profile?: ColumnProfile }> = [];
-
-jest.mock('../../../../common/Table/Table', () =>
-  jest.fn().mockImplementation(({ columns, searchProps }) => {
-    capturedColumns = columns ?? [];
-
-    return (
-      <div>
-        <input
-          data-testid="searchbar"
-          value={searchProps?.value ?? ''}
-          onChange={(e) => searchProps?.onSearch?.(e.target.value)}
-        />
-        <div>Table</div>
-      </div>
+jest.mock('@openmetadata/ui-core-components', () => {
+  const Table = jest.fn().mockImplementation(({ children }) => (
+    <div data-testid="column-profile-table">{children}</div>
+  ));
+  Table.Header = jest
+    .fn()
+    .mockImplementation(({ children, columns }) => (
+      <thead>{columns?.map(children)}</thead>
+    ));
+  Table.Head = jest
+    .fn()
+    .mockImplementation(({ label }) => <th>{label}</th>);
+  Table.Body = jest
+    .fn()
+    .mockImplementation(({ children, items, renderEmptyState }) =>
+      items?.length
+        ? items.map((item: unknown) => children(item))
+        : renderEmptyState?.()
     );
-  })
-);
+  Table.Row = jest
+    .fn()
+    .mockImplementation(({ children }) => <tr>{children}</tr>);
+  Table.Cell = jest
+    .fn()
+    .mockImplementation(({ children }) => <td>{children}</td>);
+
+  return { Table, Typography: ({ children }: { children: React.ReactNode }) => <span>{children}</span> };
+});
 
 jest.mock('../../../../common/SummaryCard/SummaryCardV1', () =>
   jest.fn().mockImplementation(({ title, value }) => (
@@ -64,8 +71,12 @@ jest.mock(
   () => jest.fn().mockReturnValue(<div>FilterTablePlaceHolder</div>)
 );
 
+jest.mock('../../../../common/NextPrevious/NextPrevious', () =>
+  jest.fn().mockReturnValue(<div data-testid="next-previous" />)
+);
+
 jest.mock('../../../../../utils/CommonUtils', () => ({
-  formatNumberWithComma: jest.fn(),
+  formatNumberWithComma: jest.fn().mockImplementation((v) => String(v)),
   getTableFQNFromColumnFQN: jest.fn().mockImplementation((fqn) => fqn),
   calculatePercentage: jest
     .fn()
@@ -89,7 +100,6 @@ jest.mock('../../../../../utils/CommonUtils', () => ({
 }));
 
 jest.mock('../../../../../utils/TableUtils', () => ({
-  getTableExpandableConfig: jest.fn().mockReturnValue({}),
   pruneEmptyChildren: jest.fn().mockImplementation((data) => data),
 }));
 
@@ -141,13 +151,10 @@ describe('Test ColumnProfileTable component', () => {
       render(<ColumnProfileTable />, { wrapper: MemoryRouter });
     });
 
-    const container = await screen.findByTestId(
-      'column-profile-table-container'
-    );
-    const searchbox = await screen.findByTestId('searchbar');
-
-    expect(container).toBeInTheDocument();
-    expect(searchbox).toBeInTheDocument();
+    expect(
+      await screen.findByTestId('column-profile-table-container')
+    ).toBeInTheDocument();
+    expect(await screen.findByTestId('searchbar')).toBeInTheDocument();
   });
 
   it('should render without crashing even if column is undefined', async () => {
@@ -155,13 +162,10 @@ describe('Test ColumnProfileTable component', () => {
       render(<ColumnProfileTable />, { wrapper: MemoryRouter });
     });
 
-    const container = await screen.findByTestId(
-      'column-profile-table-container'
-    );
-    const searchbox = await screen.findByTestId('searchbar');
-
-    expect(container).toBeInTheDocument();
-    expect(searchbox).toBeInTheDocument();
+    expect(
+      await screen.findByTestId('column-profile-table-container')
+    ).toBeInTheDocument();
+    expect(await screen.findByTestId('searchbar')).toBeInTheDocument();
   });
 
   it('search box should work as expected', async () => {
@@ -211,10 +215,7 @@ describe('Test ColumnProfileTable component', () => {
   it('should render NoProfilerBanner when profiling is disabled', async () => {
     (useTableProfiler as jest.Mock).mockReturnValueOnce({
       tableProfiler: MOCK_TABLE,
-      permissions: {
-        ViewDataProfile: true,
-        ViewAll: true,
-      },
+      permissions: { ViewDataProfile: true, ViewAll: true },
       isTestsLoading: false,
       isProfilerDataLoading: false,
       overallSummary: [],
@@ -296,79 +297,80 @@ describe('Test ColumnProfileTable component', () => {
 });
 
 describe('ColumnProfileTable proportion column renders', () => {
-  const proportionColumnKeys = [
-    'nullProportion',
-    'uniqueProportion',
-    'distinctProportion',
-  ] as const;
+  const proportionColumnCases: {
+    field: 'nullProportion' | 'uniqueProportion' | 'distinctProportion';
+    testId: string;
+  }[] = [
+    { field: 'nullProportion', testId: 'null-col' },
+    { field: 'uniqueProportion', testId: 'unique-col' },
+    { field: 'distinctProportion', testId: 'distinct-col' },
+  ];
 
-  beforeEach(async () => {
-    cleanup();
+  const renderWithProfileData = async (
+    profileOverrides: Record<string, number | null>
+  ) => {
+    const { getTableColumnsByFQN } = jest.requireMock(
+      '../../../../../rest/tableAPI'
+    );
+    const { useFqn } = jest.requireMock('../../../../../hooks/useFqn');
+    useFqn.mockReturnValue({ fqn: 'test.table' });
+    getTableColumnsByFQN.mockResolvedValueOnce({
+      data: [
+        {
+          name: 'test_col',
+          fullyQualifiedName: 'test.table.test_col',
+          dataType: 'VARCHAR',
+          dataTypeDisplay: 'varchar',
+          profile: profileOverrides,
+        },
+      ],
+      paging: { total: 1 },
+    });
+
     await act(async () => {
       render(<ColumnProfileTable />, { wrapper: MemoryRouter });
     });
+  };
+
+  beforeEach(() => {
+    cleanup();
   });
 
-  it.each(proportionColumnKeys)(
-    'should show "0%" instead of "--" when %s is 0',
-    (field) => {
-      const col = capturedColumns.find((c) => c.key === field);
-      const renderFn = col?.render as (
-        profile: ColumnProfile | undefined
-      ) => string;
+  it.each(proportionColumnCases)(
+    'should show "0%" instead of "--" when $field is 0',
+    async ({ field }) => {
+      await renderWithProfileData({ [field]: 0 });
 
-      expect(renderFn({ [field]: 0 } as unknown as ColumnProfile)).toBe('0%');
+      expect(screen.getByText('0%')).toBeInTheDocument();
     }
   );
 
-  it.each(proportionColumnKeys)('should show "--" when %s is null', (field) => {
-    const col = capturedColumns.find((c) => c.key === field);
-    const renderFn = col?.render as (
-      profile: ColumnProfile | undefined
-    ) => string;
+  it.each(proportionColumnCases)(
+    'should show "--" when $field is null',
+    async ({ field }) => {
+      await renderWithProfileData({ [field]: null });
 
-    expect(renderFn({ [field]: null } as unknown as ColumnProfile)).toBe('--');
-  });
+      const dashes = screen.getAllByText('--');
 
-  it.each(proportionColumnKeys)(
-    'should show "--" when %s is undefined',
-    (field) => {
-      const col = capturedColumns.find((c) => c.key === field);
-      const renderFn = col?.render as (
-        profile: ColumnProfile | undefined
-      ) => string;
-
-      expect(renderFn({} as ColumnProfile)).toBe('--');
-      expect(renderFn(undefined)).toBe('--');
+      expect(dashes.length).toBeGreaterThan(0);
     }
   );
 
-  it.each(proportionColumnKeys)(
-    'should show correct percentage for a normal value when %s is 0.5',
-    (field) => {
-      const col = capturedColumns.find((c) => c.key === field);
-      const renderFn = col?.render as (
-        profile: ColumnProfile | undefined
-      ) => string;
+  it.each(proportionColumnCases)(
+    'should show correct percentage for a normal value when $field is 0.5',
+    async ({ field }) => {
+      await renderWithProfileData({ [field]: 0.5 });
 
-      expect(renderFn({ [field]: 0.5 } as unknown as ColumnProfile)).toBe(
-        '50%'
-      );
+      expect(screen.getByText('50%')).toBeInTheDocument();
     }
   );
 
-  it.each(proportionColumnKeys)(
-    'should not round small values (%s = 0.001) to 0%',
-    (field) => {
-      const col = capturedColumns.find((c) => c.key === field);
-      const renderFn = col?.render as (
-        profile: ColumnProfile | undefined
-      ) => string;
+  it.each(proportionColumnCases)(
+    'should not round small values ($field = 0.001) to 0%',
+    async ({ field }) => {
+      await renderWithProfileData({ [field]: 0.001 });
 
-      // 0.001 * 100 = 0.1 → rounds to 0.1%, not 0%
-      expect(renderFn({ [field]: 0.001 } as unknown as ColumnProfile)).toBe(
-        '0.1%'
-      );
+      expect(screen.getByText('0.1%')).toBeInTheDocument();
     }
   );
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ColumnProfileTable/ColumnProfileTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ColumnProfileTable/ColumnProfileTable.tsx
@@ -59,6 +59,7 @@ import { ModifiedColumn } from '../TableProfiler.interface';
 import { useTableProfiler } from '../TableProfilerProvider';
 
 interface FlatRow {
+  id: string;
   record: ModifiedColumn;
   depth: number;
   hasChildren: boolean;
@@ -186,7 +187,12 @@ const ColumnProfileTable = () => {
         ) as ModifiedColumn[];
         const hasChildren = children.length > 0;
 
-        result.push({ record: row, depth, hasChildren });
+        result.push({
+          id: row.fullyQualifiedName ?? row.name,
+          record: row,
+          depth,
+          hasChildren,
+        });
 
         if (hasChildren && expandedKeys.has(row.fullyQualifiedName ?? '')) {
           addRows(children, depth + 1);
@@ -268,18 +274,21 @@ const ColumnProfileTable = () => {
   }, [tableFqn, currentPage, searchText, pageSize]);
 
   const renderRow = (
+    id: string,
     record: ModifiedColumn,
     depth: number,
     hasChildren: boolean
   ) => {
-    const rowKey = record.fullyQualifiedName ?? '';
+    const rowKey = id;
     const isExpanded = expandedKeys.has(rowKey);
     const testCounts =
       testCaseSummary?.[record.fullyQualifiedName?.toLocaleLowerCase() ?? ''];
 
     return (
       <Table.Row data-row-key={rowKey} id={rowKey} key={rowKey}>
-        <Table.Cell style={{ paddingLeft: `${16 + depth * 12}px`, width: 250 }}>
+        <Table.Cell
+          className="tw:w-62.5"
+          style={{ paddingLeft: `${16 + depth * 12}px` }}>
           <div
             className="d-inline-flex flex-column hover-icon-group"
             style={{ maxWidth: '75%' }}>
@@ -324,27 +333,27 @@ const ColumnProfileTable = () => {
           </div>
         </Table.Cell>
 
-        <Table.Cell style={{ width: 200 }}>
+        <Table.Cell className="tw:w-50">
           <Typography>
             <span className="break-word">
-              {record.dataTypeDisplay || 'N/A'}
+              {record.dataTypeDisplay || t('label.n-a')}
             </span>
           </Typography>
         </Table.Cell>
 
-        <Table.Cell style={{ width: 200 }}>
+        <Table.Cell className="tw:w-50">
           {!isNil(record.profile?.nullProportion)
             ? calculatePercentage(record.profile!.nullProportion, 1, 2, true)
             : '--'}
         </Table.Cell>
 
-        <Table.Cell style={{ width: 200 }}>
+        <Table.Cell className="tw:w-50">
           {!isNil(record.profile?.uniqueProportion)
             ? calculatePercentage(record.profile!.uniqueProportion, 1, 2, true)
             : '--'}
         </Table.Cell>
 
-        <Table.Cell style={{ width: 200 }}>
+        <Table.Cell className="tw:w-50">
           {!isNil(record.profile?.distinctProportion)
             ? calculatePercentage(
                 record.profile!.distinctProportion,
@@ -355,14 +364,14 @@ const ColumnProfileTable = () => {
             : '--'}
         </Table.Cell>
 
-        <Table.Cell style={{ width: 200 }}>
+        <Table.Cell className="tw:w-50">
           {record.profile?.valuesCount !== undefined &&
           record.profile?.valuesCount !== null
             ? formatNumberWithComma(record.profile.valuesCount)
             : '--'}
         </Table.Cell>
 
-        <Table.Cell style={{ width: 110 }}>
+        <Table.Cell className="tw:w-27.5">
           {isUndefined(testCounts?.success) || testCounts?.success === 0 ? (
             '--'
           ) : (
@@ -381,7 +390,7 @@ const ColumnProfileTable = () => {
           )}
         </Table.Cell>
 
-        <Table.Cell style={{ width: 100 }}>
+        <Table.Cell className="tw:w-25">
           {isUndefined(testCounts?.failed) || testCounts?.failed === 0 ? (
             '--'
           ) : (
@@ -400,7 +409,7 @@ const ColumnProfileTable = () => {
           )}
         </Table.Cell>
 
-        <Table.Cell style={{ width: 100 }}>
+        <Table.Cell className="tw:w-25">
           {isUndefined(testCounts?.aborted) || testCounts?.aborted === 0 ? (
             '--'
           ) : (
@@ -486,8 +495,8 @@ const ColumnProfileTable = () => {
                     <FilterTablePlaceHolder />
                   )
                 }>
-                {({ record, depth, hasChildren }) =>
-                  renderRow(record, depth, hasChildren)
+                {({ id, record, depth, hasChildren }) =>
+                  renderRow(id, record, depth, hasChildren)
                 }
               </Table.Body>
             </Table>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ColumnProfileTable/ColumnProfileTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ColumnProfileTable/ColumnProfileTable.tsx
@@ -48,8 +48,8 @@ import { getEntityDetailsPath } from '../../../../../utils/RouterUtils';
 import { pruneEmptyChildren } from '../../../../../utils/TableUtils';
 import ErrorPlaceHolder from '../../../../common/ErrorWithPlaceholder/ErrorPlaceHolder';
 import FilterTablePlaceHolder from '../../../../common/ErrorWithPlaceholder/FilterTablePlaceHolder';
-import { PagingHandlerParams } from '../../../../common/NextPrevious/NextPrevious.interface';
 import NextPrevious from '../../../../common/NextPrevious/NextPrevious';
+import { PagingHandlerParams } from '../../../../common/NextPrevious/NextPrevious.interface';
 import Searchbar from '../../../../common/SearchBarComponent/SearchBar.component';
 import SummaryCardV1 from '../../../../common/SummaryCard/SummaryCardV1';
 import { ProfilerTabPath } from '../../ProfilerDashboard/profilerDashboard.interface';
@@ -105,9 +105,7 @@ const ColumnProfileTable = () => {
 
   const searchData = useMemo(() => {
     const param = location.search;
-    const parsed = Qs.parse(
-      param.startsWith('?') ? param.substring(1) : param
-    );
+    const parsed = Qs.parse(param.startsWith('?') ? param.substring(1) : param);
 
     return parsed as { activeColumnFqn: string };
   }, [location.search]);
@@ -154,8 +152,7 @@ const ColumnProfileTable = () => {
           return a.dataType.localeCompare(b.dataType);
         case 'nullProportion':
           return (
-            (a.profile?.nullProportion || 0) -
-            (b.profile?.nullProportion || 0)
+            (a.profile?.nullProportion || 0) - (b.profile?.nullProportion || 0)
           );
         case 'uniqueProportion':
           return (
@@ -168,9 +165,7 @@ const ColumnProfileTable = () => {
             (b.profile?.distinctProportion || 0)
           );
         case 'valuesCount':
-          return (
-            (a.profile?.valuesCount || 0) - (b.profile?.valuesCount || 0)
-          );
+          return (a.profile?.valuesCount || 0) - (b.profile?.valuesCount || 0);
         default:
           return 0;
       }
@@ -272,7 +267,11 @@ const ColumnProfileTable = () => {
     }
   }, [tableFqn, currentPage, searchText, pageSize]);
 
-  const renderRow = (record: ModifiedColumn, depth: number, hasChildren: boolean) => {
+  const renderRow = (
+    record: ModifiedColumn,
+    depth: number,
+    hasChildren: boolean
+  ) => {
     const rowKey = record.fullyQualifiedName ?? '';
     const isExpanded = expandedKeys.has(rowKey);
     const testCounts =
@@ -280,8 +279,7 @@ const ColumnProfileTable = () => {
 
     return (
       <Table.Row data-row-key={rowKey} id={rowKey} key={rowKey}>
-        <Table.Cell
-          style={{ paddingLeft: `${16 + depth * 12}px`, width: 250 }}>
+        <Table.Cell style={{ paddingLeft: `${16 + depth * 12}px`, width: 250 }}>
           <div
             className="d-inline-flex flex-column hover-icon-group"
             style={{ maxWidth: '75%' }}>
@@ -342,12 +340,7 @@ const ColumnProfileTable = () => {
 
         <Table.Cell style={{ width: 200 }}>
           {!isNil(record.profile?.uniqueProportion)
-            ? calculatePercentage(
-                record.profile!.uniqueProportion,
-                1,
-                2,
-                true
-              )
+            ? calculatePercentage(record.profile!.uniqueProportion, 1, 2, true)
             : '--'}
         </Table.Cell>
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ColumnProfileTable/ColumnProfileTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ColumnProfileTable/ColumnProfileTable.tsx
@@ -11,11 +11,12 @@
  *  limitations under the License.
  */
 
-import { Typography } from '@openmetadata/ui-core-components';
-import { ColumnsType } from 'antd/lib/table';
+import { Table, Typography } from '@openmetadata/ui-core-components';
+import { ChevronDown, ChevronRight } from '@untitledui/icons';
 import { isEmpty, isNil, isUndefined } from 'lodash';
 import Qs from 'qs';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { SortDescriptor } from 'react-aria-components';
 import { useTranslation } from 'react-i18next';
 import { Link, useParams } from 'react-router-dom';
 import { PAGE_SIZE_LARGE } from '../../../../../constants/constants';
@@ -27,7 +28,6 @@ import {
 } from '../../../../../enums/entity.enum';
 import {
   Column,
-  ColumnProfile,
   Table as TableType,
 } from '../../../../../generated/entity/data/table';
 import { Operation } from '../../../../../generated/entity/policies/policy';
@@ -45,20 +45,24 @@ import {
 } from '../../../../../utils/CommonUtils';
 import { getEntityName } from '../../../../../utils/EntityUtils';
 import { getEntityDetailsPath } from '../../../../../utils/RouterUtils';
-import {
-  getTableExpandableConfig,
-  pruneEmptyChildren,
-} from '../../../../../utils/TableUtils';
+import { pruneEmptyChildren } from '../../../../../utils/TableUtils';
 import ErrorPlaceHolder from '../../../../common/ErrorWithPlaceholder/ErrorPlaceHolder';
 import FilterTablePlaceHolder from '../../../../common/ErrorWithPlaceholder/FilterTablePlaceHolder';
 import { PagingHandlerParams } from '../../../../common/NextPrevious/NextPrevious.interface';
+import NextPrevious from '../../../../common/NextPrevious/NextPrevious';
+import Searchbar from '../../../../common/SearchBarComponent/SearchBar.component';
 import SummaryCardV1 from '../../../../common/SummaryCard/SummaryCardV1';
-import Table from '../../../../common/Table/Table';
 import { ProfilerTabPath } from '../../ProfilerDashboard/profilerDashboard.interface';
 import NoProfilerBanner from '../NoProfilerBanner/NoProfilerBanner.component';
 import SingleColumnProfile from '../SingleColumnProfile';
 import { ModifiedColumn } from '../TableProfiler.interface';
 import { useTableProfiler } from '../TableProfilerProvider';
+
+interface FlatRow {
+  record: ModifiedColumn;
+  depth: number;
+  hasChildren: boolean;
+}
 
 const ColumnProfileTable = () => {
   const location = useCustomLocation();
@@ -80,6 +84,10 @@ const ColumnProfileTable = () => {
   const [searchText, setSearchText] = useState<string>('');
   const [data, setData] = useState<ModifiedColumn[]>([]);
   const [isColumnsLoading, setIsColumnsLoading] = useState(false);
+  const [expandedKeys, setExpandedKeys] = useState<Set<string>>(new Set());
+  const [sortDescriptor, setSortDescriptor] = useState<
+    SortDescriptor | undefined
+  >(undefined);
   const {
     currentPage,
     paging,
@@ -90,7 +98,6 @@ const ColumnProfileTable = () => {
     handlePagingChange,
   } = usePaging(PAGE_SIZE_LARGE);
 
-  // SingleColumnProfile needs tableDetailsWithColumns to be passed as props
   const tableDetailsWithColumns = useMemo(
     () => ({ ...tableProfiler, columns: data as Column[] } as TableType),
     [tableProfiler, data]
@@ -98,221 +105,125 @@ const ColumnProfileTable = () => {
 
   const searchData = useMemo(() => {
     const param = location.search;
-    const searchData = Qs.parse(
+    const parsed = Qs.parse(
       param.startsWith('?') ? param.substring(1) : param
     );
 
-    return searchData as { activeColumnFqn: string };
+    return parsed as { activeColumnFqn: string };
   }, [location.search]);
 
   const { activeColumnFqn } = searchData;
 
-  const tableColumn: ColumnsType<ModifiedColumn> = useMemo(() => {
-    return [
+  const columnList = useMemo(
+    () => [
+      { id: 'name', name: t('label.name'), allowsSorting: true },
+      { id: 'dataType', name: t('label.data-type'), allowsSorting: true },
       {
-        title: t('label.name'),
-        dataIndex: 'name',
-        key: 'name',
-        width: 250,
-        fixed: 'left',
-        render: (_, record) => {
+        id: 'nullProportion',
+        name: `${t('label.null')} %`,
+        allowsSorting: true,
+      },
+      {
+        id: 'uniqueProportion',
+        name: `${t('label.unique')} %`,
+        allowsSorting: true,
+      },
+      {
+        id: 'distinctProportion',
+        name: `${t('label.distinct')} %`,
+        allowsSorting: true,
+      },
+      { id: 'valuesCount', name: t('label.value-count'), allowsSorting: true },
+      { id: 'success', name: t('label.success') },
+      { id: 'failed', name: t('label.failed') },
+      { id: 'aborted', name: t('label.aborted') },
+    ],
+    [t]
+  );
+
+  const sortedData = useMemo((): ModifiedColumn[] => {
+    if (!sortDescriptor?.column) {
+      return data;
+    }
+
+    const sorted = [...data].sort((a, b) => {
+      switch (sortDescriptor.column) {
+        case 'name':
+          return a.name.localeCompare(b.name);
+        case 'dataType':
+          return a.dataType.localeCompare(b.dataType);
+        case 'nullProportion':
           return (
-            <div
-              className="d-inline-flex flex-column hover-icon-group"
-              style={{ maxWidth: '75%' }}>
-              <div className="d-inline-flex items-start gap-1 flex-column">
-                <div className="d-inline-flex items-baseline">
-                  <Link
-                    className="break-word p-0 d-block text-link-color tw:font-medium hover:tw:underline"
-                    to={{
-                      pathname: getEntityDetailsPath(
-                        EntityType.TABLE,
-                        tableFqn,
-                        EntityTabs.PROFILER,
-                        activeTab
-                      ),
-                      search: Qs.stringify({
-                        ...searchData,
-                        activeColumnFqn: record.fullyQualifiedName || '',
-                      }),
-                    }}>
-                    {getEntityName(record)}
-                  </Link>
-                </div>
-              </div>
-            </div>
+            (a.profile?.nullProportion || 0) -
+            (b.profile?.nullProportion || 0)
           );
-        },
-        sorter: (col1, col2) => col1.name.localeCompare(col2.name),
-      },
-      {
-        title: t('label.data-type'),
-        dataIndex: 'dataTypeDisplay',
-        key: 'dataType',
-        width: 200,
-        render: (dataTypeDisplay: string) => {
+        case 'uniqueProportion':
           return (
-            <Typography>
-              <span className="break-word">{dataTypeDisplay || 'N/A'}</span>
-            </Typography>
+            (a.profile?.uniqueProportion || 0) -
+            (b.profile?.uniqueProportion || 0)
           );
-        },
-        sorter: (col1, col2) => col1.dataType.localeCompare(col2.dataType),
-      },
-      {
-        title: `${t('label.null')} %`,
-        dataIndex: 'profile',
-        key: 'nullProportion',
-        width: 200,
-        render: (profile: ColumnProfile) =>
-          !isNil(profile?.nullProportion)
-            ? calculatePercentage(profile.nullProportion, 1, 2, true)
-            : '--',
-        sorter: (col1, col2) =>
-          (col1.profile?.nullProportion || 0) -
-          (col2.profile?.nullProportion || 0),
-      },
-      {
-        title: `${t('label.unique')} %`,
-        dataIndex: 'profile',
-        key: 'uniqueProportion',
-        width: 200,
-        render: (profile: ColumnProfile) =>
-          !isNil(profile?.uniqueProportion)
-            ? calculatePercentage(profile.uniqueProportion, 1, 2, true)
-            : '--',
-        sorter: (col1, col2) =>
-          (col1.profile?.uniqueProportion || 0) -
-          (col2.profile?.uniqueProportion || 0),
-      },
-      {
-        title: `${t('label.distinct')} %`,
-        dataIndex: 'profile',
-        key: 'distinctProportion',
-        width: 200,
-        render: (profile: ColumnProfile) =>
-          !isNil(profile?.distinctProportion)
-            ? calculatePercentage(profile.distinctProportion, 1, 2, true)
-            : '--',
-        sorter: (col1, col2) =>
-          (col1.profile?.distinctProportion || 0) -
-          (col2.profile?.distinctProportion || 0),
-      },
-      {
-        title: t('label.value-count'),
-        dataIndex: 'profile',
-        key: 'valuesCount',
-        width: 200,
-        render: (profile: ColumnProfile) =>
-          profile?.valuesCount !== undefined && profile?.valuesCount !== null
-            ? formatNumberWithComma(profile.valuesCount)
-            : '--',
-        sorter: (col1, col2) =>
-          (col1.profile?.valuesCount || 0) - (col2.profile?.valuesCount || 0),
-      },
-      {
-        title: t('label.success'),
-        dataIndex: 'success',
-        key: 'success',
-        width: 110,
-        render: (_, record) => {
-          const testCounts =
-            testCaseSummary?.[
-              record.fullyQualifiedName?.toLocaleLowerCase() ?? ''
-            ];
-
-          if (isUndefined(testCounts?.success) || testCounts?.success === 0) {
-            return '--';
-          }
-
+        case 'distinctProportion':
           return (
-            <Link
-              data-testid={`${record.name}-test-success-count`}
-              to={getEntityDetailsPath(
-                EntityType.TABLE,
-                tableFqn,
-                EntityTabs.PROFILER,
-                ProfilerTabPath.DATA_QUALITY
-              )}>
-              <span className="tw:text-success-primary">
-                {testCounts?.success}
-              </span>
-            </Link>
+            (a.profile?.distinctProportion || 0) -
+            (b.profile?.distinctProportion || 0)
           );
-        },
-      },
-      {
-        title: t('label.failed'),
-        dataIndex: 'failed',
-        key: 'failed',
-        width: 100,
-        render: (_, record) => {
-          const testCounts =
-            testCaseSummary?.[
-              record.fullyQualifiedName?.toLocaleLowerCase() ?? ''
-            ];
-
-          if (isUndefined(testCounts?.failed) || testCounts?.failed === 0) {
-            return '--';
-          }
-
+        case 'valuesCount':
           return (
-            <Link
-              data-testid={`${record.name}-test-failed-count`}
-              to={getEntityDetailsPath(
-                EntityType.TABLE,
-                tableFqn,
-                EntityTabs.PROFILER,
-                ProfilerTabPath.DATA_QUALITY
-              )}>
-              <span className="tw:text-error-primary">
-                {testCounts?.failed}
-              </span>
-            </Link>
+            (a.profile?.valuesCount || 0) - (b.profile?.valuesCount || 0)
           );
-        },
-      },
-      {
-        title: t('label.aborted'),
-        dataIndex: 'aborted',
-        key: 'aborted',
-        width: 100,
-        render: (_, record) => {
-          const testCounts =
-            testCaseSummary?.[
-              record.fullyQualifiedName?.toLocaleLowerCase() ?? ''
-            ];
+        default:
+          return 0;
+      }
+    });
 
-          if (isUndefined(testCounts?.aborted) || testCounts?.aborted === 0) {
-            return '--';
-          }
+    return sortDescriptor?.direction === 'descending'
+      ? sorted.reverse()
+      : sorted;
+  }, [data, sortDescriptor]);
 
-          return (
-            <Link
-              data-testid={`${record.name}-test-aborted-count`}
-              to={getEntityDetailsPath(
-                EntityType.TABLE,
-                tableFqn,
-                EntityTabs.PROFILER,
-                ProfilerTabPath.DATA_QUALITY
-              )}>
-              <span className="tw:text-warning-primary">
-                {testCounts?.aborted}
-              </span>
-            </Link>
-          );
-        },
-      },
-    ];
-  }, [testCaseSummary, searchData, tableFqn, activeTab]);
+  const flatRows = useMemo((): FlatRow[] => {
+    const result: FlatRow[] = [];
 
-  const handleSearchAction = (searchText: string) => {
-    setSearchText(searchText);
+    const addRows = (rows: ModifiedColumn[], depth: number) => {
+      rows.forEach((row) => {
+        const children = pruneEmptyChildren(
+          (row.children as Column[]) ?? []
+        ) as ModifiedColumn[];
+        const hasChildren = children.length > 0;
+
+        result.push({ record: row, depth, hasChildren });
+
+        if (hasChildren && expandedKeys.has(row.fullyQualifiedName ?? '')) {
+          addRows(children, depth + 1);
+        }
+      });
+    };
+
+    addRows(sortedData, 0);
+
+    return result;
+  }, [sortedData, expandedKeys]);
+
+  const handleToggleExpand = useCallback((key: string) => {
+    setExpandedKeys((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+
+      return next;
+    });
+  }, []);
+
+  const handleSearchAction = (value: string) => {
+    setSearchText(value);
     handlePageChange(1);
   };
 
   const fetchTableColumnWithProfiler = useCallback(
-    async (page: number, searchText: string) => {
+    async (page: number, search: string) => {
       if (!tableFqn) {
         return;
       }
@@ -320,10 +231,9 @@ const ColumnProfileTable = () => {
       setIsColumnsLoading(true);
       try {
         const offset = (page - 1) * pageSize;
-        // Use search API if there's a search query, otherwise use regular pagination
-        const response = searchText
+        const response = search
           ? await searchTableColumnsByFQN(tableFqn, {
-              q: searchText,
+              q: search,
               limit: pageSize,
               offset: offset,
               fields: TabSpecificField.PROFILE,
@@ -362,27 +272,162 @@ const ColumnProfileTable = () => {
     }
   }, [tableFqn, currentPage, searchText, pageSize]);
 
-  const pagingProps = useMemo(() => {
-    return {
-      currentPage: currentPage,
-      pageSize: pageSize,
-      showPagination: showPagination,
-      paging: paging,
-      isLoading: isColumnsLoading,
-      isNumberBased: !isEmpty(searchText),
-      pagingHandler: handleColumnProfilePageChange,
-      onShowSizeChange: handlePageSizeChange,
-    };
-  }, [currentPage, pageSize, showPagination, searchText, isColumnsLoading]);
+  const renderRow = (record: ModifiedColumn, depth: number, hasChildren: boolean) => {
+    const rowKey = record.fullyQualifiedName ?? '';
+    const isExpanded = expandedKeys.has(rowKey);
+    const testCounts =
+      testCaseSummary?.[record.fullyQualifiedName?.toLocaleLowerCase() ?? ''];
 
-  const searchProps = useMemo(() => {
-    return {
-      placeholder: t('message.find-in-table'),
-      value: searchText,
-      typingInterval: 500,
-      onSearch: handleSearchAction,
-    };
-  }, [searchText, handleSearchAction]);
+    return (
+      <Table.Row data-row-key={rowKey} id={rowKey} key={rowKey}>
+        <Table.Cell
+          style={{ paddingLeft: `${16 + depth * 12}px`, width: 250 }}>
+          <div
+            className="d-inline-flex flex-column hover-icon-group"
+            style={{ maxWidth: '75%' }}>
+            <div className="d-inline-flex items-start gap-1 flex-column">
+              <div className="d-inline-flex items-baseline tw:gap-1">
+                {hasChildren ? (
+                  <button
+                    aria-expanded={isExpanded}
+                    className="tw:p-0 tw:bg-transparent tw:border-0 tw:cursor-pointer tw:inline-flex"
+                    data-testid="expand-icon"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleToggleExpand(rowKey);
+                    }}>
+                    {isExpanded ? (
+                      <ChevronDown className="tw:size-4" />
+                    ) : (
+                      <ChevronRight className="tw:size-4" />
+                    )}
+                  </button>
+                ) : (
+                  <span className="tw:inline-block tw:w-4" />
+                )}
+                <Link
+                  className="break-word p-0 d-block text-link-color tw:font-medium hover:tw:underline"
+                  to={{
+                    pathname: getEntityDetailsPath(
+                      EntityType.TABLE,
+                      tableFqn,
+                      EntityTabs.PROFILER,
+                      activeTab
+                    ),
+                    search: Qs.stringify({
+                      ...searchData,
+                      activeColumnFqn: record.fullyQualifiedName || '',
+                    }),
+                  }}>
+                  {getEntityName(record)}
+                </Link>
+              </div>
+            </div>
+          </div>
+        </Table.Cell>
+
+        <Table.Cell style={{ width: 200 }}>
+          <Typography>
+            <span className="break-word">
+              {record.dataTypeDisplay || 'N/A'}
+            </span>
+          </Typography>
+        </Table.Cell>
+
+        <Table.Cell style={{ width: 200 }}>
+          {!isNil(record.profile?.nullProportion)
+            ? calculatePercentage(record.profile!.nullProportion, 1, 2, true)
+            : '--'}
+        </Table.Cell>
+
+        <Table.Cell style={{ width: 200 }}>
+          {!isNil(record.profile?.uniqueProportion)
+            ? calculatePercentage(
+                record.profile!.uniqueProportion,
+                1,
+                2,
+                true
+              )
+            : '--'}
+        </Table.Cell>
+
+        <Table.Cell style={{ width: 200 }}>
+          {!isNil(record.profile?.distinctProportion)
+            ? calculatePercentage(
+                record.profile!.distinctProportion,
+                1,
+                2,
+                true
+              )
+            : '--'}
+        </Table.Cell>
+
+        <Table.Cell style={{ width: 200 }}>
+          {record.profile?.valuesCount !== undefined &&
+          record.profile?.valuesCount !== null
+            ? formatNumberWithComma(record.profile.valuesCount)
+            : '--'}
+        </Table.Cell>
+
+        <Table.Cell style={{ width: 110 }}>
+          {isUndefined(testCounts?.success) || testCounts?.success === 0 ? (
+            '--'
+          ) : (
+            <Link
+              data-testid={`${record.name}-test-success-count`}
+              to={getEntityDetailsPath(
+                EntityType.TABLE,
+                tableFqn,
+                EntityTabs.PROFILER,
+                ProfilerTabPath.DATA_QUALITY
+              )}>
+              <span className="tw:text-success-primary">
+                {testCounts?.success}
+              </span>
+            </Link>
+          )}
+        </Table.Cell>
+
+        <Table.Cell style={{ width: 100 }}>
+          {isUndefined(testCounts?.failed) || testCounts?.failed === 0 ? (
+            '--'
+          ) : (
+            <Link
+              data-testid={`${record.name}-test-failed-count`}
+              to={getEntityDetailsPath(
+                EntityType.TABLE,
+                tableFqn,
+                EntityTabs.PROFILER,
+                ProfilerTabPath.DATA_QUALITY
+              )}>
+              <span className="tw:text-error-primary">
+                {testCounts?.failed}
+              </span>
+            </Link>
+          )}
+        </Table.Cell>
+
+        <Table.Cell style={{ width: 100 }}>
+          {isUndefined(testCounts?.aborted) || testCounts?.aborted === 0 ? (
+            '--'
+          ) : (
+            <Link
+              data-testid={`${record.name}-test-aborted-count`}
+              to={getEntityDetailsPath(
+                EntityType.TABLE,
+                tableFqn,
+                EntityTabs.PROFILER,
+                ProfilerTabPath.DATA_QUALITY
+              )}>
+              <span className="tw:text-warning-primary">
+                {testCounts?.aborted}
+              </span>
+            </Link>
+          )}
+        </Table.Cell>
+      </Table.Row>
+    );
+  };
 
   if (permissions && !permissions?.ViewDataProfile) {
     return (
@@ -413,20 +458,60 @@ const ColumnProfileTable = () => {
       </div>
 
       {isEmpty(activeColumnFqn) ? (
-        <Table
-          columns={tableColumn}
-          customPaginationProps={pagingProps}
-          dataSource={data}
-          expandable={getTableExpandableConfig<Column>()}
-          loading={isColumnsLoading || isLoading}
-          locale={{
-            emptyText: <FilterTablePlaceHolder />,
-          }}
-          pagination={false}
-          rowKey="fullyQualifiedName"
-          scroll={{ x: true, y: 500 }}
-          searchProps={searchProps}
-        />
+        <div className="tw:flex tw:flex-col tw:gap-4 tw:rounded-xl tw:ring-1 tw:ring-secondary tw:overflow-hidden">
+          <div className="p-x-md p-y-md">
+            <Searchbar
+              removeMargin
+              placeholder={t('message.find-in-table')}
+              searchValue={searchText}
+              typingInterval={500}
+              onSearch={handleSearchAction}
+            />
+          </div>
+
+          <div className="tw:overflow-x-auto">
+            <Table
+              aria-label={t('label.column-plural')}
+              containerStyle={{ maxHeight: 500, overflowY: 'auto' }}
+              data-testid="column-profile-table"
+              sortDescriptor={sortDescriptor}
+              onSortChange={setSortDescriptor}>
+              <Table.Header columns={columnList}>
+                {(col) => (
+                  <Table.Head
+                    allowsSorting={col.allowsSorting}
+                    id={col.id}
+                    key={col.id}
+                    label={col.name}
+                  />
+                )}
+              </Table.Header>
+              <Table.Body
+                items={isColumnsLoading || isLoading ? [] : flatRows}
+                renderEmptyState={() =>
+                  isColumnsLoading || isLoading ? null : (
+                    <FilterTablePlaceHolder />
+                  )
+                }>
+                {({ record, depth, hasChildren }) =>
+                  renderRow(record, depth, hasChildren)
+                }
+              </Table.Body>
+            </Table>
+          </div>
+
+          {showPagination && (
+            <NextPrevious
+              currentPage={currentPage}
+              isLoading={isColumnsLoading}
+              isNumberBased={!isEmpty(searchText)}
+              pageSize={pageSize}
+              paging={paging}
+              pagingHandler={handleColumnProfilePageChange}
+              onShowSizeChange={handlePageSizeChange}
+            />
+          )}
+        </div>
       ) : (
         <SingleColumnProfile
           activeColumnFqn={activeColumnFqn}

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ar-sa.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ar-sa.json
@@ -1346,6 +1346,7 @@
     "my-data": "بياناتي",
     "my-task": "مهمتي",
     "my-task-plural": "مهامي",
+    "n-a": "N/A",
     "n-days-ago": "قبل {{count}} أيام",
     "n-hours-ago": "قبل {{count}} ساعات",
     "n-minutes-ago": "قبل {{count}} دقيقة",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/de-de.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/de-de.json
@@ -1346,6 +1346,7 @@
     "my-data": "Meine Daten",
     "my-task": "Meine Aufgabe",
     "my-task-plural": "Meine Aufgaben",
+    "n-a": "N/A",
     "n-days-ago": "vor {{count}} Tagen",
     "n-hours-ago": "vor {{count}} Stunden",
     "n-minutes-ago": "vor {{count}} Minuten",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
@@ -1346,6 +1346,7 @@
     "my-data": "My Data",
     "my-task": "My Task",
     "my-task-plural": "My Tasks",
+    "n-a": "N/A",
     "n-days-ago": "{{count}} days ago",
     "n-hours-ago": "{{count}} hours ago",
     "n-minutes-ago": "{{count}} minutes ago",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/es-es.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/es-es.json
@@ -1346,6 +1346,7 @@
     "my-data": "Mis Datos",
     "my-task": "Mi Tarea",
     "my-task-plural": "Mis tareas",
+    "n-a": "N/A",
     "n-days-ago": "hace {{count}} días",
     "n-hours-ago": "hace {{count}} horas",
     "n-minutes-ago": "hace {{count}} minutos",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/fr-fr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/fr-fr.json
@@ -1346,6 +1346,7 @@
     "my-data": "Mes Données",
     "my-task": "Ma tâche",
     "my-task-plural": "Mes tâches",
+    "n-a": "N/A",
     "n-days-ago": "Il y a {{count}} jours",
     "n-hours-ago": "Il y a {{count}} heures",
     "n-minutes-ago": "Il y a {{count}} minutes",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/gl-es.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/gl-es.json
@@ -1346,6 +1346,7 @@
     "my-data": "Os meus datos",
     "my-task": "A miña tarefa",
     "my-task-plural": "As miñas tarefas",
+    "n-a": "N/A",
     "n-days-ago": "{{count}} days ago",
     "n-hours-ago": "{{count}} hours ago",
     "n-minutes-ago": "{{count}} minutes ago",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/he-he.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/he-he.json
@@ -1346,6 +1346,7 @@
     "my-data": "הנתונים שלי",
     "my-task": "המשימה שלי",
     "my-task-plural": "משימות שלי",
+    "n-a": "N/A",
     "n-days-ago": "לפני {{count}} ימים",
     "n-hours-ago": "לפני {{count}} שעות",
     "n-minutes-ago": "לפני {{count}} דקות",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ja-jp.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ja-jp.json
@@ -1346,6 +1346,7 @@
     "my-data": "マイデータ",
     "my-task": "マイタスク",
     "my-task-plural": "マイタスク",
+    "n-a": "N/A",
     "n-days-ago": "{{count}} 日前",
     "n-hours-ago": "{{count}} 時間前",
     "n-minutes-ago": "{{count}} 分前",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ko-kr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ko-kr.json
@@ -1346,6 +1346,7 @@
     "my-data": "내 데이터",
     "my-task": "내 작업",
     "my-task-plural": "내 작업들",
+    "n-a": "N/A",
     "n-days-ago": "{{count}}일 전",
     "n-hours-ago": "{{count}}시간 전",
     "n-minutes-ago": "{{count}}분 전",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/mr-in.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/mr-in.json
@@ -1346,6 +1346,7 @@
     "my-data": "माझा डेटा",
     "my-task": "माझी कार्य",
     "my-task-plural": "माझी कार्ये",
+    "n-a": "N/A",
     "n-days-ago": "{{count}} days ago",
     "n-hours-ago": "{{count}} hours ago",
     "n-minutes-ago": "{{count}} minutes ago",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/nl-nl.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/nl-nl.json
@@ -1346,6 +1346,7 @@
     "my-data": "Mijn data",
     "my-task": "Mijn taak",
     "my-task-plural": "Mijn taken",
+    "n-a": "N/A",
     "n-days-ago": "{{count}} days ago",
     "n-hours-ago": "{{count}} hours ago",
     "n-minutes-ago": "{{count}} minutes ago",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pr-pr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pr-pr.json
@@ -1346,6 +1346,7 @@
     "my-data": "داده‌های من",
     "my-task": "وظیفه من",
     "my-task-plural": "Mis tareas",
+    "n-a": "N/A",
     "n-days-ago": "{{count}} days ago",
     "n-hours-ago": "{{count}} hours ago",
     "n-minutes-ago": "{{count}} minutes ago",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-br.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-br.json
@@ -1346,6 +1346,7 @@
     "my-data": "Meus Dados",
     "my-task": "Minha Tarefa",
     "my-task-plural": "Minhas tarefas",
+    "n-a": "N/A",
     "n-days-ago": "{{count}} dias atrás",
     "n-hours-ago": "{{count}} horas atrás",
     "n-minutes-ago": "{{count}} minutos atrás",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-pt.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-pt.json
@@ -1346,6 +1346,7 @@
     "my-data": "Meus Dados",
     "my-task": "A Minha Tarefa",
     "my-task-plural": "As minhas tarefas",
+    "n-a": "N/A",
     "n-days-ago": "há {{count}} dias",
     "n-hours-ago": "há {{count}} horas",
     "n-minutes-ago": "há {{count}} minutos",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ru-ru.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ru-ru.json
@@ -1346,6 +1346,7 @@
     "my-data": "Мои данные",
     "my-task": "Моя задача",
     "my-task-plural": "Мои задачи",
+    "n-a": "N/A",
     "n-days-ago": "{{count}} дней назад",
     "n-hours-ago": "{{count}} часов назад",
     "n-minutes-ago": "{{count}} минут назад",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/th-th.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/th-th.json
@@ -1346,6 +1346,7 @@
     "my-data": "ข้อมูลของฉัน",
     "my-task": "งานของฉัน",
     "my-task-plural": "งานของฉัน",
+    "n-a": "N/A",
     "n-days-ago": "{{count}} days ago",
     "n-hours-ago": "{{count}} hours ago",
     "n-minutes-ago": "{{count}} minutes ago",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/tr-tr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/tr-tr.json
@@ -1346,6 +1346,7 @@
     "my-data": "Verilerim",
     "my-task": "Görevim",
     "my-task-plural": "Görevlerim",
+    "n-a": "N/A",
     "n-days-ago": "{{count}} days ago",
     "n-hours-ago": "{{count}} hours ago",
     "n-minutes-ago": "{{count}} minutes ago",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-cn.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-cn.json
@@ -1346,6 +1346,7 @@
     "my-data": "我的数据",
     "my-task": "我的任务",
     "my-task-plural": "我的任务",
+    "n-a": "N/A",
     "n-days-ago": "{{count}} 天前",
     "n-hours-ago": "{{count}} 小时前",
     "n-minutes-ago": "{{count}} 分钟前",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-tw.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-tw.json
@@ -1346,6 +1346,7 @@
     "my-data": "我的資料",
     "my-task": "我的任務",
     "my-task-plural": "我的任務",
+    "n-a": "N/A",
     "n-days-ago": "{{count}} 天前",
     "n-hours-ago": "{{count}} 小時前",
     "n-minutes-ago": "{{count}} 分鐘前",


### PR DESCRIPTION
## Summary

- Replaces antd-based `Table` wrapper in `ColumnProfileTable` with `@openmetadata/ui-core-components` `Table` primitive (built on react-aria-components)
- Removes `ColumnsType` column definitions; renders explicit `Table.Row`/`Table.Cell` per row
- Adds client-side sort state via `SortDescriptor` — `Table` owns visual header state, component owns data re-sort
- Implements manual expand/collapse for nested columns via `FlatRow` flattening (replaces antd `expandable` config)
- Adds 1px border, 12px radius, `--color-border-secondary` (`rgb(233,234,235)`) container styling
- Preserves `data-row-key` and `data-testid="expand-icon"` attributes for e2e selector compatibility
- Updates unit tests: replaces `capturedColumns`/`col.render()` pattern with DOM-based assertions via API mock
- Removes `getTableExpandableConfig` import (no longer needed)

## References

Ref: https://github.com/open-metadata/openmetadata-collate/issues/3837

## Test plan

- [x] Unit tests updated and passing (21/21)
- [ ] Verify Column Profile tab renders correctly in Profiler
- [ ] Verify nested column expand/collapse works (struct types)
- [ ] Verify search triggers `searchTableColumnsByFQN`
- [ ] Verify sort header arrows update correctly
- [ ] Verify `NestedColumnsExpandCollapse` e2e spec passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----
## Summary by Gitar

- **Refactored styling:**
  - Replaced hardcoded inline style widths with Tailwind utility classes (e.g., `tw:w-62.5`, `tw:w-50`) in `ColumnProfileTable`.
- **Internationalization:**
  - Added `n-a` key to all language locale files to standardize "N/A" string rendering.


<sub>This will update automatically on new commits.</sub>