### PR TITLE
fix(dq-dashboard): add Certification filter dropdown to Data Quality dashboard

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/CertificationFilter.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/CertificationFilter.spec.ts
@@ -191,3 +191,33 @@ test('Certification tags are not listed in the generic Tag dropdown', async ({
     page.getByTestId(cert.responseData.fullyQualifiedName)
   ).toHaveCount(0);
 });
+
+// The TagPage Data Observability tab embeds the same dashboard. Before this
+// fix every tag detail page sent `tags: [FQN]` regardless of classification,
+// so the embedded chart on a Certification page silently reported 0 (the
+// `tags.tagFQN` term never matches assets carrying a certification). This
+// test pins the post-fix routing.
+test('TagPage: Certification detail page routes through certification.tagLabel.tagFQN', async ({
+  page,
+}) => {
+  const captured = captureReports(page);
+  const certFqn = cert.responseData.fullyQualifiedName;
+  const certFqnEncoded = encodeURIComponent(certFqn);
+
+  const reloadFired = page.waitForResponse(
+    (r) =>
+      r.url().includes('/dataQualityReport') &&
+      r.url().includes(certFqnEncoded)
+  );
+  await page.goto(`/tag/${certFqnEncoded}/data_observability`);
+  await reloadFired;
+  await waitForAllLoadersToDisappear(page);
+
+  const reportsWithCertFilter = captured.filter((c) => c.q.includes(certFqn));
+  expect(reportsWithCertFilter.length).toBeGreaterThan(0);
+  for (const r of reportsWithCertFilter) {
+    expect(r.q).toContain('certification.tagLabel.tagFQN');
+    // Pre-fix path that never matched — must not regress.
+    expect(r.q).not.toContain('tags.tagFQN');
+  }
+});

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/CertificationFilter.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/CertificationFilter.spec.ts
@@ -69,7 +69,9 @@ test.afterAll('cleanup', async ({ browser }) => {
   await afterAction();
 });
 
