### PR TITLE
fix: use useClipboard hook in CodeBlockComponent to fix clipboard on non-secure contexts

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/CodeBlock/CodeBlockComponent.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/CodeBlock/CodeBlockComponent.tsx
@@ -12,43 +12,26 @@
  */
 import { NodeViewContent, NodeViewProps, NodeViewWrapper } from '@tiptap/react';
 import { Button, Tooltip } from 'antd';
-import { FC, useCallback, useEffect, useRef, useState } from 'react';
+import { FC, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ReactComponent as CopyIcon } from '../../../../assets/svg/icon-copy.svg';
+import { useClipboard } from '../../../../hooks/useClipBoard';
 
 const CodeBlockComponent: FC<NodeViewProps> = ({ node }) => {
   const { t } = useTranslation();
-  const [copied, setCopied] = useState(false);
-  const timerRef = useRef<ReturnType<typeof setTimeout>>();
-
-  useEffect(() => {
-    return () => {
-      if (timerRef.current) {
-        clearTimeout(timerRef.current);
-      }
-    };
-  }, []);
+  const { onCopyToClipBoard, hasCopied } = useClipboard('', 2000);
 
   const handleCopy = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(node.textContent);
-      setCopied(true);
-      if (timerRef.current) {
-        clearTimeout(timerRef.current);
-      }
-      timerRef.current = setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // clipboard write failed silently
-    }
-  }, [node]);
+    await onCopyToClipBoard(node.textContent);
+  }, [node, onCopyToClipBoard]);
 
   return (
     <NodeViewWrapper as="pre" className="relative code-block">
       <NodeViewContent as="code" />
-      <span className="code-copy-button" data-copied={copied}>
+      <span className="code-copy-button" data-copied={hasCopied}>
         <Tooltip
-          open={copied || undefined}
-          title={copied ? t('label.copied') : t('label.copy')}>
+          open={hasCopied || undefined}
+          title={hasCopied ? t('label.copied') : t('label.copy')}>
           <Button
             data-testid="code-block-copy-icon"
             icon={<CopyIcon height={24} width={24} />}

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/ServiceDocPanel/ServiceDocPanel.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/ServiceDocPanel/ServiceDocPanel.test.tsx
@@ -415,6 +415,11 @@ describe('CodeBlockComponent', () => {
       value: { writeText: mockWriteText },
       writable: true,
     });
+    Object.defineProperty(window, 'isSecureContext', {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
   });
 
   it('should render the copy button', () => {
@@ -455,27 +460,7 @@ describe('CodeBlockComponent', () => {
     });
   });
 
-  it('should schedule a timer to reset data-copied after clicking copy', async () => {
-    const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
-
-    const { container } = render(<CodeBlockComponent {...mockNodeViewProps} />);
-
-    fireEvent.click(screen.getByTestId('code-block-copy-icon'));
-
-    await waitFor(() => {
-      expect(container.querySelector('.code-copy-button')).toHaveAttribute(
-        'data-copied',
-        'true'
-      );
-    });
-
-    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 2000);
-
-    setTimeoutSpy.mockRestore();
-  });
-
-  it('should cancel the previous timer on rapid clicks', async () => {
-    const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+  it('should remain in copied state after rapid clicks', async () => {
     const { container } = render(<CodeBlockComponent {...mockNodeViewProps} />);
 
     fireEvent.click(screen.getByTestId('code-block-copy-icon'));
@@ -490,30 +475,9 @@ describe('CodeBlockComponent', () => {
       expect(mockWriteText).toHaveBeenCalledTimes(2);
     });
 
-    expect(clearTimeoutSpy).toHaveBeenCalled();
-
     expect(container.querySelector('.code-copy-button')).toHaveAttribute(
       'data-copied',
       'true'
     );
-
-    clearTimeoutSpy.mockRestore();
-  });
-
-  it('should clear timeout on unmount', async () => {
-    const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
-    const { unmount } = render(<CodeBlockComponent {...mockNodeViewProps} />);
-
-    fireEvent.click(screen.getByTestId('code-block-copy-icon'));
-
-    await waitFor(() => {
-      expect(mockWriteText).toHaveBeenCalled();
-    });
-
-    unmount();
-
-    expect(clearTimeoutSpy).toHaveBeenCalled();
-
-    clearTimeoutSpy.mockRestore();
   });
 });


### PR DESCRIPTION
…

<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

## Summary

- `CodeBlockComponent` used `navigator.clipboard.writeText()` directly with a silent `catch` — on `http://` (AUT/non-secure context) `window.isSecureContext` is `false`, the write silently fails, `setCopied` never fires, and E2E tests see an empty clipboard
- Replaced the manual clipboard + timer logic with the existing `useClipboard` hook (same pattern as `CopyLinkButton`) which has a `document.execCommand` fallback for non-secure contexts
- Fixed `copyAndGetClipboardText` Playwright utility: replaced fixed 300ms wait + textarea paste hack with a sentinel-based `expect.poll` — writes a known sentinel before clicking, polls `navigator.clipboard.readText()` until the value changes, eliminating races from pre-populated clipboard or slow async writes
- Updated `ServiceDocPanel.test.tsx`: added `window.isSecureContext = true` mock, removed timer implementation-detail tests (now owned by `useClipboard` hook), kept behavioral assertions

https://github.com/user-attachments/assets/540ab1cb-5bef-453d-82c1-c9a1287c5fed

<img width="1347" height="245" alt="Screenshot 2026-05-09 at 1 33 17 AM" src="https://github.com/user-attachments/assets/64cc2bf1-d7fc-4ff7-aa1a-8fe0dfa7263a" />

<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
