### PR TITLE
Fixes: Safely parse JSON from untrusted sources to prevent blank screen crashes

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/File/FileNode.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/File/FileNode.ts
@@ -12,6 +12,7 @@
  */
 import { mergeAttributes, Node } from '@tiptap/core';
 import { ReactNodeViewRenderer } from '@tiptap/react';
+import { tryParseJson } from '../../../utils/jsonUtils';
 import { FileNodeAttrs, FileNodeOptions } from './FileNode.interface';
 import FileNodeView from './FileNodeView';
 
@@ -74,7 +75,7 @@ const FileNode = Node.create<FileNodeOptions>({
             mimeType,
             isUploading,
             uploadProgress: uploadProgress ? parseInt(uploadProgress) : 0,
-            tempFile: tempFile ? JSON.parse(tempFile) : null,
+            tempFile: tempFile ? tryParseJson(tempFile) : null,
             isImage,
             alt,
           };

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useWorkflowHistory.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useWorkflowHistory.ts
@@ -34,8 +34,8 @@ export const useWorkflowHistory = ({
   const saveState = useCallback(
     (nodes: Node[], edges: Edge[], action = 'Unknown Action') => {
       const newState: WorkflowState = {
-        nodes: JSON.parse(JSON.stringify(nodes)),
-        edges: JSON.parse(JSON.stringify(edges)),
+        nodes: structuredClone(nodes),
+        edges: structuredClone(edges),
         timestamp: Date.now(),
         action,
       };
@@ -57,7 +57,7 @@ export const useWorkflowHistory = ({
         return newIndex;
       });
     },
-    [currentIndex, maxHistorySize]
+    [currentIndex, maxHistorySize],
   );
 
   const undo = useCallback((): WorkflowState | null => {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/MlModelVersionUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/MlModelVersionUtils.ts
@@ -30,18 +30,19 @@ import {
   removeDuplicateTags,
 } from './EntityVersionUtils';
 import { TagLabelWithStatus } from './EntityVersionUtils.interface';
+import { safeJsonParseStrict } from './jsonUtils';
 
 const handleFeatureDescriptionChangeDiff = (
   colList: Mlmodel['mlFeatures'],
   oldDiffs: MlFeature[],
-  newDiffs: MlFeature[]
+  newDiffs: MlFeature[],
 ) => {
   colList?.forEach((i) => {
     newDiffs.forEach((newDiff, index) => {
       if (isEqual(i.name, newDiff.name)) {
         i.description = getTextDiff(
           oldDiffs[index]?.description ?? '',
-          newDiff.description ?? ''
+          newDiff.description ?? '',
         );
       }
     });
@@ -51,7 +52,7 @@ const handleFeatureDescriptionChangeDiff = (
 const handleFeatureTagChangeDiff = (
   colList: Mlmodel['mlFeatures'],
   oldDiffs: MlFeature[],
-  newDiffs: MlFeature[]
+  newDiffs: MlFeature[],
 ) => {
   colList?.forEach((i) => {
     newDiffs.forEach((newDiff, index) => {
@@ -60,11 +61,11 @@ const handleFeatureTagChangeDiff = (
         const uniqueTags: Array<TagLabelWithStatus> = [];
         const oldTag = removeDuplicateTags(
           oldDiffs[index].tags ?? [],
-          newDiff.tags ?? []
+          newDiff.tags ?? [],
         );
         const newTag = removeDuplicateTags(
           newDiff.tags ?? [],
-          oldDiffs[index].tags ?? []
+          oldDiffs[index].tags ?? [],
         );
         const tagsDiff = getTagsDiff(oldTag, newTag);
 
@@ -74,7 +75,7 @@ const handleFeatureTagChangeDiff = (
               flag[elem.tagFQN] = true;
               uniqueTags.push(elem);
             }
-          }
+          },
         );
         i.tags = uniqueTags;
       }
@@ -84,22 +85,28 @@ const handleFeatureTagChangeDiff = (
 
 export const getMlFeatureVersionData = (
   currentVersionData: VersionData,
-  changeDescription: ChangeDescription
+  changeDescription: ChangeDescription,
 ): Mlmodel['mlFeatures'] => {
   const featureList = cloneDeep(
-    (currentVersionData as Mlmodel).mlFeatures ?? []
+    (currentVersionData as Mlmodel).mlFeatures ?? [],
   );
   const featuresDiff = getAllDiffByFieldName(
     EntityField.ML_FEATURES,
-    changeDescription
+    changeDescription,
   );
   const changedEntities = getAllChangedEntityNames(featuresDiff);
 
   changedEntities.forEach((changedField) => {
     if (changedField === EntityField.ML_FEATURES) {
       const featureDiff = getDiffByFieldName(changedField, changeDescription);
-      const oldDiff = JSON.parse(getChangedEntityOldValue(featureDiff) ?? '[]');
-      const newDiff = JSON.parse(getChangedEntityNewValue(featureDiff) ?? '[]');
+      const oldDiff = safeJsonParseStrict<MlFeature[]>(
+        getChangedEntityOldValue(featureDiff),
+        [],
+      );
+      const newDiff = safeJsonParseStrict<MlFeature[]>(
+        getChangedEntityNewValue(featureDiff),
+        [],
+      );
 
       handleFeatureDescriptionChangeDiff(featureList, oldDiff, newDiff);
 

--- a/openmetadata-ui/src/main/resources/ui/src/utils/PipelineVersionUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/PipelineVersionUtils.ts
@@ -29,11 +29,12 @@ import {
   isEndsWithField,
 } from './EntityVersionUtils';
 import { TagLabelWithStatus } from './EntityVersionUtils.interface';
+import { safeJsonParseStrict } from './jsonUtils';
 
 const handleTaskDescriptionChangeDiff = (
   tasksDiff: EntityDiffProps,
   taskList: Pipeline['tasks'] = [],
-  changedTaskName?: string
+  changedTaskName?: string,
 ) => {
   const oldDescription = getChangedEntityOldValue(tasksDiff);
   const newDescription = getChangedEntityNewValue(tasksDiff);
@@ -43,7 +44,7 @@ const handleTaskDescriptionChangeDiff = (
       i.description = getTextDiff(
         oldDescription,
         newDescription,
-        i.description
+        i.description,
       );
     }
   });
@@ -54,13 +55,15 @@ const handleTaskDescriptionChangeDiff = (
 const handleTaskTagChangeDiff = (
   tasksDiff: EntityDiffProps,
   taskList: Pipeline['tasks'] = [],
-  changedTaskName?: string
+  changedTaskName?: string,
 ) => {
-  const oldTags: Array<TagLabel> = JSON.parse(
-    getChangedEntityOldValue(tasksDiff) ?? '[]'
+  const oldTags: Array<TagLabel> = safeJsonParseStrict<Array<TagLabel>>(
+    getChangedEntityOldValue(tasksDiff),
+    [],
   );
-  const newTags: Array<TagLabel> = JSON.parse(
-    getChangedEntityNewValue(tasksDiff) ?? '[]'
+  const newTags: Array<TagLabel> = safeJsonParseStrict<Array<TagLabel>>(
+    getChangedEntityNewValue(tasksDiff),
+    [],
   );
 
   taskList?.forEach((i) => {
@@ -74,7 +77,7 @@ const handleTaskTagChangeDiff = (
             flag[elem.tagFQN] = true;
             uniqueTags.push(elem);
           }
-        }
+        },
       );
       i.tags = uniqueTags;
     }
@@ -85,10 +88,11 @@ const handleTaskTagChangeDiff = (
 
 const handleTaskDiffAdded = (
   tasksDiff: EntityDiffProps,
-  taskList: Pipeline['tasks'] = []
+  taskList: Pipeline['tasks'] = [],
 ) => {
-  const newTask: Pipeline['tasks'] = JSON.parse(
-    tasksDiff.added?.newValue ?? '[]'
+  const newTask: Pipeline['tasks'] = safeJsonParseStrict<Pipeline['tasks']>(
+    tasksDiff.added?.newValue,
+    [],
   );
   newTask?.forEach((task) => {
     const formatTaskData = (arr: Pipeline['tasks']) => {
@@ -109,8 +113,9 @@ const handleTaskDiffAdded = (
 };
 
 const getDeletedTasks = (tasksDiff: EntityDiffProps) => {
-  const newTask: Pipeline['tasks'] = JSON.parse(
-    tasksDiff.deleted?.oldValue ?? '[]'
+  const newTask: Pipeline['tasks'] = safeJsonParseStrict<Pipeline['tasks']>(
+    tasksDiff.deleted?.oldValue,
+    [],
   );
 
   return newTask?.map((task) => ({
@@ -125,7 +130,7 @@ const getDeletedTasks = (tasksDiff: EntityDiffProps) => {
 
 export const getUpdatedPipelineTasks = (
   currentVersionData: VersionData,
-  changeDescription: ChangeDescription
+  changeDescription: ChangeDescription,
 ) => {
   const taskList = cloneDeep((currentVersionData as Pipeline).tasks ?? []);
   const tasksDiff = getAllDiffByFieldName(EntityField.TASKS, changeDescription);
@@ -141,19 +146,19 @@ export const getUpdatedPipelineTasks = (
       newTasksList = handleTaskDescriptionChangeDiff(
         taskDiff,
         taskList,
-        changedTaskName
+        changedTaskName,
       );
     } else if (isEndsWithField(EntityField.TAGS, changedField)) {
       newTasksList = handleTaskTagChangeDiff(
         taskDiff,
         taskList,
-        changedTaskName
+        changedTaskName,
       );
     } else {
       const tasksDiff = getDiffByFieldName(
         EntityField.TASKS,
         changeDescription,
-        true
+        true,
       );
       if (tasksDiff.added) {
         newTasksList = handleTaskDiffAdded(tasksDiff, taskList);

--- a/openmetadata-ui/src/main/resources/ui/src/utils/RuleEnforcementUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/RuleEnforcementUtils.ts
@@ -18,12 +18,13 @@ import {
   RuleType,
 } from '../context/RuleEnforcementProvider/RuleEnforcementProvider.interface';
 import { EntityType } from '../enums/entity.enum';
+import { tryParseJson } from './jsonUtils';
 
 /**
  * Parse a rule string into a structured object
  */
 export const parseRule = (rule: EntityRule): ParsedRule => {
-  const ruleObj = JSON.parse(rule.rule);
+  const ruleObj = tryParseJson<Record<string, unknown>>(rule.rule) ?? {};
 
   // Determine rule type from the parsed object
   let ruleType = 'custom';
@@ -62,7 +63,7 @@ export const parseRule = (rule: EntityRule): ParsedRule => {
  */
 export const getEntityRulesValidation = (
   rules: ParsedRule[],
-  entityType: EntityType
+  entityType: EntityType,
 ) => {
   const hints: DataAssetRuleValidation = {
     canAddMultipleUserOwners: true,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/SchemaVersionUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/SchemaVersionUtils.ts
@@ -34,9 +34,10 @@ import {
   getTextDiff,
   isEndsWithField,
 } from './EntityVersionUtils';
+import { safeJsonParseStrict } from './jsonUtils';
 
 export function getNewFieldFromSchemaFieldDiff(
-  newCol: Array<Field>
+  newCol: Array<Field>,
 ): Array<Field> {
   return newCol.map((col) => {
     let children: Array<Field> | undefined;
@@ -57,7 +58,7 @@ export function getNewFieldFromSchemaFieldDiff(
 }
 
 export function getNewSchemaFromSchemaDiff(
-  newField: Array<Field>
+  newField: Array<Field>,
 ): Array<Field> {
   return newField.map((field) => {
     let children: Array<Field> | undefined;
@@ -79,12 +80,12 @@ export function getNewSchemaFromSchemaDiff(
 
 export function createAddedSchemasDiff(
   schemaFieldsDiff: EntityDiffProps,
-  schemaFields: Array<Field> = []
+  schemaFields: Array<Field> = [],
 ) {
-  const newField: Array<Field> = JSON.parse(
-    schemaFieldsDiff.added?.newValue ?? '[]'
+  const newField: Array<Field> = safeJsonParseStrict<Array<Field>>(
+    schemaFieldsDiff.added?.newValue,
+    [],
   );
-
   newField.forEach((field) => {
     const formatSchemaFieldsData = (arr: Array<Field>, updateAll?: boolean) => {
       arr?.forEach((i) => {
@@ -109,21 +110,22 @@ export function createAddedSchemasDiff(
 export function addDeletedSchemasDiff(
   columnsDiff: EntityDiffProps,
   colList: Array<Field> = [],
-  changedEntity = ''
+  changedEntity = '',
 ) {
-  const newCol: Array<Field> = JSON.parse(
-    columnsDiff.deleted?.oldValue ?? '[]'
+  const newCol: Array<Field> = safeJsonParseStrict<Array<Field>>(
+    columnsDiff.deleted?.oldValue,
+    [],
   );
   const newColumns = getNewFieldFromSchemaFieldDiff(newCol);
 
   const insertNewSchemaField = (
     changedEntityField: string,
-    colArray: Array<Field>
+    colArray: Array<Field>,
   ) => {
     const fieldsArray = changedEntityField.split(FQN_SEPARATOR_CHAR);
     if (isEmpty(changedEntityField)) {
       const nonExistingColumns = newColumns.filter((newColumn) =>
-        isUndefined(colArray.find((col) => col.name === newColumn.name))
+        isUndefined(colArray.find((col) => col.name === newColumn.name)),
       );
       colArray.unshift(...nonExistingColumns);
     } else {
@@ -140,30 +142,31 @@ export function getSchemasDiff(
   schemaFieldsDiff: EntityDiffProps,
   changedEntity = '',
   schemaFields: Array<Field> = [],
-  clonedMessageSchema?: MessageSchemaObject | APISchema
+  clonedMessageSchema?: MessageSchemaObject | APISchema,
 ) {
   if (schemaFieldsDiff.added) {
     createAddedSchemasDiff(schemaFieldsDiff, schemaFields);
   }
   if (schemaFieldsDiff.deleted) {
-    const newField: Array<Field> = JSON.parse(
-      schemaFieldsDiff.deleted?.oldValue ?? '[]'
+    const newField: Array<Field> = safeJsonParseStrict<Array<Field>>(
+      schemaFieldsDiff.deleted?.oldValue,
+      [],
     );
     const newFields = getNewSchemaFromSchemaDiff(newField);
     const insertNewField = (
       changedEntityField: string,
-      fieldArray: Array<Field>
+      fieldArray: Array<Field>,
     ) => {
       const changedFieldsArray = changedEntityField.split(FQN_SEPARATOR_CHAR);
       if (isEmpty(changedEntityField)) {
         const nonExistingFields = newFields.filter((newField) =>
-          isUndefined(fieldArray.find((field) => field.name === newField.name))
+          isUndefined(fieldArray.find((field) => field.name === newField.name)),
         );
         fieldArray.unshift(...nonExistingFields);
       } else {
         const parentField = changedFieldsArray.shift();
         const arr = fieldArray.find(
-          (field) => field.name === parentField
+          (field) => field.name === parentField,
         )?.children;
 
         insertNewField(changedFieldsArray.join(FQN_SEPARATOR_CHAR), arr ?? []);
@@ -181,13 +184,13 @@ export function getSchemasDiff(
 
 export const getVersionedSchema = (
   schema: MessageSchemaObject | APISchema,
-  changeDescription: ChangeDescription
+  changeDescription: ChangeDescription,
 ): MessageSchemaObject | APISchema => {
   let clonedMessageSchema = cloneDeep(schema);
   const schemaFields = clonedMessageSchema?.schemaFields;
   const schemaFieldsDiff = getAllDiffByFieldName(
     EntityField.SCHEMA_FIELDS,
-    changeDescription
+    changeDescription,
   );
 
   const changedSchemaFields = getAllChangedEntityNames(schemaFieldsDiff);
@@ -195,7 +198,7 @@ export const getVersionedSchema = (
   changedSchemaFields?.forEach((changedSchemaField) => {
     const schemaFieldDiff = getDiffByFieldName(
       changedSchemaField,
-      changeDescription
+      changeDescription,
     );
     const changedEntityName = getChangedEntityName(schemaFieldDiff);
     const changedSchemaFieldName =
@@ -205,7 +208,7 @@ export const getVersionedSchema = (
       const formattedSchema = getEntityDescriptionDiff(
         schemaFieldDiff,
         changedSchemaFieldName,
-        schemaFields
+        schemaFields,
       );
 
       clonedMessageSchema = {
@@ -216,7 +219,7 @@ export const getVersionedSchema = (
       const formattedSchema = getEntityTagDiff(
         schemaFieldDiff,
         changedSchemaFieldName,
-        schemaFields
+        schemaFields,
       );
 
       clonedMessageSchema = {
@@ -228,7 +231,7 @@ export const getVersionedSchema = (
         schemaFieldDiff,
         EntityField.DISPLAYNAME,
         changedSchemaFieldName,
-        schemaFields
+        schemaFields,
       );
 
       clonedMessageSchema = {
@@ -242,7 +245,7 @@ export const getVersionedSchema = (
         schemaFieldDiff,
         EntityField.DATA_TYPE_DISPLAY,
         changedSchemaFieldName,
-        schemaFields
+        schemaFields,
       );
 
       clonedMessageSchema = {
@@ -258,14 +261,14 @@ export const getVersionedSchema = (
       const schemaFieldsDiff = getDiffByFieldName(
         changedEntityName ?? '',
         changeDescription,
-        true
+        true,
       );
 
       clonedMessageSchema = getSchemasDiff(
         schemaFieldsDiff,
         changedEntity,
         schemaFields,
-        clonedMessageSchema
+        clonedMessageSchema,
       );
     }
   });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/SearchIndexVersionUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/SearchIndexVersionUtils.ts
@@ -32,11 +32,12 @@ import {
   isEndsWithField,
 } from './EntityVersionUtils';
 import { TagLabelWithStatus } from './EntityVersionUtils.interface';
+import { safeJsonParseStrict } from './jsonUtils';
 
 const handleFieldDescriptionChangeDiff = (
   fieldsDiff: EntityDiffProps,
   fieldList: SearchIndex['fields'] = [],
-  changedFieldName?: string
+  changedFieldName?: string,
 ) => {
   const oldDescription = getChangedEntityOldValue(fieldsDiff);
   const newDescription = getChangedEntityNewValue(fieldsDiff);
@@ -46,7 +47,7 @@ const handleFieldDescriptionChangeDiff = (
       i.description = getTextDiff(
         oldDescription,
         newDescription,
-        i.description
+        i.description,
       );
     }
   });
@@ -57,13 +58,15 @@ const handleFieldDescriptionChangeDiff = (
 const handleFieldTagChangeDiff = (
   fieldsDiff: EntityDiffProps,
   fieldList: SearchIndex['fields'] = [],
-  changedFieldName?: string
+  changedFieldName?: string,
 ) => {
-  const oldTags: Array<TagLabel> = JSON.parse(
-    getChangedEntityOldValue(fieldsDiff) ?? '[]'
+  const oldTags: Array<TagLabel> = safeJsonParseStrict<Array<TagLabel>>(
+    getChangedEntityOldValue(fieldsDiff),
+    [],
   );
-  const newTags: Array<TagLabel> = JSON.parse(
-    getChangedEntityNewValue(fieldsDiff) ?? '[]'
+  const newTags: Array<TagLabel> = safeJsonParseStrict<Array<TagLabel>>(
+    getChangedEntityNewValue(fieldsDiff),
+    [],
   );
 
   fieldList?.forEach((i) => {
@@ -77,7 +80,7 @@ const handleFieldTagChangeDiff = (
             flag[elem.tagFQN] = true;
             uniqueTags.push(elem);
           }
-        }
+        },
       );
       i.tags = uniqueTags;
     }
@@ -88,11 +91,11 @@ const handleFieldTagChangeDiff = (
 
 const handleFieldDiffAdded = (
   fieldsDiff: EntityDiffProps,
-  fieldList: SearchIndex['fields'] = []
+  fieldList: SearchIndex['fields'] = [],
 ) => {
-  const newField: SearchIndex['fields'] = JSON.parse(
-    fieldsDiff.added?.newValue ?? '[]'
-  );
+  const newField: SearchIndex['fields'] = safeJsonParseStrict<
+    SearchIndex['fields']
+  >(fieldsDiff.added?.newValue, []);
   newField?.forEach((field) => {
     const formatFieldData = (arr: SearchIndex['fields']) => {
       arr?.forEach((i) => {
@@ -112,9 +115,9 @@ const handleFieldDiffAdded = (
 };
 
 const getDeletedFields = (fieldsDiff: EntityDiffProps) => {
-  const newField: SearchIndex['fields'] = JSON.parse(
-    fieldsDiff.deleted?.oldValue ?? '[]'
-  );
+  const newField: SearchIndex['fields'] = safeJsonParseStrict<
+    SearchIndex['fields']
+  >(fieldsDiff.deleted?.oldValue, []);
 
   return newField?.map((field) => ({
     ...field,
@@ -128,14 +131,14 @@ const getDeletedFields = (fieldsDiff: EntityDiffProps) => {
 
 export const getUpdatedSearchIndexFields = (
   currentVersionData: VersionData,
-  changeDescription: ChangeDescription
+  changeDescription: ChangeDescription,
 ) => {
   const fieldsList = cloneDeep(
-    (currentVersionData as SearchIndex).fields ?? []
+    (currentVersionData as SearchIndex).fields ?? [],
   );
   const fieldsDiff = getAllDiffByFieldName(
     EntityField.FIELDS,
-    changeDescription
+    changeDescription,
   );
   const changedFields = getAllChangedEntityNames(fieldsDiff);
 
@@ -149,19 +152,19 @@ export const getUpdatedSearchIndexFields = (
       newFieldsList = handleFieldDescriptionChangeDiff(
         fieldDiff,
         fieldsList,
-        changedFieldName
+        changedFieldName,
       );
     } else if (isEndsWithField(EntityField.TAGS, changedField)) {
       newFieldsList = handleFieldTagChangeDiff(
         fieldDiff,
         fieldsList,
-        changedFieldName
+        changedFieldName,
       );
     } else {
       const fieldsDiff = getDiffByFieldName(
         EntityField.TASKS,
         changeDescription,
-        true
+        true,
       );
       if (fieldsDiff.added) {
         newFieldsList = handleFieldDiffAdded(fieldsDiff, fieldsList);

--- a/openmetadata-ui/src/main/resources/ui/src/utils/jsonUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/jsonUtils.ts
@@ -1,0 +1,69 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+export interface SafeParseResult<T> {
+  success: true;
+  data: T;
+}
+
+export interface SafeParseError {
+  success: false;
+  error: string;
+}
+
+export type SafeParseResultOrError<T> = SafeParseResult<T> | SafeParseError;
+
+export const safeJsonParse = <T>(
+  jsonString: string,
+): SafeParseResultOrError<T> => {
+  if (!jsonString || typeof jsonString !== 'string') {
+    return { success: false, error: 'Invalid input: not a string' };
+  }
+
+  try {
+    const parsed = JSON.parse(jsonString) as T;
+    return { success: true, data: parsed };
+  } catch (e) {
+    const errorMessage = e instanceof Error ? e.message : 'Unknown parse error';
+    return { success: false, error: errorMessage };
+  }
+};
+
+export const safeJsonParseStrict = <T>(
+  jsonString: string | null | undefined,
+  fallback: T,
+): T => {
+  if (!jsonString) {
+    return fallback;
+  }
+
+  try {
+    return JSON.parse(jsonString) as T;
+  } catch {
+    return fallback;
+  }
+};
+
+export const tryParseJson = <T>(
+  jsonString: string | null | undefined,
+): T | null => {
+  if (!jsonString) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(jsonString) as T;
+  } catch {
+    return null;
+  }
+};


### PR DESCRIPTION
## Fixes #28154 

The UI crashes with a blank white screen when `JSON.parse()` receives malformed data in entity version history pages. The root cause is that `JSON.parse()` is called directly without try-catch in several files, so a single corrupt version diff — from a partial upgrade, a race condition in concurrent edits, or unexpected API data — throws an unhandled `SyntaxError` that React cannot recover from.

This PR adds a shared safe JSON parsing utility and migrates all high-risk call sites to use it.

**What changed:**
- New `src/utils/jsonUtils.ts` with three functions:
  - `safeJsonParseStrict<T>(input, fallback)` — never throws, returns fallback on error
  - `tryParseJson<T>(input)` — returns `null` on error
  - `safeJsonParse<T>(input)` — returns tagged union `{success, data|error}`
- All 7 files with unsafe `JSON.parse()` calls now use the safe wrappers
- `useWorkflowHistory.ts`'s deep clone pattern (`JSON.parse(JSON.stringify(...))`) replaced with `structuredClone`

### Type of change:

- [x] Bug fix

### High-level design:

N/A — small change.

### Tests:

No behavioral change for valid data. For malformed data, the fix ensures graceful fallback (empty array `[]`) instead of a crash. No test changes needed.

### UI screen recording / screenshots:

Not applicable.

### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->
