### PR TITLE
Fixes 578 - Add NLQ Search to Marketplace Search Bar

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataMarketplace/MarketplaceSearchBar/MarketplaceSearchBar.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataMarketplace/MarketplaceSearchBar/MarketplaceSearchBar.component.tsx
@@ -21,13 +21,19 @@ import { debounce } from 'lodash';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
+import { ReactComponent as IconSuggestionsActive } from '../../../assets/svg/ic-suggestions-active.svg';
+import { ReactComponent as IconSuggestionsBlue } from '../../../assets/svg/ic-suggestions-blue.svg';
 import { INITIAL_PAGING_VALUE } from '../../../constants/constants';
 import { SearchIndex } from '../../../enums/search.enum';
 import { DataProduct } from '../../../generated/entity/domains/dataProduct';
 import { Domain } from '../../../generated/entity/domains/domain';
 import { useMarketplaceRecentSearches } from '../../../hooks/useMarketplaceRecentSearches';
 import { useMarketplaceStore } from '../../../hooks/useMarketplaceStore';
-import { searchQuery } from '../../../rest/searchAPI';
+import {
+  getNLPEnabledStatus,
+  nlqSearch,
+  searchQuery,
+} from '../../../rest/searchAPI';
 import { getDataProductIconByUrl } from '../../../utils/DataProductUtils';
 import { getDomainIcon } from '../../../utils/DomainUtils';
 import { getDomainDetailsPath } from '../../../utils/RouterUtils';
