### PR TITLE
fix(alerts): strict literal matching across alert filter functions

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/AlertsRuleEvaluatorResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/AlertsRuleEvaluatorResourceIT.java
@@ -132,6 +132,7 @@ public class AlertsRuleEvaluatorResourceIT {
         "service.db.schema.name|pipe",
         "service.db.schema.name*star",
         "service.db.schema.[bracketed].table",
+        "AENG - CSP work item bug checks (duration exceeded)",
       })
   void test_matchAnyEntityFqn_treatsRegexMetacharsAsLiteral(String fqn) {
     Table table = new Table().withName("t").withFullyQualifiedName(fqn);

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/AlertsRuleEvaluatorResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/AlertsRuleEvaluatorResourceIT.java
@@ -19,6 +19,7 @@ import org.openmetadata.it.util.TestNamespace;
 import org.openmetadata.it.util.TestNamespaceExtension;
 import org.openmetadata.schema.api.data.CreateTable;
 import org.openmetadata.schema.api.tests.CreateTestCase;
+import org.openmetadata.schema.entity.data.DataContract;
 import org.openmetadata.schema.entity.data.DatabaseSchema;
 import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.schema.entity.services.DatabaseService;
@@ -31,8 +32,10 @@ import org.openmetadata.schema.type.ChangeDescription;
 import org.openmetadata.schema.type.ChangeEvent;
 import org.openmetadata.schema.type.Column;
 import org.openmetadata.schema.type.ColumnDataType;
+import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.EventType;
 import org.openmetadata.schema.type.FieldChange;
+import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.events.subscription.AlertsRuleEvaluator;
 import org.springframework.expression.EvaluationContext;
@@ -179,6 +182,230 @@ public class AlertsRuleEvaluatorResourceIT {
     assertTrue(
         evaluateExpression("matchAnyEntityFqn({'" + testSuiteFqn + "'})", evaluationContext));
     assertFalse(evaluateExpression("matchAnyEntityFqn({'unrelated.fqn'})", evaluationContext));
+  }
+
+  @Test
+  void test_filterByTableNameTestCaseBelongsTo_happyPath() {
+    String tableFqn = "service.db.schema.orders";
+    TestCase testCase = new TestCase().withName("tc").withEntityFQN(tableFqn);
+
+    ChangeEvent changeEvent = new ChangeEvent();
+    changeEvent.setEntityType(Entity.TEST_CASE);
+    changeEvent.setEntity(testCase);
+    AlertsRuleEvaluator alertsRuleEvaluator = new AlertsRuleEvaluator(changeEvent);
+    EvaluationContext evaluationContext =
+        SimpleEvaluationContext.forReadOnlyDataBinding()
+            .withInstanceMethods()
+            .withRootObject(alertsRuleEvaluator)
+            .build();
+
+    assertTrue(
+        evaluateExpression(
+            "filterByTableNameTestCaseBelongsTo({'" + tableFqn + "'})", evaluationContext));
+    assertFalse(
+        evaluateExpression(
+            "filterByTableNameTestCaseBelongsTo({'unrelated.fqn'})", evaluationContext));
+  }
+
+  @Test
+  void test_filterByTableNameTestCaseBelongsTo_rejectsPrefixCollision() {
+    TestCase testCase =
+        new TestCase().withName("tc").withEntityFQN("service.db.schema.customer_archive");
+
+    ChangeEvent changeEvent = new ChangeEvent();
+    changeEvent.setEntityType(Entity.TEST_CASE);
+    changeEvent.setEntity(testCase);
+    AlertsRuleEvaluator alertsRuleEvaluator = new AlertsRuleEvaluator(changeEvent);
+    EvaluationContext evaluationContext =
+        SimpleEvaluationContext.forReadOnlyDataBinding()
+            .withInstanceMethods()
+            .withRootObject(alertsRuleEvaluator)
+            .build();
+
+    assertFalse(
+        evaluateExpression(
+            "filterByTableNameTestCaseBelongsTo({'service.db.schema.customer'})",
+            evaluationContext));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "service.db.schema.[bracketed].t",
+        "service.db.schema.t+plus",
+        "service.db.schema.t?question",
+        "service.db.schema.t|pipe",
+        "service.db.schema.t*star",
+        "service.db.schema.t(paren)",
+      })
+  void test_filterByTableNameTestCaseBelongsTo_treatsRegexMetacharsAsLiteral(String tableFqn) {
+    TestCase testCase = new TestCase().withName("tc").withEntityFQN(tableFqn);
+
+    ChangeEvent changeEvent = new ChangeEvent();
+    changeEvent.setEntityType(Entity.TEST_CASE);
+    changeEvent.setEntity(testCase);
+    AlertsRuleEvaluator alertsRuleEvaluator = new AlertsRuleEvaluator(changeEvent);
+    EvaluationContext evaluationContext =
+        SimpleEvaluationContext.forReadOnlyDataBinding()
+            .withInstanceMethods()
+            .withRootObject(alertsRuleEvaluator)
+            .build();
+
+    assertTrue(
+        evaluateExpression(
+            "filterByTableNameTestCaseBelongsTo({'" + tableFqn + "'})", evaluationContext));
+    assertFalse(
+        evaluateExpression(
+            "filterByTableNameTestCaseBelongsTo({'unrelated.fqn'})", evaluationContext));
+  }
+
+  @Test
+  void test_filterByTableNameTestCaseBelongsTo_fallbackToEntityLink() {
+    String tableFqn = "service.db.schema.fallback";
+    TestCase testCase =
+        new TestCase().withName("tc").withEntityLink("<#E::table::" + tableFqn + ">");
+
+    ChangeEvent changeEvent = new ChangeEvent();
+    changeEvent.setEntityType(Entity.TEST_CASE);
+    changeEvent.setEntity(testCase);
+    AlertsRuleEvaluator alertsRuleEvaluator = new AlertsRuleEvaluator(changeEvent);
+    EvaluationContext evaluationContext =
+        SimpleEvaluationContext.forReadOnlyDataBinding()
+            .withInstanceMethods()
+            .withRootObject(alertsRuleEvaluator)
+            .build();
+
+    assertTrue(
+        evaluateExpression(
+            "filterByTableNameTestCaseBelongsTo({'" + tableFqn + "'})", evaluationContext));
+  }
+
+  @Test
+  void test_filterByTableNameTestCaseBelongsTo_nonTestCaseEntityPassesThrough() {
+    Table table = new Table().withName("t").withFullyQualifiedName("service.db.schema.t");
+
+    ChangeEvent changeEvent = new ChangeEvent();
+    changeEvent.setEntityType(Entity.TABLE);
+    changeEvent.setEntity(table);
+    AlertsRuleEvaluator alertsRuleEvaluator = new AlertsRuleEvaluator(changeEvent);
+    EvaluationContext evaluationContext =
+        SimpleEvaluationContext.forReadOnlyDataBinding()
+            .withInstanceMethods()
+            .withRootObject(alertsRuleEvaluator)
+            .build();
+
+    assertTrue(
+        evaluateExpression(
+            "filterByTableNameTestCaseBelongsTo({'unrelated.fqn'})", evaluationContext));
+  }
+
+  @Test
+  void test_filterByEntityNameDataContractBelongsTo_happyPath() {
+    String entityFqn = "service.db.schema.orders";
+    ChangeEvent changeEvent = dataContractChangeEvent(entityFqn);
+    AlertsRuleEvaluator alertsRuleEvaluator = new AlertsRuleEvaluator(changeEvent);
+    EvaluationContext evaluationContext =
+        SimpleEvaluationContext.forReadOnlyDataBinding()
+            .withInstanceMethods()
+            .withRootObject(alertsRuleEvaluator)
+            .build();
+
+    assertTrue(
+        evaluateExpression(
+            "filterByEntityNameDataContractBelongsTo({'" + entityFqn + "'})", evaluationContext));
+    assertFalse(
+        evaluateExpression(
+            "filterByEntityNameDataContractBelongsTo({'unrelated.fqn'})", evaluationContext));
+  }
+
+  /**
+   * Regression: previous implementation used String.contains, so a filter on a substring of the
+   * target entity's FQN would return true (false positive). The fix uses literal equality.
+   */
+  @Test
+  void test_filterByEntityNameDataContractBelongsTo_rejectsSubstring() {
+    ChangeEvent changeEvent = dataContractChangeEvent("service.db.schema.customer");
+    AlertsRuleEvaluator alertsRuleEvaluator = new AlertsRuleEvaluator(changeEvent);
+    EvaluationContext evaluationContext =
+        SimpleEvaluationContext.forReadOnlyDataBinding()
+            .withInstanceMethods()
+            .withRootObject(alertsRuleEvaluator)
+            .build();
+
+    assertFalse(
+        evaluateExpression(
+            "filterByEntityNameDataContractBelongsTo({'service.db.schema'})", evaluationContext));
+    assertFalse(
+        evaluateExpression(
+            "filterByEntityNameDataContractBelongsTo({'customer'})", evaluationContext));
+  }
+
+  @Test
+  void test_filterByEntityNameDataContractBelongsTo_rejectsPrefixCollision() {
+    ChangeEvent changeEvent = dataContractChangeEvent("service.db.schema.customer_archive");
+    AlertsRuleEvaluator alertsRuleEvaluator = new AlertsRuleEvaluator(changeEvent);
+    EvaluationContext evaluationContext =
+        SimpleEvaluationContext.forReadOnlyDataBinding()
+            .withInstanceMethods()
+            .withRootObject(alertsRuleEvaluator)
+            .build();
+
+    assertFalse(
+        evaluateExpression(
+            "filterByEntityNameDataContractBelongsTo({'service.db.schema.customer'})",
+            evaluationContext));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "service.db.schema.[bracketed]",
+        "service.db.schema.t+plus",
+        "service.db.schema.t?question",
+        "service.db.schema.t|pipe",
+        "service.db.schema.t*star",
+      })
+  void test_filterByEntityNameDataContractBelongsTo_treatsRegexMetacharsAsLiteral(
+      String entityFqn) {
+    ChangeEvent changeEvent = dataContractChangeEvent(entityFqn);
+    AlertsRuleEvaluator alertsRuleEvaluator = new AlertsRuleEvaluator(changeEvent);
+    EvaluationContext evaluationContext =
+        SimpleEvaluationContext.forReadOnlyDataBinding()
+            .withInstanceMethods()
+            .withRootObject(alertsRuleEvaluator)
+            .build();
+
+    assertTrue(
+        evaluateExpression(
+            "filterByEntityNameDataContractBelongsTo({'" + entityFqn + "'})", evaluationContext));
+  }
+
+  @Test
+  void test_filterByEntityNameDataContractBelongsTo_nonDataContractEntityReturnsFalse() {
+    Table table = new Table().withName("t").withFullyQualifiedName("service.db.schema.t");
+
+    ChangeEvent changeEvent = new ChangeEvent();
+    changeEvent.setEntityType(Entity.TABLE);
+    changeEvent.setEntity(table);
+    AlertsRuleEvaluator alertsRuleEvaluator = new AlertsRuleEvaluator(changeEvent);
+    EvaluationContext evaluationContext =
+        SimpleEvaluationContext.forReadOnlyDataBinding()
+            .withInstanceMethods()
+            .withRootObject(alertsRuleEvaluator)
+            .build();
+
+    assertFalse(
+        evaluateExpression(
+            "filterByEntityNameDataContractBelongsTo({'unrelated.fqn'})", evaluationContext));
+  }
+
+  private ChangeEvent dataContractChangeEvent(String targetEntityFqn) {
+    DataContract dataContract = new DataContract();
+    dataContract.setEntity(new EntityReference().withFullyQualifiedName(targetEntityFqn));
+    ChangeEvent changeEvent = new ChangeEvent();
+    changeEvent.setEntityType(Entity.DATA_CONTRACT);
+    changeEvent.setEntity(JsonUtils.pojoToJson(dataContract));
+    return changeEvent;
   }
 
   @Test

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/AlertsRuleEvaluatorResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/AlertsRuleEvaluatorResourceIT.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.openmetadata.it.bootstrap.SharedEntities;
 import org.openmetadata.it.util.SdkClients;
 import org.openmetadata.it.util.TestNamespace;
