### PR TITLE
fix(dq-dashboard): denormalize certification onto testCase index + filter plumbing

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchClient.java
@@ -179,6 +179,18 @@ public interface SearchClient
       }
       """;
 
+  // Cascade variant: full-object replace (handles add/update) plus removal on
+  // null params, so child docs stay in sync when a parent's cert is added,
+  // changed, or removed.
+  String CASCADE_CERTIFICATION_SCRIPT =
+      """
+      if (params.certification == null) {
+        ctx._source.remove('certification');
+      } else {
+        ctx._source.certification = params.certification;
+      }
+      """;
+
   String UPDATE_GLOSSARY_TERM_TAG_FQN_BY_PREFIX_SCRIPT =
       """
       if (ctx._source.containsKey('tags')) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
@@ -18,6 +18,7 @@ import static org.openmetadata.service.Entity.RAW_COST_ANALYSIS_REPORT_DATA;
 import static org.openmetadata.service.Entity.WEB_ANALYTIC_ENTITY_VIEW_REPORT_DATA;
 import static org.openmetadata.service.Entity.WEB_ANALYTIC_USER_ACTIVITY_REPORT_DATA;
 import static org.openmetadata.service.search.SearchClient.ADD_FOLLOWERS_SCRIPT;
+import static org.openmetadata.service.search.SearchClient.CASCADE_CERTIFICATION_SCRIPT;
 import static org.openmetadata.service.search.SearchClient.DATA_ASSET_SEARCH_ALIAS;
 import static org.openmetadata.service.search.SearchClient.DEFAULT_UPDATE_SCRIPT;
 import static org.openmetadata.service.search.SearchClient.GLOBAL_SEARCH_ALIAS;
@@ -1816,6 +1817,47 @@ public class SearchRepository {
 
     AssetCertification certification = getCertificationFromEntity(entity);
     updateEntityCertificationInSearch(entity, certification);
+    cascadeCertificationToChildren(entity, certification);
+  }
+
+  // Pushes the cert change onto every child search doc denormalized from this
+  // entity. Without this the cert filter on the DQ dashboard (which queries
+  // children like test_case/test_case_result/test_case_resolution_status by
+  // `certification.tagLabel.tagFQN`) would silently use the stale cert until a
+  // reindex. RAW_REPLACE in PropagationDescriptor can't be used because it
+  // restores the old value on delete; we drive a dedicated script instead.
+  private void cascadeCertificationToChildren(
+      EntityInterface entity, AssetCertification certification) {
+    String type = entity.getEntityReference().getType();
+    if (!Entity.TABLE.equalsIgnoreCase(type)) {
+      // Scope: Table only. Dashboard/ApiCollection children also have cert in
+      // their mappings; extend here when those denormalization paths are added.
+      return;
+    }
+    IndexMapping indexMapping = entityIndexMap.get(Entity.TABLE);
+    if (indexMapping == null) {
+      return;
+    }
+    List<String> childAliases = indexMapping.getChildAliases(clusterAlias);
+    if (nullOrEmpty(childAliases)) {
+      return;
+    }
+
+    Map<String, Object> params = new HashMap<>();
+    params.put("certification", certification); // null when cert was removed
+
+    Pair<String, String> parentMatch = new ImmutablePair<>("table.id", entity.getId().toString());
+
+    try {
+      searchClient.updateChildren(
+          childAliases, parentMatch, new ImmutablePair<>(CASCADE_CERTIFICATION_SCRIPT, params));
+    } catch (Exception e) {
+      LOG.error(
+          "Failed to cascade certification for table [{}]: {}",
+          entity.getFullyQualifiedName(),
+          e.getMessage(),
+          e);
+    }
   }
 
   private boolean isCertificationUpdated(ChangeDescription change) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/ColumnSearchIndex.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/ColumnSearchIndex.java
@@ -135,6 +135,10 @@ public class ColumnSearchIndex implements SearchIndex {
       }
     }
 
