### PR TITLE
test: fix FailedTestCaseSampleData tests with mock Table component

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/FailedTestCaseSampleData/FailedTestCaseSampleData.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/FailedTestCaseSampleData/FailedTestCaseSampleData.test.tsx
@@ -11,12 +11,82 @@
  *  limitations under the License.
  */
 
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import React, { Fragment } from 'react';
 import { TestCase } from '../../../../generated/tests/testCase';
 import { TestCasePageTabs } from '../../../../pages/IncidentManager/IncidentManager.interface';
 import { getTestCaseFailedSampleData } from '../../../../rest/testAPI';
 import observabilityRouterClassBase from '../../../../utils/ObservabilityRouterClassBase';
 import FailedTestCaseSampleData from './FailedTestCaseSampleData.component';
+
+jest.mock('@openmetadata/ui-core-components', () => {
+  type Col = { id: string; label?: React.ReactNode };
+  type Row = Record<string, unknown> & { __rowKey: number | string };
+
+  const TableMock = Object.assign(
+    ({ children, ...rest }: React.PropsWithChildren<unknown>) => (
+      <table {...rest}>{children}</table>
+    ),
+    {
+      Header: ({
+        columns,
+        children,
+      }: {
+        columns?: Col[];
+        children: (col: Col) => React.ReactNode;
+      }) => (
+        <thead>
+          <tr>
+            {columns?.map((col) => (
+              <Fragment key={col.id}>{children(col)}</Fragment>
+            ))}
+          </tr>
+        </thead>
+      ),
+      Head: ({ label, id }: { label?: React.ReactNode; id?: string }) => (
+        <th data-testid={`head-${id}`}>{label}</th>
+      ),
+      Body: ({
+        items,
+        children,
+      }: {
+        items?: Row[];
+        children: (item: Row) => React.ReactNode;
+      }) => (
+        <tbody>
+          {items?.map((item) => (
+            <Fragment key={String(item.__rowKey)}>{children(item)}</Fragment>
+          ))}
+        </tbody>
+      ),
+      Row: ({
+        columns,
+        children,
+        id,
+      }: {
+        columns?: Col[];
+        children: (col: Col) => React.ReactNode;
+        id?: React.Key;
+      }) => (
+        <tr data-row-id={id}>
+          {columns?.map((col) => (
+            <Fragment key={col.id}>{children(col)}</Fragment>
+          ))}
+        </tr>
+      ),
+      Cell: ({ children }: React.PropsWithChildren<unknown>) => (
+        <td>{children}</td>
+      ),
+    }
+  );
+
+  return {
+    Table: TableMock,
+    Typography: ({ children }: React.PropsWithChildren<unknown>) => (
+      <span>{children}</span>
+    ),
+  };
+});
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -109,15 +179,13 @@ describe('FailedTestCaseSampleData - observabilityRouterClassBase migration', ()
       '../../../../utils/RouterUtils'
     );
 
-    await act(async () => {
-      render(<FailedTestCaseSampleData testCaseData={mockTestCase} />);
-    });
+    render(<FailedTestCaseSampleData testCaseData={mockTestCase} />);
 
     const exploreBtn = await screen.findByTestId('explore-with-query');
     const link = exploreBtn.closest('a');
 
     expect(link).not.toBeNull();
