### PR TITLE
fix(ui): preserve TagLabel server fields when saving tags (#28038)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Tags.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Tags.spec.ts
@@ -692,3 +692,123 @@ test('Disabled tag should not allow adding assets from Assets tab', async ({
     await afterAction();
   }
 });
+
+test('Adds one tag and removes another in the same save preserves appliedBy on the kept tag', async ({
+  browser,
+  page,
+}) => {
+  const { apiContext, afterAction } = await createNewPage(browser);
+  const fixtureTable = new TableClass();
+  const addedTag = new TagClass({ classification: classification.data.name });
+
+  try {
+    await fixtureTable.create(apiContext);
+    await addedTag.create(apiContext);
+
+    const keptTagFqn = tag.responseData.fullyQualifiedName;
+    const removedTagFqn = tag1.responseData.fullyQualifiedName;
+    const addedTagFqn = addedTag.responseData.fullyQualifiedName;
+
+    await fixtureTable.patch({
+      apiContext,
+      patchData: [
+        {
+          op: 'add',
+          path: '/tags',
+          value: [
+            {
+              tagFQN: keptTagFqn,
+              source: 'Classification',
+              labelType: 'Manual',
+              state: 'Confirmed',
+            },
+            {
+              tagFQN: removedTagFqn,
+              source: 'Classification',
+              labelType: 'Manual',
+              state: 'Confirmed',
+            },
+          ],
+        },
+      ],
+    });
+
+    const seededResponse = await apiContext.get(
+      `/api/v1/tables/${fixtureTable.entityResponseData?.id}?fields=tags`
+    );
+    const seededBody = await seededResponse.json();
+    const seededKept = (
+      seededBody.tags as { tagFQN: string; appliedBy?: string }[]
+    ).find((t) => t.tagFQN === keptTagFqn);
+
+    expect(seededKept?.appliedBy).toBeTruthy();
+
+    await fixtureTable.visitEntityPage(page);
+
+    const tagsPanel = page
+      .getByTestId('KnowledgePanel.Tags')
+      .getByTestId('tags-container');
+
+    await expect(tagsPanel.getByTestId(`tag-${keptTagFqn}`)).toBeVisible();
+    await expect(tagsPanel.getByTestId(`tag-${removedTagFqn}`)).toBeVisible();
+
+    await tagsPanel.getByTestId('edit-button').first().click();
+
+    await expect(page.locator('#tagsForm_tags')).toBeVisible();
+
+    await page
+      .getByTestId('tag-selector')
+      .getByTestId(`selected-tag-${removedTagFqn}`)
+      .getByTestId('remove-tags')
+      .locator('svg')
+      .click();
+
+    await page.locator('#tagsForm_tags').click();
+    await page.locator('#tagsForm_tags').fill(addedTag.data.name);
+
+    await expect(page.getByTestId(`tag-${addedTagFqn}`).first()).toBeVisible();
+    await page.getByTestId(`tag-${addedTagFqn}`).first().click();
+
+    await page
+      .locator('.ant-select-dropdown')
+      .getByTestId('saveAssociatedTag')
+      .waitFor({ state: 'visible' });
+
+    const patchResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/v1/tables/') &&
+        response.request().method() === 'PATCH'
+    );
+
+    await page.getByTestId('saveAssociatedTag').click();
+
+    const response = await patchResponse;
+
+    expect(response.status()).toBe(200);
+
+    const patchedTable = await response.json();
+    const patchedTags = (patchedTable.tags ?? []) as {
+      tagFQN: string;
+      appliedBy?: string;
+    }[];
+    const patchedFqns = patchedTags.map((t) => t.tagFQN);
+
+    expect(patchedFqns).toContain(keptTagFqn);
+    expect(patchedFqns).toContain(addedTagFqn);
+    expect(patchedFqns).not.toContain(removedTagFqn);
+
+    const survivingTag = patchedTags.find((t) => t.tagFQN === keptTagFqn);
+
+    expect(survivingTag?.appliedBy).toBe(seededKept?.appliedBy);
+
+    await expect(tagsPanel.getByTestId(`tag-${keptTagFqn}`)).toBeVisible();
+    await expect(tagsPanel.getByTestId(`tag-${addedTagFqn}`)).toBeVisible();
+    await expect(
+      tagsPanel.getByTestId(`tag-${removedTagFqn}`)
+    ).not.toBeVisible();
+  } finally {
+    await addedTag.delete(apiContext);
+    await fixtureTable.delete(apiContext);
+    await afterAction();
+  }
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsContainerV2/TagsContainerV2.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsContainerV2/TagsContainerV2.test.tsx
@@ -1,0 +1,264 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { EntityTags } from 'Models';
+import { MemoryRouter } from 'react-router-dom';
+import {
+  LabelType,
+  State,
+  TagLabel,
+  TagLabelMetadata,
+  TagSource,
+} from '../../../generated/type/tagLabel';
+import TagsContainerV2 from './TagsContainerV2';
+
+let capturedOnSubmit:
+  | ((data: { value: string; data?: Partial<EntityTags> }[]) => Promise<void>)
+  | undefined;
+
+jest.mock('../TagsSelectForm/TagsSelectForm.component', () => {
+  return jest.fn().mockImplementation((props) => {
+    capturedOnSubmit = props.onSubmit;
+
+    return <div data-testid="mock-tag-select-form">TagSelectForm</div>;
+  });
+});
+
+jest.mock('../TagsViewer/TagsViewer', () =>
+  jest.fn().mockImplementation(() => <div data-testid="tags-viewer" />)
+);
+
+jest.mock('../TagsV1/TagsV1.component', () =>
+  jest.fn().mockImplementation(() => <div data-testid="tags-v1" />)
+);
+
+jest.mock('../../Customization/GenericProvider/GenericProvider', () => ({
+  useGenericContext: () => ({
+    onThreadLinkSelect: jest.fn(),
+    activeTagDropdownKey: null,
+    updateActiveTagDropdownKey: jest.fn(),
+  }),
+}));
+
+jest.mock('../../Suggestions/SuggestionsProvider/SuggestionsProvider', () => ({
+  useSuggestionsContext: () => ({ selectedUserSuggestions: undefined }),
+}));
+
+jest.mock('../../common/ExpandableCard/ExpandableCard', () =>
+  jest
+    .fn()
+    .mockImplementation(({ children }) => (
+      <div data-testid="expandable-card">{children}</div>
+    ))
+);
+
+jest.mock('../../Suggestions/SuggestionsAlert/SuggestionsAlert', () =>
+  jest.fn().mockImplementation(() => <div data-testid="suggestions-alert" />)
+);
+
+const PERSONAL_DATA_FQN = 'PersonalData.Personal';
+const PII_SENSITIVE_FQN = 'PII.Sensitive';
+const TIER_GOLD_FQN = 'Tier.Tier1';
+
+const APPLIED_AT_ISO = '2026-01-01T00:00:00Z';
+
+const personalDataTag: EntityTags = {
+  tagFQN: PERSONAL_DATA_FQN,
+  source: TagSource.Classification,
+  labelType: LabelType.Manual,
+  state: State.Confirmed,
+  appliedBy: 'admin',
+  appliedAt: new Date(APPLIED_AT_ISO),
+  description: 'Personal data',
+};
+
+const piiSensitiveTag: EntityTags = {
+  tagFQN: PII_SENSITIVE_FQN,
+  source: TagSource.Classification,
+  labelType: LabelType.Manual,
+  state: State.Confirmed,
+  appliedBy: 'bot-classification',
+  appliedAt: new Date(APPLIED_AT_ISO),
+};
+
+const renderTagsContainer = (props: {
+  selectedTags: EntityTags[];
+  onSelectionChange: jest.Mock;
+}) => {
+  capturedOnSubmit = undefined;
+
+  return render(
+    <MemoryRouter>
+      <TagsContainerV2
+        permission
+        showInlineEditButton
+        entityFqn="sample.db.schema.table"
+        entityType="table"
+        selectedTags={props.selectedTags}
+        tagType={TagSource.Classification}
+        onSelectionChange={props.onSelectionChange}
+      />
+    </MemoryRouter>
+  );
+};
+
+const enterEditMode = () => {
+  const editButton = screen.getByTestId('edit-button');
+  fireEvent.click(editButton);
+};
+
+describe('TagsContainerV2 handleSave', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedOnSubmit = undefined;
+  });
+
+  it('preserves appliedBy and appliedAt on existing tag when a new tag is added', async () => {
+    const onSelectionChange = jest.fn().mockResolvedValue(undefined);
+    renderTagsContainer({
+      selectedTags: [personalDataTag],
+      onSelectionChange,
+    });
+
+    enterEditMode();
+
+    expect(capturedOnSubmit).toBeDefined();
+
+    await act(async () => {
+      await capturedOnSubmit?.([
+        { value: PERSONAL_DATA_FQN, data: personalDataTag },
+        {
+          value: TIER_GOLD_FQN,
+          data: { name: 'Tier1', tagFQN: TIER_GOLD_FQN },
+        },
+      ]);
+    });
+
+    expect(onSelectionChange).toHaveBeenCalledTimes(1);
+
+    const emitted = onSelectionChange.mock.calls[0][0] as EntityTags[];
+
+    const survived = emitted.find((t) => t.tagFQN === PERSONAL_DATA_FQN);
+
+    expect(survived).toEqual(
+      expect.objectContaining({
+        tagFQN: PERSONAL_DATA_FQN,
+        source: TagSource.Classification,
+        labelType: LabelType.Manual,
+        state: State.Confirmed,
+        appliedBy: 'admin',
+        appliedAt: personalDataTag.appliedAt,
+        description: 'Personal data',
+      })
+    );
+  });
+
+  it('passes every TagLabel schema field through to onSelectionChange', async () => {
+    const onSelectionChange = jest.fn().mockResolvedValue(undefined);
+    // Seed with a different tag so the new selection genuinely changes the FQN list
+    // and isn't short-circuited by the no-op guard inside handleSave.
+    renderTagsContainer({
+      selectedTags: [piiSensitiveTag],
+      onSelectionChange,
+    });
+
+    enterEditMode();
+
+    expect(capturedOnSubmit).toBeDefined();
+
+    const fullTag: Required<TagLabel> = {
+      tagFQN: PERSONAL_DATA_FQN,
+      source: TagSource.Classification,
+      labelType: LabelType.Manual,
+      state: State.Confirmed,
+      name: 'Personal',
+      displayName: 'Personal Data',
+      description: 'Full TagLabel coverage fixture',
+      style: { color: '#ABCDEF', iconURL: 'icon-url' },
+      href: 'https://example.openmetadata/api/v1/tags/PersonalData.Personal',
+      appliedBy: 'admin',
+      appliedAt: new Date('2026-01-01T00:00:00Z'),
+      metadata: {
+        recognizer: {
+          recognizerId: 'rec-1',
+          recognizerName: 'pii-recognizer',
+          score: 0.95,
+        },
+      } as TagLabelMetadata,
+      reason: 'auto-classified',
+    };
+
+    await act(async () => {
+      await capturedOnSubmit?.([{ value: fullTag.tagFQN, data: fullTag }]);
+    });
+
+    expect(onSelectionChange).toHaveBeenCalledTimes(1);
+
+    const emitted = onSelectionChange.mock.calls[0][0] as TagLabel[];
+    const survived = emitted.find((t) => t.tagFQN === PERSONAL_DATA_FQN);
+
+    for (const key of Object.keys(fullTag) as (keyof TagLabel)[]) {
+      expect(survived?.[key]).toEqual(fullTag[key]);
+    }
+  });
+
+  it('add-one-remove-another in same save keeps surviving tag fields intact', async () => {
+    const onSelectionChange = jest.fn().mockResolvedValue(undefined);
+    renderTagsContainer({
+      selectedTags: [personalDataTag, piiSensitiveTag],
+      onSelectionChange,
+    });
+
+    enterEditMode();
+
+    expect(capturedOnSubmit).toBeDefined();
+
+    await act(async () => {
+      await capturedOnSubmit?.([
+        { value: PERSONAL_DATA_FQN, data: personalDataTag },
+        {
+          value: TIER_GOLD_FQN,
+          data: { name: 'Tier1', tagFQN: TIER_GOLD_FQN },
+        },
+      ]);
+    });
+
+    expect(onSelectionChange).toHaveBeenCalledTimes(1);
+
+    const emitted = onSelectionChange.mock.calls[0][0] as EntityTags[];
+
+    expect(emitted).toHaveLength(2);
+
+    const survived = emitted.find((t) => t.tagFQN === PERSONAL_DATA_FQN);
+    const added = emitted.find((t) => t.tagFQN === TIER_GOLD_FQN);
+
+    expect(survived).toEqual(
+      expect.objectContaining({
+        appliedBy: 'admin',
+        appliedAt: personalDataTag.appliedAt,
+        description: 'Personal data',
+      })
+    );
+    expect(added).toEqual(
+      expect.objectContaining({
+        tagFQN: TIER_GOLD_FQN,
+        source: TagSource.Classification,
+        labelType: LabelType.Manual,
+        state: State.Confirmed,
+      })
+    );
+    expect(added?.appliedBy).toBeUndefined();
+    expect(added?.appliedAt).toBeUndefined();
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsContainerV2/TagsContainerV2.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsContainerV2/TagsContainerV2.tsx
@@ -27,7 +27,7 @@ import {
 } from '../../../constants/Tag.constants';
 import { EntityType } from '../../../enums/entity.enum';
 import { LabelType } from '../../../generated/entity/data/table';
-import { State, TagSource } from '../../../generated/type/tagLabel';
+import { State, TagLabel, TagSource } from '../../../generated/type/tagLabel';
 import EntityLink from '../../../utils/EntityLink';
 import { getEntityFeedLink } from '../../../utils/EntityUtils';
 import { getFilterTags } from '../../../utils/TableTags/TableTags.utils';
@@ -163,27 +163,29 @@ const TagsContainerV2 = ({
   );
 
   const handleSave = async (data: DefaultOptionType | DefaultOptionType[]) => {
+    // Pass every TagLabel field through so server-managed ones (appliedBy, appliedAt) survive the JSON-Patch diff.
     const updatedTags = (isArray(data) ? data : [data]).map((tag) => {
-      let tagData: EntityTags = {
-        tagFQN: typeof tag === 'string' ? tag : tag.value,
+      const tagFQN: string =
+        typeof tag === 'string' ? tag : String(tag.value ?? '');
+      const option = (
+        typeof tag === 'object' ? tag.data ?? {} : {}
+      ) as Partial<TagLabel>;
+
+      return {
+        tagFQN,
         source: tagType,
-        labelType: LabelType.Manual,
-      };
-
-      if (tag.data) {
-        tagData = {
-          ...tagData,
-          name: tag.data?.name,
-          displayName: tag.data?.displayName,
-          description: tag.data?.description,
-          style: tag.data?.style ?? {},
-          labelType:
-            tag.data?.labelType ?? defaultLabelType ?? LabelType.Manual,
-          state: tag.data?.state ?? defaultState ?? State.Confirmed,
-        };
-      }
-
-      return tagData;
+        labelType: option.labelType ?? defaultLabelType ?? LabelType.Manual,
+        state: option.state ?? defaultState ?? State.Confirmed,
+        name: option.name,
+        displayName: option.displayName,
+        description: option.description,
+        style: option.style ?? {},
+        href: option.href,
+        appliedBy: option.appliedBy,
+        appliedAt: option.appliedAt,
+        metadata: option.metadata,
+        reason: option.reason,
+      } as EntityTags;
     });
 
     const newTags = updatedTags.map((t) => t.tagFQN);

--- a/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsContainerV2/TagsContainerV2.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsContainerV2/TagsContainerV2.tsx
@@ -15,7 +15,6 @@ import { Col, Form, Row, Space, Typography } from 'antd';
 import { DefaultOptionType } from 'antd/lib/select';
 import classNames from 'classnames';
 import { isArray, isEmpty, isEqual } from 'lodash';
-import { EntityTags } from 'Models';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -27,7 +26,7 @@ import {
 } from '../../../constants/Tag.constants';
 import { EntityType } from '../../../enums/entity.enum';
 import { LabelType } from '../../../generated/entity/data/table';
-import { State, TagLabel, TagSource } from '../../../generated/type/tagLabel';
+import { State, TagSource } from '../../../generated/type/tagLabel';
 import EntityLink from '../../../utils/EntityLink';
 import { getEntityFeedLink } from '../../../utils/EntityUtils';
 import { getFilterTags } from '../../../utils/TableTags/TableTags.utils';
@@ -167,9 +166,8 @@ const TagsContainerV2 = ({
     const updatedTags = (isArray(data) ? data : [data]).map((tag) => {
       const tagFQN: string =
         typeof tag === 'string' ? tag : String(tag.value ?? '');
-      const option = (
-        typeof tag === 'object' ? tag.data ?? {} : {}
-      ) as Partial<TagLabel>;
+
+      const option = typeof tag === 'object' ? tag.data ?? {} : {};
 
       return {
         tagFQN,
@@ -185,7 +183,7 @@ const TagsContainerV2 = ({
         appliedAt: option.appliedAt,
         metadata: option.metadata,
         reason: option.reason,
-      } as EntityTags;
+      };
     });
 
     const newTags = updatedTags.map((t) => t.tagFQN);


### PR DESCRIPTION
## Summary

- Fix `TagsContainerV2.handleSave` to pass every TagLabel schema field on the option payload through to the PATCH, so server-managed fields (`appliedBy`, `appliedAt`, `metadata`, `reason`) survive the JSON-Patch diff.
- Closes #28038. The user-visible symptom was `500 Non-existing name/value pair in the object for key appliedBy` when adding one tag and removing another in the same save. The underlying cause was that the UI silently wiped `appliedBy`/`appliedAt` on every save: `handleSave` rebuilt each tag from an 8-field allowlist that pre-dated those fields being added to the schema in #24817. `fast-json-patch.compare(old, new)` then emitted `remove /tags/N/appliedBy` ops the UI never intended; the backend correctly refused them when the path no longer existed at apply time.


A future PR adding another optional field to `TagLabel` would re-introduce the same class of bug. To prevent that:

- The new Jest test (`passes every TagLabel schema field through to onSelectionChange`) builds a `Required<TagLabel>` fixture. Adding a new field to the schema means the fixture won't compile until it's populated; once it is, the assertion loop catches a `handleSave` that doesn't pass it through.
- The Playwright test seeds two tags via API, drives the UI to keep one and swap the other, and asserts that the surviving tag's `appliedBy` matches the server-populated value before the edit. Together with the PATCH status check, this covers both halves of the bug: no 500 and no silent data loss.

## Test plan

- [x] `yarn test src/components/Tag/TagsContainerV2/TagsContainerV2.test.tsx` — 3/3 pass
- [x] `yarn ui-checkstyle:changed` on the touched src files — clean
- [x] `yarn ui-checkstyle:playwright:changed playwright/e2e/Pages/Tags.spec.ts` — clean
- [x] `npx tsc --noEmit` — no errors on changed files
- [x] Playwright E2E (`Adds one tag and removes another in the same save preserves appliedBy on the kept tag`) — passes against `yarn start` (Vite dev server on :3000 with the live code). Test verifies (a) PATCH returns 200 and (b) the kept tag's `appliedBy` matches the pre-edit server-populated value.
- [x] Manual repro on a fully built stack: add+remove tags in the same save returns 200, and the kept tag's `appliedBy` is intact via API.