+    if (parentTable.getCertification() != null) {
+      doc.put("certification", parentTable.getCertification());
+    }
+
     if (column.getExtension() != null) {
       doc.put("extension", column.getExtension());
       doc.put(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/TestCaseIndex.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/TestCaseIndex.java
@@ -73,8 +73,8 @@ public record TestCaseIndex(TestCase testCase) implements TaggableIndex {
   }
 
   private void setParentRelationships(Map<String, Object> doc, TestCase testCase) {
-    // Denormalize parent relationships and inherit domains from the linked table.
-    // addTestSuiteParentEntityRelations already fetches the Table with "domains",
+    // Denormalize parent relationships and inherit domains/certification from the linked table.
+    // addTestSuiteParentEntityRelations already fetches the Table with these fields,
     // so we reuse it to avoid an extra DB query per test case.
     EntityInterface linkedTable = denormalizeTestSuiteParents(doc, testCase);
 
@@ -82,6 +82,12 @@ public record TestCaseIndex(TestCase testCase) implements TaggableIndex {
         && linkedTable != null
         && !nullOrEmpty(linkedTable.getDomains())) {
       doc.put("domains", getEntitiesWithDisplayName(linkedTable.getDomains()));
+    }
+
+    if (testCase.getCertification() == null
+        && linkedTable != null
+        && linkedTable.getCertification() != null) {
+      doc.put("certification", linkedTable.getCertification());
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/TestCaseResolutionStatusIndex.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/TestCaseResolutionStatusIndex.java
@@ -4,6 +4,7 @@ import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 
 import java.util.HashMap;
 import java.util.Map;
+import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.schema.tests.TestCase;
 import org.openmetadata.schema.tests.TestSuite;
 import org.openmetadata.schema.tests.type.TestCaseResolutionStatus;
@@ -62,7 +63,12 @@ public record TestCaseResolutionStatusIndex(TestCaseResolutionStatus testCaseRes
     if (testSuite == null) return;
     doc.put("testSuite", testSuite.getEntityReference());
     if (testSuite.getBasicEntityReference() != null) {
-      TestSuiteIndex.addTestSuiteParentEntityRelations(testSuite.getBasicEntityReference(), doc);
+      Table linkedTable =
+          TestSuiteIndex.addTestSuiteParentEntityRelations(
+              testSuite.getBasicEntityReference(), doc);
+      if (linkedTable != null && linkedTable.getCertification() != null) {
+        doc.put("certification", linkedTable.getCertification());
+      }
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/TestCaseResultIndex.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/TestCaseResultIndex.java
@@ -118,7 +118,7 @@ public record TestCaseResultIndex(TestCaseResult testCaseResult) implements Sear
           Entity.getEntityByName(
               Entity.TABLE,
               entityLink.getEntityFQN(),
-              "database,databaseSchema,service",
+              "database,databaseSchema,service,certification",
               Include.ALL);
       esDoc.put("database", table.getDatabase());
       esDoc.put("databaseSchema", table.getDatabaseSchema());
@@ -127,6 +127,9 @@ public record TestCaseResultIndex(TestCaseResult testCaseResult) implements Sear
         esDoc.put("serviceType", table.getServiceType());
       }
       esDoc.put("table", table.getEntityReference());
+      if (table.getCertification() != null) {
+        esDoc.put("certification", table.getCertification());
+      }
     } catch (EntityNotFoundException ex) {
       LOG.warn(
           "Table [{}] not found during search indexing: {}",

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/TestSuiteIndex.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/TestSuiteIndex.java
@@ -54,7 +54,7 @@ public record TestSuiteIndex(TestSuite testSuite) implements TaggableIndex {
       EntityReference testSuiteRef, Map<String, Object> doc) {
     if (testSuiteRef.getType().equals(Entity.TABLE)) {
       try {
-        Table table = Entity.getEntity(testSuiteRef, "domains", Include.ALL);
+        Table table = Entity.getEntity(testSuiteRef, "domains,certification", Include.ALL);
         doc.put("table", table.getEntityReference());
         doc.put("database", table.getDatabase());
         doc.put("databaseSchema", table.getDatabaseSchema());

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/TestSuiteIndex.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/TestSuiteIndex.java
@@ -47,7 +47,10 @@ public record TestSuiteIndex(TestSuite testSuite) implements TaggableIndex {
   private void setParentRelationships(Map<String, Object> doc, TestSuite testSuite) {
     EntityReference entityReference = testSuite.getBasicEntityReference();
     if (entityReference == null) return;
-    addTestSuiteParentEntityRelations(entityReference, doc);
+    Table linkedTable = addTestSuiteParentEntityRelations(entityReference, doc);
+    if (linkedTable != null && linkedTable.getCertification() != null) {
+      doc.put("certification", linkedTable.getCertification());
+    }
   }
 
   static Table addTestSuiteParentEntityRelations(

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java
@@ -850,6 +850,101 @@ class SearchRepositoryBehaviorTest {
   }
 
   @Test
+  void propagateCertificationTagsCascadesToTableChildrenOnAdd() throws IOException {
+    Table table = mock(Table.class);
+    UUID entityId = UUID.randomUUID();
+    when(table.getId()).thenReturn(entityId);
+    when(table.getEntityReference())
+        .thenReturn(new EntityReference().withId(entityId).withType(Entity.TABLE));
+    AssetCertification cert =
+        new AssetCertification()
+            .withTagLabel(
+                new TagLabel()
+                    .withName("Gold")
+                    .withDescription("Certified")
+                    .withTagFQN("Certification.Gold"));
+    when(table.getCertification()).thenReturn(cert);
+
+    ChangeDescription changeDescription =
+        changeDescription(
+            List.of(),
+            List.of(
+                new FieldChange().withName("certification").withOldValue("{}").withNewValue("{}")),
+            List.of());
+
+    repository.propagateCertificationTags(Entity.TABLE, table, changeDescription);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Pair<String, Map<String, Object>>> updatesCaptor =
+        ArgumentCaptor.forClass(Pair.class);
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Pair<String, String>> matchCaptor = ArgumentCaptor.forClass(Pair.class);
+    verify(searchClient)
+        .updateChildren(
+            eq(List.of("cluster_column_search_index")),
+            matchCaptor.capture(),
+            updatesCaptor.capture());
+    assertEquals("table.id", matchCaptor.getValue().getLeft());
+    assertEquals(entityId.toString(), matchCaptor.getValue().getRight());
+    assertEquals(SearchClient.CASCADE_CERTIFICATION_SCRIPT, updatesCaptor.getValue().getLeft());
+    assertSame(cert, updatesCaptor.getValue().getRight().get("certification"));
+  }
+
+  @Test
+  void propagateCertificationTagsCascadesNullToTableChildrenOnRemove() throws IOException {
+    Table table = mock(Table.class);
+    UUID entityId = UUID.randomUUID();
+    when(table.getId()).thenReturn(entityId);
+    when(table.getEntityReference())
+        .thenReturn(new EntityReference().withId(entityId).withType(Entity.TABLE));
+    when(table.getCertification()).thenReturn(null);
+
+    ChangeDescription changeDescription =
+        changeDescription(
+            List.of(),
+            List.of(),
+            List.of(new FieldChange().withName("certification").withOldValue("{}")));
+
+    repository.propagateCertificationTags(Entity.TABLE, table, changeDescription);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Pair<String, Map<String, Object>>> updatesCaptor =
+        ArgumentCaptor.forClass(Pair.class);
+    verify(searchClient)
+        .updateChildren(
+            eq(List.of("cluster_column_search_index")), any(Pair.class), updatesCaptor.capture());
+    assertEquals(SearchClient.CASCADE_CERTIFICATION_SCRIPT, updatesCaptor.getValue().getLeft());
+    assertNull(updatesCaptor.getValue().getRight().get("certification"));
+  }
+
+  @Test
+  void propagateCertificationTagsDoesNotCascadeForNonTableEntities() throws IOException {
+    // Pipelines carry a native certification but DQ dashboard cascade is
+    // scoped to Table — children of Pipeline aren't part of the test_case
+    // family. Verify we don't blast an updateByQuery against unrelated
+    // child indices.
+    Pipeline pipeline = mock(Pipeline.class);
+    UUID entityId = UUID.randomUUID();
+    when(pipeline.getId()).thenReturn(entityId);
+    when(pipeline.getEntityReference())
+        .thenReturn(new EntityReference().withId(entityId).withType(Entity.PIPELINE));
+    when(pipeline.getCertification())
+        .thenReturn(
+            new AssetCertification().withTagLabel(new TagLabel().withTagFQN("Certification.Gold")));
+
+    ChangeDescription changeDescription =
+        changeDescription(
+            List.of(),
+            List.of(
+                new FieldChange().withName("certification").withOldValue("{}").withNewValue("{}")),
+            List.of());
+
+    repository.propagateCertificationTags(Entity.PIPELINE, pipeline, changeDescription);
+
+    verify(searchClient, never()).updateChildren(any(List.class), any(Pair.class), any(Pair.class));
+  }
+
+  @Test
   void propagateCertificationTagsUsesQuotedOldNameWhenTagHasNoParentFqn() {
     Tag tag = mock(Tag.class);
     when(tag.getClassification())

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/column_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/column_index_mapping.json
@@ -535,6 +535,46 @@
           }
         }
       },
+      "certification": {
+        "type": "object",
+        "properties": {
+          "tagLabel": {
+            "type": "object",
+            "properties": {
+              "tagFQN": {
+                "type": "keyword",
+                "normalizer": "lowercase_normalizer",
+                "fields": {
+                  "text": {
+                    "type": "text",
+                    "analyzer": "om_analyzer"
+                  }
+                }
+              },
+              "labelType": {
+                "type": "keyword"
+              },
+              "description": {
+                "type": "text"
+              },
+              "source": {
+                "type": "keyword"
+              },
+              "state": {
+                "type": "keyword"
+              }
+            }
+          },
+          "appliedDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          },
+          "expiryDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          }
+        }
+      },
       "classificationTags": {
         "type": "keyword",
         "normalizer": "lowercase_normalizer"

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/test_case_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/test_case_index_mapping.json
@@ -577,6 +577,46 @@
           }
         }
       },
+      "certification": {
+        "type": "object",
+        "properties": {
+          "tagLabel": {
+            "type": "object",
+            "properties": {
+              "tagFQN": {
+                "type": "keyword",
+                "normalizer": "lowercase_normalizer",
+                "fields": {
+                  "text": {
+                    "type": "text",
+                    "analyzer": "om_analyzer"
+                  }
+                }
+              },
+              "labelType": {
+                "type": "keyword"
+              },
+              "description": {
+                "type": "text"
+              },
+              "source": {
+                "type": "keyword"
+              },
+              "state": {
+                "type": "keyword"
+              }
+            }
+          },
+          "appliedDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          },
+          "expiryDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          }
+        }
+      },
       "classificationTags": {
         "type": "keyword",
         "normalizer": "lowercase_normalizer"

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/test_case_resolution_status_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/test_case_resolution_status_index_mapping.json
@@ -606,6 +606,46 @@
           }
         }
       },
+      "certification": {
+        "type": "object",
+        "properties": {
+          "tagLabel": {
+            "type": "object",
+            "properties": {
+              "tagFQN": {
+                "type": "keyword",
+                "normalizer": "lowercase_normalizer",
+                "fields": {
+                  "text": {
+                    "type": "text",
+                    "analyzer": "om_analyzer"
+                  }
+                }
+              },
+              "labelType": {
+                "type": "keyword"
+              },
+              "description": {
+                "type": "text"
+              },
+              "source": {
+                "type": "keyword"
+              },
+              "state": {
+                "type": "keyword"
+              }
+            }
+          },
+          "appliedDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          },
+          "expiryDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          }
+        }
+      },
       "testSuite": {
         "properties": {
           "id": {

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/test_case_result_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/test_case_result_index_mapping.json
@@ -471,6 +471,46 @@
           }
         }
       },
+      "certification": {
+        "type": "object",
+        "properties": {
+          "tagLabel": {
+            "type": "object",
+            "properties": {
+              "tagFQN": {
+                "type": "keyword",
+                "normalizer": "lowercase_normalizer",
+                "fields": {
+                  "text": {
+                    "type": "text",
+                    "analyzer": "om_analyzer"
+                  }
+                }
+              },
+              "labelType": {
+                "type": "keyword"
+              },
+              "description": {
+                "type": "text"
+              },
+              "source": {
+                "type": "keyword"
+              },
+              "state": {
+                "type": "keyword"
+              }
+            }
+          },
+          "appliedDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          },
+          "expiryDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          }
+        }
+      },
       "service": {
         "properties": {
           "id": {

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/test_suite_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/test_suite_index_mapping.json
@@ -269,6 +269,46 @@
           }
         }
       },
+      "certification": {
+        "type": "object",
+        "properties": {
+          "tagLabel": {
+            "type": "object",
+            "properties": {
+              "tagFQN": {
+                "type": "keyword",
+                "normalizer": "lowercase_normalizer",
+                "fields": {
+                  "text": {
+                    "type": "text",
+                    "analyzer": "om_analyzer"
+                  }
+                }
+              },
+              "labelType": {
+                "type": "keyword"
+              },
+              "description": {
+                "type": "text"
+              },
+              "source": {
+                "type": "keyword"
+              },
+              "state": {
+                "type": "keyword"
+              }
+            }
+          },
+          "appliedDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          },
+          "expiryDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          }
+        }
+      },
       "classificationTags": {
         "type": "keyword",
         "normalizer": "lowercase_normalizer"

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/column_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/column_index_mapping.json
@@ -540,6 +540,46 @@
           }
         }
       },
+      "certification": {
+        "type": "object",
+        "properties": {
+          "tagLabel": {
+            "type": "object",
+            "properties": {
+              "tagFQN": {
+                "type": "keyword",
+                "normalizer": "lowercase_normalizer",
+                "fields": {
+                  "text": {
+                    "type": "text",
+                    "analyzer": "om_analyzer"
+                  }
+                }
+              },
+              "labelType": {
+                "type": "keyword"
+              },
+              "description": {
+                "type": "text"
+              },
+              "source": {
+                "type": "keyword"
+              },
+              "state": {
+                "type": "keyword"
+              }
+            }
+          },
+          "appliedDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          },
+          "expiryDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          }
+        }
+      },
       "classificationTags": {
         "type": "keyword",
         "normalizer": "lowercase_normalizer"

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/test_case_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/test_case_index_mapping.json
@@ -300,6 +300,46 @@
           }
         }
       },
+      "certification": {
+        "type": "object",
+        "properties": {
+          "tagLabel": {
+            "type": "object",
+            "properties": {
+              "tagFQN": {
+                "type": "keyword",
+                "normalizer": "lowercase_normalizer",
+                "fields": {
+                  "text": {
+                    "type": "text",
+                    "analyzer": "om_analyzer"
+                  }
+                }
+              },
+              "labelType": {
+                "type": "keyword"
+              },
+              "description": {
+                "type": "text"
+              },
+              "source": {
+                "type": "keyword"
+              },
+              "state": {
+                "type": "keyword"
+              }
+            }
+          },
+          "appliedDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          },
+          "expiryDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          }
+        }
+      },
       "classificationTags": {
         "type": "keyword",
         "normalizer": "lowercase_normalizer"

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/test_case_resolution_status_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/test_case_resolution_status_index_mapping.json
@@ -430,6 +430,46 @@
           }
         }
       },