@@ -22,6 +24,7 @@ import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.schema.entity.services.DatabaseService;
 import org.openmetadata.schema.tests.TestCase;
 import org.openmetadata.schema.tests.TestCaseParameterValue;
+import org.openmetadata.schema.tests.TestSuite;
 import org.openmetadata.schema.tests.type.TestCaseResult;
 import org.openmetadata.schema.tests.type.TestCaseStatus;
 import org.openmetadata.schema.type.ChangeDescription;
@@ -110,6 +113,72 @@ public class AlertsRuleEvaluatorResourceIT {
     assertTrue(
         evaluateExpression("matchAnyEntityFqn({'" + testSuiteFqn + "'})", evaluationContext));
     assertFalse(evaluateExpression("matchAnyEntityFqn({'nonExistentFqn'})", evaluationContext));
+  }
+
+  /**
+   * Regression: matchAnyEntityFqn must compare FQNs literally, not as Java regex. FQNs in
+   * OpenMetadata can contain characters that are regex metacharacters (e.g. test suites named like
+   * "[TML] Fraud Mart Test Suite"). Customer-reported via openmetadata-collate#4019.
+   */
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "[TML] Fraud Mart Test Suite",
+        "service.db.schema.name+plus",
+        "service.db.schema.name?question",
+        "service.db.schema.name|pipe",
+        "service.db.schema.name*star",
+        "service.db.schema.[bracketed].table",
+      })
+  void test_matchAnyEntityFqn_treatsRegexMetacharsAsLiteral(String fqn) {
+    Table table = new Table().withName("t").withFullyQualifiedName(fqn);
+    ChangeEvent changeEvent = new ChangeEvent();
+    changeEvent.setEntityType(Entity.TABLE);
+    changeEvent.setEntity(table);
+    AlertsRuleEvaluator alertsRuleEvaluator = new AlertsRuleEvaluator(changeEvent);
+    EvaluationContext evaluationContext =
+        SimpleEvaluationContext.forReadOnlyDataBinding()
+            .withInstanceMethods()
+            .withRootObject(alertsRuleEvaluator)
+            .build();
+
+    // Single-element list: matching FQN returns true.
+    assertTrue(evaluateExpression("matchAnyEntityFqn({'" + fqn + "'})", evaluationContext));
+    // Multi-element list with the matching FQN at the tail: ensures SpEL passes the full
+    // comma-separated list and the matcher iterates past the first element.
+    assertTrue(
+        evaluateExpression(
+            "matchAnyEntityFqn({'irrelevant.first', '" + fqn + "', 'irrelevant.last'})",
+            evaluationContext));
+    // Multi-element list without the matching FQN: returns false (no false positives).
+    assertFalse(
+        evaluateExpression(
+            "matchAnyEntityFqn({'unrelated.first', 'unrelated.second'})", evaluationContext));
+  }
+
+  @Test
+  void test_matchAnyEntityFqn_testSuiteFallback_treatsInputAsLiteral() {
+    String testSuiteFqn = "[TML] Fraud Mart Test Suite";
+    TestSuite testSuite = new TestSuite().withFullyQualifiedName(testSuiteFqn);
+    TestCase testCase =
+        new TestCase()
+            .withName("tc")
+            .withFullyQualifiedName("table.tc")
+            .withTestSuites(List.of(testSuite));
+
+    ChangeEvent changeEvent = new ChangeEvent();
+    changeEvent.setEntityType(Entity.TEST_CASE);
+    changeEvent.setEntity(testCase);
+    AlertsRuleEvaluator alertsRuleEvaluator = new AlertsRuleEvaluator(changeEvent);
+    EvaluationContext evaluationContext =
+        SimpleEvaluationContext.forReadOnlyDataBinding()
+            .withInstanceMethods()
+            .withRootObject(alertsRuleEvaluator)
+            .build();
+
+    assertTrue(
+        evaluateExpression("matchAnyEntityFqn({'" + testSuiteFqn + "'})", evaluationContext));
+    assertFalse(evaluateExpression("matchAnyEntityFqn({'unrelated.fqn'})", evaluationContext));
   }
 
   @Test