-    expect(link?.getAttribute('data-to')).toBe(
+    expect(link?.dataset.to).toBe(
       observabilityRouterClassBase.getTestCaseDetailPagePath(
         FQN,
         TestCasePageTabs.SQL_QUERY


### PR DESCRIPTION
# RCA: `FailedTestCaseSampleData.test.tsx` failing on `main`
fixs: https://github.com/open-metadata/OpenMetadata/issues/28030
## Summary

After PR [#27956](https://github.com/open-metadata/OpenMetadata/pull/27956) and PR [#27985](https://github.com/open-metadata/OpenMetadata/pull/27985) both landed on `main`, `FailedTestCaseSampleData.test.tsx` started crashing with:

```
TypeError: Cannot read properties of null (reading 'useContext')
  at .../openmetadata-ui-core-components/.../dist/SnackbarContent.cjs.js
  The above error occurred in the <Table> component
```

Both PRs were green on their own branches. The breakage only surfaced once they were combined on `main`.

## Root Cause

**Dual React instances triggered by an unmocked dependency.**

`@openmetadata/ui-core-components` ships a prebuilt CJS bundle resolved against its **own** nested `node_modules/react` — separate from the one Jest is running with. When a component pulls a real export (`Table`, `Typography`, etc.) into a Jest test, two React copies are live in the same process. The dispatcher inside the package's React copy is `null`, so the first `useContext` call inside the bundle throws.

This was missed because two PRs touched complementary parts of the same file and `pull_request_target` CI runs against the PR head, not against a hypothetical merge with `main`.

### Timeline

| When | PR | Change | Did it break the test? |
|---|---|---|---|
| **May 9, 09:38** | [#27985](https://github.com/open-metadata/OpenMetadata/pull/27985) — *Migrate FailedTestCaseSampleData table to core-ui Table component* | Swapped `Table` import from `antd` → `@openmetadata/ui-core-components` in `FailedTestCaseSampleData.component.tsx` | No test existed yet, so CI had nothing to fail |
| **May 10, 11:20** | [#27956](https://github.com/open-metadata/OpenMetadata/pull/27956) — *Replace RouterUtils with ObservabilityRouterClassBase* | Added `FailedTestCaseSampleData.test.tsx`. On this PR's **branch**, the component still imported `Table` from `antd` | Test passed — verified directly in CI log (stack shows `rc-table/lib/Table.js`, `antd/lib/spin`) |
| **After merge** | `main` | Has both: antd→core-ui swap *and* the new test that does **not** mock core-ui | Crashes — but nothing re-ran |

Direct evidence from PR #27956's CI run (`25601970266`):

```
PASS  src/components/DataQuality/IncidentManager/FailedTestCaseSampleData/FailedTestCaseSampleData.test.tsx
  at Table (.../node_modules/rc-table/lib/Table.js:141:25)        ← antd
  at Spin (.../node_modules/antd/lib/spin/index.js)
  at InternalTable (.../node_modules/antd/lib/table/Table.js:39)
  at testCaseData (FailedTestCaseSampleData.component.tsx:60:3)   ← antd-era line number
```

Git auto-merged the two changes without conflict (they touched different parts of the file), so no human noticed the interaction at merge time.

## Fix

Mock `@openmetadata/ui-core-components` in the test (matches the pattern already used in `IncidentManager.test.tsx` and 30+ other tests in the repo). Provides minimal stubs for `Table`, `Table.Header/Head/Body/Row/Cell`, and `Typography` — keeps the package's real bundled code out of the render tree, eliminating the dual-React issue.

```tsx
jest.mock('@openmetadata/ui-core-components', () => {
  type Col = { id: string; label?: React.ReactNode };
  type Row = Record<string, unknown> & { __rowKey: number | string };

  const TableMock = Object.assign(
    ({ children, ...rest }) => <table {...rest}>{children}</table>,
    {
      Header: ({ columns, children }) => (
        <thead>
          <tr>{columns?.map((col) => <Fragment key={col.id}>{children(col)}</Fragment>)}</tr>
        </thead>
      ),
      Head: ({ label, id }) => <th data-testid={`head-${id}`}>{label}</th>,
      Body: ({ items, children }) => (
        <tbody>{items?.map((item) => <Fragment key={String(item.__rowKey)}>{children(item)}</Fragment>)}</tbody>
      ),
      Row: ({ columns, children, id }) => (
        <tr data-row-id={id}>{columns?.map((col) => <Fragment key={col.id}>{children(col)}</Fragment>)}</tr>
      ),
      Cell: ({ children }) => <td>{children}</td>,
    }
  );

  return {
    Table: TableMock,
    Typography: ({ children }) => <span>{children}</span>,
  };
});
```

## Verification

- `yarn test --testPathPattern=FailedTestCaseSampleData` → **PASS** (1/1)
- `eslint` on the test file → clean
- `tsc --noEmit` → clean
- `prettier` + `organize-imports-cli` → no diff

## Process Gap

`yarn-coverage` CI runs against `pull_request_target` head, not against a trial merge with `main`. Two PRs that individually pass can still produce a broken `main` if they touch complementary parts of the same file. Worth considering: run UI tests against the merge ref (`refs/pull/N/merge`) instead of the head SHA so this class of interaction surfaces before merge.
