### PR TITLE
Migrate IncidentManager table to core-ui Table component

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts
@@ -145,7 +145,7 @@ const isVisible = async (locator: Locator) =>
 
 const expectIncidentTableRowsToContain = async (page: Page, text: string) => {
   const rows = page.locator(
-    '.ant-table-tbody tr:not(.ant-table-measure-row):not(.ant-table-placeholder)'
+    '[data-testid="test-case-incident-manager-table"] tbody tr'
   );
   const rowCount = await rows.count();
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts
@@ -851,9 +851,7 @@ test.describe('Incident Manager', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
         page.locator(`[data-testid="status-badge-${testCaseName}"]`)
       ).toContainText('Failed');
 
-      await page.click(
-        `[data-testid="${testCaseName}"] >> text=${testCaseName}`
-      );
+      await page.getByTestId(testCaseName).getByText(testCaseName).click();
       await expect(page.getByTestId('entity-page-header')).toBeVisible();
       await openIncidentTaskTab(page);
       await page.click('[data-testid="closed-task"]');

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts
@@ -42,10 +42,10 @@ export const acknowledgeTask = async (data: {
     page.locator(`[data-testid="status-badge-${testCase}"]`)
   ).toContainText('Failed');
 
-  await page
-    .locator(`[data-testid="${testCase}-status"] >> text=New`)
-    .waitFor();
-  await page.click(`[data-testid="${testCase}"] >> text=${testCase}`);
+  await expect(
+    page.locator(`[data-testid="${testCase}-status"]`)
+  ).toContainText('New');
+  await page.getByTestId(testCase).getByText(testCase).click();
   await waitForAllLoadersToDisappear(page);
   await page.click('[data-testid="edit-resolution-icon"]');
   await page.click('[data-testid="test-case-resolution-status-type"]');
@@ -53,9 +53,9 @@ export const acknowledgeTask = async (data: {
   const statusChangeResponse = waitForTaskResolveResponse(page);
   await page.click('#update-status-button');
   await statusChangeResponse;
-  await page
-    .locator(`[data-testid="${testCase}-status"] >> text=Ack`)
-    .waitFor();
+  await expect(
+    page.locator(`[data-testid="${testCase}-status"]`)
+  ).toContainText('Ack');
 
   await expect(
     page.locator(

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseStatus/InlineIncidentStatus/IncidentStatusPopoverShell.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseStatus/InlineIncidentStatus/IncidentStatusPopoverShell.component.tsx
@@ -21,6 +21,7 @@ export type IncidentStatusPopoverShellProps = {
   dataTestid: string;
   trigger: ReactNode;
   children: ReactNode;
+  popoverClassName?: string;
 };
 
 export const IncidentStatusPopoverShell = ({
@@ -30,10 +31,14 @@ export const IncidentStatusPopoverShell = ({
   dataTestid,
   trigger,
   children,
+  popoverClassName,
 }: IncidentStatusPopoverShellProps) => (
   <PopoverTrigger isOpen={isOpen} onOpenChange={onOpenChange}>
     {trigger}
-    <Popover containerClassName={containerClassName} data-testid={dataTestid}>
+    <Popover
+      className={popoverClassName}
+      containerClassName={containerClassName}
+      data-testid={dataTestid}>
       {children}
     </Popover>
   </PopoverTrigger>

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseStatus/InlineTestCaseIncidentStatus.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseStatus/InlineTestCaseIncidentStatus.component.tsx
@@ -569,6 +569,7 @@ const InlineTestCaseIncidentStatus = ({
           containerClassName="tw:max-h-[500px] tw:min-w-0 tw:w-[320px] tw:border tw:border-border-secondary"
           dataTestid={`${data.testCaseReference?.name}-assignee-popover`}
           isOpen={showAssigneePopover}
+          popoverClassName="tw:!max-h-none"
           trigger={renderStatusChipButton()}
           onOpenChange={(open) => {
             if (open) {
@@ -586,9 +587,10 @@ const InlineTestCaseIncidentStatus = ({
     if (showResolvedPopover) {
       return (
         <IncidentStatusPopoverShell
-          containerClassName="tw:min-w-0 tw:w-[320px] tw:border tw:border-border-secondary"
+          containerClassName="tw:min-w-0 tw:w-80 tw:overflow-y-auto tw:border tw:border-border-secondary"
           dataTestid={`${data.testCaseReference?.name}-resolved-popover`}
           isOpen={showResolvedPopover}
+          popoverClassName="tw:!max-h-none"
           trigger={renderStatusChipButton()}
           onOpenChange={(open) => {
             if (!open) {
@@ -611,7 +613,7 @@ const InlineTestCaseIncidentStatus = ({
         onOpenChange={handleStatusMenuOpenChange}>
         {renderStatusChipButton()}
         <Dropdown.Popover
-          className="tw:min-w-[100px] tw:w-max tw:overflow-auto"
+          className="tw:min-w-25 tw:w-max tw:overflow-auto"
           placement="top">
           {statusMenuItems}
         </Dropdown.Popover>

--- a/openmetadata-ui/src/main/resources/ui/src/components/IncidentManager/IncidentManager.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/IncidentManager/IncidentManager.component.tsx
@@ -10,9 +10,13 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { Button, Dropdown, Skeleton } from '@openmetadata/ui-core-components';
+import {
+  Button,
+  Dropdown,
+  Skeleton,
+  Table,
+} from '@openmetadata/ui-core-components';
 import { Form, Select } from 'antd';
-import { ColumnsType } from 'antd/lib/table';
 import { AxiosError } from 'axios';
 import { compare } from 'fast-json-patch';
 import { isEqual, isString, isUndefined, omit, parseInt, pick } from 'lodash';
@@ -75,9 +79,9 @@ import DateTimeDisplay from '../common/DateTimeDisplay/DateTimeDisplay';
 import ErrorPlaceHolder from '../common/ErrorWithPlaceholder/ErrorPlaceHolder';
 import FilterTablePlaceHolder from '../common/ErrorWithPlaceholder/FilterTablePlaceHolder';
 import MuiDatePickerMenu from '../common/MuiDatePickerMenu/MuiDatePickerMenu';
+import NextPrevious from '../common/NextPrevious/NextPrevious';
 import { PagingHandlerParams } from '../common/NextPrevious/NextPrevious.interface';
 import { OwnerLabel } from '../common/OwnerLabel/OwnerLabel.component';
-import Table from '../common/Table/Table';
 import {
   ProfilerTabPath,
   TestCasePermission,
@@ -594,140 +598,93 @@ const IncidentManager = ({
     );
   };
 
-  const columns: ColumnsType<TestCaseResolutionStatus> = useMemo(
+  const columns = useMemo(
     () => [
-      {
-        title: t('label.test-case-name'),
-        dataIndex: 'name',
-        key: 'name',
-        width: 300,
-        fixed: 'left',
-        render: (_, record) => {
-          return (
-            <Link
-              className="m-0 break-all text-primary"
-              data-testid={`test-case-${record.testCaseReference?.name}`}
-              to={getTestCaseDetailPagePath(
-                record.testCaseReference?.fullyQualifiedName ?? ''
-              )}>
-              {getEntityName(record.testCaseReference)}
-            </Link>
-          );
-        },
-      },
+      { id: 'name', label: t('label.test-case-name') },
       ...(isIncidentPage
-        ? [
-            {
-              title: t('label.table'),
-              dataIndex: 'testCaseReference',
-              key: 'testCaseReference',
-              width: 150,
-              render: (value: EntityReference) => {
-                const tableFqn = getPartialNameFromTableFQN(
-                  value.fullyQualifiedName ?? '',
-                  [
-                    FqnPart.Service,
-                    FqnPart.Database,
-                    FqnPart.Schema,
-                    FqnPart.Table,
-                  ],
-                  '.'
-                );
-
-                return (
-                  <Link
-                    data-testid="table-link"
-                    to={getEntityDetailsPath(
-                      EntityType.TABLE,
-                      tableFqn,
-                      EntityTabs.PROFILER,
-                      ProfilerTabPath.DATA_QUALITY
-                    )}
-                    onClick={(e) => e.stopPropagation()}>
-                    {getNameFromFQN(tableFqn) ?? value.fullyQualifiedName}
-                  </Link>
-                );
-              },
-            },
-          ]
+        ? [{ id: 'testCaseReference', label: t('label.table') }]
         : []),
-      {
-        title: t('label.last-updated'),
-        dataIndex: 'timestamp',
-        key: 'timestamp',
-        width: 150,
-        render: (value: number) => {
-          return <DateTimeDisplay timestamp={value} />;
-        },
-      },
-      {
-        title: t('label.status'),
-        dataIndex: 'testCaseResolutionStatusType',
-        key: 'testCaseResolutionStatusType',
-        width: 100,
-        render: (_, record: TestCaseResolutionStatus) => {
-          if (isPermissionLoading) {
-            return <Skeleton height={24} variant="rectangular" width={100} />;
-          }
-          const hasPermission = testCasePermissions.find(
-            (item) =>
-              item.fullyQualifiedName ===
-              record.testCaseReference?.fullyQualifiedName
-          );
+      { id: 'timestamp', label: t('label.last-updated') },
+      { id: 'testCaseResolutionStatusType', label: t('label.status') },
+      { id: 'severity', label: t('label.severity') },
+      { id: 'testCaseResolutionStatusDetails', label: t('label.assignee') },
+    ],
+    [isIncidentPage, t]
+  );
 
-          return (
+  const renderRow = (record: TestCaseResolutionStatus) => {
+    const ref = record.testCaseReference;
+    const tableFqn = getPartialNameFromTableFQN(
+      ref?.fullyQualifiedName ?? '',
+      [FqnPart.Service, FqnPart.Database, FqnPart.Schema, FqnPart.Table],
+      '.'
+    );
+    const hasPermission = testCasePermissions.find(
+      (item) =>
+        item.fullyQualifiedName === ref?.fullyQualifiedName
+    );
+
+    return (
+      <Table.Row id={record.id ?? ''} key={record.id}>
+        <Table.Cell>
+          <Link
+            className="m-0 break-all text-primary"
+            data-testid={`test-case-${ref?.name}`}
+            to={getTestCaseDetailPagePath(ref?.fullyQualifiedName ?? '')}>
+            {getEntityName(ref)}
+          </Link>
+        </Table.Cell>
+        {isIncidentPage && (
+          <Table.Cell>
+            <Link
+              data-testid="table-link"
+              to={getEntityDetailsPath(
+                EntityType.TABLE,
+                tableFqn,
+                EntityTabs.PROFILER,
+                ProfilerTabPath.DATA_QUALITY
+              )}
+              onClick={(e) => e.stopPropagation()}>
+              {getNameFromFQN(tableFqn) ?? ref?.fullyQualifiedName}
+            </Link>
+          </Table.Cell>
+        )}
+        <Table.Cell>
+          <DateTimeDisplay timestamp={record.timestamp as number} />
+        </Table.Cell>
+        <Table.Cell>
+          {isPermissionLoading ? (
+            <Skeleton height={24} variant="rectangular" width={100} />
+          ) : (
             <TestCaseIncidentManagerStatus
               isInline
               data={record}
               hasPermission={hasPermission?.EditAll && !tableDetails?.deleted}
               onSubmit={handleStatusSubmit}
             />
-          );
-        },
-      },
-      {
-        title: t('label.severity'),
-        dataIndex: 'severity',
-        key: 'severity',
-        width: 100,
-        render: (value: Severities, record: TestCaseResolutionStatus) => {
-          if (isPermissionLoading) {
-            return <Skeleton height={24} variant="rectangular" width={100} />;
-          }
-
-          const hasPermission = testCasePermissions.find(
-            (item) =>
-              item.fullyQualifiedName ===
-              record.testCaseReference?.fullyQualifiedName
-          );
-
-          return (
+          )}
+        </Table.Cell>
+        <Table.Cell>
+          {isPermissionLoading ? (
+            <Skeleton height={24} variant="rectangular" width={100} />
+          ) : (
             <Severity
               isInline
               hasPermission={hasPermission?.EditAll && !tableDetails?.deleted}
-              severity={value}
+              severity={record.severity}
               onSubmit={(severity) => handleSeveritySubmit(record, severity)}
             />
-          );
-        },
-      },
-      {
-        title: t('label.assignee'),
-        dataIndex: 'testCaseResolutionStatusDetails',
-        key: 'testCaseResolutionStatusDetails',
-        width: 200,
-        render: testCaseResolutionStatusDetailsRender,
-      },
-    ],
-    [
-      tableDetails?.deleted,
-      testCaseListData.data,
-      testCasePermissions,
-      isPermissionLoading,
-      handleAssigneeUpdate,
-      handleStatusSubmit,
-    ]
-  );
+          )}
+        </Table.Cell>
+        <Table.Cell>
+          {testCaseResolutionStatusDetailsRender(
+            record.testCaseResolutionStatusDetails as Assigned | undefined,
+            record
+          )}
+        </Table.Cell>
+      </Table.Row>
+    );
+  };
 
   if (
     !commonTestCasePermission?.ViewAll &&
@@ -846,31 +803,41 @@ const IncidentManager = ({
       </div>
 
       <Table
-        columns={columns}
-        containerClassName="test-case-table-container custom-card-with-table"
+        aria-label={t('label.incident-manager')}
         data-testid="test-case-incident-manager-table"
-        dataSource={testCaseListData.data}
-        loading={testCaseListData.isLoading}
-        {...(pagingData && showPagination
-          ? {
-              customPaginationProps: {
-                ...pagingData,
-                showPagination,
-              },
-            }
-          : {})}
-        locale={{
-          emptyText: (
-            <FilterTablePlaceHolder
-              placeholderText={t('message.no-incident-found')}
-            />
-          ),
-        }}
-        pagination={false}
-        rowKey="id"
-        scroll={testCaseListData.data.length > 0 ? { x: '100%' } : undefined}
-        size="small"
-      />
+        size="sm">
+        <Table.Header columns={columns}>
+          {(col) => <Table.Head id={col.id} key={col.id} label={col.label} />}
+        </Table.Header>
+        <Table.Body
+          dependencies={[
+            isPermissionLoading,
+            testCasePermissions,
+            testCaseListData.data,
+          ]}
+          items={testCaseListData.isLoading ? [] : testCaseListData.data}
+          renderEmptyState={() =>
+            testCaseListData.isLoading ? (
+              <div className="tw:p-4">
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <Skeleton
+                    className="tw:mb-2"
+                    height={40}
+                    key={i}
+                    width="100%"
+                  />
+                ))}
+              </div>
+            ) : (
+              <FilterTablePlaceHolder
+                placeholderText={t('message.no-incident-found')}
+              />
+            )
+          }>
+          {(record) => renderRow(record)}
+        </Table.Body>
+      </Table>
+      {pagingData && showPagination && <NextPrevious {...pagingData} />}
     </div>
   );
 };

--- a/openmetadata-ui/src/main/resources/ui/src/components/IncidentManager/IncidentManager.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/IncidentManager/IncidentManager.component.tsx
@@ -616,12 +616,7 @@ const IncidentManager = ({
     () => (
       <div className="tw:p-4">
         {Array.from({ length: 5 }).map((_, i) => (
-          <Skeleton
-            className="tw:mb-2"
-            height={40}
-            key={i}
-            width="100%"
-          />
+          <Skeleton className="tw:mb-2" height={40} key={i} width="100%" />
         ))}
       </div>
     ),

--- a/openmetadata-ui/src/main/resources/ui/src/components/IncidentManager/IncidentManager.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/IncidentManager/IncidentManager.component.tsx
@@ -813,6 +813,7 @@ const IncidentManager = ({
             isPermissionLoading,
             testCasePermissions,
             testCaseListData.data,
+            tableDetails?.deleted,
           ]}
           items={testCaseListData.isLoading ? [] : testCaseListData.data}
           renderEmptyState={() =>

--- a/openmetadata-ui/src/main/resources/ui/src/components/IncidentManager/IncidentManager.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/IncidentManager/IncidentManager.component.tsx
@@ -612,6 +612,22 @@ const IncidentManager = ({
     [isIncidentPage, t]
   );
 
+  const loadingSkeletons = useMemo(
+    () => (
+      <div className="tw:p-4">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton
+            className="tw:mb-2"
+            height={40}
+            key={i}
+            width="100%"
+          />
+        ))}
+      </div>
+    ),
+    []
+  );
+
   const renderRow = (record: TestCaseResolutionStatus) => {
     const ref = record.testCaseReference;
     const tableFqn = getPartialNameFromTableFQN(
@@ -818,16 +834,7 @@ const IncidentManager = ({
           items={testCaseListData.isLoading ? [] : testCaseListData.data}
           renderEmptyState={() =>
             testCaseListData.isLoading ? (
-              <div className="tw:p-4">
-                {Array.from({ length: 5 }).map((_, i) => (
-                  <Skeleton
-                    className="tw:mb-2"
-                    height={40}
-                    key={i}
-                    width="100%"
-                  />
-                ))}
-              </div>
+              loadingSkeletons
             ) : (
               <FilterTablePlaceHolder
                 placeholderText={t('message.no-incident-found')}

--- a/openmetadata-ui/src/main/resources/ui/src/components/IncidentManager/IncidentManager.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/IncidentManager/IncidentManager.component.tsx
@@ -620,8 +620,7 @@ const IncidentManager = ({
       '.'
     );
     const hasPermission = testCasePermissions.find(
-      (item) =>
-        item.fullyQualifiedName === ref?.fullyQualifiedName
+      (item) => item.fullyQualifiedName === ref?.fullyQualifiedName
     );
 
     return (

--- a/openmetadata-ui/src/main/resources/ui/src/components/IncidentManager/IncidentManager.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/IncidentManager/IncidentManager.test.tsx
@@ -169,7 +169,11 @@ jest.mock('@openmetadata/ui-core-components', () => {
         children: (col: { id: string; label: string }) => React.ReactNode;
       }) => (
         <thead>
-          <tr>{columns?.map((col) => <th key={col.id}>{children(col)}</th>)}</tr>
+          <tr>
+            {columns?.map((col) => (
+              <th key={col.id}>{children(col)}</th>
+            ))}
+          </tr>
         </thead>
       ),
       Head: ({ label }: { label?: string }) => <span>{label}</span>,
@@ -189,13 +193,9 @@ jest.mock('@openmetadata/ui-core-components', () => {
             : items.map((item) => children(item))}
         </tbody>
       ),
-      Row: ({
-        children,
-        id,
-      }: {
-        children?: React.ReactNode;
-        id?: string;
-      }) => <tr data-rowid={id}>{children}</tr>,
+      Row: ({ children, id }: { children?: React.ReactNode; id?: string }) => (
+        <tr data-rowid={id}>{children}</tr>
+      ),
       Cell: ({ children }: { children?: React.ReactNode }) => (
         <td>{children}</td>
       ),

--- a/openmetadata-ui/src/main/resources/ui/src/components/IncidentManager/IncidentManager.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/IncidentManager/IncidentManager.test.tsx
@@ -12,7 +12,7 @@
  */
 import { fireEvent, render, screen } from '@testing-library/react';
 import QueryString from 'qs';
-import { act } from 'react';
+import React, { act } from 'react';
 import { Table } from '../../generated/entity/data/table';
 import { getListTestCaseIncidentStatusFromSearch } from '../../rest/incidentManagerAPI';
 import '../../test/unit/mocks/mui.mock';
@@ -146,6 +146,62 @@ jest.mock('@openmetadata/ui-core-components', () => {
     );
   };
 
+  const TableMock = Object.assign(
+    ({
+      children,
+      'data-testid': testId,
+      'aria-label': ariaLabel,
+    }: {
+      children?: React.ReactNode;
+      'data-testid'?: string;
+      'aria-label'?: string;
+    }) => (
+      <table aria-label={ariaLabel} data-testid={testId}>
+        {children}
+      </table>
+    ),
+    {
+      Header: ({
+        columns,
+        children,
+      }: {
+        columns?: { id: string; label: string }[];
+        children: (col: { id: string; label: string }) => React.ReactNode;
+      }) => (
+        <thead>
+          <tr>{columns?.map((col) => <th key={col.id}>{children(col)}</th>)}</tr>
+        </thead>
+      ),
+      Head: ({ label }: { label?: string }) => <span>{label}</span>,
+      Body: ({
+        items,
+        children,
+        renderEmptyState,
+      }: {
+        items?: unknown[];
+        children: (item: unknown) => React.ReactNode;
+        renderEmptyState?: () => React.ReactNode;
+        dependencies?: unknown[];
+      }) => (
+        <tbody>
+          {!items || items.length === 0
+            ? renderEmptyState?.()
+            : items.map((item) => children(item))}
+        </tbody>
+      ),
+      Row: ({
+        children,
+        id,
+      }: {
+        children?: React.ReactNode;
+        id?: string;
+      }) => <tr data-rowid={id}>{children}</tr>,
+      Cell: ({ children }: { children?: React.ReactNode }) => (
+        <td>{children}</td>
+      ),
+    }
+  );
+
   return {
     Dropdown: {
       Root: DropdownRoot,
@@ -169,6 +225,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
       .mockImplementation(({ children, className }) => (
         <button className={className}>{children}</button>
       )),
+    Table: TableMock,
   };
 });
 


### PR DESCRIPTION
## Summary

- Replace Ant Design `Table` with core-ui `Table` (react-aria-components) in `IncidentManager.component.tsx`
- Fix status/severity/assignee columns stuck at loading skeleton by using plain `renderRow` function with static `Table.Cell` children and `Table.Body` `dependencies` prop (matching `DataQualityTab` pattern)
- Fix popover max-height distortion caused by react-aria `useOverlayPosition` setting `max-height` as inline style — added `popoverClassName` prop to `IncidentStatusPopoverShell` and applied `tw:!max-h-none` to override
- Update unit test mock for `@openmetadata/ui-core-components` to include `Table`
- Update e2e selector from Ant Design `.ant-table-tbody` to `data-testid` based `tbody tr` selector

## Reference

https://github.com/open-metadata/openmetadata-collate/issues/3837

## Test plan

- [ ] Verify IncidentManager table renders correctly with all columns visible
- [ ] Verify status, severity, and assignee columns show actual values (not stuck at loading skeleton)
- [ ] Verify resolved and assignee popovers open without max-height distortion
- [ ] Run unit tests: `yarn test src/components/IncidentManager/IncidentManager.test.tsx`
- [ ] Run e2e: `yarn playwright:run --grep IncidentManager`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----
## Summary by Gitar

- **E2E Stability:**
  - Replaced brittle `ant-table` selectors with `data-testid` in `IncidentManager.spec.ts`.
  - Added retry logic to `TaskNavigation.spec.ts` to ensure task notifications appear before interaction, resolving CI race conditions.


<sub>This will update automatically on new commits.</sub>