+      "certification": {
+        "type": "object",
+        "properties": {
+          "tagLabel": {
+            "type": "object",
+            "properties": {
+              "tagFQN": {
+                "type": "keyword",
+                "normalizer": "lowercase_normalizer",
+                "fields": {
+                  "text": {
+                    "type": "text",
+                    "analyzer": "om_analyzer"
+                  }
+                }
+              },
+              "labelType": {
+                "type": "keyword"
+              },
+              "description": {
+                "type": "text"
+              },
+              "source": {
+                "type": "keyword"
+              },
+              "state": {
+                "type": "keyword"
+              }
+            }
+          },
+          "appliedDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          },
+          "expiryDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          }
+        }
+      },
       "database": {
         "properties": {
           "id": {

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/test_case_result_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/test_case_result_index_mapping.json
@@ -346,6 +346,46 @@
           }
         }
       },
+      "certification": {
+        "type": "object",
+        "properties": {
+          "tagLabel": {
+            "type": "object",
+            "properties": {
+              "tagFQN": {
+                "type": "keyword",
+                "normalizer": "lowercase_normalizer",
+                "fields": {
+                  "text": {
+                    "type": "text",
+                    "analyzer": "om_analyzer"
+                  }
+                }
+              },
+              "labelType": {
+                "type": "keyword"
+              },
+              "description": {
+                "type": "text"
+              },
+              "source": {
+                "type": "keyword"
+              },
+              "state": {
+                "type": "keyword"
+              }
+            }
+          },
+          "appliedDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          },
+          "expiryDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          }
+        }
+      },
       "testDefinition": {
         "properties": {
           "id": {

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/test_suite_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/test_suite_index_mapping.json
@@ -248,6 +248,46 @@
           }
         }
       },
