### PR TITLE
test(playwright): emit json reporter for SSO nightly Slack step on 1.12.8

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright.config.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright.config.ts
@@ -46,6 +46,7 @@ export default defineConfig({
       },
     ],
     ['blob'],
+    ['json', { outputFile: './playwright/output/results.json' }],
   ],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {


### PR DESCRIPTION
## Summary
- Adds the single `['json', { outputFile: './playwright/output/results.json' }]` reporter entry to `openmetadata-ui/src/main/resources/ui/playwright.config.ts` on `1.12.8`.
- Restores the SSO Login Nightly workflow's `Send Slack Notification` step, which fails on `1.12.8` because the JSON reporter it consumes was never backported.

## Why this is needed
- PR #28075 backported the workflow `.github/workflows/playwright-sso-login-nightly.yml` to `1.12.8`. The workflow's Slack step runs:
  ```
  npx playwright-slack-report -c playwright/slack-cli.config.json \\
      -j playwright/output/results.json > slack_report.json
  ```
- That `results.json` is produced by a `json` reporter entry added in PR #26415 (commit `af31136400`, "Add Playwright failure reporting to PR comments"), which lives on `main` and `1.13` only.
- Result: on `1.12.8` the Playwright SSO tests pass, but no `results.json` is written, and the Slack step exits 1 with:
  ```
  ❌ JSON results file does not exist: playwright/output/results.json
  ```
- The sibling backport on 1.13 (#28074) works because the json reporter is already there.

Failing run that prompted this fix:
https://github.com/open-metadata/OpenMetadata/actions/runs/25787907982

## Scope
This is the minimal slice of #26415 that the SSO nightly workflow depends on. The rest of #26415 (PR-comment posting) is intentionally **not** backported — it's not required for the SSO nightly to go green.

## Test plan
- [ ] Manually trigger `SSO Login Nightly` on `1.12.8`: `gh workflow run "SSO Login Nightly" --ref 1.12.8 -f sso_provider=okta` — confirm `Send Slack Notification` succeeds and a message lands in Slack channel `C04HGB0NY04`.
- [ ] Repeat with `-f sso_provider=keycloak-azure-saml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)