### PR TITLE
fix(docker): mirror IBM iAccess driver on collate CDN

### DIFF
--- a/ingestion/Dockerfile
+++ b/ingestion/Dockerfile
@@ -61,11 +61,16 @@ RUN if [ $(uname -m) = "arm64" ] | [ $(uname -m) = "aarch64" ]; \
 ENV LD_LIBRARY_PATH=/instantclient
 
 # Install DB2 iAccess Driver
-RUN if [ $(uname -m) = "x86_64" ]; \
-  then \
-  curl https://public.dhe.ibm.com/software/ibmi/products/odbc/debs/dists/1.1.0/ibmi-acs-1.1.0.list | tee /etc/apt/sources.list.d/ibmi-acs-1.1.0.list \
-  && apt update \
-  && apt install ibm-iaccess; \
+# Mirrored on cdn.getcollate.io to decouple builds from IBM's CDN availability.
+# Use dpkg --force-depends because the .deb declares old Debian package names
+# (libodbc1, odbcinst1debian2) that don't exist in Debian 12; the actual
+# libraries (unixodbc, odbcinst) are installed earlier. SHA256 pinned to v29.
+RUN if [ $(uname -m) = "x86_64" ]; then \
+  wget -q https://cdn.getcollate.io/deps/ingestion/ibm/ibm-iaccess-1.1.0.29-1.0.amd64.deb -O /tmp/ibm-iaccess.deb \
+  && echo "e60e968d2cee96b2851964456f5b31ab990b1aa47d8f2399607809f7d4514f58  /tmp/ibm-iaccess.deb" | sha256sum -c - \
+  && dpkg -i --force-depends /tmp/ibm-iaccess.deb \
+  && apt-get install -f -y --no-install-recommends \
+  && rm -f /tmp/ibm-iaccess.deb; \
   fi
 
 # Required for Starting Ingestion Container in Docker Compose

--- a/ingestion/Dockerfile.ci
+++ b/ingestion/Dockerfile.ci
@@ -61,11 +61,16 @@ RUN if [ $(uname -m) = "arm64" ] | [ $(uname -m) = "aarch64" ]; \
 ENV LD_LIBRARY_PATH=/instantclient
 
 # Install DB2 iAccess Driver
-RUN if [ $(uname -m) = "x86_64" ]; \
-  then \
-  curl https://public.dhe.ibm.com/software/ibmi/products/odbc/debs/dists/1.1.0/ibmi-acs-1.1.0.list | tee /etc/apt/sources.list.d/ibmi-acs-1.1.0.list \
-  && apt update \
-  && apt install ibm-iaccess; \
+# Mirrored on cdn.getcollate.io to decouple builds from IBM's CDN availability.
+# Use dpkg --force-depends because the .deb declares old Debian package names
+# (libodbc1, odbcinst1debian2) that don't exist in Debian 12; the actual
+# libraries (unixodbc, odbcinst) are installed earlier. SHA256 pinned to v29.
+RUN if [ $(uname -m) = "x86_64" ]; then \
+  wget -q https://cdn.getcollate.io/deps/ingestion/ibm/ibm-iaccess-1.1.0.29-1.0.amd64.deb -O /tmp/ibm-iaccess.deb \
+  && echo "e60e968d2cee96b2851964456f5b31ab990b1aa47d8f2399607809f7d4514f58  /tmp/ibm-iaccess.deb" | sha256sum -c - \
+  && dpkg -i --force-depends /tmp/ibm-iaccess.deb \
+  && apt-get install -f -y --no-install-recommends \
+  && rm -f /tmp/ibm-iaccess.deb; \
   fi
 
 # Required for Starting Ingestion Container in Docker Compose

--- a/ingestion/operators/docker/Dockerfile
+++ b/ingestion/operators/docker/Dockerfile
@@ -63,12 +63,14 @@ RUN if [ $(uname -m) = "arm64" || $(uname -m) = "aarch64" ]; \
 ENV LD_LIBRARY_PATH=/instantclient
 
 # Install DB2 iAccess driver
-# The IBM repository approach is unreliable in CI environments, so we download the package directly
+# Mirrored on cdn.getcollate.io to decouple builds from IBM's CDN availability.
 # Use dpkg --force-depends because the package declares old Debian package names (libodbc1, odbcinst1debian2)
-# that don't exist in Debian 12, but the actual dependencies (unixodbc, odbcinst) are already installed
+# that don't exist in Debian 12, but the actual dependencies (unixodbc, odbcinst) are already installed.
+# SHA256 pinned to v1.1.0.29 — matches the version production ingestion-slim images run.
 RUN if [ $(uname -m) = "x86_64" ]; then \
-  wget -q https://public.dhe.ibm.com/software/ibmi/products/odbc/debs/dists/1.1.0/main/binary-amd64/ibm-iaccess-1.1.0.13-1.0.amd64.deb \
+  wget -q https://cdn.getcollate.io/deps/ingestion/ibm/ibm-iaccess-1.1.0.29-1.0.amd64.deb \
     -O /tmp/ibm-iaccess.deb && \
+  echo "e60e968d2cee96b2851964456f5b31ab990b1aa47d8f2399607809f7d4514f58  /tmp/ibm-iaccess.deb" | sha256sum -c - && \
   dpkg -i --force-depends /tmp/ibm-iaccess.deb && \
   apt-get install -f -y --no-install-recommends && \
   rm -f /tmp/ibm-iaccess.deb; \

--- a/ingestion/operators/docker/Dockerfile.ci
+++ b/ingestion/operators/docker/Dockerfile.ci
@@ -63,12 +63,14 @@ RUN if [ $(uname -m) = "arm64" ] | [ $(uname -m) = "aarch64" ]; \
 ENV LD_LIBRARY_PATH=/instantclient
 
 # Install DB2 iAccess Driver