+      "certification": {
+        "type": "object",
+        "properties": {
+          "tagLabel": {
+            "type": "object",
+            "properties": {
+              "tagFQN": {
+                "type": "keyword",
+                "normalizer": "lowercase_normalizer",
+                "fields": {
+                  "text": {
+                    "type": "text",
+                    "analyzer": "om_analyzer"
+                  }
+                }
+              },
+              "labelType": {
+                "type": "keyword"
+              },
+              "description": {
+                "type": "text"
+              },
+              "source": {
+                "type": "keyword"
+              },
+              "state": {
+                "type": "keyword"
+              }
+            }
+          },
+          "appliedDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          },
+          "expiryDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          }
+        }
+      },
       "classificationTags": {
         "type": "keyword",
         "normalizer": "lowercase_normalizer"

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/column_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/column_index_mapping.json
@@ -554,6 +554,46 @@
           }
         }
       },
+      "certification": {
+        "type": "object",
+        "properties": {
+          "tagLabel": {
+            "type": "object",
+            "properties": {
+              "tagFQN": {
+                "type": "keyword",
+                "normalizer": "lowercase_normalizer",
+                "fields": {
+                  "text": {
+                    "type": "text",
+                    "analyzer": "om_analyzer"
+                  }
+                }
+              },
+              "labelType": {
+                "type": "keyword"
+              },
+              "description": {
+                "type": "text"
+              },
+              "source": {
+                "type": "keyword"
+              },
+              "state": {
+                "type": "keyword"
+              }
+            }
+          },
+          "appliedDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          },
+          "expiryDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          }
+        }
+      },
       "classificationTags": {
         "type": "keyword",
         "normalizer": "lowercase_normalizer"

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/test_case_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/test_case_index_mapping.json
@@ -593,6 +593,46 @@
           }
         }
       },
