### PR TITLE
test: Refactor activity api test

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityAPI.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityAPI.spec.ts
@@ -49,23 +49,28 @@ test.describe(
   'Activity API - Entity Changes',
   { tag: ['@Features', '@Discovery'] },
   () => {
-    test.beforeAll('Setup: create table, tag and get admin display name', async ({ browser }) => {
-      const { apiContext, afterAction } = await performAdminLogin(browser);
+    test.beforeAll(
+      'Setup: create table, tag and get admin display name',
+      async ({ browser }) => {
+        const { apiContext, afterAction } = await performAdminLogin(browser);
 
-      entityChangesTable = new TableClass();
-      entityChangesTag = new TagClass({});
+        entityChangesTable = new TableClass();
+        entityChangesTag = new TagClass({});
 
-      try {
-        await entityChangesTable.create(apiContext);
-        await entityChangesTag.create(apiContext);
+        try {
+          await entityChangesTable.create(apiContext);
+          await entityChangesTag.create(apiContext);
 
-        const userResponse = await apiContext.get('/api/v1/users/loggedInUser');
-        const adminUser = await userResponse.json();
-        adminDisplayName = adminUser.displayName ?? adminUser.name;
-      } finally {
-        await afterAction();
+          const userResponse = await apiContext.get(
+            '/api/v1/users/loggedInUser'
+          );
+          const adminUser = await userResponse.json();
+          adminDisplayName = adminUser.displayName ?? adminUser.name;
+        } finally {
+          await afterAction();
+        }
       }
-    });
+    );
 
     test.afterAll('Cleanup: delete table and tag', async ({ browser }) => {
       const { apiContext, afterAction } = await performAdminLogin(browser);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityAPI.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityAPI.spec.ts
@@ -10,907 +10,514 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test as base } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { EntityTypeEndpoint } from '../../support/entity/Entity.interface';
 import { TableClass } from '../../support/entity/TableClass';
 import { TagClass } from '../../support/tag/TagClass';
-import { AdminClass } from '../../support/user/AdminClass';
-import { UserClass } from '../../support/user/UserClass';
-import { createAdminApiContext, performAdminLogin } from '../../utils/admin';
 import {
-  descriptionBox,
-  getApiContext,
-  redirectToHomePage,
-  uuid,
-} from '../../utils/common';
-import { waitForPageLoaded } from '../../utils/polling';
-
-let adminUser: AdminClass;
-let testTable: TableClass;
-let testTag: TagClass;
-
-const test = base.extend<{
-  page: Page;
-}>({
-  page: async ({ browser }, use) => {
-    const adminPage = await browser.newPage();
-    await adminUser.login(
-      adminPage,
-      adminUser.data.email,
-      adminUser.data.password
-    );
-    await use(adminPage);
-    await adminPage.close();
-  },
-});
-
-type ActivityApiEvent = {
-  actor?: { displayName?: string; name?: string };
-  eventType?: string;
-  summary?: string;
-};
-
-type ActivityApiResponse = {
-  data?: ActivityApiEvent[];
-};
-
-const openActivityFeedAndWaitForApi = async (page: Page, entityFqn: string) => {
-  const expectedActivityPath = `/api/v1/activity/entity/table/name/${entityFqn}`;
-  const activityResponsePromise = page.waitForResponse(
-    (response) =>
-      decodeURIComponent(response.url()).includes(expectedActivityPath) &&
-      response.status() === 200,
-    { timeout: 15000 }
-  );
-
-  await page.getByTestId('activity_feed').click();
-  await waitForPageLoaded(page);
-
-  const activityResponse = await activityResponsePromise;
-
-  return (await activityResponse.json()) as ActivityApiResponse;
-};
-
-const waitForActivityEvent = async (entityFqn: string, eventType: string) => {
-  const { apiContext, afterAction } = await createAdminApiContext();
-  const activityUrl = `/api/v1/activity/entity/table/name/${encodeURIComponent(
-    entityFqn
-  )}?days=30&limit=50`;
-  let events: ActivityApiEvent[] = [];
-
-  try {
-    await expect
-      .poll(
-        async () => {
-          const response = await apiContext.get(activityUrl);
-
-          if (!response.ok()) {
-            return false;
-          }
-
-          const body = (await response.json()) as ActivityApiResponse;
-          events = body.data ?? [];
-
-          return events.some((event) => event.eventType === eventType);
-        },
-        {
-          timeout: 300000, // 5 minutes
-          intervals: [1000, 2000, 5000, 10000],
-          message: `Timed out waiting for ${eventType} event for ${entityFqn}`,
-        }
-      )
-      .toBe(true);
-
-    return events.find((event) => event.eventType === eventType);
-  } finally {
-    await afterAction();
-  }
-};
-
-const addOwnerFromActivitySpec = async (page: Page, owner: string) => {
-  await page.getByTestId('edit-owner').click();
-
-  const usersTab = page.getByRole('tab', { name: /^Users\b/ });
-  if ((await usersTab.getAttribute('aria-selected')) !== 'true') {
-    await usersTab.click();
-  }
-
-  const ownerSearchInput = page.getByTestId('owner-select-users-search-bar');
-  await expect(ownerSearchInput).toBeVisible({ timeout: 30000 });
-
-  const searchUser = page.waitForResponse(
-    (response) =>
-      response.url().includes('/api/v1/search/query') && response.ok()
-  );
-  await ownerSearchInput.fill(owner);
-  await searchUser;
-
-  const ownerItem = page.getByRole('listitem', { name: owner });
-  await expect(ownerItem).toBeVisible({ timeout: 60000 });
-  await ownerItem.click();
-
-  const patchRequest = page.waitForResponse('/api/v1/tables/*');
-  await page
-    .locator('[id^="rc-tabs-"][id$="-panel-users"]')
-    .getByTestId('selectable-list-update-btn')
-    .click();
-  await patchRequest;
-
-  await expect(page.getByTestId('owner-link').getByTestId(owner)).toBeVisible();
-};
-
-test.beforeAll('Setup create admin user', async ({ browser }) => {
-  const { apiContext, afterAction } = await performAdminLogin(browser);
-  adminUser = new AdminClass();
-
-  await adminUser.create(apiContext);
-
-  await afterAction();
-});
-
-test.afterAll('Cleanup delete admin user', async ({ browser }) => {
-  const { apiContext, afterAction } = await performAdminLogin(browser);
-
-  await adminUser.delete(apiContext);
-
-  await afterAction();
-});
-
-test.describe('Activity API - Entity Changes', () => {
-  test.beforeAll('Setup: create entities and users', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-    testTable = new TableClass();
-    testTag = new TagClass({});
-
-    await testTable.create(apiContext);
-    await testTag.create(apiContext);
-
-    await afterAction();
-  });
-
-  test.afterAll('Cleanup: delete entities and users', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    await testTable.delete(apiContext);
-    await testTag.delete(apiContext);
-
-    await afterAction();
-  });
-
-  test.beforeEach(async ({ page }) => {
-    await redirectToHomePage(page);
-    await waitForPageLoaded(page);
-  });
-
-  test('Activity event is created when description is updated', async ({
-    page,
-  }) => {
-    test.setTimeout(300000);
-    const newDescription = `Test description updated at ${Date.now()}`;
-    const entityFqn = testTable.entityResponseData.fullyQualifiedName ?? '';
-
-    // Navigate to entity page
-    await testTable.visitEntityPage(page);
-
-    // Update description
-    await page.getByTestId('edit-description').click();
-
-    // Wait for description modal to appear
-    await page.locator(descriptionBox).waitFor({ state: 'visible' });
-    await page.locator(descriptionBox).clear();
-    await page.locator(descriptionBox).fill(newDescription);
-
-    const patchResponse = page.waitForResponse('/api/v1/tables/*');
-    await page.getByTestId('save').click();
-    await patchResponse;
-
-    const descriptionEvent = await waitForActivityEvent(
-      entityFqn,
-      'DescriptionUpdated'
-    );
-    const activityResponse = await openActivityFeedAndWaitForApi(
-      page,
-      entityFqn
-    );
-    const feedContainer = page.locator(
-      '#center-container [data-testid="message-container"]'
-    );
-    const renderedDescriptionEvent = activityResponse.data?.find(
-      (event) => event.eventType === 'DescriptionUpdated'
-    );
-
-    expect(descriptionEvent).toBeDefined();
-    expect(renderedDescriptionEvent).toBeDefined();
-    await expect(feedContainer.first()).toContainText(/description/i);
-  });
-
-  test('Activity event is created when tags are added', async ({ page }) => {
-    test.setTimeout(300000);
-    const entityFqn = testTable.entityResponseData.fullyQualifiedName ?? '';
-
-    // Add tag via API to bypass search indexing issues
-    const { apiContext, afterAction } = await getApiContext(page);
-
-    // Add tag to the table via API
-    await apiContext.patch(
-      `/api/v1/tables/${testTable.entityResponseData.id}`,
-      {
-        data: [
-          {
-            op: 'add',
-            path: '/tags/0',
-            value: {
-              tagFQN: testTag.responseData.fullyQualifiedName,
-              source: 'Classification',
-            },
-          },
-        ],
-        headers: {
-          'Content-Type': 'application/json-patch+json',
-        },
-      }
-    );
-
-    await afterAction();
-
-    const tagsEvent = await waitForActivityEvent(entityFqn, 'TagsUpdated');
-
-    // Navigate to entity page
-    await testTable.visitEntityPage(page);
-
-    const activityResponse = await openActivityFeedAndWaitForApi(
-      page,
-      entityFqn
-    );
-    const feedContainer = page.locator(
-      '#center-container [data-testid="message-container"]'
-    );
-    const renderedTagsEvent = activityResponse.data?.find(
-      (event) => event.eventType === 'TagsUpdated'
-    );
-
-    expect(tagsEvent).toBeDefined();
-    expect(renderedTagsEvent).toBeDefined();
-    await expect(feedContainer.first()).toContainText(/tag/i);
-  });
-
-  test('Activity event is created when owner is added', async ({ page }) => {
-    test.setTimeout(300000);
-    const entityFqn = testTable.entityResponseData.fullyQualifiedName ?? '';
-    const ownerDisplayName = adminUser.getUserDisplayName();
-
-    // Navigate to entity page
-    await testTable.visitEntityPage(page);
-
-    await addOwnerFromActivitySpec(page, ownerDisplayName);
-
-    const ownerEvent = await waitForActivityEvent(entityFqn, 'OwnerUpdated');
-    const activityResponse = await openActivityFeedAndWaitForApi(
-      page,
-      entityFqn
-    );
-    const feedContainer = page.locator(
-      '#center-container [data-testid="message-container"]'
-    );
-    const renderedOwnerEvent = activityResponse.data?.find(
-      (event) => event.eventType === 'OwnerUpdated'
-    );
-
-    expect(ownerEvent).toBeDefined();
-    expect(renderedOwnerEvent).toBeDefined();
-    await expect(feedContainer.first()).toContainText(/owner/i);
-    await expect(feedContainer.first()).toContainText(ownerDisplayName);
-  });
-
-  test('Activity event shows the actor who made the change', async ({
-    page,
-  }) => {
-    test.setTimeout(300000);
-    // Make a change via API so we know exactly who the actor is
-    const { apiContext, afterAction } = await getApiContext(page);
-    const uniqueDescription = `Actor test description ${Date.now()}`;
-
-    await apiContext.patch(
-      `/api/v1/tables/${testTable.entityResponseData.id}`,
-      {
-        data: [
-          {
-            op: 'add',
-            path: '/description',
-            value: uniqueDescription,
-          },
-        ],
-        headers: {
-          'Content-Type': 'application/json-patch+json',
-        },
-      }
-    );
-
-    await afterAction();
-
-    // Wait for activity to be indexed
-    await waitForActivityEvent(
-      testTable.entityResponseData.fullyQualifiedName ?? '',
-      'DescriptionUpdated'
-    );
-
-    // Navigate to entity page
-    await testTable.visitEntityPage(page);
-
-    // Navigate to Activity Feed tab
-    await page.getByTestId('activity_feed').click();
-    await waitForPageLoaded(page);
-
-    // Check if there are any feed items
-    const feedContainer = page
-      .locator('#center-container [data-testid="message-container"]')
-      .filter({
-        hasText: uniqueDescription,
-      });
-
-    await feedContainer.waitFor({ state: 'visible' });
-
-    const feedContent = await feedContainer.first().textContent();
-
-    // The activity should show the actor's name (admin user who made the change)
-    // Activity typically shows username or display name
-    const actorName = adminUser.responseData.displayName;
-
-    expect(feedContent).toContain(actorName);
-  });
-
-  test('Activity event links to the correct entity', async ({ page }) => {
-    // Navigate to entity page
-    await testTable.visitEntityPage(page);
-
-    // Navigate to Activity Feed tab
-    await page.getByTestId('activity_feed').click();
-    await waitForPageLoaded(page);
-
-    // Check if there are any feed items
-    const feedContainer = page.locator(
-      '#center-container [data-testid="message-container"]'
-    );
-
-    await feedContainer
-      .first()
-      .waitFor({ state: 'visible', timeout: 10000 })
-      .catch(() => {});
-
-    if ((await feedContainer.count()) > 0) {
-      // Activity cards now render actor/profile links ahead of the entity link.
-      const entityLink = feedContainer
-        .first()
-        .locator('a[href*="/table/"]')
-        .first();
-
-      if (await entityLink.isVisible()) {
-        const href = await entityLink.getAttribute('href');
-
-        // The link should point to the table entity
-        expect(href).toContain('table');
-        expect(href).toContain(
-          (testTable.entityResponseData.fullyQualifiedName ?? '')
-            .split('.')
-            .pop() ?? ''
-        );
-      } else {
-        // Some activity types may not have clickable entity links
-        test.info().annotations.push({
-          type: 'note',
-          description: 'No entity link found in activity item',
-        });
-      }
-    } else {
-      test.info().annotations.push({
-        type: 'note',
-        description: 'Activity feed is empty - cannot verify entity link',
-      });
-    }
-  });
-});
-
-test.describe('Activity API - Reactions', () => {
-  const adminUser = new UserClass();
-  const testTable = new TableClass();
-
-  test.beforeAll(
-    'Setup: create entities and conversation',
-    async ({ browser }) => {
+  ACTIVITY_TEST_TIMEOUT,
+  addTagToTable,
+  createConversationThread,
+  createDescriptionActivityEventFromPage,
+  FEED_ITEM_TIMEOUT,
+  getActivityFeedItems,
+  getFeedItemByText,
+  getTableFqn,
+  getTableLeafName,
+  openActivityFeedAndWaitForApi,
+  patchTableDescription,
+  THUMBS_UP_EMOJI,
+  toggleThumbsUpReaction,
+  visitTableActivityFeed,
+  waitForActivityEvent,
+} from '../../utils/activityAPI';
+import { postActivityComment } from '../../utils/activityFeed';
+import { performAdminLogin } from '../../utils/admin';
+import { getApiContext, redirectToHomePage, uuid } from '../../utils/common';
+import {
+  addOwner,
+  updateDescription,
+  waitForAllLoadersToDisappear,
+} from '../../utils/entity';
+import { test } from '../fixtures/pages';
+
+let entityChangesTable: TableClass;
+let entityChangesTag: TagClass;
+let adminDisplayName: string;
+
+test.describe(
+  'Activity API - Entity Changes',
+  { tag: ['@Features', '@Discovery'] },
+  () => {
+    test.beforeAll('Setup: create table, tag and get admin display name', async ({ browser }) => {
       const { apiContext, afterAction } = await performAdminLogin(browser);
 
-      try {
-        await adminUser.create(apiContext);
-        await adminUser.setAdminRole(apiContext);
-        await testTable.create(apiContext);
+      entityChangesTable = new TableClass();
+      entityChangesTag = new TagClass({});
 
-        // Create a conversation thread to have something to react to
-        const entityLink = `<#E::table::${testTable.entityResponseData.fullyQualifiedName}>`;
-        await apiContext.post('/api/v1/feed', {
-          data: {
-            message: 'Test conversation for reactions',
-            about: entityLink,
-          },
-        });
+      try {
+        await entityChangesTable.create(apiContext);
+        await entityChangesTag.create(apiContext);
+
+        const userResponse = await apiContext.get('/api/v1/users/loggedInUser');
+        const adminUser = await userResponse.json();
+        adminDisplayName = adminUser.displayName ?? adminUser.name;
       } finally {
         await afterAction();
       }
-    }
-  );
+    });
 
-  test.afterAll('Cleanup: delete entities', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await testTable.delete(apiContext);
-      await adminUser.delete(apiContext);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test.beforeEach(async ({ page }) => {
-    await redirectToHomePage(page);
-    await waitForPageLoaded(page);
-  });
-
-  test('User can add reaction to feed item', async ({ page }) => {
-    // Navigate to entity page
-    await testTable.visitEntityPage(page);
-
-    // Navigate to Activity Feed tab
-    await page.getByTestId('activity_feed').click();
-    await waitForPageLoaded(page);
-
-    // Wait for feed to load
-    const feedContainer = page.locator(
-      '#center-container [data-testid="message-container"]'
-    );
-    const emptyState = page.locator(
-      '[data-testid="no-data-placeholder-container"]'
-    );
-
-    // Wait for either feed items or empty state
-    await Promise.race([
-      feedContainer.first().waitFor({ state: 'visible', timeout: 10000 }),
-      emptyState.waitFor({ state: 'visible', timeout: 10000 }),
-    ]).catch(() => {});
-
-    // Skip if no feed items
-    if ((await feedContainer.count()) === 0) {
-      test.info().annotations.push({
-        type: 'skip',
-        description: 'No feed items available to react to',
-      });
-
-      return;
-    }
-
-    // Find reaction button and click
-    const reactionContainer = feedContainer
-      .first()
-      .locator('[data-testid="feed-reaction-container"]');
-
-    if (await reactionContainer.isVisible()) {
-      const addReactionBtn = reactionContainer.locator(
-        '[data-testid="add-reactions"]'
-      );
-
-      await expect(addReactionBtn).toBeVisible();
-      await addReactionBtn.click();
-
-      // Wait for reaction popover
-      await page
-        .locator('.ant-popover-feed-reactions')
-        .waitFor({ state: 'visible' });
-
-      // Click on thumbsUp reaction
-      const reactionResponse = page.waitForResponse(
-        (response) =>
-          (response.url().includes('/api/v1/feed') ||
-            response.url().includes('/api/v1/activity')) &&
-          response.status() === 200
-      );
-
-      await page
-        .locator('[data-testid="reaction-button"][title="thumbsUp"]')
-        .click();
-
-      await reactionResponse;
-
-      // Verify reaction is added - look for thumbsUp emoji in the feed
-      // The reaction button shows as "👍 1" or similar
-      const thumbsUpReaction = page.getByRole('button', { name: /👍/ });
-
-      await expect(thumbsUpReaction.first()).toBeVisible({ timeout: 5000 });
-    }
-  });
-
-  test('User can remove reaction from feed item', async ({ page }) => {
-    // Navigate to entity page
-    await testTable.visitEntityPage(page);
-
-    // Navigate to Activity Feed tab
-    await page.getByTestId('activity_feed').click();
-    await waitForPageLoaded(page);
-
-    // Wait for feed to load
-    const feedContainer = page.locator(
-      '#center-container [data-testid="message-container"]'
-    );
-    const emptyState = page.locator(
-      '[data-testid="no-data-placeholder-container"]'
-    );
-
-    // Wait for either feed items or empty state
-    await Promise.race([
-      feedContainer.first().waitFor({ state: 'visible', timeout: 10000 }),
-      emptyState.waitFor({ state: 'visible', timeout: 10000 }),
-    ]).catch(() => {});
-
-    // Skip if no feed items
-    if ((await feedContainer.count()) === 0) {
-      test.info().annotations.push({
-        type: 'skip',
-        description: 'No feed items available',
-      });
-
-      return;
-    }
-
-    // Find reaction container
-    const reactionContainer = feedContainer
-      .first()
-      .locator('[data-testid="feed-reaction-container"]');
-
-    if (await reactionContainer.isVisible()) {
-      // First add a reaction if not already present
-      const existingReaction = reactionContainer.locator(
-        '[data-testid="Reactions"]'
-      );
-
-      if (!(await existingReaction.isVisible())) {
-        const addReactionBtn = reactionContainer.locator(
-          '[data-testid="add-reactions"]'
-        );
-        await addReactionBtn.click();
-        await page
-          .locator('.ant-popover-feed-reactions')
-          .waitFor({ state: 'visible' });
-
-        const addResponse = page.waitForResponse(
-          (response) =>
-            (response.url().includes('/api/v1/feed') ||
-              response.url().includes('/api/v1/activity')) &&
-            response.status() === 200
-        );
-        await page
-          .locator('[data-testid="reaction-button"][title="thumbsUp"]')
-          .click();
-        await addResponse;
-      }
-
-      // Now remove the reaction by clicking again
-      await reactionContainer.locator('[data-testid="add-reactions"]').click();
-      await page
-        .locator('.ant-popover-feed-reactions')
-        .waitFor({ state: 'visible' });
-
-      const removeResponse = page.waitForResponse(
-        (response) =>
-          (response.url().includes('/api/v1/feed') ||
-            response.url().includes('/api/v1/activity')) &&
-          response.status() === 200
-      );
-
-      await page
-        .locator('[data-testid="reaction-button"][title="thumbsUp"]')
-        .click();
-
-      await removeResponse;
-    }
-  });
-});
-
-test.describe('Activity API - Comments', () => {
-  let adminUser: UserClass;
-  let testTable: TableClass;
-  let feedMessage = '';
-  let feedUrl = '';
-  let entityLink = '';
-
-  test.beforeAll(
-    'Setup: create entities and conversation',
-    async ({ browser }) => {
+    test.afterAll('Cleanup: delete table and tag', async ({ browser }) => {
       const { apiContext, afterAction } = await performAdminLogin(browser);
 
-      adminUser = new UserClass();
-      testTable = new TableClass();
+      try {
+        await entityChangesTable.delete(apiContext);
+        await entityChangesTag.delete(apiContext);
+      } finally {
+        await afterAction();
+      }
+    });
 
-      await adminUser.create(apiContext);
-      await adminUser.setAdminRole(apiContext);
-      await testTable.create(apiContext);
+    test.beforeEach(async ({ page }) => {
+      await redirectToHomePage(page);
+      await waitForAllLoadersToDisappear(page);
+    });
 
-      // Create a conversation thread to have something to comment on
-      feedMessage = `Test conversation for comments ${Date.now()}`;
-      entityLink = `<#E::table::${testTable.entityResponseData.fullyQualifiedName}>`;
-      await apiContext.post('/api/v1/feed', {
-        data: {
-          message: feedMessage,
-          about: entityLink,
-        },
-      });
-      feedUrl = `/api/v1/feed?entityLink=${encodeURIComponent(
-        entityLink
-      )}&type=Conversation&limit=25`;
+    test('creates an activity event when the description is updated', async ({
+      page,
+    }) => {
+      test.setTimeout(ACTIVITY_TEST_TIMEOUT);
 
-      await expect
-        .poll(
-          async () => {
-            const response = await apiContext.get(feedUrl);
-            const data = await response.json();
+      const newDescription = `Test description updated at ${Date.now()}`;
+      const entityFqn = getTableFqn(entityChangesTable);
 
-            return (data.data ?? []).some((thread: { message?: string }) =>
-              thread.message?.includes(feedMessage)
-            );
-          },
-          { timeout: 60_000, intervals: [2_000] }
-        )
-        .toBe(true);
-
-      await afterAction();
-    }
-  );
-
-  test.afterAll('Cleanup: delete entities', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await testTable.delete(apiContext);
-      await adminUser.delete(apiContext);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test.beforeEach(async ({ page }) => {
-    await redirectToHomePage(page);
-    await waitForPageLoaded(page);
-  });
-
-  test('User can add comment to feed item', async ({ page }) => {
-    const commentText = `Test comment ${uuid()}`;
-
-    // Navigate to entity page
-    await testTable.visitEntityPage(page);
-
-    // Navigate to Activity Feed tab
-    await page.getByTestId('activity_feed').click();
-    await waitForPageLoaded(page);
-
-    // Wait for feed to load
-    const feedContainer = page
-      .locator('#center-container [data-testid="message-container"]')
-      .filter({
-        hasText: feedMessage,
+      await test.step('Update the table description from the entity page', async () => {
+        await entityChangesTable.visitEntityPage(page);
+        await waitForAllLoadersToDisappear(page);
+        await updateDescription(
+          page,
+          newDescription,
+          false,
+          'asset-description-container',
+          EntityTypeEndpoint.Table
+        );
       });
 
-    // Wait for either feed items or empty state
+      await test.step('Verify the description event through API and UI', async () => {
+        const descriptionEvent = await waitForActivityEvent({
+          entityFqn,
+          eventType: 'DescriptionUpdated',
+          text: newDescription,
+        });
+        const activityResponse = await openActivityFeedAndWaitForApi(
+          page,
+          entityFqn
+        );
+        const renderedDescriptionEvent = activityResponse.data?.find(
+          (event) =>
+            event.eventType === 'DescriptionUpdated' &&
+            JSON.stringify(event).includes(newDescription)
+        );
+        const feedItem = await getFeedItemByText(page, newDescription);
 
-    feedContainer.waitFor({ state: 'visible' });
-
-    // Click on the feed card to open detail view
-    await feedContainer.click();
-    await waitForPageLoaded(page);
-
-    // Wait for comment input to appear
-    const commentInput = page.locator('[data-testid="comments-input-field"]');
-
-    if (await commentInput.isVisible()) {
-      await commentInput.click();
-
-      // Fill in the comment using the editor
-      const editorField = page.locator(
-        '[data-testid="editor-wrapper"] [contenteditable="true"]'
-      );
-      await editorField.fill(commentText);
-
-      // Wait for send button to be enabled
-      const sendButton = page.getByTestId('send-button');
-
-      await expect(sendButton).toBeEnabled();
-
-      // Send the comment
-      const postResponse = page.waitForResponse('/api/v1/feed/*/posts');
-      await sendButton.click();
-      await postResponse;
-
-      // Verify comment appears
-      await expect(page.getByText(commentText)).toBeVisible({ timeout: 10000 });
-    } else {
-      test.info().annotations.push({
-        type: 'note',
-        description: 'Comment input not visible for this feed item type',
+        expect(descriptionEvent).toBeDefined();
+        expect(renderedDescriptionEvent).toBeDefined();
+        await expect(feedItem).toContainText(/description/i);
       });
-    }
-  });
+    });
 
-  test('Feed detail shows conversation layout', async ({ page }) => {
-    // Navigate to entity page
-    await testTable.visitEntityPage(page);
+    test('creates an activity event when tags are added', async ({ page }) => {
+      test.setTimeout(ACTIVITY_TEST_TIMEOUT);
 
-    // Navigate to Activity Feed tab
-    await page.getByTestId('activity_feed').click();
-    await waitForPageLoaded(page);
+      const entityFqn = getTableFqn(entityChangesTable);
+      const tagDisplayName = entityChangesTag.getTagDisplayName();
 
-    // Wait for feed to load
-    const feedContainer = page.locator(
-      '#center-container [data-testid="message-container"]'
-    );
-    const emptyState = page.locator(
-      '[data-testid="no-data-placeholder-container"]'
-    );
+      await test.step('Add a tag to the table through API setup', async () => {
+        const { apiContext, afterAction } = await getApiContext(page);
 
-    // Wait for either feed items or empty state
-    await Promise.race([
-      feedContainer.first().waitFor({ state: 'visible', timeout: 10000 }),
-      emptyState.waitFor({ state: 'visible', timeout: 10000 }),
-    ]).catch(() => {});
-
-    // Skip if no feed items
-    if ((await feedContainer.count()) === 0) {
-      test.info().annotations.push({
-        type: 'skip',
-        description: 'No feed items available',
+        try {
+          await addTagToTable(apiContext, entityChangesTable, entityChangesTag);
+        } finally {
+          await afterAction();
+        }
       });
 
-      return;
-    }
+      await test.step('Verify the tag event through API and UI', async () => {
+        const tagsEvent = await waitForActivityEvent({
+          entityFqn,
+          eventType: 'TagsUpdated',
+        });
+        const activityResponse = await visitTableActivityFeed(
+          page,
+          entityChangesTable
+        );
+        const renderedTagsEvent = activityResponse.data?.find(
+          (event) => event.eventType === 'TagsUpdated'
+        );
+        const feedItem = getActivityFeedItems(page)
+          .filter({ hasText: /tag/i })
+          .filter({ hasText: tagDisplayName });
 
-    // Click on feed card to open detail view
-    await feedContainer.first().click();
-    await waitForPageLoaded(page);
-
-    // Verify layout elements are visible
-    // Feed card sidebar (at least one should be visible)
-    const leftSidebar = page
-      .locator('[data-testid="feed-card-v2-sidebar"]')
-      .first();
-
-    // Feed replies section
-    const feedReplies = page.locator('[data-testid="feed-replies"]');
-
-    // Feed content panel or activity feed panel
-    const feedContentPanel = page.locator('.activity-feed-content-panel');
-    const activityFeedPanel = page.locator(
-      '[data-testid="activity-feed-panel"]'
-    );
-
-    // Check at least one layout element is visible
-    const hasLayout =
-      (await leftSidebar.isVisible().catch(() => false)) ||
-      (await feedReplies.isVisible().catch(() => false)) ||
-      (await feedContentPanel.isVisible().catch(() => false)) ||
-      (await activityFeedPanel.isVisible().catch(() => false));
-
-    expect(hasLayout).toBe(true);
-  });
-});
-
-test.describe('Activity API - Homepage Widget', () => {
-  const adminUser = new UserClass();
-  const testTable = new TableClass();
-
-  test.beforeAll('Setup: create entities and activity', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await adminUser.create(apiContext);
-      await adminUser.setAdminRole(apiContext);
-      await testTable.create(apiContext);
-
-      // Create a conversation to ensure there's activity in the feed
-      const entityLink = `<#E::table::${testTable.entityResponseData.fullyQualifiedName}>`;
-      await apiContext.post('/api/v1/feed', {
-        data: {
-          message: 'Test conversation for homepage widget',
-          about: entityLink,
-        },
+        expect(tagsEvent).toBeDefined();
+        expect(renderedTagsEvent).toBeDefined();
+        await expect(feedItem).toBeVisible({ timeout: FEED_ITEM_TIMEOUT });
       });
-    } finally {
-      await afterAction();
-    }
-  });
+    });
 
-  test.afterAll('Cleanup: delete entities', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
+    test('creates an activity event when owner is added', async ({ page }) => {
+      test.setTimeout(ACTIVITY_TEST_TIMEOUT);
 
-    try {
-      await testTable.delete(apiContext);
-      await adminUser.delete(apiContext);
-    } finally {
-      await afterAction();
-    }
-  });
+      const entityFqn = getTableFqn(entityChangesTable);
 
-  test.beforeEach(async ({ page }) => {
-    await redirectToHomePage(page);
-    await waitForPageLoaded(page);
-  });
-
-  test('Activity Feed widget displays feed items', async ({ page }) => {
-    // Wait for feed widget to load
-    page
-      .getByTestId('KnowledgePanel.ActivityFeed')
-      .waitFor({ state: 'visible' });
-
-    // Check for feed content - either messages, empty state, or "No Recent Activity"
-    const messageContainers = page.locator(
-      '#center-container [data-testid="message-container"]'
-    );
-    const noRecentActivity = page.getByText('No Recent Activity');
-    const emptyState = page.locator(
-      '[data-testid="no-data-placeholder-container"]'
-    );
-
-    // Either we have messages or empty state
-    const hasMessages = (await messageContainers.count()) > 0;
-    const hasNoRecentActivity = await noRecentActivity
-      .isVisible()
-      .catch(() => false);
-    const hasEmpty = (await emptyState.count()) > 0;
-
-    expect(hasMessages || hasNoRecentActivity || hasEmpty).toBe(true);
-  });
-
-  test('Activity Feed widget has filter options', async ({ page }) => {
-    // Wait for feed widget to load
-    const feedWidget = page.getByTestId('KnowledgePanel.ActivityFeed');
-
-    // Widget may not exist if homepage is not customized
-    const widgetExists = await feedWidget.isVisible().catch(() => false);
-
-    if (!widgetExists) {
-      test.info().annotations.push({
-        type: 'skip',
-        description: 'Activity Feed widget not visible on homepage',
+      await test.step('Add the owner from the entity page', async () => {
+        await entityChangesTable.visitEntityPage(page);
+        await waitForAllLoadersToDisappear(page);
+        await addOwner({
+          page,
+          owner: adminDisplayName,
+          endpoint: EntityTypeEndpoint.Table,
+        });
       });
 
-      return;
-    }
+      await test.step('Verify the owner event through API and UI', async () => {
+        const ownerEvent = await waitForActivityEvent({
+          entityFqn,
+          eventType: 'OwnerUpdated',
+        });
+        const activityResponse = await openActivityFeedAndWaitForApi(
+          page,
+          entityFqn
+        );
+        const renderedOwnerEvent = activityResponse.data?.find(
+          (event) => event.eventType === 'OwnerUpdated'
+        );
+        const feedItem = getActivityFeedItems(page)
+          .filter({ hasText: /owner/i })
+          .filter({ hasText: adminDisplayName });
 
-    await expect(feedWidget).toBeVisible();
+        expect(ownerEvent).toBeDefined();
+        expect(renderedOwnerEvent).toBeDefined();
+        await expect(feedItem).toBeVisible({ timeout: FEED_ITEM_TIMEOUT });
+      });
+    });
 
-    // Find sort dropdown in widget header
-    const sortDropdown = feedWidget.getByTestId('widget-sort-by-dropdown');
+    test('shows the actor who made the activity change', async ({ page }) => {
+      test.setTimeout(ACTIVITY_TEST_TIMEOUT);
 
-    // Sort dropdown may not be visible if widget is in minimal mode
-    const dropdownExists = await sortDropdown.isVisible().catch(() => false);
+      const entityFqn = getTableFqn(entityChangesTable);
+      const uniqueDescription = `Actor test description ${Date.now()}`;
 
-    if (!dropdownExists) {
-      test.info().annotations.push({
-        type: 'note',
-        description: 'Sort dropdown not visible in widget header',
+      await test.step('Make a table change as the logged-in admin user', async () => {
+        const { apiContext, afterAction } = await getApiContext(page);
+
+        try {
+          await patchTableDescription(
+            apiContext,
+            entityChangesTable,
+            uniqueDescription
+          );
+        } finally {
+          await afterAction();
+        }
+
+        await waitForActivityEvent({
+          entityFqn,
+          eventType: 'DescriptionUpdated',
+          text: uniqueDescription,
+        });
       });
 
-      return;
-    }
+      await test.step('Verify the actor is visible in the matching feed item', async () => {
+        await visitTableActivityFeed(page, entityChangesTable);
 
-    await expect(sortDropdown).toBeVisible();
+        const feedItem = await getFeedItemByText(page, uniqueDescription);
 
-    // Click to open dropdown
-    await sortDropdown.click();
-    await page.locator('.ant-dropdown').waitFor({ state: 'visible' });
+        await expect(feedItem).toContainText(adminDisplayName);
+      });
+    });
 
-    // Verify filter options are present
-    await expect(
-      page.getByRole('menuitem', { name: 'All Activity' })
-    ).toBeVisible();
-    await expect(page.getByRole('menuitem', { name: 'My Data' })).toBeVisible();
-    await expect(
-      page.getByRole('menuitem', { name: 'Following' })
-    ).toBeVisible();
+    test('links activity items to the correct entity', async ({ page }) => {
+      test.setTimeout(ACTIVITY_TEST_TIMEOUT);
 
-    // Close dropdown by pressing escape
-    await page.keyboard.press('Escape');
-  });
-});
+      const description = `Entity link description ${uuid()}`;
+
+      await test.step('Create an activity event for the table', async () => {
+        await createDescriptionActivityEventFromPage(
+          page,
+          entityChangesTable,
+          description
+        );
+      });
+
+      await test.step('Verify the feed card has the table entity link', async () => {
+        await visitTableActivityFeed(page, entityChangesTable);
+
+        const feedItem = await getFeedItemByText(page, description);
+        const entityLink = feedItem.locator('a[href*="/table/"]').first();
+
+        await expect(entityLink).toBeVisible();
+
+        const href = await entityLink.getAttribute('href');
+
+        expect(href).toContain('table');
+        expect(href).toContain(getTableLeafName(entityChangesTable));
+      });
+    });
+  }
+);
+
+test.describe(
+  'Activity API - Reactions',
+  { tag: ['@Features', '@Discovery'] },
+  () => {
+    const reactionsTable = new TableClass();
+
+    test.beforeAll('Setup: create table', async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+
+      try {
+        await reactionsTable.create(apiContext);
+      } finally {
+        await afterAction();
+      }
+    });
+
+    test.afterAll('Cleanup: delete table', async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+
+      try {
+        await reactionsTable.delete(apiContext);
+      } finally {
+        await afterAction();
+      }
+    });
+
+    test.beforeEach(async ({ page }) => {
+      await redirectToHomePage(page);
+      await waitForAllLoadersToDisappear(page);
+    });
+
+    test('adds a reaction to a feed item', async ({ page }) => {
+      test.setTimeout(ACTIVITY_TEST_TIMEOUT);
+
+      const description = `Test activity for adding reaction ${uuid()}`;
+
+      await test.step('Create and open an activity feed item', async () => {
+        await createDescriptionActivityEventFromPage(
+          page,
+          reactionsTable,
+          description
+        );
+        await visitTableActivityFeed(page, reactionsTable);
+      });
+
+      await test.step('Add thumbs-up reaction and verify it is visible', async () => {
+        const feedItem = await getFeedItemByText(page, description);
+
+        await toggleThumbsUpReaction(feedItem, page);
+        await expect(
+          feedItem.getByRole('button', { name: new RegExp(THUMBS_UP_EMOJI) })
+        ).toBeVisible({ timeout: 5_000 });
+      });
+    });
+
+    test('removes an existing reaction from a feed item', async ({ page }) => {
+      test.setTimeout(ACTIVITY_TEST_TIMEOUT);
+
+      const description = `Test activity for removing reaction ${uuid()}`;
+
+      await test.step('Create and open an activity feed item', async () => {
+        await createDescriptionActivityEventFromPage(
+          page,
+          reactionsTable,
+          description
+        );
+        await visitTableActivityFeed(page, reactionsTable);
+      });
+
+      await test.step('Add and then remove thumbs-up reaction', async () => {
+        const feedItem = await getFeedItemByText(page, description);
+
+        await toggleThumbsUpReaction(feedItem, page);
+        await expect(
+          feedItem.getByRole('button', { name: new RegExp(THUMBS_UP_EMOJI) })
+        ).toBeVisible({ timeout: 5_000 });
+
+        await toggleThumbsUpReaction(feedItem, page);
+        await expect(
+          feedItem.getByRole('button', { name: new RegExp(THUMBS_UP_EMOJI) })
+        ).not.toBeVisible({ timeout: 5_000 });
+      });
+    });
+  }
+);
+
+test.describe(
+  'Activity API - Comments',
+  { tag: ['@Features', '@Discovery'] },
+  () => {
+    const commentsTable = new TableClass();
+
+    test.beforeAll('Setup: create table', async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+
+      try {
+        await commentsTable.create(apiContext);
+      } finally {
+        await afterAction();
+      }
+    });
+
+    test.afterAll('Cleanup: delete table', async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+
+      try {
+        await commentsTable.delete(apiContext);
+      } finally {
+        await afterAction();
+      }
+    });
+
+    test.beforeEach(async ({ page }) => {
+      await redirectToHomePage(page);
+      await waitForAllLoadersToDisappear(page);
+    });
+
+    test('adds a comment to a feed item', async ({ page }) => {
+      test.setTimeout(ACTIVITY_TEST_TIMEOUT);
+
+      const description = `Test activity for comments ${uuid()}`;
+      const commentText = `Test comment ${uuid()}`;
+
+      await test.step('Create and open an activity feed item', async () => {
+        await createDescriptionActivityEventFromPage(
+          page,
+          commentsTable,
+          description
+        );
+        await visitTableActivityFeed(page, commentsTable);
+      });
+
+      await test.step('Open the feed detail and post a comment', async () => {
+        const feedItem = await getFeedItemByText(page, description);
+
+        await feedItem.click();
+        await waitForAllLoadersToDisappear(page);
+        await postActivityComment(page, commentText);
+      });
+    });
+
+    test('shows the activity detail layout', async ({ page }) => {
+      test.setTimeout(ACTIVITY_TEST_TIMEOUT);
+
+      const description = `Test activity detail layout ${uuid()}`;
+
+      await test.step('Create and open an activity feed item', async () => {
+        await createDescriptionActivityEventFromPage(
+          page,
+          commentsTable,
+          description
+        );
+        await visitTableActivityFeed(page, commentsTable);
+      });
+
+      await test.step('Open the detail view and verify layout regions', async () => {
+        const feedItem = await getFeedItemByText(page, description);
+
+        await feedItem.click();
+        await waitForAllLoadersToDisappear(page);
+
+        const activityPanel = page.locator('#activity-panel');
+
+        await expect(activityPanel).toBeVisible();
+        await expect(
+          activityPanel.getByTestId('comments-input-field')
+        ).toBeVisible();
+      });
+    });
+  }
+);
+
+test.describe(
+  'Activity API - Homepage Widget',
+  { tag: ['@Features', '@Discovery'] },
+  () => {
+    const homepageTable = new TableClass();
+
+    test.beforeAll('Setup: create table and activity', async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+
+      try {
+        await homepageTable.create(apiContext);
+        await createConversationThread(
+          apiContext,
+          homepageTable,
+          `Test conversation for homepage widget ${uuid()}`
+        );
+      } finally {
+        await afterAction();
+      }
+    });
+
+    test.afterAll('Cleanup: delete table', async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+
+      try {
+        await homepageTable.delete(apiContext);
+      } finally {
+        await afterAction();
+      }
+    });
+
+    test.beforeEach(async ({ page }) => {
+      await redirectToHomePage(page);
+      await waitForAllLoadersToDisappear(page);
+    });
+
+    test('displays feed content in the Activity Feed widget', async ({
+      page,
+    }) => {
+      test.slow();
+
+      const feedWidget = page.getByTestId('KnowledgePanel.ActivityFeed');
+      const feedItems = feedWidget.getByTestId('message-container');
+
+      await expect(feedWidget).toBeVisible();
+      await expect(feedItems.first()).toBeVisible({
+        timeout: FEED_ITEM_TIMEOUT,
+      });
+    });
+
+    test('shows Activity Feed widget filter options', async ({ page }) => {
+      test.slow();
+
+      const feedWidget = page.getByTestId('KnowledgePanel.ActivityFeed');
+
+      await expect(feedWidget).toBeVisible();
+
+      const sortDropdown = feedWidget.getByTestId('widget-sort-by-dropdown');
+
+      await expect(sortDropdown).toBeVisible();
+      await expect(sortDropdown).toBeEnabled();
+      await sortDropdown.click();
+
+      const filterMenu = page.getByRole('menu').filter({
+        hasText: 'All Activity',
+      });
+
+      await expect(filterMenu).toBeVisible();
+      await expect(
+        page.getByRole('menuitem', { name: 'All Activity' })
+      ).toBeVisible();
+      await expect(
+        page.getByRole('menuitem', { name: 'My Data' })
+      ).toBeVisible();
+      await expect(
+        page.getByRole('menuitem', { name: 'Following' })
+      ).toBeVisible();
+
+      await page.keyboard.press('Escape');
+      await expect(filterMenu).not.toBeVisible();
+    });
+  }
+);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityAPI.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityAPI.spec.ts
@@ -42,13 +42,14 @@ import {
 } from '../../utils/entity';
 import { test } from '../fixtures/pages';
 
-let entityChangesTable: TableClass;
-let entityChangesTag: TagClass;
-
 test.describe(
   'Activity API - Entity Changes',
   { tag: [DOMAIN_TAGS.DISCOVERY] },
   () => {
+    let entityChangesTable: TableClass;
+    let entityChangesTag: TagClass;
+    let adminDisplayName: string;
+
     test.beforeAll('Setup: create table and tag', async ({ browser }) => {
       const { apiContext, afterAction } = await performAdminLogin(browser);
 
@@ -58,6 +59,10 @@ test.describe(
       try {
         await entityChangesTable.create(apiContext);
         await entityChangesTag.create(apiContext);
+
+        const userResponse = await apiContext.get('/api/v1/users/loggedInUser');
+        const adminUser = await userResponse.json();
+        adminDisplayName = adminUser.displayName ?? adminUser.name;
       } finally {
         await afterAction();
       }
@@ -159,9 +164,6 @@ test.describe(
       test.setTimeout(ACTIVITY_TEST_TIMEOUT);
 
       const entityFqn = getTableFqn(entityChangesTable);
-      const userResponse = await page.request.get('/api/v1/users/loggedInUser');
-      const adminUser = await userResponse.json();
-      const adminDisplayName = adminUser.displayName ?? adminUser.name;
 
       await test.step('Add the owner from the entity page', async () => {
         await entityChangesTable.visitEntityPage(page);
@@ -202,9 +204,6 @@ test.describe(
 
       const entityFqn = getTableFqn(entityChangesTable);
       const uniqueDescription = `Actor test description ${Date.now()}`;
-      const userResponse = await page.request.get('/api/v1/users/loggedInUser');
-      const adminUser = await userResponse.json();
-      const adminDisplayName = adminUser.displayName ?? adminUser.name;
 
       await test.step('Make a table change as the logged-in admin user', async () => {
         const { apiContext, afterAction } = await getApiContext(page);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityAPI.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityAPI.spec.ts
@@ -11,6 +11,7 @@
  *  limitations under the License.
  */
 import { expect } from '@playwright/test';
+import { DOMAIN_TAGS } from '../../constant/config';
 import { EntityTypeEndpoint } from '../../support/entity/Entity.interface';
 import { TableClass } from '../../support/entity/TableClass';
 import { TagClass } from '../../support/tag/TagClass';
@@ -43,41 +44,20 @@ import { test } from '../fixtures/pages';
 
 let entityChangesTable: TableClass;
 let entityChangesTag: TagClass;
-let adminDisplayName: string;
 
 test.describe(
   'Activity API - Entity Changes',
-  { tag: ['@Features', '@Discovery'] },
+  { tag: [DOMAIN_TAGS.DISCOVERY] },
   () => {
-    test.beforeAll(
-      'Setup: create table, tag and get admin display name',
-      async ({ browser }) => {
-        const { apiContext, afterAction } = await performAdminLogin(browser);
-
-        entityChangesTable = new TableClass();
-        entityChangesTag = new TagClass({});
-
-        try {
-          await entityChangesTable.create(apiContext);
-          await entityChangesTag.create(apiContext);
-
-          const userResponse = await apiContext.get(
-            '/api/v1/users/loggedInUser'
-          );
-          const adminUser = await userResponse.json();
-          adminDisplayName = adminUser.displayName ?? adminUser.name;
-        } finally {
-          await afterAction();
-        }
-      }
-    );
-
-    test.afterAll('Cleanup: delete table and tag', async ({ browser }) => {
+    test.beforeAll('Setup: create table and tag', async ({ browser }) => {
       const { apiContext, afterAction } = await performAdminLogin(browser);
 
+      entityChangesTable = new TableClass();
+      entityChangesTag = new TagClass({});
+
       try {
-        await entityChangesTable.delete(apiContext);
-        await entityChangesTag.delete(apiContext);
+        await entityChangesTable.create(apiContext);
+        await entityChangesTag.create(apiContext);
       } finally {
         await afterAction();
       }
@@ -91,6 +71,8 @@ test.describe(
     test('creates an activity event when the description is updated', async ({
       page,
     }) => {
+      // waitForActivityEvent polls the API for up to 5 minutes (ACTIVITY_EVENT_TIMEOUT = 300_000ms)
+      // because activity events are processed asynchronously in the background.
       test.setTimeout(ACTIVITY_TEST_TIMEOUT);
 
       const newDescription = `Test description updated at ${Date.now()}`;
@@ -132,6 +114,8 @@ test.describe(
     });
 
     test('creates an activity event when tags are added', async ({ page }) => {
+      // waitForActivityEvent polls the API for up to 5 minutes (ACTIVITY_EVENT_TIMEOUT = 300_000ms)
+      // because activity events are processed asynchronously in the background.
       test.setTimeout(ACTIVITY_TEST_TIMEOUT);
 
       const entityFqn = getTableFqn(entityChangesTable);
@@ -170,9 +154,14 @@ test.describe(
     });
 
     test('creates an activity event when owner is added', async ({ page }) => {
+      // waitForActivityEvent polls the API for up to 5 minutes (ACTIVITY_EVENT_TIMEOUT = 300_000ms)
+      // because activity events are processed asynchronously in the background.
       test.setTimeout(ACTIVITY_TEST_TIMEOUT);
 
       const entityFqn = getTableFqn(entityChangesTable);
+      const userResponse = await page.request.get('/api/v1/users/loggedInUser');
+      const adminUser = await userResponse.json();
+      const adminDisplayName = adminUser.displayName ?? adminUser.name;
 
       await test.step('Add the owner from the entity page', async () => {
         await entityChangesTable.visitEntityPage(page);
@@ -207,10 +196,15 @@ test.describe(
     });
 
     test('shows the actor who made the activity change', async ({ page }) => {
+      // waitForActivityEvent polls the API for up to 5 minutes (ACTIVITY_EVENT_TIMEOUT = 300_000ms)
+      // because activity events are processed asynchronously in the background.
       test.setTimeout(ACTIVITY_TEST_TIMEOUT);
 
       const entityFqn = getTableFqn(entityChangesTable);
       const uniqueDescription = `Actor test description ${Date.now()}`;
+      const userResponse = await page.request.get('/api/v1/users/loggedInUser');
+      const adminUser = await userResponse.json();
+      const adminDisplayName = adminUser.displayName ?? adminUser.name;
 
       await test.step('Make a table change as the logged-in admin user', async () => {
         const { apiContext, afterAction } = await getApiContext(page);
@@ -242,6 +236,8 @@ test.describe(
     });
 
     test('links activity items to the correct entity', async ({ page }) => {
+      // waitForActivityEvent polls the API for up to 5 minutes (ACTIVITY_EVENT_TIMEOUT = 300_000ms)
+      // because activity events are processed asynchronously in the background.
       test.setTimeout(ACTIVITY_TEST_TIMEOUT);
 
       const description = `Entity link description ${uuid()}`;
@@ -273,7 +269,7 @@ test.describe(
 
 test.describe(
   'Activity API - Reactions',
-  { tag: ['@Features', '@Discovery'] },
+  { tag: [DOMAIN_TAGS.DISCOVERY] },
   () => {
     const reactionsTable = new TableClass();
 
@@ -287,22 +283,14 @@ test.describe(
       }
     });
 
-    test.afterAll('Cleanup: delete table', async ({ browser }) => {
-      const { apiContext, afterAction } = await performAdminLogin(browser);
-
-      try {
-        await reactionsTable.delete(apiContext);
-      } finally {
-        await afterAction();
-      }
-    });
-
     test.beforeEach(async ({ page }) => {
       await redirectToHomePage(page);
       await waitForAllLoadersToDisappear(page);
     });
 
     test('adds a reaction to a feed item', async ({ page }) => {
+      // waitForActivityEvent polls the API for up to 5 minutes (ACTIVITY_EVENT_TIMEOUT = 300_000ms)
+      // because activity events are processed asynchronously in the background.
       test.setTimeout(ACTIVITY_TEST_TIMEOUT);
 
       const description = `Test activity for adding reaction ${uuid()}`;
@@ -327,6 +315,8 @@ test.describe(
     });
 
     test('removes an existing reaction from a feed item', async ({ page }) => {
+      // waitForActivityEvent polls the API for up to 5 minutes (ACTIVITY_EVENT_TIMEOUT = 300_000ms)
+      // because activity events are processed asynchronously in the background.
       test.setTimeout(ACTIVITY_TEST_TIMEOUT);
 
       const description = `Test activity for removing reaction ${uuid()}`;
@@ -359,7 +349,7 @@ test.describe(
 
 test.describe(
   'Activity API - Comments',
-  { tag: ['@Features', '@Discovery'] },
+  { tag: [DOMAIN_TAGS.DISCOVERY] },
   () => {
     const commentsTable = new TableClass();
 
@@ -373,22 +363,14 @@ test.describe(
       }
     });
 
-    test.afterAll('Cleanup: delete table', async ({ browser }) => {
-      const { apiContext, afterAction } = await performAdminLogin(browser);
-
-      try {
-        await commentsTable.delete(apiContext);
-      } finally {
-        await afterAction();
-      }
-    });
-
     test.beforeEach(async ({ page }) => {
       await redirectToHomePage(page);
       await waitForAllLoadersToDisappear(page);
     });
 
     test('adds a comment to a feed item', async ({ page }) => {
+      // waitForActivityEvent polls the API for up to 5 minutes (ACTIVITY_EVENT_TIMEOUT = 300_000ms)
+      // because activity events are processed asynchronously in the background.
       test.setTimeout(ACTIVITY_TEST_TIMEOUT);
 
       const description = `Test activity for comments ${uuid()}`;
@@ -413,6 +395,8 @@ test.describe(
     });
 
     test('shows the activity detail layout', async ({ page }) => {
+      // waitForActivityEvent polls the API for up to 5 minutes (ACTIVITY_EVENT_TIMEOUT = 300_000ms)
+      // because activity events are processed asynchronously in the background.
       test.setTimeout(ACTIVITY_TEST_TIMEOUT);
 
       const description = `Test activity detail layout ${uuid()}`;
@@ -445,7 +429,7 @@ test.describe(
 
 test.describe(
   'Activity API - Homepage Widget',
-  { tag: ['@Features', '@Discovery'] },
+  { tag: [DOMAIN_TAGS.DISCOVERY] },
   () => {
     const homepageTable = new TableClass();
 
@@ -464,16 +448,6 @@ test.describe(
       }
     });
 
-    test.afterAll('Cleanup: delete table', async ({ browser }) => {
-      const { apiContext, afterAction } = await performAdminLogin(browser);
-
-      try {
-        await homepageTable.delete(apiContext);
-      } finally {
-        await afterAction();
-      }
-    });
-
     test.beforeEach(async ({ page }) => {
       await redirectToHomePage(page);
       await waitForAllLoadersToDisappear(page);
@@ -482,8 +456,6 @@ test.describe(
     test('displays feed content in the Activity Feed widget', async ({
       page,
     }) => {
-      test.slow();
-
       const feedWidget = page.getByTestId('KnowledgePanel.ActivityFeed');
       const feedItems = feedWidget.getByTestId('message-container');
 
@@ -494,8 +466,6 @@ test.describe(
     });
 
     test('shows Activity Feed widget filter options', async ({ page }) => {
-      test.slow();
-
       const feedWidget = page.getByTestId('KnowledgePanel.ActivityFeed');
 
       await expect(feedWidget).toBeVisible();

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/activityAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/activityAPI.ts
@@ -1,0 +1,336 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { APIRequestContext, expect, Locator, Page } from '@playwright/test';
+import { TableClass } from '../support/entity/TableClass';
+import { TagClass } from '../support/tag/TagClass';
+import { createAdminApiContext } from './admin';
+import { getApiContext } from './common';
+import { waitForAllLoadersToDisappear } from './entity';
+
+export const ACTIVITY_EVENT_TIMEOUT = 300_000;
+export const ACTIVITY_TEST_TIMEOUT = ACTIVITY_EVENT_TIMEOUT + 60_000;
+export const ACTIVITY_FEED_RESPONSE_TIMEOUT = 15_000;
+export const FEED_ITEM_TIMEOUT = 30_000;
+export const THUMBS_UP_REACTION = 'thumbsUp';
+export const THUMBS_UP_EMOJI = '👍';
+
+const JSON_PATCH_CONTENT_TYPE = 'application/json-patch+json';
+
+export type ActivityEventType =
+  | 'DescriptionUpdated'
+  | 'OwnerUpdated'
+  | 'TagsUpdated';
+
+export type ActivityApiEvent = Record<string, unknown> & {
+  actor?: { displayName?: string; name?: string };
+  eventType?: string;
+  summary?: string;
+};
+
+export type ActivityApiResponse = {
+  data?: ActivityApiEvent[];
+};
+
+type FeedThread = {
+  id?: string;
+  message?: string;
+};
+
+type FeedResponse = {
+  data?: FeedThread[];
+};
+
+export const getTableFqn = (table: TableClass) =>
+  table.entityResponseData.fullyQualifiedName ?? '';
+
+export const getTableLeafName = (table: TableClass) =>
+  getTableFqn(table).split('.').pop() ?? getTableFqn(table);
+
+const getTableEntityLink = (table: TableClass) =>
+  `<#E::table::${getTableFqn(table)}>`;
+
+export const getActivityFeedItems = (page: Page) =>
+  page.locator('#center-container').getByTestId('message-container');
+
+export const getFeedItemByText = async (page: Page, text: string) => {
+  const feedItem = getActivityFeedItems(page).filter({ hasText: text }).first();
+
+  await expect(feedItem).toBeVisible({ timeout: FEED_ITEM_TIMEOUT });
+  await expect(feedItem).toContainText(text);
+
+  return feedItem;
+};
+
+export const openActivityFeedAndWaitForApi = async (
+  page: Page,
+  entityFqn: string
+) => {
+  const expectedActivityPath = `/api/v1/activity/entity/table/name/${entityFqn}`;
+  const activityResponsePromise = page.waitForResponse(
+    (response) =>
+      response.request().method() === 'GET' &&
+      decodeURIComponent(response.url()).includes(expectedActivityPath) &&
+      response.ok(),
+    { timeout: ACTIVITY_FEED_RESPONSE_TIMEOUT }
+  );
+
+  await page.getByTestId('activity_feed').click();
+
+  const activityResponse = await activityResponsePromise;
+
+  expect(activityResponse.status()).toBe(200);
+  await waitForAllLoadersToDisappear(page);
+
+  return (await activityResponse.json()) as ActivityApiResponse;
+};
+
+export const visitTableActivityFeed = async (page: Page, table: TableClass) => {
+  await table.visitEntityPage(page);
+  await waitForAllLoadersToDisappear(page);
+
+  return await openActivityFeedAndWaitForApi(page, getTableFqn(table));
+};
+
+export const waitForActivityEvent = async ({
+  entityFqn,
+  eventType,
+  text,
+}: {
+  entityFqn: string;
+  eventType: ActivityEventType;
+  text?: string;
+}) => {
+  const { apiContext, afterAction } = await createAdminApiContext();
+  const activityUrl = `/api/v1/activity/entity/table/name/${encodeURIComponent(
+    entityFqn
+  )}?days=30&limit=50`;
+  let events: ActivityApiEvent[] = [];
+
+  try {
+    await expect
+      .poll(
+        async () => {
+          const response = await apiContext.get(activityUrl);
+
+          if (!response.ok()) {
+            return false;
+          }
+
+          const body = (await response.json()) as ActivityApiResponse;
+          events = body.data ?? [];
+
+          return events.some(
+            (event) =>
+              event.eventType === eventType &&
+              (text === undefined || JSON.stringify(event).includes(text))
+          );
+        },
+        {
+          timeout: ACTIVITY_EVENT_TIMEOUT,
+          intervals: [1_000, 2_000, 5_000, 10_000],
+          message: `Timed out waiting for ${eventType} event for ${entityFqn}`,
+        }
+      )
+      .toBe(true);
+
+    return events.find(
+      (event) =>
+        event.eventType === eventType &&
+        (text === undefined || JSON.stringify(event).includes(text))
+    );
+  } finally {
+    await afterAction();
+  }
+};
+
+const waitForConversationThread = async ({
+  apiContext,
+  entityLink,
+  message,
+  threadId,
+}: {
+  apiContext: APIRequestContext;
+  entityLink: string;
+  message: string;
+  threadId?: string;
+}) => {
+  await expect
+    .poll(
+      async () => {
+        const response = await apiContext.get('/api/v1/feed', {
+          params: {
+            entityLink,
+            type: 'Conversation',
+            limit: '25',
+          },
+        });
+
+        if (!response.ok()) {
+          return false;
+        }
+
+        const data = (await response.json()) as FeedResponse;
+
+        return (data.data ?? []).some(
+          (thread) => thread.id === threadId || thread.message === message
+        );
+      },
+      {
+        timeout: 60_000,
+        intervals: [2_000],
+        message: `Timed out waiting for conversation "${message}"`,
+      }
+    )
+    .toBe(true);
+};
+
+export const createConversationThread = async (
+  apiContext: APIRequestContext,
+  table: TableClass,
+  message: string
+) => {
+  const entityLink = getTableEntityLink(table);
+  const response = await apiContext.post('/api/v1/feed', {
+    data: {
+      message,
+      about: entityLink,
+    },
+  });
+
+  expect(response.ok()).toBeTruthy();
+
+  const thread = (await response.json()) as FeedThread;
+
+  await waitForConversationThread({
+    apiContext,
+    entityLink,
+    message,
+    threadId: thread.id,
+  });
+
+  return thread;
+};
+
+export const createConversationThreadFromPage = async (
+  page: Page,
+  table: TableClass,
+  message: string
+) => {
+  const { apiContext, afterAction } = await getApiContext(page);
+
+  try {
+    return await createConversationThread(apiContext, table, message);
+  } finally {
+    await afterAction();
+  }
+};
+
+export const patchTableDescription = async (
+  apiContext: APIRequestContext,
+  table: TableClass,
+  description: string
+) => {
+  const response = await apiContext.patch(
+    `/api/v1/tables/${table.entityResponseData.id}`,
+    {
+      data: [
+        {
+          op: 'add',
+          path: '/description',
+          value: description,
+        },
+      ],
+      headers: {
+        'Content-Type': JSON_PATCH_CONTENT_TYPE,
+      },
+    }
+  );
+
+  expect(response.ok()).toBeTruthy();
+};
+
+export const createDescriptionActivityEventFromPage = async (
+  page: Page,
+  table: TableClass,
+  description: string
+) => {
+  const { apiContext, afterAction } = await getApiContext(page);
+  const entityFqn = getTableFqn(table);
+
+  try {
+    await patchTableDescription(apiContext, table, description);
+  } finally {
+    await afterAction();
+  }
+
+  return await waitForActivityEvent({
+    entityFqn,
+    eventType: 'DescriptionUpdated',
+    text: description,
+  });
+};
+
+export const addTagToTable = async (
+  apiContext: APIRequestContext,
+  table: TableClass,
+  tag: TagClass
+) => {
+  const response = await apiContext.patch(
+    `/api/v1/tables/${table.entityResponseData.id}`,
+    {
+      data: [
+        {
+          op: 'add',
+          path: '/tags/0',
+          value: {
+            tagFQN: tag.responseData.fullyQualifiedName,
+            source: 'Classification',
+          },
+        },
+      ],
+      headers: {
+        'Content-Type': JSON_PATCH_CONTENT_TYPE,
+      },
+    }
+  );
+
+  expect(response.ok()).toBeTruthy();
+};
+
+export const toggleThumbsUpReaction = async (feedItem: Locator, page: Page) => {
+  const addReactionButton = feedItem
+    .getByTestId('feed-reaction-container')
+    .getByTestId('add-reactions');
+
+  await expect(addReactionButton).toBeVisible();
+  await expect(addReactionButton).toBeEnabled();
+  await addReactionButton.click();
+  await expect(page.locator('.ant-popover-feed-reactions')).toBeVisible();
+
+  const reactionResponse = page.waitForResponse(
+    (response) =>
+      (response.url().includes('/api/v1/activity') ||
+        response.url().includes('/api/v1/feed')) &&
+      response.url().includes(`/reaction/${THUMBS_UP_REACTION}`) &&
+      response.ok()
+  );
+
+  await page
+    .locator(`[data-testid="reaction-button"][title="${THUMBS_UP_REACTION}"]`)
+    .click();
+
+  const response = await reactionResponse;
+
+  expect(response.ok()).toBeTruthy();
+  await waitForAllLoadersToDisappear(page);
+};


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

<img width="1510" height="516" alt="Screenshot 2026-05-12 at 11 51 47 AM" src="https://github.com/user-attachments/assets/23f570f8-bd2f-4cf3-a59d-81f6cf2307c1" />

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **Test refactoring:**
  - Cleaned up `ActivityAPI.spec.ts` by removing redundant `test.afterAll` cleanup blocks for entities.
  - Updated test suite tagging to use `DOMAIN_TAGS.DISCOVERY` for consistency.
- **Test reliability:**
  - Added informative comments explaining `waitForActivityEvent` polling for asynchronous background events.
  - Added inline logic to fetch and set `adminDisplayName` within specific test cases where required.

<sub>This will update automatically on new commits.</sub>