### PR TITLE
fix(security): pin libthrift, provided jsonschema2pojo, bump azure-kv/sjm/reactor-netty, exclude netty-epoll

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -46,64 +46,36 @@
       <version>${org.junit.jupiter.version}</version>
       <scope>test</scope>
     </dependency>
-    <!-- used for generating custom annotations in jsonschema2pojo-maven-plugin -->
+    <!--
+      jsonschema2pojo-core supplies the AbstractAnnotator base class for the custom
+      annotators in this module (PasswordAnnotator, MaskedAnnotator, DeprecatedAnnotator,
+      ExposedAnnotator, OpenMetadataAnnotator). Those annotators are invoked only by the
+      build-time jsonschema2pojo-maven-plugin (configured in openmetadata-spec/pom.xml via
+      <customAnnotator>); the plugin runs in its own classloader at code-gen time and adds
+      common.jar to its <dependencies> block, so the runtime classpath of any deployed
+      service never needs jsonschema2pojo-core or any of its transitives.
+
+      <optional>true</optional> keeps jsonschema2pojo-core on this module's compile
+      classpath (so the annotators compile) but stops Maven from propagating it — and all
+      of its transitive deps — to downstream consumers' runtime classpath. This includes:
+
+        - com.fasterxml.jackson.core:jackson-databind (Jackson 2.x)
+        - tools.jackson.core:jackson-core / jackson-databind (Jackson 3.x — affected by
+          GHSA-2m67-wjpj-xhg9, CVE-2026-29062, GHSA-72hv-8253-57qq; jsonschema2pojo-core
+          1.3.3 still pins jackson3.version=3.0.2, so upstream has no fix yet)
+        - gson, snakeyaml, commons-lang3, commons-lang (previously excluded one-by-one)
+
+      Replacing the previous explicit <exclusions> list (which only caught the deps known
+      at the time it was written) with <optional>true</optional> also future-proofs the
+      module against any new transitive dep that jsonschema2pojo-core picks up later —
+      no need to keep extending the exclusions list every time a CVE is reported on a
+      new jsonschema2pojo-core transitive.
+    -->
     <dependency>
       <groupId>org.jsonschema2pojo</groupId>
       <artifactId>jsonschema2pojo-core</artifactId>
       <version>${jsonschema2pojo.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-databind</artifactId>
-        </exclusion>
-        <!--
-          GHSA-2m67-wjpj-xhg9 / CVE-2026-29062 / GHSA-72hv-8253-57qq:
-          jsonschema2pojo-core 1.3.x switched its internal Jackson to 3.x (groupId
-          tools.jackson.core). The annotator classes in this module (PasswordAnnotator,
-          MaskedAnnotator, etc.) extend org.jsonschema2pojo.AbstractAnnotator and are
-          invoked only by the build-time jsonschema2pojo-maven-plugin — never at runtime.
-          They use only com.fasterxml.jackson.databind.JsonNode (Jackson 2.x) and
-          com.sun.codemodel.*, so they don't need Jackson 3 even at code-gen time.
-
-          Excluding the Jackson 3 transitive prevents jackson-core-3.0.2.jar /
-          jackson-databind-3.0.2.jar from leaking into the runtime classpath of every
-          downstream module (the existing com.fasterxml.jackson.core exclusion above
-          only covered the legacy 2.x groupId; the new tools.jackson.core groupId
-          sailed straight past it).
-
-          Why exclude instead of bumping jsonschema2pojo to a fix release:
-            - The CVE fix line for Jackson 3.x is 3.1.0 / 3.1.1.
-            - jsonschema2pojo-core's latest (1.3.3) still pins jackson3.version=3.0.2
-              in its parent pom — upstream has not yet bumped to 3.1.x.
-            - Verified by mvn install -pl openmetadata-spec -am (which exercises the
-              jsonschema2pojo-maven-plugin with our annotators): build succeeds with the
-              exclusion in place.
-        -->
-        <exclusion>
-          <groupId>tools.jackson.core</groupId>
-          <artifactId>jackson-core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>tools.jackson.core</groupId>
-          <artifactId>jackson-databind</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.code.gson</groupId>
-          <artifactId>gson</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.yaml</groupId>
-          <artifactId>snakeyaml</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-lang3</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>commons-lang</groupId>
-          <artifactId>commons-lang</artifactId>
-        </exclusion>
-      </exclusions>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -56,6 +56,17 @@
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-databind</artifactId>
         </exclusion>
+        <!-- jsonschema2pojo-core 1.3.x switched its internal Jackson to 3.x (tools.jackson.core).
+             Annotators are build-time only; exclude Jackson 3.x so the runtime classpath stays on 2.x
+             and avoids GHSA-2m67-wjpj-xhg9 / CVE-2026-29062 / GHSA-72hv-8253-57qq. -->
+        <exclusion>
+          <groupId>tools.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>tools.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>com.google.code.gson</groupId>
           <artifactId>gson</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -56,9 +56,29 @@
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-databind</artifactId>
         </exclusion>
-        <!-- jsonschema2pojo-core 1.3.x switched its internal Jackson to 3.x (tools.jackson.core).
-             Annotators are build-time only; exclude Jackson 3.x so the runtime classpath stays on 2.x
-             and avoids GHSA-2m67-wjpj-xhg9 / CVE-2026-29062 / GHSA-72hv-8253-57qq. -->
+        <!--
+          GHSA-2m67-wjpj-xhg9 / CVE-2026-29062 / GHSA-72hv-8253-57qq:
+          jsonschema2pojo-core 1.3.x switched its internal Jackson to 3.x (groupId
+          tools.jackson.core). The annotator classes in this module (PasswordAnnotator,
+          MaskedAnnotator, etc.) extend org.jsonschema2pojo.AbstractAnnotator and are
+          invoked only by the build-time jsonschema2pojo-maven-plugin — never at runtime.
+          They use only com.fasterxml.jackson.databind.JsonNode (Jackson 2.x) and
+          com.sun.codemodel.*, so they don't need Jackson 3 even at code-gen time.
+
+          Excluding the Jackson 3 transitive prevents jackson-core-3.0.2.jar /
+          jackson-databind-3.0.2.jar from leaking into the runtime classpath of every
+          downstream module (the existing com.fasterxml.jackson.core exclusion above
+          only covered the legacy 2.x groupId; the new tools.jackson.core groupId
+          sailed straight past it).
+
+          Why exclude instead of bumping jsonschema2pojo to a fix release:
+            - The CVE fix line for Jackson 3.x is 3.1.0 / 3.1.1.
+            - jsonschema2pojo-core's latest (1.3.3) still pins jackson3.version=3.0.2
+              in its parent pom — upstream has not yet bumped to 3.1.x.
+            - Verified by mvn install -pl openmetadata-spec -am (which exercises the
+              jsonschema2pojo-maven-plugin with our annotators): build succeeds with the
+              exclusion in place.
+        -->
         <exclusion>
           <groupId>tools.jackson.core</groupId>
           <artifactId>jackson-core</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -47,14 +47,14 @@
       <scope>test</scope>
     </dependency>
     <!-- Build-time only (used by jsonschema2pojo-maven-plugin in openmetadata-spec).
-         <optional>true</optional> stops all transitive deps — including Jackson 3.x
-         (GHSA-2m67-wjpj-xhg9, CVE-2026-29062, GHSA-72hv-8253-57qq) — from leaking
-         into the runtime classpath of downstream consumers. -->
+         <scope>provided</scope> keeps it on compile classpath but excludes it (and all
+         transitives — including Jackson 3.x: GHSA-2m67-wjpj-xhg9, CVE-2026-29062,
+         GHSA-72hv-8253-57qq) from runtime / dist packaging. -->
     <dependency>
       <groupId>org.jsonschema2pojo</groupId>
       <artifactId>jsonschema2pojo-core</artifactId>
       <version>${jsonschema2pojo.version}</version>
-      <optional>true</optional>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -46,31 +46,10 @@
       <version>${org.junit.jupiter.version}</version>
       <scope>test</scope>
     </dependency>
-    <!--
-      jsonschema2pojo-core supplies the AbstractAnnotator base class for the custom
-      annotators in this module (PasswordAnnotator, MaskedAnnotator, DeprecatedAnnotator,
-      ExposedAnnotator, OpenMetadataAnnotator). Those annotators are invoked only by the
-      build-time jsonschema2pojo-maven-plugin (configured in openmetadata-spec/pom.xml via
-      <customAnnotator>); the plugin runs in its own classloader at code-gen time and adds
-      common.jar to its <dependencies> block, so the runtime classpath of any deployed
-      service never needs jsonschema2pojo-core or any of its transitives.
-
-      <optional>true</optional> keeps jsonschema2pojo-core on this module's compile
-      classpath (so the annotators compile) but stops Maven from propagating it — and all
-      of its transitive deps — to downstream consumers' runtime classpath. This includes:
-
-        - com.fasterxml.jackson.core:jackson-databind (Jackson 2.x)
-        - tools.jackson.core:jackson-core / jackson-databind (Jackson 3.x — affected by
-          GHSA-2m67-wjpj-xhg9, CVE-2026-29062, GHSA-72hv-8253-57qq; jsonschema2pojo-core
-          1.3.3 still pins jackson3.version=3.0.2, so upstream has no fix yet)
-        - gson, snakeyaml, commons-lang3, commons-lang (previously excluded one-by-one)
-
-      Replacing the previous explicit <exclusions> list (which only caught the deps known
-      at the time it was written) with <optional>true</optional> also future-proofs the
-      module against any new transitive dep that jsonschema2pojo-core picks up later —
-      no need to keep extending the exclusions list every time a CVE is reported on a
-      new jsonschema2pojo-core transitive.
-    -->
+    <!-- Build-time only (used by jsonschema2pojo-maven-plugin in openmetadata-spec).
+         <optional>true</optional> stops all transitive deps — including Jackson 3.x
+         (GHSA-2m67-wjpj-xhg9, CVE-2026-29062, GHSA-72hv-8253-57qq) — from leaking
+         into the runtime classpath of downstream consumers. -->
     <dependency>
       <groupId>org.jsonschema2pojo</groupId>
       <artifactId>jsonschema2pojo-core</artifactId>

--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -956,6 +956,31 @@
       <artifactId>apache-jena-libs</artifactId>
       <version>4.10.0</version>
       <type>pom</type>
+      <!--
+        CVE-2026-43869: jena-arq transitively pulls org.apache.thrift:libthrift, used only
+        for the optional RDF Thrift binary serialization format. OM never reads or writes
+        that format (no `org.apache.thrift` imports anywhere in the source tree, and no
+        references to RDF_THRIFT / ThriftConvert / RDFFormat.*THRIFT). Excluding the JAR
+        eliminates the vulnerable bytecode entirely.
+
+        Why exclude instead of pinning libthrift to 0.23.0:
+          - libthrift 0.23.0 (the CVE fix) was published 2026-05-08; no Jena release ships
+            it yet. Even Jena 6.0.0 (latest) and 5.6.0 still ship libthrift 0.22.0
+            (also vulnerable to CVE-2026-43869).
+          - Pinning to a libthrift version Jena has not validated against would force a
+            mismatched transitive onto code paths Jena tests with 0.22.0.
+          - Lucene/Solr (also in this dep tree) already excludes libthrift for the same
+            reason — confirmed in lucene-solr-grandparent's pom.
+
+        When Jena ships a release with libthrift ≥ 0.23.0, this exclusion can be removed
+        (or kept; either way is safe since OM does not use the feature).
+      -->
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.thrift</groupId>
+          <artifactId>libthrift</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     
     <!-- Apache Calcite for SQL parsing -->

--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -956,31 +956,6 @@
       <artifactId>apache-jena-libs</artifactId>
       <version>4.10.0</version>
       <type>pom</type>
-      <!--
-        CVE-2026-43869: jena-arq transitively pulls org.apache.thrift:libthrift, used only
-        for the optional RDF Thrift binary serialization format. OM never reads or writes
-        that format (no `org.apache.thrift` imports anywhere in the source tree, and no
-        references to RDF_THRIFT / ThriftConvert / RDFFormat.*THRIFT). Excluding the JAR
-        eliminates the vulnerable bytecode entirely.
-
-        Why exclude instead of pinning libthrift to 0.23.0:
-          - libthrift 0.23.0 (the CVE fix) was published 2026-05-08; no Jena release ships
-            it yet. Even Jena 6.0.0 (latest) and 5.6.0 still ship libthrift 0.22.0
-            (also vulnerable to CVE-2026-43869).
-          - Pinning to a libthrift version Jena has not validated against would force a
-            mismatched transitive onto code paths Jena tests with 0.22.0.
-          - Lucene/Solr (also in this dep tree) already excludes libthrift for the same
-            reason — confirmed in lucene-solr-grandparent's pom.
-
-        When Jena ships a release with libthrift ≥ 0.23.0, this exclusion can be removed
-        (or kept; either way is safe since OM does not use the feature).
-      -->
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.thrift</groupId>
-          <artifactId>libthrift</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     
     <!-- Apache Calcite for SQL parsing -->

--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -15,7 +15,7 @@
     <dropwizard.swagger.version>4.0.5-1</dropwizard.swagger.version>
     <awssdk.version>2.30.19</awssdk.version>
     <azure-identity.version>1.15.2</azure-identity.version>
-    <azure-kv.version>4.10.0</azure-kv.version>
+    <azure-kv.version>4.10.7</azure-kv.version>
     <azure-identity-extensions.version>1.0.0</azure-identity-extensions.version>
     <expiring.map.version>0.5.11</expiring.map.version>
     <java.saml>2.9.0</java.saml>

--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -388,15 +388,31 @@
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sts</artifactId>
     </dependency>
+    <!-- GHSA-rwm7-x88c-3g2p / CVE-2026-42577: exclude Linux native epoll binding (the only
+         vulnerable artifact is the .so JAR; bug is in netty 4.2.x, GHSA range overly broad).
+         Netty falls back to Java NIO; netty-transport-classes-epoll stays. Per-direct-dep so
+         future Azure SDK bumps aren't blocked by a pinned azure-core-http-netty version. -->
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-security-keyvault-secrets</artifactId>
       <version>${azure-kv.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-identity</artifactId>
       <version>${azure-identity.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>
@@ -1023,6 +1039,12 @@
       <groupId>com.azure</groupId>
       <artifactId>azure-storage-blob</artifactId>
       <version>12.31.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>

--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -418,6 +418,12 @@
       <groupId>com.azure</groupId>
       <artifactId>azure-identity-extensions</artifactId>
       <version>${azure-identity-extensions.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     
     <!-- Redis/Cache dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,21 @@
         <artifactId>angus-mail</artifactId>
         <version>${angus-mail.version}</version>
       </dependency>
+      <!-- GHSA-rwm7-x88c-3g2p / CVE-2026-42577: exclude the Linux native epoll binding from
+           azure-core-http-netty. The actual bug is in netty 4.2.x epoll; we ship 4.1.x. Removing
+           the .so JAR drops the flagged file from the dist; Netty falls back to Java NIO (the
+           same path used on macOS/Windows already). netty-transport-classes-epoll stays. -->
+      <dependency>
+        <groupId>com.azure</groupId>
+        <artifactId>azure-core-http-netty</artifactId>
+        <version>1.16.4</version>
+        <exclusions>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
       <!-- CVE-2026-43869: pin to 0.23.0. No Jena release ships the fix yet (6.0.0 still uses 0.22.0).
            Excluding libthrift breaks RDF tests — Jena's ModelFactory statically references TException. -->
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -191,25 +191,8 @@
         <artifactId>angus-mail</artifactId>
         <version>${angus-mail.version}</version>
       </dependency>
-      <!--
-        CVE-2026-43869: org.apache.jena:apache-jena-libs:4.10.0 → jena-arq transitively
-        pulls org.apache.thrift:libthrift:0.19.0 (vulnerable; fixed in 0.23.0).
-
-        Why pin and not bump-or-exclude:
-          - Bump apache-jena-libs: latest Jena (6.0.0) still ships libthrift 0.22.0
-            (also vulnerable). libthrift 0.23.0 was published 2026-05-08; Jena upstream
-            has not released a version with the fix yet.
-          - Exclude libthrift from apache-jena-libs: BREAKS the build. Even though OM
-            does not call RDF Thrift I/O, several Jena classes (e.g. ModelFactory,
-            PrefixMappingImpl) statically reference org.apache.thrift.TException at
-            class-init time. Removing libthrift causes NoClassDefFoundError on first
-            use of any Jena Model — verified by RdfInferenceConfigurationTest /
-            RdfPropertyMapperTest failing with `Could not initialize class
-            org.apache.jena.rdf.model.ModelFactory` and `org/apache/thrift/TException`.
-          - Pin libthrift to 0.23.0: forces the fixed version onto Jena's classpath.
-            libthrift maintains backwards-compatible binary protocol semantics, so
-            Jena's runtime usage continues to work. CI will validate.
-      -->
+      <!-- CVE-2026-43869: pin to 0.23.0. No Jena release ships the fix yet (6.0.0 still uses 0.22.0).
+           Excluding libthrift breaks RDF tests — Jena's ModelFactory statically references TException. -->
       <dependency>
         <groupId>org.apache.thrift</groupId>
         <artifactId>libthrift</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,12 @@
         <artifactId>angus-mail</artifactId>
         <version>${angus-mail.version}</version>
       </dependency>
+      <!-- CVE-2026-43869: apache-jena-libs:4.10.0 → jena-arq → libthrift:0.19.0. Pin to fixed version. -->
+      <dependency>
+        <groupId>org.apache.thrift</groupId>
+        <artifactId>libthrift</artifactId>
+        <version>0.23.0</version>
+      </dependency>
       <dependency>
         <groupId>org.antlr</groupId>
         <artifactId>antlr4-runtime</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -191,21 +191,6 @@
         <artifactId>angus-mail</artifactId>
         <version>${angus-mail.version}</version>
       </dependency>
-      <!-- GHSA-rwm7-x88c-3g2p / CVE-2026-42577: exclude the Linux native epoll binding from
-           azure-core-http-netty. The actual bug is in netty 4.2.x epoll; we ship 4.1.x. Removing
-           the .so JAR drops the flagged file from the dist; Netty falls back to Java NIO (the
-           same path used on macOS/Windows already). netty-transport-classes-epoll stays. -->
-      <dependency>
-        <groupId>com.azure</groupId>
-        <artifactId>azure-core-http-netty</artifactId>
-        <version>1.16.4</version>
-        <exclusions>
-          <exclusion>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport-native-epoll</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
       <!-- CVE-2026-43869: pin to 0.23.0. No Jena release ships the fix yet (6.0.0 still uses 0.22.0).
            Excluding libthrift breaks RDF tests — Jena's ModelFactory statically references TException. -->
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,30 @@
         <artifactId>angus-mail</artifactId>
         <version>${angus-mail.version}</version>
       </dependency>
+      <!--
+        CVE-2026-43869: org.apache.jena:apache-jena-libs:4.10.0 → jena-arq transitively
+        pulls org.apache.thrift:libthrift:0.19.0 (vulnerable; fixed in 0.23.0).
+
+        Why pin and not bump-or-exclude:
+          - Bump apache-jena-libs: latest Jena (6.0.0) still ships libthrift 0.22.0
+            (also vulnerable). libthrift 0.23.0 was published 2026-05-08; Jena upstream
+            has not released a version with the fix yet.
+          - Exclude libthrift from apache-jena-libs: BREAKS the build. Even though OM
+            does not call RDF Thrift I/O, several Jena classes (e.g. ModelFactory,
+            PrefixMappingImpl) statically reference org.apache.thrift.TException at
+            class-init time. Removing libthrift causes NoClassDefFoundError on first
+            use of any Jena Model — verified by RdfInferenceConfigurationTest /
+            RdfPropertyMapperTest failing with `Could not initialize class
+            org.apache.jena.rdf.model.ModelFactory` and `org/apache/thrift/TException`.
+          - Pin libthrift to 0.23.0: forces the fixed version onto Jena's classpath.
+            libthrift maintains backwards-compatible binary protocol semantics, so
+            Jena's runtime usage continues to work. CI will validate.
+      -->
+      <dependency>
+        <groupId>org.apache.thrift</groupId>
+        <artifactId>libthrift</artifactId>
+        <version>0.23.0</version>
+      </dependency>
       <dependency>
         <groupId>org.antlr</groupId>
         <artifactId>antlr4-runtime</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
     <freemarker.version>2.3.33</freemarker.version>
     <passay.version>1.6.6</passay.version>
     <bcrypt.version>0.10.2</bcrypt.version>
-    <simplejavamail.version>8.12.2</simplejavamail.version>
+    <simplejavamail.version>8.12.6</simplejavamail.version>
     <dropwizardkafka.version>1.8.0</dropwizardkafka.version>
     <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
     <unboundsdk.version>6.0.11</unboundsdk.version>

--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
       <dependency>
         <groupId>io.projectreactor.netty</groupId>
         <artifactId>reactor-netty-http</artifactId>
-        <version>1.2.14</version>
+        <version>1.2.16</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.angus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -191,12 +191,6 @@
         <artifactId>angus-mail</artifactId>
         <version>${angus-mail.version}</version>
       </dependency>
-      <!-- CVE-2026-43869: apache-jena-libs:4.10.0 → jena-arq → libthrift:0.19.0. Pin to fixed version. -->
-      <dependency>
-        <groupId>org.apache.thrift</groupId>
-        <artifactId>libthrift</artifactId>
-        <version>0.23.0</version>
-      </dependency>
       <dependency>
         <groupId>org.antlr</groupId>
         <artifactId>antlr4-runtime</artifactId>


### PR DESCRIPTION
## Summary

CVE remediations on the OM dep tree. Mechanism chosen per CVE against the upstream's actual fix state — direct version bump where the parent has a release that ships the fixed transitive, `<scope>provided</scope>` for a build-only library that doesn't need to ship at all, pin where neither bump nor exclusion works, exclusion for a Linux-specific perf optimization that's flagged by an overly-broad GHSA range.

## Changes

### 1. `org.apache.thrift:libthrift` 0.19.0 → **0.23.0** — pin in dependencyManagement (CVE-2026-43869)

`org.apache.jena:apache-jena-libs:4.10.0` → `jena-arq` → `libthrift:0.19.0`. Apache Thrift fixed CVE-2026-43869 in 0.23.0.

| Approach | Status |
|---|---|
| Bump `apache-jena-libs` | ❌ Latest Jena 6.0.0 still ships libthrift 0.22.0 (also vulnerable). libthrift 0.23.0 published 2026-05-08; Jena upstream hasn't bumped yet. |
| Exclude libthrift from `apache-jena-libs` | ❌ Breaks the build. Jena's `ModelFactory`, `PrefixMappingImpl` statically reference `org.apache.thrift.TException` at class-init time. RDF tests fail. |
| **Pin `libthrift` to 0.23.0 in dep-mgmt** ✅ | Forces the fixed version. libthrift maintains backwards-compatible binary protocol semantics. |

### 2. `jsonschema2pojo-core` declared `<scope>provided</scope>` in common (Jackson 3.x CVEs)

The annotator classes in `common/src/main/java/org/openmetadata/annotations/*` (`PasswordAnnotator`, `MaskedAnnotator`, `DeprecatedAnnotator`, `ExposedAnnotator`, `OpenMetadataAnnotator`) are invoked only by the build-time `jsonschema2pojo-maven-plugin` (configured in `openmetadata-spec/pom.xml` via `<customAnnotator>`). The plugin runs in its own classloader at code-gen time and has `common` declared in its own `<dependencies>` block, so the runtime classpath of any deployed service never needs `jsonschema2pojo-core`.

`<scope>provided</scope>` keeps the dep on compile classpath (so annotators compile) but excludes it (and all transitives — Jackson 3.x, codemodel) from the runtime classpath and from any dist packaging. Semantically tighter than `<optional>true</optional>` for a true compile-only dep.

Removes scanner exposure to:
- GHSA-2m67-wjpj-xhg9
- CVE-2026-29062
- GHSA-72hv-8253-57qq (3.x affected line)

**Why provided rather than bump/exclude/pin Jackson 3:**
| Approach | Status |
|---|---|
| Bump `jsonschema2pojo-core` to a fix release | ❌ Latest 1.3.3 still pins `jackson3.version=3.0.2`. |
| Pin `tools.jackson.core` to 3.1.1 in dep-mgmt | ❌ Forces a version jsonschema2pojo isn't certified against. |
| Per-package `<exclusion>` list under jsonschema2pojo-core | ⚠️ Accumulates a maintenance burden. |
| **`<scope>provided</scope>` on jsonschema2pojo-core** ✅ | Stops ALL transitives from reaching runtime, current and future. |

### 3. `com.azure:azure-security-keyvault-secrets` 4.10.0 → **4.10.7** — proper upstream bump (CVE-2025-22227)

Brings `azure-core-http-netty 1.16.4` → `reactor-netty-http 1.2.16` (fixed line for CVE-2025-22227).

### 4. `io.projectreactor.netty:reactor-netty-http` dep-mgmt pin 1.2.14 → **1.2.16**

Per Copilot review: the existing dep-mgmt pin to 1.2.14 was suppressing the akv 4.10.7's transitive 1.2.16. Both are above the CVE-2025-22227 fix line (≥ 1.2.8), so this is a description-vs-code alignment, not a security delta. Pin updated to 1.2.16 to match the akv transitive.

### 5. `org.simplejavamail:simple-java-mail` 8.12.2 → **8.12.6** — hygiene bump

4 patch versions of upstream fixes. **Note**: simple-java-mail 8.12.6's master pom still pins `angus-mail` to 2.0.3, so the CVE-2025-7962 remediation in OM standalone still relies on OM's existing `<angus-mail.version>2.0.4</angus-mail.version>` dep-management pin (already winning — verified: `openmetadata-1.12.7.tar.gz` ships `angus-mail-2.0.4.jar`).

### 6. Exclude `io.netty:netty-transport-native-epoll` from `azure-core-http-netty` (GHSA-rwm7-x88c-3g2p / CVE-2026-42577)

AWS Inspector reports HIGH. The bug is in netty 4.2.x epoll handler; we ship 4.1.x. The GHSA's `vulnerable_version_range` is `< 4.2.13.Final` (overly broad), so scanners flag 4.1.x even though the buggy code path was never in 4.1. Bumping to 4.2.13.Final is blocked by Azure SDK / gRPC / AWS SDK / reactor-netty all targeting 4.1.x.

The `.so` JAR is a Linux x86_64 native perf optimization. Netty's `Epoll.isAvailable()` returns false when absent and falls back to Java NIO — the same path already used on macOS/Windows/non-x86-Linux. `netty-transport-classes-epoll` (the Java classes referenced by consumers) stays.

## Verification

```
mvn -pl openmetadata-service -am dependency:tree \
    -Dincludes='org.apache.thrift:libthrift,tools.jackson.core:*,org.jsonschema2pojo:*,com.azure:azure-security-keyvault-secrets,io.projectreactor.netty:*,org.simplejavamail:simple-java-mail,org.eclipse.angus:angus-mail,io.netty:netty-transport-native-epoll'

[INFO]    \- org.apache.thrift:libthrift:jar:0.23.0
[INFO] +- com.azure:azure-security-keyvault-secrets:jar:4.10.7
[INFO]    \- com.azure:azure-core-http-netty:jar:1.16.4
[INFO]       \- io.projectreactor.netty:reactor-netty-http:jar:1.2.16
[INFO]          \- io.projectreactor.netty:reactor-netty-core:jar:1.2.16
[INFO] +- org.simplejavamail:simple-java-mail:jar:8.12.6
[INFO]    \- org.eclipse.angus:angus-mail:jar:2.0.4
```

(no `tools.jackson.core:*`, no `org.jsonschema2pojo:*`, no `io.netty:netty-transport-native-epoll` — all excluded)

```
mvn -pl openmetadata-spec -am install -DskipTests
[INFO] BUILD SUCCESS  (annotator code-gen still works with jsonschema2pojo-core <scope>provided</scope>)
```

## Test plan

- [x] `mvn -pl openmetadata-spec -am install -DskipTests` — passes
- [x] `mvn dependency:tree` confirms every claimed version matches actual resolution
- [x] Direct curl on Maven Central confirmed each upstream bump's transitive chain
- [ ] CI green (specifically the RDF tests under `org.openmetadata.service.rdf.*` for the libthrift pin)
- [ ] Backport to `1.12.7`