### PR TITLE
perf(ui-bundle): split reactflow / recharts / rjsf / codemirror into vendor chunks

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/utils/EdgeStyleUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EdgeStyleUtils.ts
@@ -11,7 +11,9 @@
  *  limitations under the License.
  */
 import { Theme } from '@mui/material';
-import { Edge } from 'reactflow';
+// `Edge` is only used as a parameter type — keep this type-only so the file doesn't drag
+// reactflow into whatever chunk imports it.
+import type { Edge } from 'reactflow';
 
 export interface EdgeStyle {
   stroke: string;

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityUtils.tsx
@@ -16,7 +16,10 @@ import { isEmpty, isUndefined, lowerCase, startCase } from 'lodash';
 import { EntityDetailUnion } from 'Models';
 import { Fragment } from 'react';
 import { Link } from 'react-router-dom';
-import { Node } from 'reactflow';
+// Type-only import — `Node` is used solely as a type annotation in this file. A value import
+// would force `reactflow` into the eager chunk because EntityUtils.tsx is on the universal
+// page-load path (Header, Search, every entity page imports from here).
+import type { Node } from 'reactflow';
 import { TitleLink } from '../components/common/TitleBreadcrumb/TitleBreadcrumb.interface';
 import { DataAssetsWithoutServiceField } from '../components/DataAssets/DataAssetsHeader/DataAssetsHeader.interface';
 import { QueryVoteType } from '../components/Database/TableQueries/TableQueries.interface';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/NodeUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/NodeUtils.ts
@@ -11,7 +11,8 @@
  *  limitations under the License.
  */
 
-import { Node } from 'reactflow';
+// Type-only — `Node` is used solely as a type annotation here.
+import type { Node } from 'reactflow';
 import {
   CONNECTION_MODAL_RULES,
   NODE_TYPE_MAPPINGS,

--- a/openmetadata-ui/src/main/resources/ui/vite.config.ts
+++ b/openmetadata-ui/src/main/resources/ui/vite.config.ts
@@ -202,6 +202,41 @@ export default defineConfig(({ mode }) => {
               if (id.includes('@untitledui/icons')) {
                 return 'vendor-untitled-icons';
               }
+              // Heavy tab-specific libraries split into named vendor chunks. Without these
+              // explicit rules Rollup's auto-chunking lumped reactflow, recharts, rjsf,
+              // react-grid-layout, and codemirror into a single ~8.87 MB grab-bag chunk
+              // (named after the first lazy entry to pull them in). Splitting them here
+              // gives each library its own cacheable chunk so the browser can fetch them
+              // in parallel and skip the ones a given page doesn't use.
+              // `reactflow` is a meta-package that re-exports from `@reactflow/*` sub-packages
+              // (core, background, controls, minimap, node-resizer, node-toolbar). The heavy
+              // code lives in @reactflow/core, so we need to match both prefixes — matching
+              // only `node_modules/reactflow` misses the bulk of the bytes.
+              if (
+                id.includes('node_modules/reactflow') ||
+                id.includes('node_modules/@reactflow')
+              ) {
+                return 'vendor-reactflow';
+              }
+              if (
+                id.includes('node_modules/recharts') ||
+                id.includes('node_modules/d3-')
+              ) {
+                return 'vendor-recharts';
+              }
+              if (id.includes('node_modules/react-grid-layout')) {
+                return 'vendor-grid-layout';
+              }
+              if (id.includes('node_modules/@rjsf')) {
+                return 'vendor-rjsf';
+              }
+              if (
+                id.includes('node_modules/codemirror') ||
+                id.includes('node_modules/@codemirror') ||
+                id.includes('node_modules/@uiw/react-codemirror')
+              ) {
+                return 'vendor-codemirror';
+              }
             }
           },
         },


### PR DESCRIPTION
### Describe your changes:

P3.2 of the perceived-latency plan tracked in `.context/perceived-latency-design.md` — bundle-split per tab.

**Finding:** the existing repo already wraps heavy tab components (Lineage, DataObservability, SampleData, TableQueries, Contract, KnowledgeGraph) in `React.lazy() + Suspense` via `withSuspenseFallback`. So the architectural lazy boundary was in place. **But** Rollup's automatic chunking heuristic was ignoring it: it lumped `reactflow`, `recharts`, `rjsf`, `react-grid-layout`, and `codemirror` into a single 8.87 MB grab-bag chunk (named after the first lazy entry to pull them in, `AsyncDeleteProvider`). Two effects:
- On any tab change, the browser had to re-download or re-parse a chunk full of code unrelated to the tab the user clicked.
- No browser-level parallel fetch — one giant chunk instead of several smaller cacheable ones.

**Fix:** add explicit `manualChunks` rules to Vite's rollup config so each heavy library gets its own named vendor chunk.

#### Before / after chunk sizes

| Chunk | Before | After |
|---|---:|---:|
| AsyncDeleteProvider grab-bag | **8.87 MB** | **7.71 MB** (-13%) |
| vendor-reactflow | (in grab-bag) | **94 KB raw / 27 KB brotli** |
| vendor-recharts | (in grab-bag) | **492 KB raw / 106 KB brotli** |
| vendor-rjsf | (in grab-bag) | **267 KB raw / 77 KB brotli** |
| vendor-codemirror | (in grab-bag) | **277 KB raw / 80 KB brotli** |

Each vendor chunk is independently cacheable across deploys (a recharts patch upgrade doesn't bust the rjsf cache) and fetched in parallel.

**Subtle gotcha**: `reactflow` is a meta-package that re-exports from `@reactflow/*` sub-packages (`core`, `background`, `controls`, `minimap`, `node-resizer`, `node-toolbar`). The heavy code lives in `@reactflow/core`, so the rule has to match both prefixes. Matching only `reactflow` produced no chunk at all on the first attempt.

**Also fixed**: three eager-path utils were value-importing types from `reactflow` (`Node`, `Edge`). Even though those symbols are pure types in reactflow's API, value imports drag the runtime into whatever chunk imports the util. `EntityUtils.tsx` is on the universal page-load path, so this was leaking reactflow into the eager chunks. Converted to `import type` — erased at compile time, keeps the lazy boundary clean. Affected files:
- `src/utils/EntityUtils.tsx` (`Node`)
- `src/utils/EdgeStyleUtils.ts` (`Edge`)
- `src/utils/NodeUtils.ts` (`Node`)

`EntityLineageUtils.tsx` and `CanvasUtils.ts` use runtime values from reactflow (`getBezierPath`, `MarkerType`, `Position.Left`) and need value imports — left alone.

#### What's NOT in this PR

- **Splitting the 7.71 MB grab-bag further** — it's still the biggest chunk. Contains lazy-loaded application code (Lineage, KnowledgeGraph, DataInsight, AsyncDeleteProvider) co-imported by Rollup's auto-chunking. Breaking it up requires adding `manualChunks` rules for app paths (`src/pages/DataInsightPage`, `src/components/Lineage`), which is a bigger surgery and warrants its own PR.
- **Audit of remaining `reactflow` value imports in lazy-only utils** — those are fine because they're already on the lazy path. Future cleanup.

#
### Type of change:
- [x] Improvement

#
### Frontend Preview (Loom)
N/A — pure build-config / type-only change. Verified by:
1. Baseline `yarn build` on `main` → captured chunk sizes
2. Apply changes → `yarn build` → re-measure
3. Confirm AsyncDeleteProvider shrunk and vendor-* chunks created with reactflow / recharts / rjsf / codemirror code isolated

#
### Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/open-metadata/OpenMetadata/blob/main/CONTRIBUTING.md) document.
- [x] My PR title is in the form of `<type>: <title>` and follows [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] My commits follow the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] N/A — pure build-config + type-only import change. No new tests required; existing tests cover the runtime behavior.
- [x] UI checkstyle passes locally on touched files.
- [x] `yarn build` succeeds and produces the expected vendor chunks.
- [ ] I have updated the [API documentation](https://github.com/open-metadata/OpenMetadata/tree/main/openmetadata-docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)