### PR TITLE
Fix expand icon alignment and center text properly

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx
@@ -849,10 +849,10 @@ const TableV2 = <T extends object>(
                             }}>
                             <div
                               className={classNames(
-                                'tw:flex tw:items-start tw:gap-1 tw:max-w-full'
+                                'tw:flex tw:gap-1 tw:max-w-full'
                               )}>
                               {showExpandInCell && (
-                                <div className="tw:flex-shrink-0">
+                                <div className="tw:flex tw:items-center tw:shrink-0">
                                   {hasChildren ? (
                                     ExpandIcon ? (
                                       <ExpandIcon


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:
Align expand icon and center text properly in untitled table

<img width="1008" height="624" alt="Screenshot 2026-05-13 at 7 51 50 PM" src="https://github.com/user-attachments/assets/ee2fd8d2-6b07-4fad-94da-582bc571abeb" />
