### PR TITLE
avoid creating pipeline service lineage edges

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/LineagePipelineAnnotatorIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/LineagePipelineAnnotatorIT.java
@@ -46,8 +46,8 @@ import org.openmetadata.sdk.fluent.builders.ColumnBuilder;
  * <ul>
  *   <li>Bug #1: Service nodes (databaseService, messagingService, pipelineService) appeared in
  *       entity-level lineage views, making graphs noisy.
- *   <li>Bug #2: The pipeline service had no service-level edges, so the "By Service" view was
- *       empty.
+ *   <li>Bug #2: Service-level lineage should connect source and target services directly without
+ *       routing through the pipeline service.
  * </ul>
  *
  * <p>Topology: {@code table → topic} (annotated with {@code pipeline})
@@ -132,38 +132,44 @@ public class LineagePipelineAnnotatorIT {
   }
 
   @Test
-  void serviceLineage_PipelineServiceConnectedToBothServices() throws Exception {
+  void serviceLineage_PipelineServiceNotEntangledWithDataServices() throws Exception {
     JsonNode nodes =
         searchLineageNodes(pipelineService.getFullyQualifiedName(), "pipelineService", 1, 1);
 
     assertNotNull(nodes, "nodes should not be null for pipeline service lineage");
-    assertTrue(
+    assertFalse(
         nodes.has(dbService.getFullyQualifiedName()),
-        "DatabaseService should appear in pipeline service lineage");
-    assertTrue(
+        "DatabaseService should not appear in pipeline service lineage");
+    assertFalse(
         nodes.has(messagingService.getFullyQualifiedName()),
-        "MessagingService should appear in pipeline service lineage");
+        "MessagingService should not appear in pipeline service lineage");
   }
 
   @Test
-  void serviceLineage_DatabaseServiceHasPipelineServiceDownstream() throws Exception {
+  void serviceLineage_DatabaseServiceHasMessagingServiceDownstream() throws Exception {
     JsonNode nodes = searchLineageNodes(dbService.getFullyQualifiedName(), "databaseService", 0, 1);
 
     assertNotNull(nodes);
     assertTrue(
+        nodes.has(messagingService.getFullyQualifiedName()),
+        "MessagingService should appear as downstream of database service");
+    assertFalse(
         nodes.has(pipelineService.getFullyQualifiedName()),
-        "PipelineService should appear as downstream of database service");
+        "PipelineService should not appear as downstream of database service");
   }
 
   @Test
-  void serviceLineage_MessagingServiceHasPipelineServiceUpstream() throws Exception {
+  void serviceLineage_MessagingServiceHasDatabaseServiceUpstream() throws Exception {
     JsonNode nodes =
         searchLineageNodes(messagingService.getFullyQualifiedName(), "messagingService", 1, 0);
 
     assertNotNull(nodes);
     assertTrue(
+        nodes.has(dbService.getFullyQualifiedName()),
+        "DatabaseService should appear as upstream of messaging service");
+    assertFalse(
         nodes.has(pipelineService.getFullyQualifiedName()),
-        "PipelineService should appear as upstream of messaging service");
+        "PipelineService should not appear as upstream of messaging service");
   }
 
   // --- Helpers ---
@@ -255,11 +261,9 @@ public class LineagePipelineAnnotatorIT {
                   client
                       .lineage()
                       .searchLineage(
-                          pipelineService.getFullyQualifiedName(), "pipelineService", 1, 1, false);
+                          dbService.getFullyQualifiedName(), "databaseService", 0, 1, false);
               JsonNode nodes = MAPPER.readTree(result).get("nodes");
-              return nodes != null
-                  && nodes.has(dbService.getFullyQualifiedName())
-                  && nodes.has(messagingService.getFullyQualifiedName());
+              return nodes != null && nodes.has(messagingService.getFullyQualifiedName());
             });
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/LineageRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/LineageRepository.java
@@ -239,22 +239,6 @@ public class LineageRepository {
               .withPipeline(null);
       insertLineage(fromService, toService, serviceLineageDetails);
     }
