### PR TITLE
fix(security): bump jetty-http 12.1.6 → 12.1.7 + pac4j-core 5.7.0 → 5.7.10 (1.13)

### DIFF
--- a/openmetadata-mcp/pom.xml
+++ b/openmetadata-mcp/pom.xml
@@ -17,7 +17,7 @@
     
     <properties>
         <assertj-core.version>3.27.7</assertj-core.version>
-        <jetty.version>12.1.6</jetty.version>
+        <jetty.version>12.1.7</jetty.version>
     </properties>
 
     <dependencyManagement>

--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -21,7 +21,7 @@
     <java.saml>2.9.0</java.saml>
     <xmlsec.version>2.3.4</xmlsec.version>
     <quartz.version>2.5.0-rc2</quartz.version>
-    <pac4j.version>5.7.0</pac4j.version>
+    <pac4j.version>5.7.10</pac4j.version>
     <maven-javadoc-plugin.version>3.6.0</maven-javadoc-plugin.version>
     <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
     <socket.io-client.version>2.1.1</socket.io-client.version>

--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -26,7 +26,7 @@
     <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
     <socket.io-client.version>2.1.1</socket.io-client.version>
     <json-smart.version>2.5.2</json-smart.version>
-    <jetty.version>12.1.6</jetty.version>
+    <jetty.version>12.1.7</jetty.version>
     <logback-core.version>1.5.25</logback-core.version>
     <logback-classic.version>1.5.25</logback-classic.version>
     <resilience4j-ratelimiter.version>2.3.0</resilience4j-ratelimiter.version>


### PR DESCRIPTION
## Summary

Cherry-picks three existing Dependabot bumps from `main` to fix security findings missed by #27940 on 1.13.

- 8c89a997 — Bump `org.eclipse.jetty:jetty-http` in `/openmetadata-service` 12.1.6 → 12.1.7 (cherry-pick of #27372)
- 40603912 — Bump `org.eclipse.jetty:jetty-http` in `/openmetadata-mcp` 12.1.6 → 12.1.7 (cherry-pick of #27373)
- 01f07132 — Bump `org.pac4j:pac4j-core` in `/openmetadata-service` 5.7.0 → 5.7.10 (cherry-pick of #27503)

## Vulnerabilities resolved

| Severity | Module | Issue |
|---|---|---|
| **CRITICAL** | `org.eclipse.jetty:jetty-http` 12.1.6 | HTTP Request Smuggling — HTTP/1.1 parser improperly terminated quoted strings in chunked transfer encoding. Fixed in 12.0.33 / 12.1.7. |
| **HIGH** | `org.pac4j:pac4j-core` 5.7.0 | CSRF — deterministic `String.hashCode()` allowed a forged token whose hash collides with the legitimate CSRF token to perform unauthorized state-changing actions (profile updates, password changes, account linking). Fixed in 5.7.10 / 6.4.1. |

## Why these were missed

#27940 (commit `4c1ec72` on 1.13) bumped `<jetty.version>` only in the **root `pom.xml`**. On `main` that was sufficient because three child-module Dependabot PRs had already landed:

- #27372 — jetty-http in `/openmetadata-service`
- #27373 — jetty-http in `/openmetadata-mcp`
- #27503 — pac4j-core in `/openmetadata-service`

None of those were cherry-picked to 1.13, so the child modules still redeclared the older versions as local properties:

- `openmetadata-service/pom.xml:24` — `<pac4j.version>5.7.0</pac4j.version>`
- `openmetadata-service/pom.xml:29` — `<jetty.version>12.1.6</jetty.version>`
- `openmetadata-mcp/pom.xml:20` — `<jetty.version>12.1.6</jetty.version>`

Maven property resolution gives the child module's local property precedence over the parent's, so every `jetty-*` artifact pulled in by `openmetadata-service` or `openmetadata-mcp` was still resolving to 12.1.6 at build time, and pac4j-core was still resolving to 5.7.0. The published JARs in `/opt/openmetadata/libs/` therefore still contained the vulnerable versions, and Snyk's May 8 scan against the 1.13 image correctly flagged them.

## Remaining gaps on 1.13 (out of scope for this PR — separate follow-ups)

- **HIGH** `io.netty:netty-bom@4.1.132.Final` (4 findings — data amplification ×2, poison null byte, allocation throttling). Needs to land on `main` first since main is also still on 4.1.132.Final. Tracked in #27981.
- **HIGH** `org.apache.logging.log4j:log4j-core@2.25.3` (3 findings — Rfc5424Layout, XmlLayout, Log4j1XmlLayout). No upstream release available yet — Apache has only fixed in master. Recommend a Snyk policy ignore until Apache cuts a 2.25.4+ release.
- 80 Snyk Code "Unsafe Reflection" findings — separate static-analysis work on `ReflectionUtil.createConnectionConfigClass`.

## Test plan

- [ ] `mvn dependency:tree | grep jetty-http` resolves to **12.1.7** in both `openmetadata-service` and `openmetadata-mcp`
- [ ] `mvn dependency:tree | grep pac4j-core` resolves to **5.7.10** in `openmetadata-service`
- [ ] Re-run Snyk scan on a freshly built 1.13 image; CRITICAL jetty-http and HIGH pac4j-core CSRF findings should be gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)