### PR TITLE
refactor(sampler): collapse SamplerInterface to a single typed config object

### DIFF
--- a/docs/auto-classification/add-support-for-another-entity.md
+++ b/docs/auto-classification/add-support-for-another-entity.md
@@ -480,13 +480,8 @@ class YourEntityAdapter(EntityAdapter):
             "service_connection_config": deepcopy(config.source.serviceConnection.root.config),
             "ometa_client": metadata,
             "entity": entity,
-            # schema_entity, database_entity, and table_config are Database-specific;
-            # pass None for non-database entities.
-            "schema_entity": None,
-            "database_entity": None,
-            "table_config": None,
-            "default_sample_config": SampleConfig(),
-            "default_sample_data_count": source_config.sampleDataCount,
+            "sample_config": SampleConfig(),
+            "sample_data_count": source_config.sampleDataCount,
         }
 ```
 
@@ -634,6 +629,8 @@ class YourServiceSampler(SamplerInterface):
         )
 ```
 
+**No `create()` override needed:** `SamplerInterface.create()` is now a pure constructor that simply forwards its arguments to `__init__()`. Non-database samplers inherit it as-is — no override required.
+
 #### 3.5 Update Sampler Processor — No Changes Required
 
 `ingestion/src/metadata/sampler/processor.py` does **not** need to change. It resolves the service type and dispatches via the adapter registry:
@@ -645,8 +642,10 @@ self.service_type = _adapter.service_type             # ServiceType.Messaging
 
 # _run — picks up the new entity class automatically:
 adapter = adapter_for(entity)                         # finds TopicAdapter
-sampler_kwargs = adapter.build_sampler_kwargs(...)
+sampler_kwargs = adapter.build_sampler_kwargs(...)    # returns pre-resolved sampling values
 ```
+
+Config resolution (partition_details, sample_query, include/exclude columns, sample_config, sample_data_count) now happens inside `build_sampler_kwargs()`, so `SamplerInterface.create()` receives already-resolved values ready to initialize the sampler.
 
 The only file to change is `entity_adapters.py` (step 3.2).
 
@@ -1226,6 +1225,7 @@ Before submitting your PR, verify:
 ### Ingestion (Python)
 - [ ] `ClassifiableEntityType` union in `pii/types.py` includes new entity
 - [ ] `EntityAdapter` subclass added in `sampler/entity_adapters.py` with correct `pipeline_config_class`, `service_type`, `patch_fields`, `get_columns`, `set_columns`, `build_sampler_kwargs`
+- [ ] `build_sampler_kwargs` returns pre-resolved sampling values (`sample_config`, `sample_data_count`, etc.) — do NOT include `schema_entity`, `database_entity`, or `table_config` for non-database entities; those are database-specific and no longer part of `SamplerInterface.create()`
 - [ ] New adapter registered in `_BY_ENTITY` and `_BY_PIPELINE` dicts in `entity_adapters.py`
 - [ ] Fetcher strategy created for service type
 - [ ] Sampler implementation created for connector(s)
@@ -1292,6 +1292,8 @@ Before submitting your PR, verify:
 9. **Service type not found at startup**: If you see `ValueError: Could not determine service type from config`, the pipeline config class is not registered in `_BY_PIPELINE` in `entity_adapters.py`. Register it there — the sampler processor does not need any code changes.
 
 10. **Sample data not dispatched in sink**: `_ingest_entity_sample_data` in `metadata_rest.py` uses `@singledispatchmethod`. If you forget to add a `@register` for your entity type, calling it raises `NotImplementedError` and sample data is silently skipped. The column tag path (`patch_column_tags`) is fully adapter-driven and needs no sink changes — but sample data storage does require its own `@register`.
+
+11. **Passing `schema_entity=None` explicitly in non-database adapters:** `SamplerInterface.create()` no longer accepts `schema_entity`, `database_entity`, or `table_config`. These were removed from the interface entirely. Non-database adapters should return already-resolved values (`sample_config`, `sample_data_count`, `partition_details`, etc.) directly in `build_sampler_kwargs()` — not the database hierarchy params.
 
 ---
 

--- a/docs/auto-classification/add-support-for-another-entity.md
+++ b/docs/auto-classification/add-support-for-another-entity.md
@@ -480,8 +480,9 @@ class YourEntityAdapter(EntityAdapter):
             "service_connection_config": deepcopy(config.source.serviceConnection.root.config),
             "ometa_client": metadata,
             "entity": entity,
-            "sample_config": SampleConfig(),
-            "sample_data_count": source_config.sampleDataCount,
+            "config": SamplerConfig(
+                sample_data_count=source_config.sampleDataCount,
+            ),
         }
 ```
 

--- a/ingestion/src/metadata/data_quality/runner/base_test_suite_source.py
+++ b/ingestion/src/metadata/data_quality/runner/base_test_suite_source.py
@@ -33,11 +33,15 @@ from metadata.generated.schema.metadataIngestion.workflow import (
 )
 from metadata.generated.schema.type.entityReference import EntityReference
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
-from metadata.sampler.models import (
-    SampleConfig,
+from metadata.sampler.config import (
+    get_profile_sample_config,
+    get_sample_data_count_config,
 )
+from metadata.sampler.models import SampleConfig
+from metadata.sampler.sampler_config import DatabaseSamplerConfig
 from metadata.sampler.sampler_interface import SamplerInterface  # noqa: TC001
 from metadata.utils.bigquery_utils import copy_service_config
+from metadata.utils.constants import SAMPLE_DATA_DEFAULT_COUNT
 from metadata.utils.profiler_utils import get_context_entities
 from metadata.utils.service_spec.service_spec import (
     import_sampler_class,
@@ -115,17 +119,30 @@ class BaseTestSuiteRunner:
             source_type=self._interface_type,
             source_config_type=self.service_conn_config.type.value,
         )
-        # This is shared between the sampler and DQ interfaces
+        default_sample_config = SampleConfig(
+            profileSampleConfig=self.source_config.profileSampleConfig
+            if self.source_config.profileSampleConfig
+            else None,
+        )
         sampler_interface: SamplerInterface = sampler_class.create(
             service_connection_config=self.service_conn_config,
             ometa_client=self.ometa_client,
             entity=self.entity,
-            schema_entity=schema_entity,
-            database_entity=database_entity,
-            default_sample_config=SampleConfig(
-                profileSampleConfig=self.source_config.profileSampleConfig
-                if self.source_config.profileSampleConfig
-                else None,
+            config=DatabaseSamplerConfig(
+                sample_config=get_profile_sample_config(
+                    entity=self.entity,
+                    schema_entity=schema_entity,
+                    database_entity=database_entity,
+                    entity_config=None,
+                    default_sample_config=default_sample_config,
+                ),
+                sample_data_count=get_sample_data_count_config(
+                    entity=self.entity,
+                    schema_entity=schema_entity,
+                    database_entity=database_entity,
+                    entity_config=None,
+                    default_sample_data_count=SAMPLE_DATA_DEFAULT_COUNT,
+                ),
             ),
         )
 

--- a/ingestion/src/metadata/data_quality/runner/base_test_suite_source.py
+++ b/ingestion/src/metadata/data_quality/runner/base_test_suite_source.py
@@ -34,8 +34,11 @@ from metadata.generated.schema.metadataIngestion.workflow import (
 from metadata.generated.schema.type.entityReference import EntityReference
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.sampler.config import (
+    get_exclude_columns,
+    get_include_columns,
     get_profile_sample_config,
     get_sample_data_count_config,
+    get_sample_query,
 )
 from metadata.sampler.models import SampleConfig
 from metadata.sampler.partition import get_partition_details
@@ -145,6 +148,9 @@ class BaseTestSuiteRunner:
                     default_sample_data_count=SAMPLE_DATA_DEFAULT_COUNT,
                 ),
                 partition_details=get_partition_details(self.entity),
+                sample_query=get_sample_query(entity=self.entity, entity_config=None),
+                include_columns=get_include_columns(self.entity, entity_config=None) or [],
+                exclude_columns=get_exclude_columns(self.entity, entity_config=None) or [],
             ),
         )
 

--- a/ingestion/src/metadata/data_quality/runner/base_test_suite_source.py
+++ b/ingestion/src/metadata/data_quality/runner/base_test_suite_source.py
@@ -38,6 +38,7 @@ from metadata.sampler.config import (
     get_sample_data_count_config,
 )
 from metadata.sampler.models import SampleConfig
+from metadata.sampler.partition import get_partition_details
 from metadata.sampler.sampler_config import DatabaseSamplerConfig
 from metadata.sampler.sampler_interface import SamplerInterface  # noqa: TC001
 from metadata.utils.bigquery_utils import copy_service_config
@@ -143,6 +144,7 @@ class BaseTestSuiteRunner:
                     entity_config=None,
                     default_sample_data_count=SAMPLE_DATA_DEFAULT_COUNT,
                 ),
+                partition_details=get_partition_details(self.entity),
             ),
         )
 

--- a/ingestion/src/metadata/profiler/source/database/base/profiler_source.py
+++ b/ingestion/src/metadata/profiler/source/database/base/profiler_source.py
@@ -45,9 +45,15 @@ from metadata.sampler.config import (
     get_config_for_table,
     get_exclude_columns,
     get_include_columns,
+    get_profile_sample_config,
+    get_sample_data_count_config,
+    get_sample_query,
 )
 from metadata.sampler.models import SampleConfig
+from metadata.sampler.partition import get_partition_details
+from metadata.sampler.sampler_config import DatabaseSamplerConfig
 from metadata.sampler.sampler_interface import SamplerInterface  # noqa: TC001
+from metadata.utils.constants import SAMPLE_DATA_DEFAULT_COUNT
 from metadata.utils.dependency_injector.dependency_injector import (
     DependencyNotFoundError,
     Inject,
@@ -176,17 +182,33 @@ class ProfilerSource(ProfilerSourceInterface):
             source_type=self._interface_type,
         )
 
-        # This is shared between the sampler and profiler interfaces
+        default_sample_config = self._build_default_sample_config()
         sampler_interface: SamplerInterface = sampler_class.create(
             service_connection_config=self.service_conn_config,
             ometa_client=self.ometa_client,
             entity=entity,
-            schema_entity=schema_entity,
-            database_entity=database_entity,
-            table_config=config,
-            default_sample_config=self._build_default_sample_config(),
-            # TODO: Change this when we have the processing engine configuration implemented. Right now it does nothing.
-            processing_engine=self.get_processing_engine(self.source_config),
+            config=DatabaseSamplerConfig(
+                sample_config=get_profile_sample_config(
+                    entity=entity,
+                    schema_entity=schema_entity,
+                    database_entity=database_entity,
+                    entity_config=config,
+                    default_sample_config=default_sample_config,
+                ),
+                sample_data_count=get_sample_data_count_config(
+                    entity=entity,
+                    schema_entity=schema_entity,
+                    database_entity=database_entity,
+                    entity_config=config,
+                    default_sample_data_count=SAMPLE_DATA_DEFAULT_COUNT,
+                ),
+                include_columns=get_include_columns(entity, entity_config=config) or [],
+                exclude_columns=get_exclude_columns(entity, entity_config=config) or [],
+                partition_details=get_partition_details(entity=entity, entity_config=config),
+                sample_query=get_sample_query(entity=entity, entity_config=config),
+                # TODO: Change this when we have the processing engine configuration implemented.
+                processing_engine=self.get_processing_engine(self.source_config),
+            ),
         )
 
         profiler_interface: ProfilerInterface = profiler_class.create(

--- a/ingestion/src/metadata/sampler/entity_adapters.py
+++ b/ingestion/src/metadata/sampler/entity_adapters.py
@@ -41,9 +41,18 @@ from metadata.generated.schema.metadataIngestion.databaseServiceAutoClassificati
 from metadata.generated.schema.metadataIngestion.storageServiceAutoClassificationPipeline import (
     StorageServiceAutoClassificationPipeline,
 )
-from metadata.sampler.config import get_config_for_table
+from metadata.sampler.config import (
+    get_config_for_table,
+    get_exclude_columns,
+    get_include_columns,
+    get_profile_sample_config,
+    get_sample_data_count_config,
+    get_sample_query,
+)
 from metadata.sampler.config_utils import build_database_service_conn_config
 from metadata.sampler.models import SampleConfig
+from metadata.sampler.partition import get_partition_details
+from metadata.sampler.sampler_config import DatabaseSamplerConfig, StorageSamplerConfig
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -129,15 +138,31 @@ class TableAdapter(EntityAdapter[Table]):
         schema_entity, database_entity, _ = get_context_entities(entity=entity, metadata=metadata)
         if database_entity is None:
             return None
+        table_config = get_config_for_table(entity, profiler_config)
         return {
             "service_connection_config": build_database_service_conn_config(config, database_entity),
             "ometa_client": metadata,
             "entity": entity,
-            "schema_entity": schema_entity,
-            "database_entity": database_entity,
-            "table_config": get_config_for_table(entity, profiler_config),
-            "default_sample_config": SampleConfig(),
-            "default_sample_data_count": source_config.sampleDataCount,
+            "config": DatabaseSamplerConfig(
+                sample_config=get_profile_sample_config(
+                    entity=entity,
+                    schema_entity=schema_entity,
+                    database_entity=database_entity,
+                    entity_config=table_config,
+                    default_sample_config=SampleConfig(),
+                ),
+                sample_data_count=get_sample_data_count_config(
+                    entity=entity,
+                    schema_entity=schema_entity,
+                    database_entity=database_entity,
+                    entity_config=table_config,
+                    default_sample_data_count=source_config.sampleDataCount,
+                ),
+                include_columns=get_include_columns(entity, entity_config=table_config) or [],
+                exclude_columns=get_exclude_columns(entity, entity_config=table_config) or [],
+                partition_details=get_partition_details(entity=entity, entity_config=table_config),
+                sample_query=get_sample_query(entity=entity, entity_config=table_config),
+            ),
         }
 
 
@@ -168,11 +193,9 @@ class ContainerAdapter(EntityAdapter[Container]):
             "service_connection_config": deepcopy(config.source.serviceConnection.root.config),
             "ometa_client": metadata,
             "entity": entity,
-            "schema_entity": None,
-            "database_entity": None,
-            "table_config": None,
-            "default_sample_config": SampleConfig(),
-            "default_sample_data_count": source_config.sampleDataCount,
+            "config": StorageSamplerConfig(
+                sample_data_count=source_config.sampleDataCount,
+            ),
         }
 
 