-# The IBM repository approach is unreliable in CI environments, so we download the package directly
+# Mirrored on cdn.getcollate.io to decouple builds from IBM's CDN availability.
 # Use dpkg --force-depends because the package declares old Debian package names (libodbc1, odbcinst1debian2)
-# that don't exist in Debian 12, but the actual dependencies (unixodbc, odbcinst) are already installed
+# that don't exist in Debian 12, but the actual dependencies (unixodbc, odbcinst) are already installed.
+# SHA256 pinned to v1.1.0.29 — matches the version production ingestion-slim images run.
 RUN if [ $(uname -m) = "x86_64" ]; then \
-  wget -q https://public.dhe.ibm.com/software/ibmi/products/odbc/debs/dists/1.1.0/main/binary-amd64/ibm-iaccess-1.1.0.13-1.0.amd64.deb \
+  wget -q https://cdn.getcollate.io/deps/ingestion/ibm/ibm-iaccess-1.1.0.29-1.0.amd64.deb \
     -O /tmp/ibm-iaccess.deb && \
+  echo "e60e968d2cee96b2851964456f5b31ab990b1aa47d8f2399607809f7d4514f58  /tmp/ibm-iaccess.deb" | sha256sum -c - && \
   dpkg -i --force-depends /tmp/ibm-iaccess.deb && \
   apt-get install -f -y --no-install-recommends && \
   rm -f /tmp/ibm-iaccess.deb; \


### PR DESCRIPTION
### Describe your changes:

Fixes #<issue-number>
<!-- TODO: replace with the GitHub issue tracking the recent CI failure
"curl: (28) Failed to connect to public.dhe.ibm.com port 443 after 134058 ms" -->

IBM's public CDN (`public.dhe.ibm.com`) has been unreliable, causing Docker
builds to fail when curling the iAccess `.list` or `.deb`. This PR mirrors
the iAccess driver on `cdn.getcollate.io` and switches all four ingestion
Dockerfiles to wget from the mirror with SHA256 verification.

**Why:** the CI build error pasted in the linked issue is a 134-second TCP
timeout against `public.dhe.ibm.com` — IBM's CDN was unreachable from the
runner. Direct download of the `.deb` (instead of apt-list) wouldn't help:
same hostname, same network path, same failure mode. Mirroring the binary
on a CDN we control decouples Docker builds from IBM's availability.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

**Files changed (4):**
- `ingestion/Dockerfile` + `Dockerfile.ci`: replace `apt-list`+`apt-install`
  pattern with direct `wget`+`dpkg`, matching the operators' existing shape.
- `ingestion/operators/docker/Dockerfile` + `Dockerfile.ci`: bump pinned
  version from `1.1.0.13` (May 2022) to `1.1.0.29` (March 2026, matches the
  version production `ingestion-slim` images actually ship today).

**SHA256 verification** is added to all four files. The mirrored `.deb` is
byte-identical to IBM's upstream:

```
SHA256:  e60e968d2cee96b2851964456f5b31ab990b1aa47d8f2399607809f7d4514f58
Size:    1,179,698 bytes
URL:     https://cdn.getcollate.io/deps/ingestion/ibm/ibm-iaccess-1.1.0.29-1.0.amd64.deb
Source:  https://public.dhe.ibm.com/software/ibmi/products/odbc/debs/dists/1.1.0/main/binary-amd64/ibm-iaccess-1.1.0.29-1.0.amd64.deb
```

**Why `1.1.0.29` is safe:** it's the same version production
`ingestion-slim:1.13.0-n103` already runs (confirmed via `dpkg -l ibm-iaccess`
inside the image). The smaller `.deb` size (1.1 MB vs 5.5 MB for 1.1.0.28) is
because IBM finally stripped debug symbols from the shared libraries — same
438 files, same `libcwbodbc.so` ODBC driver, same `libcwbcore.so`. No
functionality removed; `file` reports v29 as "stripped" vs v28 "with
debug_info, not stripped."

**`dpkg --force-depends` retained** because the `.deb` declares old Debian
package names (`libodbc1`, `odbcinst1debian2`) that don't exist in Debian 12;
the actual libraries (`unixodbc`, `odbcinst`) are installed earlier in each
Dockerfile.

#
### Tests:

No automated test exists in the repo for the iAccess install path
(`test_db2.py` is a pure-mock unit test, doesn't exercise the driver, and
no CI workflow mentions db2/iaccess). Validated manually:

```bash
docker run --rm --platform=linux/amd64 debian:bookworm-slim bash -c '
  apt-get update -qq && apt-get install -y -qq wget ca-certificates unixodbc odbcinst >/dev/null 2>&1
  wget -q https://cdn.getcollate.io/deps/ingestion/ibm/ibm-iaccess-1.1.0.29-1.0.amd64.deb -O /tmp/x.deb
  echo "e60e968d2cee96b2851964456f5b31ab990b1aa47d8f2399607809f7d4514f58  /tmp/x.deb" | sha256sum -c -
  dpkg -i --force-depends /tmp/x.deb
  apt-get install -f -y --no-install-recommends
  dpkg -l ibm-iaccess
'
```

Result: `ii  ibm-iaccess  1.1.0.29-1.0  amd64  IBM i Access Client Solutions`.
`libcwbodbc.so` (the ODBC driver, 830 KB) and the
`/usr/lib/x86_64-linux-gnu/libcwbcore.so` symlink land at expected paths.

Adding a Dockerfile-build smoke test to CI is a worthwhile follow-up but
out of scope for this fix.