### PR TITLE
fix(playwright): expand nested columns before suggestion assertions

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DescriptionSuggestion.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DescriptionSuggestion.spec.ts
@@ -17,6 +17,7 @@ import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';
 import { redirectToHomePage } from '../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
+import { expandNestedColumn } from '../../utils/nestedColumnUpdatesUtils';
 import { createTableDescriptionSuggestions } from '../../utils/suggestions';
 import { performUserLogin } from '../../utils/user';
 
@@ -71,6 +72,21 @@ test.describe.serial(
 
         // Two users profile will be visible, 3rd one will come after AllFetch is clicked
         await expect(allAvatarSuggestion).toHaveCount(1);
+
+        // Expand nested struct/array columns so their suggestion cards render
+        const cols = table.entityResponseData.columns ?? [];
+        const structCol = cols[2];
+        const arrayCol = (structCol.children ?? [])[1];
+        await expandNestedColumn(
+          page,
+          structCol.fullyQualifiedName ?? '',
+          (structCol.children ?? [])[0].fullyQualifiedName ?? ''
+        );
+        await expandNestedColumn(
+          page,
+          arrayCol.fullyQualifiedName ?? '',
+          (arrayCol.children ?? [])[0].fullyQualifiedName ?? ''
+        );
 
         // Click the first avatar
         await allAvatarSuggestion.nth(0).click();
@@ -135,6 +151,21 @@ test.describe.serial(
           .getByTestId('asset-description-container')
           .getByTestId('profile-avatar');
 
+        // Expand nested columns so columnsName[5] row is accessible
+        const cols = table.entityResponseData.columns ?? [];
+        const structCol = cols[2];
+        const arrayCol = (structCol.children ?? [])[1];
+        await expandNestedColumn(
+          page,
+          structCol.fullyQualifiedName ?? '',
+          (structCol.children ?? [])[0].fullyQualifiedName ?? ''
+        );
+        await expandNestedColumn(
+          page,
+          arrayCol.fullyQualifiedName ?? '',
+          (arrayCol.children ?? [])[0].fullyQualifiedName ?? ''
+        );
+
         // Click the first avatar
         await allAvatarSuggestion.nth(0).click();
 
@@ -152,6 +183,22 @@ test.describe.serial(
 
         await page.reload();
         await waitForAllLoadersToDisappear(page);
+
+        // Re-expand after reload so columnsName[5] row is visible for verification
+        // and remains expanded for subsequent test steps
+        const colsAfterReload = table.entityResponseData.columns ?? [];
+        const structColAfterReload = colsAfterReload[2];
+        const arrayColAfterReload = (structColAfterReload.children ?? [])[1];
+        await expandNestedColumn(
+          page,
+          structColAfterReload.fullyQualifiedName ?? '',
+          (structColAfterReload.children ?? [])[0].fullyQualifiedName ?? ''
+        );
+        await expandNestedColumn(
+          page,
+          arrayColAfterReload.fullyQualifiedName ?? '',
+          (arrayColAfterReload.children ?? [])[0].fullyQualifiedName ?? ''
+        );
 
         // since we accepted two suggestions, the badge count should be total-2
         await expect(

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DescriptionSuggestion.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DescriptionSuggestion.spec.ts
@@ -17,8 +17,10 @@ import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';
 import { redirectToHomePage } from '../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
-import { expandNestedColumn } from '../../utils/nestedColumnUpdatesUtils';
-import { createTableDescriptionSuggestions } from '../../utils/suggestions';
+import {
+  createTableDescriptionSuggestions,
+  expandTableSuggestionColumns,
+} from '../../utils/suggestions';
 import { performUserLogin } from '../../utils/user';
 
 const table = new TableClass();
@@ -74,19 +76,7 @@ test.describe.serial(
         await expect(allAvatarSuggestion).toHaveCount(1);
 
         // Expand nested struct/array columns so their suggestion cards render
-        const cols = table.entityResponseData.columns ?? [];
-        const structCol = cols[2];
-        const arrayCol = (structCol.children ?? [])[1];
-        await expandNestedColumn(
-          page,
-          structCol.fullyQualifiedName ?? '',
-          (structCol.children ?? [])[0].fullyQualifiedName ?? ''
-        );
-        await expandNestedColumn(
-          page,
-          arrayCol.fullyQualifiedName ?? '',
-          (arrayCol.children ?? [])[0].fullyQualifiedName ?? ''
-        );
+        await expandTableSuggestionColumns(page, table);
 
         // Click the first avatar
         await allAvatarSuggestion.nth(0).click();
@@ -152,19 +142,7 @@ test.describe.serial(
           .getByTestId('profile-avatar');
 
         // Expand nested columns so columnsName[5] row is accessible
-        const cols = table.entityResponseData.columns ?? [];
-        const structCol = cols[2];
-        const arrayCol = (structCol.children ?? [])[1];
-        await expandNestedColumn(
-          page,
-          structCol.fullyQualifiedName ?? '',
-          (structCol.children ?? [])[0].fullyQualifiedName ?? ''
-        );
-        await expandNestedColumn(
-          page,
-          arrayCol.fullyQualifiedName ?? '',
-          (arrayCol.children ?? [])[0].fullyQualifiedName ?? ''
-        );
+        await expandTableSuggestionColumns(page, table);
 
         // Click the first avatar
         await allAvatarSuggestion.nth(0).click();
@@ -186,19 +164,7 @@ test.describe.serial(
 
         // Re-expand after reload so columnsName[5] row is visible for verification
         // and remains expanded for subsequent test steps
-        const colsAfterReload = table.entityResponseData.columns ?? [];
-        const structColAfterReload = colsAfterReload[2];
-        const arrayColAfterReload = (structColAfterReload.children ?? [])[1];
-        await expandNestedColumn(
-          page,
-          structColAfterReload.fullyQualifiedName ?? '',
-          (structColAfterReload.children ?? [])[0].fullyQualifiedName ?? ''
-        );
-        await expandNestedColumn(
-          page,
-          arrayColAfterReload.fullyQualifiedName ?? '',
-          (arrayColAfterReload.children ?? [])[0].fullyQualifiedName ?? ''
-        );
+        await expandTableSuggestionColumns(page, table);
 
         // since we accepted two suggestions, the badge count should be total-2
         await expect(

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TagsSuggestion.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TagsSuggestion.spec.ts
@@ -15,6 +15,7 @@ import { TableClass } from '../../support/entity/TableClass';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';
 import { redirectToHomePage } from '../../utils/common';
+import { expandNestedColumn } from '../../utils/nestedColumnUpdatesUtils';
 import { createTableTagsSuggestions } from '../../utils/suggestions';
 
 const table = new TableClass();
@@ -72,6 +73,21 @@ test.describe('Tags Suggestions Table Entity', () => {
 
       // Two users profile will be visible, 3rd one will come after AllFetch is clicked
       await expect(allAvatarSuggestion).toHaveCount(1);
+
+      // Expand nested struct/array columns so their suggestion cards render
+      const cols = table.entityResponseData.columns ?? [];
+      const structCol = cols[2];
+      const arrayCol = (structCol.children ?? [])[1];
+      await expandNestedColumn(
+        page,
+        structCol.fullyQualifiedName ?? '',
+        (structCol.children ?? [])[0].fullyQualifiedName ?? ''
+      );
+      await expandNestedColumn(
+        page,
+        arrayCol.fullyQualifiedName ?? '',
+        (arrayCol.children ?? [])[0].fullyQualifiedName ?? ''
+      );
 
       // Click the first avatar
       await allAvatarSuggestion.nth(0).click();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TagsSuggestion.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TagsSuggestion.spec.ts
@@ -15,8 +15,10 @@ import { TableClass } from '../../support/entity/TableClass';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';
 import { redirectToHomePage } from '../../utils/common';
-import { expandNestedColumn } from '../../utils/nestedColumnUpdatesUtils';
-import { createTableTagsSuggestions } from '../../utils/suggestions';
+import {
+  createTableTagsSuggestions,
+  expandTableSuggestionColumns,
+} from '../../utils/suggestions';
 
 const table = new TableClass();
 const table2 = new TableClass();
@@ -75,19 +77,7 @@ test.describe('Tags Suggestions Table Entity', () => {
       await expect(allAvatarSuggestion).toHaveCount(1);
 
       // Expand nested struct/array columns so their suggestion cards render
-      const cols = table.entityResponseData.columns ?? [];
-      const structCol = cols[2];
-      const arrayCol = (structCol.children ?? [])[1];
-      await expandNestedColumn(
-        page,
-        structCol.fullyQualifiedName ?? '',
-        (structCol.children ?? [])[0].fullyQualifiedName ?? ''
-      );
-      await expandNestedColumn(
-        page,
-        arrayCol.fullyQualifiedName ?? '',
-        (arrayCol.children ?? [])[0].fullyQualifiedName ?? ''
-      );
+      await expandTableSuggestionColumns(page, table);
 
       // Click the first avatar
       await allAvatarSuggestion.nth(0).click();

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/nestedColumnUpdatesUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/nestedColumnUpdatesUtils.ts
@@ -136,7 +136,7 @@ export const getNestedColumnDetails = (type: string, data: EntityTypes) => {
 
 const DUPLICATE_NAME = `name-${uuid()}`;
 
-const expandNestedColumn = async (
+export const expandNestedColumn = async (
   page: Page,
   rowKey: string,
   childKey: string

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/suggestions.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/suggestions.ts
@@ -10,7 +10,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { APIRequestContext } from '@playwright/test';
+import { APIRequestContext, Page } from '@playwright/test';
+import { TableClass } from '../support/entity/TableClass';
+import { expandNestedColumn } from './nestedColumnUpdatesUtils';
 
 const SUGGESTION_DESCRIPTION_DATA = {
   description: 'this is suggested data description',
@@ -43,6 +45,25 @@ const SUGGESTION_TIER_TAGS_DATA = {
     },
   ],
   type: 'SuggestTagLabel',
+};
+
+export const expandTableSuggestionColumns = async (
+  page: Page,
+  table: TableClass
+) => {
+  const cols = table.entityResponseData.columns ?? [];
+  const structCol = cols[2];
+  const arrayCol = (structCol.children ?? [])[1];
+  await expandNestedColumn(
+    page,
+    structCol.fullyQualifiedName ?? '',
+    (structCol.children ?? [])[0].fullyQualifiedName ?? ''
+  );
+  await expandNestedColumn(
+    page,
+    arrayCol.fullyQualifiedName ?? '',
+    (arrayCol.children ?? [])[0].fullyQualifiedName ?? ''
+  );
 };
 
 export const createTableDescriptionSuggestions = async (

--- a/openmetadata-ui/src/main/resources/ui/src/components/TestLibrary/TestDefinitionForm/TestDefinitionForm.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TestLibrary/TestDefinitionForm/TestDefinitionForm.test.tsx
@@ -352,8 +352,9 @@ describe('TestDefinitionForm Component', () => {
     };
 
     // testPlatforms defaults to [OpenMetadata] so it never fires an error on empty submit.
-    // name + entityType are the two required fields without defaults.
-    it('should show exactly 2 validation errors when create form is submitted empty', async () => {
+    // supportedDataTypes is required when OpenMetadata is selected.
+    // name + entityType + supportedDataTypes are the required fields without defaults.
+    it('should show exactly 3 validation errors when create form is submitted empty', async () => {
       render(
         <TestDefinitionForm onCancel={mockOnCancel} onSuccess={mockOnSuccess} />
       );
@@ -363,7 +364,7 @@ describe('TestDefinitionForm Component', () => {
       await waitFor(() => {
         const errors = screen.getAllByText('message.field-text-is-required');
 
-        expect(errors).toHaveLength(2);
+        expect(errors).toHaveLength(3);
       });
     });
 
@@ -383,9 +384,9 @@ describe('TestDefinitionForm Component', () => {
             .getByLabelText('label.name')
             .closest('.ant-form-item');
 
-          expect(nameFormItem).toHaveTextContent(
-            'message.field-text-is-required'
-          );
+          expect(
+            nameFormItem?.querySelector('.ant-form-item-explain-error')
+          ).toHaveTextContent('message.field-text-is-required');
         });
       });
 
@@ -404,9 +405,9 @@ describe('TestDefinitionForm Component', () => {
             .getByLabelText('label.entity-type')
             .closest('.ant-form-item');
 
-          expect(entityTypeFormItem).toHaveTextContent(
-            'message.field-text-is-required'
-          );
+          expect(
+            entityTypeFormItem?.querySelector('.ant-form-item-explain-error')
+          ).toHaveTextContent('message.field-text-is-required');
         });
       });
 
@@ -428,6 +429,29 @@ describe('TestDefinitionForm Component', () => {
         expect(
           testPlatformsFormItem?.querySelector('.ant-form-item-required')
         ).toBeInTheDocument();
+      });
+
+      it('supportedDataTypes field is required for OpenMetadata tests', async () => {
+        render(
+          <TestDefinitionForm
+            onCancel={mockOnCancel}
+            onSuccess={mockOnSuccess}
+          />
+        );
+
+        await submitEmptyForm();
+
+        await waitFor(() => {
+          const supportedDataTypesFormItem = screen
+            .getByLabelText('label.supported-data-type-plural')
+            .closest('.ant-form-item');
+
+          expect(
+            supportedDataTypesFormItem?.querySelector(
+              '.ant-form-item-explain-error'
+            )
+          ).toHaveTextContent('message.field-text-is-required');
+        });
       });
 
       it('parameter name field is required', async () => {
@@ -558,9 +582,14 @@ describe('TestDefinitionForm Component', () => {
         await assertNoRequiredError(formItem);
       });
 
-      it('supportedDataTypes field is optional', async () => {
+      it('supportedDataTypes field is optional for non-OpenMetadata tests', async () => {
         render(
           <TestDefinitionForm
+            initialValues={{
+              ...mockExternalTestDefinition,
+              testPlatforms: [TestPlatform.Dbt],
+              supportedDataTypes: [],
+            }}
             onCancel={mockOnCancel}
             onSuccess={mockOnSuccess}
           />


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

## Summary

- Export `expandNestedColumn` from `nestedColumnUpdatesUtils.ts` (was `const`, not reachable)
- `TagsSuggestion.spec.ts`: expand struct + array columns before avatar click so all 9 `suggested-SuggestTagLabel-card` elements render
- `DescriptionSuggestion.spec.ts`: same expansion at 3 points — before count check, before accepting a level-2 column suggestion, and after `page.reload()` to keep nested rows visible through remaining steps

## Root cause

PR #27959 changed nested columns to collapse by default. Both suggestion specs relied on implicit auto-expansion: the `toHaveCount(entityLinkColumnsName.length)` assertion and `[data-row-key*=columnsName[5]]` locators fail when the parent struct/array rows are collapsed.


<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **Test updates:**
  - Updated `TestDefinitionForm.test.tsx` to include `supportedDataTypes` as a required field for `OpenMetadata` tests.
  - Added specific test case to verify `supportedDataTypes` validation error and updated existing suite to reflect the new requirement.


<sub>This will update automatically on new commits.</sub>