### PR TITLE
fix(tasks): emit change events on Task resolve/close/applySuggestion

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TaskResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TaskResourceIT.java
@@ -15,6 +15,9 @@ package org.openmetadata.it.tests;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
@@ -3721,5 +3724,75 @@ public class TaskResourceIT extends BaseEntityIT<Task, CreateTask> {
                   task.getAvailableTransitions().isEmpty(),
                   "workflow transitions should be available before bulk resolution");
             });
+  }
+
+  // Issue #27889: Task resolve/close must emit change events so subscriptions on
+  // `task + taskResolved` / `taskClosed` actually fire. Pre-fix, the endpoints returned
+  // `Response.ok(...).build()` with no CHANGE_CUSTOM_HEADER, so ChangeEventHandler
+  // never produced a ChangeEvent for these turnarounds.
+
+  @Test
+  void testResolveTaskEmitsTaskResolvedChangeEventHeader(TestNamespace ns) throws Exception {
+    Task task =
+        createEntity(
+            new CreateTask()
+                .withName(ns.prefix("resolve-emits-event"))
+                .withCategory(TaskCategory.Approval)
+                .withType(TaskEntityType.GlossaryApproval));
+
+    String body =
+        JsonUtils.pojoToJson(
+            new ResolveTask()
+                .withResolutionType(TaskResolutionType.Approved)
+                .withComment("emit-change-event"));
+
+    HttpResponse<String> response =
+        sendDirectJson("POST", String.format("/v1/tasks/%s/resolve", task.getId()), body);
+
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        "taskResolved",
+        response.headers().firstValue("X-OpenMetadata-Change").orElse(null),
+        "resolve endpoint must set X-OpenMetadata-Change=taskResolved so the change event is emitted");
+  }
+
+  @Test
+  void testCloseTaskEmitsTaskClosedChangeEventHeader(TestNamespace ns) throws Exception {
+    Task task =
+        createEntity(
+            new CreateTask()
+                .withName(ns.prefix("close-emits-event"))
+                .withCategory(TaskCategory.Approval)
+                .withType(TaskEntityType.GlossaryApproval));
+
+    HttpResponse<String> response =
+        sendDirectJson(
+            "POST",
+            String.format("/v1/tasks/%s/close?comment=emit-change-event", task.getId()),
+            "");
+
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        "taskClosed",
+        response.headers().firstValue("X-OpenMetadata-Change").orElse(null),
+        "close endpoint must set X-OpenMetadata-Change=taskClosed so the change event is emitted");
+  }
+
+  private static HttpResponse<String> sendDirectJson(String method, String path, String body)
+      throws Exception {
+    String url = SdkClients.getServerUrl() + "/api" + path;
+    HttpRequest.Builder builder =
+        HttpRequest.newBuilder()
+            .uri(URI.create(url))
+            .header("Authorization", "Bearer " + SdkClients.getAdminToken())
+            .header("Content-Type", "application/json")
+            .timeout(Duration.ofSeconds(30));
+    HttpRequest.BodyPublisher publisher =
+        body == null || body.isEmpty()
+            ? HttpRequest.BodyPublishers.noBody()
+            : HttpRequest.BodyPublishers.ofString(body);
+    HttpRequest request = builder.method(method, publisher).build();
+    return java.net.http.HttpClient.newHttpClient()
+        .send(request, HttpResponse.BodyHandlers.ofString());
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/tasks/TaskResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/tasks/TaskResource.java
@@ -14,7 +14,10 @@
 package org.openmetadata.service.resources.tasks;
 
 import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
+import static org.openmetadata.schema.type.EventType.TASK_CLOSED;
+import static org.openmetadata.schema.type.EventType.TASK_RESOLVED;
 import static org.openmetadata.service.security.DefaultAuthorizer.getSubjectContext;
+import static org.openmetadata.service.util.RestUtil.CHANGE_CUSTOM_HEADER;
 
 import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
@@ -803,7 +806,7 @@ public class TaskResource extends EntityResource<Task, TaskRepository> {
             resolvedPayload,
             comment,
             userName);
-    return Response.ok(resolvedTask).build();
+    return Response.ok(resolvedTask).header(CHANGE_CUSTOM_HEADER, TASK_RESOLVED).build();
   }
 
   private ListFilter buildTaskListFilter(
@@ -976,7 +979,7 @@ public class TaskResource extends EntityResource<Task, TaskRepository> {
     repository.checkPermissionsForResolveTask(authorizer, task, true, securityContext);
 
     Task closedTask = repository.closeTask(task, userName, comment);
-    return Response.ok(closedTask).build();
+    return Response.ok(closedTask).header(CHANGE_CUSTOM_HEADER, TASK_CLOSED).build();
   }
 
   @DELETE
@@ -1053,7 +1056,7 @@ public class TaskResource extends EntityResource<Task, TaskRepository> {
             null,
             null,
             userName);
-    return Response.ok(resolvedTask).build();
+    return Response.ok(resolvedTask).header(CHANGE_CUSTOM_HEADER, TASK_RESOLVED).build();
   }
 
   // ========================= Bulk Operations Endpoint =========================