+      "certification": {
+        "type": "object",
+        "properties": {
+          "tagLabel": {
+            "type": "object",
+            "properties": {
+              "tagFQN": {
+                "type": "keyword",
+                "normalizer": "lowercase_normalizer",
+                "fields": {
+                  "text": {
+                    "type": "text",
+                    "analyzer": "om_analyzer"
+                  }
+                }
+              },
+              "labelType": {
+                "type": "keyword"
+              },
+              "description": {
+                "type": "text"
+              },
+              "source": {
+                "type": "keyword"
+              },
+              "state": {
+                "type": "keyword"
+              }
+            }
+          },
+          "appliedDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          },
+          "expiryDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          }
+        }
+      },
       "classificationTags": {
         "type": "keyword",
         "normalizer": "lowercase_normalizer"

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/test_case_resolution_status_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/test_case_resolution_status_index_mapping.json
@@ -625,6 +625,46 @@
           }
         }
       },
+      "certification": {
+        "type": "object",
+        "properties": {
+          "tagLabel": {
+            "type": "object",
+            "properties": {
+              "tagFQN": {
+                "type": "keyword",
+                "normalizer": "lowercase_normalizer",
+                "fields": {
+                  "text": {
+                    "type": "text",
+                    "analyzer": "om_analyzer"
+                  }
+                }
+              },
+              "labelType": {
+                "type": "keyword"
+              },
+              "description": {
+                "type": "text"
+              },
+              "source": {
+                "type": "keyword"
+              },
+              "state": {
+                "type": "keyword"
+              }
+            }
+          },
+          "appliedDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          },
+          "expiryDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          }
+        }
+      },
       "testSuite": {
         "properties": {
           "id": {

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/test_case_result_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/test_case_result_index_mapping.json
@@ -489,6 +489,46 @@
           }
         }
       },
