### PR TITLE
fix(ui): render named icons (e.g. Globe01) in Data Products widget

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataProductUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataProductUtils.tsx
@@ -52,6 +52,7 @@ import {
 
 import { getEntityName } from './EntityUtils';
 import { t } from './i18next/LocalUtil';
+import { renderIcon } from './IconUtils';
 import {
   getPrioritizedEditPermission,
   getPrioritizedViewPermission,
@@ -83,14 +84,13 @@ export interface DataProductDetailPageTabProps {
  * @returns JSX element representing the icon
  */
 export const getDataProductIconByUrl = (iconURL?: string) => {
-  if (iconURL) {
-    return (
-      <img
-        alt="data product icon"
-        className="data-product-icon-url"
-        src={iconURL}
-      />
-    );
+  const iconElement = renderIcon(iconURL, {
+    size: 24,
+    className: 'tw:h-6 tw:w-6',
+  });
+
+  if (iconElement) {
+    return iconElement;
   }
 
   return <DefaultDataProductIcon className="data-product-default-icon" />;
@@ -337,7 +337,8 @@ export const DataProductListItemRenderer = (props: EntityReference) => {
           ellipsis={{
             tooltip: props.description,
             rows: 2,
-          }}>
+          }}
+        >
           <RichTextEditorPreviewerV1 markdown={props.description} />
         </Typography.Paragraph>
       )}


### PR DESCRIPTION
## Summary

- The Data Products home-page widget rendered a Data Product's `style.iconURL` directly as `<img src>`. When that value is an Untitled UI icon name (e.g. `Globe01`) instead of a URL, the browser fetched a relative path and showed a broken image. The details page and list page resolve the same value correctly via `renderIcon` / `ICON_MAP`, which is why the bug was only visible on the widget.
- The "+ Add Data Product" drawer on the list page uses `AddDomainForm`'s `MUIIconPicker` (`FieldTypes.ICON_PICKER_MUI`), which writes canonical names like `Globe01` into `style.iconURL`, so this code path is exercised whenever a user picks an icon at creation time — no manual API call needed to reproduce.
- Route `getDataProductIconByUrl` through [`renderIcon`](https://github.com/open-metadata/OpenMetadata/blob/1.12.9/openmetadata-ui/src/main/resources/ui/src/utils/IconUtils.tsx#L167) so named icons, URL icons, and the default fallback all behave consistently with the rest of the app.
- Backport of the `DataProductUtils.tsx` portion of `b949ccade7` from `main`. The original regression was introduced by #23486 (the data-products-widget PR) and was fixed on `main` as part of the marketplace work but never landed on the 1.12.x line.

Companion PR for 1.12.8: #28141.

## Test plan

- [ ] `yarn test src/components/MyData/Widgets/DataProductsWidget/DataProductsWidget.test.tsx`
- [ ] `yarn lint`
- [ ] Manual: home-page widget shows the Globe icon for a Data Product whose `style.iconURL = "Globe01"`
- [ ] Manual: widget still works for a Data Product with an HTTPS URL `iconURL`
- [ ] Manual: widget falls back to `DefaultDataProductIcon` when `iconURL` is empty
- [ ] Manual: details page and list page icons unchanged (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)