### PR TITLE
fix(security): cherry-pick #28010 onto 1.12.7

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -46,33 +46,15 @@
       <version>${org.junit.jupiter.version}</version>
       <scope>test</scope>
     </dependency>
-    <!-- used for generating custom annotations in jsonschema2pojo-maven-plugin -->
+    <!-- Build-time only (used by jsonschema2pojo-maven-plugin in openmetadata-spec).
+         <scope>provided</scope> keeps it on compile classpath but excludes it (and all
+         transitives — including Jackson 3.x: GHSA-2m67-wjpj-xhg9, CVE-2026-29062,
+         GHSA-72hv-8253-57qq) from runtime / dist packaging. -->
     <dependency>
       <groupId>org.jsonschema2pojo</groupId>
       <artifactId>jsonschema2pojo-core</artifactId>
       <version>${jsonschema2pojo.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-databind</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.code.gson</groupId>
-          <artifactId>gson</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.yaml</groupId>
-          <artifactId>snakeyaml</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-lang3</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>commons-lang</groupId>
-          <artifactId>commons-lang</artifactId>
-        </exclusion>
-      </exclusions>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -19,7 +19,7 @@
     <org.testcontainers.version>1.21.4</org.testcontainers.version>
     <awssdk.version>2.30.19</awssdk.version>
     <azure-identity.version>1.15.2</azure-identity.version>
-    <azure-kv.version>4.10.0</azure-kv.version>
+    <azure-kv.version>4.10.7</azure-kv.version>
     <azure-identity-extensions.version>1.0.0</azure-identity-extensions.version>
     <expiring.map.version>0.5.11</expiring.map.version>
     <java.saml>2.9.0</java.saml>
@@ -397,20 +397,42 @@
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sts</artifactId>
     </dependency>
+    <!-- GHSA-rwm7-x88c-3g2p / CVE-2026-42577: exclude Linux native epoll binding (the only
+         vulnerable artifact is the .so JAR; bug is in netty 4.2.x, GHSA range overly broad).
+         Netty falls back to Java NIO; netty-transport-classes-epoll stays. Per-direct-dep so
+         future Azure SDK bumps aren't blocked by a pinned azure-core-http-netty version. -->
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-security-keyvault-secrets</artifactId>
       <version>${azure-kv.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-identity</artifactId>
       <version>${azure-identity.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-identity-extensions</artifactId>
       <version>${azure-identity-extensions.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     
     <!-- Redis/Cache dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
     <freemarker.version>2.3.33</freemarker.version>
     <passay.version>1.6.6</passay.version>
     <bcrypt.version>0.10.2</bcrypt.version>
-    <simplejavamail.version>8.12.2</simplejavamail.version>
+    <simplejavamail.version>8.12.6</simplejavamail.version>
     <dropwizardkafka.version>1.8.0</dropwizardkafka.version>
     <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
     <unboundsdk.version>6.0.11</unboundsdk.version>
@@ -183,12 +183,19 @@
       <dependency>
         <groupId>io.projectreactor.netty</groupId>
         <artifactId>reactor-netty-http</artifactId>
-        <version>1.2.14</version>
+        <version>1.2.16</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.angus</groupId>
         <artifactId>angus-mail</artifactId>
         <version>${angus-mail.version}</version>
+      </dependency>
+      <!-- CVE-2026-43869: pin to 0.23.0. No Jena release ships the fix yet (6.0.0 still uses 0.22.0).
+           Excluding libthrift breaks RDF tests — Jena's ModelFactory statically references TException. -->
+      <dependency>
+        <groupId>org.apache.thrift</groupId>
+        <artifactId>libthrift</artifactId>
+        <version>0.23.0</version>
       </dependency>
       <dependency>
         <groupId>org.antlr</groupId>


### PR DESCRIPTION
## Summary

Cherry-pick of #28010 (merged to main) onto the 1.12.7 release branch.

### What applies on 1.12.7
- **azure-kv 4.10.0 → 4.10.7** — brings azure-core-http-netty 1.16.4 → reactor-netty 1.2.16 (CVE-2025-22227 fix path)
- **libthrift pin to 0.23.0** (CVE-2024-12798 fix path — Jena still ships ≤0.22.0)
- **jsonschema2pojo-core**: switch from `<optional>true</optional>` → `<scope>provided</scope>` (so consumers like Collate-spec compile cleanly when they use the RuleFactory annotators)
- **simple-java-mail** bump for angus-mail 2.0.4 (CVE-2025-7962 fix)
- **netty-transport-native-epoll exclusion** on the 3 existing azure deps in `openmetadata-service/pom.xml`:
  - `azure-security-keyvault-secrets`
  - `azure-identity`
  - `azure-identity-extensions`

### What was dropped on resolution

The main PR also added per-direct-dep netty-epoll exclusion on `azure-storage-blob` and a "Context Center" block (object-storage providers, pdfbox/poi/tika, awssdk-cloudfront/checksums) — that's a 1.13 feature, not on 1.12.7. Skipping those additions in the cherry-pick.

## Local validation
- `mvn clean install -DskipTests` (all modules except UI) — **BUILD SUCCESS**

Original PR: #28010 (commit 6c30d82f).

Companion 1.12.7 cherry-picks:
- Collate: open-metadata/openmetadata-collate#4048
- ai-platform: open-metadata/ai-platform#672