--- a/ingestion/src/metadata/sampler/nosql/sampler.py
+++ b/ingestion/src/metadata/sampler/nosql/sampler.py
@@ -16,9 +16,11 @@ from metadata.generated.schema.entity.data.table import TableData
 from metadata.generated.schema.type.basic import ProfileSampleType
 from metadata.profiler.adaptors.factory import factory
 from metadata.profiler.adaptors.nosql_adaptor import NoSQLAdaptor
+from metadata.sampler.sampler_config import DatabaseSamplerConfig
 from metadata.sampler.sampler_interface import SamplerInterface
 from metadata.utils.constants import SAMPLE_DATA_DEFAULT_COUNT
 from metadata.utils.sqa_like_column import SQALikeColumn
+from metadata.utils.ssl_manager import get_ssl_connection
 
 
 class NoSQLSampler(SamplerInterface):
@@ -28,6 +30,9 @@ class NoSQLSampler(SamplerInterface):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        db_config = kwargs.get("config") or DatabaseSamplerConfig()
+        self.connection = get_ssl_connection(self.service_connection_config)
+        self.sample_query: str | None = db_config.sample_query
         self.client = self.get_client()
 
     @property

--- a/ingestion/src/metadata/sampler/pandas/sampler.py
+++ b/ingestion/src/metadata/sampler/pandas/sampler.py
@@ -21,10 +21,12 @@ from metadata.generated.schema.entity.data.table import (
 )
 from metadata.generated.schema.type.basic import ProfileSampleType
 from metadata.mixins.pandas.pandas_mixin import PandasInterfaceMixin
+from metadata.sampler.sampler_config import DatabaseSamplerConfig
 from metadata.sampler.sampler_interface import SamplerInterface
 from metadata.utils.datalake.datalake_utils import GenericDataFrameColumnParser
 from metadata.utils.logger import profiler_logger
 from metadata.utils.sqa_like_column import SQALikeColumn
+from metadata.utils.ssl_manager import get_ssl_connection
 
 logger = profiler_logger()
 
@@ -38,7 +40,10 @@ class DatalakeSampler(SamplerInterface, PandasInterfaceMixin):
     def __init__(self, *args, **kwargs):
         """Init the pandas sampler"""
         super().__init__(*args, **kwargs)
-        self.partition_details = cast(PartitionProfilerConfig, self.partition_details)  # noqa: TC006
+        db_config = kwargs.get("config") or DatabaseSamplerConfig()
+        self.connection = get_ssl_connection(self.service_connection_config)
+        self.partition_details = cast(PartitionProfilerConfig, db_config.partition_details)  # noqa: TC006
+        self.sample_query: str | None = db_config.sample_query
         self._table = None
         self.client = self.get_client()
 

--- a/ingestion/src/metadata/sampler/pandas/sampler.py
+++ b/ingestion/src/metadata/sampler/pandas/sampler.py
@@ -16,6 +16,7 @@ for the profiler
 from typing import Callable, List, Optional, cast  # noqa: UP035
 
 from metadata.generated.schema.entity.data.table import (
+    ColumnProfilerConfig,
     PartitionProfilerConfig,
     TableData,
 )
@@ -44,6 +45,8 @@ class DatalakeSampler(SamplerInterface, PandasInterfaceMixin):
         self.connection = get_ssl_connection(self.service_connection_config)
         self.partition_details = cast(PartitionProfilerConfig, db_config.partition_details)  # noqa: TC006
         self.sample_query: str | None = db_config.sample_query
+        self.include_columns: list[ColumnProfilerConfig] = db_config.include_columns or []
+        self.exclude_columns: list[str] = db_config.exclude_columns or []
         self._table = None
         self.client = self.get_client()
 
@@ -73,6 +76,23 @@ class DatalakeSampler(SamplerInterface, PandasInterfaceMixin):
 
     def get_client(self):
         return self.connection
+
+    @property
+    def columns(self) -> List[SQALikeColumn]:  # noqa: UP006
+        """Return columns filtered by include/exclude lists."""
+        if self._columns:
+            return self._columns
+
+        included = {col.columnName for col in self.include_columns if col.columnName}
+        excluded = set(self.exclude_columns)
+        all_columns: List[SQALikeColumn] = [col for col in self.get_columns() if col is not None]  # noqa: UP006
+
+        if included:
+            self._columns = [col for col in all_columns if col.name in included]
+        else:
+            self._columns = [col for col in all_columns if col.name not in excluded]
+
+        return self._columns
 
     def _partitioned_table(self):
         """Get partitioned table"""

--- a/ingestion/src/metadata/sampler/sampler_config.py
+++ b/ingestion/src/metadata/sampler/sampler_config.py
@@ -1,0 +1,66 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Sampler configuration hierarchy.
+
+Each sampler family declares its own config subclass containing only
+the fields it actually needs — no database-specific types leak into the
+base class or into storage/messaging samplers.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, List, Optional  # noqa: UP035
+
+from metadata.generated.schema.entity.services.connections.connectionBasicType import (
+    DataStorageConfig,
+)
+from metadata.sampler.models import SampleConfig
+from metadata.utils.constants import SAMPLE_DATA_DEFAULT_COUNT
+
+
+@dataclass
+class SamplerConfig:
+    """Base config — fields meaningful for all sampler types."""
+
+    sample_config: SampleConfig = field(default_factory=SampleConfig)
+    sample_data_count: Optional[int] = SAMPLE_DATA_DEFAULT_COUNT  # noqa: UP045
+    # Config for uploading sample data to external blob storage (optional, all types).
+    # Named "upload" to distinguish it from the sampler's own service connection.
+    upload_sample_storage_config: Optional[DataStorageConfig] = None  # noqa: UP045
+
+
+@dataclass
+class DatabaseSamplerConfig(SamplerConfig):
+    """Config for database-family samplers (SQL, NoSQL, Datalake).
+
+    Holds types that are only meaningful for database entities — SQL
+    partitions, user queries, column filters, processing engines.
+    These are NOT imported into the base SamplerConfig or SamplerInterface.
+    """
+
+    # List[ColumnProfilerConfig] — typed as Any to avoid importing the
+    # database-specific generated schema type into this base config file.
+    include_columns: List[Any] = field(default_factory=list)  # noqa: UP006
+    exclude_columns: List[str] = field(default_factory=list)  # noqa: UP006
+    # PartitionProfilerConfig — typed as Any for the same reason.
+    partition_details: Optional[Any] = None  # noqa: UP045
+    sample_query: Optional[str] = None  # noqa: UP045
+    # ProcessingEngine — typed as Any for the same reason.
+    processing_engine: Optional[Any] = None  # noqa: UP045
+
+
+@dataclass
+class StorageSamplerConfig(SamplerConfig):
+    """Config for storage-family samplers (S3, GCS, ADLS, …).
+
+    Storage samplers only need the base fields — no SQL partitions,
+    no user queries, no column filters.
+    """

--- a/ingestion/src/metadata/sampler/sampler_interface.py
+++ b/ingestion/src/metadata/sampler/sampler_interface.py
@@ -15,45 +15,19 @@ Interface for sampler
 import traceback
 from abc import ABC, abstractmethod
 from functools import cached_property
-from typing import Any, List, Optional, Set  # noqa: UP035
+from typing import Any, List, Optional  # noqa: UP035
 
 from metadata.generated.schema.configuration.profilerConfiguration import (
     SampleDataIngestionConfig,
 )
-from metadata.generated.schema.entity.data.database import Database
-from metadata.generated.schema.entity.data.databaseSchema import DatabaseSchema
-from metadata.generated.schema.entity.data.table import (
-    ColumnProfilerConfig,
-    PartitionProfilerConfig,
-    TableData,
-)
-from metadata.generated.schema.entity.services.connections.connectionBasicType import (
-    DataStorageConfig,
-)
-from metadata.generated.schema.entity.services.connections.database.datalakeConnection import (
-    DatalakeConnection,
-)
-from metadata.generated.schema.entity.services.databaseService import DatabaseConnection
-from metadata.generated.schema.entity.services.storageService import StorageConnection
-from metadata.generated.schema.metadataIngestion.databaseServiceProfilerPipeline import (
-    ProcessingEngine,
-)
+from metadata.generated.schema.entity.data.table import TableData
 from metadata.generated.schema.type.samplingConfig import SampleConfigType
 from metadata.generated.schema.type.staticSamplingConfig import StaticSamplingConfig
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.pii.types import ClassifiableEntityType
-from metadata.profiler.api.models import TableConfig
 from metadata.profiler.processor.sample_data_handler import upload_sample_data