### PR DESCRIPTION
## Problem

`TaskResource.resolveTask` (`POST /api/v1/tasks/{id}/resolve`), `closeTask` (`POST /api/v1/tasks/{id}/close`), and `applySuggestion` (`POST /api/v1/tasks/{id}/applySuggestion`) all returned `Response.ok(resolvedTask).build()` with **no** `X-OpenMetadata-Change` header. The JAX-RS response filter `ChangeEventHandler` only emits a `ChangeEvent` when that header is present (or when the status is `CREATED`), so:

- No row appeared in `change_event` for resolve/close turnarounds.
- `EventSubscription`s on `resource: task + filterByEventType: [taskResolved, taskClosed]` could never fire — empty Recent Events, no email, no webhook.
- The semantically most meaningful Task transitions were invisible to audit, alerts, and downstream consumers.

This regression was introduced by the Task System Redesign (#25894), which moved Task from a Thread sub-type to a first-class entity. The legacy `/v1/feed/tasks/{id}/resolve|close` routes still emit `TASK_RESOLVED` / `TASK_CLOSED` via `FeedRepository`, but the new `TaskResource` endpoints did not.

## Fix

Set `CHANGE_CUSTOM_HEADER` on the three affected responses:

| Endpoint                                | Event emitted     |
|-----------------------------------------|-------------------|
| `POST /v1/tasks/{id}/resolve`           | `taskResolved`    |
| `POST /v1/tasks/{id}/close`             | `taskClosed`      |
| `POST /v1/tasks/{id}/applySuggestion`   | `taskResolved`    |

`FormatterUtil.createChangeEventForEntity` then builds a `ChangeEvent` with `entityType="task"` and `entity=<Task>`, which `ChangeEventHandler` persists and forwards to `EventSubscription` consumers — restoring parity with the legacy route and the eventType values already declared in `changeEventType.json`.

## Tests

Two new integration tests in `TaskResourceIT`:

- `testResolveTaskEmitsTaskResolvedChangeEventHeader` — asserts `X-OpenMetadata-Change: taskResolved` on `/resolve`.
- `testCloseTaskEmitsTaskClosedChangeEventHeader` — asserts `X-OpenMetadata-Change: taskClosed` on `/close`.

Both use a direct `java.net.http.HttpClient` call (the SDK's `HttpClient` doesn't expose response headers). Tests use `TestNamespace` for isolation and run safely under `@Execution(ExecutionMode.CONCURRENT)`.

`applySuggestion` follows the same one-line pattern; given the same `FormatterUtil` machinery handles all three identically, a focused header test on resolve+close is sufficient to prove the wiring. A future PR can extend coverage when Suggestion-task setup helpers are needed for unrelated reasons.

## Scope

Related to #27889 (do **not** auto-close — three other problems remain). This PR addresses **only** the missing change-event emission for `resolve` / `close` / `applySuggestion` on the new `TaskResource`.

### Out of scope — needs separate work / design call

1. **Bulk operations endpoint** (`POST /v1/tasks/bulk`) processes multiple tasks in one HTTP request. The single-valued `X-OpenMetadata-Change` header can't express N events; fixing this needs per-task event emission from inside `TaskWorkflowHandler` rather than via the response filter. Tracked separately.

2. **Orphan `taskCreated` / `taskUpdated` `EventType` values** are declared in `changeEventType.json` but emitted nowhere in `openmetadata-service`. The new `TaskResource` emits `entityCreated` / `entityUpdated` like every other entity. Needs a design call: drop from the enum, or have `TaskResource` emit `TASK_CREATED` / `TASK_UPDATED` instead.

3. **UI alert builder** (`AlertsUtil.tsx`) still populates `filterByEventType` from the entire `EventType` enum regardless of selected resource. Users can continue to save unreachable combinations. Depends on the outcome of (2) before the resource→eventTypes mapping can be defined.