-function captureReports(page: Page): { url: string; q: string; index: string }[] {
+function captureReports(
+  page: Page
+): { url: string; q: string; index: string }[] {
   const captured: { url: string; q: string; index: string }[] = [];
   page.on('request', (req: Request) => {
     const url = req.url();
@@ -130,7 +132,9 @@ test('Certification filter narrows both table- and testCase-index queries via th
     .fill(cert.responseData.fullyQualifiedName);
   await page.getByTestId(cert.responseData.fullyQualifiedName).click();
 
-  const certFqnEncoded = encodeURIComponent(cert.responseData.fullyQualifiedName);
+  const certFqnEncoded = encodeURIComponent(
+    cert.responseData.fullyQualifiedName
+  );
   const tableReload = page.waitForResponse(
     (r) =>
       r.url().includes('/dataQualityReport') &&
@@ -164,9 +168,7 @@ test('Certification filter narrows both table- and testCase-index queries via th
 
   // And both index queries must have actually fired with the filter — otherwise
   // we'd accept a broken UI that just stopped sending the call entirely.
-  expect(
-    reportsWithCertFilter.some((c) => c.index === 'table')
-  ).toBeTruthy();
+  expect(reportsWithCertFilter.some((c) => c.index === 'table')).toBeTruthy();
   expect(
     reportsWithCertFilter.some((c) => c.index === 'testCase')
   ).toBeTruthy();
@@ -206,8 +208,7 @@ test('TagPage: Certification detail page routes through certification.tagLabel.t
 
   const reloadFired = page.waitForResponse(
     (r) =>
-      r.url().includes('/dataQualityReport') &&
-      r.url().includes(certFqnEncoded)
+      r.url().includes('/dataQualityReport') && r.url().includes(certFqnEncoded)
   );
   await page.goto(`/tag/${certFqnEncoded}/data_observability`);
   await reloadFired;

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/CertificationFilter.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/CertificationFilter.spec.ts
@@ -10,21 +10,27 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import test, { expect, Page, Request } from '@playwright/test';
+import test, { expect } from '@playwright/test';
 import { TableClass } from '../../../support/entity/TableClass';
 import { TagClass } from '../../../support/tag/TagClass';
 import { createNewPage } from '../../../utils/common';
-import { goToDataQualityDashboard } from '../../../utils/dataQuality';
+import {
+  captureReports,
+  goToDataQualityDashboard,
+} from '../../../utils/dataQuality';
 import { waitForAllLoadersToDisappear } from '../../../utils/entity';
 
 test.use({
   storageState: 'playwright/.auth/admin.json',
 });
 
-const certTable = new TableClass();
-const cert = new TagClass({ classification: 'Certification' });
+let certTable: TableClass;
+let cert: TagClass;
 
 test.beforeAll('setup', async ({ browser }) => {
+  certTable = new TableClass();
+  cert = new TagClass({ classification: 'Certification' });
+
   const { apiContext, afterAction } = await createNewPage(browser);
 
   await cert.create(apiContext);
@@ -59,33 +65,6 @@ test.beforeAll('setup', async ({ browser }) => {
 
   await afterAction();
 });
-
-test.afterAll('cleanup', async ({ browser }) => {
-  const { apiContext, afterAction } = await createNewPage(browser);
-
-  await certTable.delete(apiContext);
-  await cert.delete(apiContext);
-
-  await afterAction();
-});
-
-function captureReports(
-  page: Page
-): { url: string; q: string; index: string }[] {
-  const captured: { url: string; q: string; index: string }[] = [];
-  page.on('request', (req: Request) => {
-    const url = req.url();
-    if (url.includes('/dataQualityReport')) {
-      const u = new URL(url);
-      captured.push({
-        url,
-        q: u.searchParams.get('q') ?? '',
-        index: u.searchParams.get('index') ?? '',
-      });
-    }
-  });
-  return captured;
-}
 
 test('Certification filter is rendered between Tier and Tag in the filter row', async ({
   page,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/CertificationFilter.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/CertificationFilter.spec.ts
@@ -1,0 +1,193 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import test, { expect, Page, Request } from '@playwright/test';
+import { TableClass } from '../../../support/entity/TableClass';
+import { TagClass } from '../../../support/tag/TagClass';
+import { createNewPage } from '../../../utils/common';
+import { goToDataQualityDashboard } from '../../../utils/dataQuality';
+import { waitForAllLoadersToDisappear } from '../../../utils/entity';
+
+test.use({
+  storageState: 'playwright/.auth/admin.json',
+});
+
+const certTable = new TableClass();
+const cert = new TagClass({ classification: 'Certification' });
+
+test.beforeAll('setup', async ({ browser }) => {
+  const { apiContext, afterAction } = await createNewPage(browser);
+
+  await cert.create(apiContext);
+  await certTable.create(apiContext);
+
+  // Certification is a first-class entity field — patch /certification, not /tags.
+  // This is what makes the table show up at certification.tagLabel.tagFQN in the
+  // search index, which the dashboard filter queries.
+  await certTable.patch({
+    apiContext,
+    patchData: [
+      {
+        op: 'add',
+        path: '/certification',
+        value: {
+          tagLabel: {
+            tagFQN: cert.responseData.fullyQualifiedName,
+            source: 'Classification',
+            labelType: 'Manual',
+            state: 'Confirmed',
+          },
+        },
+      },
+    ],
+  });
+
+  // A test case on the certified table exercises the testCase-index branch of
+  // the coverage chart — without it, the testCase-side filter would have
+  // nothing to match and we couldn't distinguish a broken filter from an empty
+  // result set.
+  await certTable.createTestCase(apiContext);
+
+  await afterAction();
+});
+
+test.afterAll('cleanup', async ({ browser }) => {
+  const { apiContext, afterAction } = await createNewPage(browser);
+
+  await certTable.delete(apiContext);
+  await cert.delete(apiContext);
+
+  await afterAction();
+});
+
+function captureReports(page: Page): { url: string; q: string; index: string }[] {
+  const captured: { url: string; q: string; index: string }[] = [];
+  page.on('request', (req: Request) => {
+    const url = req.url();
+    if (url.includes('/dataQualityReport')) {
+      const u = new URL(url);
+      captured.push({
+        url,
+        q: u.searchParams.get('q') ?? '',
+        index: u.searchParams.get('index') ?? '',
+      });
+    }
+  });
+  return captured;
+}
+
+test('Certification filter is rendered between Tier and Tag in the filter row', async ({
+  page,
+}) => {
+  await goToDataQualityDashboard(page);
+  await waitForAllLoadersToDisappear(page);
+
+  // Wait for the new filter to render before snapshotting DOM order.
+  await expect(page.getByTestId('search-dropdown-Certification')).toBeVisible();
+
+  // Read the testids of exactly the three filter buttons in document order.
+  // CSS group selectors and `evaluateAll` both preserve DOM order, so this
+  // catches "Cert moved to the end of the filter row" without locking on
+  // pixel layout (responsive / theme / Tailwind changes don't break it).
+  const orderedTestids = await page
+    .locator(
+      [
+        '[data-testid="search-dropdown-Tier"]',
+        '[data-testid="search-dropdown-Certification"]',
+        '[data-testid="search-dropdown-Tag"]',
+      ].join(', ')
+    )
+    .evaluateAll((els) => els.map((el) => el.getAttribute('data-testid')));
+
+  expect(orderedTestids).toEqual([
+    'search-dropdown-Tier',
+    'search-dropdown-Certification',
+    'search-dropdown-Tag',
+  ]);
+});
+
+test('Certification filter narrows both table- and testCase-index queries via the flat field path', async ({
+  page,
+}) => {
+  const captured = captureReports(page);
+
+  await goToDataQualityDashboard(page);
+  await waitForAllLoadersToDisappear(page);
+
+  await page.getByRole('button', { name: 'Certification' }).click();
+  await page.getByTestId('search-input').click();
+  await page
+    .getByTestId('search-input')
+    .fill(cert.responseData.fullyQualifiedName);
+  await page.getByTestId(cert.responseData.fullyQualifiedName).click();
+
+  const certFqnEncoded = encodeURIComponent(cert.responseData.fullyQualifiedName);
+  const tableReload = page.waitForResponse(
+    (r) =>
+      r.url().includes('/dataQualityReport') &&
+      r.url().includes('index=table') &&
+      r.url().includes(certFqnEncoded)
+  );
+  const testCaseReload = page.waitForResponse(
+    (r) =>
+      r.url().includes('/dataQualityReport') &&
+      r.url().includes('index=testCase') &&
+      r.url().includes(certFqnEncoded)
+  );
+  await page.getByTestId('update-btn').click();
+  await Promise.all([tableReload, testCaseReload]);
+
+  const reportsWithCertFilter = captured.filter((c) =>
+    c.q.includes(cert.responseData.fullyQualifiedName)
+  );
+
+  // Every dashboard call that mentions the cert FQN must use the flat path:
+  // - `certification.tagLabel.tagFQN` is what the search index actually exposes.
+  // - `testCase.certification.tagLabel.tagFQN` would be a regression (the
+  //   testCase doc has no `testCase.*` namespace; that path matches nothing
+  //   and silently zeros out the coverage chart numerator).
+  // - `tags.tagFQN` would be the original bug — certifications were being
+  //   routed through the generic tag path that never matches certified entities.
+  for (const r of reportsWithCertFilter) {
+    expect(r.q).toContain('certification.tagLabel.tagFQN');
+    expect(r.q).not.toContain('testCase.certification.tagLabel.tagFQN');
+  }
+
+  // And both index queries must have actually fired with the filter — otherwise
+  // we'd accept a broken UI that just stopped sending the call entirely.
+  expect(
+    reportsWithCertFilter.some((c) => c.index === 'table')
+  ).toBeTruthy();
+  expect(
+    reportsWithCertFilter.some((c) => c.index === 'testCase')
+  ).toBeTruthy();
+});
+
+test('Certification tags are not listed in the generic Tag dropdown', async ({
+  page,
+}) => {
+  await goToDataQualityDashboard(page);
+  await waitForAllLoadersToDisappear(page);
+
+  await page.getByRole('button', { name: 'Tag', exact: true }).click();
+  await page.getByTestId('search-input').click();
+
+  // If the Certification classification leaked into the Tag dropdown's source
+  // query, searching for our cert tag's exact FQN would surface it.
+  await page
+    .getByTestId('search-input')
+    .fill(cert.responseData.fullyQualifiedName);
+
+  await expect(
+    page.getByTestId(cert.responseData.fullyQualifiedName)
+  ).toHaveCount(0);
+});

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts
@@ -386,3 +386,28 @@ export const verifyBundleSuitePageLoaded = async (
     )
     .toBe(expectedTestCaseCount);
 };
+
+/** A `dataQualityReport` call captured for assertion in tests. */
+export type CapturedReport = { url: string; q: string; index: string };
+
+/**
+ * Subscribes to every `/dataQualityReport` request fired by the page and
+ * returns a live array of (url, q, index). Useful for asserting which
+ * indices were queried and what filter the dashboard sent.
+ */
+export function captureReports(page: Page): CapturedReport[] {
+  const captured: CapturedReport[] = [];
+  page.on('request', (req) => {
+    const url = req.url();
+    if (!url.includes('/dataQualityReport')) {
+      return;
+    }
+    const u = new URL(url);
+    captured.push({
+      url,
+      q: u.searchParams.get('q') ?? '',
+      index: u.searchParams.get('index') ?? '',
+    });
+  });
+  return captured;
+}

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/DataQualityDashboard/DataQualityDashboard.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/DataQualityDashboard/DataQualityDashboard.component.tsx
@@ -79,7 +79,12 @@ const DataQualityDashboard = ({
   initialFilters?: DqDashboardChartFilters;
   hideFilterBar?: boolean;
   hiddenFilters?: Array<
-    'owner' | 'tier' | 'tags' | 'glossaryTerms' | 'dataProducts'
+    | 'owner'
+    | 'tier'
+    | 'certification'
+    | 'tags'
+    | 'glossaryTerms'
+    | 'dataProducts'
   >;
   isGovernanceView?: boolean;
   className?: string;
@@ -158,6 +163,17 @@ const DataQualityDashboard = ({
   const [selectedTierFilter, setSelectedTierFilter] = useState<
     SearchDropdownOption[]
   >([]);
+  const [selectedCertificationFilter, setSelectedCertificationFilter] =
+    useState<SearchDropdownOption[]>([]);
+  const [certification, setCertification] = useState<{
+    tags: Tag[];
+    isLoading: boolean;
+    options: SearchDropdownOption[];
+  }>({
+    tags: [],
+    isLoading: true,
+    options: [],
+  });
   const [selectedOwnerFilter, setSelectedOwnerFilter] =
     useState<EntityReference[]>();
 
@@ -195,6 +211,7 @@ const DataQualityDashboard = ({
       ownerFqn: defaultFilters.ownerFqn,
       tags: defaultFilters.tags,
       tier: defaultFilters.tier,
+      certification: defaultFilters.certification,
       dataProductFqns: defaultFilters.dataProductFqns,
       startTs: defaultFilters.startTs,
       endTs: defaultFilters.endTs,
@@ -203,6 +220,7 @@ const DataQualityDashboard = ({
   }, [
     defaultFilters.ownerFqn,
     defaultFilters.tier,
+    defaultFilters.certification,
     defaultFilters.tags,
     defaultFilters.dataProductFqns,
     defaultFilters.startTs,
@@ -226,11 +244,28 @@ const DataQualityDashboard = ({
     }));
   }, [tier]);
 
+  const defaultCertificationOptions = useMemo(() => {
+    return certification.tags.map((op) => ({
+      key: op.fullyQualifiedName ?? op.name,
+      label: getEntityName(op),
+    }));
+  }, [certification]);
+
   const handleTierChange = (tiers: SearchDropdownOption[] = []) => {
     setSelectedTierFilter(tiers);
     setChartFilter((prev) => ({
       ...prev,
       tier: tiers.map((tag) => tag.key),
+    }));
+  };
+
+  const handleCertificationChange = (
+    certifications: SearchDropdownOption[] = []
+  ) => {
+    setSelectedCertificationFilter(certifications);
+    setChartFilter((prev) => ({
+      ...prev,
+      certification: certifications.map((tag) => tag.key),
     }));
   };
 
@@ -271,7 +306,8 @@ const DataQualityDashboard = ({
     const response = await searchQuery({
       searchIndex: SearchIndex.TAG,
       query: query === WILD_CARD_CHAR ? query : `*${query}*`,
-      filters: 'disabled:false AND !classification.name:Tier',
+      filters:
+        'disabled:false AND !classification.name:Tier AND !classification.name:Certification',
       pageSize: PAGE_SIZE_BASE,
     });
     const hits = response.hits.hits;
@@ -395,6 +431,26 @@ const DataQualityDashboard = ({
       setTier((prev) => ({
         ...prev,
         options: defaultTierOptions,
+      }));
+    }
+  };
+
+  const handleCertificationSearch = async (query: string) => {
+    if (query) {
+      setCertification((prev) => ({
+        ...prev,
+        options: prev.options.filter(
+          (value) =>
+            value.label
+              .toLocaleLowerCase()
+              .includes(query.toLocaleLowerCase()) ||
+            value.key.toLocaleLowerCase().includes(query.toLocaleLowerCase())
+        ),
+      }));
+    } else {
+      setCertification((prev) => ({
+        ...prev,
+        options: defaultCertificationOptions,
       }));
     }
   };
@@ -525,6 +581,35 @@ const DataQualityDashboard = ({
     }));
   };
 
+  const getCertificationTag = async () => {
+    setCertification((prev) => ({ ...prev, isLoading: true }));
+    try {
+      const { data } = await getTags({
+        parent: 'Certification',
+      });
+
+      setCertification((prev) => ({
+        ...prev,
+        tags: data,
+        options: data.map((op) => ({
+          key: op.fullyQualifiedName ?? op.name,
+          label: getEntityName(op),
+        })),
+      }));
+    } catch {
+      // error
+    } finally {
+      setCertification((prev) => ({ ...prev, isLoading: false }));
+    }
+  };
+
+  const fetchDefaultCertificationOptions = () => {
+    setCertification((prev) => ({
+      ...prev,
+      options: defaultCertificationOptions,
+    }));
+  };
+
   const handleOwnerChange = (owners: EntityReference[] = []) => {
     setSelectedOwnerFilter(owners);
     setChartFilter((prev) => ({
@@ -541,6 +626,9 @@ const DataQualityDashboard = ({
 
   const showOwnerFilter = !hiddenFilters.includes(DQ_FILTER_KEYS.OWNER);
   const showTierFilter = !hiddenFilters.includes(DQ_FILTER_KEYS.TIER);
+  const showCertificationFilter = !hiddenFilters.includes(
+    DQ_FILTER_KEYS.CERTIFICATION
+  );
   const showTagsFilter = !hiddenFilters.includes(DQ_FILTER_KEYS.TAGS);
   const showGlossaryTermsFilter = !hiddenFilters.includes(
     DQ_FILTER_KEYS.GLOSSARY_TERMS
@@ -555,6 +643,9 @@ const DataQualityDashboard = ({
     }
     if (showTierFilter) {
       getTierTag();
+    }
+    if (showCertificationFilter) {
+      getCertificationTag();
     }
     if (showTagsFilter) {
       fetchDefaultTagOptions();
@@ -608,6 +699,18 @@ const DataQualityDashboard = ({
     [selectedTierFilter, tier]
   );
 
+  const certificationFilter = useMemo(
+    () => ({
+      options: certification.options,
+      selectedKeys: selectedCertificationFilter,
+      onChange: handleCertificationChange,
+      onGetInitialOptions: fetchDefaultCertificationOptions,
+      onSearch: handleCertificationSearch,
+      isSuggestionsLoading: certification.isLoading,
+    }),
+    [selectedCertificationFilter, certification]
+  );
+
   const dataProducts = useMemo(
     () => ({
       options: uniqBy(dataProductOptions.options, 'key'),
@@ -624,6 +727,7 @@ const DataQualityDashboard = ({
   const hasVisibleFilters =
     showOwnerFilter ||
     showTierFilter ||
+    showCertificationFilter ||
     showTagsFilter ||
     showGlossaryTermsFilter ||
     showDataProductsFilter;
@@ -693,6 +797,16 @@ const DataQualityDashboard = ({
               searchKey="tier"
               triggerButtonSize="middle"
               {...tierFilter}
+            />
+          )}
+
+          {showCertificationFilter && (
+            <SearchDropdown
+              hideCounts
+              label={t('label.certification')}
+              searchKey="certification"
+              triggerButtonSize="middle"
+              {...certificationFilter}
             />
           )}
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/DataQualityDashboard/DataQualityDashboard.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/DataQualityDashboard/DataQualityDashboard.component.tsx
@@ -439,7 +439,7 @@ const DataQualityDashboard = ({
     if (query) {
       setCertification((prev) => ({
         ...prev,
-        options: prev.options.filter(
+        options: defaultCertificationOptions.filter(
           (value) =>
             value.label
               .toLocaleLowerCase()

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/DataQualityDashboard/DataQualityDashboard.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/DataQualityDashboard/DataQualityDashboard.interface.ts
@@ -15,6 +15,7 @@ export type DqDashboardChartFilters = {
   glossaryTerms?: string[];
   tags?: string[];
   tier?: string[];
+  certification?: string[];
   dataProductFqns?: string[];
   startTs?: number;
   endTs?: number;

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/DataQualityDashboard/DataQualityDashboard.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/DataQualityDashboard/DataQualityDashboard.test.tsx
@@ -103,7 +103,7 @@ jest.mock('../../../components/PageHeader/PageHeader.component', () =>
 );
 
 jest.mock('../../../rest/tagAPI', () => ({
-  getTags: () => mockGetTags(),
+  getTags: (...args: unknown[]) => mockGetTags(...args),
 }));
 
 jest.mock('../../../rest/searchAPI', () => ({
@@ -1088,10 +1088,11 @@ describe('DataQualityDashboard', () => {
       ).toBeInTheDocument();
     });
 
-    it('does not call getTags API when tier is in hiddenFilters', async () => {
-      render(<DataQualityDashboard hiddenFilters={['tier']} />, {
-        wrapper: MemoryRouter,
-      });
+    it('does not call getTags API when both tier and certification are in hiddenFilters', async () => {
+      render(
+        <DataQualityDashboard hiddenFilters={['tier', 'certification']} />,
+        { wrapper: MemoryRouter }
+      );
 
       await waitFor(() => {
         expect(
@@ -1100,6 +1101,30 @@ describe('DataQualityDashboard', () => {
       });
 
       expect(mockGetTags).not.toHaveBeenCalled();
+    });
+
+    it('fetches only Certification (not Tier) when tier is in hiddenFilters', async () => {
+      render(<DataQualityDashboard hiddenFilters={['tier']} />, {
+        wrapper: MemoryRouter,
+      });
+
+      await waitFor(() => {
+        expect(mockGetTags).toHaveBeenCalledWith({ parent: 'Certification' });
+      });
+
+      expect(mockGetTags).not.toHaveBeenCalledWith({ parent: 'Tier' });
+    });
+
+    it('fetches only Tier (not Certification) when certification is in hiddenFilters', async () => {
+      render(<DataQualityDashboard hiddenFilters={['certification']} />, {
+        wrapper: MemoryRouter,
+      });
+
+      await waitFor(() => {
+        expect(mockGetTags).toHaveBeenCalledWith({ parent: 'Tier' });
+      });
+
+      expect(mockGetTags).not.toHaveBeenCalledWith({ parent: 'Certification' });
     });
 
     it('does not call tag search API when tags is in hiddenFilters', async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/constants/DataQuality.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/DataQuality.constants.ts
@@ -79,6 +79,7 @@ export const DATA_QUALITY_DASHBOARD_HEADER = {
 export const DQ_FILTER_KEYS = {
   OWNER: 'owner',
   TIER: 'tier',
+  CERTIFICATION: 'certification',
   TAGS: 'tags',
   GLOSSARY_TERMS: 'glossaryTerms',
   DATA_PRODUCTS: 'dataProducts',

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TagPage/TagPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TagPage/TagPage.tsx
@@ -23,7 +23,7 @@ import {
 import { ItemType } from 'antd/lib/menu/hooks/useItems';
 import { AxiosError } from 'axios';
 import { compare } from 'fast-json-patch';
-import { cloneDeep, isEmpty, startsWith } from 'lodash';
+import { cloneDeep, isEmpty } from 'lodash';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -208,10 +208,20 @@ const TagPage = () => {
     [editTagsPermission, editEntitiesTagPermission.entitiesHavingPermission]
   );
 
-  const isCertificationClassification = useMemo(
-    () => startsWith(tagFqn, 'Certification.'),
-    [tagFqn]
-  );
+  const classificationName = tagItem?.classification?.name;
+  const isCertificationClassification = classificationName === 'Certification';
+
+  // Tier and Certification are first-class entity fields (entity.tier,
+  // entity.certification), not entries in entity.tags[]. When this page
+  // embeds the DQ dashboard, route the tag's FQN through the dashboard's
+  // matching filter key — otherwise the dashboard queries `tags.tagFQN`,
+  // which never matches assets carrying these system tags.
+  const dqFilterKey: 'tier' | 'certification' | 'tags' =
+    classificationName === 'Tier'
+      ? 'tier'
+      : classificationName === 'Certification'
+      ? 'certification'
+      : 'tags';
 
   const showDisableOption = useMemo(
     () => tagPermissions.EditAll && !tagItem?.deleted,
@@ -613,10 +623,12 @@ const TagPage = () => {
             <DataQualityDashboard
               isGovernanceView
               className="data-quality-governance-tab-wrapper"
-              hiddenFilters={['tags']}
+              hiddenFilters={
+                dqFilterKey === 'tags' ? ['tags'] : ['tags', dqFilterKey]
+              }
               initialFilters={
                 tagItem.fullyQualifiedName
-                  ? { tags: [tagItem.fullyQualifiedName] }
+                  ? { [dqFilterKey]: [tagItem.fullyQualifiedName] }
                   : undefined
               }
             />
@@ -637,6 +649,7 @@ const TagPage = () => {
     feedCount,
     previewAsset,
     isCertificationClassification,
+    dqFilterKey,
     haveAssetEditPermission,
     handleAssetSave,
     handleAssetClick,


### PR DESCRIPTION
Fixes open-metadata/openmetadata-collate#4080

## What was wrong
Two places on the Data Observability dashboard silently lost certified assets:
1. The global dashboard's **Tag** filter listed certifications (Gold/Silver/Bronze), but selecting one returned zero coverage — the dashboard was querying the wrong field.
2. The **Data Observability tab on a Certification tag's detail page** (e.g. `/tag/Certification.Gold`) reported zero coverage for the same reason — the page told the dashboard to filter by `tags`, but certification doesn't live in the tags array.

## What this PR changes
- Adds a dedicated **Certification** dropdown to the dashboard filter row, sitting next to Tier. It loads Bronze/Silver/Gold from the Certification classification.
- Stops listing Certification tags inside the generic **Tag** dropdown — they live in their own filter now, no double-counting.
- Fixes the Tag detail page: when you visit a Certification tag, the embedded dashboard receives the certification through the correct filter key, so charts actually populate. The Certification filter is hidden on that page since it's already implied by the URL.
- Adds a Playwright spec to pin the new behavior end-to-end.

## Depends on
- #28084 — the backend denormalization + filter type. Without it merged first, the Certification dropdown has nothing to query against on the test-case side.

## Scope
- Targets `main` and `1.13` only — on 1.12.x the dashboard component lives in the Collate repo (separate PR: open-metadata/openmetadata-collate#4079).
- The Tag detail page's "Data Observability" tab is a 1.13+ feature, so no equivalent fix is needed for 1.12.x — the broken scenario simply doesn't exist there.

## Test plan
Validated against a temp branch combining #28084 + this PR, deployed locally:

- [x] Playwright `yarn playwright:run playwright/e2e/Features/DataQuality/CertificationFilter.spec.ts` — **4/4 passing in ~9s**.
- [x] Certification dropdown appears between Tier and Tag in the filter row.
- [x] Picking a Certification narrows both the table-index and testCase-index dashboard calls correctly (via `certification.tagLabel.tagFQN`).
- [x] Certification tags no longer appear in the generic Tag dropdown.
- [x] A Certification tag's detail page → Data Observability tab → embedded dashboard correctly reflects certified assets.
- [x] No regression on existing Tier / Tag / Glossary / Owner filters.

## Follow-ups
- Collate-side equivalent PR for 1.12.x: open-metadata/openmetadata-collate#4079.
- A separate latent routing bug for Tier on testCase-driven widgets was discovered during this work. Not in scope here; tracked in open-metadata/openmetadata-collate#4086 with fix branch `fix/dq-tier-routing`.