### PR TITLE
refactor(schema): extract chart Function/KPIDetails into chartFunctions.json

### DIFF
--- a/ingestion/src/metadata/ingestion/ometa/utils.py
+++ b/ingestion/src/metadata/ingestion/ometa/utils.py
@@ -19,7 +19,7 @@ import string
 from typing import Any, Dict, Optional, Type, TypeVar, Union  # noqa: UP035
 
 from pydantic import BaseModel
-from requests.utils import quote as url_quote
+from requests.utils import quote as url_quote  # pyright: ignore[reportPrivateImportUsage]
 
 from metadata.generated.schema.type.basic import FullyQualifiedEntityName
 from metadata.generated.schema.type.entityReference import EntityReference

--- a/ingestion/src/metadata/ingestion/source/dashboard/grafana/client.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/grafana/client.py
@@ -80,8 +80,9 @@ class GrafanaApiClient:
             response.raise_for_status()
             return response  # noqa: TRY300
         except requests.exceptions.HTTPError as err:
-            if err.response.status_code in (401, 403):
-                logger.warning(f"Permission denied for {endpoint}. Status: {err.response.status_code}")
+            status_code = err.response.status_code if err.response is not None else None
+            if status_code in (401, 403):
+                logger.warning(f"Permission denied for {endpoint}. Status: {status_code}")
             else:
                 logger.error(f"HTTP error for {endpoint}: {err}")
             return None

--- a/ingestion/src/metadata/ingestion/source/dashboard/tableau/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/tableau/metadata.py
@@ -17,7 +17,7 @@ import traceback
 from datetime import datetime
 from typing import Any, Iterable, List, Optional, Set  # noqa: UP035
 
-from requests.utils import urlparse
+from requests.utils import urlparse  # pyright: ignore[reportPrivateImportUsage]
 
 from metadata.generated.schema.api.data.createChart import CreateChartRequest
 from metadata.generated.schema.api.data.createDashboard import CreateDashboardRequest

--- a/ingestion/src/metadata/ingestion/source/database/dbt/dbt_config.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/dbt_config.py
@@ -156,9 +156,7 @@ def _(config: DbtHttpConfig):  # noqa: C901
                     f"Access denied to '{manifest_url}'. "
                     "Check your dbtHttpHeaders contain the correct authentication headers."
                 ) from exc
-            raise DBTConfigException(
-                f"HTTP error {status_code} fetching manifest from '{manifest_url}'."
-            ) from exc
+            raise DBTConfigException(f"HTTP error {status_code} fetching manifest from '{manifest_url}'.") from exc
 
         try:
             manifest_json = dbt_manifest.json()

--- a/ingestion/src/metadata/ingestion/source/database/dbt/dbt_config.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/dbt_config.py
@@ -146,17 +146,18 @@ def _(config: DbtHttpConfig):  # noqa: C901
                 f"Unable to connect to '{manifest_url}'. Please verify the URL is correct and accessible."
             ) from exc
         except requests.exceptions.HTTPError as exc:
-            if exc.response.status_code == 404:
+            status_code = exc.response.status_code if exc.response is not None else None
+            if status_code == 404:
                 raise DBTConfigException(
                     f"Manifest file not found at '{manifest_url}'. Please verify the URL is correct."
                 ) from exc
-            if exc.response.status_code in (401, 403):
+            if status_code in (401, 403):
                 raise DBTConfigException(
                     f"Access denied to '{manifest_url}'. "
                     "Check your dbtHttpHeaders contain the correct authentication headers."
                 ) from exc
             raise DBTConfigException(
-                f"HTTP error {exc.response.status_code} fetching manifest from '{manifest_url}'."
+                f"HTTP error {status_code} fetching manifest from '{manifest_url}'."
             ) from exc
 
         try:

--- a/ingestion/src/metadata/ingestion/source/database/snowflake/models.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/models.py
@@ -17,7 +17,7 @@ from datetime import datetime
 from typing import List, Optional  # noqa: UP035
 
 from pydantic import BaseModel, Field, TypeAdapter, field_validator
-from requests.utils import quote
+from requests.utils import quote  # pyright: ignore[reportPrivateImportUsage]
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 

