### PR TITLE
add primaryEntityId pre-filter to k-NN query builder

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorSearchQueryBuilder.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorSearchQueryBuilder.java
@@ -122,6 +122,10 @@ public class VectorSearchQueryBuilder {
             sb.append(',');
             appendFlat(sb, "databaseSchema.name", values);
           }
+          case "primaryEntityId" -> {
+            sb.append(',');
+            appendFlat(sb, "primaryEntity.id", values);
+          }
           default -> LOG.debug("Ignoring unrecognized filter key: {}", field);
         }
       }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/VectorSearchQueryBuilderTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/VectorSearchQueryBuilderTest.java
@@ -687,6 +687,27 @@ class VectorSearchQueryBuilderTest {
   }
 
   @Test
+  void testBuildsQueryWithPrimaryEntityIdFilter() throws Exception {
+    float[] vector = {0.1f, 0.2f};
+    int size = 10;
+    int k = 100;
+    String entityId = "a3f1c2d4-7b8e-4f2a-9c1d-0e5b6a7f8c9d";
+    Map<String, List<String>> filters = Map.of("primaryEntityId", List.of(entityId));
+
+    String query = VectorSearchQueryBuilder.build(vector, size, 0, k, filters, 0.0);
+
+    JsonNode root = MAPPER.readTree(query);
+    JsonNode mustFilters =
+        root.get("query").get("knn").get("embedding").get("filter").get("bool").get("must");
+
+    assertEquals(2, mustFilters.size());
+
+    JsonNode primaryEntityFilter = mustFilters.get(1);
+    assertTrue(primaryEntityFilter.has("term"));
+    assertEquals(entityId, primaryEntityFilter.get("term").get("primaryEntity.id").asText());
+  }
+
+  @Test
   void testIgnoresOnlyUnrecognizedFilterKeys() throws Exception {
     float[] vector = {0.1f, 0.2f};
     int size = 10;


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->



### Describe your changes:

Fixes:  https://github.com/open-metadata/ai-platform/issues/664

Added `primaryEntityId` as a handled filter key in `VectorSearchQueryBuilder.appendKnnQuery`. Previously, this key hit the `default` branch and was silently dropped. This caused k-NN vector searches scoped to a specific entity to scan the entire index instead, which made entity scoped memory retrieval return zero results as the index grows beyond a single document.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

---

## High Level Design
N/A: This is a small logic change to ensure filter key mapping consistency.

---

## Testing Profile

### Use Cases Covered
* **Scoped k-NN Queries:** Verified that queries built with the `primaryEntityId` filter correctly scope to the `primaryEntity.id` field.
* **Query Accuracy:** Confirmed that a single value filter produces a `term` query (not `terms`) on the `primaryEntity.id` field.

### Unit Tests
* [x] Added unit tests for the changed logic.
* **Files updated:** `openmetadata-service/src/test/java/org/openmetadata/service/search/vector/VectorSearchQueryBuilderTest.java`
* **New Test:** `testBuildsQueryWithPrimaryEntityIdFilter`

### Manual Verification
1. Verified entity scoped vector search returns matching documents after the fix.
2. Confirmed parity with `NLQFilterQueryBuilder`, which already mapped `primaryEntityId` to `primaryEntity.id` correctly.

---

## Checklist
- [x] I have read the CONTRIBUTING document.
- [x] My PR title is `Fixes #664: Add primaryEntityId pre-filter to k-NN query builder`
- [x] My PR is linked to a GitHub issue via `Fixes #664` above.
- [x] I have commented on my code, particularly in hard to understand areas.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: not applicable.
- [x] I have added tests (unit) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing.

----
## Summary by Gitar

- **Security dependencies:**
  - Updated `libthrift`, `jsonschema2pojo`, `azure-kv`, `sjm`, and `reactor-netty` to address vulnerabilities.
  - Excluded `netty-epoll` and applied security pinning for improved dependency integrity.
- **Search enhancements:**
  - Added `primaryEntityId` support to `VectorSearchQueryBuilder` to properly scope k-NN searches.
  - Added `testBuildsQueryWithPrimaryEntityIdFilter` to `VectorSearchQueryBuilderTest` to verify filter mapping accuracy.

<sub>This will update automatically on new commits.</sub>