-from metadata.sampler.config import (
-    get_exclude_columns,
-    get_include_columns,
-    get_profile_sample_config,
-    get_sample_data_count_config,
-    get_sample_query,
-    resolve_static_sampling_config,
-)
-from metadata.sampler.models import SampleConfig
-from metadata.sampler.partition import get_partition_details
+from metadata.sampler.config import resolve_static_sampling_config
+from metadata.sampler.sampler_config import SamplerConfig
 from metadata.utils.constants import (
     SAMPLE_DATA_DEFAULT_COUNT,
     SAMPLE_DATA_MAX_CELL_LENGTH,
@@ -61,7 +35,6 @@ from metadata.utils.constants import (
 from metadata.utils.execution_time_tracker import calculate_execution_time
 from metadata.utils.logger import sampler_logger
 from metadata.utils.sqa_like_column import SQALikeColumn
-from metadata.utils.ssl_manager import get_ssl_connection
 
 logger = sampler_logger()
 
@@ -72,123 +45,50 @@ class SamplerInterface(ABC):
     data quality, profiling, etc.
     """
 
-    # pylint: disable=too-many-instance-attributes, too-many-arguments
     def __init__(
         self,
-        service_connection_config: DatabaseConnection | DatalakeConnection | StorageConnection,
+        service_connection_config: Any,
         ometa_client: OpenMetadata,
         entity: ClassifiableEntityType,
-        include_columns: Optional[List[ColumnProfilerConfig]] = None,  # noqa: UP006, UP045
-        exclude_columns: Optional[List[str]] = None,  # noqa: UP006, UP045
-        sample_config: SampleConfig = SampleConfig(),
-        partition_details: Optional[PartitionProfilerConfig] = None,  # noqa: UP045
-        sample_query: Optional[str] = None,  # noqa: UP045
-        storage_config: Optional[DataStorageConfig] = None,  # noqa: UP045
-        sample_data_count: Optional[int] = SAMPLE_DATA_DEFAULT_COUNT,  # noqa: UP045
-        processing_engine: Optional[ProcessingEngine] = None,  # noqa: UP045
+        config: Optional[SamplerConfig] = None,  # noqa: UP045
         **__,
     ):
+        resolved_config = config or SamplerConfig()
         self.ometa_client = ometa_client
-        self._sample = None
-        self._columns: List[SQALikeColumn] = []  # noqa: UP006
-        self.sample_config = sample_config
-
         self.entity = entity
-        self.include_columns = include_columns or []
-        self.exclude_columns = exclude_columns or []
-        self.sample_query = sample_query
-        self.sample_limit = sample_data_count
-        self.partition_details = partition_details
-        self.storage_config = storage_config
-        self.processing_engine = processing_engine
-
         self.service_connection_config = service_connection_config
-        self.connection = get_ssl_connection(self.service_connection_config)
+        self.sample_config = resolved_config.sample_config
+        self.sample_limit = resolved_config.sample_data_count or SAMPLE_DATA_DEFAULT_COUNT
+        self.upload_sample_storage_config = resolved_config.upload_sample_storage_config
+        self._columns: List[SQALikeColumn] = []  # noqa: UP006
         self._row_count = None
         self._sample_config: StaticSamplingConfig | None = None
+        self.partition_details: Any = None
+        self.sample_query: Optional[str] = None  # noqa: UP045
 
-    # pylint: disable=too-many-arguments, too-many-locals
     @classmethod
     def create(
         cls,
-        service_connection_config: DatabaseConnection | DatalakeConnection | StorageConnection,
+        service_connection_config: Any,
         ometa_client: OpenMetadata,
         entity: ClassifiableEntityType,
-        schema_entity: DatabaseSchema,
-        database_entity: Database,
-        table_config: Optional[TableConfig] = None,  # noqa: UP045
-        storage_config: Optional[DataStorageConfig] = None,  # noqa: UP045
-        default_sample_config: Optional[SampleConfig] = None,  # noqa: UP045
-        default_sample_data_count: int = SAMPLE_DATA_DEFAULT_COUNT,
-        processing_engine: Optional[ProcessingEngine] = None,  # noqa: UP045
+        config: Optional[SamplerConfig] = None,  # noqa: UP045
         **kwargs,
     ) -> "SamplerInterface":
-        """Create sampler"""
-
-        sample_data_count = get_sample_data_count_config(
-            entity=entity,
-            schema_entity=schema_entity,
-            database_entity=database_entity,
-            entity_config=table_config,
-            default_sample_data_count=default_sample_data_count,
-        )
-        sample_config = get_profile_sample_config(
-            entity=entity,
-            schema_entity=schema_entity,
-            database_entity=database_entity,
-            entity_config=table_config,
-            default_sample_config=default_sample_config,
-        )
-        sample_query = get_sample_query(entity=entity, entity_config=table_config)
-        partition_details = get_partition_details(entity=entity, entity_config=table_config)
-        include_columns = get_include_columns(entity, entity_config=table_config)
-        exclude_columns = get_exclude_columns(entity, entity_config=table_config)
-
+        """Create sampler from a pre-built SamplerConfig."""
         return cls(
             service_connection_config=service_connection_config,
             ometa_client=ometa_client,
             entity=entity,
-            include_columns=include_columns,
-            exclude_columns=exclude_columns,
-            sample_config=sample_config,
-            partition_details=partition_details,
-            sample_query=sample_query,
-            storage_config=storage_config,
-            sample_data_count=sample_data_count,
-            processing_engine=processing_engine,
+            config=config or SamplerConfig(),
             **kwargs,
         )
-
-    @property
-    def columns(self) -> List[SQALikeColumn]:  # noqa: UP006
-        """
-        Return the list of columns to profile
-        by skipping the columns to ignore.
-        """
-
-        if self._columns:
-            return self._columns
-
-        if self._get_included_columns():
-            self._columns = [column for column in self.get_columns() if column.name in self._get_included_columns()]
-
-        if not self._get_included_columns():
-            self._columns = [
-                column
-                for column in self._columns or self.get_columns()
-                if column.name not in self._get_excluded_columns()
-            ]
-
-        return self._columns
 
     @cached_property
     def _resolve_sample_config(self) -> StaticSamplingConfig | None:
         """Get the static sampling config. Use cached_property to cache the
         result since it can be used multiple times during the sampling process
         and contains a potentially expensive computation.
-
-        Returns:
-            StaticSamplingConfig | None: _description_
         """
         self._sample_config = resolve_static_sampling_config(
             sample_config=self.sample_config.profileSampleConfig,
@@ -202,18 +102,6 @@ class SamplerInterface(ABC):
             ),
         )
         return self._sample_config
-
-    def _get_excluded_columns(self) -> set[str]:
-        """Get excluded  columns for table being profiled"""
-        if self.exclude_columns:
-            return set(self.exclude_columns)
-        return set()
-
-    def _get_included_columns(self) -> Set[str]:  # noqa: UP006
-        """Get include columns for table being profiled"""
-        if self.include_columns:
-            return {include_col.columnName for include_col in self.include_columns if include_col.columnName}
-        return set()
 
     @property
     @abstractmethod
@@ -243,11 +131,7 @@ class SamplerInterface(ABC):
 
     @abstractmethod
     def fetch_sample_data(self, columns: Optional[List[SQALikeColumn]]) -> TableData:  # noqa: UP006, UP045
-        """Fetch sample data
-
-        Args:
-            columns (Optional[List]): List of columns to fetch
-        """
+        """Fetch sample data"""
         raise NotImplementedError
 
     @abstractmethod
@@ -256,10 +140,7 @@ class SamplerInterface(ABC):
         raise NotImplementedError
 
     def _get_asset_row_count(self) -> int:
-        """
-        Get the row count of the asset being profiled. This is used for dynamic sampling.
-        Default implementation returns 0 and should be overridden by implementations that support fetching row count.
-        """
+        """Default row-count implementation: returns 0. Override where row count is available."""
         logger.info(
             "Row count fetching is not implemented for this sampler. "
             "Returning 0 as default row count. Dynamic sampling will be ignored."
@@ -289,24 +170,18 @@ class SamplerInterface(ABC):
             logger.info("Both storing and reading of sample data are disabled. Skipping sample data generation.")
             return TableData(rows=[], columns=[])
         try:
-            # Stores overwrites reading since if we are storing the data, we want to fetch it
-            # as well to pass down the pipeline. If we are not storing, but reading is enabled,
-            # we still want to fetch the data to pass down the pipeline, but we won't store it.
             if sample_data_config.readSampleData or sample_data_config.storeSampleData:
                 logger.debug(f"Fetching sample data for {self.entity.fullyQualifiedName.root}...")
                 table_data = self.fetch_sample_data(self.columns)
-                # Truncate large cell values to prevent OOM in downstream
-                # processing (NLP, serialization, etc.)
                 table_data.rows = [
                     [self._truncate_cell(cell) for cell in row]
                     for row in table_data.rows[: min(SAMPLE_DATA_DEFAULT_COUNT, self.sample_limit)]
                 ]
-                # Only store the data if configured to do so
-                if self.storage_config and sample_data_config.storeSampleData:
+                if self.upload_sample_storage_config and sample_data_config.storeSampleData:
                     upload_sample_data(
                         data=table_data,
                         entity=self.entity,
-                        sample_storage_config=self.storage_config,
+                        sample_storage_config=self.upload_sample_storage_config,
                     )
                 return table_data
 
@@ -316,6 +191,14 @@ class SamplerInterface(ABC):
             logger.debug(traceback.format_exc())
             logger.warning(f"Error fetching sample data: {err}")
             raise err  # noqa: TRY201
+
+    @property
+    def columns(self) -> List[SQALikeColumn]:  # noqa: UP006
+        """Return the sampled columns list. Subclasses with include/exclude
+        column filtering (database samplers) override this property."""
+        if not self._columns:
+            self._columns = self.get_columns()
+        return self._columns
 
     def close(self):  # noqa: B027
         """Default noop"""

--- a/ingestion/src/metadata/sampler/sqlalchemy/bigquery/sampler.py
+++ b/ingestion/src/metadata/sampler/sqlalchemy/bigquery/sampler.py
@@ -14,29 +14,19 @@ for the profiler
 """
 
 from copy import deepcopy  # noqa: I001
-from typing import Dict, Optional, Union  # noqa: UP035
+from typing import Optional
 
 from sqlalchemy import Column
 from sqlalchemy import Table as SqaTable
 from sqlalchemy import text
 from sqlalchemy.orm import Query
 
-from metadata.generated.schema.entity.data.table import Table, TableType
-from metadata.generated.schema.entity.services.connections.connectionBasicType import (
-    DataStorageConfig,
-)
-from metadata.generated.schema.entity.services.connections.database.datalakeConnection import (
-    DatalakeConnection,
-)
-from metadata.generated.schema.entity.services.databaseService import DatabaseConnection
+from metadata.generated.schema.entity.data.table import TableType
 from metadata.generated.schema.security.credentials.gcpValues import SingleProjectId
 from metadata.generated.schema.type.basic import ProfileSampleType
-from metadata.ingestion.connections.session import create_and_bind_thread_safe_session
-from metadata.ingestion.ometa.ometa_api import OpenMetadata
-from metadata.sampler.models import SampleConfig
-from metadata.sampler.sqlalchemy.sampler import SQASampler
 from metadata.generated.schema.type.staticSamplingConfig import StaticSamplingConfig
-from metadata.utils.constants import SAMPLE_DATA_DEFAULT_COUNT
+from metadata.ingestion.connections.session import create_and_bind_thread_safe_session
+from metadata.sampler.sqlalchemy.sampler import SQASampler
 from metadata.utils.logger import profiler_interface_registry_logger
 from metadata.utils.ssl_manager import get_ssl_connection
 
@@ -51,33 +41,12 @@ class BigQuerySampler(SQASampler):
     run the query in the whole table.
     """
 
-    # pylint: disable=too-many-arguments
-    def __init__(
-        self,
-        service_connection_config: Union[DatabaseConnection, DatalakeConnection],  # noqa: UP007
-        ometa_client: OpenMetadata,
-        entity: Table,
-        sample_config: Optional[SampleConfig] = None,  # noqa: UP045
-        partition_details: Optional[Dict] = None,  # noqa: UP006, UP045
-        sample_query: Optional[str] = None,  # noqa: UP045
-        storage_config: DataStorageConfig = None,
-        sample_data_count: Optional[int] = SAMPLE_DATA_DEFAULT_COUNT,  # noqa: UP045
-        **kwargs,
-    ):
-        super().__init__(
-            service_connection_config=service_connection_config,
-            ometa_client=ometa_client,
-            entity=entity,
-            sample_config=sample_config,
-            partition_details=partition_details,
-            sample_query=sample_query,
-            storage_config=storage_config,
-            sample_data_count=sample_data_count,
-            **kwargs,
-        )
-        self.raw_dataset_type: Optional[TableType] = entity.tableType  # noqa: UP045
+    def __init__(self, *args, **kwargs):
+        table_type = kwargs.pop("table_type", None)
+        super().__init__(*args, **kwargs)
+        self.raw_dataset_type: Optional[TableType] = table_type or (self.entity.tableType if self.entity else None)  # noqa: UP045
 
-        connection_config = deepcopy(service_connection_config)
+        connection_config = deepcopy(self.service_connection_config)
         # Create a modified connection for BigQuery with the correct project ID
         if hasattr(connection_config.credentials.gcpConfig, "projectId") and self.entity.database:
             connection_config.credentials.gcpConfig.projectId = SingleProjectId(root=self.entity.database.name)

--- a/ingestion/src/metadata/sampler/sqlalchemy/bigquery/sampler.py
+++ b/ingestion/src/metadata/sampler/sqlalchemy/bigquery/sampler.py
@@ -21,7 +21,7 @@ from sqlalchemy import Table as SqaTable
 from sqlalchemy import text
 from sqlalchemy.orm import Query
 
-from metadata.generated.schema.entity.data.table import TableType
+from metadata.generated.schema.entity.data.table import Table, TableType
 from metadata.generated.schema.security.credentials.gcpValues import SingleProjectId
 from metadata.generated.schema.type.basic import ProfileSampleType
 from metadata.generated.schema.type.staticSamplingConfig import StaticSamplingConfig
@@ -44,7 +44,9 @@ class BigQuerySampler(SQASampler):
     def __init__(self, *args, **kwargs):
         table_type = kwargs.pop("table_type", None)
         super().__init__(*args, **kwargs)
-        self.raw_dataset_type: Optional[TableType] = table_type or (self.entity.tableType if self.entity else None)  # noqa: UP045
+        self.raw_dataset_type: Optional[TableType] = table_type or (  # noqa: UP045
+            self.entity.tableType if isinstance(self.entity, Table) else None
+        )
 
         connection_config = deepcopy(self.service_connection_config)
         # Create a modified connection for BigQuery with the correct project ID

--- a/ingestion/src/metadata/sampler/sqlalchemy/postgres/sampler.py
+++ b/ingestion/src/metadata/sampler/sqlalchemy/postgres/sampler.py
@@ -12,27 +12,14 @@
 Helper module to handle data sampling for the profiler
 """
 
-from typing import Dict, Optional, Union  # noqa: UP035
-
 from sqlalchemy import Table as SqaTable
 from sqlalchemy import func
 from sqlalchemy.orm import Query
 
-from metadata.generated.schema.entity.data.table import Table
-from metadata.generated.schema.entity.services.connections.connectionBasicType import (
-    DataStorageConfig,
-)
-from metadata.generated.schema.entity.services.connections.database.datalakeConnection import (
-    DatalakeConnection,
-)
-from metadata.generated.schema.entity.services.databaseService import DatabaseConnection
 from metadata.generated.schema.type.basic import ProfileSampleType
 from metadata.generated.schema.type.staticSamplingConfig import StaticSamplingConfig
-from metadata.ingestion.ometa.ometa_api import OpenMetadata
-from metadata.sampler.models import SampleConfig
 from metadata.sampler.sqlalchemy.sampler import SQASampler
 from metadata.sampler.sqlalchemy.snowflake.sampler import SamplingMethodType
-from metadata.utils.constants import SAMPLE_DATA_DEFAULT_COUNT
 
 
 class PostgresSampler(SQASampler):
@@ -41,36 +28,13 @@ class PostgresSampler(SQASampler):
     run the query in the whole table.
     """
 
-    # pylint: disable=too-many-arguments
-    def __init__(
-        self,
-        service_connection_config: Union[DatabaseConnection, DatalakeConnection],  # noqa: UP007
-        ometa_client: OpenMetadata,
-        entity: Table,
-        sample_config: Optional[SampleConfig] = None,  # noqa: UP045
-        partition_details: Optional[Dict] = None,  # noqa: UP006, UP045
-        sample_query: Optional[str] = None,  # noqa: UP045
-        storage_config: DataStorageConfig = None,
-        sample_data_count: Optional[int] = SAMPLE_DATA_DEFAULT_COUNT,  # noqa: UP045
-        **kwargs,
-    ):
-        super().__init__(
-            service_connection_config=service_connection_config,
-            ometa_client=ometa_client,
-            entity=entity,
-            sample_config=sample_config,
-            partition_details=partition_details,
-            sample_query=sample_query,
-            storage_config=storage_config,
-            sample_data_count=sample_data_count,
-            **kwargs,
-        )
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.sampling_fn = func.bernoulli
         self.sampling_method_type = SamplingMethodType.BERNOULLI
-        if sample_config:
-            static = self._resolve_sample_config
-            if static and static.samplingMethodType == SamplingMethodType.SYSTEM:
-                self.sampling_fn = func.system
+        static = self._resolve_sample_config
+        if static and static.samplingMethodType == SamplingMethodType.SYSTEM:
+            self.sampling_fn = func.system
 
     def set_tablesample(self, static: StaticSamplingConfig | None, selectable: SqaTable):
         """Set the TABLESAMPLE clause for postgres

--- a/ingestion/src/metadata/sampler/sqlalchemy/sampler.py
+++ b/ingestion/src/metadata/sampler/sqlalchemy/sampler.py
@@ -24,6 +24,7 @@ from sqlalchemy.sql.selectable import TableSample
 from sqlalchemy.sql.sqltypes import Enum
 
 from metadata.generated.schema.entity.data.table import (
+    ColumnProfilerConfig,
     PartitionProfilerConfig,
     TableData,
 )
@@ -40,10 +41,12 @@ from metadata.profiler.orm.functions.table_metric_computer import (
 )
 from metadata.profiler.processor.handle_partition import build_partition_predicate
 from metadata.profiler.processor.runner import QueryRunner
+from metadata.sampler.sampler_config import DatabaseSamplerConfig
 from metadata.sampler.sampler_interface import SamplerInterface
 from metadata.utils.constants import UTF_8
 from metadata.utils.helpers import is_safe_sql_query
 from metadata.utils.logger import profiler_interface_registry_logger
+from metadata.utils.ssl_manager import get_ssl_connection
 
 logger = profiler_interface_registry_logger()
 
@@ -80,8 +83,41 @@ class SQASampler(SamplerInterface, SQAInterfaceMixin):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        db_config = kwargs.get("config") or DatabaseSamplerConfig()
+        self.connection = get_ssl_connection(self.service_connection_config)
+        self.include_columns: list[ColumnProfilerConfig] = db_config.include_columns or []
+        self.exclude_columns: list[str] = db_config.exclude_columns or []
+        self.partition_details: PartitionProfilerConfig | None = db_config.partition_details
+        self.sample_query: str | None = db_config.sample_query
+        self.processing_engine = db_config.processing_engine
         self._table = self.build_table_orm(self.entity, self.service_connection_config, self.ometa_client)
         self.session_factory = create_and_bind_thread_safe_session(self.connection)
+
+    def _get_excluded_columns(self) -> set[str]:
+        if self.exclude_columns:
+            return set(self.exclude_columns)
+        return set()
+
+    def _get_included_columns(self) -> set[str]:
+        if self.include_columns:
+            return {col.columnName for col in self.include_columns if col.columnName}
+        return set()
+
+    @property
+    def columns(self):
+        """Return columns filtered by include/exclude lists."""
+        if self._columns:
+            return self._columns
+
+        if self._get_included_columns():
+            self._columns = [col for col in self.get_columns() if col.name in self._get_included_columns()]
+
+        if not self._get_included_columns():
+            self._columns = [
+                col for col in self._columns or self.get_columns() if col.name not in self._get_excluded_columns()
+            ]
+
+        return self._columns
 
     @property
     def raw_dataset(self):

--- a/ingestion/src/metadata/sampler/sqlalchemy/snowflake/sampler.py
+++ b/ingestion/src/metadata/sampler/sqlalchemy/snowflake/sampler.py
@@ -13,24 +13,12 @@ Helper module to handle data sampling
 for the profiler
 """
 
-from typing import Dict, Optional, Union  # noqa: UP035
-
 from sqlalchemy import Table, func, text
 from sqlalchemy.sql.selectable import CTE
 
-from metadata.generated.schema.entity.services.connections.connectionBasicType import (
-    DataStorageConfig,
-)
-from metadata.generated.schema.entity.services.connections.database.datalakeConnection import (
-    DatalakeConnection,
-)
-from metadata.generated.schema.entity.services.databaseService import DatabaseConnection
 from metadata.generated.schema.type.basic import ProfileSampleType, SamplingMethodType
 from metadata.generated.schema.type.staticSamplingConfig import StaticSamplingConfig
-from metadata.ingestion.ometa.ometa_api import OpenMetadata
-from metadata.sampler.models import SampleConfig
 from metadata.sampler.sqlalchemy.sampler import SQASampler
-from metadata.utils.constants import SAMPLE_DATA_DEFAULT_COUNT
 
 
 class SnowflakeSampler(SQASampler):
@@ -39,35 +27,12 @@ class SnowflakeSampler(SQASampler):
     run the query in the whole table.
     """
 
-    # pylint: disable=too-many-arguments
-    def __init__(
-        self,
-        service_connection_config: Union[DatabaseConnection, DatalakeConnection],  # noqa: UP007
-        ometa_client: OpenMetadata,
-        entity: Table,
-        sample_config: Optional[SampleConfig] = None,  # noqa: UP045
-        partition_details: Optional[Dict] = None,  # noqa: UP006, UP045
-        sample_query: Optional[str] = None,  # noqa: UP045
-        storage_config: DataStorageConfig = None,
-        sample_data_count: Optional[int] = SAMPLE_DATA_DEFAULT_COUNT,  # noqa: UP045
-        **kwargs,
-    ):
-        super().__init__(
-            service_connection_config=service_connection_config,
-            ometa_client=ometa_client,
-            entity=entity,
-            sample_config=sample_config,
-            partition_details=partition_details,
-            sample_query=sample_query,
-            storage_config=storage_config,
-            sample_data_count=sample_data_count,
-            **kwargs,
-        )
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.sampling_method_type = func.bernoulli
-        if sample_config:
-            static = self._resolve_sample_config
-            if static and static.samplingMethodType == SamplingMethodType.SYSTEM:
-                self.sampling_method_type = func.system
+        static = self._resolve_sample_config
+        if static and static.samplingMethodType == SamplingMethodType.SYSTEM:
+            self.sampling_method_type = func.system
 
     def set_tablesample(self, static: StaticSamplingConfig | None, selectable: Table):
         """Set the TABLESAMPLE clause for Snowflake

--- a/ingestion/src/metadata/sampler/storage/sampler.py
+++ b/ingestion/src/metadata/sampler/storage/sampler.py
@@ -16,24 +16,13 @@ from abc import abstractmethod
 from typing import Any, List, Optional  # noqa: UP035
 
 from metadata.generated.schema.entity.data.container import Container
-from metadata.generated.schema.entity.data.table import (
-    ColumnProfilerConfig,
-    PartitionProfilerConfig,
-    TableData,
-)
-from metadata.generated.schema.entity.services.connections.connectionBasicType import (
-    DataStorageConfig,
-)
+from metadata.generated.schema.entity.data.table import TableData
 from metadata.generated.schema.entity.services.storageService import StorageConnection
-from metadata.generated.schema.metadataIngestion.databaseServiceProfilerPipeline import (
-    ProcessingEngine,
-)
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.readers.dataframe.models import DatalakeTableSchemaWrapper
 from metadata.readers.dataframe.reader_factory import SupportedTypes
-from metadata.sampler.models import SampleConfig
+from metadata.sampler.sampler_config import StorageSamplerConfig
 from metadata.sampler.sampler_interface import SamplerInterface
-from metadata.utils.constants import SAMPLE_DATA_DEFAULT_COUNT
 from metadata.utils.datalake.datalake_utils import fetch_dataframe_first_chunk
 from metadata.utils.logger import sampler_logger
 from metadata.utils.sqa_like_column import SQALikeColumn
@@ -43,7 +32,8 @@ logger = sampler_logger()
 
 class StorageSampler(SamplerInterface):
     """
-    Base sampler for storage services that reads data from cloud storage buckets
+    Base sampler for storage services that reads data from cloud storage buckets.
+    Accepts a StorageSamplerConfig — no database-specific fields required.
     """
 
     def __init__(
@@ -51,72 +41,17 @@ class StorageSampler(SamplerInterface):
         service_connection_config: StorageConnection,
         ometa_client: OpenMetadata,
         entity: Container,
-        include_columns: Optional[List[ColumnProfilerConfig]] = None,  # noqa: UP006, UP045
-        exclude_columns: Optional[List[str]] = None,  # noqa: UP006, UP045
-        sample_config: SampleConfig = SampleConfig(),
-        partition_details: Optional[PartitionProfilerConfig] = None,  # noqa: UP045
-        sample_query: Optional[str] = None,  # noqa: UP045
-        storage_config: Optional[DataStorageConfig] = None,  # noqa: UP045
-        sample_data_count: Optional[int] = SAMPLE_DATA_DEFAULT_COUNT,  # noqa: UP045
-        processing_engine: Optional[ProcessingEngine] = None,  # noqa: UP045
+        config: Optional[StorageSamplerConfig] = None,  # noqa: UP045
         **kwargs,
     ):
         super().__init__(
-            service_connection_config,
-            ometa_client,
-            entity,
-            include_columns,
-            exclude_columns,
-            sample_config,
-            partition_details,
-            sample_query,
-            storage_config,
-            sample_data_count,
-            processing_engine,
-            **kwargs,
-        )
-        self.client = self.get_client()
-
-    @classmethod
-    def create(
-        cls,
-        service_connection_config: StorageConnection,
-        ometa_client: OpenMetadata,
-        entity: Container,
-        schema_entity=None,
-        database_entity=None,
-        table_config=None,
-        storage_config: Optional[DataStorageConfig] = None,  # noqa: UP045
-        default_sample_config: Optional[SampleConfig] = None,  # noqa: UP045
-        default_sample_data_count: int = SAMPLE_DATA_DEFAULT_COUNT,
-        processing_engine: Optional[ProcessingEngine] = None,  # noqa: UP045
-        **kwargs,
-    ) -> "StorageSampler":
-        """Create storage sampler instance
-
-        Args:
-            service_connection_config: Storage service connection config
-            ometa_client: OpenMetadata client
-            entity: Container entity to sample
-            schema_entity: Ignored for storage samplers (Table-specific)
-            database_entity: Ignored for storage samplers (Table-specific)
-            table_config: Ignored for storage samplers (Table-specific)
-            storage_config: Optional storage config for sample data
-            default_sample_config: Default sample config
-            default_sample_data_count: Number of rows to sample
-            processing_engine: Ignored for storage samplers (Table-specific)
-            **kwargs: Additional arguments
-        """
-        return cls(
             service_connection_config=service_connection_config,
             ometa_client=ometa_client,
             entity=entity,
-            sample_config=default_sample_config or SampleConfig(),
-            storage_config=storage_config,
-            sample_data_count=default_sample_data_count,
-            processing_engine=processing_engine,
+            config=config or StorageSamplerConfig(),
             **kwargs,
         )
+        self.client = self.get_client()
 
     @property
     def raw_dataset(self):

--- a/ingestion/tests/integration/datalake/test_data_quality.py
+++ b/ingestion/tests/integration/datalake/test_data_quality.py
@@ -62,7 +62,7 @@ class TestDataQuality:
         "test_case_name,failed_rows",
         [
             ("first_name_includes_john", None),
-            ("first_name_is_john", 1),
+            ("first_name_is_john", 2),
         ],
     )
     def test_data_quality_with_sample(
@@ -81,7 +81,7 @@ class TestDataQuality:
             nullable=False,
         )
         if failed_rows:
-            assert test_case.testCaseResult.failedRows == pytest.approx(failed_rows, abs=1)
+            assert test_case.testCaseResult.failedRows == failed_rows
 
     @pytest.mark.parametrize(
         "test_case_name,expected_status,failed_rows",

--- a/ingestion/tests/unit/observability/profiler/pandas/test_burstiq_profiler_interface.py
+++ b/ingestion/tests/unit/observability/profiler/pandas/test_burstiq_profiler_interface.py
@@ -121,15 +121,9 @@ def _make_interface(df_factory, table_entity=FULL_TABLE_ENTITY):
     sampler.get_dataset.return_value = df_factory
     sampler.raw_dataset = df_factory
 
-    with (
-        patch(
-            "metadata.profiler.interface.profiler_interface.get_ssl_connection",
-            return_value=FakeConnection(),
-        ),
-        patch(
-            "metadata.sampler.sampler_interface.get_ssl_connection",
-            return_value=FakeConnection(),
-        ),
+    with patch(
+        "metadata.profiler.interface.profiler_interface.get_ssl_connection",
+        return_value=FakeConnection(),
     ):
         interface = BurstIQProfilerInterface(
             service_connection_config=BURSTIQ_CONNECTION,

--- a/ingestion/tests/unit/observability/profiler/pandas/test_custom_metrics.py
+++ b/ingestion/tests/unit/observability/profiler/pandas/test_custom_metrics.py
@@ -122,7 +122,7 @@ class MetricsTest(TestCase):
         return_value=FakeConnection(),
     )
     @mock.patch(
-        "metadata.sampler.sampler_interface.get_ssl_connection",
+        "metadata.sampler.pandas.sampler.get_ssl_connection",
         return_value=FakeConnection(),
     )
     def setUp(self, *_):
@@ -157,7 +157,7 @@ class MetricsTest(TestCase):
         return_value=FakeConnection(),
     )
     @mock.patch(
-        "metadata.sampler.sampler_interface.get_ssl_connection",
+        "metadata.sampler.pandas.sampler.get_ssl_connection",
         return_value=FakeConnection(),
     )
     def test_table_custom_metric(self, *_):
@@ -248,7 +248,7 @@ class MetricsTest(TestCase):
         return_value=FakeConnection(),
     )
     @mock.patch(
-        "metadata.sampler.sampler_interface.get_ssl_connection",
+        "metadata.sampler.pandas.sampler.get_ssl_connection",
         return_value=FakeConnection(),
     )
     def test_column_custom_metric(self, *_):

--- a/ingestion/tests/unit/observability/profiler/pandas/test_datalake_metrics.py
+++ b/ingestion/tests/unit/observability/profiler/pandas/test_datalake_metrics.py
@@ -103,7 +103,7 @@ class DatalakeMetricsTest(TestCase):
         return_value=FakeConnection(),
     )
     @mock.patch(
-        "metadata.sampler.sampler_interface.get_ssl_connection",
+        "metadata.sampler.pandas.sampler.get_ssl_connection",
         return_value=FakeConnection(),
     )
     def setUpClass(cls, mock_get_connection, mock_sample_get_connection):

--- a/ingestion/tests/unit/observability/profiler/pandas/test_profiler.py
+++ b/ingestion/tests/unit/observability/profiler/pandas/test_profiler.py
@@ -164,7 +164,7 @@ class ProfilerTest(TestCase):
         return_value=FakeConnection(),
     )
     @mock.patch(
-        "metadata.sampler.sampler_interface.get_ssl_connection",
+        "metadata.sampler.pandas.sampler.get_ssl_connection",
         return_value=FakeConnection(),
     )
     def setUp(cls, mock_get_connection, *_) -> None:

--- a/ingestion/tests/unit/observability/profiler/pandas/test_profiler_interface.py
+++ b/ingestion/tests/unit/observability/profiler/pandas/test_profiler_interface.py
@@ -162,7 +162,7 @@ class PandasInterfaceTest(TestCase):
         return_value=FakeConnection(),
     )
     @mock.patch(
-        "metadata.sampler.sampler_interface.get_ssl_connection",
+        "metadata.sampler.pandas.sampler.get_ssl_connection",
         return_value=FakeConnection(),
     )
     def setUp(cls, mock_get_connection, *_) -> None:

--- a/ingestion/tests/unit/observability/profiler/pandas/test_sample.py
+++ b/ingestion/tests/unit/observability/profiler/pandas/test_sample.py
@@ -42,6 +42,7 @@ from metadata.sampler.models import (
     SampleConfig,
 )
 from metadata.sampler.pandas.sampler import DatalakeSampler
+from metadata.sampler.sampler_config import DatabaseSamplerConfig
 
 
 class Base(DeclarativeBase):
@@ -154,7 +155,7 @@ class DatalakeSampleTest(TestCase):
         return_value=FakeConnection(),
     )
     @mock.patch(
-        "metadata.sampler.sampler_interface.get_ssl_connection",
+        "metadata.sampler.pandas.sampler.get_ssl_connection",
         return_value=FakeConnection(),
     )
     def setUpClass(cls, mock_get_connection, mock_sample_get_connection) -> None:
@@ -177,10 +178,12 @@ class DatalakeSampleTest(TestCase):
                 service_connection_config=DatalakeConnection(configSource={}),
                 ometa_client=None,
                 entity=cls.table_entity,
-                sample_config=SampleConfig(
-                    profileSampleConfig=ProfileSampleConfig(
-                        sampleConfigType=SampleConfigType.STATIC,
-                        config=StaticSamplingConfig(profileSample=50.0),
+                config=DatabaseSamplerConfig(
+                    sample_config=SampleConfig(
+                        profileSampleConfig=ProfileSampleConfig(
+                            sampleConfigType=SampleConfigType.STATIC,
+                            config=StaticSamplingConfig(profileSample=50.0),
+                        )
                     )
                 ),
             )
@@ -194,7 +197,7 @@ class DatalakeSampleTest(TestCase):
             )
 
     @mock.patch(
-        "metadata.sampler.sampler_interface.get_ssl_connection",
+        "metadata.sampler.pandas.sampler.get_ssl_connection",
         return_value=FakeConnection(),
     )
     def test_random_sampler(self, _):
@@ -218,10 +221,12 @@ class DatalakeSampleTest(TestCase):
                 service_connection_config=DatalakeConnection(configSource={}),
                 ometa_client=None,
                 entity=self.table_entity,
-                sample_config=SampleConfig(
-                    profileSampleConfig=ProfileSampleConfig(
-                        sampleConfigType=SampleConfigType.STATIC,
-                        config=StaticSamplingConfig(profileSample=50.0),
+                config=DatabaseSamplerConfig(
+                    sample_config=SampleConfig(
+                        profileSampleConfig=ProfileSampleConfig(
+                            sampleConfigType=SampleConfigType.STATIC,
+                            config=StaticSamplingConfig(profileSample=50.0),
+                        )
                     )
                 ),
             )
@@ -234,7 +239,7 @@ class DatalakeSampleTest(TestCase):
         return_value=FakeConnection(),
     )
     @mock.patch(
-        "metadata.sampler.sampler_interface.get_ssl_connection",
+        "metadata.sampler.pandas.sampler.get_ssl_connection",
         return_value=FakeConnection(),
     )
     def test_sample_property(self, *_):
@@ -257,10 +262,12 @@ class DatalakeSampleTest(TestCase):
                 service_connection_config=DatalakeConnection(configSource={}),
                 ometa_client=None,
                 entity=self.table_entity,
-                sample_config=SampleConfig(
-                    profileSampleConfig=ProfileSampleConfig(
-                        sampleConfigType=SampleConfigType.STATIC,
-                        config=StaticSamplingConfig(profileSample=50.0),
+                config=DatabaseSamplerConfig(
+                    sample_config=SampleConfig(
+                        profileSampleConfig=ProfileSampleConfig(
+                            sampleConfigType=SampleConfigType.STATIC,
+                            config=StaticSamplingConfig(profileSample=50.0),
+                        )
                     )
                 ),
             )
@@ -320,7 +327,7 @@ class DatalakeSampleTest(TestCase):
         assert sum(res.get(User.age.name)[Metrics.histogram.name]["frequencies"]) < 30
 
     @mock.patch(
-        "metadata.sampler.sampler_interface.get_ssl_connection",
+        "metadata.sampler.pandas.sampler.get_ssl_connection",
         return_value=FakeConnection(),
     )
     def test_sample_data(self, *_):
@@ -343,10 +350,12 @@ class DatalakeSampleTest(TestCase):
                 service_connection_config=DatalakeConnection(configSource={}),
                 ometa_client=None,
                 entity=self.table_entity,
-                sample_config=SampleConfig(
-                    profileSampleConfig=ProfileSampleConfig(
-                        sampleConfigType=SampleConfigType.STATIC,
-                        config=StaticSamplingConfig(profileSample=50.0),
+                config=DatabaseSamplerConfig(
+                    sample_config=SampleConfig(
+                        profileSampleConfig=ProfileSampleConfig(
+                            sampleConfigType=SampleConfigType.STATIC,
+                            config=StaticSamplingConfig(profileSample=50.0),
+                        )
                     )
                 ),
             )
@@ -357,7 +366,7 @@ class DatalakeSampleTest(TestCase):
             assert len(sample_data.rows) == 4
 
     @mock.patch(
-        "metadata.sampler.sampler_interface.get_ssl_connection",
+        "metadata.sampler.pandas.sampler.get_ssl_connection",
         return_value=FakeConnection(),
     )
     def test_sample_from_user_query(self, *_):
@@ -380,13 +389,15 @@ class DatalakeSampleTest(TestCase):
                 service_connection_config=DatalakeConnection(configSource={}),
                 ometa_client=None,
                 entity=self.table_entity,
-                default_sample_config=SampleConfig(
-                    profileSampleConfig=ProfileSampleConfig(
-                        sampleConfigType=SampleConfigType.STATIC,
-                        config=StaticSamplingConfig(profileSample=50.0),
-                    )
+                config=DatabaseSamplerConfig(
+                    sample_config=SampleConfig(
+                        profileSampleConfig=ProfileSampleConfig(
+                            sampleConfigType=SampleConfigType.STATIC,
+                            config=StaticSamplingConfig(profileSample=50.0),
+                        )
+                    ),
+                    sample_query="`age` > 30",
                 ),
-                sample_query="`age` > 30",
             )
             sample_data = sampler.fetch_sample_data()
 

--- a/ingestion/tests/unit/observability/profiler/sqlalchemy/azuresql/test_azuresql_sampling.py
+++ b/ingestion/tests/unit/observability/profiler/sqlalchemy/azuresql/test_azuresql_sampling.py
@@ -36,6 +36,7 @@ from metadata.sampler.models import (
     ProfileSampleConfig,
     SampleConfig,
 )
+from metadata.sampler.sampler_config import DatabaseSamplerConfig
 from metadata.sampler.sqlalchemy.azuresql.sampler import AzureSQLSampler
 from metadata.sampler.sqlalchemy.sampler import SQASampler
 
@@ -97,13 +98,15 @@ class SampleTest(TestCase):
             service_connection_config=self.azuresql_conn,
             ometa_client=None,
             entity=self.table_entity,
-            sample_config=SampleConfig(
-                profileSampleConfig=ProfileSampleConfig(
-                    sampleConfigType=SampleConfigType.STATIC,
-                    config=StaticSamplingConfig(
-                        profileSample=50.0,
-                        profileSampleType=ProfileSampleType.PERCENTAGE,
-                    ),
+            config=DatabaseSamplerConfig(
+                sample_config=SampleConfig(
+                    profileSampleConfig=ProfileSampleConfig(
+                        sampleConfigType=SampleConfigType.STATIC,
+                        config=StaticSamplingConfig(
+                            profileSample=50.0,
+                            profileSampleType=ProfileSampleType.PERCENTAGE,
+                        ),
+                    )
                 )
             ),
         )
@@ -123,13 +126,15 @@ class SampleTest(TestCase):
             service_connection_config=self.azuresql_conn,
             ometa_client=None,
             entity=self.table_entity,
-            sample_config=SampleConfig(
-                profileSampleConfig=ProfileSampleConfig(
-                    sampleConfigType=SampleConfigType.STATIC,
-                    config=StaticSamplingConfig(
-                        profileSample=50,
-                        profileSampleType=ProfileSampleType.ROWS,
-                    ),
+            config=DatabaseSamplerConfig(
+                sample_config=SampleConfig(
+                    profileSampleConfig=ProfileSampleConfig(
+                        sampleConfigType=SampleConfigType.STATIC,
+                        config=StaticSamplingConfig(
+                            profileSample=50,
+                            profileSampleType=ProfileSampleType.ROWS,
+                        ),
+                    )
                 )
             ),
         )
@@ -155,7 +160,6 @@ class SampleTest(TestCase):
             service_connection_config=self.azuresql_conn,
             ometa_client=None,
             entity=self.table_entity,
-            sample_config=SampleConfig(),
         )
 
         valid_from_col = MagicMock()
@@ -213,7 +217,6 @@ class SampleTest(TestCase):
             service_connection_config=self.azuresql_conn,
             ometa_client=None,
             entity=self.table_entity,
-            sample_config=SampleConfig(),
         )
 
         valid_from_col = MagicMock()
@@ -256,20 +259,22 @@ class SampleTest(TestCase):
             service_connection_config=self.azuresql_conn,
             ometa_client=None,
             entity=self.table_entity,
-            sample_config=SampleConfig(
-                profileSampleConfig=ProfileSampleConfig(
-                    sampleConfigType=SampleConfigType.STATIC,
-                    config=StaticSamplingConfig(
-                        profileSample=50.0,
-                        profileSampleType=ProfileSampleType.PERCENTAGE,
-                    ),
-                )
-            ),
-            partition_details=PartitionProfilerConfig(
-                enablePartitioning=True,
-                partitionColumnName="id",
-                partitionIntervalType=PartitionIntervalTypes.COLUMN_VALUE,
-                partitionValues=["1", "2"],
+            config=DatabaseSamplerConfig(
+                sample_config=SampleConfig(
+                    profileSampleConfig=ProfileSampleConfig(
+                        sampleConfigType=SampleConfigType.STATIC,
+                        config=StaticSamplingConfig(
+                            profileSample=50.0,
+                            profileSampleType=ProfileSampleType.PERCENTAGE,
+                        ),
+                    )
+                ),
+                partition_details=PartitionProfilerConfig(
+                    enablePartitioning=True,
+                    partitionColumnName="id",
+                    partitionIntervalType=PartitionIntervalTypes.COLUMN_VALUE,
+                    partitionValues=["1", "2"],
+                ),
             ),
         )
         query: CTE = sampler.get_sample_query(sampler._resolve_sample_config)

--- a/ingestion/tests/unit/observability/profiler/sqlalchemy/bigquery/test_bigquery_sampling.py
+++ b/ingestion/tests/unit/observability/profiler/sqlalchemy/bigquery/test_bigquery_sampling.py
@@ -30,6 +30,7 @@ from metadata.profiler.interface.sqlalchemy.profiler_interface import (
 )
 from metadata.profiler.orm.functions.table_metric_computer import TableType
 from metadata.sampler.models import SampleConfig
+from metadata.sampler.sampler_config import DatabaseSamplerConfig
 from metadata.sampler.sqlalchemy.bigquery.sampler import BigQuerySampler
 from metadata.sampler.sqlalchemy.sampler import SQASampler
 
@@ -116,13 +117,15 @@ class SampleTest(TestCase):
             service_connection_config=self.bq_conn,
             ometa_client=None,
             entity=self.table_entity,
-            sample_config=SampleConfig(
-                profileSampleConfig=ProfileSampleConfig(
-                    sampleConfigType=SampleConfigType.STATIC,
-                    config=StaticSamplingConfig(
-                        profileSample=50.0,
-                        profileSampleType=ProfileSampleType.PERCENTAGE,
-                    ),
+            config=DatabaseSamplerConfig(
+                sample_config=SampleConfig(
+                    profileSampleConfig=ProfileSampleConfig(
+                        sampleConfigType=SampleConfigType.STATIC,
+                        config=StaticSamplingConfig(
+                            profileSample=50.0,
+                            profileSampleType=ProfileSampleType.PERCENTAGE,
+                        ),
+                    )
                 )
             ),
             table_type=TableType.Regular,
@@ -152,13 +155,15 @@ class SampleTest(TestCase):
             service_connection_config=self.bq_conn,
             ometa_client=None,
             entity=view_entity,
-            sample_config=SampleConfig(
-                profileSampleConfig=ProfileSampleConfig(
-                    sampleConfigType=SampleConfigType.STATIC,
-                    config=StaticSamplingConfig(
-                        profileSample=50.0,
-                        profileSampleType=ProfileSampleType.PERCENTAGE,
-                    ),
+            config=DatabaseSamplerConfig(
+                sample_config=SampleConfig(
+                    profileSampleConfig=ProfileSampleConfig(
+                        sampleConfigType=SampleConfigType.STATIC,
+                        config=StaticSamplingConfig(
+                            profileSample=50.0,
+                            profileSampleType=ProfileSampleType.PERCENTAGE,
+                        ),
+                    )
                 )
             ),
         )
@@ -191,20 +196,22 @@ class SampleTest(TestCase):
             service_connection_config=self.bq_conn,
             ometa_client=None,
             entity=view_entity,
-            sample_config=SampleConfig(
-                profileSampleConfig=ProfileSampleConfig(
-                    sampleConfigType=SampleConfigType.STATIC,
-                    config=StaticSamplingConfig(
-                        profileSample=50.0,
-                        profileSampleType=ProfileSampleType.PERCENTAGE,
-                    ),
-                )
-            ),
-            partition_details=PartitionProfilerConfig(
-                enablePartitioning=True,
-                partitionColumnName="id",
-                partitionIntervalType=PartitionIntervalTypes.COLUMN_VALUE,
-                partitionValues=["1", "2"],
+            config=DatabaseSamplerConfig(
+                sample_config=SampleConfig(
+                    profileSampleConfig=ProfileSampleConfig(
+                        sampleConfigType=SampleConfigType.STATIC,
+                        config=StaticSamplingConfig(
+                            profileSample=50.0,
+                            profileSampleType=ProfileSampleType.PERCENTAGE,
+                        ),
+                    )
+                ),
+                partition_details=PartitionProfilerConfig(
+                    enablePartitioning=True,
+                    partitionColumnName="id",
+                    partitionIntervalType=PartitionIntervalTypes.COLUMN_VALUE,
+                    partitionValues=["1", "2"],
+                ),
             ),
             table_type=TableType.View,
         )
@@ -224,20 +231,22 @@ class SampleTest(TestCase):
             service_connection_config=self.bq_conn,
             ometa_client=None,
             entity=self.table_entity,
-            sample_config=SampleConfig(
-                profileSampleConfig=ProfileSampleConfig(
-                    sampleConfigType=SampleConfigType.STATIC,
-                    config=StaticSamplingConfig(
-                        profileSample=50.0,
-                        profileSampleType=ProfileSampleType.PERCENTAGE,
-                    ),
-                )
-            ),
-            partition_details=PartitionProfilerConfig(
-                enablePartitioning=True,
-                partitionColumnName="id",
-                partitionIntervalType=PartitionIntervalTypes.COLUMN_VALUE,
-                partitionValues=["1", "2"],
+            config=DatabaseSamplerConfig(
+                sample_config=SampleConfig(
+                    profileSampleConfig=ProfileSampleConfig(
+                        sampleConfigType=SampleConfigType.STATIC,
+                        config=StaticSamplingConfig(
+                            profileSample=50.0,
+                            profileSampleType=ProfileSampleType.PERCENTAGE,
+                        ),
+                    )
+                ),
+                partition_details=PartitionProfilerConfig(
+                    enablePartitioning=True,
+                    partitionColumnName="id",
+                    partitionIntervalType=PartitionIntervalTypes.COLUMN_VALUE,
+                    partitionValues=["1", "2"],
+                ),
             ),
         )
         query: CTE = sampler.get_sample_query(sampler._resolve_sample_config)

--- a/ingestion/tests/unit/observability/profiler/sqlalchemy/mssql/test_mssql_sampling.py
+++ b/ingestion/tests/unit/observability/profiler/sqlalchemy/mssql/test_mssql_sampling.py
@@ -27,6 +27,7 @@ from metadata.sampler.models import (
     ProfileSampleConfig,
     SampleConfig,
 )
+from metadata.sampler.sampler_config import DatabaseSamplerConfig
 from metadata.sampler.sqlalchemy.mssql.sampler import MssqlSampler
 from metadata.sampler.sqlalchemy.sampler import SQASampler
 
@@ -88,13 +89,15 @@ class SampleTest(TestCase):
             service_connection_config=self.mssql_conn,
             ometa_client=None,
             entity=self.table_entity,
-            sample_config=SampleConfig(
-                profileSampleConfig=ProfileSampleConfig(
-                    sampleConfigType=SampleConfigType.STATIC,
-                    config=StaticSamplingConfig(
-                        profileSample=50.0,
-                        profileSampleType=ProfileSampleType.PERCENTAGE,
-                    ),
+            config=DatabaseSamplerConfig(
+                sample_config=SampleConfig(
+                    profileSampleConfig=ProfileSampleConfig(
+                        sampleConfigType=SampleConfigType.STATIC,
+                        config=StaticSamplingConfig(
+                            profileSample=50.0,
+                            profileSampleType=ProfileSampleType.PERCENTAGE,
+                        ),
+                    )
                 )
             ),
         )
@@ -114,13 +117,15 @@ class SampleTest(TestCase):
             service_connection_config=self.mssql_conn,
             ometa_client=None,
             entity=self.table_entity,
-            sample_config=SampleConfig(
-                profileSampleConfig=ProfileSampleConfig(
-                    sampleConfigType=SampleConfigType.STATIC,
-                    config=StaticSamplingConfig(
-                        profileSample=50,
-                        profileSampleType=ProfileSampleType.ROWS,
-                    ),
+            config=DatabaseSamplerConfig(
+                sample_config=SampleConfig(
+                    profileSampleConfig=ProfileSampleConfig(
+                        sampleConfigType=SampleConfigType.STATIC,
+                        config=StaticSamplingConfig(
+                            profileSample=50,
+                            profileSampleType=ProfileSampleType.ROWS,
+                        ),
+                    )
                 )
             ),
         )
@@ -140,20 +145,22 @@ class SampleTest(TestCase):
             service_connection_config=self.mssql_conn,
             ometa_client=None,
             entity=self.table_entity,
-            sample_config=SampleConfig(
-                profileSampleConfig=ProfileSampleConfig(
-                    sampleConfigType=SampleConfigType.STATIC,
-                    config=StaticSamplingConfig(
-                        profileSample=50.0,
-                        profileSampleType=ProfileSampleType.PERCENTAGE,
-                    ),
-                )
-            ),
-            partition_details=PartitionProfilerConfig(
-                enablePartitioning=True,
-                partitionColumnName="id",
-                partitionIntervalType=PartitionIntervalTypes.COLUMN_VALUE,
-                partitionValues=["1", "2"],
+            config=DatabaseSamplerConfig(
+                sample_config=SampleConfig(
+                    profileSampleConfig=ProfileSampleConfig(
+                        sampleConfigType=SampleConfigType.STATIC,
+                        config=StaticSamplingConfig(
+                            profileSample=50.0,
+                            profileSampleType=ProfileSampleType.PERCENTAGE,
+                        ),
+                    )
+                ),
+                partition_details=PartitionProfilerConfig(
+                    enablePartitioning=True,
+                    partitionColumnName="id",
+                    partitionIntervalType=PartitionIntervalTypes.COLUMN_VALUE,
+                    partitionValues=["1", "2"],
+                ),
             ),
         )
         query: CTE = sampler.get_sample_query(sampler._resolve_sample_config)

--- a/ingestion/tests/unit/observability/profiler/sqlalchemy/postgres/test_postgres_sampling.py
+++ b/ingestion/tests/unit/observability/profiler/sqlalchemy/postgres/test_postgres_sampling.py
@@ -27,6 +27,7 @@ from metadata.sampler.models import (
     ProfileSampleConfig,
     SampleConfig,
 )
+from metadata.sampler.sampler_config import DatabaseSamplerConfig
 from metadata.sampler.sqlalchemy.postgres.sampler import PostgresSampler
 from metadata.sampler.sqlalchemy.sampler import SQASampler
 
@@ -86,13 +87,15 @@ class SampleTest(TestCase):
             service_connection_config=self.psql_conn,
             ometa_client=None,
             entity=self.table_entity,
-            sample_config=SampleConfig(
-                profileSampleConfig=ProfileSampleConfig(
-                    sampleConfigType=SampleConfigType.STATIC,
-                    config=StaticSamplingConfig(
-                        profileSample=50.0,
-                        profileSampleType=ProfileSampleType.PERCENTAGE,
-                    ),
+            config=DatabaseSamplerConfig(
+                sample_config=SampleConfig(
+                    profileSampleConfig=ProfileSampleConfig(
+                        sampleConfigType=SampleConfigType.STATIC,
+                        config=StaticSamplingConfig(
+                            profileSample=50.0,
+                            profileSampleType=ProfileSampleType.PERCENTAGE,
+                        ),
+                    )
                 )
             ),
         )
@@ -112,14 +115,16 @@ class SampleTest(TestCase):
                 service_connection_config=self.psql_conn,
                 ometa_client=None,
                 entity=self.table_entity,
-                sample_config=SampleConfig(
-                    profileSampleConfig=ProfileSampleConfig(
-                        sampleConfigType=SampleConfigType.STATIC,
-                        config=StaticSamplingConfig(
-                            profileSample=50.0,
-                            profileSampleType=ProfileSampleType.PERCENTAGE,
-                            samplingMethodType=sampling_method_type,
-                        ),
+                config=DatabaseSamplerConfig(
+                    sample_config=SampleConfig(
+                        profileSampleConfig=ProfileSampleConfig(
+                            sampleConfigType=SampleConfigType.STATIC,
+                            config=StaticSamplingConfig(
+                                profileSample=50.0,
+                                profileSampleType=ProfileSampleType.PERCENTAGE,
+                                samplingMethodType=sampling_method_type,
+                            ),
+                        )
                     )
                 ),
             )
@@ -135,20 +140,22 @@ class SampleTest(TestCase):
             service_connection_config=self.psql_conn,
             ometa_client=None,
             entity=self.table_entity,
-            sample_config=SampleConfig(
-                profileSampleConfig=ProfileSampleConfig(
-                    sampleConfigType=SampleConfigType.STATIC,
-                    config=StaticSamplingConfig(
-                        profileSample=50.0,
-                        profileSampleType=ProfileSampleType.PERCENTAGE,
-                    ),
-                )
-            ),
-            partition_details=PartitionProfilerConfig(
-                enablePartitioning=True,
-                partitionColumnName="id",
-                partitionIntervalType=PartitionIntervalTypes.COLUMN_VALUE,
-                partitionValues=["1", "2"],
+            config=DatabaseSamplerConfig(
+                sample_config=SampleConfig(
+                    profileSampleConfig=ProfileSampleConfig(
+                        sampleConfigType=SampleConfigType.STATIC,
+                        config=StaticSamplingConfig(
+                            profileSample=50.0,
+                            profileSampleType=ProfileSampleType.PERCENTAGE,
+                        ),
+                    )
+                ),
+                partition_details=PartitionProfilerConfig(
+                    enablePartitioning=True,
+                    partitionColumnName="id",
+                    partitionIntervalType=PartitionIntervalTypes.COLUMN_VALUE,
+                    partitionValues=["1", "2"],
+                ),
             ),
         )
         query: CTE = sampler.get_sample_query(sampler._resolve_sample_config)

--- a/ingestion/tests/unit/observability/profiler/sqlalchemy/snowflake/test_snowflake_sampling.py
+++ b/ingestion/tests/unit/observability/profiler/sqlalchemy/snowflake/test_snowflake_sampling.py
@@ -27,6 +27,7 @@ from metadata.sampler.models import (
     ProfileSampleConfig,
     SampleConfig,
 )
+from metadata.sampler.sampler_config import DatabaseSamplerConfig
 from metadata.sampler.sqlalchemy.sampler import SQASampler
 from metadata.sampler.sqlalchemy.snowflake.sampler import SnowflakeSampler
 
@@ -83,13 +84,15 @@ class SampleTest(TestCase):
             service_connection_config=self.snowflake_conn,
             ometa_client=None,
             entity=self.table_entity,
-            sample_config=SampleConfig(
-                profileSampleConfig=ProfileSampleConfig(
-                    sampleConfigType=SampleConfigType.STATIC,
-                    config=StaticSamplingConfig(
-                        profileSample=50.0,
-                        profileSampleType=ProfileSampleType.PERCENTAGE,
-                    ),
+            config=DatabaseSamplerConfig(
+                sample_config=SampleConfig(
+                    profileSampleConfig=ProfileSampleConfig(
+                        sampleConfigType=SampleConfigType.STATIC,
+                        config=StaticSamplingConfig(
+                            profileSample=50.0,
+                            profileSampleType=ProfileSampleType.PERCENTAGE,
+                        ),
+                    )
                 )
             ),
         )
@@ -113,14 +116,16 @@ class SampleTest(TestCase):
                 service_connection_config=self.snowflake_conn,
                 ometa_client=None,
                 entity=self.table_entity,
-                sample_config=SampleConfig(
-                    profileSampleConfig=ProfileSampleConfig(
-                        sampleConfigType=SampleConfigType.STATIC,
-                        config=StaticSamplingConfig(
-                            profileSample=50.0,
-                            profileSampleType=ProfileSampleType.PERCENTAGE,
-                            samplingMethodType=sampling_method_type,
-                        ),
+                config=DatabaseSamplerConfig(
+                    sample_config=SampleConfig(
+                        profileSampleConfig=ProfileSampleConfig(
+                            sampleConfigType=SampleConfigType.STATIC,
+                            config=StaticSamplingConfig(
+                                profileSample=50.0,
+                                profileSampleType=ProfileSampleType.PERCENTAGE,
+                                samplingMethodType=sampling_method_type,
+                            ),
+                        )
                     )
                 ),
             )
@@ -140,13 +145,15 @@ class SampleTest(TestCase):
             service_connection_config=self.snowflake_conn,
             ometa_client=None,
             entity=self.table_entity,
-            sample_config=SampleConfig(
-                profileSampleConfig=ProfileSampleConfig(
-                    sampleConfigType=SampleConfigType.STATIC,
-                    config=StaticSamplingConfig(
-                        profileSample=50,
-                        profileSampleType=ProfileSampleType.ROWS,
-                    ),
+            config=DatabaseSamplerConfig(
+                sample_config=SampleConfig(
+                    profileSampleConfig=ProfileSampleConfig(
+                        sampleConfigType=SampleConfigType.STATIC,
+                        config=StaticSamplingConfig(
+                            profileSample=50,
+                            profileSampleType=ProfileSampleType.ROWS,
+                        ),
+                    )
                 )
             ),
         )
@@ -166,20 +173,22 @@ class SampleTest(TestCase):
             service_connection_config=self.snowflake_conn,
             ometa_client=None,
             entity=self.table_entity,
-            sample_config=SampleConfig(
-                profileSampleConfig=ProfileSampleConfig(
-                    sampleConfigType=SampleConfigType.STATIC,
-                    config=StaticSamplingConfig(
-                        profileSample=50.0,
-                        profileSampleType=ProfileSampleType.PERCENTAGE,
-                    ),
-                )
-            ),
-            partition_details=PartitionProfilerConfig(
-                enablePartitioning=True,
-                partitionColumnName="id",
-                partitionIntervalType=PartitionIntervalTypes.COLUMN_VALUE,
-                partitionValues=["1", "2"],
+            config=DatabaseSamplerConfig(
+                sample_config=SampleConfig(
+                    profileSampleConfig=ProfileSampleConfig(
+                        sampleConfigType=SampleConfigType.STATIC,
+                        config=StaticSamplingConfig(
+                            profileSample=50.0,
+                            profileSampleType=ProfileSampleType.PERCENTAGE,
+                        ),
+                    )
+                ),
+                partition_details=PartitionProfilerConfig(
+                    enablePartitioning=True,
+                    partitionColumnName="id",
+                    partitionIntervalType=PartitionIntervalTypes.COLUMN_VALUE,
+                    partitionValues=["1", "2"],
+                ),
             ),
         )
         query: CTE = sampler.get_sample_query(sampler._resolve_sample_config)

--- a/ingestion/tests/unit/observability/profiler/sqlalchemy/test_runner.py
+++ b/ingestion/tests/unit/observability/profiler/sqlalchemy/test_runner.py
@@ -31,6 +31,7 @@ from metadata.sampler.models import (
     ProfileSampleConfig,
     SampleConfig,
 )
+from metadata.sampler.sampler_config import DatabaseSamplerConfig
 from metadata.sampler.sqlalchemy.sampler import SQASampler
 from metadata.utils.timeout import cls_timeout
 
@@ -88,7 +89,7 @@ class RunnerTest(TestCase):
             patch.object(SQASampler, "get_client", return_value=cls.session),
             patch.object(SQASampler, "build_table_orm", return_value=User),
             mock.patch(
-                "metadata.sampler.sampler_interface.get_ssl_connection",
+                "metadata.sampler.sqlalchemy.sampler.get_ssl_connection",
                 return_value=Mock(),
             ),
         ):
@@ -98,10 +99,12 @@ class RunnerTest(TestCase):
                 service_connection_config=Mock(),
                 ometa_client=None,
                 entity=None,
-                sample_config=SampleConfig(
-                    profileSampleConfig=ProfileSampleConfig(
-                        sampleConfigType=SampleConfigType.STATIC,
-                        config=StaticSamplingConfig(profileSample=50.0),
+                config=DatabaseSamplerConfig(
+                    sample_config=SampleConfig(
+                        profileSampleConfig=ProfileSampleConfig(
+                            sampleConfigType=SampleConfigType.STATIC,
+                            config=StaticSamplingConfig(profileSample=50.0),
+                        )
                     )
                 ),
             )

--- a/ingestion/tests/unit/observability/profiler/sqlalchemy/test_sample.py
+++ b/ingestion/tests/unit/observability/profiler/sqlalchemy/test_sample.py
@@ -40,6 +40,7 @@ from metadata.sampler.models import (
     ProfileSampleConfig,
     SampleConfig,
 )
+from metadata.sampler.sampler_config import DatabaseSamplerConfig
 from metadata.sampler.sqlalchemy.sampler import SQASampler
 
 
@@ -111,10 +112,12 @@ class SampleTest(TestCase):
                 service_connection_config=cls.sqlite_conn,
                 ometa_client=None,
                 entity=None,
-                sample_config=SampleConfig(
-                    profileSampleConfig=ProfileSampleConfig(
-                        sampleConfigType=SampleConfigType.STATIC,
-                        config=StaticSamplingConfig(profileSample=50.0),
+                config=DatabaseSamplerConfig(
+                    sample_config=SampleConfig(
+                        profileSampleConfig=ProfileSampleConfig(
+                            sampleConfigType=SampleConfigType.STATIC,
+                            config=StaticSamplingConfig(profileSample=50.0),
+                        )
                     )
                 ),
             )
@@ -362,13 +365,15 @@ class SampleTest(TestCase):
                 service_connection_config=self.sqlite_conn,
                 ometa_client=None,
                 entity=None,
-                sample_config=SampleConfig(
-                    profileSampleConfig=ProfileSampleConfig(
-                        sampleConfigType=SampleConfigType.STATIC,
-                        config=StaticSamplingConfig(profileSample=50.0),
-                    )
+                config=DatabaseSamplerConfig(
+                    sample_config=SampleConfig(
+                        profileSampleConfig=ProfileSampleConfig(
+                            sampleConfigType=SampleConfigType.STATIC,
+                            config=StaticSamplingConfig(profileSample=50.0),
+                        )
+                    ),
+                    sample_query=stmt,
                 ),
-                sample_query=stmt,
             )
         sample_data = sampler.fetch_sample_data()
 
@@ -384,17 +389,19 @@ class SampleTest(TestCase):
                 service_connection_config=self.sqlite_conn,
                 ometa_client=None,
                 entity=None,
-                sample_config=SampleConfig(
-                    profileSampleConfig=ProfileSampleConfig(
-                        sampleConfigType=SampleConfigType.STATIC,
-                        config=StaticSamplingConfig(
-                            profileSample=100,
-                            profileSampleType=ProfileSampleType.PERCENTAGE,
+                config=DatabaseSamplerConfig(
+                    sample_config=SampleConfig(
+                        profileSampleConfig=ProfileSampleConfig(
+                            sampleConfigType=SampleConfigType.STATIC,
+                            config=StaticSamplingConfig(
+                                profileSample=100,
+                                profileSampleType=ProfileSampleType.PERCENTAGE,
+                            ),
                         ),
+                        randomizedSample=True,
                     ),
-                    randomizedSample=True,
+                    sample_data_count=5,
                 ),
-                sample_data_count=5,
             )
 
         with patch.object(sampler, "get_sample_query", wraps=sampler.get_sample_query) as mock_gsq:
@@ -409,17 +416,19 @@ class SampleTest(TestCase):
                 service_connection_config=self.sqlite_conn,
                 ometa_client=None,
                 entity=None,
-                sample_config=SampleConfig(
-                    profileSampleConfig=ProfileSampleConfig(
-                        sampleConfigType=SampleConfigType.STATIC,
-                        config=StaticSamplingConfig(
-                            profileSample=100,
-                            profileSampleType=ProfileSampleType.PERCENTAGE,
+                config=DatabaseSamplerConfig(
+                    sample_config=SampleConfig(
+                        profileSampleConfig=ProfileSampleConfig(
+                            sampleConfigType=SampleConfigType.STATIC,
+                            config=StaticSamplingConfig(
+                                profileSample=100,
+                                profileSampleType=ProfileSampleType.PERCENTAGE,
+                            ),
                         ),
+                        randomizedSample=False,
                     ),
-                    randomizedSample=False,
+                    sample_data_count=5,
                 ),
-                sample_data_count=5,
             )
 
         with patch.object(sampler, "get_sample_query", wraps=sampler.get_sample_query) as mock_gsq:
@@ -434,17 +443,19 @@ class SampleTest(TestCase):
                 service_connection_config=self.sqlite_conn,
                 ometa_client=None,
                 entity=None,
-                sample_config=SampleConfig(
-                    profileSampleConfig=ProfileSampleConfig(
-                        sampleConfigType=SampleConfigType.STATIC,
-                        config=StaticSamplingConfig(
-                            profileSample=100,
-                            profileSampleType=ProfileSampleType.PERCENTAGE,
+                config=DatabaseSamplerConfig(
+                    sample_config=SampleConfig(
+                        profileSampleConfig=ProfileSampleConfig(
+                            sampleConfigType=SampleConfigType.STATIC,
+                            config=StaticSamplingConfig(
+                                profileSample=100,
+                                profileSampleType=ProfileSampleType.PERCENTAGE,
+                            ),
                         ),
+                        randomizedSample=None,
                     ),
-                    randomizedSample=None,
+                    sample_data_count=5,
                 ),
-                sample_data_count=5,
             )
 
         with patch.object(sampler, "get_sample_query", wraps=sampler.get_sample_query) as mock_gsq:
@@ -459,17 +470,19 @@ class SampleTest(TestCase):
                 service_connection_config=self.sqlite_conn,
                 ometa_client=None,
                 entity=None,
-                sample_config=SampleConfig(
-                    profileSampleConfig=ProfileSampleConfig(
-                        sampleConfigType=SampleConfigType.STATIC,
-                        config=StaticSamplingConfig(
-                            profileSample=100,
-                            profileSampleType=ProfileSampleType.PERCENTAGE,
+                config=DatabaseSamplerConfig(
+                    sample_config=SampleConfig(
+                        profileSampleConfig=ProfileSampleConfig(
+                            sampleConfigType=SampleConfigType.STATIC,
+                            config=StaticSamplingConfig(
+                                profileSample=100,
+                                profileSampleType=ProfileSampleType.PERCENTAGE,
+                            ),
                         ),
+                        randomizedSample=True,
                     ),
-                    randomizedSample=True,
+                    sample_data_count=5,
                 ),
-                sample_data_count=5,
             )
 
         results = [sampler.fetch_sample_data().rows for _ in range(20)]
@@ -485,17 +498,19 @@ class SampleTest(TestCase):
                 service_connection_config=self.sqlite_conn,
                 ometa_client=None,
                 entity=None,
-                sample_config=SampleConfig(
-                    profileSampleConfig=ProfileSampleConfig(
-                        sampleConfigType=SampleConfigType.STATIC,
-                        config=StaticSamplingConfig(
-                            profileSample=100,
-                            profileSampleType=ProfileSampleType.PERCENTAGE,
+                config=DatabaseSamplerConfig(
+                    sample_config=SampleConfig(
+                        profileSampleConfig=ProfileSampleConfig(
+                            sampleConfigType=SampleConfigType.STATIC,
+                            config=StaticSamplingConfig(
+                                profileSample=100,
+                                profileSampleType=ProfileSampleType.PERCENTAGE,
+                            ),
                         ),
+                        randomizedSample=False,
                     ),
-                    randomizedSample=False,
+                    sample_data_count=5,
                 ),
-                sample_data_count=5,
             )
 
         results = [sampler.fetch_sample_data().rows for _ in range(5)]

--- a/ingestion/tests/unit/sampler/pandas/test_pandas_truncation.py
+++ b/ingestion/tests/unit/sampler/pandas/test_pandas_truncation.py
@@ -33,8 +33,8 @@ from metadata.generated.schema.entity.services.connections.database.datalakeConn
 )
 from metadata.generated.schema.type.entityReference import EntityReference
 from metadata.readers.dataframe.models import DatalakeColumnWrapper
-from metadata.sampler.models import SampleConfig
 from metadata.sampler.pandas.sampler import DatalakeSampler
+from metadata.sampler.sampler_config import DatabaseSamplerConfig
 from metadata.utils.constants import SAMPLE_DATA_MAX_CELL_LENGTH
 
 
@@ -98,7 +98,7 @@ def _fetch_truncated_sample():
             service_connection_config=DatalakeConnection(configSource={}),
             ometa_client=None,
             entity=TABLE_ENTITY,
-            sample_config=SampleConfig(),
+            config=DatabaseSamplerConfig(),
         )
         return sampler.fetch_sample_data()
 
@@ -107,7 +107,7 @@ class TestDatalakeSamplerTruncation:
     """Verify that DatalakeSampler truncates values exceeding SAMPLE_DATA_MAX_CELL_LENGTH."""
 
     @patch(
-        "metadata.sampler.sampler_interface.get_ssl_connection",
+        "metadata.sampler.pandas.sampler.get_ssl_connection",
         return_value=FakeConnection(),
     )
     def test_fetch_sample_data_truncates_oversized_cells(self, _):
@@ -119,7 +119,7 @@ class TestDatalakeSamplerTruncation:
                     assert len(cell) <= SAMPLE_DATA_MAX_CELL_LENGTH
 
     @patch(
-        "metadata.sampler.sampler_interface.get_ssl_connection",
+        "metadata.sampler.pandas.sampler.get_ssl_connection",
         return_value=FakeConnection(),
     )
     def test_oversized_body_is_truncated_to_limit(self, _):
@@ -130,7 +130,7 @@ class TestDatalakeSamplerTruncation:
         assert len(oversized_row[body_idx]) == SAMPLE_DATA_MAX_CELL_LENGTH
 
     @patch(
-        "metadata.sampler.sampler_interface.get_ssl_connection",
+        "metadata.sampler.pandas.sampler.get_ssl_connection",
         return_value=FakeConnection(),
     )
     def test_value_at_limit_is_not_truncated(self, _):
@@ -141,7 +141,7 @@ class TestDatalakeSamplerTruncation:
         assert len(at_limit_row[body_idx]) == SAMPLE_DATA_MAX_CELL_LENGTH
 
     @patch(
-        "metadata.sampler.sampler_interface.get_ssl_connection",
+        "metadata.sampler.pandas.sampler.get_ssl_connection",
         return_value=FakeConnection(),
     )
     def test_small_value_is_unchanged(self, _):

--- a/ingestion/tests/unit/sampler/test_container_sampler_processor.py
+++ b/ingestion/tests/unit/sampler/test_container_sampler_processor.py
@@ -175,24 +175,35 @@ def test_sampler_processor_handles_table(mock_import_sampler, table_entity, work
     metadata_mock.get_profiler_config_settings.return_value = None
 
     with patch("metadata.utils.profiler_utils.get_context_entities") as mock_get_context:
-        mock_get_context.return_value = (Mock(), Mock(), None)
+        mock_database_entity = MagicMock()
+        mock_get_context.return_value = (None, mock_database_entity, None)
 
         with patch("metadata.sampler.entity_adapters.build_database_service_conn_config") as mock_build_conn:
             mock_build_conn.return_value = {}
 
-            processor = SamplerProcessor(
-                config=workflow_config,
-                metadata=metadata_mock,
-            )
+            with patch("metadata.sampler.entity_adapters.get_profile_sample_config") as mock_sample_cfg:
+                from metadata.sampler.models import SampleConfig
 
-            profiler_source = MagicMock()
-            record = ProfilerSourceAndEntity.model_construct(profiler_source=profiler_source, entity=table_entity)
+                mock_sample_cfg.return_value = SampleConfig()
 
-            result = processor._run(record)
+                with patch("metadata.sampler.entity_adapters.get_sample_data_count_config") as mock_count:
+                    mock_count.return_value = 50
 
-            assert result.right is not None
-            assert result.left is None
-            assert result.right.entity == table_entity
+                    processor = SamplerProcessor(
+                        config=workflow_config,
+                        metadata=metadata_mock,
+                    )
+
+                    profiler_source = MagicMock()
+                    record = ProfilerSourceAndEntity.model_construct(
+                        profiler_source=profiler_source, entity=table_entity
+                    )
+
+                    result = processor._run(record)
+
+                    assert result.right is not None
+                    assert result.left is None
+                    assert result.right.entity == table_entity
 
 
 def test_sampler_processor_container_no_context_entities_needed(container_entity, workflow_config):
@@ -219,8 +230,8 @@ def test_sampler_processor_container_no_context_entities_needed(container_entity
         processor._run(record)
 
         call_args = mock_sampler_class.create.call_args
-        assert call_args.kwargs["schema_entity"] is None
-        assert call_args.kwargs["database_entity"] is None
+        assert "schema_entity" not in call_args.kwargs
+        assert "database_entity" not in call_args.kwargs
         assert call_args.kwargs["entity"] == container_entity
 
 

--- a/ingestion/tests/unit/sampler/test_sampler_interface.py
+++ b/ingestion/tests/unit/sampler/test_sampler_interface.py
@@ -70,7 +70,7 @@ class TestGenerateSampleData:
         sampler.entity.fullyQualifiedName.root = "test_service.db.schema.table"
         sampler.columns = [MagicMock(name="col1"), MagicMock(name="col2")]
         sampler.sample_limit = 50
-        sampler.storage_config = None
+        sampler.upload_sample_storage_config = None
 
         sample_table_data = TableData(
             columns=["col1", "col2"],
@@ -121,7 +121,7 @@ class TestGenerateSampleData:
         sampler.fetch_sample_data.assert_called_once()
 
     def test_store_enabled_with_storage_config_uploads(self, sampler):
-        sampler.storage_config = MagicMock()
+        sampler.upload_sample_storage_config = MagicMock()
         config = SampleDataIngestionConfig(storeSampleData=True, readSampleData=True)
         with patch("metadata.sampler.sampler_interface.upload_sample_data") as mock_upload:
             result = sampler.generate_sample_data(config)
@@ -130,7 +130,7 @@ class TestGenerateSampleData:
             assert len(result.rows) == 2
 
     def test_store_disabled_with_storage_config_does_not_upload(self, sampler):
-        sampler.storage_config = MagicMock()
+        sampler.upload_sample_storage_config = MagicMock()
         config = SampleDataIngestionConfig(storeSampleData=False, readSampleData=True)
         with patch("metadata.sampler.sampler_interface.upload_sample_data") as mock_upload:
             result = sampler.generate_sample_data(config)

--- a/ingestion/tests/unit/topology/database/test_burstiq_sampler.py
+++ b/ingestion/tests/unit/topology/database/test_burstiq_sampler.py
@@ -78,14 +78,13 @@ def mock_client():
 @pytest.fixture
 def sampler(mock_client):
     with patch(
-        "metadata.sampler.sampler_interface.get_ssl_connection",
+        "metadata.sampler.pandas.sampler.get_ssl_connection",
         return_value=mock_client,
     ):
         s = _ConcreteBurstIQSampler(
             service_connection_config=BURSTIQ_CONNECTION,
             ometa_client=None,
             entity=TABLE_ENTITY,
-            sample_config=SampleConfig(),
         )
     return s  # noqa: RET504
 


### PR DESCRIPTION
## Summary

- Introduce `SamplerConfig` dataclass hierarchy (`SamplerConfig` → `DatabaseSamplerConfig` / `StorageSamplerConfig`) in a new `sampler_config.py` module
- Replace the 9-parameter `SamplerInterface.__init__` / `create()` signature with a single `config: SamplerConfig` parameter — eliminates the `too-many-arguments` pylint suppress and removes database-specific imports from the base class
- Move config resolution (partition_details, sample_query, include/exclude columns, sample_config, sample_data_count) to callers (`entity_adapters`, `profiler_source`, `base_test_suite_source`) so the interface receives already-resolved values
- Move SSL connection setup and column include/exclude filtering down to database-family subclasses (`SQASampler`, `PandasSampler`, `NoSQLSampler`) — storage samplers remain clean
- Simplify `BigQuerySampler`, `PostgresSampler`, `SnowflakeSampler` to `*args/**kwargs` init (no longer need to re-declare 8 parameters)
- Remove `StorageSampler.create()` override; the base `create()` is now sufficient
- Rename `storage_config` → `upload_sample_storage_config` on the interface to clarify it's the destination for sample data upload, not the service connection

## Test plan

- [ ] All existing unit tests updated and passing (`make unit_ingestion_dev_env`)
- [ ] Sampling tests: SQLAlchemy (BigQuery, Snowflake, Postgres, AzureSQL, MSSQL), Pandas/Datalake, storage container
- [ ] `test_sampler_interface.py` — `storage_config` → `upload_sample_storage_config` rename covered
- [ ] `test_container_sampler_processor.py`, `test_burstiq_sampler.py` — adapted to new config object

🤖 Generated with [Claude Code](https://claude.com/claude-code)