### PR TITLE
fix(security): bump netty-bom 4.1.132.Final → 4.1.133.Final (4 HIGH CVEs)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -669,7 +669,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>
-        <version>4.1.132.Final</version>
+        <version>4.1.133.Final</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Summary

Bumps `io.netty:netty-bom` from **4.1.132.Final → 4.1.133.Final** to resolve four HIGH-severity Snyk findings observed in the May 8 2026 scan of the 1.13 image. A single bump on the netty-bom import propagates the version to every netty artifact pulled in transitively (codec, codec-http2, codec-dns, etc.), so this one-line change retires all four CVEs.

## Vulnerabilities resolved

| Severity | Module | CWE / Issue |
|---|---|---|
| HIGH | `io.netty:netty-codec-http2` | Improper Handling of Highly Compressed Data — `HttpContentDecompressor` / `DelegatingDecompressorFrameListener` accept `br`/`zstd`/`snappy` payloads that bypass the configured decompression limit (data amplification → DoS) |
| HIGH | `io.netty:netty-codec-dns` | Null Byte Interaction Error — `encodeDomainName` / `decodeDomainName` inadequately validate domain-label lengths, enabling DNS cache poisoning, domain validation bypass, and excessive memory allocation |
| HIGH | `io.netty:netty-codec` | Allocation of Resources Without Limits or Throttling — `Lz4FrameDecoder` over-allocates on crafted compressed frames with manipulated header fields (resource exhaustion → DoS) |
| HIGH | `io.netty:netty-codec` | Improper Handling of Highly Compressed Data — same data-amplification class as above, in the base codec |

All four are fixed in `4.1.133.Final` (Snyk-recommended remediation: \"Upgrade `io.netty:netty-*` to 4.1.133.Final or higher\").

## Why this is needed on `main`

The May 8 Snyk report against the 1.13 OSS image flagged 9 vulnerable dependency paths. The previous security cherry-pick (#27940 → 1.13 commit `4c1ec72`) covered jetty-http, BouncyCastle, postgresql, jackson, spring, gson, httpcore5-h2 and commons-compress — but did **not** touch netty. `main` is also still on `4.1.132.Final`, so this gap exists here as well; the bump has to land on `main` first before it can be cherry-picked into 1.13.x.

## Other findings from the same Snyk report (tracked separately, **not** in this PR)

- **CRITICAL** `org.eclipse.jetty:jetty-http@12.1.6` — already fixed on `main` via Dependabot #27372 (`/openmetadata-service`) and #27373 (`/openmetadata-mcp`). Cherry-picked to 1.13 in #27980.
- **HIGH** `org.pac4j:pac4j-core@5.7.0` (CSRF) — already fixed on `main` via Dependabot #27503 → 5.7.10. Needs a separate cherry-pick to 1.13.
- **HIGH** `org.apache.logging.log4j:log4j-core@2.25.3` × 3 (Rfc5424Layout / XmlLayout / Log4j1XmlLayout). **No upstream release available** — the Apache advisory states the fix is only in master. Recommend a Snyk policy ignore until Apache cuts a 2.25.4+ release.
- 80 Snyk Code \"Unsafe Reflection\" findings, all flowing from `ReflectionUtil.createConnectionConfigClass` → `Class.forName(clazzName)` driven by user-supplied `connectionType`. This is a static-analysis finding on OpenMetadata's own code, separate from dependency CVEs, and is best addressed by replacing `Class.forName` with an allowlist of registered service-type → class mappings.

## Test plan

- [ ] `mvn dependency:tree` resolves `io.netty:netty-codec`, `io.netty:netty-codec-http2`, and `io.netty:netty-codec-dns` to **4.1.133.Final** in `openmetadata-service` and `openmetadata-mcp`
- [ ] Full backend build passes (`mvn clean package -DskipTests`)
- [ ] Re-run Snyk scan against a fresh build and confirm all four netty findings are gone
- [ ] Smoke test: HTTP/2 traffic, DNS resolution, and any Lz4-compressed paths still function

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----
## Summary by Gitar

- **UI/UX improvements:**
  - Migrated `ColumnProfileTable` from `antd` to `core` components `Table`.

<sub>This will update automatically on new commits.</sub>