### PR TITLE
CHORE: Revert repository to https://repo1.maven.org/maven2/

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -765,7 +765,7 @@
         <enabled>false</enabled>
       </snapshots>
       <id>central</id>
-      <url>https://repo.maven.apache.org/maven2/</url>
+      <url>https://repo1.maven.org/maven2/</url>
     </repository>
     <repository>
       <releases>


### PR DESCRIPTION
### Describe your changes:

Testing if setting back the mvn-central repository to https://repo1.maven.org/maven2/ improves CI times