### PR TITLE
fix(alerts): thread events now trigger entity-scoped notification alerts

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertUtil.java
@@ -25,6 +25,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -144,12 +145,8 @@ public final class AlertUtil {
     }
 
     // Trigger Specific Settings
-    if (event.getEntityType().equals(THREAD)
-        && (config.getResources().get(0).equals("announcement")
-            || config.getResources().get(0).equals("task")
-            || config.getResources().get(0).equals("conversation"))) {
-      Thread thread = AlertsRuleEvaluator.getThread(event);
-      return config.getResources().get(0).equalsIgnoreCase(thread.getType().value());
+    if (event.getEntityType().equals(THREAD)) {
+      return shouldTriggerAlertForThread(event, config.getResources().get(0));
     }
 
     // Test Suite
@@ -163,6 +160,22 @@ public final class AlertUtil {
     }
 
     return config.getResources().contains(event.getEntityType()); // Use Trigger Specific Settings
+  }
+
+  private static final Set<String> THREAD_TYPE_RESOURCES =
+      Set.of("announcement", "task", "conversation");
+
+  private static boolean shouldTriggerAlertForThread(ChangeEvent event, String resource) {
+    Thread thread = AlertsRuleEvaluator.getThread(event);
+    if (thread == null) {
+      return false;
+    }
+    if (THREAD_TYPE_RESOURCES.contains(resource.toLowerCase(Locale.ROOT))) {
+      return resource.equalsIgnoreCase(thread.getType().value());
+    }
+    // Entity-type resource (e.g., "glossaryTerm"): match threads whose parent entity type matches
+    return thread.getEntityRef() != null
+        && resource.equalsIgnoreCase(thread.getEntityRef().getType());
   }
 
   public static SubscriptionStatus buildSubscriptionStatus(

--- a/openmetadata-service/src/test/java/org/openmetadata/service/events/subscription/AlertUtilTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/events/subscription/AlertUtilTest.java
@@ -1,9 +1,20 @@
 package org.openmetadata.service.events.subscription;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.entity.events.FilteringRules;
+import org.openmetadata.schema.entity.feed.Thread;
+import org.openmetadata.schema.type.ChangeEvent;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.type.EventType;
+import org.openmetadata.schema.type.ThreadType;
+import org.openmetadata.service.Entity;
 
 class AlertUtilTest {
 
@@ -66,5 +77,190 @@ class AlertUtilTest {
     List<String> input = List.of("test''value");
     String result = AlertUtil.convertInputListToString(input);
     assertEquals("'test''''value'", result);
+  }
+
+  // ---- shouldTriggerAlert: null / "all" resource ----------------------------
+
+  @Test
+  void shouldTriggerAlert_nullConfig_returnsTrue() {
+    ChangeEvent event = entityChangeEvent("table");
+    assertTrue(AlertUtil.shouldTriggerAlert(event, null));
+  }
+
+  @Test
+  void shouldTriggerAlert_allResource_returnsTrue() {
+    ChangeEvent event = entityChangeEvent("glossaryTerm");
+    FilteringRules config = filteringRules("all");
+    assertTrue(AlertUtil.shouldTriggerAlert(event, config));
+  }
+
+  // ---- shouldTriggerAlert: entity change events ----------------------------
+
+  @Test
+  void shouldTriggerAlert_entityEvent_matchingResource_returnsTrue() {
+    ChangeEvent event = entityChangeEvent("glossaryTerm");
+    FilteringRules config = filteringRules("glossaryTerm");
+    assertTrue(AlertUtil.shouldTriggerAlert(event, config));
+  }
+
+  @Test
+  void shouldTriggerAlert_entityEvent_nonMatchingResource_returnsFalse() {
+    ChangeEvent event = entityChangeEvent("table");
+    FilteringRules config = filteringRules("glossaryTerm");
+    assertFalse(AlertUtil.shouldTriggerAlert(event, config));
+  }
+
+  // ---- shouldTriggerAlert: thread-type resource ("conversation" etc.) ------
+
+  @Test
+  void shouldTriggerAlert_conversationThread_conversationResource_returnsTrue() {
+    Thread thread =
+        new Thread()
+            .withId(UUID.randomUUID())
+            .withType(ThreadType.Conversation)
+            .withEntityRef(glossaryTermRef());
+    ChangeEvent event = threadChangeEvent(thread, EventType.THREAD_CREATED);
+    FilteringRules config = filteringRules("conversation");
+    assertTrue(AlertUtil.shouldTriggerAlert(event, config));
+  }
+
+  @Test
+  void shouldTriggerAlert_taskThread_conversationResource_returnsFalse() {
+    Thread thread =
+        new Thread()
+            .withId(UUID.randomUUID())
+            .withType(ThreadType.Task)
+            .withEntityRef(glossaryTermRef());
+    ChangeEvent event = threadChangeEvent(thread, EventType.TASK_CREATED);
+    FilteringRules config = filteringRules("conversation");
+    assertFalse(AlertUtil.shouldTriggerAlert(event, config));
+  }
+
+  @Test
+  void shouldTriggerAlert_taskThread_taskResource_returnsTrue() {
+    Thread thread =
+        new Thread()
+            .withId(UUID.randomUUID())
+            .withType(ThreadType.Task)
+            .withEntityRef(glossaryTermRef());
+    ChangeEvent event = threadChangeEvent(thread, EventType.TASK_CREATED);
+    FilteringRules config = filteringRules("task");
+    assertTrue(AlertUtil.shouldTriggerAlert(event, config));
+  }
+
+  @Test
+  void shouldTriggerAlert_announcementThread_announcementResource_returnsTrue() {
+    Thread thread =
+        new Thread()
+            .withId(UUID.randomUUID())
+            .withType(ThreadType.Announcement)
+            .withEntityRef(new EntityReference().withId(UUID.randomUUID()).withType("table"));
+    ChangeEvent event = threadChangeEvent(thread, EventType.THREAD_CREATED);
+    FilteringRules config = filteringRules("announcement");
+    assertTrue(AlertUtil.shouldTriggerAlert(event, config));
+  }
+
+  // ---- shouldTriggerAlert: entity-type resource for thread events ----------
+  // These are the bug cases: thread events on a GlossaryTerm should fire
+  // when the subscription resource is "glossaryTerm", not just "conversation".
+
+  @Test
+  void shouldTriggerAlert_conversationOnGlossaryTerm_glossaryTermResource_returnsTrue() {
+    Thread thread =
+        new Thread()
+            .withId(UUID.randomUUID())
+            .withType(ThreadType.Conversation)
+            .withEntityRef(glossaryTermRef());
+    ChangeEvent event = threadChangeEvent(thread, EventType.THREAD_CREATED);
+    FilteringRules config = filteringRules("glossaryTerm");
+    assertTrue(AlertUtil.shouldTriggerAlert(event, config));
+  }
+
+  @Test
+  void shouldTriggerAlert_threadUpdateOnGlossaryTerm_glossaryTermResource_returnsTrue() {
+    Thread thread =
+        new Thread()
+            .withId(UUID.randomUUID())
+            .withType(ThreadType.Conversation)
+            .withEntityRef(glossaryTermRef());
+    ChangeEvent event = threadChangeEvent(thread, EventType.THREAD_UPDATED);
+    FilteringRules config = filteringRules("glossaryTerm");
+    assertTrue(AlertUtil.shouldTriggerAlert(event, config));
+  }
+
+  @Test
+  void shouldTriggerAlert_postCreatedOnGlossaryTerm_glossaryTermResource_returnsTrue() {
+    Thread thread =
+        new Thread()
+            .withId(UUID.randomUUID())
+            .withType(ThreadType.Conversation)
+            .withEntityRef(glossaryTermRef());
+    ChangeEvent event = threadChangeEvent(thread, EventType.POST_CREATED);
+    FilteringRules config = filteringRules("glossaryTerm");
+    assertTrue(AlertUtil.shouldTriggerAlert(event, config));
+  }
+
+  @Test
+  void shouldTriggerAlert_threadOnTable_glossaryTermResource_returnsFalse() {
+    Thread thread =
+        new Thread()
+            .withId(UUID.randomUUID())
+            .withType(ThreadType.Conversation)
+            .withEntityRef(new EntityReference().withId(UUID.randomUUID()).withType("table"));
+    ChangeEvent event = threadChangeEvent(thread, EventType.THREAD_CREATED);
+    FilteringRules config = filteringRules("glossaryTerm");
+    assertFalse(AlertUtil.shouldTriggerAlert(event, config));
+  }
+
+  @Test
+  void shouldTriggerAlert_threadOnTable_tableResource_returnsTrue() {
+    Thread thread =
+        new Thread()
+            .withId(UUID.randomUUID())
+            .withType(ThreadType.Conversation)
+            .withEntityRef(new EntityReference().withId(UUID.randomUUID()).withType("table"));
+    ChangeEvent event = threadChangeEvent(thread, EventType.THREAD_CREATED);
+    FilteringRules config = filteringRules("table");
+    assertTrue(AlertUtil.shouldTriggerAlert(event, config));
+  }
+
+  @Test
+  void shouldTriggerAlert_threadWithNullEntityRef_entityTypeResource_returnsFalse() {
+    Thread thread =
+        new Thread()
+            .withId(UUID.randomUUID())
+            .withType(ThreadType.Conversation)
+            .withEntityRef(null);
+    ChangeEvent event = threadChangeEvent(thread, EventType.THREAD_CREATED);
+    FilteringRules config = filteringRules("glossaryTerm");
+    assertFalse(AlertUtil.shouldTriggerAlert(event, config));
+  }
+
+  // ---- helpers ---------------------------------------------------------------
+
+  private static ChangeEvent entityChangeEvent(String entityType) {
+    return new ChangeEvent()
+        .withId(UUID.randomUUID())
+        .withEventType(EventType.ENTITY_UPDATED)
+        .withEntityType(entityType);
+  }
+
+  private static ChangeEvent threadChangeEvent(Thread thread, EventType eventType) {
+    return new ChangeEvent()
+        .withId(UUID.randomUUID())
+        .withEventType(eventType)
+        .withEntityType(Entity.THREAD)
+        .withEntity(thread);
+  }
+
+  private static FilteringRules filteringRules(String resource) {
+    return new FilteringRules()
+        .withResources(List.of(resource))
+        .withRules(Collections.emptyList())
+        .withActions(Collections.emptyList());
+  }
+
+  private static EntityReference glossaryTermRef() {
+    return new EntityReference().withId(UUID.randomUUID()).withType("glossaryTerm");
   }
 }


### PR DESCRIPTION
Related to #27889 (partial fix — see Scope below)


## Problem

Users configured Notification Alerts for entity types (e.g. **GlossaryTerm**) and selected **Thread Creation** / **Thread Update** event types expecting email notifications when conversations were posted on their glossary terms. No events appeared in the **Recent Events** tab and no emails were sent. Alerts for **Entity Change** on the same subscription worked correctly.

---

## Root Cause Analysis

### How thread change events are produced

When a thread is created (`POST /api/v1/feed`), `FeedResource` sets a custom header:

```java
// FeedResource.java:421
return Response.created(thread.getHref())
    .entity(thread)
    .header(CHANGE_CUSTOM_HEADER, THREAD_CREATED)
    .build();
```

`ChangeEventHandler` intercepts the response and calls `FormatterUtil.createChangeEventForThread()`, which produces a `ChangeEvent` with:

```
entityType = "THREAD"   ← constant Entity.THREAD, NOT the parent entity's type
eventType  = THREAD_CREATED / THREAD_UPDATED / POST_CREATED
entity     = Thread object (with entityRef pointing to the GlossaryTerm)
```

The event is stored in `change_event` table — so the events **are persisted** correctly.

---

### Where the events were dropped

`AbstractEventConsumer.publishEvents()` calls `AlertUtil.getFilteredEvents()` → `checkIfChangeEventIsAllowed()` → **`shouldTriggerAlert()`**.

Before the fix, `shouldTriggerAlert()` had two paths for thread events:

```java
// Path 1 — only matches if resource is "conversation" / "task" / "announcement"
if (event.getEntityType().equals(THREAD)
    && (config.getResources().get(0).equals("announcement")
        || config.getResources().get(0).equals("task")
        || config.getResources().get(0).equals("conversation"))) {
  Thread thread = AlertsRuleEvaluator.getThread(event);
  return config.getResources().get(0).equalsIgnoreCase(thread.getType().value());
}

// Path 2 — fallback for all other events
return config.getResources().contains(event.getEntityType());
//  ["glossaryTerm"].contains("THREAD")  →  false  ❌
```

When a user creates a **GlossaryTerm** alert:
- `config.getResources()` = `["glossaryTerm"]`
- Path 1 condition: `"glossaryTerm".equals("announcement" | "task" | "conversation")` → **false** — skipped
- Path 2: `["glossaryTerm"].contains("THREAD")` → **false** — event dropped

The thread event is filtered out **before** `evaluateAlertConditions()` even runs, so the `matchAnyEventType("threadCreated", "threadUpdated")` rule never gets a chance to evaluate.

---

### Why Entity Change events worked

Entity change events on a GlossaryTerm carry `entityType = "glossaryTerm"` (the actual entity type), not a constant. Path 2 correctly evaluates:

```
["glossaryTerm"].contains("glossaryTerm")  →  true  ✅
```

---

### Thread-type resources ("conversation" / "task" / "announcement") also worked

If a user created an alert with resource = `"conversation"`, Path 1 matched and the thread's `ThreadType` was compared against the resource. This path was correct and is preserved by the fix.

---

## Fix

Extracted `shouldTriggerAlertForThread()` to consolidate both thread-matching cases:

```java
// AlertUtil.java — before
if (event.getEntityType().equals(THREAD)
    && (config.getResources().get(0).equals("announcement")
        || config.getResources().get(0).equals("task")
        || config.getResources().get(0).equals("conversation"))) {
  Thread thread = AlertsRuleEvaluator.getThread(event);
  return config.getResources().get(0).equalsIgnoreCase(thread.getType().value());
}

// AlertUtil.java — after
if (event.getEntityType().equals(THREAD)) {
  return shouldTriggerAlertForThread(event, config.getResources().get(0));
}

private static boolean shouldTriggerAlertForThread(ChangeEvent event, String resource) {
  Thread thread = AlertsRuleEvaluator.getThread(event);
  if (thread == null) {
    return false;
  }
  // Thread-type resource ("conversation", "task", "announcement"): existing behaviour
  if (THREAD_TYPE_RESOURCES.contains(resource.toLowerCase(Locale.ROOT))) {
    return resource.equalsIgnoreCase(thread.getType().value());
  }
  // Entity-type resource ("glossaryTerm", "table", …): match via the thread's parent entity type
  return thread.getEntityRef() != null
      && resource.equalsIgnoreCase(thread.getEntityRef().getType());
}
```

The two dispatch cases are now explicit:

| Resource type | Example | How it matches |
|---|---|---|
| Thread-type | `conversation`, `task`, `announcement` | `thread.getType().value()` (unchanged) |
| Entity-type | `glossaryTerm`, `table`, `dashboard`, … | `thread.getEntityRef().getType()` (**new**) |

---

## Files Changed

| File | Change |
|---|---|
| `openmetadata-service/.../events/subscription/AlertUtil.java` | Bug fix + `shouldTriggerAlertForThread()` helper |
| `openmetadata-service/.../events/subscription/AlertUtilTest.java` | 14 new unit tests |

---

## Tests

14 new unit tests added to `AlertUtilTest` — covering every branch of the fixed logic:

| Test | Asserts |
|---|---|
| `shouldTriggerAlert_nullConfig_returnsTrue` | null config always passes |
| `shouldTriggerAlert_allResource_returnsTrue` | `"all"` resource always passes |
| `shouldTriggerAlert_entityEvent_matchingResource_returnsTrue` | entity event matches its resource |
| `shouldTriggerAlert_entityEvent_nonMatchingResource_returnsFalse` | entity event rejects wrong resource |
| `shouldTriggerAlert_conversationThread_conversationResource_returnsTrue` | existing conversation→conversation path preserved |
| `shouldTriggerAlert_taskThread_conversationResource_returnsFalse` | task thread rejected by conversation resource |
| `shouldTriggerAlert_taskThread_taskResource_returnsTrue` | task thread matches task resource |
| `shouldTriggerAlert_announcementThread_announcementResource_returnsTrue` | announcement thread matches announcement resource |
| **`shouldTriggerAlert_conversationOnGlossaryTerm_glossaryTermResource_returnsTrue`** | **bug fix — THREAD_CREATED fires for glossaryTerm alert** |
| **`shouldTriggerAlert_threadUpdateOnGlossaryTerm_glossaryTermResource_returnsTrue`** | **bug fix — THREAD_UPDATED fires for glossaryTerm alert** |
| **`shouldTriggerAlert_postCreatedOnGlossaryTerm_glossaryTermResource_returnsTrue`** | **bug fix — POST_CREATED fires for glossaryTerm alert** |
| **`shouldTriggerAlert_threadOnTable_glossaryTermResource_returnsFalse`** | thread on wrong entity type is correctly rejected |
| **`shouldTriggerAlert_threadOnTable_tableResource_returnsTrue`** | **bug fix — works for any entity type, not just glossaryTerm** |
| **`shouldTriggerAlert_threadWithNullEntityRef_entityTypeResource_returnsFalse`** | null entityRef handled safely, no NPE |

All 23 tests in `AlertUtilTest` pass (`Tests run: 23, Failures: 0, Errors: 0`).

---

## How to Reproduce (before fix)

1. Create a Notification Alert → resource: **GlossaryTerm** → add `filterByEventType` with `threadCreated` / `threadUpdated`
2. Add a conversation to any GlossaryTerm
3. Observe: **Recent Events tab shows nothing**, no email sent
4. Create an alert for the same GlossaryTerm with `entityUpdated` → works immediately

---

## Scope

Fixes the customer-reported reproduction in #27889: resource `glossaryTerm` + filter `threadCreated` / `threadUpdated` / `postCreated`.

Does **not** fix (still open after this merges):
- `TaskResource.resolveTask` / `closeTask` emit no change events.
- `taskCreated` / `taskUpdated` `EventType` values are never emitted by any code.
- `AlertsUtil.tsx` offers every `EventType` regardless of selected resource.
