### PR TITLE
test(ui): remove compound test.slow() multipliers in playwright tests

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CustomizeDetailPage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CustomizeDetailPage.spec.ts
@@ -128,8 +128,6 @@ test.beforeAll('Setup Customize tests', async ({ browser }) => {
 });
 
 test.afterAll('Cleanup Customize tests', async ({ browser }) => {
-  test.slow();
-
   const { apiContext, afterAction } = await performAdminLogin(browser);
   await adminUser.delete(apiContext);
   await user.delete(apiContext);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/EntityDataConsumer.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/EntityDataConsumer.spec.ts
@@ -203,8 +203,6 @@ entities.forEach((EntityClass) => {
     });
 
     test.afterAll('Cleanup', async ({ browser }) => {
-      test.slow();
-
       const { apiContext, afterAction } = await performAdminLogin(browser);
       await user.delete(apiContext);
       await entity.delete(apiContext);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/EntityDataSteward.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/EntityDataSteward.spec.ts
@@ -222,8 +222,6 @@ entities.forEach((EntityClass) => {
     });
 
     test.afterAll('Cleanup', async ({ browser }) => {
-      test.slow();
-
       const { apiContext, afterAction } = await performAdminLogin(browser);
       await user.delete(apiContext);
       await entity.delete(apiContext);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/EntityVersionPages.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/EntityVersionPages.spec.ts
@@ -71,8 +71,6 @@ const test = base.extend<{ page: Page }>({
 
 test.describe('Entity Version pages', () => {
   test.beforeAll('Setup pre-requests', async ({ browser }) => {
-    test.slow();
-
     adminUser = new UserClass();
     entities = entityClasses.map((EntityClass) => new EntityClass());
 
@@ -144,8 +142,6 @@ test.describe('Entity Version pages', () => {
   });
 
   test.afterAll('Cleanup', async ({ browser }) => {
-    test.slow();
-
     const { apiContext, afterAction } = await performAdminLogin(browser);
     await adminUser.delete(apiContext);
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/ServiceEntityVersionPage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/VersionPages/ServiceEntityVersionPage.spec.ts
@@ -64,8 +64,6 @@ const test = base.extend<{ page: Page }>({
 
 test.describe('Service Version pages', () => {
   test.beforeAll('Setup pre-requests', async ({ browser }) => {
-    test.slow();
-
     const { apiContext, afterAction } = await performAdminLogin(browser);
     await adminUser.create(apiContext);
     await adminUser.setAdminRole(apiContext);
@@ -118,8 +116,6 @@ test.describe('Service Version pages', () => {
   });
 
   test.afterAll('Cleanup', async ({ browser }) => {
-    test.slow();
-
     const { apiContext, afterAction } = await performAdminLogin(browser);
     await adminUser.delete(apiContext);
 


### PR DESCRIPTION
## Summary

Removes redundant hook-level `test.slow()` calls that compound with test-level calls within the same scope.

`test.slow()` triples the test timeout each time it's evaluated. When placed inside both a hook (`beforeAll` / `afterAll` / `beforeEach`) and an individual `test()` body, the multipliers compound — a `beforeEach` + test gives **9×** the default timeout, and three layers (e.g. `beforeAll` + `afterAll` + test) push it toward **27×**. That masks real flakiness, makes CI slower than necessary, and makes per-test timeouts non-obvious for new contributors.

### Changes

| File | Removed from |
|---|---|
| `e2e/VersionPages/EntityVersionPages.spec.ts` | `beforeAll` + `afterAll` |
| `e2e/VersionPages/ServiceEntityVersionPage.spec.ts` | `beforeAll` + `afterAll` |
| `e2e/Features/CustomizeDetailPage.spec.ts` | `afterAll` |
| `e2e/Pages/EntityDataConsumer.spec.ts` | `afterAll` |
| `e2e/Pages/EntityDataSteward.spec.ts` | `afterAll` |

Test-level `test.slow()` calls (where genuinely needed) are preserved.

### Fix pattern

```ts
// compound (9× timeout) — what we removed
test.beforeAll(async () => { test.slow(); /* setup */ });
test('foo', async () => { test.slow(); /* body */ });

// kept — slow only where genuinely needed
test.beforeAll(async () => { /* setup */ });
test('foo', async () => { test.slow(); /* body */ });
```

Tracked in https://github.com/open-metadata/openmetadata-collate/issues/4059, which also covers parallel Collate-side fixes and follow-up cleanup for `waitForTimeout` / oversized `test.setTimeout`.

## Test plan

- [ ] Verify each modified spec still passes locally (`yarn playwright:run <file>`)
- [ ] CI green