### PR TITLE
fix(security): pin libthrift 0.23.0 and exclude Jackson 3.x transitive from jsonschema2pojo-core

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -56,6 +56,17 @@
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-databind</artifactId>
         </exclusion>
+        <!-- jsonschema2pojo-core 1.3.x switched its internal Jackson to 3.x (tools.jackson.core).
+             Annotators are build-time only; exclude Jackson 3.x so the runtime classpath stays on 2.x
+             and avoids GHSA-2m67-wjpj-xhg9 / CVE-2026-29062 / GHSA-72hv-8253-57qq. -->
+        <exclusion>
+          <groupId>tools.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>tools.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>com.google.code.gson</groupId>
           <artifactId>gson</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,12 @@
         <artifactId>angus-mail</artifactId>
         <version>${angus-mail.version}</version>
       </dependency>
+      <!-- CVE-2026-43869: apache-jena-libs:4.10.0 → jena-arq → libthrift:0.19.0. Pin to fixed version. -->
+      <dependency>
+        <groupId>org.apache.thrift</groupId>
+        <artifactId>libthrift</artifactId>
+        <version>0.23.0</version>
+      </dependency>
       <dependency>
         <groupId>org.antlr</groupId>
         <artifactId>antlr4-runtime</artifactId>


### PR DESCRIPTION
## Summary

Two unrelated dependency-tree fixes for CVEs flagged by the SCA scanner. Both are CVE remediations only — no functional changes.

### 1. `libthrift` 0.19.0 → 0.23.0 (CVE-2026-43869)

`apache-jena-libs:4.10.0` transitively pulls `org.apache.thrift:libthrift:0.19.0`, which is vulnerable to CVE-2026-43869. Apache Thrift fixed the issue in 0.23.0. Pinning via `<dependencyManagement>` in the parent pom forces the transitive resolution onto the fixed version without changing Jena.

Verified post-fix:
\`\`\`
mvn -pl openmetadata-service -am dependency:tree -Dincludes='org.apache.thrift:libthrift'
[INFO]          \- org.apache.thrift:libthrift:jar:0.23.0:compile
\`\`\`

### 2. Exclude `tools.jackson.core:*` from `jsonschema2pojo-core` (Jackson 3.x CVEs)

`common/pom.xml` declares `jsonschema2pojo-core` as a `compile`-scope dep so the custom annotator classes (`PasswordAnnotator`, `MaskedAnnotator`, etc.) can extend `org.jsonschema2pojo.AbstractAnnotator` for the build-time `jsonschema2pojo-maven-plugin`.

`jsonschema2pojo-core` 1.3.x switched its internal Jackson to **3.x** (`tools.jackson.core`). The existing exclusion in `common/pom.xml` only covered the legacy `com.fasterxml.jackson.core` groupId, so `jackson-core-3.0.2.jar` and `jackson-databind-3.0.2.jar` were leaking into the runtime classpath of every downstream module — even though all OpenMetadata code uses Jackson 2.x (`com.fasterxml.jackson.core`).

This removes scanner exposure to:
- GHSA-2m67-wjpj-xhg9
- CVE-2026-29062
- GHSA-72hv-8253-57qq (3.x affected line)

Our annotator classes only import `com.fasterxml.jackson.databind.JsonNode` (Jackson 2.x) and `com.sun.codemodel.*`, so they don't need Jackson 3 even at code-gen time. Verified by running `mvn install -pl openmetadata-spec -am` (which exercises `jsonschema2pojo-maven-plugin` with our annotators) — build succeeds with the exclusions in place.

## Test plan

- [x] `mvn -pl openmetadata-spec -am install -DskipTests` — exercises code-gen with our annotators; passes
- [x] `mvn -pl openmetadata-service -am dependency:tree -Dincludes='org.apache.thrift:libthrift'` — confirms 0.23.0
- [x] `mvn -pl openmetadata-service -am dependency:tree -Dincludes='tools.jackson.core:*'` — confirms no Jackson 3.x in tree
- [ ] CI green
- [ ] Backport to `1.12.7`