--- a/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertsRuleEvaluator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertsRuleEvaluator.java
@@ -127,12 +127,14 @@ public class AlertsRuleEvaluator {
 
   @Function(
       name = "matchAnyEntityFqn",
-      input = "List of comma separated entityName",
+      input = "List of comma separated fully qualified entity names",
       description =
-          "Returns true if the change event entity being accessed has following entityName from the List.",
-      examples = {"matchAnyEntityFqn({'FQN1', 'FQN2'})"},
+          "Returns true if the change event entity's fully qualified name equals any of the listed FQNs.",
+      examples = {
+        "matchAnyEntityFqn({'service.database.schema.table1', 'service.database.schema.table2'})"
+      },
       paramInputType = ALL_INDEX_ELASTIC_SEARCH)
-  public boolean matchAnyEntityFqn(List<String> entityNames) {
+  public boolean matchAnyEntityFqn(List<String> entityFqns) {
     if (changeEvent == null || changeEvent.getEntity() == null) {
       return false;
     }
@@ -143,12 +145,8 @@ public class AlertsRuleEvaluator {
     }
 
     EntityInterface entity = getEntity(changeEvent);
-    for (String name : entityNames) {
-      Pattern pattern = Pattern.compile(name);
-      Matcher matcher = pattern.matcher(entity.getFullyQualifiedName());
-      if (matcher.find()) {
-        return true;
-      }
+    if (entityFqns.contains(entity.getFullyQualifiedName())) {
+      return true;
     }
 
     if (changeEvent.getEntityType().equals(TEST_CASE)) {
@@ -156,7 +154,7 @@ public class AlertsRuleEvaluator {
       // check if the match happens on the test suite FQN
       TestCase testCase = ((TestCase) entity);
       Optional<List<TestSuite>> testSuites = Optional.ofNullable(testCase.getTestSuites());
-      return testSuites.filter(suites -> testSuiteMatcher(suites, entityNames)).isPresent();
+      return testSuites.filter(suites -> testSuiteMatcher(suites, entityFqns)).isPresent();
     }
 
     return false;
@@ -600,16 +598,15 @@ public class AlertsRuleEvaluator {
     }
   }
 
-  private boolean testSuiteMatcher(List<TestSuite> testSuites, List<String> entityNames) {
+  private boolean testSuiteMatcher(List<TestSuite> testSuites, List<String> entityFqns) {
     for (TestSuite testSuite : testSuites) {
-      for (String name : entityNames) {
-        Pattern pattern = Pattern.compile(name);
-        Matcher matcherTestSuiteFQN = pattern.matcher(testSuite.getFullyQualifiedName());
-        if (matcherTestSuiteFQN.find()) return true;
-        if (!nullOrEmpty(testSuite.getDomains())) {
-          for (EntityReference domain : testSuite.getDomains()) {
-            Matcher matcherDomainFQN = pattern.matcher(domain.getFullyQualifiedName());
-            if (matcherDomainFQN.find()) return true;
+      if (entityFqns.contains(testSuite.getFullyQualifiedName())) {
+        return true;
+      }
+      if (!nullOrEmpty(testSuite.getDomains())) {
+        for (EntityReference domain : testSuite.getDomains()) {
+          if (entityFqns.contains(domain.getFullyQualifiedName())) {
+            return true;
           }
         }
       }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertsRuleEvaluator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertsRuleEvaluator.java
@@ -20,8 +20,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.Function;
@@ -261,40 +259,33 @@ public class AlertsRuleEvaluator {
 
   @Function(
       name = "filterByTableNameTestCaseBelongsTo",
-      input = "List of comma separated Test Suite",
+      input = "List of comma separated fully qualified table names",
       description =
-          "Returns true if the change event entity being accessed has following entityId from the List.",
-      examples = {"filterByTableNameTestCaseBelongsTo({'tableName1', 'tableName2'})"},
+          "Returns true if the change event entity is a test case whose parent table FQN equals any of the listed FQNs.",
+      examples = {
+        "filterByTableNameTestCaseBelongsTo({'service.database.schema.table1', 'service.database.schema.table2'})"
+      },
       paramInputType = READ_FROM_PARAM_CONTEXT)
-  public boolean filterByTableNameTestCaseBelongsTo(List<String> tableNameList) {
+  public boolean filterByTableNameTestCaseBelongsTo(List<String> tableFqns) {
     if (changeEvent == null) {
       return false;
     }
     if (!changeEvent.getEntityType().equals(TEST_CASE)) {
-      // in case the entity is not test case return since the filter doesn't apply
       return true;
     }
+    TestCase testCase = (TestCase) getEntity(changeEvent);
+    String parentFqn = resolveParentTableFqn(testCase);
+    return parentFqn != null && tableFqns.contains(parentFqn);
+  }
 
-    // Filter does not apply to Thread Change Events
-    if (changeEvent.getEntityType().equals(THREAD)) {
-      return true;
+  private String resolveParentTableFqn(TestCase testCase) {
+    if (testCase.getEntityFQN() != null) {
+      return testCase.getEntityFQN();
     }
-
-    EntityInterface entity = getEntity(changeEvent);
-    for (String name : tableNameList) {
-      // Escape regex special characters in table name for exact matching
-      String escapedName = Pattern.quote(name);
-
-      // Construct regex to match table name exactly, allowing for end of string or delimiter (.)
-      String regex = "\\b" + escapedName + "(\\b|\\.|$)";
-      Pattern pattern = Pattern.compile(regex);
-
-      Matcher matcher = pattern.matcher(entity.getFullyQualifiedName());
-      if (matcher.find()) {
-        return true;
-      }
+    if (testCase.getEntityLink() != null) {
+      return MessageParser.EntityLink.parse(testCase.getEntityLink()).getEntityFQN();
     }
-    return false;
+    return null;
   }
 
   @Function(
@@ -670,24 +661,25 @@ public class AlertsRuleEvaluator {
 
   @Function(
       name = "filterByEntityNameDataContractBelongsTo",
-      input = "List of entity names",
+      input = "List of comma separated fully qualified entity names",
       description =
-          "Returns true if the data contract belongs to an entity with name in the given list.",
-      examples = {"filterByEntityNameDataContractBelongsTo({'table1', 'table2'})"},
+          "Returns true if the change event is for a data contract whose target entity FQN equals any of the listed FQNs.",
+      examples = {"filterByEntityNameDataContractBelongsTo({'service.database.schema.table1'})"},
       paramInputType = READ_FROM_PARAM_CONTEXT)
-  public Boolean filterByEntityNameDataContractBelongsTo(List<String> entityNames) {
-    if (changeEvent.getEntityType().equals(DATA_CONTRACT)) {
-      try {
-        DataContract dataContract =
-            JsonUtils.readValue(changeEvent.getEntity().toString(), DataContract.class);
-        if (dataContract.getEntity() != null) {
-          String entityFqn = dataContract.getEntity().getFullyQualifiedName();
-          return entityNames.stream().anyMatch(entityFqn::contains);
-        }
-      } catch (Exception e) {
-        LOG.warn("Failed to parse DataContract from change event", e);
-      }
+  public Boolean filterByEntityNameDataContractBelongsTo(List<String> entityFqns) {
+    if (changeEvent == null || !changeEvent.getEntityType().equals(DATA_CONTRACT)) {
+      return false;
     }
-    return false;
+    try {
+      DataContract dataContract =
+          JsonUtils.readValue(changeEvent.getEntity().toString(), DataContract.class);
+      if (dataContract.getEntity() == null) {
+        return false;
+      }
+      return entityFqns.contains(dataContract.getEntity().getFullyQualifiedName());
+    } catch (Exception e) {
+      LOG.warn("Failed to parse DataContract from change event", e);
+      return false;
+    }
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataInsightSystemChartRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataInsightSystemChartRepository.java
@@ -98,8 +98,6 @@ public class DataInsightSystemChartRepository extends EntityRepository<DataInsig
   public static final String FORMULA_FUNC_REGEX =
       "\\b(count|sum|min|max|avg|unique)+\\((k='([^']*)')?,?\\s*(q='([^']*)')?\\)?";
 
-  public static final String NUMERIC_VALIDATION_REGEX = "[\\d\\.+-\\/\\*\\(\\) ]+";
-
   public DataInsightSystemChartRepository() {
     super(
         DataInsightSystemChartResource.COLLECTION_PATH,

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/dataInsightAggregators/ElasticSearchDynamicChartAggregatorInterface.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/dataInsightAggregators/ElasticSearchDynamicChartAggregatorInterface.java
@@ -30,8 +30,7 @@ import org.openmetadata.schema.dataInsight.custom.DataInsightCustomChartResultLi
 import org.openmetadata.schema.dataInsight.custom.FormulaHolder;
 import org.openmetadata.schema.dataInsight.custom.Function;
 import org.openmetadata.service.jdbi3.DataInsightSystemChartRepository;
-import org.openmetadata.service.security.policyevaluator.CompiledRule;
-import org.springframework.expression.Expression;
+import org.openmetadata.service.util.DataInsightFormulaEvaluator;
 
 public interface ElasticSearchDynamicChartAggregatorInterface {
 
@@ -160,10 +159,9 @@ public interface ElasticSearchDynamicChartAggregatorInterface {
             formulaCopy.replace(holder.get(i).getFormula(), result.get(i).getCount().toString());
       }
       if (evaluate
-          && formulaCopy.matches(DataInsightSystemChartRepository.NUMERIC_VALIDATION_REGEX)
+          && formulaCopy.matches(DataInsightFormulaEvaluator.NUMERIC_VALIDATION_REGEX)
           && (day != null || term != null)) {
-        Expression expression = CompiledRule.parseExpression(formulaCopy);
-        Double value = (Double) expression.getValue();
+        Double value = DataInsightFormulaEvaluator.evaluate(formulaCopy);
         // Convert NaN and Infinite values to 0.0
         if (value == null || value.isNaN() || value.isInfinite()) {
           value = 0.0;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/dataInsightAggregator/OpenSearchDynamicChartAggregatorInterface.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/dataInsightAggregator/OpenSearchDynamicChartAggregatorInterface.java
@@ -18,8 +18,7 @@ import org.openmetadata.schema.dataInsight.custom.DataInsightCustomChartResultLi
 import org.openmetadata.schema.dataInsight.custom.FormulaHolder;
 import org.openmetadata.schema.dataInsight.custom.Function;
 import org.openmetadata.service.jdbi3.DataInsightSystemChartRepository;
-import org.openmetadata.service.security.policyevaluator.CompiledRule;
-import org.springframework.expression.Expression;
+import org.openmetadata.service.util.DataInsightFormulaEvaluator;
 import os.org.opensearch.client.json.JsonData;
 import os.org.opensearch.client.opensearch._types.aggregations.Aggregate;
 import os.org.opensearch.client.opensearch._types.aggregations.Aggregation;
@@ -154,10 +153,9 @@ public interface OpenSearchDynamicChartAggregatorInterface {
             formulaCopy.replace(holder.get(i).getFormula(), result.get(i).getCount().toString());
       }
       if (evaluate
-          && formulaCopy.matches(DataInsightSystemChartRepository.NUMERIC_VALIDATION_REGEX)
+          && formulaCopy.matches(DataInsightFormulaEvaluator.NUMERIC_VALIDATION_REGEX)
           && (day != null || term != null)) {
-        Expression expression = CompiledRule.parseExpression(formulaCopy);
-        Double value = (Double) expression.getValue();
+        Double value = DataInsightFormulaEvaluator.evaluate(formulaCopy);
         // Convert NaN and Infinite values to 0.0
         if (value == null || value.isNaN() || value.isInfinite()) {
           value = 0.0;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/ExpressionValidator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/ExpressionValidator.java
@@ -114,6 +114,8 @@ public class ExpressionValidator {
               "matchPipelineState",
               "matchAnyDomain",
               "matchConversationUser",
+              "matchDataContractStatus",
+              "filterByEntityNameDataContractBelongsTo",
               "isBot"));
       LOG.info("Using fallback list of {} allowed functions", allowedFunctions.size());
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/ExpressionValidator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/ExpressionValidator.java
@@ -19,59 +19,158 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.Function;
+import org.springframework.expression.ParseException;
+import org.springframework.expression.spel.SpelNode;
+import org.springframework.expression.spel.ast.BooleanLiteral;
+import org.springframework.expression.spel.ast.Elvis;
+import org.springframework.expression.spel.ast.FloatLiteral;
+import org.springframework.expression.spel.ast.InlineList;
+import org.springframework.expression.spel.ast.InlineMap;
+import org.springframework.expression.spel.ast.IntLiteral;
+import org.springframework.expression.spel.ast.LongLiteral;
+import org.springframework.expression.spel.ast.MethodReference;
+import org.springframework.expression.spel.ast.NullLiteral;
+import org.springframework.expression.spel.ast.OpAnd;
+import org.springframework.expression.spel.ast.OpEQ;
+import org.springframework.expression.spel.ast.OpGE;
+import org.springframework.expression.spel.ast.OpGT;
+import org.springframework.expression.spel.ast.OpLE;
+import org.springframework.expression.spel.ast.OpLT;
+import org.springframework.expression.spel.ast.OpNE;
+import org.springframework.expression.spel.ast.OpOr;
+import org.springframework.expression.spel.ast.OperatorNot;
+import org.springframework.expression.spel.ast.RealLiteral;
+import org.springframework.expression.spel.ast.StringLiteral;
+import org.springframework.expression.spel.ast.Ternary;
+import org.springframework.expression.spel.standard.SpelExpression;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
 
 /**
- * Utility class for validating SpEL expressions to prevent code injection.
+ * Validates SpEL expressions used in alert and policy rules against a strict allowlist to
+ * prevent code injection.
+ *
+ * <p>Strategy is AST-based default-deny. The previous regex-based approach produced repeated
+ * false positives whenever user-supplied string-literal arguments contained tokens that
+ * looked like dangerous syntax (e.g. a test-suite name {@code 'AENG - CSP work item bug
+ * checks (duration exceeded)'} was rejected because the regex saw {@code checks(} as a
+ * function call inside the string). String-literal content cannot execute code, so
+ * inspecting it as syntax was architecturally wrong.
+ *
+ * <p>Replacement strategy:
+ *
+ * <ol>
+ *   <li>Parse the expression with {@link SpelExpressionParser} to obtain the canonical
+ *       SpEL AST. Parse failures throw {@link IllegalArgumentException}.
+ *   <li>Walk the AST. A node is accepted only if its concrete class is in
+ *       {@link #ALLOWED_NODE_CLASSES}: literals, boolean/comparison operators, list/map
+ *       literals, ternaries, and {@link MethodReference}s. Every other construct
+ *       (type references, constructors, bean references, property/field accesses,
+ *       projections/selections, indexers, assignments, arithmetic, variable references,
+ *       compound expressions, ...) is rejected by default-deny.
+ *   <li>For {@link MethodReference} nodes, the called name must also be on
+ *       {@link #ALLOWED_FUNCTIONS} — i.e. a method annotated with
+ *       {@link Function @Function} on one of the evaluator classes.
+ * </ol>
+ *
+ * <p>Defense-in-depth: any new SpEL syntax feature is implicitly rejected by the
+ * default-deny policy until explicitly allowlisted, eliminating the bypass surface a
+ * regex-based scan carries.
  */
 @Slf4j
-public class ExpressionValidator {
-  // Cache of allowed function names from RuleEvaluator class
+public final class ExpressionValidator {
+
   private static final Set<String> ALLOWED_FUNCTIONS = initAllowedFunctions();
 
-  // Patterns that indicate potentially dangerous expressions
-  // Using precise regex patterns to avoid false positives while maintaining security
-  // Each pattern uses (?<![\\w$]) negative lookbehind to ensure the token isn't part of an
-  // identifier
-  private static final List<Pattern> DANGEROUS_PATTERNS =
-      Arrays.asList(
-          // SpEL type reference: T(java.lang.Runtime) - used to access static methods
-          Pattern.compile("(?<![\\w$])T\\s*\\("),
+  private static final Set<Class<?>> ALLOWED_NODE_CLASSES =
+      Set.of(
+          // Literals — non-executable data
+          StringLiteral.class,
+          IntLiteral.class,
+          LongLiteral.class,
+          FloatLiteral.class,
+          RealLiteral.class,
+          BooleanLiteral.class,
+          NullLiteral.class,
+          // Boolean operators — safe combinators of allowed sub-expressions
+          OpAnd.class,
+          OpOr.class,
+          OperatorNot.class,
+          // Comparison operators
+          OpEQ.class,
+          OpNE.class,
+          OpGT.class,
+          OpGE.class,
+          OpLT.class,
+          OpLE.class,
+          // Collection literals used to pass arguments to filter functions
+          InlineList.class,
+          InlineMap.class,
+          // Method calls — subject to ALLOWED_FUNCTIONS check below
+          MethodReference.class,
+          // Conditional combinators
+          Ternary.class,
+          Elvis.class);
 
-          // Constructor invocation: new ProcessBuilder() - prevents object instantiation
-          // Requires whitespace after 'new' to avoid matching "renewable", "brand_new", etc.
-          Pattern.compile("(?<![\\w$])new\\s+"),
+  private ExpressionValidator() {}
 
-          // System class access: System.exit(), System.getenv() - keep broad for security
-          Pattern.compile("(?<![\\w$])System\\."),
+  public static void validateExpressionSafety(String expression) {
+    if (expression == null || expression.trim().isEmpty()) {
+      return;
+    }
+    SpelExpression compiled;
+    try {
+      compiled = (SpelExpression) new SpelExpressionParser().parseExpression(expression);
+    } catch (ParseException e) {
+      throw new IllegalArgumentException("Cannot parse policy expression: " + e.getMessage(), e);
+    }
+    validateNode(compiled.getAST());
+    LOG.debug("Validated expression: {}", expression);
+  }
 
-          // Runtime class reference - catches Runtime.getRuntime() pattern
-          Pattern.compile("(?<![\\w$])Runtime\\b"),
+  public static Set<String> getAllowedFunctions() {
+    return new HashSet<>(ALLOWED_FUNCTIONS);
+  }
 
-          // Reflection via getClass() method - requires dot prefix to ensure method call
-          Pattern.compile("\\.\\s*getClass\\s*\\("),
+  private static void validateNode(SpelNode node) {
+    if (node == null) {
+      return;
+    }
+    ensureNodeKindAllowed(node);
+    ensureMethodNameAllowed(node);
+    for (int i = 0; i < node.getChildCount(); i++) {
+      validateNode(node.getChild(i));
+    }
+  }
 
-          // ClassLoader reference - can load arbitrary bytecode
-          Pattern.compile("(?<![\\w$])ClassLoader\\b"),
+  private static void ensureNodeKindAllowed(SpelNode node) {
+    if (ALLOWED_NODE_CLASSES.contains(node.getClass())) {
+      return;
+    }
+    throw new IllegalArgumentException(
+        "Expression contains a disallowed SpEL construct: "
+            + node.getClass().getSimpleName()
+            + " ('"
+            + node.toStringAST()
+            + "'). Only literals, boolean/comparison operators, list/map literals,"
+            + " ternaries, and method calls on approved @Function-annotated methods are allowed.");
+  }
 
-          // Class.forName() or any forName() call - dynamic class loading
-          Pattern.compile("\\.\\s*forName\\s*\\("),
-
-          // exec() method call - executes system commands
-          Pattern.compile("\\.\\s*exec\\s*\\("),
-
-          // eval() function call - requires function call syntax to avoid false positives
-          // This prevents matching table names like "customer_evaluations"
-          Pattern.compile("(?<![\\w$])eval\\s*\\("),
-
-          // ProcessBuilder class - used to spawn system processes
-          Pattern.compile("(?<![\\w$])ProcessBuilder\\b"),
-
-          // Java reflection package - direct reflection access
-          Pattern.compile("(?<![\\w$])java\\.lang\\.reflect\\b"));
+  private static void ensureMethodNameAllowed(SpelNode node) {
+    if (!(node instanceof MethodReference methodRef)) {
+      return;
+    }
+    String name = methodRef.getName();
+    if (ALLOWED_FUNCTIONS.contains(name)) {
+      return;
+    }
+    throw new IllegalArgumentException(
+        "Function '"
+            + name
+            + "' is not allowed in policy expressions. "
+            + "Only use approved functions with @Function annotations in evaluator classes.");
+  }
 
   private static Set<String> initAllowedFunctions() {
     Set<String> allowedFunctions = new HashSet<>();
@@ -81,11 +180,13 @@ public class ExpressionValidator {
       evaluatorClasses.add(RuleEvaluator.class);
       evaluatorClasses.addAll(getClassesAlertAndCompletion());
 
-      for (Class<?> evaluatorClass : evaluatorClasses) {
-        scanClassForFunctions(evaluatorClass, allowedFunctions);
+      for (Class<?> clazz : evaluatorClasses) {
+        scanClassForFunctions(clazz, allowedFunctions);
       }
-
-      LOG.info("Initialized {} allowed functions for policy expressions", allowedFunctions.size());
+      LOG.info(
+          "Initialized ExpressionValidator with {} allowed functions: {}",
+          allowedFunctions.size(),
+          allowedFunctions);
     } catch (Exception e) {
       LOG.error("Failed to initialize allowed functions", e);
       // Fallback to hardcoded list if reflection fails
@@ -152,53 +253,5 @@ public class ExpressionValidator {
     } catch (Exception e) {
       LOG.warn("Failed to scan functions from class {}", clazz.getName(), e);
     }
-  }
-
-  public static void validateExpressionSafety(String expression) {
-    if (expression == null || expression.trim().isEmpty()) {
-      return;
-    }
-
-    // Check for dangerous patterns using regex to avoid false positives
-    for (Pattern pattern : DANGEROUS_PATTERNS) {
-      Matcher patternMatcher = pattern.matcher(expression);
-      if (patternMatcher.find()) {
-        throw new IllegalArgumentException(
-            "Expression contains potentially unsafe pattern: "
-                + pattern.pattern()
-                + ". "
-                + "Only use approved policy functions with @Function annotations.");
-      }
-    }
-
-    // Extract function calls from the expression
-    Pattern functionPattern = Pattern.compile("\\b([a-zA-Z0-9_]+)\\s*\\(");
-    Matcher matcher = functionPattern.matcher(expression);
-
-    List<String> foundFunctions = new ArrayList<>();
-    while (matcher.find()) {
-      String functionName = matcher.group(1);
-      // Skip empty function names and logical operators
-      if (!functionName.isEmpty()
-          && !functionName.equals("and")
-          && !functionName.equals("or")
-          && !functionName.equals("not")) {
-        foundFunctions.add(functionName);
-        // Check if function is allowed
-        if (!ALLOWED_FUNCTIONS.contains(functionName)) {
-          throw new IllegalArgumentException(
-              "Function '"
-                  + functionName
-                  + "' is not allowed in policy expressions. "
-                  + "Only use approved functions with @Function annotations in evaluator classes.");
-        }
-      }
-    }
-
-    LOG.debug("Validated expression contains only allowed functions: {}", foundFunctions);
-  }
-
-  public static Set<String> getAllowedFunctions() {
-    return new HashSet<>(ALLOWED_FUNCTIONS);
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/DataInsightFormulaEvaluator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/DataInsightFormulaEvaluator.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.util;
+
+import org.springframework.expression.Expression;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+
+/**
+ * Evaluates Data Insight chart formulas as numeric arithmetic.
+ *
+ * <p>Callers must gate the input with {@link #NUMERIC_VALIDATION_REGEX} (digits, decimal,
+ * {@code + - * /}, parens, space) before calling {@link #evaluate(String)}. The regex is
+ * the security boundary; this util bypasses {@code ExpressionValidator} on purpose
+ * because that validator's allowlist does not include arithmetic operators.
+ */
+public final class DataInsightFormulaEvaluator {
+
+  public static final String NUMERIC_VALIDATION_REGEX = "[\\d\\.+-\\/\\*\\(\\) ]+";
+
+  private static final SpelExpressionParser PARSER = new SpelExpressionParser();
+
+  private DataInsightFormulaEvaluator() {}
+
+  /**
+   * Evaluate a DI chart formula previously gated by {@link #NUMERIC_VALIDATION_REGEX}.
+   * Returns {@code null}, NaN, or Infinity for ill-formed numeric inputs; callers coerce
+   * these to {@code 0.0}.
+   */
+  public static Double evaluate(String regexGatedFormula) {
+    Expression expression = PARSER.parseExpression(regexGatedFormula);
+    return (Double) expression.getValue();
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/ExpressionValidatorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/ExpressionValidatorTest.java
@@ -595,4 +595,21 @@ public class ExpressionValidatorTest {
         () -> ExpressionValidator.validateExpressionSafety("'unterminated"),
         "Unterminated string should throw");
   }
+
+  /**
+   * Arithmetic is not in the policy/alert allowlist. Data Insight evaluates it via {@link
+   * org.openmetadata.service.util.DataInsightFormulaEvaluator#evaluate}, which bypasses
+   * this validator.
+   */
+  @Test
+  void testArithmeticIsRejectedByPolicyValidator() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ExpressionValidator.validateExpressionSafety("1 + 2"),
+        "Addition should be rejected by the policy/alert validator");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ExpressionValidator.validateExpressionSafety("((0.0 / 1500.0) * 100)"),
+        "Substituted DI chart formula shape should be rejected by the policy/alert validator");
+  }
 }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/ExpressionValidatorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/ExpressionValidatorTest.java
@@ -507,4 +507,92 @@ public class ExpressionValidatorTest {
         () -> ExpressionValidator.validateExpressionSafety("  "),
         "Whitespace expression should not throw an exception");
   }
+
+  /**
+   * Regex-based validation rejected expressions whose string-literal arguments contained
+   * tokens that looked like SpEL syntax (parens, identifier ( ... ), {@code System.}, etc.).
+   * The AST-based validator parses string content as {@link
+   * org.springframework.expression.spel.ast.StringLiteral} nodes and does not inspect them
+   * as code. Customer-reported regression: a test-suite name like
+   * {@code 'AENG - CSP work item bug checks (duration exceeded)'} now validates.
+   */
+  @Test
+  void testStringLiteralContentIsNotInterpretedAsSyntax() {
+    // Parens — the customer-reported case
+    assertDoesNotThrow(
+        () ->
+            ExpressionValidator.validateExpressionSafety(
+                "matchAnyEntityFqn('AENG - CSP work item bug checks (duration exceeded)')"),
+        "Identifier followed by '(' inside a string literal should be allowed");
+    assertDoesNotThrow(
+        () ->
+            ExpressionValidator.validateExpressionSafety(
+                "matchAnyEntityFqn('service.db.schema.table(beta)')"),
+        "Trailing parenthesised qualifier inside a string literal should be allowed");
+
+    // Dangerous-looking tokens that are inert when inside a string literal
+    assertDoesNotThrow(
+        () ->
+            ExpressionValidator.validateExpressionSafety(
+                "matchAnyEntityFqn('this contains System.exit(0) as text')"),
+        "Dangerous-looking syntax inside a string literal should be allowed (cannot execute)");
+    assertDoesNotThrow(
+        () ->
+            ExpressionValidator.validateExpressionSafety(
+                "matchAnyEntityFqn('a name containing T(java.lang.Runtime)')"),
+        "SpEL type-reference syntax inside a string literal should be allowed (cannot execute)");
+    assertDoesNotThrow(
+        () ->
+            ExpressionValidator.validateExpressionSafety(
+                "matchAnyEntityFqn('table with new ProcessBuilder() in its name')"),
+        "Constructor syntax inside a string literal should be allowed (cannot execute)");
+
+    // SpEL doubled-single-quote escape inside a string literal
+    assertDoesNotThrow(
+        () -> ExpressionValidator.validateExpressionSafety("matchAnyEntityFqn('it''s a name')"),
+        "Escaped single quote (doubled) inside a string literal should be allowed");
+
+    // Multiple parens-containing names in one expression
+    assertDoesNotThrow(
+        () ->
+            ExpressionValidator.validateExpressionSafety(
+                "matchAnyEntityFqn('first (a)') && matchAnyEntityFqn('second (b)')"),
+        "Multiple string literals each containing parens should all be allowed");
+  }
+
+  /**
+   * Unsafe SpEL constructs remain blocked even when nested inside otherwise-safe
+   * combinators — the AST walker rejects them at the node level, not by surface-string
+   * pattern matching.
+   */
+  @Test
+  void testUnsafeConstructsRejectedInsideCombinators() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            ExpressionValidator.validateExpressionSafety(
+                "matchAnyTag('PII') ? T(java.lang.Runtime).getRuntime() : isOwner()"),
+        "Type reference inside a ternary branch should be blocked");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ExpressionValidator.validateExpressionSafety("noOwner() && (new java.io.File('x'))"),
+        "Constructor inside a parenthesised sub-expression should be blocked");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ExpressionValidator.validateExpressionSafety("!System.exit(0)"),
+        "Property access on System remains blocked even under negation");
+  }
+
+  /** Malformed SpEL must surface as an IllegalArgumentException, not a crash. */
+  @Test
+  void testMalformedExpressionsThrow() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ExpressionValidator.validateExpressionSafety("noOwner( && isOwner()"),
+        "Unbalanced parens should throw");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ExpressionValidator.validateExpressionSafety("'unterminated"),
+        "Unterminated string should throw");
+  }
 }

--- a/openmetadata-ui/src/main/resources/ui/playwright/constant/alert.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/constant/alert.interface.ts
@@ -58,6 +58,7 @@ export interface ObservabilityCreationDetails {
     inputs?: Array<{
       inputSelector: string;
       inputValue: string;
+      inputValueId?: string;
       waitForAPI?: boolean;
     }>;
   }>;

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ObservabilityAlerts.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ObservabilityAlerts.spec.ts
@@ -17,6 +17,7 @@ import {
   TEST_CASE_NAME,
   TEST_SUITE_NAME,
 } from '../../constant/alert';
+import { ObservabilityCreationDetails } from '../../constant/alert.interface';
 import { Domain } from '../../support/domain/Domain';
 import { PipelineClass } from '../../support/entity/PipelineClass';
 import { TableClass } from '../../support/entity/TableClass';
@@ -44,6 +45,7 @@ import {
   getObservabilityCreationDetails,
   visitObservabilityAlertPage,
 } from '../../utils/observabilityAlert';
+import { waitForSearchIndexed } from '../../utils/polling';
 import { test as base } from '../fixtures/pages';
 
 const table1 = new TableClass();
@@ -107,6 +109,55 @@ test.beforeAll(async ({ browser }) => {
   await table1.createTestCase(apiContext, { name: TEST_CASE_NAME });
   await pipeline.create(apiContext);
   await pipeline.createIngestionPipeline(apiContext, INGESTION_PIPELINE_NAME);
+
+  // Wait for the entities used as alert-filter dropdown picks to be searchable.
+  // In mode="multiple" the user can only pick options returned by the search API,
+  // so the test must wait for ES indexing before the UI flow runs.
+  await waitForSearchIndexed(
+    apiContext,
+    table1.entityResponseData.fullyQualifiedName ?? '',
+    'table'
+  );
+  await waitForSearchIndexed(
+    apiContext,
+    table2.entityResponseData.fullyQualifiedName ?? '',
+    'table'
+  );
+  await waitForSearchIndexed(
+    apiContext,
+    table1.testSuiteResponseData.fullyQualifiedName ?? '',
+    'testSuite'
+  );
+  await waitForSearchIndexed(
+    apiContext,
+    table1.testCasesResponseData[0]?.fullyQualifiedName ?? '',
+    'testCase'
+  );
+  await waitForSearchIndexed(
+    apiContext,
+    pipeline.ingestionPipelineResponseData.fullyQualifiedName ?? '',
+    'ingestionPipeline'
+  );
+
+  // Build the observability creation details using the entity FQNs returned
+  // from the API. The alert filter dropdowns run in mode="multiple", whose
+  // option `title` attribute equals the entity FQN, so the test's expected
+  // `inputValue` must match the FQN exactly.
+  observabilityDetailsBySource.clear();
+  const details = getObservabilityCreationDetails({
+    tableName1: table1.entityResponseData.fullyQualifiedName ?? '',
+    tableName2: table2.entityResponseData.fullyQualifiedName ?? '',
+    testSuiteFQN: table1.testSuiteResponseData.fullyQualifiedName ?? '',
+    testCaseName: table1.testCasesResponseData[0]?.fullyQualifiedName ?? '',
+    ingestionPipelineName:
+      pipeline.ingestionPipelineResponseData.fullyQualifiedName ?? '',
+    domainName: domain.data.name,
+    domainDisplayName: domain.data.displayName,
+    userName: `${user1.data.firstName}${user1.data.lastName}`,
+  });
+  for (const detail of details) {
+    observabilityDetailsBySource.set(detail.source, detail);
+  }
 
   await afterAction();
 });
@@ -202,21 +253,34 @@ test('Pipeline Alert', async ({ page }) => {
   });
 });
 
-const OBSERVABILITY_CREATION_DETAILS = getObservabilityCreationDetails({
-  tableName1: table1.entity.name,
-  tableName2: table2.entity.name,
-  testSuiteFQN: TEST_SUITE_NAME,
-  testCaseName: TEST_CASE_NAME,
-  ingestionPipelineName: INGESTION_PIPELINE_NAME,
-  domainName: domain.data.name,
-  domainDisplayName: domain.data.displayName,
-  userName: `${user1.data.firstName}${user1.data.lastName}`,
-});
+// Test names must be known at module load, but filter/action values must use
+// FQNs that only exist after entity creation. Declare the source list statically
+// and look up the full details (built in beforeAll) inside each test.
+const OBSERVABILITY_SOURCES: Array<{
+  source: string;
+  sourceDisplayName: string;
+}> = [
+  { source: 'table', sourceDisplayName: 'Table' },
+  { source: 'ingestionPipeline', sourceDisplayName: 'Ingestion Pipeline' },
+  { source: 'testCase', sourceDisplayName: 'Test case' },
+  { source: 'testSuite', sourceDisplayName: 'Test Suite' },
+];
 
-for (const alertDetails of OBSERVABILITY_CREATION_DETAILS) {
-  const { source, sourceDisplayName, filters, actions } = alertDetails;
+const observabilityDetailsBySource = new Map<
+  string,
+  ObservabilityCreationDetails
+>();
 
+for (const { source, sourceDisplayName } of OBSERVABILITY_SOURCES) {
   test(`${sourceDisplayName} alert`, async ({ page }) => {
+    const alertDetails = observabilityDetailsBySource.get(source);
+    if (!alertDetails) {
+      throw new Error(
+        `Observability creation details missing for source "${source}". ` +
+          `Was beforeAll set up correctly?`
+      );
+    }
+    const { filters, actions } = alertDetails;
     const ALERT_NAME = generateAlertName();
 
     await test.step('Create alert', async () => {
@@ -282,13 +346,23 @@ test('Alert operations for a user with and without permissions', async ({
       .locator('.ant-select-dropdown:visible')
       .waitFor({ state: 'hidden' });
 
+    // The mode="multiple" AsyncSelect renders dropdown options whose `title`
+    // equals the entity FQN, not the bare name. Search and pick by FQN.
+    const table1Fqn = table1.entityResponseData.fullyQualifiedName ?? '';
+
+    // Focus the combobox first so the search input becomes editable
+    // (mode="multiple" keeps the input readonly until focused).
+    await userWithPermissionsPage.click(
+      `[data-testid="fqn-list-select"] [role="combobox"]`
+    );
+
     // Search and select filter input value
     const searchOptions = userWithPermissionsPage.waitForResponse(
       '/api/v1/search/query?q=*'
     );
     await userWithPermissionsPage.fill(
       `[data-testid="fqn-list-select"] [role="combobox"]`,
-      table1.entity.name,
+      table1Fqn,
       {
         force: true, // eslint-disable-line playwright/no-force-option -- Ant Select overlay covers combobox input
       }
@@ -297,14 +371,14 @@ test('Alert operations for a user with and without permissions', async ({
     await searchOptions;
 
     await userWithPermissionsPage.click(
-      `.ant-select-dropdown:visible [title="${table1.entity.name}"]`
+      `.ant-select-dropdown:visible [title="${table1Fqn}"]`
     );
 
     // Check if option is selected
     await test
       .expect(
         userWithPermissionsPage.locator(
-          `[data-testid="fqn-list-select"] [title="${table1.entity.name}"]`
+          `[data-testid="fqn-list-select"] [title="${table1Fqn}"]`
         )
       )
       .toBeAttached();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ObservabilityAlerts.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ObservabilityAlerts.spec.ts
@@ -148,6 +148,7 @@ test.beforeAll(async ({ browser }) => {
     tableName1: table1.entityResponseData.fullyQualifiedName ?? '',
     tableName2: table2.entityResponseData.fullyQualifiedName ?? '',
     testSuiteFQN: table1.testSuiteResponseData.fullyQualifiedName ?? '',
+    testSuiteName: table1.testSuiteResponseData.name ?? '',
     testCaseName: table1.testCasesResponseData[0]?.fullyQualifiedName ?? '',
     ingestionPipelineName:
       pipeline.ingestionPipelineResponseData.fullyQualifiedName ?? '',

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/alert.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/alert.ts
@@ -399,6 +399,11 @@ export const addEntityFQNFilter = async ({
   // Ensure no dropdowns visible before searching
   await ensureNoDropdownVisible(page);
 
+  // Focus the combobox before filling — Ant Design Select with mode="multiple"
+  // renders the search input as readonly until it receives focus, which makes
+  // page.fill() fail with "element is not editable".
+  await page.click('[data-testid="fqn-list-select"] [role="combobox"]');
+
   // Search and select entity
   const getSearchResult = page.waitForResponse('/api/v1/search/query?q=*');
   await page.fill(

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/observabilityAlert.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/observabilityAlert.ts
@@ -651,6 +651,14 @@ export const createCommonObservabilityAlert = async ({
 
     if (action.inputs && action.inputs.length > 0) {
       for (const input of action.inputs) {
+        // Focus the combobox first. Ant Design Select with mode="multiple" renders
+        // the search input as readonly until focused; without the click, page.fill()
+        // (even with force: true) doesn't trigger AsyncSelect's onSearch handler, so
+        // the API call never fires and no options appear in the dropdown.
+        await page.click(
+          `[data-testid="${input.inputSelector}"] [role="combobox"]`
+        );
+
         const getSearchResult = page.waitForResponse(
           '/api/v1/search/query?q=*'
         );

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/observabilityAlert.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/observabilityAlert.ts
@@ -589,6 +589,13 @@ export const createCommonObservabilityAlert = async ({
       `.ant-select-dropdown:visible [data-testid="${filter.name}-filter-option"]`
     );
 
+    // Focus the combobox first. Ant Design Select with mode="multiple" renders the
+    // search input as readonly until focused, which makes page.fill() fail. Click also
+    // opens the dropdown so the search query fires when we fill.
+    await page.click(
+      `[data-testid="${filter.inputSelector}"] [role="combobox"]`
+    );
+
     // Search and select filter input value
     const searchOptions = page.waitForResponse('/api/v1/search/query?q=*');
     await page.fill(

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/observabilityAlert.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/observabilityAlert.ts
@@ -220,6 +220,7 @@ export const getObservabilityCreationDetails = ({
   domainDisplayName,
   userName,
   testSuiteFQN,
+  testSuiteName,
 }: {
   tableName1: string;
   tableName2: string;
@@ -229,6 +230,7 @@ export const getObservabilityCreationDetails = ({
   domainDisplayName: string;
   userName: string;
   testSuiteFQN: string;
+  testSuiteName: string;
 }): Array<ObservabilityCreationDetails> => {
   return [
     {
@@ -374,7 +376,9 @@ export const getObservabilityCreationDetails = ({
           inputs: [
             {
               inputSelector: 'test-suite-select',
+              // Options are labeled by test suite name; search by FQN, click by name.
               inputValue: testSuiteFQN,
+              inputValueId: testSuiteName,
               waitForAPI: true,
             },
             {
@@ -566,6 +570,7 @@ export const createCommonObservabilityAlert = async ({
     inputs?: Array<{
       inputSelector: string;
       inputValue: string;
+      inputValueId?: string;
       waitForAPI?: boolean;
     }>;
   }[];
@@ -672,10 +677,13 @@ export const createCommonObservabilityAlert = async ({
         if (input.waitForAPI) {
           await getSearchResult;
         }
-        await page.click(`[title="${input.inputValue}"]:visible`);
+        // Click the option whose title is the rendered label. Use inputValueId
+        // when the displayed label differs from the searched value.
+        const optionTitle = input.inputValueId ?? input.inputValue;
+        await page.click(`[title="${optionTitle}"]:visible`);
 
         await expect(page.getByTestId(input.inputSelector)).toHaveText(
-          input.inputValue
+          optionTitle
         );
 
         await clickOutside(page);

--- a/openmetadata-ui/src/main/resources/ui/src/constants/regex.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/regex.constants.ts
@@ -57,6 +57,9 @@ export const ENDS_WITH_NUMBER_REGEX = /\d+$/;
 
 export const HEX_COLOR_CODE_REGEX = /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/;
 
+export const UUID_REGEX =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
 export const TASK_SANITIZE_VALUE_REGEX = /^"|"$/g;
 
 export const TIMESTAMP_UNIX_IN_MILLISECONDS_REGEX = /^\d{13}$/;

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Alerts/AlertsUtil.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Alerts/AlertsUtil.test.tsx
@@ -469,19 +469,123 @@ describe('getFieldByArgumentType tests', () => {
     expect(selectDiv).toBeInTheDocument();
   });
 
-  it('should return correct fields for argumentType entityIdList', () => {
+  it('should return correct fields for argumentType entityIdList', async () => {
+    const { AsyncSelect: MockedAsyncSelect } = jest.requireMock(
+      '../../components/common/AsyncSelect/AsyncSelect'
+    );
+    MockedAsyncSelect.mockClear();
+
+    const field = getFieldByArgumentType(0, 'entityIdList', 0, 'table');
+
+    render(field);
+
+    expect(MockedAsyncSelect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        'data-testid': 'entity-id-select',
+        mode: 'multiple',
+        optionLabelProp: 'uuid',
+      }),
+      expect.anything()
+    );
+
+    const selectDiv = screen.getByText('AsyncSelect');
+    fireEvent.click(selectDiv);
+
+    expect(searchQuery).toHaveBeenCalledWith({
+      query: '',
+      pageNumber: 1,
+      pageSize: 50,
+      queryFilter: undefined,
+      searchIndex: SearchIndex.TABLE,
+    });
+  });
+
+  it('entityIdList: UUID-format input adds a term filter on the id field', async () => {
+    const { AsyncSelect: MockedAsyncSelect } = jest.requireMock(
+      '../../components/common/AsyncSelect/AsyncSelect'
+    );
+    MockedAsyncSelect.mockClear();
+    (searchQuery as jest.Mock).mockClear();
+
+    const field = getFieldByArgumentType(0, 'entityIdList', 0, 'table');
+
+    render(field);
+
+    const apiFn = MockedAsyncSelect.mock.calls[0][0].api as (
+      s: string
+    ) => Promise<unknown>;
+    const uuid = '550e8400-e29b-41d4-a716-446655440000';
+    await apiFn(uuid);
+
+    expect(searchQuery).toHaveBeenCalledWith({
+      query: uuid,
+      pageNumber: 1,
+      pageSize: 50,
+      queryFilter: getTermQuery({ id: uuid }),
+      searchIndex: SearchIndex.TABLE,
+    });
+  });
+
+  it('fqnList: strict-pick (mode="multiple", no free-text tags)', () => {
+    const { AsyncSelect: MockedAsyncSelect } = jest.requireMock(
+      '../../components/common/AsyncSelect/AsyncSelect'
+    );
+    MockedAsyncSelect.mockClear();
+
+    const field = getFieldByArgumentType(0, 'fqnList', 0, 'table');
+
+    render(field);
+
+    expect(MockedAsyncSelect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        'data-testid': 'fqn-list-select',
+        mode: 'multiple',
+      }),
+      expect.anything()
+    );
+  });
+
+  it('tableNameList: strict-pick (mode="multiple", no free-text tags)', () => {
+    const { AsyncSelect: MockedAsyncSelect } = jest.requireMock(
+      '../../components/common/AsyncSelect/AsyncSelect'
+    );
+    MockedAsyncSelect.mockClear();
+
+    const field = getFieldByArgumentType(0, 'tableNameList', 0, 'testCase');
+
+    render(field);
+
+    expect(MockedAsyncSelect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        'data-testid': 'table-name-select',
+        mode: 'multiple',
+      }),
+      expect.anything()
+    );
+  });
+
+  it('entityNameList: strict-pick (mode="multiple", no free-text tags)', () => {
+    const { AsyncSelect: MockedAsyncSelect } = jest.requireMock(
+      '../../components/common/AsyncSelect/AsyncSelect'
+    );
+    MockedAsyncSelect.mockClear();
+
     const field = getFieldByArgumentType(
       0,
-      'entityIdList',
+      'entityNameList',
       0,
-      'selectedTrigger'
+      'dataContract'
     );
 
     render(field);
 
-    const selectDiv = screen.getByTestId('entity-id-select');
-
-    expect(selectDiv).toBeInTheDocument();
+    expect(MockedAsyncSelect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        'data-testid': 'entity-name-select',
+        mode: 'multiple',
+      }),
+      expect.anything()
+    );
   });
 
   it('should return correct fields for argumentType pipelineStateList', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Alerts/AlertsUtil.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Alerts/AlertsUtil.tsx
@@ -68,6 +68,7 @@ import {
   EXTERNAL_CATEGORY_OPTIONS,
 } from '../../constants/Alerts.constants';
 import { PAGE_SIZE_LARGE } from '../../constants/constants';
+import { UUID_REGEX } from '../../constants/regex.constants';
 import { OPEN_METADATA } from '../../constants/Services.constant';
 import { AlertRecentEventFilters } from '../../enums/Alerts.enum';
 import { SearchIndex } from '../../enums/search.enum';
@@ -103,9 +104,6 @@ import searchClassBase from '../SearchClassBase';
 import { getTermQuery } from '../SearchUtils';
 import { showErrorToast } from '../ToastUtils';
 import './alerts-util.less';
-
-const UUID_PATTERN =
-  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
 
 export const getAlertsActionTypeIcon = (type?: SubscriptionType) => {
   switch (type) {
@@ -1064,7 +1062,7 @@ export const getFieldByArgumentType = (
     const searchIndexMapping =
       searchClassBase.getEntityTypeSearchIndexMapping();
     const trimmed = (searchText ?? '').trim();
-    const isUuidInput = UUID_PATTERN.test(trimmed);
+    const isUuidInput = UUID_REGEX.test(trimmed);
 
     try {
       const response = await searchQuery({

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Alerts/AlertsUtil.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Alerts/AlertsUtil.tsx
@@ -104,6 +104,9 @@ import { getTermQuery } from '../SearchUtils';
 import { showErrorToast } from '../ToastUtils';
 import './alerts-util.less';
 
+const UUID_PATTERN =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
 export const getAlertsActionTypeIcon = (type?: SubscriptionType) => {
   switch (type) {
     case SubscriptionType.Slack:
@@ -1056,6 +1059,49 @@ export const getFieldByArgumentType = (
       showDisplayNameAsLabel: false,
     });
   };
+
+  const getEntityByIdSuggestions = async (searchText?: string) => {
+    const searchIndexMapping =
+      searchClassBase.getEntityTypeSearchIndexMapping();
+    const trimmed = (searchText ?? '').trim();
+    const isUuidInput = UUID_PATTERN.test(trimmed);
+
+    try {
+      const response = await searchQuery({
+        query: trimmed,
+        pageNumber: 1,
+        pageSize: PAGE_SIZE_LARGE,
+        queryFilter: isUuidInput ? getTermQuery({ id: trimmed }) : undefined,
+        searchIndex: searchIndexMapping[selectedTrigger],
+      });
+
+      return uniqBy(
+        response.hits.hits.map((d) => {
+          const id = d._source.id ?? '';
+          const fqn = d._source.fullyQualifiedName ?? '';
+
+          return {
+            uuid: id,
+            value: id,
+            label: (
+              <div className="entity-id-option">
+                <div>{id}</div>
+                <div className="entity-id-option-fqn">{fqn}</div>
+              </div>
+            ),
+          };
+        }),
+        'value'
+      );
+    } catch (error) {
+      showErrorToast(
+        error as AxiosError,
+        t('server.entity-fetch-error', { entity: t('label.search') })
+      );
+
+      return [];
+    }
+  };
   const translatedContractStatusOptions = DATA_CONTRACT_STATUS_OPTIONS.map(
     (option) => ({
       ...option,
@@ -1071,12 +1117,11 @@ export const getFieldByArgumentType = (
           className="w-full"
           data-testid="fqn-list-select"
           maxTagTextLength={45}
-          mode="tags"
+          mode="multiple"
           optionFilterProp="label"
           placeholder={t('label.search-by-type', {
             type: t('label.fqn-uppercase'),
           })}
-          showArrow={false}
         />
       );
 
@@ -1104,7 +1149,7 @@ export const getFieldByArgumentType = (
           className="w-full"
           data-testid="table-name-select"
           maxTagTextLength={45}
-          mode="tags"
+          mode="multiple"
           optionFilterProp="label"
           placeholder={t('label.search-by-type', {
             type: t('label.table-lowercase'),
@@ -1121,7 +1166,7 @@ export const getFieldByArgumentType = (
           className="w-full"
           data-testid="entity-name-select"
           maxTagTextLength={45}
-          mode="tags"
+          mode="multiple"
           optionFilterProp="label"
           placeholder={t('label.search-by-type', {
             type: t('label.entity-lowercase'),
@@ -1183,11 +1228,13 @@ export const getFieldByArgumentType = (
 
     case 'entityIdList':
       field = (
-        <Select
+        <AsyncSelect
+          api={getEntityByIdSuggestions}
           className="w-full"
           data-testid="entity-id-select"
-          mode="tags"
-          open={false}
+          maxTagTextLength={45}
+          mode="multiple"
+          optionLabelProp="uuid"
           placeholder={t('label.search-by-type', {
             type: t('label.entity-id', {
               entity: t('label.data-asset'),

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Alerts/alerts-util.less
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Alerts/alerts-util.less
@@ -55,5 +55,5 @@
 
 .entity-id-option-fqn {
   color: @grey-3;
-  font-size: 12px;
+  font-size: @size-sm;
 }

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Alerts/alerts-util.less
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Alerts/alerts-util.less
@@ -46,3 +46,14 @@
     padding: 0;
   }
 }
+
+.entity-id-option {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.3;
+}
+
+.entity-id-option-fqn {
+  color: @grey-3;
+  font-size: 12px;
+}


### PR DESCRIPTION
Fixes open-metadata/openmetadata-collate#4019

### Summary

Fixes a bug where alert filters dropped events if entity names contained regex metacharacters (e.g., `[TML] Fraud Mart Suite`).

Previously, the UI allowed free-text input while the backend applied inconsistent regex or substring evaluations. This PR standardizes the contract across the stack: **strict-pick UI inputs ⇔ literal equality backend evaluation**.

### Backend Changes (`AlertsRuleEvaluator.java`)

Removed all undocumented regex/substring evaluations in favor of literal equality (`String.equals` or `List.contains`).

| Function | Before | After |
| --- | --- | --- |
| `matchAnyEntityFqn` | Raw regex (`matcher.find()`) | Literal `List.contains` |
| `testSuiteMatcher` | Raw regex on FQNs | Literal `List.contains` |
| `filterByTableNameTestCaseBelongsTo` | Regex with word boundaries `\b` | Literal equality on parsed parent FQN |
| `filterByEntityNameDataContractBelongsTo` | Substring match (`anyMatch(contains)`) | Literal `List.contains` |

* **Defense-in-depth:** Added a null `changeEvent` guard to `filterByEntityNameDataContractBelongsTo` (fixing a latent bug exposed by SpEL validators).
* **Housekeeping:** Updated `@Function` annotations, parameters, and `ExpressionValidator` allowlists to reflect the new literal semantics.

### Policy expression validator (`ExpressionValidator.java`)

Customer-reported follow-up: a test suite named like `AENG - CSP work item bug checks (duration exceeded)` was rejected with `Function 'checks' is not allowed in policy expressions`. Same root cause class as the metachar bug — the regex-based validator scanned the entire expression string and matched `checks(` as a function call inside the quoted argument.

Replaced the regex-based validator with **AST-based default-deny validation**:

| Before | After |
| --- | --- |
| Regex pass over the surface string | Parse with `SpelExpressionParser`, walk the AST |
| String-literal content scanned as syntax | `StringLiteral` nodes never inspected as code |
| Accumulated band-aids for false positives (`(?<![\w$])`, `\s+`, hardcoded `and`/`or`/`not` exceptions) | Whitelist of safe `SpelNode` classes; every other node rejected |

* **Allowed nodes:** literals, boolean/comparison operators, list/map literals, ternaries, and `MethodReference`s whose name is on the existing function allowlist.
* **All previously-blocked patterns remain blocked** (`T(...)`, `new`, `System.`, `Runtime`, `ClassLoader`, `.forName()`, `.exec()`, `eval()`, `ProcessBuilder`, `java.lang.reflect`) — now by node type rather than regex pattern, eliminating the bypass surface a regex carries.

### Data Insight chart formula evaluation (`DataInsightFormulaEvaluator.java`, new)

Tightening the validator surfaced a second false-positive class: Data Insight chart aggregators (`Elastic/OpenSearchDynamicChartAggregatorInterface`) route through the same `CompiledRule.parseExpression` entry point, but use SpEL purely as a *calculator* on regex-gated numeric strings.

Formula evaluation flow at the aggregator:
1. User formula like `(count(...) / count(...)) * 100` is stored on `DataInsightCustomChart`
2. ES/OS aggregation results are substituted for each placeholder → `(127.0 / 384.0) * 100`
3. The substituted string is gated by `NUMERIC_VALIDATION_REGEX = [\d\.+-\/\*\(\) ]+` (digits, decimal, `+ - * /`, parens, space only), provably free of identifiers, methods, or SpEL syntax
4. The arithmetic expression is parsed and evaluated to a `Double`

The AST validator (correctly) rejects arithmetic operators like `OpMultiply` because policy/alert conditions never need them. But DI formulas are pure arithmetic. The two threat models accidentally shared one validator entry point. Pre-PR the regex-based validator was a no-op on these strings (no `DANGEROUS_PATTERN` and no `[a-zA-Z0-9_]+(` match); the new AST validator rejected them.

**Fix:** extracted DI formula evaluation into a new `DataInsightFormulaEvaluator` util (with `NUMERIC_VALIDATION_REGEX` colocated). The two aggregators now use this util directly, bypassing `ExpressionValidator`. The regex remains the security boundary for DI; the validator stays focused on the policy/alert allowlist.

`ExpressionValidatorTest.testArithmeticIsRejectedByPolicyValidator` asserts that the validator continues to reject arithmetic. That path is now exclusively for DI formula evaluation.

### UI Changes (`AlertsUtil.tsx`)

Switched four filter renderers from `mode="tags"` (free-text) to `mode="multiple"` (strict dropdown pick) to prevent invalid inputs:

* `fqnList`
* `tableNameList`
* `entityNameList`
* `entityIdList`

**Enhancements to `entityIdList`:**

* Added a richer dropdown (`getEntityByIdSuggestions`) supporting typeahead by entity name.
* Supports a paste-UUID flow: if text matches a UUID pattern, it augments the search with an exact `id` term filter.
* UI renders the UUID on top and FQN below (muted), but selected chips and the backend contract strictly retain the UUID.

### Tests

* **Integration (`AlertsRuleEvaluatorResourceIT.java`):** 10 new tests covering literal matching, regex metacharacters, prefix-collision rejections, and entityLink fallbacks. Crucially, verified substring/regex payloads now correctly return `false`. `@ValueSource` extended with the customer-reported case `AENG - CSP work item bug checks (duration exceeded)`.
* **Policy validator (`ExpressionValidatorTest.java`):** Added a corpus pinning the literal-content-not-syntax contract (parens, dotted identifiers, dangerous-looking tokens inside quoted arguments, doubled-quote escape, malformed expressions). Every pre-existing `_Negative` case (`T()`, `new`, `System.`, `Runtime`, `ClassLoader`, `.forName()`, `.exec()`, `eval()`, `ProcessBuilder`, `java.lang.reflect`) remains blocked.
* **UI Jest (`AlertsUtil.test.tsx`):** 108/108 pass. Added assertions for the new `mode="multiple"` strict-picks and the UUID-format term-filter branch.
* **E2E (Manual):** Verified end-to-end via a local webhook receiver. All 9 scenarios passed (entity creation → alert triggered → webhook received).

### Type of change

* [x] Bug fix
* [x] UX hardening (strict-pick filter inputs)

----
## Summary by Gitar

- **Test infrastructure:**
  - Added interaction logic to `observabilityAlert.ts` to focus comboboxes before filling inputs, ensuring `onSearch` triggers correctly in Playwright tests.
- **Refactored Data Insight evaluation:**
  - Moved numeric formula evaluation logic into a new dedicated `DataInsightFormulaEvaluator` utility.
  - Decoupled chart formula arithmetic processing from the main `ExpressionValidator` to maintain strict security boundaries.
- **Improved Security Validation:**
  - Added a regression test in `ExpressionValidatorTest` to ensure that arithmetic operators used in chart formulas are explicitly rejected by the policy/alert validator.

<sub>This will update automatically on new commits.</sub>