-    addPipelineServiceEdges(fromService, toService, entityLineageDetails, childRelationExists);
-  }
-
-  private void addPipelineServiceEdges(
-      EntityReference fromService,
-      EntityReference toService,
-      LineageDetails entityLineageDetails,
-      boolean childRelationExists) {
-    EntityReference pipelineService = getPipelineService(entityLineageDetails);
-    if (pipelineService == null) {
-      return;
-    }
-    insertServiceEdgeIfDistinct(
-        fromService, pipelineService, entityLineageDetails, childRelationExists);
-    insertServiceEdgeIfDistinct(
-        pipelineService, toService, entityLineageDetails, childRelationExists);
   }
 
   private EntityReference getPipelineService(LineageDetails entityLineageDetails) {
@@ -268,21 +252,6 @@ public class LineageRepository {
     EntityInterface pipelineEntity =
         Entity.getEntity(pipelineRef.getType(), pipelineRef.getId(), FIELD_SERVICE, Include.ALL);
     return pipelineEntity.getService();
-  }
-
-  private void insertServiceEdgeIfDistinct(
-      EntityReference fromService,
-      EntityReference toService,
-      LineageDetails entityLineageDetails,
-      boolean childRelationExists) {
-    if (fromService.getId().equals(toService.getId())) {
-      return;
-    }
-    LineageDetails serviceDetails =
-        getOrCreateLineageDetails(
-                fromService.getId(), toService.getId(), entityLineageDetails, childRelationExists)
-            .withPipeline(null);
-    insertLineage(fromService, toService, serviceDetails);
   }
 
   private void addDomainLineage(

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/LineageRepositoryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/LineageRepositoryTest.java
@@ -658,19 +658,15 @@ class LineageRepositoryTest {
         "Updating an existing service-level edge must not inherit pipeline annotation from entity lineage");
   }
 
-  /**
-   * Bug #2: When entity lineage has a pipeline whose service is distinct from fromService and
-   * toService, three service-level edges must be created: fromService→toService,
-   * fromService→pipelineService, and pipelineService→toService.
-   */
+  /** Service-level lineage should stay direct even when entity lineage has a pipeline annotation. */
   @Test
-  void testPipelineServiceEdges_WithDistinctPipelineService_CreatesBothEdges() throws Exception {
+  void testServiceLineage_WithDistinctPipelineService_CreatesOnlyDirectServiceEdge()
+      throws Exception {
     UUID fromEntityId = UUID.randomUUID();
     UUID toEntityId = UUID.randomUUID();
     UUID fromServiceId = UUID.randomUUID();
     UUID toServiceId = UUID.randomUUID();
     UUID pipelineId = UUID.randomUUID();
-    UUID pipelineServiceId = UUID.randomUUID();
     String entityType = "table";
 
     EntityReference fromRef = new EntityReference().withId(fromEntityId).withType(entityType);
@@ -680,8 +676,6 @@ class LineageRepositoryTest {
         new EntityReference().withId(fromServiceId).withType("databaseService");
     EntityReference toServiceRef =
         new EntityReference().withId(toServiceId).withType("messagingService");
-    EntityReference pipelineServiceRef =
-        new EntityReference().withId(pipelineServiceId).withType("pipelineService");
 
     LineageDetails entityDetails =
         new LineageDetails().withPipeline(pipelineRef).withCreatedBy("testUser");
@@ -693,9 +687,6 @@ class LineageRepositoryTest {
     EntityInterface toEntityMock = mock(EntityInterface.class);
     when(toEntityMock.getService()).thenReturn(toServiceRef);
     when(toEntityMock.getEntityReference()).thenReturn(toRef);
-
-    EntityInterface pipelineEntityMock = mock(EntityInterface.class);
-    when(pipelineEntityMock.getService()).thenReturn(pipelineServiceRef);
 
     CollectionDAO freshDao = mock(CollectionDAO.class);
     CollectionDAO.EntityRelationshipDAO relDAO = mock(CollectionDAO.EntityRelationshipDAO.class);
@@ -711,10 +702,6 @@ class LineageRepositoryTest {
     mockedEntity
         .when(() -> Entity.getEntity(eq(entityType), eq(toEntityId), any(), any()))
         .thenReturn(toEntityMock);
-    mockedEntity.when(() -> Entity.entityHasField("pipeline", "service")).thenReturn(true);
-    mockedEntity
-        .when(() -> Entity.getEntity(eq("pipeline"), eq(pipelineId), any(), any()))
-        .thenReturn(pipelineEntityMock);
 
     ArgumentCaptor<UUID> fromCaptor = ArgumentCaptor.forClass(UUID.class);
     ArgumentCaptor<UUID> toCaptor = ArgumentCaptor.forClass(UUID.class);
@@ -730,7 +717,7 @@ class LineageRepositoryTest {
     buildExtendedLineage.setAccessible(true);
     buildExtendedLineage.invoke(repo, fromRef, toRef, entityDetails, false);
 
-    verify(relDAO, times(3))
+    verify(relDAO, times(1))
         .insert(fromCaptor.capture(), toCaptor.capture(), any(), any(), anyInt(), any());
 
     List<UUID> insertedFromIds = fromCaptor.getAllValues();
@@ -739,12 +726,6 @@ class LineageRepositoryTest {
     assertTrue(
         edgePairExists(insertedFromIds, insertedToIds, fromServiceId, toServiceId),
         "fromService→toService edge must be created");
-    assertTrue(
-        edgePairExists(insertedFromIds, insertedToIds, fromServiceId, pipelineServiceId),
-        "fromService→pipelineService edge must be created");
-    assertTrue(
-        edgePairExists(insertedFromIds, insertedToIds, pipelineServiceId, toServiceId),
-        "pipelineService→toService edge must be created");
   }
 
   /**


### PR DESCRIPTION
**Context**: Original discussed here with the team: https://github.com/open-metadata/OpenMetadata/pull/25054#issuecomment-3985101434. 
This PR avoids creating pipeline service lineage edges through the pipeline service. Previously, when an asset lineage edge had a pipeline annotation, omd created:
```
sourceService -> targetService
sourceService -> pipelineService
pipelineService -> targetService
```

This made service lineage graphs noisy and entangled pipeline services with data services. With this change, the server now keeps service lineage direct:

```
sourceService -> targetService
```

**Changes**:
- Removed creation of derived sourceService -> pipelineService and pipelineService -> targetService edges.
- Kept direct derived service lineage between source and target services.
- Updated unit and integration tests to assert the new service lineage behavior.

