### PR TITLE
chore(mcp): add server.json for MCP Registry publishing

### DIFF
--- a/openmetadata-mcp/server.json
+++ b/openmetadata-mcp/server.json
@@ -2,13 +2,14 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.open-metadata/openmetadata-mcp",
   "title": "OpenMetadata",
-  "description": "Query metadata, lineage, glossary, data quality, and governance information from your OpenMetadata instance. Supports search, entity discovery, lineage traversal, glossary management, and test case creation through OAuth 2.0 authenticated MCP tools.",
+  "description": "Governed context and business semantics from OpenMetadata for AI assistants and agents.",
   "version": "1.1.0",
   "repository": {
     "url": "https://github.com/open-metadata/OpenMetadata",
     "source": "github",
     "subfolder": "openmetadata-mcp"
   },
+  "websiteUrl": "https://docs.open-metadata.org/v1.12.x/how-to-guides/mcp",
   "remotes": [
     {
       "type": "streamable-http",

--- a/openmetadata-mcp/server.json
+++ b/openmetadata-mcp/server.json
@@ -9,7 +9,7 @@
     "source": "github",
     "subfolder": "openmetadata-mcp"
   },
-  "websiteUrl": "https://docs.open-metadata.org/v1.12.x/how-to-guides/mcp",
+  "websiteUrl": "https://docs.open-metadata.org/how-to-guides/mcp",
   "remotes": [
     {
       "type": "streamable-http",

--- a/openmetadata-mcp/server.json
+++ b/openmetadata-mcp/server.json
@@ -16,7 +16,7 @@
       "url": "https://{openmetadata_host}/mcp",
       "variables": {
         "openmetadata_host": {
-          "description": "Hostname of your OpenMetadata deployment (e.g. metadata.example.com). The MCP endpoint is mounted at /mcp and uses OAuth 2.0 with PKCE for authentication via your OpenMetadata SSO provider or Basic Auth.",
+          "description": "Hostname of your OpenMetadata deployment, including port if non-standard. Examples: 'metadata.example.com' (behind a reverse proxy on 443) or 'metadata.example.com:8585' (direct, default OpenMetadata port). The MCP endpoint is mounted at /mcp and authenticates via OAuth 2.0 with PKCE through your existing OpenMetadata SSO provider or Basic Auth.",
           "isRequired": true
         }
       }

--- a/openmetadata-mcp/server.json
+++ b/openmetadata-mcp/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.open-metadata/openmetadata-mcp",
   "title": "OpenMetadata",
-  "description": "Governed context and business semantics from OpenMetadata for AI assistants and agents.",
+  "description": "Official OpenMetadata MCP: governed context and business semantics for AI assistants and agents.",
   "version": "1.1.0",
   "repository": {
     "url": "https://github.com/open-metadata/OpenMetadata",

--- a/openmetadata-mcp/server.json
+++ b/openmetadata-mcp/server.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.open-metadata/openmetadata-mcp",
+  "title": "OpenMetadata",
+  "description": "Query metadata, lineage, glossary, data quality, and governance information from your OpenMetadata instance. Supports search, entity discovery, lineage traversal, glossary management, and test case creation through OAuth 2.0 authenticated MCP tools.",
+  "version": "1.1.0",
+  "repository": {
+    "url": "https://github.com/open-metadata/OpenMetadata",
+    "source": "github",
+    "subfolder": "openmetadata-mcp"
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://{openmetadata_host}/mcp",
+      "variables": {
+        "openmetadata_host": {
+          "description": "Hostname of your OpenMetadata deployment (e.g. metadata.example.com). The MCP endpoint is mounted at /mcp and uses OAuth 2.0 with PKCE for authentication via your OpenMetadata SSO provider or Basic Auth.",
+          "isRequired": true
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `openmetadata-mcp/server.json` so the MCP server can be published to the [official MCP Registry](https://registry.modelcontextprotocol.io). Downstream aggregators (PulseMCP, Smithery, etc.) scrape the official registry, so a single entry surfaces the server across the ecosystem.
- Uses GitHub-based authentication namespace: `io.github.open-metadata/openmetadata-mcp`.
- Declares a `streamable-http` remote at `https://{openmetadata_host}/mcp` — the `/mcp` mount point matches the transport registered in `McpServer.java`. Because OpenMetadata is self-hosted, `openmetadata_host` is a required template variable that clients fill in with their own deployment hostname.
- No `headers` are declared: clients negotiate OAuth 2.0 + PKCE automatically through the `.well-known` discovery endpoints already exposed by the server.

## Publishing (post-merge)

```bash
brew install mcp-publisher
cd openmetadata-mcp
mcp-publisher login github   # must be signed in as a member of the open-metadata org
mcp-publisher publish
curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=openmetadata"
```

## Test plan

- [x] `python3 -m json.tool openmetadata-mcp/server.json` validates cleanly
- [ ] Manually verify the schema URL (`2025-12-11/server.schema.json`) is the latest stable version at publish time
- [ ] After merging, run `mcp-publisher publish` from `openmetadata-mcp/` and confirm the entry appears in the registry search results

🤖 Generated with [Claude Code](https://claude.com/claude-code)