### PR TITLE
fix(ingestion): register Drive entities in ENTITY_REFERENCE_CLASS_MAP and ES_INDEX_MAP

### DIFF
--- a/ingestion/src/metadata/utils/constants.py
+++ b/ingestion/src/metadata/utils/constants.py
@@ -21,15 +21,19 @@ from metadata.generated.schema.entity.data.dashboard import Dashboard
 from metadata.generated.schema.entity.data.dashboardDataModel import DashboardDataModel
 from metadata.generated.schema.entity.data.database import Database
 from metadata.generated.schema.entity.data.databaseSchema import DatabaseSchema
+from metadata.generated.schema.entity.data.directory import Directory
+from metadata.generated.schema.entity.data.file import File
 from metadata.generated.schema.entity.data.glossary import Glossary
 from metadata.generated.schema.entity.data.glossaryTerm import GlossaryTerm
 from metadata.generated.schema.entity.data.metric import Metric
 from metadata.generated.schema.entity.data.mlmodel import MlModel
 from metadata.generated.schema.entity.data.pipeline import Pipeline
 from metadata.generated.schema.entity.data.searchIndex import SearchIndex
+from metadata.generated.schema.entity.data.spreadsheet import Spreadsheet
 from metadata.generated.schema.entity.data.storedProcedure import StoredProcedure
 from metadata.generated.schema.entity.data.table import Table
 from metadata.generated.schema.entity.data.topic import Topic
+from metadata.generated.schema.entity.data.worksheet import Worksheet
 from metadata.generated.schema.entity.domains.dataProduct import DataProduct
 from metadata.generated.schema.entity.domains.domain import Domain
 from metadata.generated.schema.entity.services.apiService import ApiService
@@ -68,6 +72,7 @@ from metadata.generated.schema.entity.services.connections.database.sasConnectio
 )
 from metadata.generated.schema.entity.services.dashboardService import DashboardService
 from metadata.generated.schema.entity.services.databaseService import DatabaseService
+from metadata.generated.schema.entity.services.driveService import DriveService
 from metadata.generated.schema.entity.services.messagingService import MessagingService
 from metadata.generated.schema.entity.services.metadataService import MetadataService
 from metadata.generated.schema.entity.services.mlmodelService import MlModelService
@@ -132,6 +137,7 @@ ENTITY_REFERENCE_CLASS_MAP = {
     "metadataService": MetadataService,
     "searchService": SearchService,
     "securityService": SecurityService,
+    "driveService": DriveService,
     # Data Asset Entities
     "apiCollection": APICollection,
     "apiEndpoint": APIEndpoint,
@@ -147,6 +153,11 @@ ENTITY_REFERENCE_CLASS_MAP = {
     "searchIndex": SearchIndex,
     "mlmodel": MlModel,
     "container": Container,
+    # Drive Entities
+    "directory": Directory,
+    "file": File,
+    "spreadsheet": Spreadsheet,
+    "worksheet": Worksheet,
     # User Entities
     "user": User,
     "team": Team,

--- a/ingestion/src/metadata/utils/elasticsearch.py
+++ b/ingestion/src/metadata/utils/elasticsearch.py
@@ -29,6 +29,8 @@ from metadata.generated.schema.entity.data.dashboard import Dashboard
 from metadata.generated.schema.entity.data.dashboardDataModel import DashboardDataModel
 from metadata.generated.schema.entity.data.database import Database
 from metadata.generated.schema.entity.data.databaseSchema import DatabaseSchema
+from metadata.generated.schema.entity.data.directory import Directory
+from metadata.generated.schema.entity.data.file import File
 from metadata.generated.schema.entity.data.glossary import Glossary
 from metadata.generated.schema.entity.data.glossaryTerm import GlossaryTerm
 from metadata.generated.schema.entity.data.metric import Metric
@@ -36,9 +38,11 @@ from metadata.generated.schema.entity.data.mlmodel import MlModel
 from metadata.generated.schema.entity.data.pipeline import Pipeline
 from metadata.generated.schema.entity.data.query import Query
 from metadata.generated.schema.entity.data.searchIndex import SearchIndex
+from metadata.generated.schema.entity.data.spreadsheet import Spreadsheet
 from metadata.generated.schema.entity.data.storedProcedure import StoredProcedure
 from metadata.generated.schema.entity.data.table import Table
 from metadata.generated.schema.entity.data.topic import Topic
+from metadata.generated.schema.entity.data.worksheet import Worksheet
 from metadata.generated.schema.entity.services.apiService import ApiService
 from metadata.generated.schema.entity.services.databaseService import DatabaseService
 from metadata.generated.schema.entity.teams.team import Team
@@ -71,6 +75,10 @@ ES_INDEX_MAP = {
     Tag.__name__: "tag_search_index",
     Classification.__name__: "classification_search_index",
     Container.__name__: "container_search_index",
+    Directory.__name__: "directory_search_index",
+    File.__name__: "file_search_index",
+    Spreadsheet.__name__: "spreadsheet_search_index",
+    Worksheet.__name__: "worksheet_search_index",
     Query.__name__: "query_search_index",
     ReportData.__name__: "entity_report_data_index",
     Metric.__name__: "metric_search_index",


### PR DESCRIPTION
## Summary

Drive entities (`directory`, `file`, `spreadsheet`, `worksheet`) and the `driveService` were missing from two ingestion-side registries:

1. **`ENTITY_REFERENCE_CLASS_MAP`** in `metadata/utils/constants.py` — used by the Automator app to resolve entity classes from `resources.type`. Selecting a Drive entity in the Add Automation UI (`AUTOMATOR_DATA_ASSETS_LIST`) failed at runtime in `Automator.fetch_entities`:

    ```
    AutomatorException: Can't get class from resource type: directory
    ```

2. **`ES_INDEX_MAP`** in `metadata/utils/elasticsearch.py` — used to resolve the correct search index per entity class. Drive entities had no mapping, breaking search-index lookups during ingestion/automation flows.

This PR registers the Drive data entities and `driveService` in both maps.

## Changes

**`metadata/utils/constants.py`**
- Import `Directory`, `File`, `Spreadsheet`, `Worksheet`, `DriveService`
- Add `driveService` to the service entities section of `ENTITY_REFERENCE_CLASS_MAP`
- Add `directory`, `file`, `spreadsheet`, `worksheet` under a new "Drive Entities" section

`ENTITY_REFERENCE_TYPE_MAP` is derived from the class map, so it picks these up automatically.

**`metadata/utils/elasticsearch.py`**
- Import `Directory`, `File`, `Spreadsheet`, `Worksheet`
- Add entries to `ES_INDEX_MAP` mapping each class to its `*_search_index`

## Test plan

- [ ] `from metadata.utils.constants import ENTITY_REFERENCE_CLASS_MAP` resolves `directory`/`file`/`spreadsheet`/`worksheet`/`driveService` to their classes
- [ ] `from metadata.utils.elasticsearch import ES_INDEX_MAP` resolves `Directory`/`File`/`Spreadsheet`/`Worksheet` to their corresponding search indexes
- [ ] Automator workflow targeting a `directory` resource type no longer raises `AutomatorException`

🤖 Generated with [Claude Code](https://claude.com/claude-code)