+      "certification": {
+        "type": "object",
+        "properties": {
+          "tagLabel": {
+            "type": "object",
+            "properties": {
+              "tagFQN": {
+                "type": "keyword",
+                "normalizer": "lowercase_normalizer",
+                "fields": {
+                  "text": {
+                    "type": "text",
+                    "analyzer": "om_analyzer"
+                  }
+                }
+              },
+              "labelType": {
+                "type": "keyword"
+              },
+              "description": {
+                "type": "text"
+              },
+              "source": {
+                "type": "keyword"
+              },
+              "state": {
+                "type": "keyword"
+              }
+            }
+          },
+          "appliedDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          },
+          "expiryDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          }
+        }
+      },
       "service": {
         "properties": {
           "id": {

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/test_suite_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/test_suite_index_mapping.json
@@ -287,6 +287,46 @@
           }
         }
       },
+      "certification": {
+        "type": "object",
+        "properties": {
+          "tagLabel": {
+            "type": "object",
+            "properties": {
+              "tagFQN": {
+                "type": "keyword",
+                "normalizer": "lowercase_normalizer",
+                "fields": {
+                  "text": {
+                    "type": "text",
+                    "analyzer": "om_analyzer"
+                  }
+                }
+              },
+              "labelType": {
+                "type": "keyword"
+              },
+              "description": {
+                "type": "text"
+              },
+              "source": {
+                "type": "keyword"
+              },
+              "state": {
+                "type": "keyword"
+              }
+            }
+          },
+          "appliedDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          },
+          "expiryDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          }
+        }
+      },
       "classificationTags": {
         "type": "keyword",
         "normalizer": "lowercase_normalizer"

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/column_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/column_index_mapping.json
@@ -532,6 +532,46 @@
           }
         }
       },
