### PR TITLE
refactor(powerbi): trim tile-pinned report registry to set[str]

### DIFF
--- a/ingestion/src/metadata/ingestion/source/dashboard/powerbi/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/powerbi/metadata.py
@@ -743,9 +743,7 @@ class PowerbiSource(DashboardServiceSource):
                 )
                 return
             tile_report_ids = [
-                chart.reportId
-                for chart in dashboard_details.tiles or []
-                if self.state.is_known_report(chart.reportId)
+                chart.reportId for chart in dashboard_details.tiles or [] if self.state.is_known_report(chart.reportId)
             ]
         except Exception as exc:  # pylint: disable=broad-except
             yield Either(

--- a/ingestion/src/metadata/ingestion/source/dashboard/powerbi/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/powerbi/metadata.py
@@ -743,10 +743,9 @@ class PowerbiSource(DashboardServiceSource):
                 )
                 return
             tile_report_ids = [
-                report.id
+                chart.reportId
                 for chart in dashboard_details.tiles or []
-                for report in [self.state.find_report(chart.reportId)]
-                if report is not None
+                if self.state.is_known_report(chart.reportId)
             ]
         except Exception as exc:  # pylint: disable=broad-except
             yield Either(

--- a/ingestion/src/metadata/ingestion/source/dashboard/powerbi/workspace_state.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/powerbi/workspace_state.py
@@ -37,15 +37,17 @@ DataModelLike = Dataset | Dataflow
 class WorkspaceState:
     """State container for PowerBI workspace iteration.
 
-    Per-workspace caches released on `exit`. Cross-workspace report
-    registry persists for the whole run (tile-pinned lineage needs it).
+    Per-workspace caches released on `exit`. Cross-workspace report-id
+    registry persists for the whole run (tile-pinned lineage needs it
+    to verify that a tile's referenced report exists somewhere in the
+    tenant; only the id is required, not the report payload).
     """
 
     def __init__(self) -> None:
         self._current: Group | None = None
         self._datasets_by_id: dict[str, Dataset] = {}
         self._dataflow_exports: dict[str, DataflowExportResponse] = {}
-        self._reports_by_id: dict[str, PowerBIReport] = {}
+        self._known_report_ids: set[str] = set()
         self._filtered_dashboards: list[DashboardLike] = []
         self._filtered_datamodels: list[DataModelLike] | None = None
         self._dashboard_charts: dict[str, list[str]] = {}
@@ -67,7 +69,7 @@ class WorkspaceState:
         self._filtered_datamodels = None
         self._dashboard_charts = {}
         for report in workspace.reports or []:
-            self._reports_by_id[report.id] = report
+            self._known_report_ids.add(report.id)
 
     def exit(self) -> None:
         """Release per-workspace caches. Idempotent. Cross-workspace report registry persists."""
@@ -91,9 +93,9 @@ class WorkspaceState:
         """Look up a dataset by id in the current workspace."""
         return self._datasets_by_id.get(dataset_id)
 
-    def find_report(self, report_id: str | None) -> PowerBIReport | None:
-        """Look up a report by id across all workspaces entered so far."""
-        return self._reports_by_id.get(report_id) if report_id else None
+    def is_known_report(self, report_id: str | None) -> bool:
+        """Return True if `report_id` was seen in any workspace entered so far."""
+        return report_id is not None and report_id in self._known_report_ids
 
     def cache_dataflow_export(self, key: str, export: DataflowExportResponse) -> None:
         """Memoise a dataflow export for the current workspace's lineage stage."""

--- a/ingestion/tests/unit/topology/dashboard/test_powerbi_workspace_state.py
+++ b/ingestion/tests/unit/topology/dashboard/test_powerbi_workspace_state.py
@@ -126,10 +126,10 @@ def test_reports_registry_persists_across_workspaces(state, ws_a, ws_b):
     state.exit()
     state.enter(ws_b)
     state.exit()
-    assert state.find_report("r_a1") is not None
-    assert state.find_report("r_b1") is not None
-    assert state.find_report(None) is None
-    assert state.find_report("nonexistent") is None
+    assert state.is_known_report("r_a1") is True
+    assert state.is_known_report("r_b1") is True
+    assert state.is_known_report(None) is False
+    assert state.is_known_report("nonexistent") is False
 
 
 # -- Dashboard charts: operation-shaped consume API ---------------------


### PR DESCRIPTION
### Describe your changes:

Follow-up to #28098.

#28098 introduced `WorkspaceState._reports_by_id: dict[str, PowerBIReport]` as a cross-workspace registry so tile-pinned report → dashboard lineage can resolve report IDs that live in a different workspace. The dict stored the full `PowerBIReport` pydantic model per id, but its only consumer (`create_report_dashboard_lineage`) reads exactly one attribute — `report.id`, which equals the lookup key tautologically. The registry's actual semantic value is set membership.

This PR replaces `dict[str, PowerBIReport]` with `set[str]`, renames `find_report(id) -> Optional[PowerBIReport]` to `is_known_report(id) -> bool`, and simplifies the lineage call site to collect `chart.reportId` directly when present in the registry.

### Type of change:
- [x] Improvement

### High-level design:

The change is mechanical:

- `WorkspaceState._reports_by_id: dict[str, PowerBIReport]` → `WorkspaceState._known_report_ids: set[str]`
- `enter()` populates the set with `report.id` instead of the full model
- `find_report(id)` → `is_known_report(id) -> bool`
- Call site in `create_report_dashboard_lineage`: the previous comprehension used a `for report in [find_report(...)]` idiom to bind a temp var; now it filters on `is_known_report(chart.reportId)` and collects `chart.reportId` directly (which equals `report.id` from the lookup)

**Memory impact at 100k retained reports** (admin scans set `getArtifactUsers=True`, so the populated-users rows are the realistic case):

| Shape | RSS delta for 100k reports |
| --- | --- |
| `dict[str, PowerBIReport]`, no users | ~278 MB |
| `dict[str, PowerBIReport]`, 5 users/report | ~896 MB |
| `dict[str, PowerBIReport]`, 20 users/report | ~2.2 GB |
| `set[str]` (any user fanout) | ~5 MB |

For tenants with thousands of workspaces and tens of thousands of reports, this drops the registry's upper bound by ~180–400x and removes the residual scaling concern left after #28098.

### Tests:

#### Unit tests
Updated `test_powerbi_workspace_state.py` assertions from `find_report(...) is not None` to `is_known_report(...) is True`. Existing `test_powerbi.py` integration tests cover the lineage call site unchanged.

- `ingestion/tests/unit/topology/dashboard/test_powerbi_workspace_state.py`
- `ingestion/tests/unit/topology/dashboard/test_powerbi.py`

Local run: 59/59 pass.

#### Manual testing performed

Verified end-to-end on a real PowerBI tenant in OpenMetadata (1.12.8 release branch, where this refactor was developed first as a follow-up to the cherry-pick of #28098):

1. Ran `metadata ingest` against the same tenant with five service names — four baseline runs (pre-refactor) and one with the `set[str]` refactor applied.
2. Counted lineage edges per service via `/api/v1/lineage/dashboard/{id}`.
3. All five runs produced **47 identical edges**: 8 tile-pinned `dashboard → dashboard` (the edges this registry is responsible for) + 38 `dashboardDataModel → dashboard` + 1 `table → dashboardDataModel`.
4. 8/8 tile-pinned edges resolve correctly with the new set-based check.

No regression in lineage topology.

### UI screen recording / screenshots:

Not applicable.

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests (unit) and listed them above.

----
## Summary by Gitar

- **Registry optimization:**
  - Replaced `dict[str, PowerBIReport]` with `set[str]` in `WorkspaceState` to optimize memory usage by up to 400x.
  - Refactored `find_report` to `is_known_report` returning `bool` to reflect simplified registry membership checks.
- **Robustness improvements:**
  - Added safety checks for `None` names across multiple metadata entities (`dashboard`, `table`, `column`, `dataset`, `dataflow`, `attribute`) to prevent ingestion failures.
  - Enhanced lineage generation logic to filter out nameless entities and attributes that previously triggered noisy errors.

<sub>This will update automatically on new commits.</sub>