--- a/ingestion/src/metadata/ingestion/source/mcp/client.py
+++ b/ingestion/src/metadata/ingestion/source/mcp/client.py
@@ -291,7 +291,7 @@ class HttpTransport:
 
     def send_request(self, method: str, params: Optional[Dict] = None) -> Dict[str, Any]:  # noqa: UP006, UP045
         """Send a JSON-RPC request via HTTP POST"""
-        request = {
+        request: Dict[str, Any] = {  # noqa: UP006
             "jsonrpc": "2.0",
             "id": str(uuid.uuid4()),
             "method": method,

--- a/ingestion/src/metadata/ingestion/source/mcp/client.py
+++ b/ingestion/src/metadata/ingestion/source/mcp/client.py
@@ -277,7 +277,7 @@ class HttpTransport:
 
     def send_notification(self, method: str, params: Optional[Dict] = None) -> None:  # noqa: UP006, UP045
         """Send a JSON-RPC notification via HTTP POST (no response expected)"""
-        notification = {"jsonrpc": "2.0", "method": method}
+        notification: Dict[str, Any] = {"jsonrpc": "2.0", "method": method}  # noqa: UP006
         if params:
             notification["params"] = params
         try:

--- a/ingestion/src/metadata/utils/entity_link.py
+++ b/ingestion/src/metadata/utils/entity_link.py
@@ -20,7 +20,7 @@ from antlr4.CommonTokenStream import CommonTokenStream
 from antlr4.error.ErrorStrategy import BailErrorStrategy
 from antlr4.InputStream import InputStream
 from antlr4.tree.Tree import ParseTreeWalker
-from requests.compat import unquote_plus
+from requests.compat import unquote_plus  # pyright: ignore[reportPrivateImportUsage]
 
 from metadata.antlr.split_listener import EntityLinkSplitListener
 from metadata.generated.antlr.EntityLinkLexer import EntityLinkLexer

--- a/ingestion/tests/unit/test_data_insight_chart_imports.py
+++ b/ingestion/tests/unit/test_data_insight_chart_imports.py
@@ -1,0 +1,79 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Regression tests for the dataInsightCustomChart ⇄ lineChart/summaryCard
+circular import.
+
+`dataInsightCustomChart.json` previously owned both the `function` /
+`kpiDetails` definitions and `oneOf` `$ref`s to `lineChart.json` /
+`summaryCard.json`, while those two `$ref`-ed the definitions back.
+Generated Pydantic v2 models tripped on the cycle with
+``AttributeError: partially initialized module ... has no attribute
+'Function'``.
+
+The fix extracted the shared definitions into ``chartFunctions.json`` so
+the chart modules depend only on it, never on ``dataInsightCustomChart``.
+"""
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCHEMA_DIR = (
+    Path(__file__).resolve().parents[3]
+    / "openmetadata-spec/src/main/resources/json/schema/dataInsight/custom"
+)
+
+CHART_MODULES = (
+    "metadata.generated.schema.dataInsight.custom.chartFunctions",
+    "metadata.generated.schema.dataInsight.custom.dataInsightCustomChart",
+    "metadata.generated.schema.dataInsight.custom.lineChart",
+    "metadata.generated.schema.dataInsight.custom.summaryCard",
+)
+
+
+def test_chart_functions_owns_shared_definitions():
+    """The shared types must live in ``chartFunctions.json`` — moving them
+    back into ``dataInsightCustomChart.json`` would re-close the cycle."""
+    schema = json.loads((SCHEMA_DIR / "chartFunctions.json").read_text())
+
+    assert set(schema["definitions"]) >= {"function", "kpiDetails"}
+
+
+@pytest.mark.parametrize("filename", ["lineChart.json", "summaryCard.json"])
+def test_chart_does_not_ref_data_insight_custom_chart(filename):
+    """``lineChart`` / ``summaryCard`` must not ``$ref`` back into
+    ``dataInsightCustomChart`` — that's exactly what closed the cycle."""
+    body = (SCHEMA_DIR / filename).read_text()
+
+    assert "dataInsightCustomChart" not in body, (
+        f"{filename} references dataInsightCustomChart — re-introduces the "
+        f"circular import the chartFunctions.json extraction was meant to break."
+    )
+
+
+@pytest.mark.parametrize("entry_point", CHART_MODULES)
+def test_module_imports_cold(entry_point):
+    """Each module must succeed as the first to import in the cycle. Purges
+    ``sys.modules`` AND the parent package's cached attribute — without the
+    latter, ``from . import X`` resolves to the cached child and skips the
+    load that would otherwise trigger the cycle."""
+    for name in CHART_MODULES:
+        sys.modules.pop(name, None)
+        parent_name, _, leaf = name.rpartition(".")
+        parent = sys.modules.get(parent_name)
+        if parent is not None and hasattr(parent, leaf):
+            delattr(parent, leaf)
+
+    assert importlib.import_module(entry_point) is not None

--- a/ingestion/tests/unit/test_data_insight_chart_imports.py
+++ b/ingestion/tests/unit/test_data_insight_chart_imports.py
@@ -30,10 +30,7 @@ from pathlib import Path
 
 import pytest
 
-SCHEMA_DIR = (
-    Path(__file__).resolve().parents[3]
-    / "openmetadata-spec/src/main/resources/json/schema/dataInsight/custom"
-)
+SCHEMA_DIR = Path(__file__).resolve().parents[3] / "openmetadata-spec/src/main/resources/json/schema/dataInsight/custom"
 
 CHART_MODULES = (
     "metadata.generated.schema.dataInsight.custom.chartFunctions",

--- a/openmetadata-spec/src/main/resources/json/schema/dataInsight/custom/chartFunctions.json
+++ b/openmetadata-spec/src/main/resources/json/schema/dataInsight/custom/chartFunctions.json
@@ -1,0 +1,41 @@
+{
+    "$id": "https://open-metadata.org/schema/dataInsight/custom/chartFunctions.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ChartFunctions",
+    "description": "Shared aggregation function and KPI types referenced by data insight chart configurations. Kept in its own schema so lineChart/summaryCard/formulaHolder/dataInsightCustomChart can $ref these without forming a circular import in the generated code.",
+    "type": "object",
+    "definitions": {
+        "function": {
+            "javaType": "org.openmetadata.schema.dataInsight.custom.Function",
+            "description": "aggregation function for chart",
+            "type": "string",
+            "enum": [
+                "count",
+                "sum",
+                "avg",
+                "min",
+                "max",
+                "unique"
+            ]
+        },
+        "kpiDetails": {
+            "type": "object",
+            "javaType": "org.openmetadata.schema.dataInsight.custom.KPIDetails",
+            "description": "KPI details for the data insight chart.",
+            "properties": {
+                "startDate": {
+                    "description": "Start Date of KPI",
+                    "type": "string"
+                },
+                "endDate": {
+                    "description": "End Date of KPI",
+                    "type": "string"
+                },
+                "target": {
+                    "description": "Target value of KPI",
+                    "type": "number"
+                }
+            }
+        }
+    }
+}

--- a/openmetadata-spec/src/main/resources/json/schema/dataInsight/custom/dataInsightCustomChart.json
+++ b/openmetadata-spec/src/main/resources/json/schema/dataInsight/custom/dataInsightCustomChart.json
@@ -8,40 +8,6 @@
     "javaInterfaces": [
         "org.openmetadata.schema.EntityInterface"
     ],
-    "definitions": {
-        "function": {
-            "javaType": "org.openmetadata.schema.dataInsight.custom.Function",
-            "description": "aggregation function for chart",
-            "type": "string",
-            "enum": [
-                "count",
-                "sum",
-                "avg",
-                "min",
-                "max",
-                "unique"
-            ]
-        },
-        "kpiDetails": {
-            "type": "object",
-            "javaType": "org.openmetadata.schema.dataInsight.custom.KPIDetails",
-            "description": "KPI details for the data insight chart.",
-            "properties": {
-                "startDate": {
-                    "description": "Start Date of KPI",
-                    "type": "string"
-                },
-                "endDate": {
-                    "description": "End Date of KPI",
-                    "type": "string"
-                },
-                "target": {
-                    "description": "Target value of KPI",
-                    "type": "number"
-                }
-            }
-        }
-    },
     "properties": {
         "id": {
             "description": "Unique identifier of this table instance.",

--- a/openmetadata-spec/src/main/resources/json/schema/dataInsight/custom/dataInsightCustomChartResultList.json
+++ b/openmetadata-spec/src/main/resources/json/schema/dataInsight/custom/dataInsightCustomChartResultList.json
@@ -14,7 +14,7 @@
             }
         },
         "kpiDetails": {
-            "$ref": "dataInsightCustomChart.json#/definitions/kpiDetails"
+            "$ref": "chartFunctions.json#/definitions/kpiDetails"
         }
     },
     "additionalProperties": false

--- a/openmetadata-spec/src/main/resources/json/schema/dataInsight/custom/formulaHolder.json
+++ b/openmetadata-spec/src/main/resources/json/schema/dataInsight/custom/formulaHolder.json
@@ -11,7 +11,7 @@
             "type": "string"
         },
         "function": {
-            "$ref": "dataInsightCustomChart.json#/definitions/function"
+            "$ref": "chartFunctions.json#/definitions/function"
         },
         "field": {
             "description": "Group of Result",

--- a/openmetadata-spec/src/main/resources/json/schema/dataInsight/custom/lineChart.json
+++ b/openmetadata-spec/src/main/resources/json/schema/dataInsight/custom/lineChart.json
@@ -16,7 +16,7 @@
                     "type": "string"
                 },
                 "function": {
-                    "$ref": "dataInsightCustomChart.json#/definitions/function"
+                    "$ref": "chartFunctions.json#/definitions/function"
                 },
                 "field": {
                     "description": "Filter field for the data insight chart.",
@@ -80,7 +80,7 @@
             "type": "string"
         },
         "kpiDetails": {
-            "$ref": "dataInsightCustomChart.json#/definitions/kpiDetails"
+            "$ref": "chartFunctions.json#/definitions/kpiDetails"
         },
         "xAxisField": {
             "description": "X-axis field for the data insight chart.",

--- a/openmetadata-spec/src/main/resources/json/schema/dataInsight/custom/summaryCard.json
+++ b/openmetadata-spec/src/main/resources/json/schema/dataInsight/custom/summaryCard.json
@@ -16,7 +16,7 @@
                     "type": "string"
                 },
                 "function": {
-                    "$ref": "dataInsightCustomChart.json#/definitions/function"
+                    "$ref": "chartFunctions.json#/definitions/function"
                 },
                 "field": {
                     "description": "Filter field for the data insight chart.",


### PR DESCRIPTION
Changes were tested by running DI w/ backfill, plus running AskCollate to generate DI charts.

fixes https://github.com/open-metadata/openmetadata-collate/issues/4063

## Summary

Moves the shared `function` and `kpiDetails` definitions out of `dataInsightCustomChart.json` into a new leaf schema `chartFunctions.json` so the chart-config schemas (`lineChart`, `summaryCard`, `formulaHolder`, `dataInsightCustomChartResultList`) can `$ref` them without pulling in the full chart entity model.

### Why

In Collate, `entity/ai/dataInsightQueryConfig.json` `oneOf`s `lineChart` and `summaryCard` from OpenMetadata. Those previously `$ref`'d back to definitions inside `dataInsightCustomChart.json` — an entity schema — which created an unwanted generated-code import chain:

```
Collate dataInsightQueryConfig
  → OpenMetadata lineChart / summaryCard
    → OpenMetadata dataInsightCustomChart (full entity)
```

Splitting the two shared definitions into their own leaf schema makes the chain terminate at a small types-only module instead of the entity:

```
Collate dataInsightQueryConfig
  → OpenMetadata lineChart / summaryCard
    → OpenMetadata chartFunctions (leaf)
```

### Compatibility

`javaType` annotations are preserved, so generated Java classes remain at:
- `org.openmetadata.schema.dataInsight.custom.Function`
- `org.openmetadata.schema.dataInsight.custom.KPIDetails`

Existing Java imports (`ElasticSearchDynamicChartAggregatorInterface`, `OpenSearchDynamicChartAggregatorInterface`) are unaffected.

## Test plan

- [ ] `make generate` succeeds (Java + Python model generation)
- [ ] `mvn -pl openmetadata-spec clean install` passes
- [ ] Backend builds and existing data-insight tests pass
- [ ] Collate `dataInsightQueryConfig` no longer pulls in `dataInsightCustomChart` after regeneration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----
## Summary by Gitar

- **Ingestion code fixes:**
  - Suppressed `basedpyright` warnings for private import usages in various ingestion modules.
  - Improved `requests.exceptions.HTTPError` handling in `dbt_config` and `grafana/client` to safely access status codes.
  - Added type hinting for `notification` dictionary in `mcp/client`.


<sub>This will update automatically on new commits.</sub>