### PR TITLE
fix(search): scope column-grid metadata-status ITs + surface ES shard-failure reason

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ColumnGridResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ColumnGridResourceIT.java
@@ -292,10 +292,12 @@ public class ColumnGridResourceIT {
   @Test
   void test_getColumnGrid_withMetadataStatusMissing(TestNamespace ns) throws Exception {
     OpenMetadataClient client = SdkClients.adminClient();
-    createTableWithoutMetadata(ns);
+    DatabaseService service = createTableWithoutMetadata(ns);
     waitForSearchIndexRefresh();
 
-    ColumnGridResponse response = getColumnGrid(client, "entityTypes=table&metadataStatus=MISSING");
+    ColumnGridResponse response =
+        getColumnGrid(
+            client, "entityTypes=table&metadataStatus=MISSING&serviceName=" + service.getName());
 
     assertNotNull(response);
     assertNotNull(response.getColumns());
@@ -304,11 +306,12 @@ public class ColumnGridResourceIT {
   @Test
   void test_getColumnGrid_withMetadataStatusComplete(TestNamespace ns) throws Exception {
     OpenMetadataClient client = SdkClients.adminClient();
-    createTableWithFullMetadata(ns);
+    DatabaseService service = createTableWithFullMetadata(ns);
     waitForSearchIndexRefresh();
 
     ColumnGridResponse response =
-        getColumnGrid(client, "entityTypes=table&metadataStatus=COMPLETE");
+        getColumnGrid(
+            client, "entityTypes=table&metadataStatus=COMPLETE&serviceName=" + service.getName());
 
     assertNotNull(response);
     assertNotNull(response.getColumns());
@@ -317,11 +320,12 @@ public class ColumnGridResourceIT {
   @Test
   void test_getColumnGrid_withMetadataStatusIncomplete(TestNamespace ns) throws Exception {
     OpenMetadataClient client = SdkClients.adminClient();
-    createTableWithPartialMetadata(ns);
+    DatabaseService service = createTableWithPartialMetadata(ns);
     waitForSearchIndexRefresh();
 
     ColumnGridResponse response =
-        getColumnGrid(client, "entityTypes=table&metadataStatus=INCOMPLETE");
+        getColumnGrid(
+            client, "entityTypes=table&metadataStatus=INCOMPLETE&serviceName=" + service.getName());
 
     assertNotNull(response);
     assertNotNull(response.getColumns());
@@ -1383,7 +1387,7 @@ public class ColumnGridResourceIT {
         .execute();
   }
 
-  private void createTableWithoutMetadata(TestNamespace ns) {
+  private DatabaseService createTableWithoutMetadata(TestNamespace ns) {
     DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
     DatabaseSchema schema = DatabaseSchemaTestFactory.createSimple(ns, service);
 
@@ -1396,9 +1400,10 @@ public class ColumnGridResourceIT {
         .inSchema(schema.getFullyQualifiedName())
         .withColumns(List.of(idColumn, nameColumn))
         .execute();
+    return service;
   }
 
-  private void createTableWithFullMetadata(TestNamespace ns) {
+  private DatabaseService createTableWithFullMetadata(TestNamespace ns) {
     DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
     DatabaseSchema schema = DatabaseSchemaTestFactory.createSimple(ns, service);
 
@@ -1413,9 +1418,10 @@ public class ColumnGridResourceIT {
         .inSchema(schema.getFullyQualifiedName())
         .withColumns(List.of(idColumn))
         .execute();
+    return service;
   }
 
-  private void createTableWithPartialMetadata(TestNamespace ns) {
+  private DatabaseService createTableWithPartialMetadata(TestNamespace ns) {
     DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
     DatabaseSchema schema = DatabaseSchemaTestFactory.createSimple(ns, service);
 
@@ -1430,6 +1436,7 @@ public class ColumnGridResourceIT {
         .inSchema(schema.getFullyQualifiedName())
         .withColumns(List.of(idColumn))
         .execute();
+    return service;
   }
 
   private void createTableWithCompleteMetadata(TestNamespace ns) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchColumnAggregator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchColumnAggregator.java
@@ -171,6 +171,7 @@ public class ElasticSearchColumnAggregator implements ColumnAggregator {
           LOG.warn("Search index not found for indexes {}, returning empty results", indexes);
           continue;
         }
+        logShardFailureDetails(e, indexes, query);
         throw e;
       }
     }
@@ -212,6 +213,7 @@ public class ElasticSearchColumnAggregator implements ColumnAggregator {
         totalOccurrencesAcrossGroups += result.totalDocCount();
       } catch (ElasticsearchException e) {
         if (!isIndexNotFoundException(e)) {
+          logShardFailureDetails(e, indexes, query);
           throw e;
         }
       }
@@ -250,6 +252,7 @@ public class ElasticSearchColumnAggregator implements ColumnAggregator {
         }
       } catch (ElasticsearchException e) {
         if (!isIndexNotFoundException(e)) {
+          logShardFailureDetails(e, indexes, query);
           throw e;
         }
       }
@@ -325,6 +328,7 @@ public class ElasticSearchColumnAggregator implements ColumnAggregator {
         fetchColumnsWithTagsFromSource(indexes, query, columnFieldPath, targetTags, columnsByName);
       } catch (ElasticsearchException e) {
         if (!isIndexNotFoundException(e)) {
+          logShardFailureDetails(e, indexes, query);
           throw e;
         }
       }
@@ -480,6 +484,23 @@ public class ElasticSearchColumnAggregator implements ColumnAggregator {
   private boolean isIndexNotFoundException(ElasticsearchException e) {
     String message = e.getMessage();
     return message != null && message.contains("index_not_found_exception");
+  }
+
+  private void logShardFailureDetails(ElasticsearchException e, List<String> indexes, Query query) {
+    try {
+      String queryJson = JsonUtils.pojoToJson(query);
+      LOG.error(
+          "ES search failed on indexes {} | query={} | rootCause={} | error={}",
+          indexes,
+          queryJson,
+          e.error() != null ? e.error().rootCause() : "n/a",
+          e.error() != null ? e.error() : e.getMessage());
+    } catch (Exception ignored) {
+      LOG.error(
+          "ES search failed on indexes {} (failed to serialize query): {}",
+          indexes,
+          e.getMessage());
+    }
   }
 
   private String escapeWildcardPattern(String input) {


### PR DESCRIPTION
### Describe your changes:

`test_getColumnGrid_withMetadataStatusIncomplete` has been failing consistently on the new `Integration Tests - PostgreSQL + Elasticsearch + Redis` CI lane (added in #28012). Prior attempts with `@Isolated` + 2 GB ES heap (on `harshach/fix-cache-it-failures`) **did not fix it**, so this is not parallel-test contention or generic heap pressure as previously assumed.

The blocker for root-causing it is that the aggregator's `catch (ElasticsearchException)` blocks swallow the per-shard failure reason — we only see the generic `[search_phase_execution_exception] all shards failed`. This PR makes the next failure self-diagnosing, and also tightens the three offending tests defensively.

### Type of change:
- [x] Bug fix

### High-level design:

Two changes:

1. **`ElasticSearchColumnAggregator`** — add `logShardFailureDetails(e, indexes, query)` to all four `catch (ElasticsearchException)` sites. Logs the serialized query plus `e.error().rootCause()` before rethrowing, so the next failed CI run reveals the actual shard-level reason (circuit_breaker, too_many_buckets, mapping conflict, etc.) instead of just \"all shards failed\".

2. **`ColumnGridResourceIT`** — scope the three `metadataStatus=*` tests (`Missing`/`Complete`/`Incomplete`) to their own `serviceName=` like every other test in the file. They were the only tests aggregating over the entire index instead of just their own service's data; this drops the per-test query workload to ~1 doc regardless of accumulated index state.

### Tests:

Defensive scoping fix on three tests in `ColumnGridResourceIT`; the diagnostic logging is a no-op on success paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)