+      "certification": {
+        "type": "object",
+        "properties": {
+          "tagLabel": {
+            "type": "object",
+            "properties": {
+              "tagFQN": {
+                "type": "keyword",
+                "normalizer": "lowercase_normalizer",
+                "fields": {
+                  "text": {
+                    "type": "text",
+                    "analyzer": "om_analyzer"
+                  }
+                }
+              },
+              "labelType": {
+                "type": "keyword"
+              },
+              "description": {
+                "type": "text"
+              },
+              "source": {
+                "type": "keyword"
+              },
+              "state": {
+                "type": "keyword"
+              }
+            }
+          },
+          "appliedDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          },
+          "expiryDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          }
+        }
+      },
       "classificationTags": {
         "type": "keyword",
         "normalizer": "lowercase_normalizer"

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/test_case_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/test_case_index_mapping.json
@@ -209,6 +209,46 @@
           }
         }
       },
+      "certification": {
+        "type": "object",
+        "properties": {
+          "tagLabel": {
+            "type": "object",
+            "properties": {
+              "tagFQN": {
+                "type": "keyword",
+                "normalizer": "lowercase_normalizer",
+                "fields": {
+                  "text": {
+                    "type": "text",
+                    "analyzer": "om_analyzer"
+                  }
+                }
+              },
+              "labelType": {
+                "type": "keyword"
+              },
+              "description": {
+                "type": "text"
+              },
+              "source": {
+                "type": "keyword"
+              },
+              "state": {
+                "type": "keyword"
+              }
+            }
+          },
+          "appliedDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          },
+          "expiryDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          }
+        }
+      },
       "classificationTags": {
         "type": "keyword",
         "normalizer": "lowercase_normalizer"

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/test_case_resolution_status_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/test_case_resolution_status_index_mapping.json
@@ -420,6 +420,46 @@
           }
         }
       },
+      "certification": {
+        "type": "object",
+        "properties": {
+          "tagLabel": {
+            "type": "object",
+            "properties": {
+              "tagFQN": {
+                "type": "keyword",
+                "normalizer": "lowercase_normalizer",
+                "fields": {
+                  "text": {
+                    "type": "text",
+                    "analyzer": "om_analyzer"
+                  }
+                }
+              },
+              "labelType": {
+                "type": "keyword"
+              },
+              "description": {
+                "type": "text"
+              },
+              "source": {
+                "type": "keyword"
+              },
+              "state": {
+                "type": "keyword"
+              }
+            }
+          },
+          "appliedDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          },
+          "expiryDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          }
+        }
+      },
       "database": {
         "properties": {
           "id": {

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/test_case_result_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/test_case_result_index_mapping.json
@@ -345,6 +345,46 @@
           }
         }
       },
+      "certification": {
+        "type": "object",
+        "properties": {
+          "tagLabel": {
+            "type": "object",
+            "properties": {
+              "tagFQN": {
+                "type": "keyword",
+                "normalizer": "lowercase_normalizer",
+                "fields": {
+                  "text": {
+                    "type": "text",
+                    "analyzer": "om_analyzer"
+                  }
+                }
+              },
+              "labelType": {
+                "type": "keyword"
+              },
+              "description": {
+                "type": "text"
+              },
+              "source": {
+                "type": "keyword"
+              },
+              "state": {
+                "type": "keyword"
+              }
+            }
+          },
+          "appliedDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          },
+          "expiryDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          }
+        }
+      },
       "testDefinition": {
         "properties": {
           "id": {

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/test_suite_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/test_suite_index_mapping.json
@@ -223,6 +223,46 @@
           }
         }
       },