@@ -40,6 +46,8 @@ const MarketplaceSearchBar = ({ isEditView }: { isEditView?: boolean }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { dataProductBasePath } = useMarketplaceStore();
+  const [isNLPEnabled, setIsNLPEnabled] = useState(true);
+  const [isNLQActive, setIsNLQActive] = useState(false);
   const [searchValue, setSearchValue] = useState('');
   const [isOpen, setIsOpen] = useState(false);
   const [dataProducts, setDataProducts] = useState<DataProduct[]>([]);
@@ -48,41 +56,73 @@ const MarketplaceSearchBar = ({ isEditView }: { isEditView?: boolean }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const { addSearch } = useMarketplaceRecentSearches();
 
-  const fetchResults = useCallback(async (query: string) => {
-    if (!query.trim()) {
-      setDataProducts([]);
-      setDomains([]);
-
-      return;
-    }
-    setIsSearching(true);
-    try {
-      const [dpRes, domainRes] = await Promise.all([
-        searchQuery({
-          query,
-          pageNumber: INITIAL_PAGING_VALUE,
-          pageSize: PAGE_SIZE,
-          searchIndex: SearchIndex.DATA_PRODUCT,
-        }),
-        searchQuery({
-          query,
-          pageNumber: INITIAL_PAGING_VALUE,
-          pageSize: PAGE_SIZE,
-          searchIndex: SearchIndex.DOMAIN,
-        }),
-      ]);
-
-      setDataProducts(
-        dpRes.hits.hits.map((hit) => hit._source) as DataProduct[]
-      );
-      setDomains(domainRes.hits.hits.map((hit) => hit._source) as Domain[]);
-    } catch {
-      setDataProducts([]);
-      setDomains([]);
-    } finally {
-      setIsSearching(false);
-    }
+  useEffect(() => {
+    getNLPEnabledStatus()
+      .then(setIsNLPEnabled)
+      .catch(() => setIsNLPEnabled(false));
   }, []);
+
+  const fetchResults = useCallback(
+    async (query: string) => {
+      if (!query.trim()) {
+        setDataProducts([]);
+        setDomains([]);
+
+        return;
+      }
+      setIsSearching(true);
+      try {
+        if (isNLPEnabled && isNLQActive) {
+          const res = await nlqSearch({
+            query,
+            pageNumber: INITIAL_PAGING_VALUE,
+            pageSize: PAGE_SIZE * 2,
+            searchIndex: SearchIndex.MARKETPLACE,
+          });
+
+          const hits = res.hits.hits;
+          setDataProducts(
+            hits
+              .filter((h) => h._source.entityType === SearchIndex.DATA_PRODUCT)
+              .slice(0, PAGE_SIZE)
+              .map((h) => h._source as unknown as DataProduct)
+          );
+          setDomains(
+            hits
+              .filter((h) => h._source.entityType === SearchIndex.DOMAIN)
+              .slice(0, PAGE_SIZE)
+              .map((h) => h._source as unknown as Domain)
+          );
+        } else {
+          const [dpRes, domainRes] = await Promise.all([
+            searchQuery({
+              query,
+              pageNumber: INITIAL_PAGING_VALUE,
+              pageSize: PAGE_SIZE,
+              searchIndex: SearchIndex.DATA_PRODUCT,
+            }),
+            searchQuery({
+              query,
+              pageNumber: INITIAL_PAGING_VALUE,
+              pageSize: PAGE_SIZE,
+              searchIndex: SearchIndex.DOMAIN,
+            }),
+          ]);
+
+          setDataProducts(
+            dpRes.hits.hits.map((hit) => hit._source) as DataProduct[]
+          );
+          setDomains(domainRes.hits.hits.map((hit) => hit._source) as Domain[]);
+        }
+      } catch {
+        setDataProducts([]);
+        setDomains([]);
+      } finally {
+        setIsSearching(false);
+      }
+    },
+    [isNLPEnabled, isNLQActive]
+  );
 
   const debouncedFetch = useMemo(
     () => debounce(fetchResults, 400),
@@ -248,27 +288,50 @@ const MarketplaceSearchBar = ({ isEditView }: { isEditView?: boolean }) => {
       className="marketplace-search-bar"
       data-testid="marketplace-search-bar"
       ref={containerRef}>
-      <Input
-        autoComplete="off"
-        data-testid="marketplace-search-input"
-        fontSize="sm"
-        icon={SearchLg}
-        iconClassName="tw:!size-4"
-        inputClassName="tw:!pl-9"
-        isDisabled={isEditView}
-        placeholder={t('label.search-for-type', {
-          type:
-            t('label.data-product-plural') + ', ' + t('label.domain-plural'),
-        })}
-        value={searchValue}
-        wrapperClassName="marketplace-search-input tw:!rounded-xl tw:!items-center tw:!py-1"
-        onChange={(value) => handleChange(value)}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') {
-            handleSearch(searchValue);
-          }
-        }}
-      />
+      <div className="tw:relative">
+        <div className="tw:absolute tw:left-3 tw:top-1/2 tw:-translate-y-1/2 tw:z-10 tw:flex tw:items-center">
+          {isNLPEnabled ? (
+            <button
+              className={`marketplace-nlq-button${
+                isNLQActive ? ' active' : ''
+              }`}
+              data-testid="marketplace-nlq-toggle"
+              title={
+                isNLQActive
+                  ? t('message.natural-language-search-active')
+                  : t('label.use-natural-language-search')
+              }
+              onClick={() => setIsNLQActive((prev) => !prev)}>
+              {isNLQActive ? (
+                <IconSuggestionsActive />
+              ) : (
+                <IconSuggestionsBlue />
+              )}
+            </button>
+          ) : (
+            <SearchLg className="tw:size-4 tw:text-text-tertiary" />
+          )}
+        </div>
+        <Input
+          autoComplete="off"
+          data-testid="marketplace-search-input"
+          fontSize="sm"
+          inputClassName="tw:!pl-11"
+          isDisabled={isEditView}
+          placeholder={t('label.search-for-type', {
+            type:
+              t('label.data-product-plural') + ', ' + t('label.domain-plural'),
+          })}
+          value={searchValue}
+          wrapperClassName="marketplace-search-input tw:!rounded-xl tw:!items-center tw:!py-1"
+          onChange={(value) => handleChange(value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              handleSearch(searchValue);
+            }
+          }}
+        />
+      </div>
       <SelectPopover
         isNonModal
         className="!tw:max-h-[400px]"

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataMarketplace/MarketplaceSearchBar/MarketplaceSearchBar.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataMarketplace/MarketplaceSearchBar/MarketplaceSearchBar.component.tsx
@@ -46,7 +46,7 @@ const MarketplaceSearchBar = ({ isEditView }: { isEditView?: boolean }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { dataProductBasePath } = useMarketplaceStore();
-  const [isNLPEnabled, setIsNLPEnabled] = useState(true);
+  const [isNLPEnabled, setIsNLPEnabled] = useState(false);
   const [isNLQActive, setIsNLQActive] = useState(false);
   const [searchValue, setSearchValue] = useState('');
   const [isOpen, setIsOpen] = useState(false);

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataMarketplace/MarketplaceSearchBar/MarketplaceSearchBar.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataMarketplace/MarketplaceSearchBar/MarketplaceSearchBar.test.tsx
@@ -1,0 +1,482 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import {
+  getNLPEnabledStatus,
+  nlqSearch,
+  searchQuery,
+} from '../../../rest/searchAPI';
+import MarketplaceSearchBar from './MarketplaceSearchBar.component';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock('../../../rest/searchAPI', () => ({
+  getNLPEnabledStatus: jest.fn().mockResolvedValue(true),
+  nlqSearch: jest.fn().mockResolvedValue({ hits: { hits: [] } }),
+  searchQuery: jest.fn().mockResolvedValue({ hits: { hits: [] } }),
+}));
+
+jest.mock('../../../hooks/useMarketplaceStore', () => ({
+  useMarketplaceStore: jest.fn().mockReturnValue({
+    dataProductBasePath: '/dataProduct',
+  }),
+}));
+
+jest.mock('../../../hooks/useMarketplaceRecentSearches', () => ({
+  useMarketplaceRecentSearches: jest.fn().mockReturnValue({
+    addSearch: jest.fn(),
+  }),
+}));
+
+jest.mock('../../../utils/DataProductUtils', () => ({
+  getDataProductIconByUrl: jest.fn().mockReturnValue(<span>dp-icon</span>),
+}));
+
+jest.mock('../../../utils/DomainUtils', () => ({
+  getDomainIcon: jest.fn().mockReturnValue(<span>domain-icon</span>),
+}));
+
+jest.mock('../../../utils/RouterUtils', () => ({
+  getDomainDetailsPath: jest.fn((fqn) => `/domain/${fqn}`),
+}));
+
+jest.mock('../../../utils/StringsUtils', () => ({
+  getEncodedFqn: jest.fn((fqn) => fqn),
+}));
+
+jest.mock('@openmetadata/ui-core-components', () => {
+  const Input = ({
+    value,
+    onChange,
+    onKeyDown,
+    placeholder,
+    isDisabled,
+    ...rest
+  }: {
+    value?: string;
+    onChange?: (val: string) => void;
+    onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+    placeholder?: string;
+    isDisabled?: boolean;
+  } & Record<string, unknown>) => (
+    <input
+      data-testid="marketplace-search-input"
+      disabled={isDisabled}
+      placeholder={placeholder}
+      value={value}
+      onChange={(e) => onChange?.(e.target.value)}
+      onKeyDown={onKeyDown}
+      {...rest}
+    />
+  );
+
+  const SelectPopover = ({
+    children,
+    isOpen,
+  }: {
+    children: React.ReactNode;
+    isOpen?: boolean;
+  }) => (isOpen ? <div data-testid="search-popover">{children}</div> : null);
+
+  const Typography = ({
+    children,
+    ...rest
+  }: {
+    children?: React.ReactNode;
+  } & Record<string, unknown>) => <span {...rest}>{children}</span>;
+
+  return { Input, SelectPopover, Typography };
+});
+
+jest.mock('@untitledui/icons', () => ({
+  SearchLg: () => <span data-testid="search-icon">search</span>,
+}));
+
+const mockDataProducts = [
+  {
+    id: 'dp-1',
+    name: 'product-one',
+    displayName: 'Product One',
+    fullyQualifiedName: 'domain.product-one',
+    style: { iconURL: '' },
+  },
+];
+
+const mockDomains = [
+  {
+    id: 'domain-1',
+    name: 'marketing',
+    displayName: 'Marketing',
+    fullyQualifiedName: 'marketing',
+    style: { iconURL: '' },
+  },
+];
+
+const renderComponent = (props = {}) =>
+  render(<MarketplaceSearchBar {...props} />, { wrapper: MemoryRouter });
+
+describe('MarketplaceSearchBar', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getNLPEnabledStatus as jest.Mock).mockResolvedValue(true);
+    (searchQuery as jest.Mock).mockResolvedValue({ hits: { hits: [] } });
+    (nlqSearch as jest.Mock).mockResolvedValue({ hits: { hits: [] } });
+  });
+
+  it('renders the search input', async () => {
+    await act(async () => {
+      renderComponent();
+    });
+
+    expect(screen.getByTestId('marketplace-search-bar')).toBeInTheDocument();
+    expect(screen.getByTestId('marketplace-search-input')).toBeInTheDocument();
+  });
+
+  it('shows NLQ toggle button when NLP is enabled', async () => {
+    await act(async () => {
+      renderComponent();
+    });
+
+    const toggleBtn = screen.getByTestId('marketplace-nlq-toggle');
+
+    expect(toggleBtn).toBeInTheDocument();
+    expect(toggleBtn).not.toHaveClass('active');
+  });
+
+  it('shows search icon fallback when NLP is disabled', async () => {
+    (getNLPEnabledStatus as jest.Mock).mockResolvedValue(false);
+
+    await act(async () => {
+      renderComponent();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('search-icon')).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('marketplace-nlq-toggle')
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it('toggles NLQ active state when the toggle button is clicked', async () => {
+    await act(async () => {
+      renderComponent();
+    });
+
+    const toggleBtn = screen.getByTestId('marketplace-nlq-toggle');
+
+    expect(toggleBtn).not.toHaveClass('active');
+    expect(toggleBtn).toHaveAttribute(
+      'title',
+      'label.use-natural-language-search'
+    );
+
+    await act(async () => {
+      fireEvent.click(toggleBtn);
+    });
+
+    expect(toggleBtn).toHaveClass('active');
+    expect(toggleBtn).toHaveAttribute(
+      'title',
+      'message.natural-language-search-active'
+    );
+
+    await act(async () => {
+      fireEvent.click(toggleBtn);
+    });
+
+    expect(toggleBtn).not.toHaveClass('active');
+  });
+
+  it('calls searchQuery for data products and domains on input change', async () => {
+    (searchQuery as jest.Mock).mockResolvedValue({
+      hits: { hits: mockDataProducts.map((dp) => ({ _source: dp })) },
+    });
+
+    await act(async () => {
+      renderComponent();
+    });
+
+    const input = screen.getByTestId('marketplace-search-input');
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'product' } });
+    });
+
+    await waitFor(() => {
+      expect(searchQuery).toHaveBeenCalledWith(
+        expect.objectContaining({ query: 'product' })
+      );
+    });
+  });
+
+  it('calls nlqSearch when NLQ is active and NLP is enabled', async () => {
+    (nlqSearch as jest.Mock).mockResolvedValue({ hits: { hits: [] } });
+
+    await act(async () => {
+      renderComponent();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('marketplace-nlq-toggle'));
+    });
+
+    const input = screen.getByTestId('marketplace-search-input');
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'revenue data' } });
+    });
+
+    await waitFor(() => {
+      expect(nlqSearch).toHaveBeenCalledWith(
+        expect.objectContaining({ query: 'revenue data' })
+      );
+    });
+  });
+
+  it('does not open popover when input is empty', async () => {
+    await act(async () => {
+      renderComponent();
+    });
+
+    const input = screen.getByTestId('marketplace-search-input');
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: '' } });
+    });
+
+    expect(screen.queryByTestId('search-popover')).not.toBeInTheDocument();
+  });
+
+  it('shows data product results in the popover', async () => {
+    (searchQuery as jest.Mock)
+      .mockResolvedValueOnce({
+        hits: { hits: mockDataProducts.map((dp) => ({ _source: dp })) },
+      })
+      .mockResolvedValueOnce({ hits: { hits: [] } });
+
+    await act(async () => {
+      renderComponent();
+    });
+
+    const input = screen.getByTestId('marketplace-search-input');
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'product' } });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('search-result-dp-dp-1')).toBeInTheDocument();
+      expect(screen.getByText('Product One')).toBeInTheDocument();
+    });
+  });
+
+  it('shows domain results in the popover', async () => {
+    (searchQuery as jest.Mock)
+      .mockResolvedValueOnce({ hits: { hits: [] } })
+      .mockResolvedValueOnce({
+        hits: { hits: mockDomains.map((d) => ({ _source: d })) },
+      });
+
+    await act(async () => {
+      renderComponent();
+    });
+
+    const input = screen.getByTestId('marketplace-search-input');
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'marketing' } });
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('search-result-domain-domain-1')
+      ).toBeInTheDocument();
+      expect(screen.getByText('Marketing')).toBeInTheDocument();
+    });
+  });
+
+  it('shows no-data message when search returns empty results', async () => {
+    (searchQuery as jest.Mock).mockResolvedValue({ hits: { hits: [] } });
+
+    await act(async () => {
+      renderComponent();
+    });
+
+    const input = screen.getByTestId('marketplace-search-input');
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'xyz-no-match' } });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('search-popover')).toBeInTheDocument();
+      expect(screen.getByText(/no-data-found/i)).toBeInTheDocument();
+    });
+  });
+
+  it('navigates to data product page when a result is clicked', async () => {
+    (searchQuery as jest.Mock)
+      .mockResolvedValueOnce({
+        hits: { hits: mockDataProducts.map((dp) => ({ _source: dp })) },
+      })
+      .mockResolvedValueOnce({ hits: { hits: [] } });
+
+    await act(async () => {
+      renderComponent();
+    });
+
+    const input = screen.getByTestId('marketplace-search-input');
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'product' } });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('search-result-dp-dp-1')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('search-result-dp-dp-1'));
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/dataProduct/domain.product-one',
+      { state: { fromMarketplace: true } }
+    );
+  });
+
+  it('navigates to domain page when a domain result is clicked', async () => {
+    (searchQuery as jest.Mock)
+      .mockResolvedValueOnce({ hits: { hits: [] } })
+      .mockResolvedValueOnce({
+        hits: { hits: mockDomains.map((d) => ({ _source: d })) },
+      });
+
+    await act(async () => {
+      renderComponent();
+    });
+
+    const input = screen.getByTestId('marketplace-search-input');
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'marketing' } });
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('search-result-domain-domain-1')
+      ).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('search-result-domain-domain-1'));
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('/domain/marketing', {
+      state: { fromMarketplace: true },
+    });
+  });
+
+  it('clears results and closes popover when input is cleared', async () => {
+    (searchQuery as jest.Mock)
+      .mockResolvedValueOnce({
+        hits: { hits: mockDataProducts.map((dp) => ({ _source: dp })) },
+      })
+      .mockResolvedValueOnce({ hits: { hits: [] } });
+
+    await act(async () => {
+      renderComponent();
+    });
+
+    const input = screen.getByTestId('marketplace-search-input');
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'product' } });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('search-popover')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: '' } });
+    });
+
+    expect(screen.queryByTestId('search-popover')).not.toBeInTheDocument();
+  });
+
+  it('does not search when component is in edit view', async () => {
+    await act(async () => {
+      renderComponent({ isEditView: true });
+    });
+
+    const input = screen.getByTestId('marketplace-search-input');
+
+    expect(input).toBeDisabled();
+  });
+
+  it('triggers search on Enter key press', async () => {
+    (searchQuery as jest.Mock).mockResolvedValue({ hits: { hits: [] } });
+
+    await act(async () => {
+      renderComponent();
+    });
+
+    const input = screen.getByTestId('marketplace-search-input');
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'test query' } });
+    });
+
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Enter' });
+    });
+
+    await waitFor(() => {
+      expect(searchQuery).toHaveBeenCalled();
+    });
+  });
+
+  it('handles search API error gracefully', async () => {
+    (searchQuery as jest.Mock).mockRejectedValue(new Error('API error'));
+
+    await act(async () => {
+      renderComponent();
+    });
+
+    const input = screen.getByTestId('marketplace-search-input');
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'error case' } });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('search-popover')).toBeInTheDocument();
+      expect(screen.getByText(/no-data-found/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataMarketplace/MarketplaceSearchBar/marketplace-search-bar.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataMarketplace/MarketplaceSearchBar/marketplace-search-bar.less
@@ -15,6 +15,34 @@
 .marketplace-search-bar {
   margin-bottom: 8px;
   position: relative;
+
+  .marketplace-nlq-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 0.5px solid @nlp-border-color;
+    border-radius: @border-rad-xs;
+    padding: 4px;
+    background-color: @primary-button-background;
+    cursor: pointer;
+
+    svg {
+      width: 14px;
+      height: 14px;
+      fill: transparent;
+    }
+
+    &.active {
+      padding: 0;
+      border: none;
+
+      svg {
+        width: 24px;
+        height: 24px;
+        fill: none;
+      }
+    }
+  }
 }
 
 .marketplace-search-results {

--- a/openmetadata-ui/src/main/resources/ui/src/enums/search.enum.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/enums/search.enum.ts
@@ -57,4 +57,5 @@ export enum SearchIndex {
   SPREADSHEET = 'spreadsheet',
   WORKSHEET = 'worksheet',
   KNOWLEDGE_PAGE_INDEX = 'page',
+  MARKETPLACE = 'marketplace',
 }

--- a/openmetadata-ui/src/main/resources/ui/src/interface/search.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/interface/search.interface.ts
@@ -49,6 +49,7 @@ import { DatabaseService } from '../generated/entity/services/databaseService';
 import { DriveService } from '../generated/entity/services/driveService';
 import { IngestionPipeline } from '../generated/entity/services/ingestionPipelines/ingestionPipeline';
 import { MessagingService } from '../generated/entity/services/messagingService';
+import { MetadataService } from '../generated/entity/services/metadataService';
 import { MlmodelService } from '../generated/entity/services/mlmodelService';
 import { PipelineService } from '../generated/entity/services/pipelineService';
 import { SearchService } from '../generated/entity/services/searchService';
@@ -210,6 +211,10 @@ export interface StorageServiceSearchSource
 
 export interface APIServiceSearchSource extends SearchSourceBase, APIService {}
 
+export interface MetadataServiceSearchSource
+  extends SearchSourceBase,
+    MetadataService {}
+
 export interface DriveServiceSearchSource
   extends SearchSourceBase,
     DriveService {}
@@ -308,6 +313,7 @@ export type SearchIndexSearchSourceMapping = {
   [SearchIndex.TEST_SUITE]: TestSuiteSearchSource;
   [SearchIndex.INGESTION_PIPELINE]: IngestionPipelineSearchSource;
   [SearchIndex.API_SERVICE]: APIServiceSearchSource;
+  [SearchIndex.METADATA_SERVICE]: MetadataServiceSearchSource;
   [SearchIndex.API_COLLECTION]: APICollectionSearchSource;
   [SearchIndex.API_ENDPOINT]: APIEndpointSearchSource;
   [SearchIndex.METRIC]: MetricSearchSource;
@@ -317,6 +323,7 @@ export type SearchIndexSearchSourceMapping = {
   [SearchIndex.WORKSHEET]: WorksheetSearchSource;
   [SearchIndex.COLUMN]: TableColumnSearchSource;
   [SearchIndex.KNOWLEDGE_PAGE_INDEX]: KnowledgePageSearchSource;
+  [SearchIndex.MARKETPLACE]: DataProductSearchSource | DomainSearchSource;
 };
 
 export type SearchRequest<


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Add NLQ Search to Marketplace Search Bar

MarketplaceSearchBar - Added a Natural Language Query (NLQ) toggle button inside the search input, matching the style of the global search bar's NLQ icon. The toggle is independent of the global search bar state - each has its own on/off state.

NLQ flow — When the toggle is active and NLP is enabled on the backend, the search calls nlqSearch with index=marketplace (the Elasticsearch alias covering both domain and dataProduct indexes). Results are split by entityType into data products and domains. Falls back to regular keyword search if NLQ is unavailable.
<img width="3024" height="1378" alt="image" src="https://github.com/user-attachments/assets/b004cb03-e402-41fb-a132-4b1059aeece1" />

Fixes https://github.com/open-metadata/ai-platform/issues/578
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **UI adjustments:**
  - Disabled `isNLPEnabled` state by default in `MarketplaceSearchBar` component to prevent premature NLQ activation.

<sub>This will update automatically on new commits.</sub>