### PR TITLE
fix(profiler): restore unique constraint dropped in 1.9.9 — 1.12.9 backport (#3488)

### DIFF
--- a/bootstrap/sql/migrations/native/1.12.9/mysql/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.12.9/mysql/schemaChanges.sql
@@ -1,0 +1,5 @@
+-- Placeholder for 1.12.9 MySQL schema changes
+-- The Postgres-side fix for collate#3488 has no MySQL counterpart: MySQL's
+-- 1.1.5 unique constraint on profiler_data_time_series was never dropped
+-- (MODIFY COLUMN re-evaluates generated expressions in place), so the
+-- regression that hit Postgres did not affect MySQL.

--- a/bootstrap/sql/migrations/native/1.12.9/postgres/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/1.12.9/postgres/schemaChanges.sql
@@ -1,0 +1,14 @@
+-- Restore the unique constraint dropped in 1.9.9. Closes the 1.9.9 regression that caused
+-- /columns?fields=profile 504s, and brings Postgres back in line with MySQL (which never
+-- lost it). The leading (entityFQNHash, extension) prefix serves the column-profile batch query.
+-- Two-phase: CONCURRENTLY build avoids ACCESS EXCLUSIVE lock; ADD CONSTRAINT USING INDEX
+-- promotes the built index without re-scanning.
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS
+    profiler_data_time_series_unique_hash_extension_ts
+    ON profiler_data_time_series (entityFQNHash, extension, operation, timestamp);
+
+ALTER TABLE profiler_data_time_series
+    ADD CONSTRAINT profiler_data_time_series_unique_hash_extension_ts
+    UNIQUE USING INDEX profiler_data_time_series_unique_hash_extension_ts;
+
+ANALYZE profiler_data_time_series;

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TableResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TableResourceIT.java
@@ -5141,4 +5141,141 @@ public class TableResourceIT extends BaseEntityIT<Table, CreateTable> {
       assertFalse(table.getTags().isEmpty(), "Table tags should not be empty");
     }
   }
