### PR TITLE
chore(security): bump deps to address reported CVEs

### DIFF
--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -14,7 +14,7 @@
   <properties>
     <dropwizard.swagger.version>4.0.5-1</dropwizard.swagger.version>
     <awssdk.version>2.30.19</awssdk.version>
-    <azure-identity.version>1.14.0</azure-identity.version>
+    <azure-identity.version>1.15.2</azure-identity.version>
     <azure-kv.version>4.10.0</azure-kv.version>
     <azure-identity-extensions.version>1.0.0</azure-identity-extensions.version>
     <expiring.map.version>0.5.11</expiring.map.version>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
     <gson.version>2.13.1</gson.version>
     <mysql.connector.version>9.3.0</mysql.connector.version>
     <postgres.connector.version>42.7.11</postgres.connector.version>
-    <jsonschema2pojo.version>1.2.2</jsonschema2pojo.version>
+    <jsonschema2pojo.version>1.3.0</jsonschema2pojo.version>
     <lombok.version>1.18.36</lombok.version>
     <tomcat-jdbc.version>11.0.5</tomcat-jdbc.version>
     <hikaricp.version>7.0.2</hikaricp.version>
@@ -108,7 +108,7 @@
     <openapiswagger.version>2.2.25</openapiswagger.version>
     <httpclient.version>4.5.14</httpclient.version>
     <spring.version>6.2.18</spring.version>
-    <log4j.version>2.25.3</log4j.version>
+    <log4j.version>2.25.4</log4j.version>
     <org.junit.jupiter.version>5.11.4</org.junit.jupiter.version>
     <org.junit.platform.version>1.11.4</org.junit.platform.version>
     <dropwizard-health.version>5.0.0</dropwizard-health.version>
@@ -669,7 +669,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>
-        <version>4.1.132.Final</version>
+        <version>4.1.133.Final</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
     <gson.version>2.13.1</gson.version>
     <mysql.connector.version>9.3.0</mysql.connector.version>
     <postgres.connector.version>42.7.11</postgres.connector.version>
-    <jsonschema2pojo.version>1.3.0</jsonschema2pojo.version>
+    <jsonschema2pojo.version>1.3.1</jsonschema2pojo.version>
     <lombok.version>1.18.36</lombok.version>
     <tomcat-jdbc.version>11.0.5</tomcat-jdbc.version>
     <hikaricp.version>7.0.2</hikaricp.version>


### PR DESCRIPTION
### Describe your changes:

Bumps a few Maven dependencies to address vulnerabilities reported by our SCA / AWS Inspector scans.

| Dependency | Before | After | Addresses |
|---|---|---|---|
| `log4j` | 2.25.3 | 2.25.4 | CVE-2026-34477, CVE-2026-34478, CVE-2026-34480 |
| `jsonschema2pojo` | 1.2.2 | 1.3.0 | CVE-2025-3588 |
| `netty-bom` | 4.1.132.Final | 4.1.133.Final | netty-codec-http / netty-codec / netty-transport-native-epoll GHSAs |
| `azure-identity` (in `openmetadata-service`) | 1.14.0 | 1.15.2 | aligns service module with parent `dependencyManagement`; covers CVE-2024-35255 |

Other CVEs in the report (jetty 12.1.7, bouncycastle 1.84, logback 1.5.25, angus-mail 2.0.4) are already at fix versions on `main`. `net.i2p.crypto:eddsa` and `org.eclipse.jgit` are not in our Maven dependency tree (verified via `mvn dependency:tree` across all 16 modules) — they originate elsewhere (likely the Airflow base image or a stale scanned image) and cannot be addressed from `pom.xml`. `lcms2` is an Alpine OS package handled by the Docker `apk upgrade` step.

#
### Type of change:
- [x] Bug fix

#
### Tests:

#### Manual testing performed
- Ran `mvn dependency:tree -pl openmetadata-service -am` and confirmed the resolved versions are `log4j-core:2.25.4`, `jsonschema2pojo-core:1.3.0`, `netty-codec:4.1.133.Final`, `azure-identity:1.15.2`.

#
### UI screen recording / screenshots:
Not applicable.

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.

----
## Summary by Gitar

- **Dependency updates:**
  - Bumped `jsonschema2pojo.version` from `1.3.0` to `1.3.1` in `pom.xml` to resolve classpath issues with the maven-plugin.

<sub>This will update automatically on new commits.</sub>