+      "certification": {
+        "type": "object",
+        "properties": {
+          "tagLabel": {
+            "type": "object",
+            "properties": {
+              "tagFQN": {
+                "type": "keyword",
+                "normalizer": "lowercase_normalizer",
+                "fields": {
+                  "text": {
+                    "type": "text",
+                    "analyzer": "om_analyzer"
+                  }
+                }
+              },
+              "labelType": {
+                "type": "keyword"
+              },
+              "description": {
+                "type": "text"
+              },
+              "source": {
+                "type": "keyword"
+              },
+              "state": {
+                "type": "keyword"
+              }
+            }
+          },
+          "appliedDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          },
+          "expiryDate": {
+            "type": "date",
+            "format": "strict_date_optional_time||epoch_millis"
+          }
+        }
+      },
       "classificationTags": {
         "type": "keyword",
         "normalizer": "lowercase_normalizer"

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DataQuality/DataQualityPage.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DataQuality/DataQualityPage.interface.ts
@@ -36,6 +36,7 @@ export type DataQualityDashboardChartFilters = {
   ownerFqn?: string;
   tags?: string[];
   tier?: string[];
+  certification?: string[];
   dataProductFqns?: string[];
   startTs?: number;
   endTs?: number;

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityUtils.tsx
@@ -282,6 +282,16 @@ export const buildDataQualityDashboardFilters = (data: {
     });
   }
 
+  if (filters?.certification) {
+    mustFilter.push({
+      bool: {
+        should: filters.certification.map((fqn) => ({
+          term: { 'certification.tagLabel.tagFQN': fqn },
+        })),
+      },
+    });
+  }
+
   if ((filters?.tags || filters?.tier) && !isTableApi) {
     mustFilter.push(
       buildMustEsFilterForTags([


### PR DESCRIPTION
Fixes open-metadata/openmetadata-collate#4080

## What was wrong
On the Data Observability dashboard, filtering by a Certification (Bronze/Silver/Gold) returned zero coverage even when certified assets existed. The same bug surfaces when navigating to a Certification tag's detail page — the Data Observability tab shows empty charts.

There are two reasons this happens, both fixed in this PR's foundation layer:
1. The test-case search index didn't carry the parent table's certification, so any filter by certification on test-case data had nothing to match.
2. The dashboard's filter-building code had no way to express a "certification" filter in the first place — only owners, tier, tags, glossary terms, and data products.

## What this PR changes
- Teaches the test-case indexer to copy each parent table's `certification` onto its testCase docs, the same way it already copies `domains`. Mapping updated for all four supported languages.
- Adds a `certification` filter slot to `DataQualityDashboardChartFilters` and a matching branch in `buildDataQualityDashboardFilters` so callers can ask the dashboard to filter by certification.

This PR is plumbing only — it doesn't change anything you'd see in the UI. The visible UI piece (Certification dropdown, Tag-list exclusion, Tag detail page wiring) lives in #28085.

## Why split from the UI fix
The dashboard component lives in a different repo on 1.12.x (Collate) than on 1.13+ (OM). Splitting the backend + filter plumbing here lets this PR cherry-pick cleanly to `1.12.9`, `1.13`, and `main`. The visible UI then lands as #28085 on main/1.13 and via a separate Collate PR on 1.12.x.

## Test plan
- [x] After deploy, a test case on a Gold-certified table has `certification.tagLabel.tagFQN: Certification.Gold` denormalized onto its testCase index doc.
- [x] `/api/v1/dataQuality/testSuites/dataQualityReport?index=testCase` with a `certification.tagLabel.tagFQN` term filter returns the expected test cases.
- [x] No regression on the existing tier / tag / owner filter paths.

## Follow-ups
- The user-facing dashboard UI: #28085.
- The Collate-side dashboard UI for 1.12.x: open-metadata/openmetadata-collate#4079.
- A separate latent routing bug surfaced for Tier (silently fails on several testCase-driven widgets that bypass the centralized filter builder) — tracked in open-metadata/openmetadata-collate#4086 and staged on branch \`fix/dq-tier-routing\`.