+
+  // ===================================================================
+  // REGRESSION TEST - columns API with fields=profile (collate#3488)
+  // ===================================================================
+
+  @Test
+  @Execution(ExecutionMode.SAME_THREAD)
+  void test_getColumnsWithProfileField_correctnessAndNoBatchRegression(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+    DatabaseSchema schema = DatabaseSchemaTestFactory.createSimple(ns, service);
+
+    CreateClassification createClassification =
+        new CreateClassification()
+            .withName(ns.prefix("cls"))
+            .withDescription("Classification for profile regression test");
+    Classification cls = client.classifications().create(createClassification);
+
+    CreateTag createTag =
+        new CreateTag()
+            .withName(ns.prefix("tag"))
+            .withDescription("Tag for profile regression test")
+            .withClassification(cls.getName());
+    Tag tag = client.tags().create(createTag);
+
+    TagLabel tagLabel =
+        new TagLabel()
+            .withTagFQN(tag.getFullyQualifiedName())
+            .withSource(TagLabel.TagSource.CLASSIFICATION);
+
+    Column idCol = ColumnBuilder.of("id", "BIGINT").primaryKey().notNull().build();
+    idCol.setTags(List.of(tagLabel));
+    Column emailCol = ColumnBuilder.of("email", "VARCHAR").dataLength(255).build();
+    emailCol.setTags(List.of(tagLabel));
+    Column nameCol = ColumnBuilder.of("name", "VARCHAR").dataLength(255).build();
+
+    CreateTable createRequest = createRequest(ns.prefix("profile_regression_table"), ns);
+    createRequest.setDatabaseSchema(schema.getFullyQualifiedName());
+    createRequest.setColumns(List.of(idCol, emailCol, nameCol));
+    Table table = client.tables().create(createRequest);
+
+    Long timestamp = System.currentTimeMillis();
+    ColumnProfile idProfile =
+        new ColumnProfile()
+            .withName("id")
+            .withMin(1.0)
+            .withMax(999.0)
+            .withUniqueCount(100.0)
+            .withTimestamp(timestamp);
+    ColumnProfile emailProfile =
+        new ColumnProfile()
+            .withName("email")
+            .withNullCount(5.0)
+            .withNullProportion(0.05)
+            .withTimestamp(timestamp);
+
+    TableProfile tableProfile =
+        new TableProfile().withRowCount(100.0).withColumnCount(3.0).withTimestamp(timestamp);
+
+    CreateTableProfile createProfile =
+        new CreateTableProfile()
+            .withTableProfile(tableProfile)
+            .withColumnProfile(List.of(idProfile, emailProfile));
+    client.tables().updateTableProfile(table.getId(), createProfile);
+
+    // Verify the three field combinations exercised below don't regress:
+    // (a) fields=profile — completes within 30s and returns the expected column profiles
+    TableColumnList withProfile =
+        assertTimeout(
+            Duration.ofSeconds(30),
+            () -> client.tables().getColumns(table.getId(), "profile"),
+            "columns?fields=profile should complete within 30s");
+
+    assertEquals(3, withProfile.getData().size());
+    Column returnedId =
+        withProfile.getData().stream()
+            .filter(c -> "id".equals(c.getName()))
+            .findFirst()
+            .orElse(null);
+    Column returnedName =
+        withProfile.getData().stream()
+            .filter(c -> "name".equals(c.getName()))
+            .findFirst()
+            .orElse(null);
+    assertNotNull(returnedId, "id column should be present");
+    assertNotNull(returnedId.getProfile(), "id column should have profile data");
+    assertEquals(1.0, returnedId.getProfile().getMin(), "id column min should match");
+    assertEquals(999.0, returnedId.getProfile().getMax(), "id column max should match");
+    assertNotNull(returnedName, "name column should be present");
+    assertNull(returnedName.getProfile(), "name column has no profile, should be null");
+
+    // (b) fields=tags,customMetrics,extension,profile — the exact production query
+    TableColumnList withAllFields =
+        assertTimeout(
+            Duration.ofSeconds(30),
+            () -> client.tables().getColumns(table.getId(), "tags,customMetrics,extension,profile"),
+            "columns?fields=tags,customMetrics,extension,profile should complete within 30s");
+
+    assertEquals(3, withAllFields.getData().size());
+
+    Column idResult =
+        withAllFields.getData().stream()
+            .filter(c -> "id".equals(c.getName()))
+            .findFirst()
+            .orElse(null);
+    assertNotNull(idResult, "id column must be present");
+    assertNotNull(idResult.getProfile(), "id column must have profile");
+    assertNotNull(idResult.getTags(), "id column must have tags");
+    assertFalse(idResult.getTags().isEmpty(), "id column tags must not be empty");
+    assertTrue(
+        idResult.getTags().stream()
+            .anyMatch(t -> tag.getFullyQualifiedName().equals(t.getTagFQN())),
+        "id column should carry the test tag");
+
+    // (c) fields=tags,profile — both tags and profile are populated correctly when requested
+    TableColumnList withTagsAndProfile =
+        assertTimeout(
+            Duration.ofSeconds(30),
+            () -> client.tables().getColumns(table.getId(), "tags,profile"),
+            "columns?fields=tags,profile should complete within 30s");
+
+    Column idTagsAndProfile =
+        withTagsAndProfile.getData().stream()
+            .filter(c -> "id".equals(c.getName()))
+            .findFirst()
+            .orElse(null);
+    assertNotNull(idTagsAndProfile, "id column must be present");
+    assertNotNull(idTagsAndProfile.getProfile(), "id column must have profile");
+    assertEquals(
+        1.0, idTagsAndProfile.getProfile().getMin(), "id column min should match in tags+profile");
+    assertNotNull(idTagsAndProfile.getTags(), "id column must have tags");
+    assertTrue(
+        idTagsAndProfile.getTags().stream()
+            .anyMatch(t -> tag.getFullyQualifiedName().equals(t.getTagFQN())),
+        "id column should carry the test tag in tags+profile");
+  }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -1426,6 +1426,13 @@ public interface CollectionDAO {
     List<ExtensionRecord> getExtensions(
         @BindUUID("id") UUID id, @Bind("extensionPrefix") String extensionPrefix);
 
+    @RegisterRowMapper(ExtensionMapper.class)
+    @SqlQuery(
+        "SELECT extension, json FROM entity_extension WHERE id = :id AND jsonschema = :jsonSchema "
+            + "ORDER BY extension")
+    List<ExtensionRecord> getExtensionsByJsonSchema(
+        @BindUUID("id") UUID id, @Bind("jsonSchema") String jsonSchema);
+
     @ConnectionAwareSqlQuery(
         value =
             "SELECT json FROM ("

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
@@ -149,6 +149,7 @@ public class TableRepository extends EntityRepository<Table> {
   public static final String TABLE_COLUMN_EXTENSION = "table.column";
   public static final String TABLE_EXTENSION = "table.table";
   public static final String CUSTOM_METRICS_EXTENSION = "customMetrics.";
+  public static final String COLUMN_EXTENSION_JSON_SCHEMA = "columnExtension";
   public static final String TABLE_PROFILER_CONFIG = "tableProfilerConfig";
 
   public static final String COLUMN_FIELD = "columns";
@@ -1827,6 +1828,21 @@ public class TableRepository extends EntityRepository<Table> {
     return null;
   }
 
+  private Map<String, List<CustomMetric>> batchFetchCustomMetricsByColumn(UUID tableId) {
+    List<ExtensionRecord> records =
+        daoCollection
+            .entityExtensionDAO()
+            .getExtensions(tableId, CUSTOM_METRICS_EXTENSION + TABLE_COLUMN_EXTENSION);
+    Map<String, List<CustomMetric>> metricsByColumn = new HashMap<>();
+    for (ExtensionRecord record : records) {
+      CustomMetric metric = JsonUtils.readValue(record.extensionJson(), CustomMetric.class);
+      if (metric != null && metric.getColumnName() != null) {
+        metricsByColumn.computeIfAbsent(metric.getColumnName(), k -> new ArrayList<>()).add(metric);
+      }
+    }
+    return metricsByColumn;
+  }
+
   private List<CustomMetric> getCustomMetrics(Table table, String columnName) {
     String extension = columnName != null ? TABLE_COLUMN_EXTENSION : TABLE_EXTENSION;
     extension = CUSTOM_METRICS_EXTENSION + extension;
@@ -2395,20 +2411,43 @@ public class TableRepository extends EntityRepository<Table> {
     }
 
     if (fieldsParam != null && fieldsParam.contains("customMetrics")) {
+      Map<String, List<CustomMetric>> metricsByColumn =
+          batchFetchCustomMetricsByColumn(table.getId());
       for (Column column : paginatedColumns) {
-        column.setCustomMetrics(getCustomMetrics(table, column.getName()));
+        column.setCustomMetrics(metricsByColumn.getOrDefault(column.getName(), List.of()));
       }
     }
 
     if (fieldsParam != null && fieldsParam.contains("extension")) {
+      List<ExtensionRecord> allColumnExtensions =
+          daoCollection
+              .entityExtensionDAO()
+              .getExtensionsByJsonSchema(table.getId(), COLUMN_EXTENSION_JSON_SCHEMA);
+      Map<String, Object> extensionByColumnHash = new HashMap<>();
+      for (ExtensionRecord record : allColumnExtensions) {
+        try {
+          extensionByColumnHash.put(
+              record.extensionName(), JsonUtils.readValue(record.extensionJson(), Object.class));
+        } catch (Exception e) {
+          LOG.warn(
+              "Failed to deserialize column extension for table {} extensionKey {}: {}",
+              table.getId(),
+              record.extensionName(),
+              e.getMessage());
+        }
+      }
       for (Column column : paginatedColumns) {
-        column.setExtension(getColumnExtension(table.getId(), column.getFullyQualifiedName()));
+        column.setExtension(
+            extensionByColumnHash.get(
+                FullyQualifiedName.buildHash(column.getFullyQualifiedName())));
       }
     }
 
     if (fieldsParam != null && fieldsParam.contains("profile")) {
       setColumnProfile(paginatedColumns);
-      populateEntityFieldTags(entityType, paginatedColumns, table.getFullyQualifiedName(), true);
+      if (!fieldsParam.contains("tags")) {
+        populateEntityFieldTags(entityType, paginatedColumns, table.getFullyQualifiedName(), true);
+      }
       paginatedColumns =
           PIIMasker.getTableProfile(
               table.getFullyQualifiedName(), paginatedColumns, authorizer, securityContext);
@@ -2729,8 +2768,10 @@ public class TableRepository extends EntityRepository<Table> {
 
     Fields fields = getFields(fieldsParam);
     if (fields.contains("customMetrics") || fields.contains("*")) {
+      Map<String, List<CustomMetric>> metricsByColumn =
+          batchFetchCustomMetricsByColumn(table.getId());
       for (Column column : paginatedResults) {
-        column.setCustomMetrics(getCustomMetrics(table, column.getName()));
+        column.setCustomMetrics(metricsByColumn.getOrDefault(column.getName(), List.of()));
       }
     }
 


### PR DESCRIPTION
Backport of #27746 to **1.12.9**.

## Scope

Everything from #27746 except the SQL fix to `getLatestExtensionsBatch` (that method does not exist on 1.12.x — it was introduced by the separate `setColumnProfile` batch refactor in #25751 on main).

Commits in this PR:

1. **`fix(profiler): restore unique constraint dropped in 1.9.9`** — the migration that closes the regression (primary fix, 10,000× speedup).
2. **`fix(profiler): backport applicable N+1 batches and IT regression`** — defence-in-depth on top.

## Root cause (recap)

1.9.9 dropped the Postgres unique constraint `profiler_data_time_series_unique_hash_extension_ts (entityFQNHash, extension, operation, timestamp)` to alter the generated `operation` column expression — and never recreated it. Without an index on `entityFQNHash`, the per-column profile query was seq-scanning the entire table; customers with millions of profiler rows hit 6-minute 504s on `/columns?fields=profile`.

MySQL was unaffected: `MODIFY COLUMN` re-evaluates the generated expression in place without touching the constraint, so MySQL retained it from 1.1.5.

## Fix

### Postgres migration — restores the unique constraint

```sql
CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS
    profiler_data_time_series_unique_hash_extension_ts
    ON profiler_data_time_series (entityFQNHash, extension, operation, timestamp);

ALTER TABLE profiler_data_time_series
    ADD CONSTRAINT profiler_data_time_series_unique_hash_extension_ts
    UNIQUE USING INDEX profiler_data_time_series_unique_hash_extension_ts;

ANALYZE profiler_data_time_series;
```

`CONCURRENTLY` avoids `ACCESS EXCLUSIVE` lock; `ADD CONSTRAINT USING INDEX` promotes the built index via catalog flip without re-scanning. `IF NOT EXISTS` makes it idempotent.

MySQL file is a placeholder explaining no-op.

### Java N+1 batches (defence-in-depth)

| Location | Change |
|---|---|
| `TableRepository.getTableColumnsInternal` — `customMetrics` block | One `entityExtensionDAO.getExtensions(tableId, prefix)` call grouped by column name |
| `TableRepository.getTableColumnsInternal` — `extension` block | New `entityExtensionDAO.getExtensionsByJsonSchema(tableId, "columnExtension")` keyed by hashed FQN |
| `TableRepository.getTableColumnsInternal` — `profile` block | Skip duplicate `populateEntityFieldTags` when `tags` already requested |
| `TableRepository.searchTableColumnsInternal` — `customMetrics` block | Same batch helper as above |
| `CollectionDAO.EntityExtensionDAO` | New `getExtensionsByJsonSchema(id, jsonSchema)` |

### IT regression test

`TableResourceIT.test_getColumnsWithProfileField_correctnessAndNoBatchRegression` — asserts the three production field combinations (`?fields=profile`, `?fields=tags,customMetrics,extension,profile`, `?fields=tags,profile`) return correct profile/tag attribution within a 30s timeout.

## Not backported

- SQL fix to `getLatestExtensionsBatch` — method introduced by #25751 on main, not present on 1.12.x. The 1.12.x `setColumnProfile` is per-column N+1; the index alone fixes the customer-visible issue. Re-introducing the upstream batch refactor would expand scope significantly.

## Test plan

- [x] `mvn compile spotless:check` clean on `openmetadata-service`
- [x] `mvn test-compile spotless:check` clean on `openmetadata-integration-tests`
- [x] Migration uses `IF NOT EXISTS` + `CONCURRENTLY` guards (idempotent, no lock storm)
- [x] Full perf validation already done on #27746 (10,000× speedup on 6.94M-row pdts)
- [ ] CI on this PR validates IT runtime